### PR TITLE
Fix missing authConfig in pentest component and CLI commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,6 +91,7 @@ async function runPentest() {
 
   const { runPentestAgent } = await import("./core/api/blackboxPentest");
   const { sessions } = await import("./core/session");
+  const { config: appConfig } = await import("./core/config");
   type AIModel = import("./core/ai").AIModel;
 
   const target = getArgRequired("--target");
@@ -105,6 +106,8 @@ async function runPentest() {
   console.log(`Model:   ${model}`);
   console.log();
 
+  const pensarConfig = await appConfig.get();
+
   const session = await sessions.create({
     name: cwd ? "Whitebox Pentest" : "Blackbox Pentest",
     targets: [target],
@@ -117,6 +120,14 @@ async function runPentest() {
       ...(cwd ? { cwd } : {}),
       session,
       model,
+      authConfig: {
+        anthropicAPIKey: pensarConfig.anthropicAPIKey ?? undefined,
+        openAiAPIKey: pensarConfig.openAiAPIKey ?? undefined,
+        openRouterAPIKey: pensarConfig.openRouterAPIKey ?? undefined,
+        local: pensarConfig.localModelUrl
+          ? { baseURL: pensarConfig.localModelUrl }
+          : undefined,
+      },
       callbacks: {
         onTextDelta: (d) => process.stdout.write(d.text),
         onToolCall: (d) => console.log(`\n→ ${d.toolName}`),
@@ -142,6 +153,7 @@ async function runTargetedPentest() {
   const { runTargetedPentestAgent } =
     await import("./core/api/targetedPentest");
   const { sessions } = await import("./core/session");
+  const { config: appConfig } = await import("./core/config");
   type AIModel = import("./core/ai").AIModel;
 
   const target = getArgRequired("--target");
@@ -162,6 +174,8 @@ async function runTargetedPentest() {
   objectives.forEach((o, i) => console.log(`  ${i + 1}. ${o}`));
   console.log();
 
+  const pensarConfig = await appConfig.get();
+
   const session = await sessions.create({
     name: "Targeted Pentest",
     targets: [target],
@@ -172,6 +186,14 @@ async function runTargetedPentest() {
     objectives,
     session,
     model,
+    authConfig: {
+      anthropicAPIKey: pensarConfig.anthropicAPIKey ?? undefined,
+      openAiAPIKey: pensarConfig.openAiAPIKey ?? undefined,
+      openRouterAPIKey: pensarConfig.openRouterAPIKey ?? undefined,
+      local: pensarConfig.localModelUrl
+        ? { baseURL: pensarConfig.localModelUrl }
+        : undefined,
+    },
   });
 
   console.log();

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -9,6 +9,7 @@ import { sessions, type SessionInfo } from "../../../core/session";
 import { runPentestAgent } from "../../../core/api/blackboxPentest";
 import { useAgent } from "../../context/agent";
 import { useRoute } from "../../context/route";
+import { useConfig } from "../../context/config";
 import { useDialog } from "../../context/dialog";
 import { useTheme, type ThemeColors } from "../../theme";
 import AgentDisplay, { type DisplayMessage } from "../agent-display";
@@ -45,6 +46,7 @@ type ViewMode = "overview" | "detail";
 export default function Pentest({ sessionId }: { sessionId: string }) {
   const { colors } = useTheme();
   const route = useRoute();
+  const config = useConfig();
   const { model, setThinking, setIsExecuting, isExecuting } = useAgent();
   const { stack, externalDialogOpen } = useDialog();
 
@@ -483,6 +485,14 @@ export default function Pentest({ sessionId }: { sessionId: string }) {
           session: s,
           model: model.id,
           abortSignal: controller.signal,
+          authConfig: {
+            anthropicAPIKey: config.data.anthropicAPIKey ?? undefined,
+            openAiAPIKey: config.data.openAiAPIKey ?? undefined,
+            openRouterAPIKey: config.data.openRouterAPIKey ?? undefined,
+            local: config.data.localModelUrl
+              ? { baseURL: config.data.localModelUrl }
+              : undefined,
+          },
           callbacks: {
             // Orchestrator's own stream events → panel
             onTextDelta: (d) => {


### PR DESCRIPTION
The pentest TUI component and both CLI commands (`pensar pentest`, `pensar targeted-pentest`) weren't passing `authConfig` to the agent runners, so API keys from `~/.pensar/config.json` never reached the provider. Only the operator dashboard had this wired up.

Fixes #185


https://github.com/user-attachments/assets/e541ac2e-f83a-4c75-8380-84a70bd3a577