### PR TITLE
Implemented improved error handling

### DIFF
--- a/src/core/logger/index.ts
+++ b/src/core/logger/index.ts
@@ -38,13 +38,15 @@ function pruneErrorLog(): void {
     const lines = raw.split("\n");
 
     const kept: string[] = [];
+    let keeping = true;
     for (const line of lines) {
       const match = TIMESTAMP_RE.exec(line);
       if (match) {
-        const ts = new Date(match[1]!).getTime();
-        if (ts < cutoff) continue;
+        keeping = new Date(match[1]!).getTime() >= cutoff;
       }
-      kept.push(line);
+      if (keeping) {
+        kept.push(line);
+      }
     }
 
     writeFileSync(ERROR_LOG_PATH, kept.join("\n"), "utf8");

--- a/src/core/logger/index.ts
+++ b/src/core/logger/index.ts
@@ -1,5 +1,12 @@
 import { sessions, type SessionInfo } from "../session";
-import { appendFileSync, existsSync, mkdirSync } from "fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "fs";
+import os from "os";
 import path from "path";
 
 export enum LogLevel {
@@ -8,6 +15,72 @@ export enum LogLevel {
   DEBUG = "DEBUG",
   WARN = "WARN",
   LOG = "LOG",
+}
+
+const ERROR_LOG_PATH = path.join(os.homedir(), ".pensar", "error.log");
+const RETENTION_DAYS = 7;
+const TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2}T[\d:.]+Z) - /;
+
+let hasPruned = false;
+
+/**
+ * Drop log entries older than RETENTION_DAYS. Runs at most once per process.
+ */
+function pruneErrorLog(): void {
+  if (hasPruned) return;
+  hasPruned = true;
+
+  try {
+    if (!existsSync(ERROR_LOG_PATH)) return;
+
+    const cutoff = Date.now() - RETENTION_DAYS * 86_400_000;
+    const raw = readFileSync(ERROR_LOG_PATH, "utf8");
+    const lines = raw.split("\n");
+
+    const kept: string[] = [];
+    for (const line of lines) {
+      const match = TIMESTAMP_RE.exec(line);
+      if (match) {
+        const ts = new Date(match[1]!).getTime();
+        if (ts < cutoff) continue;
+      }
+      kept.push(line);
+    }
+
+    writeFileSync(ERROR_LOG_PATH, kept.join("\n"), "utf8");
+  } catch {
+    // Don't let pruning failures break anything
+  }
+}
+
+/**
+ * Append an error entry to ~/.pensar/error.log.
+ * Safe to call from anywhere — no session required.
+ *
+ * @param error  The error value (Error instance or anything stringifiable)
+ * @param source Optional tag identifying the subsystem, e.g. "TUI", "CORE"
+ */
+export function writeErrorLog(error: unknown, source?: string): void {
+  try {
+    pruneErrorLog();
+
+    const dir = path.dirname(ERROR_LOG_PATH);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    const timestamp = new Date().toISOString();
+    const tag = source ? `[${source}] ` : "";
+    const message =
+      error instanceof Error
+        ? `${error.message}\n${error.stack ?? ""}`
+        : String(error);
+    const entry = `${timestamp} - [ERROR] ${tag}${message}\n`;
+
+    appendFileSync(ERROR_LOG_PATH, entry, "utf8");
+  } catch {
+    // Last resort — don't throw from the error logger
+  }
 }
 
 export class Logger {

--- a/src/tui/components/error-boundary.tsx
+++ b/src/tui/components/error-boundary.tsx
@@ -1,0 +1,82 @@
+import React, { useCallback } from "react";
+import { useToast } from "../context/toast";
+import { writeErrorLog } from "../../core/logger";
+
+const MAX_ERRORS = 3;
+const ERROR_WINDOW_MS = 5000;
+
+interface ErrorBoundaryInnerProps {
+  children?: React.ReactNode;
+  onError: (message: string) => void;
+}
+
+interface ErrorBoundaryInnerState {
+  hasError: boolean;
+  errorTimestamps: number[];
+  halted: boolean;
+}
+
+class ErrorBoundaryInner extends React.Component<
+  ErrorBoundaryInnerProps,
+  ErrorBoundaryInnerState
+> {
+  override state: ErrorBoundaryInnerState = {
+    hasError: false,
+    errorTimestamps: [],
+    halted: false,
+  };
+
+  static getDerivedStateFromError(): Pick<ErrorBoundaryInnerState, "hasError"> {
+    return { hasError: true };
+  }
+
+  override componentDidCatch(error: Error) {
+    console.error("[ErrorBoundary]", error);
+    writeErrorLog(error, "TUI");
+    this.props.onError(error.message);
+
+    const now = Date.now();
+    const recent = [...this.state.errorTimestamps, now].filter(
+      (t) => now - t < ERROR_WINDOW_MS,
+    );
+
+    if (recent.length >= MAX_ERRORS) {
+      this.setState({ halted: true, errorTimestamps: recent });
+      return;
+    }
+
+    this.setState({ hasError: false, errorTimestamps: recent });
+  }
+
+  override render() {
+    if (this.state.halted) {
+      return null;
+    }
+    if (this.state.hasError) {
+      return null;
+    }
+    return this.props.children;
+  }
+}
+
+/**
+ * Functional wrapper that bridges the useToast hook into the class-based
+ * ErrorBoundary. Uses React.createElement to avoid @opentui/react JSX
+ * type mismatch with class components.
+ */
+export function ErrorBoundary({ children }: { children: React.ReactNode }) {
+  const { toast } = useToast();
+
+  const handleError = useCallback(
+    (message: string) => {
+      toast(message, "error");
+    },
+    [toast],
+  );
+
+  return React.createElement(
+    ErrorBoundaryInner,
+    { onError: handleError },
+    children,
+  );
+}

--- a/src/tui/components/error-boundary.tsx
+++ b/src/tui/components/error-boundary.tsx
@@ -41,7 +41,10 @@ class ErrorBoundaryInner extends React.Component<
     );
 
     if (recent.length >= MAX_ERRORS) {
-      this.setState({ halted: true, errorTimestamps: recent });
+      this.props.onError(
+        "Too many errors in quick succession — UI recovery halted.",
+      );
+      this.setState({ halted: true, hasError: false, errorTimestamps: recent });
       return;
     }
 
@@ -50,9 +53,6 @@ class ErrorBoundaryInner extends React.Component<
 
   override render() {
     if (this.state.halted) {
-      return null;
-    }
-    if (this.state.hasError) {
       return null;
     }
     return this.props.children;

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -13,13 +13,7 @@ const providerNames: Record<string, string> = {
   local: "Local LLM",
 };
 
-const providerOrder = [
-  "anthropic",
-  "openai",
-  "openrouter",
-  "bedrock",
-  "local",
-];
+const providerOrder = ["anthropic", "openai", "openrouter", "bedrock", "local"];
 
 type NavigationItem =
   | { type: "provider"; provider: string }
@@ -352,20 +346,30 @@ export function ModelPicker({
                   {(() => {
                     const isUrlFocused =
                       navigationItems[focusedIndex]?.type === "local-input" &&
-                      (navigationItems[focusedIndex] as { type: "local-input"; field: LocalInputField }).field === "url";
+                      (
+                        navigationItems[focusedIndex] as {
+                          type: "local-input";
+                          field: LocalInputField;
+                        }
+                      ).field === "url";
                     const isUrlEditing = editingLocalField === "url";
                     if (isUrlEditing) {
                       return (
                         <box flexDirection="row">
-                          <text fg={colors.primary}>  URL: </text>
+                          <text fg={colors.primary}> URL: </text>
                           <input
                             focused={true}
                             value={localUrl}
                             backgroundColor="transparent"
                             cursorColor={colors.textMuted}
-                            onInput={(v) => setLocalUrl(typeof v === "string" ? v : "")}
+                            onInput={(v) =>
+                              setLocalUrl(typeof v === "string" ? v : "")
+                            }
                             onPaste={(event) => {
-                              const cleaned = String(event.text).replace(/\r?\n/g, "");
+                              const cleaned = String(event.text).replace(
+                                /\r?\n/g,
+                                "",
+                              );
                               setLocalUrl((prev) => `${prev}${cleaned}`);
                             }}
                             onSubmit={finishEditing}
@@ -374,7 +378,9 @@ export function ModelPicker({
                       );
                     }
                     return (
-                      <text fg={isUrlFocused ? colors.primary : colors.textMuted}>
+                      <text
+                        fg={isUrlFocused ? colors.primary : colors.textMuted}
+                      >
                         {`  URL: ${localUrl || "(press Enter to set)"}`}
                       </text>
                     );
@@ -384,20 +390,30 @@ export function ModelPicker({
                   {(() => {
                     const isModelFocused =
                       navigationItems[focusedIndex]?.type === "local-input" &&
-                      (navigationItems[focusedIndex] as { type: "local-input"; field: LocalInputField }).field === "model";
+                      (
+                        navigationItems[focusedIndex] as {
+                          type: "local-input";
+                          field: LocalInputField;
+                        }
+                      ).field === "model";
                     const isModelEditing = editingLocalField === "model";
                     if (isModelEditing) {
                       return (
                         <box flexDirection="row">
-                          <text fg={colors.primary}>  Model: </text>
+                          <text fg={colors.primary}> Model: </text>
                           <input
                             focused={true}
                             value={localModelName}
                             backgroundColor="transparent"
                             cursorColor={colors.textMuted}
-                            onInput={(v) => setLocalModelName(typeof v === "string" ? v : "")}
+                            onInput={(v) =>
+                              setLocalModelName(typeof v === "string" ? v : "")
+                            }
                             onPaste={(event) => {
-                              const cleaned = String(event.text).replace(/\r?\n/g, "");
+                              const cleaned = String(event.text).replace(
+                                /\r?\n/g,
+                                "",
+                              );
                               setLocalModelName((prev) => `${prev}${cleaned}`);
                             }}
                             onSubmit={finishEditing}
@@ -406,7 +422,9 @@ export function ModelPicker({
                       );
                     }
                     return (
-                      <text fg={isModelFocused ? colors.primary : colors.textMuted}>
+                      <text
+                        fg={isModelFocused ? colors.primary : colors.textMuted}
+                      >
                         {`  Model: ${localModelName || "(press Enter to set)"}`}
                       </text>
                     );

--- a/src/tui/components/toast.tsx
+++ b/src/tui/components/toast.tsx
@@ -1,0 +1,91 @@
+import { useTerminalDimensions } from "@opentui/react";
+import { useEffect, useState } from "react";
+import type { RGBA } from "@opentui/core";
+import { useTheme } from "../theme";
+import { type ToastVariant, useToast } from "../context/toast";
+
+const VARIANT_ICONS: Record<ToastVariant, string> = {
+  default: "●",
+  error: "✖",
+  warn: "⚠",
+};
+
+function variantColor(variant: ToastVariant, colors: { error: RGBA; warning: RGBA; info: RGBA }): RGBA {
+  switch (variant) {
+    case "error":
+      return colors.error;
+    case "warn":
+      return colors.warning;
+    default:
+      return colors.info;
+  }
+}
+
+function ToastItem({
+  message,
+  variant,
+  duration,
+  onDismiss,
+}: {
+  message: string;
+  variant: ToastVariant;
+  duration: number;
+  onDismiss: () => void;
+}) {
+  const { colors } = useTheme();
+  const [visible, setVisible] = useState(true);
+  const accent = variantColor(variant, colors);
+
+  useEffect(() => {
+    const fadeTimer = setTimeout(() => setVisible(false), duration - 300);
+    return () => clearTimeout(fadeTimer);
+  }, [duration]);
+
+  if (!visible) return null;
+
+  return (
+    <box
+      flexDirection="row"
+      gap={1}
+      paddingLeft={1}
+      paddingRight={1}
+      border={["left"]}
+      borderColor={accent}
+      backgroundColor={colors.backgroundPanel}
+      onMouseUp={async () => onDismiss()}
+    >
+      <text fg={accent}>{VARIANT_ICONS[variant]}</text>
+      <text fg={colors.text}>{message}</text>
+    </box>
+  );
+}
+
+export function ToastContainer() {
+  const { toasts, dismiss } = useToast();
+  const dims = useTerminalDimensions();
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <box
+      position="absolute"
+      right={1}
+      top={0}
+      flexDirection="column"
+      gap={0}
+      alignItems="flex-end"
+      maxWidth={Math.min(60, dims.width - 4)}
+      zIndex={9999}
+    >
+      {toasts.map((t) => (
+        <ToastItem
+          key={t.id}
+          message={t.message}
+          variant={t.variant}
+          duration={t.duration}
+          onDismiss={() => dismiss(t.id)}
+        />
+      ))}
+    </box>
+  );
+}

--- a/src/tui/components/toast.tsx
+++ b/src/tui/components/toast.tsx
@@ -10,7 +10,10 @@ const VARIANT_ICONS: Record<ToastVariant, string> = {
   warn: "⚠",
 };
 
-function variantColor(variant: ToastVariant, colors: { error: RGBA; warning: RGBA; info: RGBA }): RGBA {
+function variantColor(
+  variant: ToastVariant,
+  colors: { error: RGBA; warning: RGBA; info: RGBA },
+): RGBA {
   switch (variant) {
     case "error":
       return colors.error;

--- a/src/tui/components/toast.tsx
+++ b/src/tui/components/toast.tsx
@@ -1,5 +1,4 @@
 import { useTerminalDimensions } from "@opentui/react";
-import { useEffect, useState } from "react";
 import type { RGBA } from "@opentui/core";
 import { useTheme } from "../theme";
 import { type ToastVariant, useToast } from "../context/toast";
@@ -27,24 +26,14 @@ function variantColor(
 function ToastItem({
   message,
   variant,
-  duration,
   onDismiss,
 }: {
   message: string;
   variant: ToastVariant;
-  duration: number;
   onDismiss: () => void;
 }) {
   const { colors } = useTheme();
-  const [visible, setVisible] = useState(true);
   const accent = variantColor(variant, colors);
-
-  useEffect(() => {
-    const fadeTimer = setTimeout(() => setVisible(false), duration - 300);
-    return () => clearTimeout(fadeTimer);
-  }, [duration]);
-
-  if (!visible) return null;
 
   return (
     <box
@@ -55,7 +44,7 @@ function ToastItem({
       border={["left"]}
       borderColor={accent}
       backgroundColor={colors.backgroundPanel}
-      onMouseUp={async () => onDismiss()}
+      onMouseUp={() => onDismiss()}
     >
       <text fg={accent}>{VARIANT_ICONS[variant]}</text>
       <text fg={colors.text}>{message}</text>
@@ -85,7 +74,6 @@ export function ToastContainer() {
           key={t.id}
           message={t.message}
           variant={t.variant}
-          duration={t.duration}
           onDismiss={() => dismiss(t.id)}
         />
       ))}

--- a/src/tui/context/toast.tsx
+++ b/src/tui/context/toast.tsx
@@ -1,0 +1,66 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useMemo,
+  type ReactNode,
+} from "react";
+
+export type ToastVariant = "default" | "error" | "warn";
+
+export interface Toast {
+  id: number;
+  message: string;
+  variant: ToastVariant;
+  duration: number;
+}
+
+interface ToastContextValue {
+  toasts: Toast[];
+  toast: (message: string, variant?: ToastVariant, duration?: number) => void;
+  dismiss: (id: number) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+let nextId = 0;
+
+const DEFAULT_DURATION: Record<ToastVariant, number> = {
+  default: 3000,
+  warn: 4000,
+  error: 5000,
+};
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const toast = useCallback(
+    (message: string, variant: ToastVariant = "default", duration?: number) => {
+      const id = nextId++;
+      const ms = duration ?? DEFAULT_DURATION[variant];
+      setToasts((prev) => [...prev, { id, message, variant, duration: ms }]);
+      setTimeout(() => dismiss(id), ms);
+    },
+    [dismiss],
+  );
+
+  const value = useMemo(
+    () => ({ toasts, toast, dismiss }),
+    [toasts, toast, dismiss],
+  );
+
+  return (
+    <ToastContext.Provider value={value}>{children}</ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast() must be used within <ToastProvider>");
+  return ctx;
+}

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -22,6 +22,9 @@ import { SessionProvider } from "./context/session";
 import { InputProvider } from "./context/input";
 import { FocusProvider, useFocus } from "./context/focus";
 import { DialogProvider, useDialog } from "./context/dialog";
+import { ToastProvider } from "./context/toast";
+import { ToastContainer } from "./components/toast";
+import { ErrorBoundary } from "./components/error-boundary";
 import ShortcutsDialog from "./components/commands/shortcuts-dialog";
 import HelpDialog from "./components/commands/help-dialog";
 import ModelsDisplay from "./components/commands/models-display";
@@ -35,67 +38,62 @@ import { detectTerminalMode } from "./theme/detect-mode";
 
 interface AppProps {
   appConfig: Config;
-  initialTheme: string;
-  initialMode: ColorMode;
 }
 
-function App(props: AppProps) {
-  const { appConfig, initialTheme, initialMode } = props;
+function App({ appConfig }: AppProps) {
   const [focusIndex, setFocusIndex] = useState(0);
   const [cwd, setCwd] = useState(process.cwd());
   const [ctrlCPressTime, setCtrlCPressTime] = useState<number | null>(null);
   const [showExitWarning, setShowExitWarning] = useState(false);
-  const [inputKey, setInputKey] = useState(0); // Force input remount on clear
+  const [inputKey, setInputKey] = useState(0);
   const [showSessionsDialog, setShowSessionsDialog] = useState(false);
   const [showShortcutsDialog, setShowShortcutsDialog] = useState(false);
 
-  const navigableItems = ["command-input"]; // List of items that can be focused
+  const navigableItems = ["command-input"];
 
   return (
-    <ThemeProvider initialTheme={initialTheme} initialMode={initialMode}>
-      <ConfigProvider config={appConfig}>
-        <SessionProvider>
-          <RouteProvider>
-            <FocusProvider>
-              <InputProvider>
-                <DialogProvider>
-                  <AgentProvider>
-                    <CommandProvider>
-                      <KeybindingProvider
-                        deps={{
-                          ctrlCPressTime,
-                          setCtrlCPressTime,
-                          setShowExitWarning,
-                          setInputKey,
-                          setShowSessionsDialog,
-                          setShowShortcutsDialog,
-                          setFocusIndex,
-                          navigableItems,
-                        }}
-                      >
-                        <AppContent
-                          focusIndex={focusIndex}
-                          showSessionsDialog={showSessionsDialog}
-                          setShowSessionsDialog={setShowSessionsDialog}
-                          showShortcutsDialog={showShortcutsDialog}
-                          setShowShortcutsDialog={setShowShortcutsDialog}
-                          cwd={cwd}
-                          setCtrlCPressTime={setCtrlCPressTime}
-                          showExitWarning={showExitWarning}
-                          setShowExitWarning={setShowExitWarning}
-                          inputKey={inputKey}
-                          setInputKey={setInputKey}
-                        />
-                      </KeybindingProvider>
-                    </CommandProvider>
-                  </AgentProvider>
-                </DialogProvider>
-              </InputProvider>
-            </FocusProvider>
-          </RouteProvider>
-        </SessionProvider>
-      </ConfigProvider>
-    </ThemeProvider>
+    <ConfigProvider config={appConfig}>
+      <SessionProvider>
+        <RouteProvider>
+          <FocusProvider>
+            <InputProvider>
+              <DialogProvider>
+                <AgentProvider>
+                  <CommandProvider>
+                    <KeybindingProvider
+                      deps={{
+                        ctrlCPressTime,
+                        setCtrlCPressTime,
+                        setShowExitWarning,
+                        setInputKey,
+                        setShowSessionsDialog,
+                        setShowShortcutsDialog,
+                        setFocusIndex,
+                        navigableItems,
+                      }}
+                    >
+                      <AppContent
+                        focusIndex={focusIndex}
+                        showSessionsDialog={showSessionsDialog}
+                        setShowSessionsDialog={setShowSessionsDialog}
+                        showShortcutsDialog={showShortcutsDialog}
+                        setShowShortcutsDialog={setShowShortcutsDialog}
+                        cwd={cwd}
+                        setCtrlCPressTime={setCtrlCPressTime}
+                        showExitWarning={showExitWarning}
+                        setShowExitWarning={setShowExitWarning}
+                        inputKey={inputKey}
+                        setInputKey={setInputKey}
+                      />
+                    </KeybindingProvider>
+                  </CommandProvider>
+                </AgentProvider>
+              </DialogProvider>
+            </InputProvider>
+          </FocusProvider>
+        </RouteProvider>
+      </SessionProvider>
+    </ConfigProvider>
   );
 }
 
@@ -188,7 +186,6 @@ function AppContent({
     >
       <CommandDisplay focusIndex={focusIndex} inputKey={inputKey} />
 
-      {/* Only show footer on non-home routes */}
       <Footer cwd={cwd} showExitWarning={showExitWarning} />
 
       {showSessionsDialog && (
@@ -359,7 +356,14 @@ async function main() {
   });
 
   createRoot(renderer).render(
-    <App appConfig={appConfig} initialTheme={themeName} initialMode={mode} />,
+    <ThemeProvider initialTheme={themeName} initialMode={mode}>
+      <ToastProvider>
+        <ErrorBoundary>
+          <App appConfig={appConfig} />
+        </ErrorBoundary>
+        <ToastContainer />
+      </ToastProvider>
+    </ThemeProvider>,
   );
 }
 

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -25,6 +25,7 @@ import { DialogProvider, useDialog } from "./context/dialog";
 import { ToastProvider } from "./context/toast";
 import { ToastContainer } from "./components/toast";
 import { ErrorBoundary } from "./components/error-boundary";
+import { writeErrorLog } from "../core/logger";
 import ShortcutsDialog from "./components/commands/shortcuts-dialog";
 import HelpDialog from "./components/commands/help-dialog";
 import ModelsDisplay from "./components/commands/models-display";
@@ -346,12 +347,14 @@ async function main() {
   process.on("uncaughtException", (err) => {
     renderer.destroy();
     console.error("Uncaught exception:", err);
+    writeErrorLog(err, "UNCAUGHT");
     process.exit(1);
   });
 
   process.on("unhandledRejection", (reason) => {
     renderer.destroy();
     console.error("Unhandled rejection:", reason);
+    writeErrorLog(reason, "UNHANDLED_REJECTION");
     process.exit(1);
   });
 


### PR DESCRIPTION
Implemented improved error handling within the TUI

TUI errors should no longer completely kill the TUI process, but are caught, displayed in an error toast, and written to `.pensar/error.log`

This way if users encounter an error, they have immediate feedback in the TUI with details, and we can ask them to share their error.log for further debugging. 

Fixes #166 


Where this should be improved upon is during agent execution, we should display errors properly in the TUI rather than silently hanging, and also write this to the error.log with an `[AGENT]` indicator so we know the error came form the agent.