### PR TITLE
Worktree/kill subagent

### DIFF
--- a/src/core/agent/metaTestingAgent/index.ts
+++ b/src/core/agent/metaTestingAgent/index.ts
@@ -14,6 +14,7 @@
 // Main agents
 export {
   runMetaVulnerabilityTestAgent,
+  saveAgentMessages,
   type MetaVulnerabilityTestInput,
   type MetaVulnerabilityTestResult,
   type SpawnVulnerabilityTestRequest,

--- a/src/core/agent/metaTestingAgent/metaVulnerabilityTestAgent.ts
+++ b/src/core/agent/metaTestingAgent/metaVulnerabilityTestAgent.ts
@@ -587,27 +587,32 @@ Call when:
 
       logger.info(`Testing finished. Findings: ${findingPaths.length}`);
 
-      try {
-        const response = await streamResult.response;
-        if (response.messages?.length > 0) {
-          const sanitizedTarget = target
-            .replace(/[^a-z0-9]/gi, "-")
-            .substring(0, 30);
-          saveAgentMessages(
-            session.rootPath,
-            `meta-vuln-${vulnerabilityClass}-${sanitizedTarget}`,
-            response.messages,
-            {
-              target,
-              objective,
-              vulnerabilityClass,
-              findingsCount: findingPaths.length,
-              status: "completed",
-            }
-          );
+      // Only save "completed" if the agent wasn't killed — the kill handler
+      // already persists a "canceled" file, and saving both creates ghost
+      // "completed" entries that appear on session resume.
+      if (!abortSignal?.aborted) {
+        try {
+          const response = await streamResult.response;
+          if (response.messages?.length > 0) {
+            const sanitizedTarget = target
+              .replace(/[^a-z0-9]/gi, "-")
+              .substring(0, 30);
+            saveAgentMessages(
+              session.rootPath,
+              `meta-vuln-${vulnerabilityClass}-${sanitizedTarget}`,
+              response.messages,
+              {
+                target,
+                objective,
+                vulnerabilityClass,
+                findingsCount: findingPaths.length,
+                status: "completed",
+              }
+            );
+          }
+        } catch (e: any) {
+          logger.error(`Failed to save messages: ${e.message}`);
         }
-      } catch (e: any) {
-        logger.error(`Failed to save messages: ${e.message}`);
       }
 
       return {

--- a/src/core/agent/metaTestingAgent/metaVulnerabilityTestAgent.ts
+++ b/src/core/agent/metaTestingAgent/metaVulnerabilityTestAgent.ts
@@ -88,7 +88,7 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function saveAgentMessages(
+export function saveAgentMessages(
   sessionRootPath: string,
   agentName: string,
   messages: any[],
@@ -602,6 +602,7 @@ Call when:
               objective,
               vulnerabilityClass,
               findingsCount: findingPaths.length,
+              status: "completed",
             }
           );
         }

--- a/src/core/agent/metaTestingAgent/metaVulnerabilityTestAgent.ts
+++ b/src/core/agent/metaTestingAgent/metaVulnerabilityTestAgent.ts
@@ -92,7 +92,7 @@ export function saveAgentMessages(
   sessionRootPath: string,
   agentName: string,
   messages: any[],
-  metadata?: Record<string, any>
+  metadata?: Record<string, any>,
 ): string {
   const subagentsDir = join(sessionRootPath, "subagents");
   if (!existsSync(subagentsDir)) {
@@ -114,8 +114,8 @@ export function saveAgentMessages(
         messages,
       },
       null,
-      2
-    )
+      2,
+    ),
   );
 
   return filepath;
@@ -275,7 +275,7 @@ export async function runMetaVulnerabilityTestAgent(opts: {
   abortSignal?: AbortSignal;
   toolOverride?: {
     execute_command?: (
-      opts: ExecuteCommandOpts
+      opts: ExecuteCommandOpts,
     ) => Promise<ExecuteCommandResult>;
     http_request?: (opts: HttpRequestOpts) => Promise<HttpRequestResult>;
   };
@@ -311,11 +311,11 @@ export async function runMetaVulnerabilityTestAgent(opts: {
       rootPath: session.rootPath,
       logsPath: session.logsPath,
     } as Session.SessionInfo,
-    `meta-vuln-test-${vulnerabilityClass}.log`
+    `meta-vuln-test-${vulnerabilityClass}.log`,
   );
 
   logger.info(
-    `Starting MetaVulnerabilityTestAgent for ${target} [${vulnerabilityClass}]`
+    `Starting MetaVulnerabilityTestAgent for ${target} [${vulnerabilityClass}]`,
   );
   logger.info(`Objective: ${objective}`);
 
@@ -348,13 +348,13 @@ export async function runMetaVulnerabilityTestAgent(opts: {
     undefined,
     toolOverride,
     undefined, // onTokenUsage - not needed here
-    abortSignal
+    abortSignal,
   );
 
   const { create_poc, pocPaths } = createPocTool(
     sessionInfo,
     logger,
-    toolOverride
+    toolOverride,
   );
   const { document_finding, findingPaths } = createDocumentFindingTool(
     sessionInfo,
@@ -364,18 +364,18 @@ export async function runMetaVulnerabilityTestAgent(opts: {
       enableCvssScoring: sessionConfig?.enableCvssScoring,
       cvssModel: sessionConfig?.cvssModel,
       getMessages: () => messagesRef.current,
-    }
+    },
   );
   const { store_plan, get_plan, store_adaptation } = createPlanMemoryTools(
     sessionInfo,
-    logger
+    logger,
   );
   const { optimize_prompt } = createPromptOptimizerTool(sessionInfo, logger);
   const auth_bypass_test = createAuthBypassTool(
     sessionInfo,
     logger,
     model,
-    toolOverride
+    toolOverride,
   );
 
   const spawn_vulnerability_test = tool({
@@ -399,7 +399,7 @@ Use SPAWN when both are worth testing. Use PIVOT when discovered vuln is clearly
       vulnerabilityClass: z
         .string()
         .describe(
-          "Vulnerability class to test: deserialization, ssti, sqli, xss, lfi, ssrf, xxe, command-injection, idor, crypto"
+          "Vulnerability class to test: deserialization, ssti, sqli, xss, lfi, ssrf, xxe, command-injection, idor, crypto",
         ),
       objective: z
         .string()
@@ -407,12 +407,12 @@ Use SPAWN when both are worth testing. Use PIVOT when discovered vuln is clearly
       evidence: z
         .string()
         .describe(
-          "Evidence that led to this discovery (error message, behavior, etc.)"
+          "Evidence that led to this discovery (error message, behavior, etc.)",
         ),
       priority: z
         .enum(["critical", "high", "medium"])
         .describe(
-          "Priority: critical=RCE potential, high=data access, medium=other"
+          "Priority: critical=RCE potential, high=data access, medium=other",
         ),
     }),
     execute: async (params) => {
@@ -425,7 +425,7 @@ Use SPAWN when both are worth testing. Use PIVOT when discovered vuln is clearly
         const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
         const spawnFile = join(
           spawnDir,
-          `spawn-${params.vulnerabilityClass}-${timestamp}.json`
+          `spawn-${params.vulnerabilityClass}-${timestamp}.json`,
         );
         writeFileSync(
           spawnFile,
@@ -437,11 +437,11 @@ Use SPAWN when both are worth testing. Use PIVOT when discovered vuln is clearly
               timestamp: new Date().toISOString(),
             },
             null,
-            2
-          )
+            2,
+          ),
         );
         logger.info(
-          `Spawn request saved (no callback): ${params.vulnerabilityClass} for ${target}`
+          `Spawn request saved (no callback): ${params.vulnerabilityClass} for ${target}`,
         );
         return {
           success: true,
@@ -460,7 +460,7 @@ Use SPAWN when both are worth testing. Use PIVOT when discovered vuln is clearly
       });
 
       logger.info(
-        `Spawned new agent: ${params.vulnerabilityClass} for ${target}`
+        `Spawned new agent: ${params.vulnerabilityClass} for ${target}`,
       );
       return {
         success: true,
@@ -488,7 +488,7 @@ Call when:
     execute: async (result) => {
       testingSummary = result.summary;
       logger.info(
-        `Testing complete: ${result.vulnerabilitiesFound ? "Found" : "None"}`
+        `Testing complete: ${result.vulnerabilitiesFound ? "Found" : "None"}`,
       );
       return { success: true, message: "Testing completed." };
     },
@@ -514,7 +514,7 @@ Call when:
 
   const vulnClassPrompt = buildVulnClassPrompt(
     vulnerabilityClass,
-    outcomeGuidance
+    outcomeGuidance,
   );
   const systemPrompt = vulnClassPrompt + "\n\n---\n" + COGNITIVE_LOOP_PROMPT;
 
@@ -534,7 +534,7 @@ Call when:
 
     try {
       logger.info(
-        `Running agent (attempt ${attempt}/${RETRY_CONFIG.maxRetries})`
+        `Running agent (attempt ${attempt}/${RETRY_CONFIG.maxRetries})`,
       );
 
       const streamResult = streamResponse({
@@ -587,9 +587,6 @@ Call when:
 
       logger.info(`Testing finished. Findings: ${findingPaths.length}`);
 
-      // Only save "completed" if the agent wasn't killed — the kill handler
-      // already persists a "canceled" file, and saving both creates ghost
-      // "completed" entries that appear on session resume.
       if (!abortSignal?.aborted) {
         try {
           const response = await streamResult.response;
@@ -607,7 +604,7 @@ Call when:
                 vulnerabilityClass,
                 findingsCount: findingPaths.length,
                 status: "completed",
-              }
+              },
             );
           }
         } catch (e: any) {
@@ -623,7 +620,7 @@ Call when:
         summary:
           testingSummary ||
           `Tested ${target} for ${getVulnerabilityClassName(
-            vulnerabilityClass
+            vulnerabilityClass,
           )}`,
       };
     } catch (error: any) {
@@ -633,7 +630,7 @@ Call when:
         const delay = Math.min(
           RETRY_CONFIG.initialDelayMs *
             Math.pow(RETRY_CONFIG.backoffMultiplier, attempt - 1),
-          RETRY_CONFIG.maxDelayMs
+          RETRY_CONFIG.maxDelayMs,
         );
         logger.info(`API overloaded, retrying in ${delay / 1000}s...`);
         await sleep(delay);
@@ -642,7 +639,7 @@ Call when:
 
       if (isContextTooLongError(error)) {
         logger.error(
-          `Context too long for ${target} [${vulnerabilityClass}]: ${error.message}`
+          `Context too long for ${target} [${vulnerabilityClass}]: ${error.message}`,
         );
         return {
           vulnerabilitiesFound: false,
@@ -650,7 +647,7 @@ Call when:
           pocPaths: [],
           findingPaths: [],
           summary: `Testing terminated: Context exceeded model limits for ${getVulnerabilityClassName(
-            vulnerabilityClass
+            vulnerabilityClass,
           )}`,
           error: `Context too long: ${error.message}`,
         };
@@ -661,7 +658,7 @@ Call when:
   }
 
   logger.error(
-    `Failed after ${RETRY_CONFIG.maxRetries} attempts: ${lastError?.message}`
+    `Failed after ${RETRY_CONFIG.maxRetries} attempts: ${lastError?.message}`,
   );
   throw new Error(`Max retries exhausted. Last error: ${lastError?.message}`);
 }
@@ -690,7 +687,7 @@ function buildUserPrompt(params: {
 ## Your Task
 
 Test for ${getVulnerabilityClassName(
-    vulnerabilityClass
+    vulnerabilityClass,
   )} vulnerabilities using the cognitive loop:
 
 1. **Create initial plan** with store_plan (phases: Recon, Test, Exploit)

--- a/src/core/agent/orchestrator/orchestrator.ts
+++ b/src/core/agent/orchestrator/orchestrator.ts
@@ -49,7 +49,7 @@ function saveOrchestratorSummary(
     }>;
     totalFindings: number;
     concurrencyLimit: number;
-  }
+  },
 ): string {
   const subagentsDir = join(sessionRootPath, "subagents");
   if (!existsSync(subagentsDir)) {
@@ -125,11 +125,14 @@ export interface PentestOrchestratorInput {
   /** Callback when a sub-agent completes */
   onAgentComplete?: (
     agentId: string,
-    result: MetaVulnerabilityTestResult
+    result: MetaVulnerabilityTestResult,
   ) => void;
 
   /** Called when a per-agent AbortController is created, allowing callers to abort individual agents */
-  onAgentAbortControllerCreated?: (agentId: string, controller: AbortController) => void;
+  onAgentAbortControllerCreated?: (
+    agentId: string,
+    controller: AbortController,
+  ) => void;
 
   /** Abort signal */
   abortSignal?: AbortSignal;
@@ -137,7 +140,7 @@ export interface PentestOrchestratorInput {
   /** Tool overrides for sandboxed execution */
   toolOverride?: {
     execute_command?: (
-      opts: ExecuteCommandOpts
+      opts: ExecuteCommandOpts,
     ) => Promise<ExecuteCommandResult>;
     http_request?: (opts: HttpRequestOpts) => Promise<HttpRequestResult>;
   };
@@ -210,7 +213,7 @@ interface TestTask {
  * a configurable concurrency limit (default: 20).
  */
 export async function runPentestOrchestrator(
-  input: PentestOrchestratorInput
+  input: PentestOrchestratorInput,
 ): Promise<PentestOrchestratorResult> {
   const {
     targets,
@@ -263,7 +266,7 @@ export async function runPentestOrchestrator(
   }
 
   logger.info(
-    `Starting pentest orchestrator: ${targets.length} targets, ${testTasks.length} tasks, concurrency limit ${concurrencyLimit}`
+    `Starting pentest orchestrator: ${targets.length} targets, ${testTasks.length} tasks, concurrency limit ${concurrencyLimit}`,
   );
 
   // Progress tracking
@@ -345,9 +348,6 @@ export async function runPentestOrchestrator(
 
       // Create per-agent AbortController and combine with global signal
       const agentAbortController = new AbortController();
-      const combinedSignal = abortSignal
-        ? AbortSignal.any([abortSignal, agentAbortController.signal])
-        : agentAbortController.signal;
 
       // Register with caller so they can abort this specific agent
       onAgentAbortControllerCreated?.(agentId, agentAbortController);
@@ -385,11 +385,13 @@ export async function runPentestOrchestrator(
           model,
           remoteSandboxUrl: sessionConfig?.remoteSandboxUrl,
           toolOverride,
-          abortSignal: combinedSignal,
+          abortSignal: abortSignal
+            ? AbortSignal.any([abortSignal, agentAbortController.signal])
+            : agentAbortController.signal,
           // Handle spawned vulnerability tests - adds to the same unified queue
           onSpawnAgent: (request: SpawnVulnerabilityTestRequest) => {
             logger.info(
-              `Agent ${agentId} spawning new test: ${request.vulnerabilityClass} for ${request.target}`
+              `Agent ${agentId} spawning new test: ${request.vulnerabilityClass} for ${request.target}`,
             );
 
             // Create a new task and add it to the unified queue
@@ -407,7 +409,7 @@ export async function runPentestOrchestrator(
             queueTask(spawnedTask);
 
             logger.info(
-              `Queued spawned task: ${request.vulnerabilityClass} (total queue: ${totalTasksQueued})`
+              `Queued spawned task: ${request.vulnerabilityClass} (total queue: ${totalTasksQueued})`,
             );
           },
           // Forward real-time stream chunks to caller
@@ -441,7 +443,7 @@ export async function runPentestOrchestrator(
         return taskResult;
       } catch (error: any) {
         logger.error(
-          `Error testing ${task.vulnClass} on ${task.target}: ${error.message}`
+          `Error testing ${task.vulnClass} on ${task.target}: ${error.message}`,
         );
         const taskResult = {
           task,
@@ -500,7 +502,7 @@ export async function runPentestOrchestrator(
   logger.info(
     `All tasks completed: ${allTaskResults.length} total (${
       testTasks.length
-    } initial + ${allTaskResults.length - testTasks.length} spawned)`
+    } initial + ${allTaskResults.length - testTasks.length} spawned)`,
   );
 
   // Aggregate results by target (includes both initial and spawned tasks)
@@ -522,7 +524,7 @@ export async function runPentestOrchestrator(
     const pentestTarget = targets[i];
     const vulnerabilityResults = resultsMap.get(i)!;
     const targetFindingsCount = Array.from(
-      vulnerabilityResults.values()
+      vulnerabilityResults.values(),
     ).reduce((sum, r) => sum + r.findingsCount, 0);
 
     targetResults.push({
@@ -535,7 +537,7 @@ export async function runPentestOrchestrator(
     });
 
     logger.info(
-      `Target ${pentestTarget.target} complete. Findings: ${targetFindingsCount}`
+      `Target ${pentestTarget.target} complete. Findings: ${targetFindingsCount}`,
     );
   }
 
@@ -592,7 +594,7 @@ export async function runPentestOrchestrator(
  */
 function generateSummary(
   targetResults: TargetTestResult[],
-  totalFindings: number
+  totalFindings: number,
 ): string {
   const lines: string[] = [
     "=".repeat(50),
@@ -609,13 +611,13 @@ function generateSummary(
     lines.push(`  - ${result.target}: ${result.totalFindings} findings`);
 
     for (const [vulnClass, vulnResult] of Array.from(
-      result.vulnerabilityResults.entries()
+      result.vulnerabilityResults.entries(),
     )) {
       if (vulnResult.findingsCount > 0) {
         lines.push(
           `    • ${getVulnerabilityClassName(vulnClass)}: ${
             vulnResult.findingsCount
-          }`
+          }`,
         );
       }
     }

--- a/src/core/agent/orchestrator/orchestrator.ts
+++ b/src/core/agent/orchestrator/orchestrator.ts
@@ -128,6 +128,9 @@ export interface PentestOrchestratorInput {
     result: MetaVulnerabilityTestResult
   ) => void;
 
+  /** Called when a per-agent AbortController is created, allowing callers to abort individual agents */
+  onAgentAbortControllerCreated?: (agentId: string, controller: AbortController) => void;
+
   /** Abort signal */
   abortSignal?: AbortSignal;
 
@@ -217,6 +220,7 @@ export async function runPentestOrchestrator(
     onAgentSpawn,
     onAgentStream,
     onAgentComplete,
+    onAgentAbortControllerCreated,
     abortSignal,
     toolOverride,
     concurrencyLimit = DEFAULT_CONCURRENCY_LIMIT,
@@ -339,6 +343,15 @@ export async function runPentestOrchestrator(
         ? `spawned-${task.vulnClass}-${Date.now()}`
         : `meta-vuln-${task.targetIndex}-${task.vulnClass}`;
 
+      // Create per-agent AbortController and combine with global signal
+      const agentAbortController = new AbortController();
+      const combinedSignal = abortSignal
+        ? AbortSignal.any([abortSignal, agentAbortController.signal])
+        : agentAbortController.signal;
+
+      // Register with caller so they can abort this specific agent
+      onAgentAbortControllerCreated?.(agentId, agentAbortController);
+
       // Notify spawn
       onAgentSpawn?.({
         id: agentId,
@@ -372,7 +385,7 @@ export async function runPentestOrchestrator(
           model,
           remoteSandboxUrl: sessionConfig?.remoteSandboxUrl,
           toolOverride,
-          abortSignal,
+          abortSignal: combinedSignal,
           // Handle spawned vulnerability tests - adds to the same unified queue
           onSpawnAgent: (request: SpawnVulnerabilityTestRequest) => {
             logger.info(

--- a/src/core/agent/thoroughPentestAgent/streamlined.ts
+++ b/src/core/agent/thoroughPentestAgent/streamlined.ts
@@ -89,6 +89,8 @@ export interface StreamlinedPentestInput {
 
   onPentestAgentComplete?: (agentId: string, result: MetaVulnerabilityTestResult) => void;
 
+  onAgentAbortControllerCreated?: (agentId: string, controller: AbortController) => void;
+
   abortSignal?: AbortSignal;
 
   /** Tool overrides for sandboxed execution */
@@ -139,6 +141,7 @@ export async function runStreamlinedPentest(
     onPentestAgentSpawn,
     onPentestAgentStream,
     onPentestAgentComplete,
+    onAgentAbortControllerCreated,
     abortSignal,
     toolOverride,
   } = input;
@@ -236,6 +239,7 @@ export async function runStreamlinedPentest(
       onAgentSpawn: onPentestAgentSpawn,
       onAgentStream: onPentestAgentStream,
       onAgentComplete: onPentestAgentComplete,
+      onAgentAbortControllerCreated,
     });
 
     logger.info(`Vulnerability testing complete. Total findings: ${pentestResult.totalFindings}`);

--- a/src/core/session/loader.ts
+++ b/src/core/session/loader.ts
@@ -107,7 +107,7 @@ export interface LoadedSessionState {
  */
 function convertMessagesToUI(
   messages: SavedMessage[],
-  baseTime: Date
+  baseTime: Date,
 ): UIMessage[] {
   const uiMessages: UIMessage[] = [];
   let messageIndex = 0;
@@ -227,7 +227,7 @@ function loadSubagents(rootPath: string): UISubagent[] {
     try {
       const filePath = join(subagentsPath, file);
       const data = JSON.parse(
-        readFileSync(filePath, "utf-8")
+        readFileSync(filePath, "utf-8"),
       ) as SavedSubagentData;
 
       const { agentType, name } = parseSubagentFilename(file);
@@ -240,17 +240,23 @@ function loadSubagents(rootPath: string): UISubagent[] {
 
       const messages = convertMessagesToUI(data.messages, timestamp);
 
-      // Determine status: prefer explicit status field, fall back to findingsCount heuristic
+      // Determine subagent status, prefer explicit status, fallback to findingsCount heuristic
       let status: "pending" | "completed" | "failed" | "canceled" = "completed";
-      if (data.status === "canceled") {
-        status = "canceled";
-      } else if (data.status === "failed") {
-        status = "failed";
-      } else if (data.status === "completed") {
-        status = "completed";
-      } else if (data.findingsCount !== undefined && data.findingsCount < 0) {
-        // Legacy heuristic for files without explicit status
-        status = "failed";
+      switch (data.status) {
+        case "canceled":
+        case "failed":
+        case "completed":
+        case "pending":
+          status = data.status;
+          break;
+        default:
+          if (
+            typeof data.findingsCount === "number" &&
+            data.findingsCount < 0
+          ) {
+            status = "failed";
+          }
+          break;
       }
 
       subagents.push({
@@ -277,7 +283,7 @@ function loadSubagents(rootPath: string): UISubagent[] {
  * Load attack surface results
  */
 function loadAttackSurfaceResults(
-  rootPath: string
+  rootPath: string,
 ): AttackSurfaceResults | null {
   const resultsPath = join(rootPath, "attack-surface-results.json");
   if (!existsSync(resultsPath)) {
@@ -305,7 +311,7 @@ function hasReport(rootPath: string): boolean {
  */
 function createDiscoveryFromLogs(
   rootPath: string,
-  session: Session.SessionInfo
+  session: Session.SessionInfo,
 ): UISubagent | null {
   const logPath = join(rootPath, "logs", "streamlined-pentest.log");
   if (!existsSync(logPath)) {
@@ -321,7 +327,7 @@ function createDiscoveryFromLogs(
 
     for (const line of lines) {
       const match = line.match(
-        /^(\d{4}-\d{2}-\d{2}T[\d:.]+Z) - \[(\w+)\] (.+)$/
+        /^(\d{4}-\d{2}-\d{2}T[\d:.]+Z) - \[(\w+)\] (.+)$/,
       );
       if (!match) continue;
 
@@ -376,7 +382,7 @@ function createDiscoveryFromLogs(
  * Load complete session state from execution directory
  */
 export async function loadSessionState(
-  session: Session.SessionInfo
+  session: Session.SessionInfo,
 ): Promise<LoadedSessionState> {
   const rootPath = session.rootPath;
 
@@ -385,7 +391,7 @@ export async function loadSessionState(
 
   // Check if we have attack surface agent in subagents
   const hasAttackSurfaceAgent = subagents.some(
-    (s) => s.type === "attack-surface"
+    (s) => s.type === "attack-surface",
   );
 
   // If no attack surface agent saved, try to reconstruct from logs

--- a/src/core/session/loader.ts
+++ b/src/core/session/loader.ts
@@ -41,6 +41,8 @@ export interface SavedSubagentData {
   toolCallCount?: number;
   stepCount?: number;
   findingsCount?: number;
+  status?: string;
+  error?: string;
   messages: SavedMessage[];
 }
 
@@ -86,7 +88,7 @@ export interface UISubagent {
   target: string;
   messages: UIMessage[];
   createdAt: Date;
-  status: "pending" | "completed" | "failed";
+  status: "pending" | "completed" | "failed" | "canceled";
 }
 
 /**
@@ -238,9 +240,16 @@ function loadSubagents(rootPath: string): UISubagent[] {
 
       const messages = convertMessagesToUI(data.messages, timestamp);
 
-      // Determine status based on agent type and available data
-      let status: "pending" | "completed" | "failed" = "completed";
-      if (data.findingsCount !== undefined && data.findingsCount < 0) {
+      // Determine status: prefer explicit status field, fall back to findingsCount heuristic
+      let status: "pending" | "completed" | "failed" | "canceled" = "completed";
+      if (data.status === "canceled") {
+        status = "canceled";
+      } else if (data.status === "failed") {
+        status = "failed";
+      } else if (data.status === "completed") {
+        status = "completed";
+      } else if (data.findingsCount !== undefined && data.findingsCount < 0) {
+        // Legacy heuristic for files without explicit status
         status = "failed";
       }
 

--- a/src/tui/components/session-view/index.tsx
+++ b/src/tui/components/session-view/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useKeyboard } from "@opentui/react";
 import { RGBA } from "@opentui/core";
 import { useRoute } from "../../context/route";
@@ -23,6 +23,7 @@ import type {
   SubAgentStreamEvent,
 } from "../../../core/agent/orchestrator/orchestrator";
 import type { MetaVulnerabilityTestResult } from "../../../core/agent/metaTestingAgent";
+import { saveAgentMessages } from "../../../core/agent/metaTestingAgent";
 import { existsSync } from "fs";
 import { exec } from "child_process";
 import { SpinnerDots } from "../sprites";
@@ -65,6 +66,44 @@ export default function SessionView({
     useState<AbortController | null>(null);
   const [startTime, setStartTime] = useState<Date | null>(null);
   const [hasStarted, setHasStarted] = useState(false);
+
+  // Per-agent abort controllers for individual kill capability
+  const agentAbortControllers = useRef<Map<string, AbortController>>(new Map());
+
+  const killAgent = useCallback((agentId: string) => {
+    const controller = agentAbortControllers.current.get(agentId);
+    if (controller) {
+      controller.abort();
+      setSubagents(prev => {
+        const agent = prev.find(a => a.id === agentId);
+        // Persist canceled status to disk so it survives session resume
+        if (agent && session) {
+          try {
+            const messages = agent.messages.map(m => ({
+              role: m.role,
+              content: m.content,
+            }));
+            saveAgentMessages(
+              session.rootPath,
+              agent.id,
+              messages,
+              {
+                target: agent.target,
+                status: "canceled",
+              }
+            );
+          } catch (_e) {
+            // Best-effort persistence — don't break the kill flow
+          }
+        }
+        return prev.map(a =>
+          a.id === agentId
+            ? { ...a, status: "canceled" as const }
+            : a
+        );
+      });
+    }
+  }, [session]);
 
   // Load session on mount
   useEffect(() => {
@@ -170,6 +209,9 @@ export default function SessionView({
           session: execSession,
           sessionConfig: execSession.config,
           abortSignal: controller.signal,
+          onAgentAbortControllerCreated: (agentId, abortCtrl) => {
+            agentAbortControllers.current.set(agentId, abortCtrl);
+          },
 
           // Use onStepFinish for UI updates (like metavuln agent does)
           // This is more reliable than raw stream chunks which can be interrupted
@@ -598,7 +640,7 @@ export default function SessionView({
           ) => {
             setSubagents((prev) =>
               prev.map((sub) =>
-                sub.id === agentId
+                sub.id === agentId && sub.status !== "canceled"
                   ? {
                       ...sub,
                       status: agentResult.error ? "failed" : "completed",
@@ -728,6 +770,7 @@ export default function SessionView({
       isCompleted={isCompleted}
       onBack={handleBack}
       onViewReport={openReport}
+      onKillAgent={killAgent}
     />
   );
 }

--- a/src/tui/components/swarm-dashboard/index.tsx
+++ b/src/tui/components/swarm-dashboard/index.tsx
@@ -510,7 +510,7 @@ function AgentCard({ agent, focused, onSelect }: AgentCardProps) {
       flexBasis={0}
       minWidth={40}
       border
-      borderColor={focused ? greenBullet : dimText}
+      borderColor={agent.status === "cancelled" ? cancelledColor : focused ? greenBullet : dimText}
       backgroundColor={darkBg}
       flexDirection="column"
       padding={1}
@@ -538,7 +538,9 @@ function AgentCard({ agent, focused, onSelect }: AgentCardProps) {
 
       {/* Activity / Status - single line */}
       <box height={1} overflow="hidden">
-        {agent.status === "pending" ? (
+        {agent.status === "cancelled" ? (
+          <text fg={cancelledColor}>⊘ Cancelled</text>
+        ) : agent.status === "pending" ? (
           <SpinnerDots label={lastActivity} fg="green" />
         ) : (
           <text fg={agent.status === "completed" ? greenBullet : dimText}>
@@ -604,16 +606,20 @@ interface MetricsBarProps {
   totalFindings: number;
   activeAgents: number;
   totalAgents: number;
+  cancelledAgents: number;
   duration: number;
   isExecuting: boolean;
+  showKillHint?: boolean;
 }
 
 function MetricsBar({
   totalFindings,
   activeAgents,
   totalAgents,
+  cancelledAgents,
   duration,
   isExecuting,
+  showKillHint,
 }: MetricsBarProps) {
   // Format duration as mm:ss
   const formattedDuration = useMemo(() => {
@@ -642,12 +648,27 @@ function MetricsBar({
           <span fg={isExecuting ? greenBullet : dimText}>{activeAgents}</span>
           <span fg={dimText}>/{totalAgents} active</span>
         </text>
+        {cancelledAgents > 0 && (
+          <>
+            <text fg={dimText}>|</text>
+            <text>
+              <span fg={cancelledColor}>{cancelledAgents}</span>
+              <span fg={dimText}> cancelled</span>
+            </text>
+          </>
+        )}
         <text fg={dimText}>|</text>
         <text fg={dimText}>{formattedDuration}</text>
       </box>
 
       {/* Right: Keyboard hints */}
       <box flexDirection="row" gap={2}>
+        {showKillHint && (
+          <text>
+            <span fg={greenBullet}>[K]</span>
+            <span fg={dimText}> Kill</span>
+          </text>
+        )}
         <text>
           <span fg={greenBullet}>[D]</span>
           <span fg={dimText}> Discovery</span>
@@ -679,6 +700,7 @@ function AgentDetailView({ agent, onBack }: AgentDetailViewProps) {
     pending: greenBullet,
     completed: greenBullet,
     failed: RGBA.fromInts(244, 67, 54, 255),
+    cancelled: cancelledColor,
   }[agent.status];
 
   return (

--- a/src/tui/components/swarm-dashboard/index.tsx
+++ b/src/tui/components/swarm-dashboard/index.tsx
@@ -151,7 +151,7 @@ export default function SwarmDashboard({
         return;
       }
 
-      // Kill focused agent with K or Delete
+      // Kill focused agent with X or Delete
       if (
         (key.name === "x" || key.name === "X" || key.name === "delete") &&
         pentestAgents[focusedIndex]

--- a/src/tui/components/swarm-dashboard/index.tsx
+++ b/src/tui/components/swarm-dashboard/index.tsx
@@ -22,7 +22,7 @@ export type Subagent = {
   target: string;
   messages: DisplayMessage[];
   createdAt: Date;
-  status: "pending" | "completed" | "failed";
+  status: "pending" | "completed" | "failed" | "cancelled";
 };
 
 interface SwarmDashboardProps {
@@ -33,6 +33,7 @@ interface SwarmDashboardProps {
   isCompleted?: boolean;
   onBack?: () => void;
   onViewReport?: () => void;
+  onKillAgent?: (agentId: string) => void;
   children?: React.ReactNode;
 }
 
@@ -44,6 +45,7 @@ export default function SwarmDashboard({
   isCompleted,
   onBack,
   onViewReport,
+  onKillAgent,
 }: SwarmDashboardProps) {
   const [currentView, setCurrentView] = useState<"overview" | "detail">(
     "overview"
@@ -82,6 +84,7 @@ export default function SwarmDashboard({
       totalFindings: findingsCount,
       activeAgents: subagents.filter((s) => s.status === "pending").length,
       completedAgents: subagents.filter((s) => s.status === "completed").length,
+      cancelledAgents: subagents.filter((s) => s.status === "cancelled").length,
       totalAgents: pentestAgents.length,
       duration: startTime
         ? Math.floor((Date.now() - startTime.getTime()) / 1000)
@@ -145,6 +148,18 @@ export default function SwarmDashboard({
       if (key.name === "up") {
         // Move up 2 (2-column grid)
         setFocusedIndex((prev) => Math.max(prev - 2, 0));
+        return;
+      }
+
+      // Kill focused agent with K or Delete
+      if (
+        (key.name === "k" || key.name === "K" || key.name === "delete") &&
+        pentestAgents[focusedIndex]
+      ) {
+        const focusedAgent = pentestAgents[focusedIndex]!;
+        if (focusedAgent.status === "pending") {
+          onKillAgent?.(focusedAgent.id);
+        }
         return;
       }
 
@@ -264,8 +279,10 @@ export default function SwarmDashboard({
         totalFindings={metrics.totalFindings}
         activeAgents={metrics.activeAgents}
         totalAgents={metrics.totalAgents}
+        cancelledAgents={metrics.cancelledAgents}
         duration={metrics.duration}
         isExecuting={isExecuting}
+        showKillHint={!!onKillAgent}
       />
     </box>
   );
@@ -445,17 +462,21 @@ interface AgentCardProps {
   onSelect: () => void;
 }
 
+const cancelledColor = RGBA.fromInts(186, 104, 200, 255);
+
 function AgentCard({ agent, focused, onSelect }: AgentCardProps) {
   const statusIcon = {
     pending: "◐",
     completed: "✓",
     failed: "✗",
+    cancelled: "⊘",
   }[agent.status];
 
   const statusColor = {
     pending: greenBullet,
     completed: greenBullet,
     failed: RGBA.fromInts(244, 67, 54, 255),
+    cancelled: cancelledColor,
   }[agent.status];
 
   // Get brief activity from last message (truncated to single line)

--- a/src/tui/components/swarm-dashboard/index.tsx
+++ b/src/tui/components/swarm-dashboard/index.tsx
@@ -22,7 +22,7 @@ export type Subagent = {
   target: string;
   messages: DisplayMessage[];
   createdAt: Date;
-  status: "pending" | "completed" | "failed" | "cancelled";
+  status: "pending" | "completed" | "failed" | "canceled";
 };
 
 interface SwarmDashboardProps {
@@ -84,7 +84,7 @@ export default function SwarmDashboard({
       totalFindings: findingsCount,
       activeAgents: subagents.filter((s) => s.status === "pending").length,
       completedAgents: subagents.filter((s) => s.status === "completed").length,
-      cancelledAgents: subagents.filter((s) => s.status === "cancelled").length,
+      canceledAgents: subagents.filter((s) => s.status === "canceled").length,
       totalAgents: pentestAgents.length,
       duration: startTime
         ? Math.floor((Date.now() - startTime.getTime()) / 1000)
@@ -153,7 +153,7 @@ export default function SwarmDashboard({
 
       // Kill focused agent with K or Delete
       if (
-        (key.name === "k" || key.name === "K" || key.name === "delete") &&
+        (key.name === "x" || key.name === "X" || key.name === "delete") &&
         pentestAgents[focusedIndex]
       ) {
         const focusedAgent = pentestAgents[focusedIndex]!;
@@ -279,7 +279,7 @@ export default function SwarmDashboard({
         totalFindings={metrics.totalFindings}
         activeAgents={metrics.activeAgents}
         totalAgents={metrics.totalAgents}
-        cancelledAgents={metrics.cancelledAgents}
+        canceledAgents={metrics.canceledAgents}
         duration={metrics.duration}
         isExecuting={isExecuting}
         showKillHint={!!onKillAgent}
@@ -462,21 +462,19 @@ interface AgentCardProps {
   onSelect: () => void;
 }
 
-const cancelledColor = RGBA.fromInts(186, 104, 200, 255);
-
 function AgentCard({ agent, focused, onSelect }: AgentCardProps) {
   const statusIcon = {
     pending: "◐",
     completed: "✓",
     failed: "✗",
-    cancelled: "⊘",
+    canceled: "⊘",
   }[agent.status];
 
   const statusColor = {
     pending: greenBullet,
     completed: greenBullet,
     failed: RGBA.fromInts(244, 67, 54, 255),
-    cancelled: cancelledColor,
+    canceled: dimText,
   }[agent.status];
 
   // Get brief activity from last message (truncated to single line)
@@ -510,7 +508,7 @@ function AgentCard({ agent, focused, onSelect }: AgentCardProps) {
       flexBasis={0}
       minWidth={40}
       border
-      borderColor={agent.status === "cancelled" ? cancelledColor : focused ? greenBullet : dimText}
+      borderColor={focused ? greenBullet : dimText}
       backgroundColor={darkBg}
       flexDirection="column"
       padding={1}
@@ -538,8 +536,8 @@ function AgentCard({ agent, focused, onSelect }: AgentCardProps) {
 
       {/* Activity / Status - single line */}
       <box height={1} overflow="hidden">
-        {agent.status === "cancelled" ? (
-          <text fg={cancelledColor}>⊘ Cancelled</text>
+        {agent.status === "canceled" ? (
+          <text fg={dimText}>⊘ Canceled</text>
         ) : agent.status === "pending" ? (
           <SpinnerDots label={lastActivity} fg="green" />
         ) : (
@@ -606,7 +604,7 @@ interface MetricsBarProps {
   totalFindings: number;
   activeAgents: number;
   totalAgents: number;
-  cancelledAgents: number;
+  canceledAgents: number;
   duration: number;
   isExecuting: boolean;
   showKillHint?: boolean;
@@ -616,7 +614,7 @@ function MetricsBar({
   totalFindings,
   activeAgents,
   totalAgents,
-  cancelledAgents,
+  canceledAgents,
   duration,
   isExecuting,
   showKillHint,
@@ -648,12 +646,12 @@ function MetricsBar({
           <span fg={isExecuting ? greenBullet : dimText}>{activeAgents}</span>
           <span fg={dimText}>/{totalAgents} active</span>
         </text>
-        {cancelledAgents > 0 && (
+        {canceledAgents > 0 && (
           <>
             <text fg={dimText}>|</text>
             <text>
-              <span fg={cancelledColor}>{cancelledAgents}</span>
-              <span fg={dimText}> cancelled</span>
+              <span fg={dimText}>{canceledAgents}</span>
+              <span fg={dimText}> canceled</span>
             </text>
           </>
         )}
@@ -665,7 +663,7 @@ function MetricsBar({
       <box flexDirection="row" gap={2}>
         {showKillHint && (
           <text>
-            <span fg={greenBullet}>[K]</span>
+            <span fg={greenBullet}>[X]</span>
             <span fg={dimText}> Kill</span>
           </text>
         )}
@@ -700,7 +698,7 @@ function AgentDetailView({ agent, onBack }: AgentDetailViewProps) {
     pending: greenBullet,
     completed: greenBullet,
     failed: RGBA.fromInts(244, 67, 54, 255),
-    cancelled: cancelledColor,
+    canceled: dimText,
   }[agent.status];
 
   return (


### PR DESCRIPTION
Implements #96.

Adds ability to kill subagent in pentest dashboard with the x key.

[Screen recording](https://drive.google.com/file/d/1bvWzxVkDBz9b5tekwVcYXMLpvoClYEJ7/view?usp=sharing)