### PR TITLE
[BUG] Show args event bubbling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensar/apex",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
   "main": "build/index.js",


### PR DESCRIPTION
When you click the "Show args" button inside a tool message that's within a SubAgentDisplay:

  1. First: ToolArgs component's onMouseDown handler fires (line 379) → toggles open to
  true to show args
  2. Then: The mouse event bubbles up to the parent SubAgentDisplay component's
  onMouseDown handler (line 261) → toggles ITS open state to false, collapsing the entire
   subagent

So now, with the addition of 

```
e.stopPropagation();
```

the mouse down event does not propogate up to the larger element
