### PR TITLE
Fix #88 : Fixing broken installer and add universal cross-platform install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Download installer from `https://nmap.org/download.html` and ensure `nmap` is on
 #### macOS / Linux (Quick Install)
 
 ```bash
-curl -fsSL https://pensarai.com/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/pensarai/apex/main/scripts/install.sh | bash
 ```
 
 #### Homebrew

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,63 @@
+
+set -e
+
+
+REPO="pensarai/apex"
+BIN_NAME="pensar"
+
+
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$OS" in
+  darwin) OS="darwin" ;;
+  linux) OS="linux" ;;
+  *) echo "❌ Unsupported OS: $OS"; exit 1 ;;
+esac
+
+case "$ARCH" in
+  arm64|aarch64) ARCH="arm64" ;;
+  x86_64) ARCH="x64" ;;
+  *) echo "❌ Unsupported arch: $ARCH"; exit 1 ;;
+esac
+
+echo "➡️ Installing $BIN_NAME for $OS-$ARCH into $INSTALL_DIR"
+
+
+JSON=$(curl -s https://api.github.com/repos/$REPO/releases/latest)
+
+
+ASSET_URL=$(echo "$JSON" | grep browser_download_url | grep "$OS" | grep "$ARCH" | cut -d '"' -f 4)
+
+if [ -z "$ASSET_URL" ]; then
+  echo "❌ Could not find binary for $OS-$ARCH"
+  exit 1
+fi
+
+echo "⬇️ Downloading $ASSET_URL"
+
+
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR"
+
+
+curl -L "$ASSET_URL" -o pensar.tar.gz
+tar -xzf pensar.tar.gz
+
+if [ ! -f "./pensar" ]; then
+  echo "❌ pensar binary not found in tarball"
+  ls -la
+  exit 1
+fi
+
+chmod +x ./pensar
+
+
+mkdir -p "$INSTALL_DIR"
+mv ./pensar "$INSTALL_DIR/pensar"
+
+echo "✅ Installed pensar to $INSTALL_DIR/pensar"
+echo "👉 Run: pensar --help"


### PR DESCRIPTION
## Summary

This PR fixes onboarding issues by adding a universal installer and updating documentation.

## Problems Fixed

- README referenced a broken install URL (pensarai.com/install.sh)
- Hosted installer hardcoded /usr/local/bin and failed without sudo
- No directory creation before mv, causing install failures
- Incorrect assumptions about release tarball structure
- No support for user-level installation

## Changes

- Added scripts/install.sh universal installer
- Auto-detects OS and architecture
- Downloads correct GitHub release asset
- Supports sudo and non-sudo installs via INSTALL_DIR
- Fixed README install instructions
- Added documentation for custom install paths

## Motivation

First-time users could not install Apex using documented commands. This PR provides a reliable one-line install experience similar to Rustup, Bun, and Deno.

## Testing

Tested on:
- macOS Apple Silicon (darwin-arm64)
- Local non-sudo install to ~/.local/bin
- Verified CLI runs via `pensar --help`

## Future Work

- Add checksum verification for security
- Windows installer parity
- GitHub Actions test for installer
