### PR TITLE
Fix:Pass API key from default config file(#122)

### DIFF
--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -61,13 +61,13 @@ export async function get(): Promise<Config> {
   return {
     ...parsedConfig,
     version: version,
-    openAiAPIKey: process.env.OPENAI_API_KEY,
-    anthropicAPIKey: process.env.ANTHROPIC_API_KEY,
-    openRouterAPIKey: process.env.OPENROUTER_API_KEY,
-    bedrockAPIKey: process.env.BEDROCK_API_KEY,
-    daytonaAPIKey: process.env.DAYTONA_API_KEY,
-    daytonaOrgId: process.env.DAYTONA_ORG_ID,
-    runloopAPIKey: process.env.RUNLOOP_API_KEY,
+    openAiAPIKey: process.env.OPENAI_API_KEY ?? parsedConfig.openAiAPIKey,
+    anthropicAPIKey: process.env.ANTHROPIC_API_KEY ?? parsedConfig.anthropicAPIKey,
+    openRouterAPIKey: process.env.OPENROUTER_API_KEY ?? parsedConfig.openRouterAPIKey,
+    bedrockAPIKey: process.env.BEDROCK_API_KEY ?? parsedConfig.bedrockAPIKey,
+    daytonaAPIKey: process.env.DAYTONA_API_KEY ?? parsedConfig.daytonaAPIKey,
+    daytonaOrgId: process.env.DAYTONA_ORG_ID ?? parsedConfig.daytonaOrgId,
+    runloopAPIKey: process.env.RUNLOOP_API_KEY ?? parsedConfig.runloopAPIKey,
   };
 }
 


### PR DESCRIPTION
Currently, the application defaults to `undefined` if environment variables like `OPENAI_API_KEY` are not set. This PR updates the configuration logic to fall back to the values saved in the user's file if the env variables are missing.

## Changes
- Modified [src/core/config/config.ts](cci:7://file:///Users/wetinee-macbook-air/Downloads/apex/src/core/config/config.ts:0:0-0:0) to use nullish coalescing (`??`) for all API key providers.
- Priority remains: **Environment Variable** > **Config File**.

Fixes #122 