### PR TITLE
Resolved Pressing Esc To Close Shortcut Menu Ending Pentest

### DIFF
--- a/src/tui/components/dialog.tsx
+++ b/src/tui/components/dialog.tsx
@@ -54,6 +54,8 @@ interface DialogContextValue {
   stack: DialogStackItem[];
   size: "medium" | "large";
   setSize: (size: "medium" | "large") => void;
+  externalDialogOpen: boolean;
+  setExternalDialogOpen: (open: boolean) => void;
 }
 
 const DialogContext = createContext<DialogContextValue | null>(null);
@@ -61,6 +63,7 @@ const DialogContext = createContext<DialogContextValue | null>(null);
 export function DialogProvider({ children }: { children: ReactNode }) {
   const [stack, setStack] = useState<DialogStackItem[]>([]);
   const [size, setSize] = useState<"medium" | "large">("medium");
+  const [externalDialogOpen, setExternalDialogOpen] = useState(false);
   const renderer = useRenderer();
   const focusRef = useRef<Renderable | null>(null);
 
@@ -120,6 +123,8 @@ export function DialogProvider({ children }: { children: ReactNode }) {
     stack,
     size,
     setSize,
+    externalDialogOpen,
+    setExternalDialogOpen,
   };
 
   return (

--- a/src/tui/components/driver-dashboard/index.tsx
+++ b/src/tui/components/driver-dashboard/index.tsx
@@ -23,6 +23,7 @@ import AgentDisplay from "../agent-display";
 import { SpinnerDots } from "../sprites";
 import { useRoute } from "../../context/route";
 import { useAgent } from "../../agentProvider";
+import { useDialog } from "../dialog";
 import EndpointSidebar from "./endpoint-sidebar";
 import AgentChatView from "./agent-chat-view";
 import MentionAutocomplete from "./mention-autocomplete";
@@ -53,6 +54,7 @@ interface DriverDashboardProps {
 export default function DriverDashboard({ session }: DriverDashboardProps) {
   const route = useRoute();
   const { model } = useAgent();
+  const { stack, externalDialogOpen } = useDialog();
 
   // State
   const [currentView, setCurrentView] = useState<'overview' | 'agent-chat' | 'recon-view'>('overview');
@@ -345,6 +347,9 @@ export default function DriverDashboard({ session }: DriverDashboardProps) {
 
   // Keyboard navigation
   useKeyboard((key) => {
+    // Skip all keyboard handling when any dialog is open
+    if (stack.length > 0 || externalDialogOpen) return;
+
     // Handle agent chat view separately
     if (currentView === 'agent-chat') {
       // Shift+/ to return to dashboard

--- a/src/tui/components/swarm-dashboard/index.tsx
+++ b/src/tui/components/swarm-dashboard/index.tsx
@@ -3,6 +3,7 @@ import { useKeyboard } from "@opentui/react";
 import { RGBA } from "@opentui/core";
 import AgentDisplay, { type DisplayMessage } from "../agent-display";
 import { SpinnerDots } from "../sprites";
+import { useDialog } from "../dialog";
 
 // Color palette (matching home view)
 export const greenBullet = RGBA.fromInts(76, 175, 80, 255);
@@ -50,6 +51,7 @@ export default function SwarmDashboard({
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [focusedIndex, setFocusedIndex] = useState(0);
   const [showDiscoveryLogs, setShowDiscoveryLogs] = useState(false);
+  const { stack, externalDialogOpen } = useDialog();
 
   // Separate discovery and pentest agents
   const discoveryAgent = useMemo(
@@ -96,6 +98,9 @@ export default function SwarmDashboard({
 
   // Keyboard navigation
   useKeyboard((key) => {
+    // Skip all keyboard handling when any dialog is open
+    if (stack.length > 0 || externalDialogOpen) return;
+
     if (currentView === "overview") {
       // D to toggle discovery logs
       if (key.name === "d" || key.name === "D") {

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -32,7 +32,7 @@ import { AsciiTitle } from "./components/ascii-title";
 import { SessionProvider } from "./context/session";
 import { InputProvider, useInput } from "./context/input";
 import { FocusProvider, useFocus } from "./context/focus";
-import { DialogProvider } from "./components/dialog";
+import { DialogProvider, useDialog } from "./components/dialog";
 import { Session } from "../core/session";
 import ShortcutsDialog from "./components/commands/shortcuts-dialog";
 
@@ -123,6 +123,7 @@ function AppContent({
   const renderer = useRenderer();
   const { isInputEmpty } = useInput();
   const { refocusCommandInput } = useFocus();
+  const { setExternalDialogOpen } = useDialog();
   const [showCreateSessionDialog, setShowCreateSessionDialog] = useState(false);
   const [showSessionsDialog, setShowSessionsDialog] = useState(false);
   const [showShortcutsDialog, setShowShortcutsDialog] = useState(false);
@@ -211,6 +212,7 @@ function AppContent({
 
     // ? - Show keyboard shortcuts (when input is empty)
     if (key.sequence === "?" && isInputEmpty) {
+      setExternalDialogOpen(true);
       setShowShortcutsDialog(true);
       return;
     }
@@ -259,6 +261,7 @@ function AppContent({
 
   const handleCloseShortcutsDialog = () => {
     setShowShortcutsDialog(false);
+    setExternalDialogOpen(false);
     setInputKey((prev) => prev + 1);
     refocusCommandInput();
   };


### PR DESCRIPTION
## Problem

When pressing `?` to view keyboard shortcuts while in a `/web` pentest session (auto or manual mode), pressing Escape to close the dialog would also exit the entire pentest back to the home screen.

## Root Cause

In this TUI framework, `key.preventDefault()` does not stop other `useKeyboard` handlers from firing—each handler receives the keypress independently. The ShortcutsDialog used local state (`showShortcutsDialog`) but child components (SwarmDashboard/DriverDashboard) had no way to know a dialog was open, so they also processed the escape key.

## Solution

Extended the existing DialogContext to track external dialogs:

1. Added `externalDialogOpen` boolean to DialogContext
2. Set it when ShortcutsDialog opens/closes
3. SwarmDashboard and DriverDashboard now check this flag before processing keyboard events

This approach:

- **Minimal**: Extends existing infrastructure rather than creating new patterns
- **Correct**: React's batched updates guarantee the flag check works regardless of handler execution order
- **Efficient**: O(1) boolean check in keyboard handlers

## Files Changed

- `src/tui/components/dialog.tsx` - Added `externalDialogOpen` state to context
- `src/tui/index.tsx` - Track dialog state when opening/closing ShortcutsDialog
- `src/tui/components/swarm-dashboard/index.tsx` - Skip keyboard handling when dialog open
- `src/tui/components/driver-dashboard/index.tsx` - Skip keyboard handling when dialog open
- `src/tui/components/commands/shortcuts-dialog.tsx` - Removed unnecessary `preventDefault()`

## Testing

1. Start `/web` pentest (auto or manual mode)
2. Press `?` to open shortcuts dialog
3. Press Escape to close dialog → pentest view remains active ✓
4. Press Escape again → exits to home as expected ✓