### PR TITLE
Added Rate Limiting 

### DIFF
--- a/scripts/pentest.ts
+++ b/scripts/pentest.ts
@@ -23,6 +23,7 @@ async function runPentest(options: PentestOptions): Promise<void> {
   console.log("=".repeat(80));
   console.log(`Target: ${target}`);
   console.log(`Model: ${model}`);
+  console.log(`Rate Limit: ${rps ? `${rps} req/s` : 'Unlimited'}`);
   console.log(`Headers: ${headerMode === 'none' ? 'None' : headerMode === 'default' ? 'Default (pensar-apex)' : 'Custom'}`);
   if (headerMode === 'custom' && customHeaders) {
     for (const [key, value] of Object.entries(customHeaders)) {
@@ -43,6 +44,11 @@ async function runPentest(options: PentestOptions): Promise<void> {
         mode: headerMode,
         headers: headerMode === 'custom' ? customHeaders : undefined,
       },
+      ...(rps && {
+        rateLimiter: {
+          requestsPerSecond: rps,
+        },
+      }),
     };
 
     // Run the thorough pentest agent
@@ -113,6 +119,9 @@ async function main() {
       "  --model <model>          AI model to use (default: claude-sonnet-4-5)"
     );
     console.error(
+      "  --rps <number>           Rate limit: requests per second (default: unlimited)"
+    );
+    console.error(
       "  --headers <mode>         Header mode: none, default, or custom (default: default)"
     );
     console.error(
@@ -146,7 +155,7 @@ async function main() {
       "  pensar pentest --target api.example.com --headers none"
     );
     console.error(
-      "  pensar pentest --target example.com --headers custom \\"
+      "  pensar pentest --target example.com --rps 5 --headers custom \\"
     );
     console.error(
       "    --header 'User-Agent: pensar_client123' --header 'X-Bug-Bounty: researcher'"
@@ -179,6 +188,23 @@ async function main() {
       process.exit(1);
     }
     model = modelArg as AIModel;
+  }
+
+  // Parse RPS option
+  const rpsIndex = args.indexOf("--rps");
+  let rps: number | undefined;
+  if (rpsIndex !== -1) {
+    const rpsArg = args[rpsIndex + 1];
+    if (!rpsArg) {
+      console.error("Error: --rps must be followed by a number");
+      process.exit(1);
+    }
+    const parsedRps = parseInt(rpsArg, 10);
+    if (isNaN(parsedRps) || parsedRps <= 0) {
+      console.error("Error: --rps must be a positive number");
+      process.exit(1);
+    }
+    rps = parsedRps;
   }
 
   // Parse header options

--- a/scripts/pentest.ts
+++ b/scripts/pentest.ts
@@ -8,6 +8,7 @@ interface PentestOptions {
   model?: AIModel;
   headerMode?: 'none' | 'default' | 'custom';
   customHeaders?: Record<string, string>;
+  rps?: number;
 }
 
 async function runPentest(options: PentestOptions): Promise<void> {
@@ -15,7 +16,8 @@ async function runPentest(options: PentestOptions): Promise<void> {
     target,
     model = "claude-sonnet-4-5" as AIModel,
     headerMode = 'default',
-    customHeaders
+    customHeaders,
+    rps
   } = options;
 
   console.log("=".repeat(80));
@@ -265,6 +267,7 @@ async function main() {
       ...(model && { model }),
       headerMode,
       ...(headerMode === 'custom' && { customHeaders }),
+      ...(rps && { rps }),
     });
   } catch (error: any) {
     console.error("Fatal error:", error.message);

--- a/scripts/quicktest.ts
+++ b/scripts/quicktest.ts
@@ -9,6 +9,7 @@ interface QuicktestOptions {
   model?: AIModel;
   headerMode?: 'none' | 'default' | 'custom';
   customHeaders?: Record<string, string>;
+  rps?: number;
 }
 
 async function runQuicktest(options: QuicktestOptions): Promise<void> {
@@ -17,7 +18,8 @@ async function runQuicktest(options: QuicktestOptions): Promise<void> {
     objective,
     model = "claude-sonnet-4-5" as AIModel,
     headerMode = 'default',
-    customHeaders
+    customHeaders,
+    rps
   } = options;
 
   console.log("=".repeat(80));
@@ -272,6 +274,7 @@ async function main() {
       ...(model && { model }),
       headerMode,
       ...(headerMode === 'custom' && { customHeaders }),
+      ...(rps && { rps }),
     });
   } catch (error: any) {
     console.error("Fatal error:", error.message);

--- a/scripts/quicktest.ts
+++ b/scripts/quicktest.ts
@@ -26,6 +26,7 @@ async function runQuicktest(options: QuicktestOptions): Promise<void> {
   console.log(`Target: ${target}`);
   console.log(`Objective: ${objective}`);
   console.log(`Model: ${model}`);
+  console.log(`Rate Limit: ${rps ? `${rps} req/s` : 'Unlimited'}`);
   console.log(`Headers: ${headerMode === 'none' ? 'None' : headerMode === 'default' ? 'Default (pensar-apex)' : 'Custom'}`);
   if (headerMode === 'custom' && customHeaders) {
     for (const [key, value] of Object.entries(customHeaders)) {
@@ -41,6 +42,11 @@ async function runQuicktest(options: QuicktestOptions): Promise<void> {
         mode: headerMode,
         headers: headerMode === 'custom' ? customHeaders : undefined,
       },
+      ...(rps && {
+        rateLimiter: {
+          requestsPerSecond: rps,
+        },
+      }),
     };
 
     // Run the pentest agent
@@ -115,6 +121,9 @@ async function main() {
       "  --model <model>          AI model to use (default: claude-sonnet-4-5)"
     );
     console.error(
+      "  --rps <number>           Rate limit: requests per second (default: unlimited)"
+    );
+    console.error(
       "  --headers <mode>         Header mode: none, default, or custom (default: default)"
     );
     console.error(
@@ -140,7 +149,7 @@ async function main() {
       "  pensar quicktest --target 192.168.1.100 --objective 'Test auth bypass' --headers none"
     );
     console.error(
-      "  pensar quicktest --target api.example.com --objective 'API testing' \\"
+      "  pensar quicktest --target api.example.com --objective 'API testing' --rps 5 \\"
     );
     console.error(
       "    --headers custom --header 'User-Agent: pensar_client123' --header 'X-Bug-Bounty: researcher'"
@@ -185,6 +194,23 @@ async function main() {
       process.exit(1);
     }
     model = modelArg as AIModel;
+  }
+
+  // Parse RPS option
+  const rpsIndex = args.indexOf("--rps");
+  let rps: number | undefined;
+  if (rpsIndex !== -1) {
+    const rpsArg = args[rpsIndex + 1];
+    if (!rpsArg) {
+      console.error("Error: --rps must be followed by a number");
+      process.exit(1);
+    }
+    const parsedRps = parseInt(rpsArg, 10);
+    if (isNaN(parsedRps) || parsedRps <= 0) {
+      console.error("Error: --rps must be a positive number");
+      process.exit(1);
+    }
+    rps = parsedRps;
   }
 
   // Parse header options

--- a/src/core/agent/sessions/index.ts
+++ b/src/core/agent/sessions/index.ts
@@ -10,7 +10,7 @@ import {
 import { join } from "path";
 import { homedir } from "os";
 import { randomBytes } from "crypto";
-import { RateLimiter, type RateLimiterConfig } from '../services/rateLimiter';
+import { RateLimiter, type RateLimiterConfig } from '../../services/rateLimiter';
 
 /**
  * Configuration for offensive security testing headers
@@ -102,6 +102,13 @@ export function createSession(
     startTime: new Date().toISOString(),
     config,
   };
+
+  // Initialize rate limiter eagerly to prevent race conditions
+  // when multiple agents access the session simultaneously
+  if (config?.rateLimiter) {
+    console.log(`[RATE_LIMIT_INIT] Creating rate limiter for session ${sessionId} with RPS=${config.rateLimiter.requestsPerSecond}`);
+    session._rateLimiter = new RateLimiter(config.rateLimiter);
+  }
 
   // Write session metadata
   const metadataPath = join(rootPath, "session.json");

--- a/src/core/agent/sessions/index.ts
+++ b/src/core/agent/sessions/index.ts
@@ -106,7 +106,6 @@ export function createSession(
   // Initialize rate limiter eagerly to prevent race conditions
   // when multiple agents access the session simultaneously
   if (config?.rateLimiter) {
-    console.log(`[RATE_LIMIT_INIT] Creating rate limiter for session ${sessionId} with RPS=${config.rateLimiter.requestsPerSecond}`);
     session._rateLimiter = new RateLimiter(config.rateLimiter);
   }
 

--- a/src/core/agent/sessions/index.ts
+++ b/src/core/agent/sessions/index.ts
@@ -10,6 +10,7 @@ import {
 import { join } from "path";
 import { homedir } from "os";
 import { randomBytes } from "crypto";
+import { RateLimiter, type RateLimiterConfig } from '../services/rateLimiter';
 
 /**
  * Configuration for offensive security testing headers
@@ -24,6 +25,7 @@ export interface OffensiveHeadersConfig {
  */
 export interface SessionConfig {
   offensiveHeaders?: OffensiveHeadersConfig;
+  rateLimiter?: RateLimiterConfig;
 }
 
 /**
@@ -43,6 +45,7 @@ export interface Session {
   objective: string;
   startTime: string;
   config?: SessionConfig;
+  _rateLimiter?: RateLimiter;
 }
 
 /**

--- a/src/core/agent/tools.ts
+++ b/src/core/agent/tools.ts
@@ -2763,9 +2763,6 @@ export function createPentestTools(
 
   // Get rate limiter from session (initialized eagerly in createSession)
   const rateLimiter = session._rateLimiter;
-  if (rateLimiter) {
-    console.log(`[RATE_LIMIT_TOOLS] Using rate limiter for session ${session.id}`);
-  }
 
   const executeCommand = tool({
     name: "execute_command",

--- a/src/core/agent/tools.ts
+++ b/src/core/agent/tools.ts
@@ -12,7 +12,7 @@ import {
 import { join } from "path";
 import type { Session } from "./sessions";
 import { getOffensiveHeaders } from "./sessions";
-import { RateLimiter } from '../../services/rateLimiter';
+import { RateLimiter } from '../services/rateLimiter';
 import { runAgent } from "./pentestAgent";
 import type { AIModel } from "../ai";
 import { generateObjectResponse } from "../ai";

--- a/src/core/agent/tools.ts
+++ b/src/core/agent/tools.ts
@@ -12,7 +12,7 @@ import {
 import { join } from "path";
 import type { Session } from "./sessions";
 import { getOffensiveHeaders } from "./sessions";
-import { RateLimiter } from '../services/rateLimiter';
+import { RateLimiter } from '../../services/rateLimiter';
 import { runAgent } from "./pentestAgent";
 import type { AIModel } from "../ai";
 import { generateObjectResponse } from "../ai";
@@ -2761,12 +2761,11 @@ export function createPentestTools(
   // Get offensive headers from session config
   const offensiveHeaders = getOffensiveHeaders(session);
 
-  // Initialize rate limiter as SINGLETON on the session object
-  // All agents sharing this session will share the same rate limiter instance
-  if (!session._rateLimiter && session.config?.rateLimiter) {
-    session._rateLimiter = new RateLimiter(session.config.rateLimiter);
-  }
+  // Get rate limiter from session (initialized eagerly in createSession)
   const rateLimiter = session._rateLimiter;
+  if (rateLimiter) {
+    console.log(`[RATE_LIMIT_TOOLS] Using rate limiter for session ${session.id}`);
+  }
 
   const executeCommand = tool({
     name: "execute_command",

--- a/src/core/agent/tools.ts
+++ b/src/core/agent/tools.ts
@@ -12,6 +12,7 @@ import {
 import { join } from "path";
 import type { Session } from "./sessions";
 import { getOffensiveHeaders } from "./sessions";
+import { RateLimiter } from '../services/rateLimiter';
 import { runAgent } from "./pentestAgent";
 import type { AIModel } from "../ai";
 import { generateObjectResponse } from "../ai";
@@ -2760,6 +2761,13 @@ export function createPentestTools(
   // Get offensive headers from session config
   const offensiveHeaders = getOffensiveHeaders(session);
 
+  // Initialize rate limiter as SINGLETON on the session object
+  // All agents sharing this session will share the same rate limiter instance
+  if (!session._rateLimiter && session.config?.rateLimiter) {
+    session._rateLimiter = new RateLimiter(session.config.rateLimiter);
+  }
+  const rateLimiter = session._rateLimiter;
+
   const executeCommand = tool({
     name: "execute_command",
     description: `Execute a shell command for penetration testing activities.
@@ -2804,6 +2812,11 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
     inputSchema: ExecuteCommandInput,
     execute: async ({ command, timeout = 30000, toolCallDescription }) => {
       try {
+        // Apply rate limiting before command execution
+        if (rateLimiter) {
+          await rateLimiter.acquireSlot();
+        }
+
         if (toolOverride?.execute_command) {
           return toolOverride.execute_command({
             command,
@@ -2870,6 +2883,11 @@ COMMON TESTING PATTERNS:
     inputSchema: HttpRequestInput,
     execute: async ({ url, method, headers, body, followRedirects, timeout, toolCallDescription }) => {
       try {
+        // Apply rate limiting before HTTP request
+        if (rateLimiter) {
+          await rateLimiter.acquireSlot();
+        }
+
         if (toolOverride?.http_request) {
           return toolOverride.http_request({
             url,

--- a/src/core/services/rateLimiter/index.ts
+++ b/src/core/services/rateLimiter/index.ts
@@ -1,0 +1,75 @@
+import type { RateLimiterConfig } from './types';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Token bucket rate limiter with optimal time/space efficiency
+ *
+ * Optimizations:
+ * - Uses performance.now() for monotonic clock
+ * - Precomputes msPerToken in constructor
+ * - Caches now value in acquireSlot
+ * - Early returns when bucket is full
+ * - Skips all logic in unlimited mode
+ *
+ * Complexity: O(1) time, O(1) space
+ */
+export class RateLimiter {
+  private tokens: number;
+  private lastRefillTime: number;
+  private readonly rps: number | undefined;
+  private readonly bucketSize: number;
+  private readonly msPerToken: number | undefined;
+
+  constructor(config?: RateLimiterConfig) {
+    this.rps = config?.requestsPerSecond;
+    this.bucketSize = this.rps || 0;
+    this.tokens = this.bucketSize;
+    this.lastRefillTime = performance.now();
+    // Precompute msPerToken once in constructor
+    this.msPerToken = this.rps ? 1000 / this.rps : undefined;
+  }
+
+  /**
+   * Acquire a slot for making a request
+   * Blocks until a token is available
+   */
+  async acquireSlot(): Promise<void> {
+    // Early exit for unlimited mode - skip all token logic
+    if (!this.rps || !this.msPerToken) return;
+
+    // Cache now for this call to avoid multiple time calls
+    const now = performance.now();
+    this.refill(now);
+
+    if (this.tokens < 1) {
+      const waitTime = (1 - this.tokens) * this.msPerToken;
+      await sleep(waitTime);
+      const nowAfterSleep = performance.now();
+      this.refill(nowAfterSleep);
+    }
+
+    this.tokens -= 1;
+  }
+
+  private refill(now: number): void {
+    // Early return if bucket already full - just update time and skip math
+    if (this.tokens >= this.bucketSize) {
+      this.lastRefillTime = now;
+      return;
+    }
+
+    const elapsed = now - this.lastRefillTime;
+    const tokensToAdd = elapsed / this.msPerToken!;
+    this.tokens = Math.min(this.bucketSize, this.tokens + tokensToAdd);
+    this.lastRefillTime = now;
+  }
+
+  isEnabled(): boolean {
+    return this.rps !== undefined;
+  }
+}
+
+export { RateLimiterConfig };

--- a/src/core/services/rateLimiter/index.ts
+++ b/src/core/services/rateLimiter/index.ts
@@ -5,7 +5,10 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Token bucket rate limiter with optimal time/space efficiency
+ * Token bucket rate limiter with queue-based concurrency control
+ *
+ * Uses a promise queue to ensure requests are processed sequentially,
+ * preventing race conditions when multiple requests try to acquire tokens simultaneously.
  *
  * Optimizations:
  * - Uses performance.now() for monotonic clock
@@ -14,7 +17,7 @@ function sleep(ms: number): Promise<void> {
  * - Early returns when bucket is full
  * - Skips all logic in unlimited mode
  *
- * Complexity: O(1) time, O(1) space
+ * Complexity: O(1) time per request, O(n) space for queue (where n = concurrent requests)
  */
 export class RateLimiter {
   private tokens: number;
@@ -22,36 +25,58 @@ export class RateLimiter {
   private readonly rps: number | undefined;
   private readonly bucketSize: number;
   private readonly msPerToken: number | undefined;
+  private queue: Promise<void>;
 
   constructor(config?: RateLimiterConfig) {
     this.rps = config?.requestsPerSecond;
-    this.bucketSize = this.rps || 0;
+    // Bucket size = 1 for strict rate limiting (no bursts)
+    // Note: Setting bucketSize = this.rps would allow bursts (e.g., 5 immediate requests for RPS=5)
+    // which violates rate limiting in security testing contexts
+    this.bucketSize = this.rps ? 1 : 0;
     this.tokens = this.bucketSize;
     this.lastRefillTime = performance.now();
     // Precompute msPerToken once in constructor
     this.msPerToken = this.rps ? 1000 / this.rps : undefined;
+    // Initialize promise queue for sequential processing
+    this.queue = Promise.resolve();
   }
 
   /**
    * Acquire a slot for making a request
    * Blocks until a token is available
+   * Uses a queue to prevent race conditions from concurrent calls
    */
   async acquireSlot(): Promise<void> {
     // Early exit for unlimited mode - skip all token logic
     if (!this.rps || !this.msPerToken) return;
 
-    // Cache now for this call to avoid multiple time calls
-    const now = performance.now();
-    this.refill(now);
+    // Queue this request to ensure sequential processing
+    const previousPromise = this.queue;
+    let resolveCurrentRequest: () => void;
+    this.queue = new Promise<void>((resolve) => {
+      resolveCurrentRequest = resolve;
+    });
 
-    if (this.tokens < 1) {
-      const waitTime = (1 - this.tokens) * this.msPerToken;
-      await sleep(waitTime);
-      const nowAfterSleep = performance.now();
-      this.refill(nowAfterSleep);
+    // Wait for previous request to complete
+    await previousPromise;
+
+    try {
+      // Cache now for this call to avoid multiple time calls
+      const now = performance.now();
+      this.refill(now);
+
+      if (this.tokens < 1) {
+        const waitTime = (1 - this.tokens) * this.msPerToken;
+        await sleep(waitTime);
+        const nowAfterSleep = performance.now();
+        this.refill(nowAfterSleep);
+      }
+
+      this.tokens -= 1;
+    } finally {
+      // Signal next request can proceed
+      resolveCurrentRequest!();
     }
-
-    this.tokens -= 1;
   }
 
   private refill(now: number): void {

--- a/src/core/services/rateLimiter/index.ts
+++ b/src/core/services/rateLimiter/index.ts
@@ -50,9 +50,6 @@ export class RateLimiter {
     // Early exit for unlimited mode - skip all token logic
     if (!this.rps || !this.msPerToken) return;
 
-    const requestStartTime = performance.now();
-    console.log(`[RATE_LIMIT_ACQUIRE] Request queued at ${Date.now()} (perf: ${requestStartTime.toFixed(2)}ms)`);
-
     // Queue this request to ensure sequential processing
     const previousPromise = this.queue;
     let resolveCurrentRequest: () => void;
@@ -62,8 +59,6 @@ export class RateLimiter {
 
     // Wait for previous request to complete
     await previousPromise;
-    const queueWaitTime = performance.now() - requestStartTime;
-    console.log(`[RATE_LIMIT_ACQUIRE] Queue wait: ${queueWaitTime.toFixed(2)}ms`);
 
     try {
       // Cache now for this call to avoid multiple time calls
@@ -72,15 +67,12 @@ export class RateLimiter {
 
       if (this.tokens < 1) {
         const waitTime = (1 - this.tokens) * this.msPerToken;
-        console.log(`[RATE_LIMIT_ACQUIRE] Waiting ${waitTime.toFixed(2)}ms for token (tokens: ${this.tokens.toFixed(3)})`);
         await sleep(waitTime);
         const nowAfterSleep = performance.now();
         this.refill(nowAfterSleep);
       }
 
       this.tokens -= 1;
-      const totalWaitTime = performance.now() - requestStartTime;
-      console.log(`[RATE_LIMIT_RELEASE] Request approved at ${Date.now()} (total wait: ${totalWaitTime.toFixed(2)}ms, tokens remaining: ${this.tokens.toFixed(3)})`);
     } finally {
       // Signal next request can proceed
       resolveCurrentRequest!();

--- a/src/core/services/rateLimiter/index.ts
+++ b/src/core/services/rateLimiter/index.ts
@@ -50,6 +50,9 @@ export class RateLimiter {
     // Early exit for unlimited mode - skip all token logic
     if (!this.rps || !this.msPerToken) return;
 
+    const requestStartTime = performance.now();
+    console.log(`[RATE_LIMIT_ACQUIRE] Request queued at ${Date.now()} (perf: ${requestStartTime.toFixed(2)}ms)`);
+
     // Queue this request to ensure sequential processing
     const previousPromise = this.queue;
     let resolveCurrentRequest: () => void;
@@ -59,6 +62,8 @@ export class RateLimiter {
 
     // Wait for previous request to complete
     await previousPromise;
+    const queueWaitTime = performance.now() - requestStartTime;
+    console.log(`[RATE_LIMIT_ACQUIRE] Queue wait: ${queueWaitTime.toFixed(2)}ms`);
 
     try {
       // Cache now for this call to avoid multiple time calls
@@ -67,12 +72,15 @@ export class RateLimiter {
 
       if (this.tokens < 1) {
         const waitTime = (1 - this.tokens) * this.msPerToken;
+        console.log(`[RATE_LIMIT_ACQUIRE] Waiting ${waitTime.toFixed(2)}ms for token (tokens: ${this.tokens.toFixed(3)})`);
         await sleep(waitTime);
         const nowAfterSleep = performance.now();
         this.refill(nowAfterSleep);
       }
 
       this.tokens -= 1;
+      const totalWaitTime = performance.now() - requestStartTime;
+      console.log(`[RATE_LIMIT_RELEASE] Request approved at ${Date.now()} (total wait: ${totalWaitTime.toFixed(2)}ms, tokens remaining: ${this.tokens.toFixed(3)})`);
     } finally {
       // Signal next request can proceed
       resolveCurrentRequest!();

--- a/src/core/services/rateLimiter/index.ts
+++ b/src/core/services/rateLimiter/index.ts
@@ -97,4 +97,4 @@ export class RateLimiter {
   }
 }
 
-export { RateLimiterConfig };
+export type { RateLimiterConfig };

--- a/src/core/services/rateLimiter/types.ts
+++ b/src/core/services/rateLimiter/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Configuration for rate limiting offensive requests
+ */
+export interface RateLimiterConfig {
+  /**
+   * Maximum requests per second
+   * @default undefined (unlimited)
+   */
+  requestsPerSecond?: number;
+}

--- a/src/tui/components/commands/pentest-agent-display.tsx
+++ b/src/tui/components/commands/pentest-agent-display.tsx
@@ -24,6 +24,7 @@ export default function PentestAgentDisplay() {
   const [sessionPath, setSessionPath] = useState<string>("");
   const [abortController, setAbortController] =
     useState<AbortController | null>(null);
+  const [rps, setRps] = useState("");
 
   // Header configuration state
   const [headerMode, setHeaderMode] = useState<'none' | 'default' | 'custom'>('default');
@@ -46,8 +47,8 @@ export default function PentestAgentDisplay() {
   } = useAgent();
 
   const inputs = headerMode === 'custom' && headerEditMode === 'input'
-    ? ["target", "objective", "headerMode", "headerInputName", "headerInputValue"]
-    : ["target", "objective", "headerMode"];
+    ? ["target", "objective", "rps", "headerMode", "headerInputName", "headerInputValue"]
+    : ["target", "objective", "rps", "headerMode"];
 
   const headerEntries = Object.entries(customHeaders);
 
@@ -78,7 +79,7 @@ export default function PentestAgentDisplay() {
     }
 
     // Arrow Up/Down for radio buttons when focused on headerMode
-    if (focusedIndex === 2 && key.name === 'up') {
+    if (focusedIndex === 3 && key.name === 'up') {
       if (headerMode === 'custom' && headerEditMode === 'list') {
         // Navigate header list
         if (headerEntries.length > 0) {
@@ -94,7 +95,7 @@ export default function PentestAgentDisplay() {
       return;
     }
 
-    if (focusedIndex === 2 && key.name === 'down') {
+    if (focusedIndex === 3 && key.name === 'down') {
       if (headerMode === 'custom' && headerEditMode === 'list') {
         // Navigate header list
         if (headerEntries.length > 0) {
@@ -111,7 +112,7 @@ export default function PentestAgentDisplay() {
     }
 
     // Hotkeys for custom mode
-    if (headerMode === 'custom' && focusedIndex === 2) {
+    if (headerMode === 'custom' && focusedIndex === 3) {
       // A = Add header
       if (key.name === 'a' && headerEditMode === 'list') {
         setHeaderEditMode('input');
@@ -211,13 +212,19 @@ export default function PentestAgentDisplay() {
     }
 
     // Enter - Begin execution (when all fields filled and not in header editing mode)
-    if (key.name === "return" && focusedIndex < 3) {
+    if (key.name === "return" && focusedIndex < 4) {
       if (target && objective) {
+        const parsedRps = rps ? parseInt(rps, 10) : undefined;
         const sessionConfig = {
           offensiveHeaders: {
             mode: headerMode,
             headers: headerMode === 'custom' ? customHeaders : undefined,
           },
+          ...(parsedRps && !isNaN(parsedRps) && parsedRps > 0 && {
+            rateLimiter: {
+              requestsPerSecond: parsedRps,
+            },
+          }),
         };
         beginExecution(sessionConfig);
       }
@@ -449,6 +456,14 @@ export default function PentestAgentDisplay() {
             onInput={setObjective}
             focused={focusedIndex === 1}
           />
+          <Input
+            label="Rate Limit (RPS)"
+            description="Max requests/sec (leave empty for unlimited)"
+            placeholder="15 (recommended)"
+            value={rps}
+            onInput={setRps}
+            focused={focusedIndex === 2}
+          />
 
           {/* Offensive Headers Configuration */}
           <box
@@ -456,7 +471,7 @@ export default function PentestAgentDisplay() {
             width="100%"
             borderStyle="heavy"
             backgroundColor="black"
-            borderColor={focusedIndex === 2 ? "green" : "gray"}
+            borderColor={focusedIndex === 3 ? "green" : "gray"}
             flexDirection="column"
             padding={1}
           >

--- a/src/tui/components/commands/thorough-pentest-agent-display.tsx
+++ b/src/tui/components/commands/thorough-pentest-agent-display.tsx
@@ -8,6 +8,7 @@ import useThoroughPentestAgent from "../hooks/thoroughPentestAgent";
 export default function ThoroughPentestAgentDisplay() {
   const [focusedIndex, setFocusedIndex] = useState(0);
   const { closeThoroughPentest } = useCommand();
+  const [rps, setRps] = useState("");
 
   // Header configuration state
   const [headerMode, setHeaderMode] = useState<'none' | 'default' | 'custom'>('default');
@@ -36,8 +37,8 @@ export default function ThoroughPentestAgentDisplay() {
   } = useThoroughPentestAgent();
 
   const inputs = headerMode === 'custom' && headerEditMode === 'input'
-    ? ["target", "headerMode", "headerInputName", "headerInputValue"]
-    : ["target", "headerMode"];
+    ? ["target", "rps", "headerMode", "headerInputName", "headerInputValue"]
+    : ["target", "rps", "headerMode"];
 
   const headerEntries = Object.entries(customHeaders);
 
@@ -68,7 +69,7 @@ export default function ThoroughPentestAgentDisplay() {
     }
 
     // Arrow Up/Down for radio buttons when focused on headerMode
-    if (focusedIndex === 1 && key.name === 'up') {
+    if (focusedIndex === 2 && key.name === 'up') {
       if (headerMode === 'custom' && headerEditMode === 'list') {
         // Navigate header list
         if (headerEntries.length > 0) {
@@ -84,7 +85,7 @@ export default function ThoroughPentestAgentDisplay() {
       return;
     }
 
-    if (focusedIndex === 1 && key.name === 'down') {
+    if (focusedIndex === 2 && key.name === 'down') {
       if (headerMode === 'custom' && headerEditMode === 'list') {
         // Navigate header list
         if (headerEntries.length > 0) {
@@ -101,7 +102,7 @@ export default function ThoroughPentestAgentDisplay() {
     }
 
     // Hotkeys for custom mode
-    if (headerMode === 'custom' && focusedIndex === 1) {
+    if (headerMode === 'custom' && focusedIndex === 2) {
       // A = Add header
       if (key.name === 'a' && headerEditMode === 'list') {
         setHeaderEditMode('input');
@@ -203,13 +204,19 @@ export default function ThoroughPentestAgentDisplay() {
     }
 
     // Enter - Begin execution (when all fields filled and not in header editing mode)
-    if (key.name === "return" && focusedIndex < 2) {
+    if (key.name === "return" && focusedIndex < 3) {
       if (target) {
+        const parsedRps = rps ? parseInt(rps, 10) : undefined;
         const sessionConfig = {
           offensiveHeaders: {
             mode: headerMode,
             headers: headerMode === 'custom' ? customHeaders : undefined,
           },
+          ...(parsedRps && !isNaN(parsedRps) && parsedRps > 0 && {
+            rateLimiter: {
+              requestsPerSecond: parsedRps,
+            },
+          }),
         };
         beginExecution(sessionConfig);
       }
@@ -292,6 +299,14 @@ export default function ThoroughPentestAgentDisplay() {
             onInput={setTarget}
             focused={focusedIndex === 0}
           />
+          <Input
+            label="Rate Limit (RPS)"
+            description="Max requests/sec (leave empty for unlimited)"
+            placeholder="15 (recommended)"
+            value={rps}
+            onInput={setRps}
+            focused={focusedIndex === 1}
+          />
 
           {/* Offensive Headers Configuration */}
           <box
@@ -299,7 +314,7 @@ export default function ThoroughPentestAgentDisplay() {
             width="100%"
             borderStyle="heavy"
             backgroundColor="black"
-            borderColor={focusedIndex === 1 ? "green" : "gray"}
+            borderColor={focusedIndex === 2 ? "green" : "gray"}
             flexDirection="column"
             padding={1}
           >


### PR DESCRIPTION
## Overview (Issue #40)

Adds configurable rate limiting for requests made to client infrastructure during penetration testing. Users can now set a maximum requests-per-second (RPS) limit at session start to prevent overwhelming target systems. 

## Features

- **Configurable RPS**: Set via CLI (`--rps` flag) or TUI (interactive input field)
- **Default unlimited**: Backward compatible—no rate limiting unless explicitly configured
- **Session-level enforcement**: Single rate limiter shared across all agents (including parallel pentest agents)
- **Strict limiting**: Token bucket with size=1 prevents bursts while maintaining steady request rate
- **Applies to offensive requests only**: Only limits `http_request` and `execute_command` tools—AI API calls are unaffected

## Implementation

- Token bucket algorithm with queue-based concurrency control
- O(1) time complexity per request
- Uses `performance.now()` for monotonic timing
- Singleton pattern ensures multiple agents share the same rate limiter
- Eager initialization in `createSession()` prevents race conditions

# Smoke Test Results: Coffee Shop

## Summary

- **Total Requests**: 164
- **Elapsed Time**: 523.79 seconds (~8.7 minutes)
- **Average RPS**: 0.31 requests/second

## Request Distribution

The test shows two distinct phases:

**Phase 1 (Seconds 91-303)**: Initial requests spread across ~200 seconds with very light traffic, averaging roughly 1 request per second with occasional bursts of 2 requests.

**Phase 2 (Seconds 423-519)**: Sustained load period spanning ~100 seconds with significantly higher request density. Notable peaks include:
- Second 424: 5 requests
- Second 425: 3 requests
- Second 454: 3 requests
- Second 460: 3 requests
- Second 466: 3 requests
- Second 492: 5 requests (highest spike)
- Second 500: 3 requests
- Second 501: 3 requests
- Second 517: 4 requests

The gap between Phase 1 and Phase 2 (seconds 303-423) suggests agent thinking. 

## Analysis

Smoke test conducted against the coffee shop with a 5 RPS load. The rate limiter successfully caps requests during load spikes, maintaining configured limits without degradation.