### PR TITLE
fix: auto-scroll sessions browser on keyboard navigation (#156)

### DIFF
--- a/src/tui/components/commands/help-dialog.tsx
+++ b/src/tui/components/commands/help-dialog.tsx
@@ -9,6 +9,7 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useKeyboard, useTerminalDimensions } from "@opentui/react";
 import { RGBA, ScrollBoxRenderable } from "@opentui/core";
+import { scrollToIndex } from "../../utils/scroll";
 import { useCommand } from "../../context/command";
 import { useRoute } from "../../context/route";
 import type { CommandConfig } from "../../command-registry";
@@ -58,26 +59,12 @@ export default function HelpDialog() {
 
   // Scroll to keep selected item in view
   useEffect(() => {
-    if (!scrollboxRef.current || flatCommands.length === 0) return;
-
-    const scroll = scrollboxRef.current;
-    const viewportHeight = scroll.height;
-    const children = scroll.getChildren();
-
-    const selectedCmd = flatCommands[selectedIndex];
-    if (!selectedCmd) return;
-
-    const target = children.find((child) => child.id === selectedCmd.name);
-    if (!target) return;
-
-    const targetVisualY = target.y - scroll.y;
-    const targetHeight = target.height || 1;
-
-    if (targetVisualY + targetHeight > viewportHeight) {
-      scroll.scrollBy(targetVisualY - viewportHeight + targetHeight + 1);
-    } else if (targetVisualY < 0) {
-      scroll.scrollBy(targetVisualY);
-    }
+    scrollToIndex(
+      scrollboxRef.current,
+      selectedIndex,
+      flatCommands,
+      (cmd) => cmd.name,
+    );
   }, [selectedIndex, flatCommands]);
 
   const handleClose = () => {

--- a/src/tui/components/commands/sessions-browser.tsx
+++ b/src/tui/components/commands/sessions-browser.tsx
@@ -150,7 +150,7 @@ export default function SessionsBrowser() {
       const newIndex =
         selectedIndex > 0 ? selectedIndex - 1 : visualOrderSessions.length - 1;
       setSelectedIndex(newIndex);
-      scrollToIndex(scroll.current, newIndex, visualOrderSessions);
+      scrollToIndex(scroll.current, newIndex, visualOrderSessions, (s) => s.id);
       return;
     }
 
@@ -159,7 +159,7 @@ export default function SessionsBrowser() {
       const newIndex =
         selectedIndex < visualOrderSessions.length - 1 ? selectedIndex + 1 : 0;
       setSelectedIndex(newIndex);
-      scrollToIndex(scroll.current, newIndex, visualOrderSessions);
+      scrollToIndex(scroll.current, newIndex, visualOrderSessions, (s) => s.id);
       return;
     }
   });

--- a/src/tui/components/commands/sessions-browser.tsx
+++ b/src/tui/components/commands/sessions-browser.tsx
@@ -7,7 +7,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useKeyboard } from "@opentui/react";
 import { exec } from "child_process";
 import { existsSync } from "fs";
-import { RGBA, ScrollBoxRenderable } from "@opentui/core";
+import { RGBA, Renderable, ScrollBoxRenderable } from "@opentui/core";
 import { useRoute } from "../../context/route";
 import { useSession } from "../../context/session";
 import { useFocus } from "../../context/focus";
@@ -42,6 +42,49 @@ export default function SessionsBrowser() {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [statusMessage, setStatusMessage] = useState("");
   const scroll = useRef<ScrollBoxRenderable>(null);
+
+  function scrollToIndex(index: number, list: EnrichedSession[]) {
+    if (!scroll.current || list.length === 0) return;
+
+    const targetSession = list[index];
+    if (!targetSession) return;
+
+    // Find the target element by searching through date groups
+    let target: Renderable | undefined;
+    for (const group of scroll.current.getChildren()) {
+      const found = group
+        .getChildren()
+        .find((child) => child.id === targetSession.id);
+      if (found) {
+        target = found;
+        break;
+      }
+    }
+
+    if (!target) return;
+
+    const targetVisualY = target.y - scroll.current.y;
+    const viewportHeight = scroll.current.height;
+    const targetHeight = target.height || 1;
+
+    if (index === 0) {
+      scroll.current.scrollTo(0);
+      return;
+    }
+
+    if (index === list.length - 1) {
+      scroll.current.scrollTo(Infinity);
+      return;
+    }
+
+    if (targetVisualY + targetHeight > viewportHeight) {
+      scroll.current.scrollBy(
+        targetVisualY - viewportHeight + targetHeight + 1,
+      );
+    } else if (targetVisualY < 0) {
+      scroll.current.scrollBy(targetVisualY);
+    }
+  }
 
   // Clamp selected index when list changes
   useEffect(() => {
@@ -146,13 +189,19 @@ export default function SessionsBrowser() {
 
     // Up
     if (key.name === "up" && visualOrderSessions.length > 0) {
-      setSelectedIndex((i) => (i > 0 ? i - 1 : visualOrderSessions.length - 1));
+      const newIndex =
+        selectedIndex > 0 ? selectedIndex - 1 : visualOrderSessions.length - 1;
+      setSelectedIndex(newIndex);
+      scrollToIndex(newIndex, visualOrderSessions);
       return;
     }
 
     // Down
     if (key.name === "down" && visualOrderSessions.length > 0) {
-      setSelectedIndex((i) => (i < visualOrderSessions.length - 1 ? i + 1 : 0));
+      const newIndex =
+        selectedIndex < visualOrderSessions.length - 1 ? selectedIndex + 1 : 0;
+      setSelectedIndex(newIndex);
+      scrollToIndex(newIndex, visualOrderSessions);
       return;
     }
   });

--- a/src/tui/components/commands/sessions-browser.tsx
+++ b/src/tui/components/commands/sessions-browser.tsx
@@ -7,7 +7,8 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useKeyboard } from "@opentui/react";
 import { exec } from "child_process";
 import { existsSync } from "fs";
-import { RGBA, Renderable, ScrollBoxRenderable } from "@opentui/core";
+import { RGBA, ScrollBoxRenderable } from "@opentui/core";
+import { scrollToIndex } from "../../utils/scroll";
 import { useRoute } from "../../context/route";
 import { useSession } from "../../context/session";
 import { useFocus } from "../../context/focus";
@@ -42,49 +43,6 @@ export default function SessionsBrowser() {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [statusMessage, setStatusMessage] = useState("");
   const scroll = useRef<ScrollBoxRenderable>(null);
-
-  function scrollToIndex(index: number, list: EnrichedSession[]) {
-    if (!scroll.current || list.length === 0) return;
-
-    const targetSession = list[index];
-    if (!targetSession) return;
-
-    // Find the target element by searching through date groups
-    let target: Renderable | undefined;
-    for (const group of scroll.current.getChildren()) {
-      const found = group
-        .getChildren()
-        .find((child) => child.id === targetSession.id);
-      if (found) {
-        target = found;
-        break;
-      }
-    }
-
-    if (!target) return;
-
-    const targetVisualY = target.y - scroll.current.y;
-    const viewportHeight = scroll.current.height;
-    const targetHeight = target.height || 1;
-
-    if (index === 0) {
-      scroll.current.scrollTo(0);
-      return;
-    }
-
-    if (index === list.length - 1) {
-      scroll.current.scrollTo(Infinity);
-      return;
-    }
-
-    if (targetVisualY + targetHeight > viewportHeight) {
-      scroll.current.scrollBy(
-        targetVisualY - viewportHeight + targetHeight + 1,
-      );
-    } else if (targetVisualY < 0) {
-      scroll.current.scrollBy(targetVisualY);
-    }
-  }
 
   // Clamp selected index when list changes
   useEffect(() => {
@@ -192,7 +150,7 @@ export default function SessionsBrowser() {
       const newIndex =
         selectedIndex > 0 ? selectedIndex - 1 : visualOrderSessions.length - 1;
       setSelectedIndex(newIndex);
-      scrollToIndex(newIndex, visualOrderSessions);
+      scrollToIndex(scroll.current, newIndex, visualOrderSessions);
       return;
     }
 
@@ -201,7 +159,7 @@ export default function SessionsBrowser() {
       const newIndex =
         selectedIndex < visualOrderSessions.length - 1 ? selectedIndex + 1 : 0;
       setSelectedIndex(newIndex);
-      scrollToIndex(newIndex, visualOrderSessions);
+      scrollToIndex(scroll.current, newIndex, visualOrderSessions);
       return;
     }
   });

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -204,7 +204,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
       const newIndex =
         selectedIndex > 0 ? selectedIndex - 1 : visualOrderSessions.length - 1;
       setSelectedIndex(newIndex);
-      scrollToIndex(scroll.current, newIndex, visualOrderSessions);
+      scrollToIndex(scroll.current, newIndex, visualOrderSessions, (s) => s.id);
       return;
     }
 
@@ -213,7 +213,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
       const newIndex =
         selectedIndex < visualOrderSessions.length - 1 ? selectedIndex + 1 : 0;
       setSelectedIndex(newIndex);
-      scrollToIndex(scroll.current, newIndex, visualOrderSessions);
+      scrollToIndex(scroll.current, newIndex, visualOrderSessions, (s) => s.id);
       return;
     }
 

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -8,7 +8,8 @@ import { useFocus } from "../../context/focus";
 import { Session } from "../../../core/session";
 import { Storage } from "../../../core/storage";
 import { Dialog } from "../../context/dialog";
-import { Renderable, ScrollBoxRenderable } from "@opentui/core";
+import { ScrollBoxRenderable } from "@opentui/core";
+import { scrollToIndex } from "../../utils/scroll";
 
 interface SessionsDisplayProps {
   onClose: () => void;
@@ -65,57 +66,6 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
         setTimeout(() => setStatusMessage(""), 2000);
       }
     });
-  }
-
-  function scrollToIndex(index: number, list: Session.SessionInfo[]) {
-    if (!scroll.current || list.length === 0) return;
-
-    const targetSession = list[index];
-    if (!targetSession) return;
-
-    // Find the target element by searching through date groups
-    let target: Renderable | undefined;
-    for (const group of scroll.current.getChildren()) {
-      const found = group
-        .getChildren()
-        .find((child) => child.id === targetSession.id);
-      if (found) {
-        target = found;
-        break;
-      }
-    }
-
-    if (!target) return;
-
-    // Calculate target's visual position relative to the scroll container
-    const targetVisualY = target.y - scroll.current.y;
-    const viewportHeight = scroll.current.height;
-    const targetHeight = target.height || 1;
-
-    // If first item, always scroll to top
-    if (index === 0) {
-      scroll.current.scrollTo(0);
-      return;
-    }
-
-    // If last item, scroll to bottom
-    if (index === list.length - 1) {
-      scroll.current.scrollTo(Infinity);
-      return;
-    }
-
-    // Check if target is below visible area (accounting for its height)
-    if (targetVisualY + targetHeight > viewportHeight) {
-      // Scroll down by the amount needed to bring target into view
-      scroll.current.scrollBy(
-        targetVisualY - viewportHeight + targetHeight + 1,
-      );
-    }
-    // Check if target is above visible area
-    else if (targetVisualY < 0) {
-      // Scroll up by the amount needed (targetVisualY is negative)
-      scroll.current.scrollBy(targetVisualY);
-    }
   }
 
   // Filter sessions based on search term
@@ -254,7 +204,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
       const newIndex =
         selectedIndex > 0 ? selectedIndex - 1 : visualOrderSessions.length - 1;
       setSelectedIndex(newIndex);
-      scrollToIndex(newIndex, visualOrderSessions);
+      scrollToIndex(scroll.current, newIndex, visualOrderSessions);
       return;
     }
 
@@ -263,7 +213,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
       const newIndex =
         selectedIndex < visualOrderSessions.length - 1 ? selectedIndex + 1 : 0;
       setSelectedIndex(newIndex);
-      scrollToIndex(newIndex, visualOrderSessions);
+      scrollToIndex(scroll.current, newIndex, visualOrderSessions);
       return;
     }
 

--- a/src/tui/components/tools-panel/index.tsx
+++ b/src/tui/components/tools-panel/index.tsx
@@ -9,6 +9,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useKeyboard, useTerminalDimensions } from "@opentui/react";
 import { RGBA, ScrollBoxRenderable } from "@opentui/core";
+import { scrollToIndex } from "../../utils/scroll";
 import {
   ALL_TOOLS,
   getCategoryDisplayName,
@@ -69,33 +70,9 @@ export default function ToolsPanel({
     }
   }, [filteredTools.length, selectedIndex]);
 
-  // Scroll to keep selected item in view (only when out of view)
+  // Scroll to keep selected item in view
   useEffect(() => {
-    if (!scrollboxRef.current || filteredTools.length === 0) return;
-
-    const scroll = scrollboxRef.current;
-    const viewportHeight = scroll.height;
-    const children = scroll.getChildren();
-
-    // Find the selected item element
-    const selectedTool = filteredTools[selectedIndex];
-    if (!selectedTool) return;
-
-    const target = children.find((child) => child.id === selectedTool.id);
-    if (!target) return;
-
-    // Calculate target's visual position relative to the scroll container
-    const targetVisualY = target.y - scroll.y;
-    const targetHeight = target.height || 1;
-
-    // Check if target is below visible area
-    if (targetVisualY + targetHeight > viewportHeight) {
-      scroll.scrollBy(targetVisualY - viewportHeight + targetHeight + 1);
-    }
-    // Check if target is above visible area
-    else if (targetVisualY < 0) {
-      scroll.scrollBy(targetVisualY);
-    }
+    scrollToIndex(scrollboxRef.current, selectedIndex, filteredTools, (t) => t.id);
   }, [selectedIndex, filteredTools]);
 
   // Check if a tool is enabled

--- a/src/tui/components/tools-panel/index.tsx
+++ b/src/tui/components/tools-panel/index.tsx
@@ -72,7 +72,12 @@ export default function ToolsPanel({
 
   // Scroll to keep selected item in view
   useEffect(() => {
-    scrollToIndex(scrollboxRef.current, selectedIndex, filteredTools, (t) => t.id);
+    scrollToIndex(
+      scrollboxRef.current,
+      selectedIndex,
+      filteredTools,
+      (t) => t.id,
+    );
   }, [selectedIndex, filteredTools]);
 
   // Check if a tool is enabled

--- a/src/tui/utils/scroll.ts
+++ b/src/tui/utils/scroll.ts
@@ -2,32 +2,33 @@ import { Renderable, ScrollBoxRenderable } from "@opentui/core";
 
 /**
  * Scrolls a ScrollBox to keep the item at `index` visible.
- * Finds the target element by matching `id` within nested child groups
- * (e.g., date-grouped session lists).
+ * Searches for the target element by ID among direct children
+ * and one level of nesting (e.g., date-grouped lists).
  */
-export function scrollToIndex<T extends { id: string }>(
+export function scrollToIndex<T>(
   scrollBox: ScrollBoxRenderable | null,
   index: number,
   list: T[],
+  getId: (item: T) => string,
 ) {
   if (!scrollBox || list.length === 0) return;
 
-  const target = findChildById(scrollBox, list[index]?.id);
+  const item = list[index];
+  if (!item) return;
+
+  const target = findChildById(scrollBox, getId(item));
   if (!target) return;
 
-  // First item — scroll to top
   if (index === 0) {
     scrollBox.scrollTo(0);
     return;
   }
 
-  // Last item — scroll to bottom
   if (index === list.length - 1) {
     scrollBox.scrollTo(Infinity);
     return;
   }
 
-  // Scroll into view if outside the viewport
   const targetVisualY = target.y - scrollBox.y;
   const viewportHeight = scrollBox.height;
   const targetHeight = target.height || 1;
@@ -41,9 +42,11 @@ export function scrollToIndex<T extends { id: string }>(
 
 function findChildById(
   scrollBox: ScrollBoxRenderable,
-  id: string | undefined,
+  id: string,
 ): Renderable | undefined {
-  if (!id) return undefined;
+  const direct = scrollBox.getChildren().find((child) => child.id === id);
+  if (direct) return direct;
+
   for (const group of scrollBox.getChildren()) {
     const found = group.getChildren().find((child) => child.id === id);
     if (found) return found;

--- a/src/tui/utils/scroll.ts
+++ b/src/tui/utils/scroll.ts
@@ -1,0 +1,52 @@
+import { Renderable, ScrollBoxRenderable } from "@opentui/core";
+
+/**
+ * Scrolls a ScrollBox to keep the item at `index` visible.
+ * Finds the target element by matching `id` within nested child groups
+ * (e.g., date-grouped session lists).
+ */
+export function scrollToIndex<T extends { id: string }>(
+  scrollBox: ScrollBoxRenderable | null,
+  index: number,
+  list: T[],
+) {
+  if (!scrollBox || list.length === 0) return;
+
+  const target = findChildById(scrollBox, list[index]?.id);
+  if (!target) return;
+
+  // First item — scroll to top
+  if (index === 0) {
+    scrollBox.scrollTo(0);
+    return;
+  }
+
+  // Last item — scroll to bottom
+  if (index === list.length - 1) {
+    scrollBox.scrollTo(Infinity);
+    return;
+  }
+
+  // Scroll into view if outside the viewport
+  const targetVisualY = target.y - scrollBox.y;
+  const viewportHeight = scrollBox.height;
+  const targetHeight = target.height || 1;
+
+  if (targetVisualY + targetHeight > viewportHeight) {
+    scrollBox.scrollBy(targetVisualY - viewportHeight + targetHeight + 1);
+  } else if (targetVisualY < 0) {
+    scrollBox.scrollBy(targetVisualY);
+  }
+}
+
+function findChildById(
+  scrollBox: ScrollBoxRenderable,
+  id: string | undefined,
+): Renderable | undefined {
+  if (!id) return undefined;
+  for (const group of scrollBox.getChildren()) {
+    const found = group.getChildren().find((child) => child.id === id);
+    if (found) return found;
+  }
+  return undefined;
+}


### PR DESCRIPTION
The `/sessions` browser wasn't scrolling to keep the selected item visible when navigating with arrow keys. Adapted the existing `scrollToIndex` logic from `sessions-display` so the scrollbox follows the selection — including wrapping from last→first and first→last.

Fixes #156


https://github.com/user-attachments/assets/14644b88-6a84-4f1e-b7d4-7a0e4239d3e4