### PR TITLE
Fix /resume command not rendering ResumeWizard

### DIFF
--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -9,6 +9,7 @@ import ConfigDialog from "./components/commands/config-dialog";
 import ChatApp from "./components/chat";
 import HITLWizard from "./components/commands/operator-wizard";
 import WebWizard from "./components/commands/web-wizard";
+import ResumeWizard from "./components/commands/resume-wizard";
 import ProviderManager from "./components/commands/provider-manager";
 import type { Config } from "../core/config/config";
 import { config } from "../core/config";
@@ -280,6 +281,9 @@ function CommandDisplay({
           </RouteSwitch.Case>
           <RouteSwitch.Case when="providers">
             <ProviderManager />
+          </RouteSwitch.Case>
+          <RouteSwitch.Case when="resume">
+            <ResumeWizard />
           </RouteSwitch.Case>
           <RouteSwitch.Case when="help">
             <HelpDialog />


### PR DESCRIPTION
Fixes #103.

The `/resume` command wasn't rendering the `ResumeWizard` component since it wasn't wired into the route switch.

Added the missing import and `RouteSwitch.Case`.

[Screen recording](https://drive.google.com/file/d/1muGLQgfO1_VMpFlwb9mU15xYSsSKv3Bd/view?usp=sharing)