### PR TITLE
Fix /chat command not rendering ChatApp

### DIFF
--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -287,7 +287,7 @@ export const commands: CommandConfig[] = [
     handler: async (args, ctx) => {
       ctx.navigate({
         type: "base",
-        path: "chat",
+        path: "home",
       });
     },
   },


### PR DESCRIPTION
Fixes #104.

The `/chat` command wasn't rendering the `ChatApp` component since it navigated to path `"chat"` but the `RouteSwitch` had no matching case.

Changed it to navigate to `"home"` which already renders `ChatApp`.

Note: The command is somewhat redundant at the moment since it doesn't work from within an existing session—it only navigates back to home. This can be addressed separately.

[Screen recording](https://drive.google.com/file/d/1WcMDMMboBeMWIabl17wfnIeIlGW8nkWt/view?usp=sharing)