### PR TITLE
Stop Agent Execution, HTTP Requests, and Commands When Exiting Pentest Session

### DIFF
--- a/src/core/agent/attackSurfaceAgent/agent.ts
+++ b/src/core/agent/attackSurfaceAgent/agent.ts
@@ -95,7 +95,8 @@ export async function runAgent(opts: RunAgentProps): Promise<{
     session,
     model,
     toolOverride,
-    onToolTokenUsage
+    onToolTokenUsage,
+    abortSignal
   );
 
   // Attack Surface specific tool: document_asset

--- a/src/core/agent/metaTestingAgent/agent.ts
+++ b/src/core/agent/metaTestingAgent/agent.ts
@@ -158,7 +158,9 @@ export async function runMetaTestingAgent(
   const baseTools = createPentestTools(
     session,
     model,
-    toolOverride
+    toolOverride,
+    undefined,  // onTokenUsage - not needed here
+    abortSignal
   );
 
   // Create our specialized tools

--- a/src/core/agent/metaTestingAgent/metaVulnerabilityTestAgent.ts
+++ b/src/core/agent/metaTestingAgent/metaVulnerabilityTestAgent.ts
@@ -246,7 +246,9 @@ export async function runMetaVulnerabilityTestAgent(
   const { execute_command, http_request, fuzz_endpoint } = createPentestTools(
     sessionForTools,
     undefined,
-    toolOverride
+    toolOverride,
+    undefined,  // onTokenUsage - not needed here
+    abortSignal
   );
 
   // Create cognitive loop tools

--- a/src/core/agent/tools.ts
+++ b/src/core/agent/tools.ts
@@ -3120,7 +3120,8 @@ export function createPentestTools(
     ) => Promise<ExecuteCommandResult>;
     http_request?: (opts: HttpRequestOpts) => Promise<HttpRequestResult>;
   },
-  onTokenUsage?: (inputTokens: number, outputTokens: number) => void
+  onTokenUsage?: (inputTokens: number, outputTokens: number) => void,
+  abortSignal?: AbortSignal
 ) {
   // Get offensive headers from session config
   const offensiveHeaders = Session.getOffensiveHeaders(session);
@@ -3161,15 +3162,25 @@ export function createPentestTools(
       method,
       headers,
     }) => {
+      // Check if already aborted before starting
+      if (abortSignal?.aborted) {
+        return { error: "Fuzzing aborted by user", results: [] };
+      }
+
       const length = Math.floor(endNumber - startNumber) + 1;
       const ids = Array.from({ length }, (_, i) => startNumber + i);
 
       const fuzz = async (value: number) => {
+        // Check abort before each request
+        if (abortSignal?.aborted) {
+          throw new Error("Aborted");
+        }
         const result = await fetch(
           url.replace(`{${parameter}}`, value.toLocaleString()),
           {
             method: method,
             headers: { ...offensiveHeaders, ...headers },
+            signal: abortSignal,
           }
         );
         const body = await result.text();
@@ -3181,6 +3192,11 @@ export function createPentestTools(
       const input = ids.map((id) => limit(() => fuzz(id)));
 
       const results = await Promise.allSettled(input);
+
+      // Check if aborted after all requests
+      if (abortSignal?.aborted) {
+        return { error: "Fuzzing aborted by user", results: [] };
+      }
 
       // TODO: probably a better way to do this
       return results
@@ -3237,9 +3253,31 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
     inputSchema: ExecuteCommandInput,
     execute: async ({ command, timeout = 30000, toolCallDescription }) => {
       try {
+        // Check if already aborted before starting
+        if (abortSignal?.aborted) {
+          return {
+            success: false,
+            error: "Command aborted by user",
+            stdout: "",
+            stderr: "",
+            command,
+          };
+        }
+
         // Apply rate limiting before command execution
         if (rateLimiter) {
           await rateLimiter.acquireSlot();
+        }
+
+        // Check again after rate limiting wait
+        if (abortSignal?.aborted) {
+          return {
+            success: false,
+            error: "Command aborted by user",
+            stdout: "",
+            stderr: "",
+            command,
+          };
         }
 
         if (toolOverride?.execute_command) {
@@ -3259,6 +3297,18 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
           timeout,
           maxBuffer: 10 * 1024 * 1024, // 10MB buffer
         });
+
+        // Check if aborted while command was running
+        if (abortSignal?.aborted) {
+          return {
+            success: false,
+            error: "Command completed but session was aborted",
+            stdout: stdout || "",
+            stderr: stderr || "",
+            command: finalCommand,
+          };
+        }
+
         return {
           success: true,
           stdout:
@@ -3315,6 +3365,7 @@ COMMON TESTING PATTERNS:
       timeout,
       toolCallDescription,
     }) => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
       try {
         // Apply rate limiting before HTTP request
         if (rateLimiter) {
@@ -3333,8 +3384,28 @@ COMMON TESTING PATTERNS:
           });
         }
 
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), timeout);
+        // Check if already aborted before starting
+        if (abortSignal?.aborted) {
+          return {
+            success: false,
+            error: "Request aborted by user",
+            url,
+            method,
+            status: 0,
+            statusText: "",
+            headers: {},
+            body: "",
+            redirected: false,
+          };
+        }
+
+        const timeoutController = new AbortController();
+        timeoutId = setTimeout(() => timeoutController.abort(), timeout);
+
+        // Combine parent abort signal with timeout - either can cancel
+        const combinedSignal = abortSignal
+          ? AbortSignal.any([abortSignal, timeoutController.signal])
+          : timeoutController.signal;
 
         const response = await fetch(url, {
           method,
@@ -3344,7 +3415,7 @@ COMMON TESTING PATTERNS:
           },
           body: body || undefined,
           redirect: followRedirects ? "follow" : "manual",
-          signal: controller.signal,
+          signal: combinedSignal,
         });
 
         clearTimeout(timeoutId);
@@ -3374,6 +3445,26 @@ COMMON TESTING PATTERNS:
           redirected: response.redirected,
         };
       } catch (error: any) {
+        if (timeoutId) clearTimeout(timeoutId);
+
+        // Distinguish between user abort and timeout
+        if (error.name === 'AbortError') {
+          const errorMsg = abortSignal?.aborted
+            ? "Request aborted by user"
+            : `Request timeout after ${timeout}ms`;
+          return {
+            success: false,
+            error: errorMsg,
+            url,
+            method,
+            status: 0,
+            statusText: "",
+            headers: {},
+            body: "",
+            redirected: false,
+          };
+        }
+
         return {
           success: false,
           error: error.message,

--- a/src/tui/components/session-view/index.tsx
+++ b/src/tui/components/session-view/index.tsx
@@ -120,6 +120,15 @@ export default function SessionView({
     }
   }, [session, hasStarted, loading, isResume]);
 
+  // Cleanup: abort on unmount (safety net)
+  useEffect(() => {
+    return () => {
+      if (abortController) {
+        abortController.abort();
+      }
+    };
+  }, [abortController]);
+
   // Start the pentest
   const startPentest = useCallback(
     async (execSession: Session.SessionInfo) => {
@@ -485,13 +494,11 @@ export default function SessionView({
 
   // Handle back navigation
   const handleBack = useCallback(() => {
+    if (abortController) {
+      abortController.abort();
+    }
     route.navigate({ type: "base", path: "home" });
-    // if (isExecuting && abortController) {
-    //   abortController.abort();
-    // } else {
-    //   route.navigate({ type: "base", path: "home" });
-    // }
-  }, [isExecuting, abortController, route]);
+  }, [abortController, route]);
 
   // Loading state
   if (loading) {


### PR DESCRIPTION
## Summary

- Fix abort signal not being triggered when pressing ESC to exit a pentest
- Stop LLM calls and token consumption immediately on exit
- Propagate abort signal to all pentest tools so HTTP requests and commands stop immediately

## Problem

When pressing ESC to exit a `/web` pentest session:

1. LLM calls continued—token count kept climbing after exit
2. HTTP requests kept hitting the target server
3. Commands continued executing in the background

Root cause: Two issues:

1. `handleBack()` in session-view was not calling `abort()` on the AbortController—so the AI SDK never received the abort signal
2. Tools (`http_request`, `execute_command`, `fuzz_endpoint`) created independent AbortControllers and never received the parent abort signal

## Solution

### 1. Fix abort trigger in session-view (`session-view/index.tsx`)

- Actually call `abortController.abort()` in `handleBack()` when ESC is pressed
- Add cleanup effect to abort on component unmount
- This stops the AI SDK stream, halting LLM calls and token consumption

### 2. Propagate abort signal to tools (`tools.ts`)

- Add `abortSignal?: AbortSignal` parameter to `createPentestTools()`
- `http_request`: Use `AbortSignal.any()` to combine parent abort + timeout signals
- `execute_command`: Check abort signal before/after execution
- `fuzz_endpoint`: Pass abort signal to fetch calls, check before each request

### 3. Pass abort signal from all agents

- `attackSurfaceAgent/agent.ts`
- `metaTestingAgent/agent.ts`
- `metaVulnerabilityTestAgent.ts`

## Test Plan

1. Start `/web` pentest against a target
2. Wait for HTTP requests to begin (visible in target logs or network)
3. Press ESC to exit the pentest
4. Verify token count stops increasing immediately
5. Verify no new LLM calls are made
6. Verify no new HTTP requests hit the target server
7. Verify graceful error messages ("Request aborted by user") in logs