### PR TITLE
Add Mistral Large 3 2512 to OpenRouter models

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensar/apex",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
   "main": "build/index.js",

--- a/src/core/agent/benchmark/remote/daytona-wrapper.ts
+++ b/src/core/agent/benchmark/remote/daytona-wrapper.ts
@@ -370,7 +370,7 @@ async function installApex(sandbox: any, branch?: string): Promise<void> {
   try {
     // Install using bun (ensures bun PATH is working)
     const installResult = await sandbox.process.executeCommand(
-      'export BUN_INSTALL="$HOME/.bun" && export PATH="$BUN_INSTALL/bin:$PATH" && bun install -g @pensar/apex'
+      'export BUN_INSTALL="$HOME/.bun" && export PATH="$BUN_INSTALL/bin:$PATH" && bun install -g @pensar/apex@canary'
     );
 
     if (installResult.exitCode !== 0) {

--- a/src/core/ai/models/openrouter.ts
+++ b/src/core/ai/models/openrouter.ts
@@ -92,6 +92,12 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
     contextLength: 64000,
   },
   {
+    id: "mistralai/mistral-large-2512",
+    name: "Mistral Large 3 2512",
+    provider: "openrouter",
+    contextLength: 262144,
+  },
+  {
     id: "moonshotai/kimi-k2-thinking",
     name: "Kimi K2 Thinking",
     provider: "openrouter",


### PR DESCRIPTION
## Summary
- Add `mistralai/mistral-large-2512` to OpenRouter models
- 262K context length
- Mistral's most capable model (41B active / 675B total params)
