### PR TITLE
Fix discovery panel message duplication (#147)

### DIFF
--- a/src/tui/components/session-view/index.tsx
+++ b/src/tui/components/session-view/index.tsx
@@ -293,8 +293,9 @@ export default function SessionView({
                 step.usage.outputTokens ?? 0,
               );
 
-            // Update messages from step data (same pattern as onPentestAgentStream)
-            const { text, toolCalls, toolResults } = step;
+            // Update messages from step data — only tool calls and tool results.
+            // Text content is handled solely by onDiscoveryStream to avoid duplication.
+            const { toolCalls, toolResults } = step;
 
             setSubagents((prev) => {
               const idx = prev.findIndex(
@@ -305,24 +306,6 @@ export default function SessionView({
               const updated = [...prev];
               const subagent = updated[idx]!;
               const newMessages = [...subagent.messages];
-
-              // Add text content
-              if (text && text.trim()) {
-                setThinking(false);
-                const lastMsg = newMessages[newMessages.length - 1];
-                if (lastMsg && lastMsg.role === "assistant") {
-                  newMessages[newMessages.length - 1] = {
-                    ...lastMsg,
-                    content: (lastMsg.content || "") + text,
-                  };
-                } else {
-                  newMessages.push({
-                    role: "assistant",
-                    content: text,
-                    createdAt: new Date(),
-                  });
-                }
-              }
 
               // Add tool calls (check if not already exists to avoid duplicates)
               if (toolCalls && toolCalls.length > 0) {
@@ -525,7 +508,7 @@ export default function SessionView({
                 updated[idx] = { ...subagent, messages: newMessages };
                 return updated;
               });
-            } else if (chunk.type === "step-finish") {
+            } else if (chunk.type === "finish-step") {
               // Reset accumulated text at step boundaries
               currentDiscoveryText = "";
             }


### PR DESCRIPTION
Assistant messages in the discovery panel were prefixed with all previous messages concatenated. Two independent bugs caused this:

**1. Wrong stream event type (`"step-finish"` → `"finish-step"`)**
The stream handler checked for `"step-finish"` to reset the text accumulator between steps, but the AI SDK `fullStream` uses `"finish-step"` for step completion events ([docs](https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol), [ref](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text)). The check never matched, so `currentDiscoveryText` accumulated across the entire session.

Pentest agents weren't affected because the orchestrator manually constructs `SubAgentStreamEvent` objects with `type: "step-finish"` in its `onStepFinish` callback, bypassing the raw stream event name.

**2. Dual-write between `onDiscoveryStream` and `onDiscoveryStepFinish`**
Both handlers wrote assistant text to the same message array. The stream handler set content via accumulated deltas, then `onDiscoveryStepFinish` appended `step.text` (the same content) to the last assistant message.

With only fix 1, the old step's text briefly flashes in a new message bubble before being overwritten by the next step's first streaming token. Removing text-writing from `onDiscoveryStepFinish` eliminates that flash — tool call/result handling and token tracking remain.

Closes #147