### PR TITLE
[BUG] error code critical failure

### DIFF
--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -151,7 +151,7 @@ export async function summarizeConversation(
 // Helper function to check if an error is related to context length
 export function checkIfContextLengthError(error: any): boolean {
   const errorMessage = error?.message?.toLowerCase() || "";
-  const errorCode = error?.code?.toLowerCase() || "";
+  const errorCode = String(error?.code || "").toLowerCase();
 
   return (
     errorMessage.includes("context length") ||


### PR DESCRIPTION
This bug is caused by a lack of proper type casting of error codes, so it fails the entire process. The fix is a simple cast to String and allows XBEN-001-24 to pass. 
