### PR TITLE
OpenAI Key Not Being Utilized + Model Selection in Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensar/apex",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
   "main": "build/index.js",

--- a/src/core/ai/models.ts
+++ b/src/core/ai/models.ts
@@ -95,20 +95,14 @@ export const AVAILABLE_MODELS: ModelInfo[] = [
 
   // OpenAI Models
   {
-    id: "gpt-4.5-turbo",
-    name: "GPT-4.5 Turbo",
+    id: "gpt-4o-mini",
+    name: "GPT-4o Mini",
     provider: "openai",
     contextLength: 128000,
   },
   {
     id: "gpt-4o",
     name: "GPT-4o",
-    provider: "openai",
-    contextLength: 128000,
-  },
-  {
-    id: "gpt-4o-mini",
-    name: "GPT-4o Mini",
     provider: "openai",
     contextLength: 128000,
   },

--- a/src/tui/agentProvider.tsx
+++ b/src/tui/agentProvider.tsx
@@ -1,6 +1,8 @@
-import { createContext, useContext, useState, useMemo, useCallback, type ReactNode } from "react";
+import { createContext, useContext, useState, useMemo, useCallback, useEffect, type ReactNode } from "react";
 import { type ModelInfo } from "../core/ai";
 import { AVAILABLE_MODELS } from "../core/ai/models";
+import { get as getConfig } from "../core/config/config";
+import { getAvailableModels } from "../core/providers/utils";
 
 interface TokenUsage {
   inputTokens: number;
@@ -45,6 +47,16 @@ export function AgentProvider({ children }: AgentProviderProps) {
   const [hasExecuted, setHasExecuted] = useState<boolean>(false);
   const [thinking, setThinking] = useState<boolean>(false);
   const [isExecuting, setIsExecuting] = useState<boolean>(false);
+
+  // Auto-select first model from a configured provider
+  useEffect(() => {
+    getConfig().then((config) => {
+      const available = getAvailableModels(config);
+      if (available.length > 0) {
+        setModel(available[0]!);
+      }
+    }).catch(() => {});
+  }, []);
 
   const addTokenUsage = useCallback((input: number, output: number) => {
     setHasExecuted(true);


### PR DESCRIPTION
OpenAI key, even when set wasn't being utilized: 
<img width="1061" height="389" alt="Screenshot 2025-12-23 at 1 43 46 PM" src="https://github.com/user-attachments/assets/ea6e8d90-fbbb-4d3c-a83e-adc574bb322f" />

Resolved the above bug then added section to configuration wizard to allow user to set the model (with defaults being our current default of Haiku (and if just OpenAI set then o4-mini)). 

<img width="835" height="494" alt="Screenshot 2025-12-23 at 1 39 07 PM" src="https://github.com/user-attachments/assets/d5d33510-8440-4eaa-9c09-213426f9440c" />
<img width="838" height="767" alt="Screenshot 2025-12-23 at 1 39 18 PM" src="https://github.com/user-attachments/assets/3d5c5ffb-9909-4739-b33e-53a917b10cdc" />
<img width="816" height="612" alt="Screenshot 2025-12-23 at 1 38 35 PM" src="https://github.com/user-attachments/assets/fffe229d-67b1-48dc-b598-ef55ed6088a5" />
<img width="847" height="570" alt="Screenshot 2025-12-23 at 1 39 28 PM" src="https://github.com/user-attachments/assets/086fff43-d605-4ce0-bc65-9e3b233c1e89" />

Drop down by provider with fuzzy searching for usability. 