### PR TITLE
Add ESLint rule to auto-remove unused imports

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "dotenv": "^17.2.3",
         "eslint": "^10.0.0",
         "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-unused-imports": "^4.4.1",
         "prettier": "^3.8.1",
         "typescript-eslint": "^8.55.0",
         "vitest": "^2.1.8",
@@ -690,6 +691,8 @@
     "eslint": ["eslint@10.0.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.0", "@eslint/config-helpers": "^0.5.2", "@eslint/core": "^1.1.0", "@eslint/plugin-kit": "^0.6.0", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.0", "eslint-visitor-keys": "^5.0.0", "espree": "^11.1.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.1.1", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-O0piBKY36YSJhlFSG8p9VUdPV/SxxS4FYDWVpr/9GJuMaepzwlf4J8I4ov1b+ySQfDTPhc3DtLaxcT1fN0yqCg=="],
 
     "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
+
+    "eslint-plugin-unused-imports": ["eslint-plugin-unused-imports@4.4.1", "", { "peerDependencies": { "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0", "eslint": "^10.0.0 || ^9.0.0 || ^8.0.0" }, "optionalPeers": ["@typescript-eslint/eslint-plugin"] }, "sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ=="],
 
     "eslint-scope": ["eslint-scope@9.1.0", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-CkWE42hOJsNj9FJRaoMX9waUFYhqY4jmyLFdAdzZr6VaCg3ynLYx4WnOdkaIifGfH4gsUcBTn4OZbHXkpLD0FQ=="],
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,17 +1,22 @@
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import prettierConfig from "eslint-config-prettier";
+import unusedImports from "eslint-plugin-unused-imports";
 
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
+    plugins: {
+      "unused-imports": unusedImports,
+    },
     rules: {
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-unused-vars": "off",
       "@typescript-eslint/no-namespace": "off",
       "@typescript-eslint/no-require-imports": "off",
       "no-unused-vars": "off",
+      "unused-imports/no-unused-imports": "error",
       "no-useless-assignment": "off",
       "no-useless-escape": "off",
       "react-hooks/exhaustive-deps": "off",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "dotenv": "^17.2.3",
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-unused-imports": "^4.4.1",
     "prettier": "^3.8.1",
     "typescript-eslint": "^8.55.0",
     "vitest": "^2.1.8"

--- a/src/core/agent/authenticationSubagent/agent.ts
+++ b/src/core/agent/authenticationSubagent/agent.ts
@@ -17,7 +17,6 @@ import { z } from "zod";
 import { streamResponse, type AIModel } from "../../ai";
 import { type AIAuthConfig } from "../../ai/utils";
 import { Logger } from "../logger";
-import { Session } from "../../session";
 import { join } from "path";
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 

--- a/src/core/agent/authenticationSubagent/integration.ts
+++ b/src/core/agent/authenticationSubagent/integration.ts
@@ -10,7 +10,6 @@ import type { Session } from "../../session";
 import { runAuthenticationSubagent } from "./agent";
 import { AuthStateManager } from "./authStateManager";
 import type {
-  AuthenticationSubagentInput,
   AuthenticationSubagentResult,
   AuthCredentials,
   AuthFlowHints,

--- a/src/core/agent/benchmark/comparisonAgent.ts
+++ b/src/core/agent/benchmark/comparisonAgent.ts
@@ -1,10 +1,9 @@
-import { hasToolCall, stepCountIs, tool } from "ai";
+import { stepCountIs, tool } from "ai";
 import { z } from "zod";
 import { streamResponse, type AIModel } from "../../ai";
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "fs";
 import { join } from "path";
-import type { ComparisonResult, ActualFinding } from "./types";
-import { detectOSAndEnhancePrompt } from "../utils";
+import type { ComparisonResult } from "./types";
 
 const COMPARISON_SYSTEM_PROMPT = `
 You are a security findings comparison agent. Your role is to compare expected security findings against actual findings from a penetration test and provide an accurate assessment.

--- a/src/core/agent/benchmark/remote/daytona-benchmark.ts
+++ b/src/core/agent/benchmark/remote/daytona-benchmark.ts
@@ -7,7 +7,6 @@ import {
   extractPACEFlags,
   detectMultipleFlagsInArtifacts,
 } from "../flag-detector";
-import { runComparisonAgent } from "../comparisonAgent";
 import { runStreamlinedPentest } from "../../thoroughPentestAgent/streamlined";
 import type { BenchmarkResults } from "../types";
 import type {

--- a/src/core/agent/driverModeAgent/index.ts
+++ b/src/core/agent/driverModeAgent/index.ts
@@ -18,7 +18,6 @@ import type { VulnerabilityClass } from "../orchestrator/types";
 import {
   runMetaVulnerabilityTestAgent,
   type MetaVulnerabilityTestInput,
-  type MetaVulnerabilityTestResult,
 } from "../metaTestingAgent/metaVulnerabilityTestAgent";
 import type { DisplayMessage } from "../../../tui/components/agent-display";
 

--- a/src/core/agent/metaTestingAgent/pocTools.ts
+++ b/src/core/agent/metaTestingAgent/pocTools.ts
@@ -7,7 +7,6 @@
  */
 
 import { tool } from "ai";
-import { z } from "zod";
 import { join } from "path";
 import { promisify } from "util";
 import { exec } from "child_process";
@@ -15,7 +14,6 @@ import {
   existsSync,
   writeFileSync,
   chmodSync,
-  unlinkSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -23,7 +21,6 @@ import {
 } from "fs";
 import { nanoid } from "nanoid";
 import { Logger } from "../logger";
-import type { Session } from "../../session";
 import type {
   CreatePocInput,
   CreatePocResult,

--- a/src/core/agent/metaTestingAgent/promptOptimizer.ts
+++ b/src/core/agent/metaTestingAgent/promptOptimizer.ts
@@ -16,11 +16,7 @@ import { z } from "zod";
 import { join } from "path";
 import { existsSync, writeFileSync, readFileSync } from "fs";
 import { Logger } from "../logger";
-import type {
-  Adaptation,
-  PromptOptimization,
-  MetaTestingSessionInfo,
-} from "./types";
+import type { PromptOptimization, MetaTestingSessionInfo } from "./types";
 import { loadAdaptations } from "./planMemory";
 
 const BASE_OPTIMIZATION_PROMPT = `

--- a/src/core/agent/sessions/index.ts
+++ b/src/core/agent/sessions/index.ts
@@ -1,19 +1,6 @@
-import {
-  mkdirSync,
-  existsSync,
-  writeFileSync,
-  readFileSync,
-  readdirSync,
-  statSync,
-  rmSync,
-} from "fs";
+import { mkdirSync } from "fs";
 import { join } from "path";
-import { homedir } from "os";
-import { randomBytes } from "crypto";
-import {
-  RateLimiter,
-  type RateLimiterConfig,
-} from "../../services/rateLimiter";
+
 import { Identifier } from "../../id/id";
 
 /**

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -1,9 +1,5 @@
-import { createAnthropic } from "@ai-sdk/anthropic";
 import type { AnthropicMessagesModelId } from "@ai-sdk/anthropic/internal";
-import { createOpenAI } from "@ai-sdk/openai";
 import type { OpenAIChatModelId } from "@ai-sdk/openai/internal";
-import { createOpenRouter } from "@openrouter/ai-sdk-provider";
-import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
 import {
   generateText,
   Output,
@@ -15,7 +11,6 @@ import {
   type StreamTextOnStepFinishCallback,
   type StreamTextResult,
   type TextStreamPart,
-  type ToolCallRepairFunction,
   type ToolChoice,
   type ToolSet,
 } from "ai";
@@ -24,7 +19,6 @@ import {
   checkIfContextLengthError,
   createSummarizationStream,
   getProviderModel,
-  summarizeConversation,
   type AIAuthConfig,
 } from "./utils";
 

--- a/src/core/messages/index.ts
+++ b/src/core/messages/index.ts
@@ -1,7 +1,5 @@
 import fs from "fs";
 import { z } from "zod";
-import { nanoid } from "nanoid";
-import { ModelMessageObject } from "./types";
 import type { ToolMessage, Message } from "./types";
 import { Identifier } from "../id/id";
 import { Storage } from "../storage";

--- a/src/lib/cvss/calculator.ts
+++ b/src/lib/cvss/calculator.ts
@@ -5,21 +5,13 @@
  * Reference: https://www.first.org/cvss/v4-0/specification-document
  */
 
-import type {
-  CVSS4Metrics,
-  CVSS4Score,
-  CVSS4ScoreType,
-  CVSS4Severity,
-} from "./types";
+import type { CVSS4Metrics, CVSS4Score, CVSS4ScoreType } from "./types";
 import { getSeverityFromScore } from "./types";
 import {
   MACROVECTOR_LOOKUP,
   METRIC_LEVELS,
   MAX_SEVERITY,
-  MAX_COMPOSED,
-  NO_IMPACT_METRICS,
   STEP,
-  EPSILON,
 } from "./macrovector-scores";
 
 // =============================================================================

--- a/src/tui/components/agent-display.tsx
+++ b/src/tui/components/agent-display.tsx
@@ -1,4 +1,4 @@
-import { RGBA, StyledText } from "@opentui/core";
+import { RGBA } from "@opentui/core";
 import { SpinnerDots } from "./sprites";
 import { useState, memo } from "react";
 import type { Message } from "../../core/messages/types";

--- a/src/tui/components/alert-dialog.tsx
+++ b/src/tui/components/alert-dialog.tsx
@@ -3,7 +3,6 @@ import {
   useTerminalDimensions,
   useRenderer,
 } from "@opentui/react";
-import { RGBA } from "@opentui/core";
 import type { JSX } from "react";
 
 export interface AlertDialogProps {

--- a/src/tui/components/box-logo.tsx
+++ b/src/tui/components/box-logo.tsx
@@ -1,6 +1,3 @@
-import React from "react";
-import { RGBA } from "@opentui/core";
-
 /**
  * A box-style logo component that renders the letter "A" using colored block characters
  * in a green gradient style, similar to the Minecraft-style pixel art logo.

--- a/src/tui/components/chat/header.tsx
+++ b/src/tui/components/chat/header.tsx
@@ -5,7 +5,7 @@
  * Layout: MODE | target URL | endpoints found | findings documented | tokens | tool calls
  */
 
-import { colors, formatTokenCount, getTierColor } from "../../theme";
+import { colors, getTierColor } from "../../theme";
 import type {
   OperatorMode,
   OperatorStage,

--- a/src/tui/components/chat/lib/petri-simulation.ts
+++ b/src/tui/components/chat/lib/petri-simulation.ts
@@ -10,7 +10,7 @@
  * - Sensing: Agents sense trail ahead and turn toward stronger concentrations
  */
 
-import { vec2, add, mul, norm, fromAngle, type Vec2 } from "./play-core/vec2";
+import { vec2, add, fromAngle, type Vec2 } from "./play-core/vec2";
 import { clamp, random, mod } from "./play-core/num";
 
 // Simulation parameters (tuned for terminal)

--- a/src/tui/components/chat/tool-message.tsx
+++ b/src/tui/components/chat/tool-message.tsx
@@ -16,7 +16,7 @@ import {
   getResultSummary,
   type ResultSummary,
 } from "../shared/result-registry";
-import { isToolMessage, type ToolDisplayMessage } from "../shared/type-guards";
+import { isToolMessage } from "../shared/type-guards";
 import type { DisplayMessage } from "../agent-display";
 
 // Tool category icons

--- a/src/tui/components/commands/config-dialog.tsx
+++ b/src/tui/components/commands/config-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import AlertDialog from "../alert-dialog";
 import { config } from "../../../core/config";
 import type { Config } from "../../../core/config/config";

--- a/src/tui/components/commands/models-display-old.tsx
+++ b/src/tui/components/commands/models-display-old.tsx
@@ -3,8 +3,6 @@ import { RGBA } from "@opentui/core";
 import { type ModelInfo } from "../../../core/ai";
 import { useAgent } from "../../context/agent";
 import { useEffect, useState } from "react";
-import type { Config } from "../../../core/config/config";
-import { config } from "../../../core/config";
 import Input from "../input";
 import { AVAILABLE_MODELS } from "../../../core/ai/models";
 import { useRoute } from "../../context/route";

--- a/src/tui/components/commands/provider-selection.tsx
+++ b/src/tui/components/commands/provider-selection.tsx
@@ -1,6 +1,6 @@
 import { useKeyboard } from "@opentui/react";
 import { RGBA } from "@opentui/core";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useRoute } from "../../context/route";
 import { useConfig } from "../../context/config";
 import {

--- a/src/tui/components/header.tsx
+++ b/src/tui/components/header.tsx
@@ -1,6 +1,5 @@
 import { useAgent } from "../context/agent";
 import { AgentStatus } from "./footer";
-import { SpinnerDots } from "./sprites";
 
 export default function Header() {
   const { thinking } = useAgent();

--- a/src/tui/components/session-view/index.tsx
+++ b/src/tui/components/session-view/index.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { useKeyboard } from "@opentui/react";
 import { RGBA } from "@opentui/core";
 import { useRoute } from "../../context/route";
 import { useAgent } from "../../context/agent";
@@ -10,10 +9,7 @@ import SwarmDashboard, {
 import DriverDashboard from "../driver-dashboard";
 import OperatorDashboard from "../operator-dashboard";
 import { Session } from "../../../core/session";
-import {
-  loadSessionState,
-  type UISubagent,
-} from "../../../core/session/loader";
+import { loadSessionState } from "../../../core/session/loader";
 import {
   runStreamlinedPentest,
   type StreamlinedPentestProgress,

--- a/src/tui/components/shared/approval-prompt.tsx
+++ b/src/tui/components/shared/approval-prompt.tsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 import { useKeyboard } from "@opentui/react";
 import { colors, getTierColor } from "../../theme";
 import { getToolSummary } from "./tool-registry";
-import type { PendingApproval, PermissionTier } from "../../../core/operator";
+import type { PendingApproval } from "../../../core/operator";
 
 interface InlineApprovalPromptProps {
   approval: PendingApproval;

--- a/src/tui/components/shared/tool-renderer.tsx
+++ b/src/tui/components/shared/tool-renderer.tsx
@@ -10,7 +10,7 @@ import { colors } from "../../theme";
 import { AsciiSpinner } from "./ascii-spinner";
 import { getToolSummary } from "./tool-registry";
 import { getResultSummary, type ResultSummary } from "./result-registry";
-import { isToolMessage, type ToolDisplayMessage } from "./type-guards";
+import { isToolMessage } from "./type-guards";
 import type { DisplayMessage } from "../agent-display";
 
 interface ToolRendererProps {

--- a/src/tui/components/sprites.tsx
+++ b/src/tui/components/sprites.tsx
@@ -1,5 +1,5 @@
 import { RGBA } from "@opentui/core";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 
 // Global animation tick - shared by all spinners to avoid excessive re-renders
 let globalTick = 0;

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  useContext,
-  useState,
-  useMemo,
-  useCallback,
-  useEffect,
-} from "react";
+import { createContext, useContext, useMemo, useCallback } from "react";
 import type { ReactNode } from "react";
 import { CommandRouter } from "../command-router";
 import {

--- a/src/tui/context/dialog.tsx
+++ b/src/tui/context/dialog.tsx
@@ -9,7 +9,6 @@ import {
   useState,
   useCallback,
   useRef,
-  useEffect,
   type ReactNode,
 } from "react";
 import { RGBA, type Renderable } from "@opentui/core";

--- a/src/tui/context/keybinding.tsx
+++ b/src/tui/context/keybinding.tsx
@@ -1,6 +1,6 @@
 import type { KeyEvent } from "@opentui/core";
 import { useKeyboard } from "@opentui/react";
-import { createContext, useContext, useState, type ReactNode } from "react";
+import { createContext, useContext, type ReactNode } from "react";
 import {
   createKeybindings,
   Keybind,

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -20,7 +20,7 @@ import { type RoutePath, RouteProvider, useRoute } from "./context/route";
 import { ResponsibleUseDisclosure } from "./components/responsible-use-disclosure";
 import { hasAnyProviderConfigured } from "../core/providers";
 import { SessionProvider } from "./context/session";
-import { InputProvider, useInput } from "./context/input";
+import { InputProvider } from "./context/input";
 import { FocusProvider, useFocus } from "./context/focus";
 import { DialogProvider, useDialog } from "./context/dialog";
 import ShortcutsDialog from "./components/commands/shortcuts-dialog";

--- a/src/tui/keybindings/registry.ts
+++ b/src/tui/keybindings/registry.ts
@@ -1,5 +1,5 @@
 import { useRenderer } from "@opentui/react";
-import { useRoute, type Route } from "../context/route";
+import { useRoute } from "../context/route";
 import { useFocus } from "../context/focus";
 import { useInput } from "../context/input";
 

--- a/src/tui/session/index.tsx
+++ b/src/tui/session/index.tsx
@@ -49,8 +49,6 @@ import type {
   EndpointStatus,
   VerifiedVuln,
   Credential,
-  Hypothesis,
-  Evidence,
 } from "../components/operator-dashboard/types";
 import ToolsPanel from "../components/tools-panel";
 import type { ToolsetState } from "../../core/toolset";
@@ -62,11 +60,7 @@ import { adaptSwarmStateForOperator } from "./swarm-to-operator-adapter";
 import { Header } from "../components/chat/header";
 import { MessageList } from "../components/chat/message-list";
 import { InputArea } from "../components/chat/input-area";
-import {
-  Sidebar,
-  useSidebarState,
-  type SidebarState,
-} from "../components/chat/sidebar";
+import { Sidebar, useSidebarState } from "../components/chat/sidebar";
 
 // ============================================
 // Types


### PR DESCRIPTION
Adds `eslint-plugin-unused-imports` so `eslint --fix` automatically strips unused imports.

Depends on #134.