### PR TITLE
Fixed Docker Build

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -19,10 +19,14 @@ RUN apt-get update && apt-get dist-upgrade -y && \
       gobuster sqlmap nikto hydra john hashcat \
       foremost exiftool \
       wireshark-common \
-      nodejs npm \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @pensar/apex
+# Install bun system-wide (required for @pensar/apex)
+ENV BUN_INSTALL="/usr/local"
+RUN curl -fsSL https://bun.sh/install | bash
+
+# Install @pensar/apex globally
+RUN bun install -g @pensar/apex
 
 # Create non-root user for safety
 RUN groupadd -g ${GID} ${USER} || true \

--- a/container/README.md
+++ b/container/README.md
@@ -10,19 +10,15 @@ Kali-based container to run the Apex agent with common pentest tools preinstalle
 2. Build and start the container:
    ```bash
    cd container
-   docker compose up --build -d
+   docker compose build --no-cache
+   docker compose up -d
    ```
 3. Exec into the container shell:
    ```bash
    docker compose exec kali-apex bash
    ```
-4. Inside the container, run the agent from the mounted repo:
+4. Inside the container, run the agent:
    ```bash
-   cd ~/app
-   bun install
-   bun run build
-   node build/index.js
-   # or if installed globally inside container
    pensar
    ```
 
@@ -30,3 +26,4 @@ Notes:
 
 - Use `network_mode: host` on Linux if you need full network reachability for scans.
 - The image includes nmap and other common tooling for convenience.
+- The container uses bun as the JavaScript runtime (required by @pensar/apex).

--- a/container/docker-compose.yml
+++ b/container/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   kali-apex:
     build: .


### PR DESCRIPTION
# Summary

- Fixed Docker build: `@pensar/apex` requires bun runtime but only nodejs/npm was installed
- Installed bun system-wide (`/usr/local/bin`) so it's accessible to the non-root pentest user
- Replaced `npm install -g` with `bun install -g` for installing the package
- Removed deprecated `version` attribute from `docker-compose.yml`
- Updated README with simplified instructions

# Changes

**container/Dockerfile:**
- Removed `nodejs` `npm` from apt packages
- Added bun installation with `BUN_INSTALL="/usr/local"` for system-wide access
- Changed to `bun install -g @pensar/apex`

**container/docker-compose.yml:**
- Removed deprecated `version: "3.8"` attribute

**container/README.md:**
- Simplified quick start (just run `pensar` - no manual build needed)

# Root Cause

The `bin/pensar.js` shebang is `#!/usr/bin/env bun`, so the package requires bun to run. The previous Dockerfile only installed Node.js/npm.