### PR TITLE
Resolved Sharp Pipeline Type Error

### DIFF
--- a/src/tui/components/ascii-art.tsx
+++ b/src/tui/components/ascii-art.tsx
@@ -125,6 +125,7 @@ export async function convertImageToColoredAscii(
       width: colorBuffer.info.width,
       height: colorBuffer.info.height,
       channels: 4,
+      premultiplied: false,
     },
   })
     .grayscale()


### PR DESCRIPTION
### Summary
Fixed `TypeError: A boolean was expected` error when running the pensar command under Bun runtime v1.3.2.

### Description
The `convertImageToColoredAscii` function was throwing a TypeError during Sharp pipeline execution:

```
TypeError: A boolean was expected
    at <anonymous> (/usr/local/lib/node_modules/@pensar/apex/build/index.js:17026:17)
    at new Promise (1:11)
    at _pipeline (/usr/local/lib/node_modules/@pensar/apex/build/index.js:17025:16)
    at convertImageToColoredAscii (/usr/local/lib/node_modules/@pensar/apex/build/index.js:33519:117)
```

### Environment
- Runtime: Bun v1.3.2 (macOS arm64)
- Sharp version: 0.34.4
- Affected file: `src/tui/components/ascii-art.tsx`

### Root Cause
The Sharp instance created from raw pixel data was missing the `premultiplied` parameter in the raw configuration object. While technically optional in Sharp's TypeScript definitions, Bun v1.3.2 performs stricter type validation on native module parameters, causing this error to surface during the internal pipeline call.

### Solution
Added `premultiplied: false` to the raw configuration object in `src/tui/components/ascii-art.tsx`:

```typescript
const grayscaleBuffer = await sharp(colorBuffer.data, {
  raw: {
    width: colorBuffer.info.width,
    height: colorBuffer.info.height,
    channels: 4,
    premultiplied: false,  // Added: explicitly specify non-premultiplied RGBA data
  },
})
```

### Technical Details
The `premultiplied: false` setting is correct because the raw pixel data comes from `sharp().ensureAlpha().raw()`, which produces non-premultiplied RGBA data with separate RGB and alpha channels. Bun's N-API implementation has stricter type checking for native module parameters, requiring explicit boolean values even when Sharp's TypeScript definitions mark them as optional.