### PR TITLE
Playwright MCP Integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensar/apex",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
   "main": "build/index.js",

--- a/src/core/agent/attackSurfaceAgent/agent.ts
+++ b/src/core/agent/attackSurfaceAgent/agent.ts
@@ -108,7 +108,8 @@ export async function runAgent(opts: RunAgentProps): Promise<{
   const browserTools = createBrowserTools(
     target,
     evidenceDir,
-    undefined, // No logger needed for attack surface
+    "operator", // Attack surface uses operator mode (reconnaissance-focused)
+    undefined,  // No logger needed for attack surface
     abortSignal
   );
 

--- a/src/core/agent/attackSurfaceAgent/agent.ts
+++ b/src/core/agent/attackSurfaceAgent/agent.ts
@@ -19,6 +19,10 @@ import { getScopeDescription } from "../scope";
 import { extractJavascriptEndpoints } from "./jsExtraction";
 import { generateRandomName } from "../../../util/name";
 import { nanoid } from "nanoid";
+import {
+  createBrowserTools,
+  disconnectMcpClient,
+} from "../browserTools/playwrightMcp";
 
 export interface RunAgentProps {
   target: string;
@@ -96,6 +100,15 @@ export async function runAgent(opts: RunAgentProps): Promise<{
     model,
     toolOverride,
     onToolTokenUsage,
+    abortSignal
+  );
+
+  // Create browser tools for JavaScript-heavy page analysis
+  const evidenceDir = join(session.rootPath, "evidence");
+  const browserTools = createBrowserTools(
+    target,
+    evidenceDir,
+    undefined, // No logger needed for attack surface
     abortSignal
   );
 
@@ -847,7 +860,9 @@ You MUST provide the final report using create_attack_surface_report tool.
       validate_discovery_completeness,
       create_attack_surface_report,
       cve_lookup,
-      smart_enumerate
+      smart_enumerate,
+      // Browser automation tools for JavaScript-heavy apps and SPAs
+      ...browserTools,
     },
     stopWhen: stepCountIs(10000),
     toolChoice: "auto", // Let the model decide when to use tools vs respond

--- a/src/core/agent/operatorAgent/index.ts
+++ b/src/core/agent/operatorAgent/index.ts
@@ -653,7 +653,8 @@ Document significant findings using the document_finding tool.`;
     const browserTools = createBrowserTools(
       session.targets[0] || "",
       evidenceDir,
-      undefined, // logger - could be passed in future
+      "operator", // Operator mode for user-driven reconnaissance
+      undefined,  // logger - could be passed in future
       this.abortController?.signal
     );
 


### PR DESCRIPTION
## Add Playwright MCP Integration for Browser-Based Reconnaissance

Adds browser automation tools to the attack surface agent for analyzing JavaScript-heavy applications and SPAs.

### Changes

- **New `browserTools/playwrightMcp.ts`** - MCP client integration with tools for navigation, screenshots, clicking, form filling, JS evaluation, and console capture
- **Updated `agent.ts`** - Integrates browser tools into the attack surface agent's toolset
- **Updated `prompts.ts`** - Documents when and how to use browser tools for SPA analysis

### Why

curl/HTTP requests miss endpoints defined in client-side JavaScript. Browser tools enable extracting routes from `window.__NEXT_DATA__`, React Router, Vue Router, and other SPA frameworks.

### Notes

- Uses singleton MCP client with lazy connection
- Cleans up on abort signal
- Runs headless by default