### PR TITLE
Show hint message for non-command input on home screen

### DIFF
--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -7,7 +7,7 @@
  * - Centered command input with inline autocomplete
  */
 
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { RGBA } from "@opentui/core";
 import { useTerminalDimensions } from "@opentui/react";
 import { PetriAnimation } from "./petri-animation";
@@ -38,11 +38,20 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
   const { setInputValue } = useInput();
   const { promptRef } = useFocus();
 
+  const [hintMessage, setHintMessage] = useState<string | null>(null);
+
   const handleSubmit = useCallback((value: string) => {
-    // Commands are handled by PromptInput, this only gets non-command text
-    onStartSession(value);
+    // Commands are handled by PromptInput; non-command text shows a hint
+    setHintMessage("Type /help to get started");
     setInputValue("");
-  }, [onStartSession, setInputValue]);
+  }, [setInputValue]);
+
+  // Auto-clear hint after 3 seconds
+  useEffect(() => {
+    if (!hintMessage) return;
+    const timer = setTimeout(() => setHintMessage(null), 3000);
+    return () => clearTimeout(timer);
+  }, [hintMessage]);
 
   const handleCommandExecute = useCallback(async (command: string) => {
     await executeCommand(command);
@@ -100,6 +109,13 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
           onCommandExecute={handleCommandExecute}
           showPromptIndicator={true}
         />
+
+        {/* Hint message */}
+        {hintMessage && (
+          <box marginTop={1}>
+            <text fg={creamText}>{hintMessage}</text>
+          </box>
+        )}
 
         {/* Help text */}
         <box marginTop={1}>


### PR DESCRIPTION
## Summary
- When users type normal text (not a `/command`) on the home screen and press Enter, the app previously crashed by calling `onStartSession()` which attempted to create an exploration session
- Now shows a friendly **"Type /help to get started"** hint message in cream text that auto-clears after 3 seconds
- Input is cleared on submit, and `/commands` continue working as before

## Changes
- **`src/tui/components/chat/home-view.tsx`**: Replaced `onStartSession(value)` call in `handleSubmit` with a hint message via `useState`/`useEffect`

## Test plan
- [x] On the home screen, type normal text (e.g. "Hi") and press Enter → hint appears, app does not crash
- [x] Hint auto-disappears after ~3 seconds
- [x] Typing `/help` still works as expected
- [x] Other `/commands` with autocomplete still function normally