### PR TITLE
fix: resolve responsible use disclosure race condition

### DIFF
--- a/src/tui/components/responsible-use-disclosure.tsx
+++ b/src/tui/components/responsible-use-disclosure.tsx
@@ -1,5 +1,4 @@
 import { useKeyboard } from "@opentui/react";
-import { useRef } from "react";
 import { useTheme } from "../theme";
 
 export function ResponsibleUseDisclosure({
@@ -7,19 +6,9 @@ export function ResponsibleUseDisclosure({
 }: {
   onAccept: () => void;
 }) {
-  const processedRef = useRef(false);
-
   useKeyboard((key) => {
-    // Enter key accepts the policy - prevent duplicate processing
-    if (
-      (key.name === "return" || key.name === "enter") &&
-      !processedRef.current
-    ) {
-      processedRef.current = true;
-      // Small delay to ensure state updates process correctly
-      setTimeout(() => {
-        onAccept();
-      }, 50);
+    if (key.name === "return" || key.name === "enter") {
+      onAccept();
     }
   });
 

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -130,31 +130,23 @@ function AppContent({
   const { refocusPrompt } = useFocus();
   const { setExternalDialogOpen } = useDialog();
 
-  // First check: responsible use disclosure
-  if (
-    !config.data.responsibleUseAccepted &&
-    route.data.type === "base" &&
-    route.data.path !== "disclosure"
-  ) {
-    route.navigate({
-      type: "base",
-      path: "disclosure",
-    });
-  }
+  useEffect(() => {
+    if (route.data.type !== "base") return;
 
-  // Second check: provider configuration (only if not already on providers page)
-  if (
-    config.data.responsibleUseAccepted &&
-    !hasAnyProviderConfigured(config.data) &&
-    route.data.type === "base" &&
-    route.data.path !== "providers" &&
-    route.data.path !== "disclosure"
-  ) {
-    route.navigate({
-      type: "base",
-      path: "providers",
-    });
-  }
+    if (
+      !config.data.responsibleUseAccepted &&
+      route.data.path !== "disclosure"
+    ) {
+      route.navigate({ type: "base", path: "disclosure" });
+    } else if (
+      config.data.responsibleUseAccepted &&
+      !hasAnyProviderConfigured(config.data) &&
+      route.data.path !== "providers" &&
+      route.data.path !== "disclosure"
+    ) {
+      route.navigate({ type: "base", path: "providers" });
+    }
+  }, [config.data.responsibleUseAccepted, route.data]);
 
   // Auto-clear the exit warning after 1 second
   useEffect(() => {


### PR DESCRIPTION
The disclosure screen ignores Enter because of a race between route navigation and async config state updates. The navigation guards in AppContent were bare if-statements during render, so when handleAcceptPolicy updated config and navigated to "home", the re-render would see the new route before the config update propagated, bouncing right back to "disclosure".

Moved the guards into useEffect so they evaluate after state has settled, and removed the setTimeout/useRef workaround from #131.

Fixes #126


https://github.com/user-attachments/assets/ac2343c1-cea0-43c9-af45-97fcaf5dc158