### PR TITLE
feat: add /exit command with /quit and /q aliases

### DIFF
--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -311,17 +311,15 @@ export const commands: CommandConfig[] = [
     },
   },
 
-  // Add more commands here...
-  // Example:
-  // {
-  //   name: "clear",
-  //   aliases: ["cls"],
-  //   description: "Clear the screen",
-  //   category: "General",
-  //   handler: async (args, ctx) => {
-  //     ctx.clearScreen?.();
-  //   },
-  // },
+  {
+    name: "exit",
+    aliases: ["quit", "q"],
+    description: "Exit the application",
+    category: "General",
+    handler: async () => {
+      process.kill(process.pid, "SIGINT");
+    },
+  },
 ];
 
 /**


### PR DESCRIPTION
Adds a standard `/exit` command (also `/quit` and `/q`) to gracefully exit the app. Uses the existing SIGINT cleanup path so the terminal is properly restored on exit. Closes #140.


https://github.com/user-attachments/assets/92e87c71-80a2-45b5-93c5-27b0692fb344