### PR TITLE
Agent TUI streaming display

### DIFF
--- a/src/core/agent/metaTestingAgent/metaVulnerabilityTestAgent.ts
+++ b/src/core/agent/metaTestingAgent/metaVulnerabilityTestAgent.ts
@@ -253,6 +253,8 @@ export async function runMetaVulnerabilityTestAgent(
     model: AIModel;
     remoteSandboxUrl?: string;
     onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
+    /** Callback for real-time stream chunks (text-delta, tool-call, tool-result) */
+    onStream?: (chunk: any) => void;
     abortSignal?: AbortSignal;
     toolOverride?: {
       execute_command?: (opts: ExecuteCommandOpts) => Promise<ExecuteCommandResult>;
@@ -261,7 +263,7 @@ export async function runMetaVulnerabilityTestAgent(
     onSpawnAgent?: (request: SpawnVulnerabilityTestRequest) => void;
   }
 ): Promise<MetaVulnerabilityTestResult> {
-  const { input, model, remoteSandboxUrl, onStepFinish, abortSignal, toolOverride, onSpawnAgent } = opts;
+  const { input, model, remoteSandboxUrl, onStepFinish, onStream, abortSignal, toolOverride, onSpawnAgent } = opts;
   const {
     target,
     objective,
@@ -482,13 +484,17 @@ Call when:
         silent: true,
       });
 
-      // Consume stream
+      // Consume stream with real-time forwarding
       for await (const chunk of streamResult.fullStream) {
         if (chunk.type === 'error') {
           const error = (chunk as any).error;
           if (isOverloadedError(error)) {
             throw error;
           }
+        }
+        // Forward stream chunks for real-time UI updates
+        if (onStream && (chunk.type === 'text-delta' || chunk.type === 'tool-call' || chunk.type === 'tool-result')) {
+          onStream(chunk);
         }
       }
 

--- a/src/core/agent/operatorAgent/index.ts
+++ b/src/core/agent/operatorAgent/index.ts
@@ -714,11 +714,116 @@ Document significant findings using the document_finding tool.`;
           onStepFinish: (step) => this.handleStepFinish(step),
         });
 
-        // Consume stream
+        // Consume stream with real-time UI updates
         let assistantContent = "";
+        let currentAssistantMessageIndex = -1;
+
         for await (const chunk of streamResult.fullStream) {
           if (chunk.type === "text-delta") {
             assistantContent += chunk.text;
+
+            // Emit real-time updates for streaming text
+            if (currentAssistantMessageIndex === -1) {
+              // Create new assistant message
+              const newMessage: DisplayMessage = {
+                role: "assistant",
+                content: assistantContent,
+                createdAt: new Date(),
+              };
+              currentAssistantMessageIndex = this.messages.length;
+              this.addMessage(newMessage);
+            } else {
+              // Update existing assistant message with accumulated text
+              const existingMsg = this.messages[currentAssistantMessageIndex];
+              if (existingMsg) {
+                this.updateMessage(currentAssistantMessageIndex, {
+                  ...existingMsg,
+                  content: assistantContent,
+                });
+              }
+            }
+          } else if (chunk.type === "tool-call") {
+            // Handle tool calls during streaming
+            const tc = chunk as any;
+            const args = tc.input ? (typeof tc.input === 'string' ? JSON.parse(tc.input) : tc.input) : {};
+            const description = args.toolCallDescription || tc.toolName;
+
+            this.log("tool_call_stream", {
+              toolCallId: tc.toolCallId,
+              toolName: tc.toolName,
+              args,
+            });
+
+            this.addMessage({
+              role: "tool",
+              status: "pending",
+              toolCallId: tc.toolCallId,
+              toolName: tc.toolName,
+              content: description,
+              args,
+              createdAt: new Date(),
+            });
+
+            // Reset assistant message index for next text segment
+            currentAssistantMessageIndex = -1;
+            assistantContent = "";
+          } else if (chunk.type === "tool-result") {
+            // Handle tool results during streaming
+            const tr = chunk as any;
+            const msgIdx = this.toolCallIdToIndex.get(tr.toolCallId) ?? -1;
+
+            if (msgIdx !== -1) {
+              const existingMsg = this.messages[msgIdx];
+
+              this.log("tool_result_stream", {
+                toolCallId: tr.toolCallId,
+                toolName: existingMsg?.toolName,
+                result: tr.result,
+              });
+
+              if (existingMsg) {
+                this.updateMessage(msgIdx, {
+                  ...existingMsg,
+                  status: "completed",
+                  content: `+ ${existingMsg.content}`,
+                  result: tr.result,
+                });
+
+                // Extract findings from tool results
+                this.extractFindings(existingMsg.toolName || "", tr.result);
+
+                // Emit sidebar events for sidebar-updating tools
+                const output = tr.result;
+                if (output && typeof output === "object") {
+                  if (output.endpoints && Array.isArray(output.endpoints)) {
+                    this.emit("operator-event", {
+                      type: "attack-surface-updated",
+                      endpoints: output.endpoints,
+                    });
+                  }
+                  if (output.credential) {
+                    this.emit("operator-event", {
+                      type: "credential-found",
+                      credential: output.credential,
+                    });
+                  }
+                  if (output.finding) {
+                    this.emit("operator-event", {
+                      type: "finding-verified",
+                      finding: output.finding,
+                    });
+                  }
+                  if (output.endpointId && output.status) {
+                    this.emit("operator-event", {
+                      type: "endpoint-status-changed",
+                      endpointId: output.endpointId,
+                      status: output.status,
+                      vulnType: output.vulnType,
+                    });
+                  }
+                }
+              }
+            }
           }
         }
 
@@ -848,10 +953,11 @@ Document significant findings using the document_finding tool.`;
 
   /**
    * Handle step finish callback from AI streaming
+   * Note: Text, tool calls, and tool results are now handled in real-time during
+   * the streaming loop for better UI responsiveness. This callback only handles
+   * user directive interrupts now.
    */
   private handleStepFinish(step: any): void {
-    const { text, toolCalls, toolResults } = step;
-
     // Check for user directives - if user typed something, interrupt to process it sooner
     if (this.userDirectives.length > 0 && this.abortController && !this.abortController.signal.aborted) {
       // Abort current stream to pick up user input on next iteration
@@ -859,109 +965,9 @@ Document significant findings using the document_finding tool.`;
       // Note: The abort will be caught in runAgentLoop, which will continue and pick up the directive
     }
 
-    // Handle text content
-    if (text && text.trim()) {
-      this.log("assistant_text", { text: text.slice(0, 500) }); // Truncate to avoid huge logs
-      const lastMsg = this.messages[this.messages.length - 1];
-      if (lastMsg && lastMsg.role === "assistant") {
-        this.updateMessage(this.messages.length - 1, {
-          ...lastMsg,
-          content: (lastMsg.content || "") + text,
-        });
-      } else {
-        this.addMessage({
-          role: "assistant",
-          content: text,
-          createdAt: new Date(),
-        });
-      }
-    }
-
-    // Handle tool calls
-    if (toolCalls && toolCalls.length > 0) {
-      for (const tc of toolCalls) {
-        const args = (tc as any).input || {};
-        const description = args.toolCallDescription || tc.toolName;
-
-        this.log("tool_call", {
-          toolCallId: tc.toolCallId,
-          toolName: tc.toolName,
-          args,
-        });
-
-        this.addMessage({
-          role: "tool",
-          status: "pending",
-          toolCallId: tc.toolCallId,
-          toolName: tc.toolName,
-          content: description,
-          args,
-          createdAt: new Date(),
-        });
-      }
-    }
-
-    // Handle tool results
-    if (toolResults && toolResults.length > 0) {
-      for (const tr of toolResults) {
-        // O(1) lookup using pre-built index map (was O(n) findIndex)
-        const msgIdx = this.toolCallIdToIndex.get(tr.toolCallId) ?? -1;
-        if (msgIdx !== -1) {
-          const existingMsg = this.messages[msgIdx];
-
-          this.log("tool_result", {
-            toolCallId: tr.toolCallId,
-            toolName: existingMsg.toolName,
-            result: (tr as any).output,
-          });
-
-          this.updateMessage(msgIdx, {
-            ...existingMsg,
-            status: "completed",
-            content: `+ ${existingMsg.content}`,
-            result: (tr as any).output,
-          });
-
-          // Extract findings from significant tool results
-          this.extractFindings(existingMsg.toolName || "", (tr as any).output);
-
-          // Emit sidebar events for sidebar-updating tools
-          const output = (tr as any).output;
-          if (output && typeof output === "object") {
-            // Attack surface updates
-            if (output.endpoints && Array.isArray(output.endpoints)) {
-              this.emit("operator-event", {
-                type: "attack-surface-updated",
-                endpoints: output.endpoints,
-              });
-            }
-            // Credential discoveries
-            if (output.credential) {
-              this.emit("operator-event", {
-                type: "credential-found",
-                credential: output.credential,
-              });
-            }
-            // Verified findings
-            if (output.finding) {
-              this.emit("operator-event", {
-                type: "finding-verified",
-                finding: output.finding,
-              });
-            }
-            // Endpoint status changes
-            if (output.endpointId && output.status) {
-              this.emit("operator-event", {
-                type: "endpoint-status-changed",
-                endpointId: output.endpointId,
-                status: output.status,
-                vulnType: output.vulnType,
-              });
-            }
-          }
-        }
-      }
-    }
+    // Note: Text, toolCalls, and toolResults are now processed in real-time
+    // during the streaming loop (for await...of streamResult.fullStream) to
+    // enable proper token-by-token streaming in the TUI.
   }
 
   /**

--- a/src/core/agent/orchestrator/orchestrator.ts
+++ b/src/core/agent/orchestrator/orchestrator.ts
@@ -380,6 +380,14 @@ export async function runPentestOrchestrator(
               },
             });
           },
+          onStream: (chunk) => {
+            // Forward real-time stream chunks
+            onAgentStream?.({
+              type: chunk.type,
+              agentId,
+              data: chunk,
+            });
+          },
         });
 
         // Notify completion

--- a/src/tui/components/driver-dashboard/index.tsx
+++ b/src/tui/components/driver-dashboard/index.tsx
@@ -125,11 +125,16 @@ export default function DriverDashboard({ session }: DriverDashboardProps) {
   // Start recon agent
   const startRecon = useCallback(async () => {
     setReconStatus('running');
-    setReconMessages([{
+    
+    // Mutable state for streaming - similar to v0.0.39 pattern
+    let currentReconText = "";
+    const reconMsgs: DisplayMessage[] = [{
       role: 'user',
       content: `Starting attack surface discovery for: ${session.targets[0]}`,
       createdAt: new Date(),
-    }]);
+    }];
+    
+    setReconMessages([...reconMsgs]);
 
     try {
       const { streamResult } = await runAttackSurfaceAgent({
@@ -138,79 +143,91 @@ export default function DriverDashboard({ session }: DriverDashboardProps) {
         model: model.id,
         session,
         onStepFinish: async (step) => {
-          const { text, toolCalls, toolResults } = step;
-
-          setReconMessages(prev => {
-            const newMessages = [...prev];
-
-            // Add text content
-            if (text && text.trim()) {
-              const lastMsg = newMessages[newMessages.length - 1];
-              if (lastMsg && lastMsg.role === 'assistant') {
-                newMessages[newMessages.length - 1] = {
-                  ...lastMsg,
-                  content: (lastMsg.content || '') + text,
-                };
-              } else {
-                newMessages.push({
-                  role: 'assistant',
-                  content: text,
-                  createdAt: new Date(),
-                });
-              }
-            }
-
-            // Add tool calls
-            if (toolCalls && toolCalls.length > 0) {
-              for (const tc of toolCalls) {
-                const args = (tc as any).input as Record<string, unknown> | undefined;
-                const toolDescription =
-                  typeof args?.toolCallDescription === 'string'
-                    ? args.toolCallDescription
-                    : tc.toolName;
-                newMessages.push({
-                  role: 'tool',
-                  status: 'pending',
-                  toolCallId: tc.toolCallId,
-                  toolName: tc.toolName,
-                  content: toolDescription,
-                  args: args,
-                  createdAt: new Date(),
-                });
-              }
-            }
-
-            // Update tool results
-            if (toolResults && toolResults.length > 0) {
-              for (const tr of toolResults) {
-                const msgIdx = newMessages.findIndex(
-                  (m) => m.role === 'tool' && (m as any).toolCallId === tr.toolCallId
-                );
-                if (msgIdx !== -1) {
-                  const existingMsg = newMessages[msgIdx] as DisplayMessage & { toolName?: string; toolCallId?: string };
-                  const description =
-                    typeof existingMsg.content === 'string' &&
-                    existingMsg.content !== existingMsg.toolName
-                      ? existingMsg.content
-                      : existingMsg.toolName || 'tool';
-                  newMessages[msgIdx] = {
-                    ...existingMsg,
-                    status: 'completed',
-                    content: `✓ ${description}`,
-                    result: (tr as any).output,
-                  };
-                }
-              }
-            }
-
-            return newMessages;
-          });
+          // Token tracking only - real-time updates handled in stream consumption
         },
       });
 
-      // Consume the stream to let the agent complete
-      for await (const _chunk of streamResult.fullStream) {
-        // Just consume - messages are captured via onStepFinish
+      // Consume the stream with real-time UI updates
+      for await (const chunk of streamResult.fullStream) {
+        if (chunk.type === 'text-delta' && (chunk as any).text) {
+          currentReconText += (chunk as any).text;
+          
+          // Update or create assistant message
+          const lastMsg = reconMsgs[reconMsgs.length - 1];
+          if (lastMsg && lastMsg.role === 'assistant') {
+            // Create new message object (not mutation)
+            reconMsgs[reconMsgs.length - 1] = {
+              ...lastMsg,
+              content: currentReconText,
+            };
+          } else {
+            reconMsgs.push({
+              role: 'assistant',
+              content: currentReconText,
+              createdAt: new Date(),
+            });
+          }
+          
+          // Create new array with new object references for React
+          setReconMessages(reconMsgs.map(m => ({ ...m })));
+        } else if (chunk.type === 'tool-call') {
+          const tc = chunk as any;
+          let args: Record<string, unknown> = {};
+          try {
+            if (typeof tc.input === 'string') {
+              args = JSON.parse(tc.input);
+            } else if (tc.input && typeof tc.input === 'object') {
+              args = tc.input;
+            }
+          } catch {
+            args = {};
+          }
+          
+          const toolDescription =
+            typeof args?.toolCallDescription === 'string'
+              ? args.toolCallDescription
+              : tc.toolName;
+          
+          reconMsgs.push({
+            role: 'tool',
+            status: 'pending',
+            toolCallId: tc.toolCallId,
+            toolName: tc.toolName,
+            content: toolDescription,
+            args: args,
+            createdAt: new Date(),
+          });
+          
+          // Reset text for next segment
+          currentReconText = "";
+          
+          // Create new array with new object references
+          setReconMessages(reconMsgs.map(m => ({ ...m })));
+        } else if (chunk.type === 'tool-result') {
+          const tr = chunk as any;
+          
+          const msgIdx = reconMsgs.findIndex(
+            (m) => m.role === 'tool' && (m as any).toolCallId === tr.toolCallId
+          );
+          if (msgIdx !== -1) {
+            const existingMsg = reconMsgs[msgIdx] as DisplayMessage & { toolName?: string; toolCallId?: string };
+            const description =
+              typeof existingMsg.content === 'string' &&
+              existingMsg.content !== existingMsg.toolName
+                ? existingMsg.content
+                : existingMsg.toolName || 'tool';
+            
+            reconMsgs[msgIdx] = {
+              ...existingMsg,
+              status: 'completed',
+              content: `✓ ${description}`,
+              result: tr.result || (tr as any).output,
+            };
+            
+            // Create new array with new object references
+            setReconMessages(reconMsgs.map(m => ({ ...m })));
+          }
+        }
       }
 
       // Read results from the JSON file created by the agent

--- a/src/tui/components/session-view/index.tsx
+++ b/src/tui/components/session-view/index.tsx
@@ -145,24 +145,22 @@ export default function SessionView({
       const controller = new AbortController();
       setAbortController(controller);
 
-      // Mutable state for streaming - following v0.0.39 pattern
-      // These are mutated directly and then new array references are created for React
+      // Mutable state for streaming text accumulation
       let currentDiscoveryText = "";
       const discoveryMessages: UIMessage[] = [];
-      const allSubagents: Subagent[] = [
+
+      // Initial render - add discovery subagent
+      setSubagents([
         {
           id: "attack-surface-discovery",
           name: "Attack Surface Discovery",
           type: "attack-surface",
           target: execSession.targets[0],
-          messages: discoveryMessages,
+          messages: [],
           status: "pending",
           createdAt: new Date(),
         },
-      ];
-
-      // Initial render
-      setSubagents([...allSubagents]);
+      ]);
 
       try {
         // Run streamlined pentest
@@ -185,7 +183,7 @@ export default function SessionView({
           },
 
           // Real-time streaming - create new objects for every update
-          // This ensures React detects changes even with memo()
+          // Use functional setState to preserve other subagents (pentest agents)
           onDiscoveryStream: (chunk) => {
             if (chunk.type === "text-delta" && (chunk as any).text) {
               currentDiscoveryText += (chunk as any).text;
@@ -208,16 +206,17 @@ export default function SessionView({
                 });
               }
 
-              // Create completely new array and object references for React
+              // Create new message array with new object references
               const newMessages = discoveryMessages.map(m => ({ ...m }));
-              const newSubagent = {
-                ...allSubagents[0]!,
-                messages: newMessages,
-              };
-              setSubagents([newSubagent, ...allSubagents.slice(1)]);
               
-              // Keep reference in sync
-              allSubagents[0] = newSubagent;
+              // Use functional setState to preserve pentest agents
+              setSubagents((prev) => {
+                return prev.map((s) => 
+                  s.id === "attack-surface-discovery"
+                    ? { ...s, messages: newMessages }
+                    : s
+                );
+              });
             } else if (chunk.type === "tool-call") {
               const tc = chunk as any;
               let args: Record<string, unknown> = {};
@@ -250,14 +249,17 @@ export default function SessionView({
               // Reset text for next segment
               currentDiscoveryText = "";
 
-              // Create completely new array and object references
+              // Create new message array with new object references
               const newMessages = discoveryMessages.map(m => ({ ...m }));
-              const newSubagent = {
-                ...allSubagents[0]!,
-                messages: newMessages,
-              };
-              setSubagents([newSubagent, ...allSubagents.slice(1)]);
-              allSubagents[0] = newSubagent;
+              
+              // Use functional setState to preserve pentest agents
+              setSubagents((prev) => {
+                return prev.map((s) => 
+                  s.id === "attack-surface-discovery"
+                    ? { ...s, messages: newMessages }
+                    : s
+                );
+              });
             } else if (chunk.type === "tool-result") {
               const tr = chunk as any;
               setThinking(true);
@@ -282,14 +284,17 @@ export default function SessionView({
                   result: tr.result || (tr as any).output,
                 };
 
-                // Create completely new array and object references
+                // Create new message array with new object references
                 const newMessages = discoveryMessages.map(m => ({ ...m }));
-                const newSubagent = {
-                  ...allSubagents[0]!,
-                  messages: newMessages,
-                };
-                setSubagents([newSubagent, ...allSubagents.slice(1)]);
-                allSubagents[0] = newSubagent;
+                
+                // Use functional setState to preserve pentest agents
+                setSubagents((prev) => {
+                  return prev.map((s) => 
+                    s.id === "attack-surface-discovery"
+                      ? { ...s, messages: newMessages }
+                      : s
+                  );
+                });
               }
             } else if (chunk.type === "step-finish") {
               // Reset accumulated text at step boundaries

--- a/src/tui/components/session-view/index.tsx
+++ b/src/tui/components/session-view/index.tsx
@@ -169,8 +169,7 @@ export default function SessionView({
           sessionConfig: execSession.config,
           abortSignal: controller.signal,
 
-          // Use onStepFinish for UI updates (like metavuln agent does)
-          // This is more reliable than raw stream chunks which can be interrupted
+          // Token tracking only - message updates are handled by onDiscoveryStream
           onDiscoveryStepFinish: (step) => {
             const stepTokens =
               (step.usage?.inputTokens ?? 0) + (step.usage?.outputTokens ?? 0);
@@ -179,100 +178,15 @@ export default function SessionView({
                 step.usage.inputTokens ?? 0,
                 step.usage.outputTokens ?? 0
               );
-
-            // Update messages from step data (same pattern as onPentestAgentStream)
-            const { text, toolCalls, toolResults } = step;
-
-            setSubagents((prev) => {
-              const idx = prev.findIndex(
-                (s) => s.id === "attack-surface-discovery"
-              );
-              if (idx === -1) return prev;
-
-              const updated = [...prev];
-              const subagent = updated[idx]!;
-              const newMessages = [...subagent.messages];
-
-              // Add text content
-              if (text && text.trim()) {
-                setThinking(false);
-                const lastMsg = newMessages[newMessages.length - 1];
-                if (lastMsg && lastMsg.role === "assistant") {
-                  newMessages[newMessages.length - 1] = {
-                    ...lastMsg,
-                    content: (lastMsg.content || "") + text,
-                  };
-                } else {
-                  newMessages.push({
-                    role: "assistant",
-                    content: text,
-                    createdAt: new Date(),
-                  });
-                }
-              }
-
-              // Add tool calls
-              if (toolCalls && toolCalls.length > 0) {
-                setThinking(false);
-                for (const tc of toolCalls) {
-                  // AI SDK v5.x uses 'input' instead of 'args'
-                  const args = (tc as any).input as
-                    | Record<string, unknown>
-                    | undefined;
-                  const toolDescription =
-                    typeof args?.toolCallDescription === "string"
-                      ? args.toolCallDescription
-                      : tc.toolName;
-                  newMessages.push({
-                    role: "tool",
-                    status: "pending",
-                    toolCallId: tc.toolCallId,
-                    toolName: tc.toolName,
-                    content: toolDescription,
-                    args: args,
-                    createdAt: new Date(),
-                  });
-                }
-              }
-
-              // Update tool results
-              if (toolResults && toolResults.length > 0) {
-                setThinking(true);
-                for (const tr of toolResults) {
-                  const msgIdx = newMessages.findIndex(
-                    (m) => m.role === "tool" && m.toolCallId === tr.toolCallId
-                  );
-                  if (msgIdx !== -1) {
-                    const existingMsg = newMessages[msgIdx] as ToolUIMessage;
-                    // Use the stored toolCallDescription (in content) if available, fallback to toolName
-                    const description =
-                      typeof existingMsg.content === "string" &&
-                      existingMsg.content !== existingMsg.toolName
-                        ? existingMsg.content
-                        : existingMsg.toolName || "tool";
-                    newMessages[msgIdx] = {
-                      ...existingMsg,
-                      status: "completed",
-                      content: `✓ ${description}`,
-                      result: (tr as any).output, // Store the tool output
-                    };
-                  }
-                }
-              }
-
-              updated[idx] = { ...subagent, messages: newMessages };
-              return updated;
-            });
           },
 
-          // Keep onDiscoveryStream as backup for real-time text streaming
+          // Real-time streaming for discovery agent - handles all chunk types
           onDiscoveryStream: (chunk) => {
-            // Only handle text-delta for real-time streaming effect
-            // Other chunk types are handled by onStepFinish for reliability
             if (chunk.type === "text-delta" && (chunk as any).text) {
               currentDiscoveryText += (chunk as any).text;
+              setThinking(false);
 
-              // Debounce updates - only update every 100ms worth of text
+              // Update subagent messages with streaming text
               if (currentDiscoveryText.trim()) {
                 setSubagents((prev) => {
                   const idx = prev.findIndex(
@@ -308,6 +222,89 @@ export default function SessionView({
                   return updated;
                 });
               }
+            } else if (chunk.type === "tool-call") {
+              // Handle tool calls in real-time
+              const tc = chunk as any;
+              let args: Record<string, unknown> = {};
+              try {
+                if (typeof tc.input === "string") {
+                  args = JSON.parse(tc.input);
+                } else if (tc.input && typeof tc.input === "object") {
+                  args = tc.input;
+                }
+              } catch {
+                args = {};
+              }
+
+              const toolDescription =
+                typeof args?.toolCallDescription === "string"
+                  ? args.toolCallDescription
+                  : tc.toolName;
+
+              setSubagents((prev) => {
+                const idx = prev.findIndex(
+                  (s) => s.id === "attack-surface-discovery"
+                );
+                if (idx === -1) return prev;
+
+                const updated = [...prev];
+                const subagent = updated[idx]!;
+                updated[idx] = {
+                  ...subagent,
+                  messages: [
+                    ...subagent.messages,
+                    {
+                      role: "tool",
+                      status: "pending",
+                      toolCallId: tc.toolCallId,
+                      toolName: tc.toolName,
+                      content: toolDescription,
+                      args: args,
+                      createdAt: new Date(),
+                    },
+                  ],
+                };
+                return updated;
+              });
+
+              // Reset text accumulator for next segment
+              currentDiscoveryText = "";
+            } else if (chunk.type === "tool-result") {
+              // Handle tool results in real-time
+              const tr = chunk as any;
+              setThinking(true);
+
+              setSubagents((prev) => {
+                const idx = prev.findIndex(
+                  (s) => s.id === "attack-surface-discovery"
+                );
+                if (idx === -1) return prev;
+
+                const updated = [...prev];
+                const subagent = updated[idx]!;
+                const newMessages = [...subagent.messages];
+
+                const msgIdx = newMessages.findIndex(
+                  (m) => m.role === "tool" && m.toolCallId === tr.toolCallId
+                );
+                if (msgIdx !== -1) {
+                  const existingMsg = newMessages[msgIdx] as ToolUIMessage;
+                  const description =
+                    typeof existingMsg.content === "string" &&
+                    existingMsg.content !== existingMsg.toolName
+                      ? existingMsg.content
+                      : existingMsg.toolName || "tool";
+                  newMessages[msgIdx] = {
+                    ...existingMsg,
+                    status: "completed",
+                    content: `✓ ${description}`,
+                    result: tr.result || (tr as any).output,
+                  };
+                }
+
+                updated[idx] = { ...subagent, messages: newMessages };
+                return updated;
+              });
             } else if (chunk.type === "step-finish") {
               // Reset accumulated text at step boundaries
               currentDiscoveryText = "";

--- a/src/tui/components/session-view/index.tsx
+++ b/src/tui/components/session-view/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useKeyboard } from "@opentui/react";
 import { RGBA } from "@opentui/core";
 import { useRoute } from "../../context/route";
@@ -145,22 +145,26 @@ export default function SessionView({
       const controller = new AbortController();
       setAbortController(controller);
 
+      // Mutable state for streaming - following v0.0.39 pattern
+      // These are mutated directly and then new array references are created for React
       let currentDiscoveryText = "";
+      const discoveryMessages: UIMessage[] = [];
+      const allSubagents: Subagent[] = [
+        {
+          id: "attack-surface-discovery",
+          name: "Attack Surface Discovery",
+          type: "attack-surface",
+          target: execSession.targets[0],
+          messages: discoveryMessages,
+          status: "pending",
+          createdAt: new Date(),
+        },
+      ];
+
+      // Initial render
+      setSubagents([...allSubagents]);
 
       try {
-        // Add discovery subagent
-        setSubagents([
-          {
-            id: "attack-surface-discovery",
-            name: "Attack Surface Discovery",
-            type: "attack-surface",
-            target: execSession.targets[0],
-            messages: [],
-            status: "pending",
-            createdAt: new Date(),
-          },
-        ]);
-
         // Run streamlined pentest
         const result = await runStreamlinedPentest({
           target: execSession.targets[0],
@@ -169,7 +173,7 @@ export default function SessionView({
           sessionConfig: execSession.config,
           abortSignal: controller.signal,
 
-          // Token tracking only - message updates are handled by onDiscoveryStream
+          // Token tracking only
           onDiscoveryStepFinish: (step) => {
             const stepTokens =
               (step.usage?.inputTokens ?? 0) + (step.usage?.outputTokens ?? 0);
@@ -180,50 +184,34 @@ export default function SessionView({
               );
           },
 
-          // Real-time streaming for discovery agent - handles all chunk types
+          // Real-time streaming - following v0.0.39 pattern exactly
+          // Mutate local arrays directly, then create new references for React
           onDiscoveryStream: (chunk) => {
             if (chunk.type === "text-delta" && (chunk as any).text) {
               currentDiscoveryText += (chunk as any).text;
               setThinking(false);
 
-              // Update subagent messages with streaming text
-              if (currentDiscoveryText.trim()) {
-                setSubagents((prev) => {
-                  const idx = prev.findIndex(
-                    (s) => s.id === "attack-surface-discovery"
-                  );
-                  if (idx === -1) return prev;
-
-                  const updated = [...prev];
-                  const subagent = updated[idx]!;
-                  const lastMsg =
-                    subagent.messages[subagent.messages.length - 1];
-
-                  if (lastMsg && lastMsg.role === "assistant") {
-                    const newMessages = [...subagent.messages];
-                    newMessages[newMessages.length - 1] = {
-                      ...lastMsg,
-                      content: currentDiscoveryText,
-                    };
-                    updated[idx] = { ...subagent, messages: newMessages };
-                  } else {
-                    updated[idx] = {
-                      ...subagent,
-                      messages: [
-                        ...subagent.messages,
-                        {
-                          role: "assistant",
-                          content: currentDiscoveryText,
-                          createdAt: new Date(),
-                        },
-                      ],
-                    };
-                  }
-                  return updated;
+              // Update or create assistant message (mutate in place like v0.0.39)
+              const lastMsg = discoveryMessages[discoveryMessages.length - 1];
+              if (lastMsg && lastMsg.role === "assistant") {
+                // Mutate directly
+                lastMsg.content = currentDiscoveryText;
+              } else {
+                // Add new message
+                discoveryMessages.push({
+                  role: "assistant",
+                  content: currentDiscoveryText,
+                  createdAt: new Date(),
                 });
               }
+
+              // Create new references for React (critical for re-render)
+              allSubagents[0] = {
+                ...allSubagents[0]!,
+                messages: [...discoveryMessages],
+              };
+              setSubagents([...allSubagents]);
             } else if (chunk.type === "tool-call") {
-              // Handle tool calls in real-time
               const tc = chunk as any;
               let args: Record<string, unknown> = {};
               try {
@@ -241,70 +229,57 @@ export default function SessionView({
                   ? args.toolCallDescription
                   : tc.toolName;
 
-              setSubagents((prev) => {
-                const idx = prev.findIndex(
-                  (s) => s.id === "attack-surface-discovery"
-                );
-                if (idx === -1) return prev;
-
-                const updated = [...prev];
-                const subagent = updated[idx]!;
-                updated[idx] = {
-                  ...subagent,
-                  messages: [
-                    ...subagent.messages,
-                    {
-                      role: "tool",
-                      status: "pending",
-                      toolCallId: tc.toolCallId,
-                      toolName: tc.toolName,
-                      content: toolDescription,
-                      args: args,
-                      createdAt: new Date(),
-                    },
-                  ],
-                };
-                return updated;
+              // Add tool message
+              discoveryMessages.push({
+                role: "tool",
+                status: "pending",
+                toolCallId: tc.toolCallId,
+                toolName: tc.toolName,
+                content: toolDescription,
+                args: args,
+                createdAt: new Date(),
               });
 
-              // Reset text accumulator for next segment
+              // Reset text for next segment
               currentDiscoveryText = "";
+
+              // Create new references for React
+              allSubagents[0] = {
+                ...allSubagents[0]!,
+                messages: [...discoveryMessages],
+              };
+              setSubagents([...allSubagents]);
             } else if (chunk.type === "tool-result") {
-              // Handle tool results in real-time
               const tr = chunk as any;
               setThinking(true);
 
-              setSubagents((prev) => {
-                const idx = prev.findIndex(
-                  (s) => s.id === "attack-surface-discovery"
-                );
-                if (idx === -1) return prev;
+              // Find and update tool message
+              const msgIdx = discoveryMessages.findIndex(
+                (m) => m.role === "tool" && m.toolCallId === tr.toolCallId
+              );
+              if (msgIdx !== -1) {
+                const existingMsg = discoveryMessages[msgIdx] as ToolUIMessage;
+                const description =
+                  typeof existingMsg.content === "string" &&
+                  existingMsg.content !== existingMsg.toolName
+                    ? existingMsg.content
+                    : existingMsg.toolName || "tool";
+                
+                // Mutate directly
+                discoveryMessages[msgIdx] = {
+                  ...existingMsg,
+                  status: "completed",
+                  content: `✓ ${description}`,
+                  result: tr.result || (tr as any).output,
+                };
 
-                const updated = [...prev];
-                const subagent = updated[idx]!;
-                const newMessages = [...subagent.messages];
-
-                const msgIdx = newMessages.findIndex(
-                  (m) => m.role === "tool" && m.toolCallId === tr.toolCallId
-                );
-                if (msgIdx !== -1) {
-                  const existingMsg = newMessages[msgIdx] as ToolUIMessage;
-                  const description =
-                    typeof existingMsg.content === "string" &&
-                    existingMsg.content !== existingMsg.toolName
-                      ? existingMsg.content
-                      : existingMsg.toolName || "tool";
-                  newMessages[msgIdx] = {
-                    ...existingMsg,
-                    status: "completed",
-                    content: `✓ ${description}`,
-                    result: tr.result || (tr as any).output,
-                  };
-                }
-
-                updated[idx] = { ...subagent, messages: newMessages };
-                return updated;
-              });
+                // Create new references for React
+                allSubagents[0] = {
+                  ...allSubagents[0]!,
+                  messages: [...discoveryMessages],
+                };
+                setSubagents([...allSubagents]);
+              }
             } else if (chunk.type === "step-finish") {
               // Reset accumulated text at step boundaries
               currentDiscoveryText = "";

--- a/src/tui/components/session-view/index.tsx
+++ b/src/tui/components/session-view/index.tsx
@@ -269,8 +269,8 @@ export default function SessionView({
           onDiscoveryStream: (chunk) => {
             // Only handle text-delta for real-time streaming effect
             // Other chunk types are handled by onStepFinish for reliability
-            if (chunk.type === "text-delta" && chunk.textDelta) {
-              currentDiscoveryText += chunk.textDelta;
+            if (chunk.type === "text-delta" && (chunk as any).text) {
+              currentDiscoveryText += (chunk as any).text;
 
               // Debounce updates - only update every 100ms worth of text
               if (currentDiscoveryText.trim()) {

--- a/src/tui/components/session-view/index.tsx
+++ b/src/tui/components/session-view/index.tsx
@@ -148,6 +148,10 @@ export default function SessionView({
       // Mutable state for streaming text accumulation
       let currentDiscoveryText = "";
       const discoveryMessages: UIMessage[] = [];
+      
+      // Mutable state for pentest agent streaming (multiple agents run in parallel)
+      const pentestAgentText: Map<string, string> = new Map();
+      const pentestAgentMessages: Map<string, UIMessage[]> = new Map();
 
       // Initial render - add discovery subagent
       setSubagents([
@@ -325,9 +329,18 @@ export default function SessionView({
           },
 
           onPentestAgentStream: (event: SubAgentStreamEvent) => {
+            const agentId = event.agentId;
+            
+            // Initialize message arrays if needed
+            if (!pentestAgentMessages.has(agentId)) {
+              pentestAgentMessages.set(agentId, []);
+              pentestAgentText.set(agentId, "");
+            }
+            const agentMessages = pentestAgentMessages.get(agentId)!;
+            
+            // Handle step-finish for token tracking only
             if (event.type === "step-finish" && event.data) {
-              const { text, toolCalls, toolResults, usage } = event.data;
-
+              const { usage } = event.data;
               if (usage) {
                 const stepTokens =
                   (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
@@ -337,79 +350,123 @@ export default function SessionView({
                     usage.outputTokens ?? 0
                   );
               }
-
-              setSubagents((prev) => {
-                const idx = prev.findIndex((s) => s.id === event.agentId);
-                if (idx === -1) return prev;
-
-                const updated = [...prev];
-                const subagent = updated[idx]!;
-                const newMessages = [...subagent.messages];
-
-                if (text && text.trim()) {
-                  const lastMsg = newMessages[newMessages.length - 1];
-                  if (lastMsg && lastMsg.role === "assistant") {
-                    newMessages[newMessages.length - 1] = {
-                      ...lastMsg,
-                      content: (lastMsg.content || "") + text,
-                    };
-                  } else {
-                    newMessages.push({
-                      role: "assistant",
-                      content: text,
-                      createdAt: new Date(),
-                    });
-                  }
+              // Reset accumulated text at step boundary
+              pentestAgentText.set(agentId, "");
+              return;
+            }
+            
+            // Handle real-time text-delta
+            if (event.type === "text-delta") {
+              const text = (event.data as any)?.text || (event.data as any)?.textDelta || "";
+              if (text) {
+                const currentText = (pentestAgentText.get(agentId) || "") + text;
+                pentestAgentText.set(agentId, currentText);
+                
+                // Update or create assistant message
+                const lastMsg = agentMessages[agentMessages.length - 1];
+                if (lastMsg && lastMsg.role === "assistant") {
+                  agentMessages[agentMessages.length - 1] = {
+                    ...lastMsg,
+                    content: currentText,
+                  };
+                } else {
+                  agentMessages.push({
+                    role: "assistant",
+                    content: currentText,
+                    createdAt: new Date(),
+                  });
                 }
-
-                if (toolCalls && toolCalls.length > 0) {
-                  for (const tc of toolCalls) {
-                    // AI SDK v5.x uses 'input' instead of 'args'
-                    const args = (tc as any).input as
-                      | Record<string, unknown>
-                      | undefined;
-                    const toolDescription =
-                      typeof args?.toolCallDescription === "string"
-                        ? args.toolCallDescription
-                        : tc.toolName;
-                    newMessages.push({
-                      role: "tool",
-                      status: "pending",
-                      toolCallId: tc.toolCallId,
-                      toolName: tc.toolName,
-                      content: toolDescription,
-                      args: args,
-                      createdAt: new Date(),
-                    });
-                  }
+                
+                // Create new array with new object references for React re-render
+                const newMessages = agentMessages.map(m => ({ ...m }));
+                
+                setSubagents((prev) => {
+                  return prev.map((s) => 
+                    s.id === agentId
+                      ? { ...s, messages: newMessages }
+                      : s
+                  );
+                });
+              }
+            }
+            
+            // Handle tool-call
+            else if (event.type === "tool-call") {
+              const tc = event.data as any;
+              let args: Record<string, unknown> = {};
+              try {
+                if (typeof tc.input === "string") {
+                  args = JSON.parse(tc.input);
+                } else if (tc.input && typeof tc.input === "object") {
+                  args = tc.input;
+                } else if (tc.args && typeof tc.args === "object") {
+                  args = tc.args;
                 }
-
-                if (toolResults && toolResults.length > 0) {
-                  for (const tr of toolResults) {
-                    const msgIdx = newMessages.findIndex(
-                      (m) => m.role === "tool" && m.toolCallId === tr.toolCallId
-                    );
-                    if (msgIdx !== -1) {
-                      const existingMsg = newMessages[msgIdx] as ToolUIMessage;
-                      // Use the stored toolCallDescription (in content) if available, fallback to toolName
-                      const description =
-                        typeof existingMsg.content === "string" &&
-                        existingMsg.content !== existingMsg.toolName
-                          ? existingMsg.content
-                          : existingMsg.toolName || "tool";
-                      newMessages[msgIdx] = {
-                        ...existingMsg,
-                        status: "completed",
-                        content: `✓ ${description}`,
-                        result: (tr as any).output, // Store the tool output
-                      };
-                    }
-                  }
-                }
-
-                updated[idx] = { ...subagent, messages: newMessages };
-                return updated;
+              } catch {
+                // ignore parse errors
+              }
+              
+              const toolDescription =
+                typeof args?.toolCallDescription === "string"
+                  ? args.toolCallDescription
+                  : tc.toolName;
+                  
+              agentMessages.push({
+                role: "tool",
+                status: "pending",
+                toolCallId: tc.toolCallId,
+                toolName: tc.toolName,
+                content: toolDescription,
+                args: args,
+                createdAt: new Date(),
               });
+              
+              // Reset accumulated text after tool call
+              pentestAgentText.set(agentId, "");
+              
+              // Create new array with new object references
+              const newMessages = agentMessages.map(m => ({ ...m }));
+              
+              setSubagents((prev) => {
+                return prev.map((s) => 
+                  s.id === agentId
+                    ? { ...s, messages: newMessages }
+                    : s
+                );
+              });
+            }
+            
+            // Handle tool-result
+            else if (event.type === "tool-result") {
+              const tr = event.data as any;
+              const msgIdx = agentMessages.findIndex(
+                (m) => m.role === "tool" && m.toolCallId === tr.toolCallId
+              );
+              if (msgIdx !== -1) {
+                const existingMsg = agentMessages[msgIdx] as ToolUIMessage;
+                const description =
+                  typeof existingMsg.content === "string" &&
+                  existingMsg.content !== existingMsg.toolName
+                    ? existingMsg.content
+                    : existingMsg.toolName || "tool";
+                agentMessages[msgIdx] = {
+                  ...existingMsg,
+                  status: "completed",
+                  content: `✓ ${description}`,
+                  result: (tr as any).result || (tr as any).output,
+                };
+                
+                // Create new array with new object references
+                const newMessages = agentMessages.map(m => ({ ...m }));
+                
+                setSubagents((prev) => {
+                  return prev.map((s) => 
+                    s.id === agentId
+                      ? { ...s, messages: newMessages }
+                      : s
+                  );
+                });
+              }
             }
           },
 

--- a/src/tui/components/session-view/index.tsx
+++ b/src/tui/components/session-view/index.tsx
@@ -184,18 +184,21 @@ export default function SessionView({
               );
           },
 
-          // Real-time streaming - following v0.0.39 pattern exactly
-          // Mutate local arrays directly, then create new references for React
+          // Real-time streaming - create new objects for every update
+          // This ensures React detects changes even with memo()
           onDiscoveryStream: (chunk) => {
             if (chunk.type === "text-delta" && (chunk as any).text) {
               currentDiscoveryText += (chunk as any).text;
               setThinking(false);
 
-              // Update or create assistant message (mutate in place like v0.0.39)
+              // Update or create assistant message - always create new objects
               const lastMsg = discoveryMessages[discoveryMessages.length - 1];
               if (lastMsg && lastMsg.role === "assistant") {
-                // Mutate directly
-                lastMsg.content = currentDiscoveryText;
+                // Create new message object (not mutation!)
+                discoveryMessages[discoveryMessages.length - 1] = {
+                  ...lastMsg,
+                  content: currentDiscoveryText,
+                };
               } else {
                 // Add new message
                 discoveryMessages.push({
@@ -205,12 +208,16 @@ export default function SessionView({
                 });
               }
 
-              // Create new references for React (critical for re-render)
-              allSubagents[0] = {
+              // Create completely new array and object references for React
+              const newMessages = discoveryMessages.map(m => ({ ...m }));
+              const newSubagent = {
                 ...allSubagents[0]!,
-                messages: [...discoveryMessages],
+                messages: newMessages,
               };
-              setSubagents([...allSubagents]);
+              setSubagents([newSubagent, ...allSubagents.slice(1)]);
+              
+              // Keep reference in sync
+              allSubagents[0] = newSubagent;
             } else if (chunk.type === "tool-call") {
               const tc = chunk as any;
               let args: Record<string, unknown> = {};
@@ -243,12 +250,14 @@ export default function SessionView({
               // Reset text for next segment
               currentDiscoveryText = "";
 
-              // Create new references for React
-              allSubagents[0] = {
+              // Create completely new array and object references
+              const newMessages = discoveryMessages.map(m => ({ ...m }));
+              const newSubagent = {
                 ...allSubagents[0]!,
-                messages: [...discoveryMessages],
+                messages: newMessages,
               };
-              setSubagents([...allSubagents]);
+              setSubagents([newSubagent, ...allSubagents.slice(1)]);
+              allSubagents[0] = newSubagent;
             } else if (chunk.type === "tool-result") {
               const tr = chunk as any;
               setThinking(true);
@@ -265,7 +274,7 @@ export default function SessionView({
                     ? existingMsg.content
                     : existingMsg.toolName || "tool";
                 
-                // Mutate directly
+                // Create new message object
                 discoveryMessages[msgIdx] = {
                   ...existingMsg,
                   status: "completed",
@@ -273,12 +282,14 @@ export default function SessionView({
                   result: tr.result || (tr as any).output,
                 };
 
-                // Create new references for React
-                allSubagents[0] = {
+                // Create completely new array and object references
+                const newMessages = discoveryMessages.map(m => ({ ...m }));
+                const newSubagent = {
                   ...allSubagents[0]!,
-                  messages: [...discoveryMessages],
+                  messages: newMessages,
                 };
-                setSubagents([...allSubagents]);
+                setSubagents([newSubagent, ...allSubagents.slice(1)]);
+                allSubagents[0] = newSubagent;
               }
             } else if (chunk.type === "step-finish") {
               // Reset accumulated text at step boundaries


### PR DESCRIPTION
Restore real-time, token-by-token streaming of agent messages in the TUI by emitting UI update events during the streaming loop and correcting a property name mismatch.

The `operatorAgent`'s `runAgentLoop` was accumulating text from the stream but not sending updates to the UI until the entire step finished via `handleStepFinish`. This meant users only saw full messages, not the token-by-token stream. The fix modifies the streaming loop to emit `message` and `message-updated` events as `text-delta`, `tool-call`, and `tool-result` chunks arrive. Additionally, `session-view/index.tsx` was using `chunk.textDelta` instead of the correct `chunk.text` for AI SDK text-delta chunks, which was also corrected.

---
<a href="https://cursor.com/background-agent?bcId=bc-2abbab1a-c16a-4b3d-ba5f-50baa4e0cc92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2abbab1a-c16a-4b3d-ba5f-50baa4e0cc92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

