### PR TITLE
Replace callback architecture with typed AgentEventBus and async-iterable AgentRun<T> API

### DIFF
--- a/scripts/attack-surface.ts
+++ b/scripts/attack-surface.ts
@@ -101,6 +101,16 @@ async function runAttackSurface(options: AttackSurfaceOptions): Promise<void> {
     });
 
     const eventBus = new AgentEventBus();
+    eventBus.on("text-delta", (e) => process.stdout.write(e.data.text));
+    eventBus.on("tool-call", (e) =>
+      console.log(
+        `\n→ calling ${e.data.toolName} \n ${JSON.stringify(e.data.input, null, 2)}`,
+      ),
+    );
+    eventBus.on("tool-result", (e) =>
+      console.log(`✓ ${e.data.toolName} completed`),
+    );
+    eventBus.on("error", (e) => console.error(e.error));
 
     const result = await runAttackSurfaceAgent({
       target: TARGET_URL,

--- a/scripts/attack-surface.ts
+++ b/scripts/attack-surface.ts
@@ -5,6 +5,7 @@ import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { sessions } from "../src/core/session";
 import { runAttackSurfaceAgent } from "../src/core/api";
+import { AgentEventBus } from "../src/core/agents/offSecAgent";
 import { config } from "dotenv";
 
 config();
@@ -99,19 +100,13 @@ async function runAttackSurface(options: AttackSurfaceOptions): Promise<void> {
       },
     });
 
+    const eventBus = new AgentEventBus();
+
     const result = await runAttackSurfaceAgent({
       target: TARGET_URL,
       model: "claude-haiku-4-5",
       session,
-      callbacks: {
-        onTextDelta: (d) => process.stdout.write(d.text),
-        onToolCall: (d) =>
-          console.log(
-            `\n→ calling ${d.toolName} \n ${JSON.stringify(d.input, null, 2)}`,
-          ),
-        onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
-        onError: (e) => console.error(e),
-      },
+      eventBus,
     });
 
     console.log(`Session ID: ${session.id}`);

--- a/scripts/attack-surface.ts
+++ b/scripts/attack-surface.ts
@@ -5,7 +5,6 @@ import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { sessions } from "../src/core/session";
 import { runAttackSurfaceAgent } from "../src/core/api";
-import { AgentEventBus } from "../src/core/agents/offSecAgent";
 import { config } from "dotenv";
 
 config();
@@ -100,24 +99,32 @@ async function runAttackSurface(options: AttackSurfaceOptions): Promise<void> {
       },
     });
 
-    const eventBus = new AgentEventBus();
-    eventBus.on("text-delta", (e) => process.stdout.write(e.data.text));
-    eventBus.on("tool-call", (e) =>
-      console.log(
-        `\n→ calling ${e.data.toolName} \n ${JSON.stringify(e.data.input, null, 2)}`,
-      ),
-    );
-    eventBus.on("tool-result", (e) =>
-      console.log(`✓ ${e.data.toolName} completed`),
-    );
-    eventBus.on("error", (e) => console.error(e.error));
-
-    const result = await runAttackSurfaceAgent({
+    const run = runAttackSurfaceAgent({
       target: TARGET_URL,
       model: "claude-haiku-4-5",
       session,
-      eventBus,
     });
+
+    for await (const event of run) {
+      switch (event.type) {
+        case "text-delta":
+          process.stdout.write(event.data.text);
+          break;
+        case "tool-call":
+          console.log(
+            `\n→ calling ${event.data.toolName} \n ${JSON.stringify(event.data.input, null, 2)}`,
+          );
+          break;
+        case "tool-result":
+          console.log(`✓ ${event.data.toolName} completed`);
+          break;
+        case "error":
+          console.error(event.error);
+          break;
+      }
+    }
+
+    const result = await run.result;
 
     console.log(`Session ID: ${session.id}`);
     console.log(`Session Path: ${session.rootPath}`);

--- a/scripts/auth.ts
+++ b/scripts/auth.ts
@@ -26,7 +26,6 @@ import type { AuthCredentials } from "../src/core/agents/specialized/authenticat
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { runAuthenticationAgent } from "../src/core/api";
-import { AgentEventBus } from "../src/core/agents/offSecAgent";
 import { config } from "dotenv";
 
 config();
@@ -113,17 +112,7 @@ async function runAuth(options: AuthOptions): Promise<void> {
       console.log("=".repeat(80));
       console.log();
 
-      const eventBus = new AgentEventBus();
-      eventBus.on("text-delta", (e) => process.stdout.write(e.data.text));
-      eventBus.on("tool-call", (e) =>
-        console.log(`→ calling ${e.data.toolName}`),
-      );
-      eventBus.on("tool-result", (e) =>
-        console.log(`✓ ${e.data.toolName} completed`),
-      );
-      eventBus.on("error", (e) => console.error("Agent error:", e.error));
-
-      const result = await runAuthenticationAgent({
+      const run = runAuthenticationAgent({
         session,
         model: model as AIModel,
         target,
@@ -131,8 +120,26 @@ async function runAuth(options: AuthOptions): Promise<void> {
           username,
           password,
         },
-        eventBus,
       });
+
+      for await (const event of run) {
+        switch (event.type) {
+          case "text-delta":
+            process.stdout.write(event.data.text);
+            break;
+          case "tool-call":
+            console.log(`→ calling ${event.data.toolName}`);
+            break;
+          case "tool-result":
+            console.log(`✓ ${event.data.toolName} completed`);
+            break;
+          case "error":
+            console.error("Agent error:", event.error);
+            break;
+        }
+      }
+
+      const result = await run.result;
 
       console.log();
       console.log("=".repeat(80));
@@ -190,7 +197,7 @@ async function runAuth(options: AuthOptions): Promise<void> {
       session,
       credentials: hasCredentials ? credentials : undefined,
       model: model as AIModel,
-    });
+    }).result;
 
     console.log();
     console.log("=".repeat(80));

--- a/scripts/auth.ts
+++ b/scripts/auth.ts
@@ -114,6 +114,14 @@ async function runAuth(options: AuthOptions): Promise<void> {
       console.log();
 
       const eventBus = new AgentEventBus();
+      eventBus.on("text-delta", (e) => process.stdout.write(e.data.text));
+      eventBus.on("tool-call", (e) =>
+        console.log(`→ calling ${e.data.toolName}`),
+      );
+      eventBus.on("tool-result", (e) =>
+        console.log(`✓ ${e.data.toolName} completed`),
+      );
+      eventBus.on("error", (e) => console.error("Agent error:", e.error));
 
       const result = await runAuthenticationAgent({
         session,

--- a/scripts/auth.ts
+++ b/scripts/auth.ts
@@ -26,6 +26,7 @@ import type { AuthCredentials } from "../src/core/agents/specialized/authenticat
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { runAuthenticationAgent } from "../src/core/api";
+import { AgentEventBus } from "../src/core/agents/offSecAgent";
 import { config } from "dotenv";
 
 config();
@@ -112,6 +113,8 @@ async function runAuth(options: AuthOptions): Promise<void> {
       console.log("=".repeat(80));
       console.log();
 
+      const eventBus = new AgentEventBus();
+
       const result = await runAuthenticationAgent({
         session,
         model: model as AIModel,
@@ -120,12 +123,7 @@ async function runAuth(options: AuthOptions): Promise<void> {
           username,
           password,
         },
-        callbacks: {
-          onTextDelta: (d) => process.stdout.write(d.text),
-          onToolCall: (d) => console.log(`→ calling ${d.toolName}`),
-          onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
-          onError: (e) => console.error("Agent error:", e),
-        },
+        eventBus,
       });
 
       console.log();

--- a/scripts/blackbox-pentest.ts
+++ b/scripts/blackbox-pentest.ts
@@ -1,4 +1,5 @@
 import { runPentestAgent } from "../src/core/api";
+import { AgentEventBus } from "../src/core/agents/offSecAgent";
 import { sessions } from "../src/core/session";
 import { config } from "dotenv";
 
@@ -19,17 +20,14 @@ export async function runBlackboxPentest() {
     },
   });
 
+  const eventBus = new AgentEventBus();
+
   const { findings, findingsPath, pocsPath, reportPath } =
     await runPentestAgent({
       target: TARGET_URL,
       session,
       model: "claude-haiku-4-5",
-      callbacks: {
-        onTextDelta: (d) => process.stdout.write(d.text),
-        onToolCall: (d) => console.log(`→ calling ${d.toolName}`),
-        onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
-        onError: (e) => console.error(e),
-      },
+      eventBus,
     });
 }
 

--- a/scripts/blackbox-pentest.ts
+++ b/scripts/blackbox-pentest.ts
@@ -1,5 +1,4 @@
 import { runPentestAgent } from "../src/core/api";
-import { AgentEventBus } from "../src/core/agents/offSecAgent";
 import { sessions } from "../src/core/session";
 import { config } from "dotenv";
 
@@ -20,23 +19,30 @@ export async function runBlackboxPentest() {
     },
   });
 
-  const eventBus = new AgentEventBus();
-  eventBus.on("text-delta", (e) => process.stdout.write(e.data.text));
-  eventBus.on("tool-call", (e) =>
-    console.log(`→ calling ${e.data.toolName}`),
-  );
-  eventBus.on("tool-result", (e) =>
-    console.log(`✓ ${e.data.toolName} completed`),
-  );
-  eventBus.on("error", (e) => console.error(e.error));
+  const run = runPentestAgent({
+    target: TARGET_URL,
+    session,
+    model: "claude-haiku-4-5",
+  });
 
-  const { findings, findingsPath, pocsPath, reportPath } =
-    await runPentestAgent({
-      target: TARGET_URL,
-      session,
-      model: "claude-haiku-4-5",
-      eventBus,
-    });
+  for await (const event of run) {
+    switch (event.type) {
+      case "text-delta":
+        process.stdout.write(event.data.text);
+        break;
+      case "tool-call":
+        console.log(`→ calling ${event.data.toolName}`);
+        break;
+      case "tool-result":
+        console.log(`✓ ${event.data.toolName} completed`);
+        break;
+      case "error":
+        console.error(event.error);
+        break;
+    }
+  }
+
+  const { findings, findingsPath, pocsPath, reportPath } = await run.result;
 }
 
 runBlackboxPentest().catch(console.error);

--- a/scripts/blackbox-pentest.ts
+++ b/scripts/blackbox-pentest.ts
@@ -21,6 +21,14 @@ export async function runBlackboxPentest() {
   });
 
   const eventBus = new AgentEventBus();
+  eventBus.on("text-delta", (e) => process.stdout.write(e.data.text));
+  eventBus.on("tool-call", (e) =>
+    console.log(`→ calling ${e.data.toolName}`),
+  );
+  eventBus.on("tool-result", (e) =>
+    console.log(`✓ ${e.data.toolName} completed`),
+  );
+  eventBus.on("error", (e) => console.error(e.error));
 
   const { findings, findingsPath, pocsPath, reportPath } =
     await runPentestAgent({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,6 +90,7 @@ async function runPentest() {
   config();
 
   const { runPentestAgent } = await import("./core/api/blackboxPentest");
+  const { AgentEventBus } = await import("./core/agents/offSecAgent");
   const { sessions } = await import("./core/session");
   const { config: appConfig } = await import("./core/config");
   type AIModel = import("./core/ai").AIModel;
@@ -114,6 +115,8 @@ async function runPentest() {
     ...(cwd ? { config: { cwd } } : {}),
   });
 
+  const eventBus = new AgentEventBus();
+
   const { findings, findingsPath, pocsPath, reportPath } =
     await runPentestAgent({
       target,
@@ -128,12 +131,7 @@ async function runPentest() {
           ? { baseURL: pensarConfig.localModelUrl }
           : undefined,
       },
-      callbacks: {
-        onTextDelta: (d) => process.stdout.write(d.text),
-        onToolCall: (d) => console.log(`\n→ ${d.toolName}`),
-        onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
-        onError: (e) => console.error("Error:", e),
-      },
+      eventBus,
     });
 
   console.log();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,6 +116,12 @@ async function runPentest() {
   });
 
   const eventBus = new AgentEventBus();
+  eventBus.on("text-delta", (e) => process.stdout.write(e.data.text));
+  eventBus.on("tool-call", (e) => console.log(`\n→ ${e.data.toolName}`));
+  eventBus.on("tool-result", (e) =>
+    console.log(`✓ ${e.data.toolName} completed`),
+  );
+  eventBus.on("error", (e) => console.error("Error:", e.error));
 
   const { findings, findingsPath, pocsPath, reportPath } =
     await runPentestAgent({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,7 +90,6 @@ async function runPentest() {
   config();
 
   const { runPentestAgent } = await import("./core/api/blackboxPentest");
-  const { AgentEventBus } = await import("./core/agents/offSecAgent");
   const { sessions } = await import("./core/session");
   const { config: appConfig } = await import("./core/config");
   type AIModel = import("./core/ai").AIModel;
@@ -115,30 +114,39 @@ async function runPentest() {
     ...(cwd ? { config: { cwd } } : {}),
   });
 
-  const eventBus = new AgentEventBus();
-  eventBus.on("text-delta", (e) => process.stdout.write(e.data.text));
-  eventBus.on("tool-call", (e) => console.log(`\n→ ${e.data.toolName}`));
-  eventBus.on("tool-result", (e) =>
-    console.log(`✓ ${e.data.toolName} completed`),
-  );
-  eventBus.on("error", (e) => console.error("Error:", e.error));
+  const run = runPentestAgent({
+    target,
+    ...(cwd ? { cwd } : {}),
+    session,
+    model,
+    authConfig: {
+      anthropicAPIKey: pensarConfig.anthropicAPIKey ?? undefined,
+      openAiAPIKey: pensarConfig.openAiAPIKey ?? undefined,
+      openRouterAPIKey: pensarConfig.openRouterAPIKey ?? undefined,
+      local: pensarConfig.localModelUrl
+        ? { baseURL: pensarConfig.localModelUrl }
+        : undefined,
+    },
+  });
 
-  const { findings, findingsPath, pocsPath, reportPath } =
-    await runPentestAgent({
-      target,
-      ...(cwd ? { cwd } : {}),
-      session,
-      model,
-      authConfig: {
-        anthropicAPIKey: pensarConfig.anthropicAPIKey ?? undefined,
-        openAiAPIKey: pensarConfig.openAiAPIKey ?? undefined,
-        openRouterAPIKey: pensarConfig.openRouterAPIKey ?? undefined,
-        local: pensarConfig.localModelUrl
-          ? { baseURL: pensarConfig.localModelUrl }
-          : undefined,
-      },
-      eventBus,
-    });
+  for await (const event of run) {
+    switch (event.type) {
+      case "text-delta":
+        process.stdout.write(event.data.text);
+        break;
+      case "tool-call":
+        console.log(`\n→ ${event.data.toolName}`);
+        break;
+      case "tool-result":
+        console.log(`✓ ${event.data.toolName} completed`);
+        break;
+      case "error":
+        console.error("Error:", event.error);
+        break;
+    }
+  }
+
+  const { findings, findingsPath, pocsPath, reportPath } = await run.result;
 
   console.log();
   console.log("=".repeat(60));
@@ -185,7 +193,7 @@ async function runTargetedPentest() {
     targets: [target],
   });
 
-  const { findings, findingsPath, pocsPath } = await runTargetedPentestAgent({
+  const run = runTargetedPentestAgent({
     target,
     objectives,
     session,
@@ -199,6 +207,25 @@ async function runTargetedPentest() {
         : undefined,
     },
   });
+
+  for await (const event of run) {
+    switch (event.type) {
+      case "text-delta":
+        process.stdout.write(event.data.text);
+        break;
+      case "tool-call":
+        console.log(`\n→ ${event.data.toolName}`);
+        break;
+      case "tool-result":
+        console.log(`✓ ${event.data.toolName} completed`);
+        break;
+      case "error":
+        console.error("Error:", event.error);
+        break;
+    }
+  }
+
+  const { findings, findingsPath, pocsPath } = await run.result;
 
   console.log();
   console.log("=".repeat(60));

--- a/src/core/agents/offSecAgent/eventBus.test.ts
+++ b/src/core/agents/offSecAgent/eventBus.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import {
   AgentEventBus,
   type AgentEvent,

--- a/src/core/agents/offSecAgent/eventBus.test.ts
+++ b/src/core/agents/offSecAgent/eventBus.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  AgentEventBus,
+  type AgentEvent,
+  type TextDeltaData,
+  type ToolCallData,
+  type ToolResultData,
+} from "./eventBus";
+
+function makeTextDelta(text: string): TextDeltaData {
+  return { type: "text-delta", id: "td-1", text } as TextDeltaData;
+}
+
+function makeToolCall(toolName: string): ToolCallData {
+  return {
+    type: "tool-call",
+    toolCallId: "tc-1",
+    toolName,
+    args: {},
+  } as unknown as ToolCallData;
+}
+
+function makeToolResult(toolName: string): ToolResultData {
+  return {
+    type: "tool-result",
+    toolCallId: "tr-1",
+    toolName,
+    result: "ok",
+  } as unknown as ToolResultData;
+}
+
+describe("AgentEventBus", () => {
+  let bus: AgentEventBus;
+
+  beforeEach(() => {
+    bus = new AgentEventBus();
+  });
+
+  describe("emit and subscribe (unfiltered)", () => {
+    it("delivers events to unfiltered subscribers", () => {
+      const received: AgentEvent[] = [];
+      bus.on((e) => received.push(e));
+
+      const event: AgentEvent = {
+        type: "text-delta",
+        data: makeTextDelta("hello"),
+      };
+      bus.emit(event);
+
+      expect(received).toHaveLength(1);
+      expect(received[0]).toEqual(event);
+    });
+
+    it("delivers events to multiple unfiltered subscribers", () => {
+      const a: AgentEvent[] = [];
+      const b: AgentEvent[] = [];
+      bus.on((e) => a.push(e));
+      bus.on((e) => b.push(e));
+
+      bus.emit({ type: "text-delta", data: makeTextDelta("hi") });
+
+      expect(a).toHaveLength(1);
+      expect(b).toHaveLength(1);
+    });
+  });
+
+  describe("type-filtered subscriptions", () => {
+    it("only delivers matching event types", () => {
+      const textDeltas: AgentEvent[] = [];
+      const toolCalls: AgentEvent[] = [];
+
+      bus.on("text-delta", (e) => textDeltas.push(e));
+      bus.on("tool-call", (e) => toolCalls.push(e));
+
+      bus.emit({ type: "text-delta", data: makeTextDelta("a") });
+      bus.emit({ type: "tool-call", data: makeToolCall("nmap") });
+      bus.emit({ type: "text-delta", data: makeTextDelta("b") });
+
+      expect(textDeltas).toHaveLength(2);
+      expect(toolCalls).toHaveLength(1);
+      expect(toolCalls[0].type).toBe("tool-call");
+    });
+
+    it("delivers to both unfiltered and type-filtered subscribers", () => {
+      const all: AgentEvent[] = [];
+      const errorsOnly: AgentEvent[] = [];
+
+      bus.on((e) => all.push(e));
+      bus.on("error", (e) => errorsOnly.push(e));
+
+      bus.emit({ type: "text-delta", data: makeTextDelta("x") });
+      bus.emit({ type: "error", error: new Error("boom") });
+
+      expect(all).toHaveLength(2);
+      expect(errorsOnly).toHaveLength(1);
+      expect(errorsOnly[0].type).toBe("error");
+    });
+
+    it("handles subagent-spawn and subagent-complete event types", () => {
+      const spawns: AgentEvent[] = [];
+      const completions: AgentEvent[] = [];
+
+      bus.on("subagent-spawn", (e) => spawns.push(e));
+      bus.on("subagent-complete", (e) => completions.push(e));
+
+      bus.emit({
+        type: "subagent-spawn",
+        subagentId: "agent-1",
+        input: { target: "example.com" },
+        status: "pending",
+      });
+      bus.emit({
+        type: "subagent-complete",
+        subagentId: "agent-1",
+        input: { target: "example.com" },
+        status: "completed",
+      });
+
+      expect(spawns).toHaveLength(1);
+      expect(completions).toHaveLength(1);
+    });
+
+    it("handles tool-result events", () => {
+      const results: AgentEvent[] = [];
+      bus.on("tool-result", (e) => results.push(e));
+
+      bus.emit({ type: "tool-result", data: makeToolResult("nmap") });
+      bus.emit({ type: "text-delta", data: makeTextDelta("ignored") });
+
+      expect(results).toHaveLength(1);
+    });
+  });
+
+  describe("unsubscribe", () => {
+    it("unsubscribes an unfiltered handler", () => {
+      const received: AgentEvent[] = [];
+      const unsub = bus.on((e) => received.push(e));
+
+      bus.emit({ type: "text-delta", data: makeTextDelta("a") });
+      expect(received).toHaveLength(1);
+
+      unsub();
+
+      bus.emit({ type: "text-delta", data: makeTextDelta("b") });
+      expect(received).toHaveLength(1);
+    });
+
+    it("unsubscribes a type-filtered handler", () => {
+      const received: AgentEvent[] = [];
+      const unsub = bus.on("tool-call", (e) => received.push(e));
+
+      bus.emit({ type: "tool-call", data: makeToolCall("nmap") });
+      expect(received).toHaveLength(1);
+
+      unsub();
+
+      bus.emit({ type: "tool-call", data: makeToolCall("curl") });
+      expect(received).toHaveLength(1);
+    });
+
+    it("does not affect other subscribers when one unsubscribes", () => {
+      const a: AgentEvent[] = [];
+      const b: AgentEvent[] = [];
+
+      const unsubA = bus.on("text-delta", (e) => a.push(e));
+      bus.on("text-delta", (e) => b.push(e));
+
+      bus.emit({ type: "text-delta", data: makeTextDelta("1") });
+      expect(a).toHaveLength(1);
+      expect(b).toHaveLength(1);
+
+      unsubA();
+
+      bus.emit({ type: "text-delta", data: makeTextDelta("2") });
+      expect(a).toHaveLength(1);
+      expect(b).toHaveLength(2);
+    });
+  });
+
+  describe("child bus", () => {
+    it("auto-tags events with subagentId", () => {
+      const received: AgentEvent[] = [];
+      bus.on((e) => received.push(e));
+
+      const child = bus.child("agent-1");
+      child.emit({ type: "text-delta", data: makeTextDelta("from child") });
+
+      expect(received).toHaveLength(1);
+      expect(received[0].subagentId).toBe("agent-1");
+    });
+
+    it("does not overwrite an existing subagentId on the event", () => {
+      const received: AgentEvent[] = [];
+      bus.on((e) => received.push(e));
+
+      const child = bus.child("agent-1");
+      child.emit({
+        type: "text-delta",
+        subagentId: "already-set",
+        data: makeTextDelta("pre-tagged"),
+      });
+
+      expect(received).toHaveLength(1);
+      expect(received[0].subagentId).toBe("already-set");
+    });
+
+    it("bubbles events to the parent bus", () => {
+      const parentEvents: AgentEvent[] = [];
+      bus.on((e) => parentEvents.push(e));
+
+      const child = bus.child("child-1");
+      child.emit({ type: "error", error: "something broke" });
+
+      expect(parentEvents).toHaveLength(1);
+      expect(parentEvents[0].type).toBe("error");
+      expect(parentEvents[0].subagentId).toBe("child-1");
+    });
+
+    it("delivers to child-local subscribers AND parent", () => {
+      const parentEvents: AgentEvent[] = [];
+      const childEvents: AgentEvent[] = [];
+
+      bus.on((e) => parentEvents.push(e));
+
+      const child = bus.child("c1");
+      child.on((e) => childEvents.push(e));
+
+      child.emit({ type: "text-delta", data: makeTextDelta("both") });
+
+      expect(childEvents).toHaveLength(1);
+      expect(parentEvents).toHaveLength(1);
+      expect(childEvents[0].subagentId).toBe("c1");
+      expect(parentEvents[0].subagentId).toBe("c1");
+    });
+
+    it("supports type-filtered subscriptions on child bus", () => {
+      const childToolCalls: AgentEvent[] = [];
+
+      const child = bus.child("c1");
+      child.on("tool-call", (e) => childToolCalls.push(e));
+
+      child.emit({ type: "text-delta", data: makeTextDelta("ignored") });
+      child.emit({ type: "tool-call", data: makeToolCall("curl") });
+
+      expect(childToolCalls).toHaveLength(1);
+    });
+  });
+
+  describe("nested child buses", () => {
+    it("bubbles through multiple levels to root", () => {
+      const rootEvents: AgentEvent[] = [];
+      bus.on((e) => rootEvents.push(e));
+
+      const level1 = bus.child("orchestrator");
+      const level2 = level1.child("pentest-agent-0");
+
+      level2.emit({ type: "text-delta", data: makeTextDelta("deep") });
+
+      expect(rootEvents).toHaveLength(1);
+      expect(rootEvents[0].subagentId).toBe("pentest-agent-0");
+    });
+
+    it("each level receives bubbled events", () => {
+      const rootEvents: AgentEvent[] = [];
+      const level1Events: AgentEvent[] = [];
+      const level2Events: AgentEvent[] = [];
+
+      bus.on((e) => rootEvents.push(e));
+
+      const level1 = bus.child("l1");
+      level1.on((e) => level1Events.push(e));
+
+      const level2 = level1.child("l2");
+      level2.on((e) => level2Events.push(e));
+
+      level2.emit({ type: "tool-call", data: makeToolCall("scan") });
+
+      expect(level2Events).toHaveLength(1);
+      expect(level1Events).toHaveLength(1);
+      expect(rootEvents).toHaveLength(1);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("does not throw when emitting with no subscribers", () => {
+      expect(() => {
+        bus.emit({ type: "text-delta", data: makeTextDelta("lonely") });
+      }).not.toThrow();
+    });
+
+    it("calling unsubscribe multiple times is safe", () => {
+      const received: AgentEvent[] = [];
+      const unsub = bus.on((e) => received.push(e));
+
+      unsub();
+      unsub();
+
+      bus.emit({ type: "text-delta", data: makeTextDelta("test") });
+      expect(received).toHaveLength(0);
+    });
+
+    it("root bus events have no subagentId", () => {
+      const received: AgentEvent[] = [];
+      bus.on((e) => received.push(e));
+
+      bus.emit({ type: "text-delta", data: makeTextDelta("root") });
+
+      expect(received[0].subagentId).toBeUndefined();
+    });
+  });
+});

--- a/src/core/agents/offSecAgent/eventBus.ts
+++ b/src/core/agents/offSecAgent/eventBus.ts
@@ -1,0 +1,105 @@
+import type { TextStreamPart, ToolSet } from "ai";
+
+export type TextDeltaData = Extract<
+  TextStreamPart<ToolSet>,
+  { type: "text-delta" }
+>;
+export type ToolCallData = Extract<
+  TextStreamPart<ToolSet>,
+  { type: "tool-call" }
+>;
+export type ToolResultData = Extract<
+  TextStreamPart<ToolSet>,
+  { type: "tool-result" }
+>;
+
+export type AgentEvent =
+  | { type: "text-delta"; subagentId?: string; data: TextDeltaData }
+  | { type: "tool-call"; subagentId?: string; data: ToolCallData }
+  | { type: "tool-result"; subagentId?: string; data: ToolResultData }
+  | { type: "error"; subagentId?: string; error: unknown }
+  | {
+      type: "subagent-spawn";
+      subagentId: string;
+      input: unknown;
+      status: "pending";
+    }
+  | {
+      type: "subagent-complete";
+      subagentId: string;
+      input: unknown;
+      status: "completed" | "failed";
+    };
+
+export type AgentEventOfType<T extends AgentEvent["type"]> = Extract<
+  AgentEvent,
+  { type: T }
+>;
+
+export class AgentEventBus {
+  private handlers: Array<(event: AgentEvent) => void> = [];
+  private typedHandlers: Map<string, Array<(event: AgentEvent) => void>> =
+    new Map();
+  private parent: AgentEventBus | null;
+  private subagentId: string | null;
+
+  constructor(
+    parent: AgentEventBus | null = null,
+    subagentId: string | null = null,
+  ) {
+    this.parent = parent;
+    this.subagentId = subagentId;
+  }
+
+  emit(event: AgentEvent): void {
+    const tagged =
+      this.subagentId && !event.subagentId
+        ? { ...event, subagentId: this.subagentId }
+        : event;
+
+    for (const handler of this.handlers) {
+      handler(tagged);
+    }
+
+    const typed = this.typedHandlers.get(tagged.type);
+    if (typed) {
+      for (const handler of typed) {
+        handler(tagged);
+      }
+    }
+
+    if (this.parent) {
+      this.parent.emit(tagged);
+    }
+  }
+
+  on(handler: (event: AgentEvent) => void): () => void;
+  on<T extends AgentEvent["type"]>(
+    type: T,
+    handler: (event: AgentEventOfType<T>) => void,
+  ): () => void;
+  on(
+    typeOrHandler: AgentEvent["type"] | ((event: AgentEvent) => void),
+    handler?: (event: AgentEvent) => void,
+  ): () => void {
+    if (typeof typeOrHandler === "function") {
+      this.handlers.push(typeOrHandler);
+      return () => {
+        const idx = this.handlers.indexOf(typeOrHandler);
+        if (idx !== -1) this.handlers.splice(idx, 1);
+      };
+    }
+
+    const list = this.typedHandlers.get(typeOrHandler) ?? [];
+    list.push(handler!);
+    this.typedHandlers.set(typeOrHandler, list);
+    return () => {
+      const idx = list.indexOf(handler!);
+      if (idx !== -1) list.splice(idx, 1);
+    };
+  }
+
+  child(subagentId: string): AgentEventBus {
+    return new AgentEventBus(this, subagentId);
+  }
+}

--- a/src/core/agents/offSecAgent/index.ts
+++ b/src/core/agents/offSecAgent/index.ts
@@ -5,8 +5,13 @@ export { OffensiveSecurityAgent } from "./offensiveSecurityAgent";
 export type {
   OffensiveSecurityAgentInput,
   SpecializedAgentInput,
-  ConsumeCallbacks,
 } from "./types";
+
+// ---------------------------------------------------------------------------
+// Event Bus
+// ---------------------------------------------------------------------------
+export { AgentEventBus } from "./eventBus";
+export type { AgentEvent, AgentEventOfType } from "./eventBus";
 
 // ---------------------------------------------------------------------------
 // Tools

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -6,7 +6,8 @@ import type {
   ToolSet,
 } from "ai";
 import { hasToolCall } from "ai";
-import type { OffensiveSecurityAgentInput, ConsumeCallbacks } from "./types";
+import type { OffensiveSecurityAgentInput } from "./types";
+import type { AgentEventBus } from "./eventBus";
 import { createAllTools } from "./tools";
 import { createResponseTool, RESPONSE_TOOL_NAME } from "./tools/response";
 import { DEFAULT_SYSTEM_PROMPT } from "./prompt";
@@ -27,12 +28,12 @@ import { DEFAULT_SYSTEM_PROMPT } from "./prompt";
  *
  * ## Consumption (pick one — stream is single-read)
  *
- * **1. Typed callbacks via `.consume()` → `TResult`**
+ * **1. Event bus via `.consume()` → `TResult`**
  * ```ts
- * const result = await agent.consume({
- *   onTextDelta: (d) => process.stdout.write(d.text),
- *   onToolCall:  (d) => console.log(`→ ${d.toolName}`),
- * });
+ * const bus = new AgentEventBus();
+ * bus.on("text-delta", (e) => process.stdout.write(e.data.text));
+ * const agent = new OffensiveSecurityAgent({ ..., eventBus: bus });
+ * const result = await agent.consume();
  * ```
  *
  * **2. `for await` directly on the agent**
@@ -53,11 +54,10 @@ export class OffensiveSecurityAgent<TResult = void> {
     streamResult: StreamTextResult<ToolSet, never>,
   ) => TResult | Promise<TResult>;
 
-  /** Identifier for this agent when it is running as a subagent. */
-  private readonly subagentId?: string;
+  private readonly eventBus?: AgentEventBus;
 
   constructor(input: OffensiveSecurityAgentInput<TResult>) {
-    this.subagentId = input.subagentId;
+    this.eventBus = input.eventBus;
 
     // -- Tools ----------------------------------------------------------------
     const builtinTools = createAllTools({
@@ -66,8 +66,7 @@ export class OffensiveSecurityAgent<TResult = void> {
       abortSignal: input.abortSignal,
       model: input.model,
       authConfig: input.authConfig,
-      callbacks: input.callbacks,
-      subagentCallbacks: input.subagentCallbacks,
+      eventBus: input.eventBus,
       sandbox: input.sandbox,
     });
 
@@ -161,45 +160,23 @@ export class OffensiveSecurityAgent<TResult = void> {
   // Convenience helpers
   // ---------------------------------------------------------------------------
 
-  /**
-   * Consume the stream with typed callbacks, then resolve the final result.
-   *
-   * Dispatches each chunk to the appropriate callback, and after the stream
-   * is fully consumed, calls `resolveResult` (if provided at construction)
-   * to produce a typed return value.
-   *
-   * @returns The value produced by `resolveResult`, or `void` if none was provided.
-   */
-  async consume(callbacks: ConsumeCallbacks = {}): Promise<TResult> {
-    const {
-      onTextDelta,
-      onToolCall,
-      onToolResult,
-      onError,
-      subagentCallbacks,
-    } = callbacks;
-
-    const sid = this.subagentId;
-
+  async consume(): Promise<TResult> {
     for await (const chunk of this.streamResult.fullStream) {
       switch (chunk.type) {
         case "text-delta":
-          onTextDelta?.(chunk);
-          subagentCallbacks?.onTextDelta?.({ ...chunk, subagentId: sid });
+          this.eventBus?.emit({ type: "text-delta", data: chunk });
           break;
         case "tool-call":
-          onToolCall?.(chunk);
-          subagentCallbacks?.onToolCall?.({ ...chunk, subagentId: sid });
+          this.eventBus?.emit({ type: "tool-call", data: chunk });
           break;
         case "tool-result":
-          onToolResult?.(chunk);
-          subagentCallbacks?.onToolResult?.({ ...chunk, subagentId: sid });
+          this.eventBus?.emit({ type: "tool-result", data: chunk });
           break;
         case "error":
-          if (onError) {
-            onError((chunk as { type: "error"; error: unknown }).error);
-          }
-          subagentCallbacks?.onError?.(chunk.error);
+          this.eventBus?.emit({
+            type: "error",
+            error: (chunk as { type: "error"; error: unknown }).error,
+          });
           break;
       }
     }

--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -235,20 +235,21 @@ When to use delegate_to_auth_subagent vs authenticate_session:
         });
 
         // Dynamic import to break circular dependency:
-        // authAgent → offensiveSecurityAgent → tools/index → delegateAuth → api/authentication → authAgent
-        const { runAuthenticationAgent } =
-          await import("../../../api/authentication");
+        // authAgent → offensiveSecurityAgent → tools/index → delegateAuth → authAgent
+        const { AuthenticationAgent } =
+          await import("../../specialized/authenticationAgent/agent");
 
-        const result = await runAuthenticationAgent({
+        const authAgent = new AuthenticationAgent({
           target,
           session: ctx.session,
           credentials,
           authHints,
-          model: ctx.model,
+          model: ctx.model!,
           authConfig: ctx.authConfig,
           abortSignal: ctx.abortSignal,
           eventBus: ctx.eventBus,
         });
+        const result = await authAgent.consume();
 
         if (result.success) {
           const sessionInfoPath = join(

--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -247,7 +247,7 @@ When to use delegate_to_auth_subagent vs authenticate_session:
           model: ctx.model,
           authConfig: ctx.authConfig,
           abortSignal: ctx.abortSignal,
-          callbacks: ctx.callbacks,
+          eventBus: ctx.eventBus,
         });
 
         if (result.success) {

--- a/src/core/agents/offSecAgent/tools/runAttackSurface.ts
+++ b/src/core/agents/offSecAgent/tools/runAttackSurface.ts
@@ -51,19 +51,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
         };
       }
 
-      const subagentId = "attack-surface-agent";
-      const cbs = ctx.subagentCallbacks;
-      const subagentCallbacks = cbs
-        ? {
-            onTextDelta: (d: { type: "text-delta"; [k: string]: unknown }) =>
-              cbs.onTextDelta?.({ ...d, subagentId } as never),
-            onToolCall: (d: { type: "tool-call"; [k: string]: unknown }) =>
-              cbs.onToolCall?.({ ...d, subagentId } as never),
-            onToolResult: (d: { type: "tool-result"; [k: string]: unknown }) =>
-              cbs.onToolResult?.({ ...d, subagentId } as never),
-            onError: (e: unknown) => cbs.onError?.(e),
-          }
-        : undefined;
+      const childBus = ctx.eventBus?.child("attack-surface-agent");
 
       // -----------------------------------------------------------------------
       // Whitebox mode — analyze source code (cwd is the indicator)
@@ -79,16 +67,10 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
             session: ctx.session,
             authConfig: ctx.authConfig,
             abortSignal: ctx.abortSignal,
-            callbacks: ctx.callbacks,
+            eventBus: childBus,
           });
 
-          const result: WhiteboxAttackSurfaceResult = await agent.consume({
-            onToolCall: (d) =>
-              console.log(`  [recon:whitebox] → ${d.toolName}`),
-            onToolResult: (d) =>
-              console.log(`  [recon:whitebox] ✓ ${d.toolName}`),
-            subagentCallbacks,
-          });
+          const result: WhiteboxAttackSurfaceResult = await agent.consume();
 
           // Flatten whitebox results into the same targets shape the swarm expects
           const targets = result.apps.flatMap((app) =>
@@ -137,15 +119,10 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
           session: ctx.session,
           authConfig: ctx.authConfig,
           abortSignal: ctx.abortSignal,
-          callbacks: ctx.callbacks,
+          eventBus: childBus,
         });
 
-        const result: AttackSurfaceResult = await agent.consume({
-          onToolCall: (d) => console.log(`  [recon:blackbox] → ${d.toolName}`),
-          onToolResult: (d) =>
-            console.log(`  [recon:blackbox] ✓ ${d.toolName}`),
-          subagentCallbacks,
-        });
+        const result: AttackSurfaceResult = await agent.consume();
 
         const targetCount = result.targets.length;
         console.log(

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -148,8 +148,10 @@ async function runSingleCodingAgent(
   const { CodeAgent } = await import("../../specialized/codeAgent/agent");
 
   const subagentId = `coding-agent-${agentIndex}`;
+  const childBus = ctx.eventBus?.child(subagentId);
 
-  ctx.subagentCallbacks?.onSubagentSpawn?.({
+  childBus?.emit({
+    type: "subagent-spawn",
     subagentId,
     input: { codebasePath, objective },
     status: "pending",
@@ -162,30 +164,20 @@ async function runSingleCodingAgent(
     session: ctx.session,
     authConfig: ctx.authConfig,
     abortSignal: ctx.abortSignal,
+    eventBus: childBus,
   });
 
   try {
     // Collect the agent's text output
     let textOutput = "";
-
-    await agent.consume({
-      onTextDelta: (d) => {
-        textOutput += d.text;
-      },
-      subagentCallbacks: ctx.subagentCallbacks
-        ? {
-            onTextDelta: (d) =>
-              ctx.subagentCallbacks!.onTextDelta?.({ ...d, subagentId }),
-            onToolCall: (d) =>
-              ctx.subagentCallbacks!.onToolCall?.({ ...d, subagentId }),
-            onToolResult: (d) =>
-              ctx.subagentCallbacks!.onToolResult?.({ ...d, subagentId }),
-            onError: (e) => ctx.subagentCallbacks!.onError?.(e),
-          }
-        : undefined,
+    childBus?.on("text-delta", (e) => {
+      textOutput += e.data.text;
     });
 
-    ctx.subagentCallbacks?.onSubagentComplete?.({
+    await agent.consume();
+
+    childBus?.emit({
+      type: "subagent-complete",
       subagentId,
       input: { codebasePath, objective },
       status: "completed",
@@ -193,7 +185,8 @@ async function runSingleCodingAgent(
 
     return textOutput;
   } catch (error) {
-    ctx.subagentCallbacks?.onSubagentComplete?.({
+    childBus?.emit({
+      type: "subagent-complete",
       subagentId,
       input: { codebasePath, objective },
       status: "failed",

--- a/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
@@ -177,9 +177,11 @@ async function runSingleAgent(
     await import("../../specialized/pentest/agent");
 
   const subagentId = `pentest-agent-${agentIndex}`;
+  const childBus = ctx.eventBus?.child(subagentId);
 
   // Notify parent that a new subagent is starting
-  ctx.subagentCallbacks?.onSubagentSpawn?.({
+  childBus?.emit({
+    type: "subagent-spawn",
     subagentId,
     input: { target, objectives },
     status: "pending",
@@ -192,24 +194,14 @@ async function runSingleAgent(
     session: ctx.session,
     authConfig: ctx.authConfig,
     abortSignal: ctx.abortSignal,
+    eventBus: childBus,
   });
 
   try {
-    const result = await agent.consume({
-      subagentCallbacks: ctx.subagentCallbacks
-        ? {
-            onTextDelta: (d) =>
-              ctx.subagentCallbacks!.onTextDelta?.({ ...d, subagentId }),
-            onToolCall: (d) =>
-              ctx.subagentCallbacks!.onToolCall?.({ ...d, subagentId }),
-            onToolResult: (d) =>
-              ctx.subagentCallbacks!.onToolResult?.({ ...d, subagentId }),
-            onError: (e) => ctx.subagentCallbacks!.onError?.(e),
-          }
-        : undefined,
-    });
+    const result = await agent.consume();
 
-    ctx.subagentCallbacks?.onSubagentComplete?.({
+    childBus?.emit({
+      type: "subagent-complete",
       subagentId,
       input: { target, objectives },
       status: "completed",
@@ -217,7 +209,8 @@ async function runSingleAgent(
 
     return result;
   } catch (error) {
-    ctx.subagentCallbacks?.onSubagentComplete?.({
+    childBus?.emit({
+      type: "subagent-complete",
       subagentId,
       input: { target, objectives },
       status: "failed",

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -1,8 +1,7 @@
 import type { AIModel } from "../../../ai";
 import type { AIAuthConfig } from "../../../ai/utils";
 import type { SessionInfo } from "../../../session";
-
-import type { ConsumeCallbacks, SubagentConsumeCallbacks } from "../types";
+import type { AgentEventBus } from "../eventBus";
 import type { UnifiedSandbox } from "./sandbox";
 
 /**
@@ -28,9 +27,8 @@ export type ToolContext = {
   /** Per-provider API key overrides — needed by tools that spawn sub-agents */
   authConfig?: AIAuthConfig;
 
-  /** Callbacks for forwarding subagent stream events to the parent consumer */
-  subagentCallbacks?: SubagentConsumeCallbacks;
-  callbacks?: ConsumeCallbacks;
+  /** Event bus for emitting agent events */
+  eventBus?: AgentEventBus;
 
   /**
    * When set, tools like execute_command / http_request / create_poc

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -4,7 +4,6 @@ import type {
   StreamTextOnFinishCallback,
   StreamTextOnStepFinishCallback,
   StreamTextResult,
-  TextStreamPart,
   ToolChoice,
   ToolSet,
 } from "ai";
@@ -13,6 +12,7 @@ import type { AIAuthConfig } from "../../ai/utils";
 import type { SessionInfo } from "../../session";
 import type { ToolName } from "./tools";
 import type { UnifiedSandbox } from "./tools/sandbox";
+import type { AgentEventBus } from "./eventBus";
 import { z } from "zod";
 
 // Backward-compatible Finding schema (toolCallDescription is optional for parsing old findings)
@@ -126,20 +126,8 @@ export type OffensiveSecurityAgentInput<TResult = void> = {
     streamResult: StreamTextResult<ToolSet, never>,
   ) => TResult | Promise<TResult>;
 
-  /** The subagent ID if this agent is a subagent */
-  subagentId?: string;
-
-  /**
-   * Callbacks for forwarding subagent stream events to the parent consumer.
-   *
-   * Passed through to the tool context so orchestration tools
-   * (run_attack_surface, spawn_pentest_swarm) can forward their
-   * sub-agent events back to the top-level consumer.
-   */
-  subagentCallbacks?: SubagentConsumeCallbacks;
-
-  /** Callbacks for persisting agent discoveries to external storage (e.g., database). */
-  callbacks?: ConsumeCallbacks;
+  /** Event bus for emitting stream events (text-delta, tool-call, etc.). */
+  eventBus?: AgentEventBus;
 
   /**
    * Zod schema for structured output via the `response` tool.
@@ -177,68 +165,9 @@ export interface SpecializedAgentInput {
   /** AbortSignal to cancel the agent mid-run */
   abortSignal?: AbortSignal;
 
-  /** Callbacks for stream events and subagent forwarding */
-  callbacks?: ConsumeCallbacks;
+  /** Event bus for emitting stream events */
+  eventBus?: AgentEventBus;
 
   /** Override the default stop condition */
   stopWhen?: StopCondition<ToolSet>;
 }
-
-/**
- * Typed callbacks for consuming the agent's output stream.
- * Pass to `agent.consume()` for ergonomic stream processing.
- */
-export type ConsumeCallbacks = {
-  onTextDelta?: (
-    delta: Extract<TextStreamPart<ToolSet>, { type: "text-delta" }>,
-  ) => void;
-  onToolCall?: (
-    delta: Extract<TextStreamPart<ToolSet>, { type: "tool-call" }>,
-  ) => void;
-  onToolResult?: (
-    delta: Extract<TextStreamPart<ToolSet>, { type: "tool-result" }>,
-  ) => void;
-  onError?: (error: unknown) => void;
-  subagentCallbacks?: SubagentConsumeCallbacks;
-};
-
-/**
- * Typed callbacks for consuming the subagent's output stream.
- * Pass to `subagent.consume()` for ergonomic stream processing.
- */
-export type SubagentConsumeCallbacks = {
-  onSubagentSpawn?: ({
-    subagentId,
-    input,
-    status,
-  }: {
-    subagentId: string;
-    input: unknown;
-    status: "pending" | "completed" | "failed";
-  }) => void;
-  onSubagentComplete?: ({
-    subagentId,
-    input,
-    status,
-  }: {
-    subagentId: string;
-    input: unknown;
-    status: "completed" | "failed";
-  }) => void;
-  onTextDelta?: (
-    delta: Extract<TextStreamPart<ToolSet>, { type: "text-delta" }> & {
-      subagentId?: string;
-    },
-  ) => void;
-  onToolCall?: (
-    delta: Extract<TextStreamPart<ToolSet>, { type: "tool-call" }> & {
-      subagentId?: string;
-    },
-  ) => void;
-  onToolResult?: (
-    delta: Extract<TextStreamPart<ToolSet>, { type: "tool-result" }> & {
-      subagentId?: string;
-    },
-  ) => void;
-  onError?: (error: unknown) => void;
-};

--- a/src/core/agents/specialized/attackSurface/blackboxAgent.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxAgent.ts
@@ -60,10 +60,7 @@ export interface AttackSurfaceResult {
  *   session,
  * });
  *
- * const { targets, results } = await agent.consume({
- *   onTextDelta: (d) => process.stdout.write(d.text),
- *   onToolCall:  (d) => console.log(`→ ${d.toolName}`),
- * });
+ * const { targets, results } = await agent.consume();
  *
  * console.log(`Identified ${targets.length} targets for deep testing`);
  * ```
@@ -93,6 +90,7 @@ export class BlackboxAttackSurfaceAgent extends OffensiveSecurityAgent<AttackSur
       session,
       target,
       authConfig,
+      eventBus: opts.eventBus,
       onStepFinish: (e) => {
         onStepFinish?.(e);
         const messages = e.response.messages;

--- a/src/core/agents/specialized/authenticationAgent/agent.ts
+++ b/src/core/agents/specialized/authenticationAgent/agent.ts
@@ -6,7 +6,7 @@ import { type SessionInfo } from "../../../session";
 import { AUTH_SUBAGENT_SYSTEM_PROMPT } from "./prompts";
 import { detectOSAndEnhancePrompt } from "../utils";
 import { OffensiveSecurityAgent } from "../../offSecAgent/offensiveSecurityAgent";
-import type { AgentEventBus } from "../../offSecAgent/eventBus";
+import { AgentEventBus } from "../../offSecAgent/eventBus";
 import type { AuthBarrier } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -249,7 +249,17 @@ You have credentials — authenticate immediately.
 // ---------------------------------------------------------------------------
 
 export async function runAuthenticationAgent(input: AuthenticationAgentInput) {
-  const agent = new AuthenticationAgent(input);
+  const eventBus = input.eventBus ?? (() => {
+    const bus = new AgentEventBus();
+    bus.on("text-delta", (e) => process.stdout.write(e.data.text));
+    bus.on("tool-call", (e) => console.log(`→ calling ${e.data.toolName}`));
+    bus.on("tool-result", (e) =>
+      console.log(`✓ ${e.data.toolName} completed`),
+    );
+    bus.on("error", (e) => console.error("Agent error:", e.error));
+    return bus;
+  })();
+  const agent = new AuthenticationAgent({ ...input, eventBus });
 
   const { success, summary } = await agent.consume();
 

--- a/src/core/agents/specialized/authenticationAgent/agent.ts
+++ b/src/core/agents/specialized/authenticationAgent/agent.ts
@@ -6,7 +6,7 @@ import { type SessionInfo } from "../../../session";
 import { AUTH_SUBAGENT_SYSTEM_PROMPT } from "./prompts";
 import { detectOSAndEnhancePrompt } from "../utils";
 import { OffensiveSecurityAgent } from "../../offSecAgent/offensiveSecurityAgent";
-import type { ConsumeCallbacks } from "../../offSecAgent/types";
+import type { AgentEventBus } from "../../offSecAgent/eventBus";
 import type { AuthBarrier } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -48,8 +48,8 @@ export interface AuthenticationAgentInput {
   /** AbortSignal to cancel mid-run */
   abortSignal?: AbortSignal;
 
-  /** Optional persistence callbacks for external storage integration */
-  callbacks?: ConsumeCallbacks;
+  /** Event bus for emitting stream events */
+  eventBus?: AgentEventBus;
 }
 
 /** The typed result returned by `AuthenticationAgent.consume()`. */
@@ -92,9 +92,7 @@ export interface AuthenticationResult {
  *   credentials: { username: "admin", password: "admin" },
  * });
  *
- * const { success, summary } = await agent.consume({
- *   onTextDelta: (d) => process.stdout.write(d.text),
- * });
+ * const { success, summary } = await agent.consume();
  *
  * console.log(success ? "Authenticated!" : "Failed");
  * ```
@@ -119,6 +117,7 @@ export class AuthenticationAgent extends OffensiveSecurityAgent<AuthenticationRe
       session,
       target,
       authConfig,
+      eventBus: opts.eventBus,
       onStepFinish,
       abortSignal,
       toolChoice: "auto",
@@ -252,12 +251,7 @@ You have credentials — authenticate immediately.
 export async function runAuthenticationAgent(input: AuthenticationAgentInput) {
   const agent = new AuthenticationAgent(input);
 
-  const { success, summary } = await agent.consume({
-    onTextDelta: (d) => process.stdout.write(d.text),
-    onToolCall: (d) => console.log(`→ calling ${d.toolName}`),
-    onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
-    onError: (e) => console.error("Agent error:", e),
-  });
+  const { success, summary } = await agent.consume();
 
   console.log(
     `\nAuthentication ${success ? "succeeded" : "failed"}: ${summary}`,

--- a/src/core/agents/specialized/authenticationAgent/agent.ts
+++ b/src/core/agents/specialized/authenticationAgent/agent.ts
@@ -249,16 +249,18 @@ You have credentials — authenticate immediately.
 // ---------------------------------------------------------------------------
 
 export async function runAuthenticationAgent(input: AuthenticationAgentInput) {
-  const eventBus = input.eventBus ?? (() => {
-    const bus = new AgentEventBus();
-    bus.on("text-delta", (e) => process.stdout.write(e.data.text));
-    bus.on("tool-call", (e) => console.log(`→ calling ${e.data.toolName}`));
-    bus.on("tool-result", (e) =>
-      console.log(`✓ ${e.data.toolName} completed`),
-    );
-    bus.on("error", (e) => console.error("Agent error:", e.error));
-    return bus;
-  })();
+  const eventBus =
+    input.eventBus ??
+    (() => {
+      const bus = new AgentEventBus();
+      bus.on("text-delta", (e) => process.stdout.write(e.data.text));
+      bus.on("tool-call", (e) => console.log(`→ calling ${e.data.toolName}`));
+      bus.on("tool-result", (e) =>
+        console.log(`✓ ${e.data.toolName} completed`),
+      );
+      bus.on("error", (e) => console.error("Agent error:", e.error));
+      return bus;
+    })();
   const agent = new AuthenticationAgent({ ...input, eventBus });
 
   const { success, summary } = await agent.consume();

--- a/src/core/agents/specialized/benchmarkComparisonAgent.ts
+++ b/src/core/agents/specialized/benchmarkComparisonAgent.ts
@@ -7,6 +7,7 @@ import type { AIAuthConfig } from "../../ai/utils";
 import { type SessionInfo } from "../../session";
 import type { ComparisonResult } from "./benchmark/types";
 import { OffensiveSecurityAgent } from "../offSecAgent/offensiveSecurityAgent";
+import type { AgentEventBus } from "../offSecAgent/eventBus";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -30,6 +31,9 @@ export interface BenchmarkComparisonAgentInput {
 
   /** AbortSignal to cancel mid-run */
   abortSignal?: AbortSignal;
+
+  /** Event bus for emitting stream events */
+  eventBus?: AgentEventBus;
 }
 
 /** The typed result returned by `BenchmarkComparisonAgent.consume()`. */
@@ -68,6 +72,7 @@ export class BenchmarkComparisonAgent extends OffensiveSecurityAgent<BenchmarkCo
       model,
       session,
       authConfig,
+      eventBus: opts.eventBus,
       onStepFinish,
       abortSignal,
 

--- a/src/core/agents/specialized/codeAgent/agent.ts
+++ b/src/core/agents/specialized/codeAgent/agent.ts
@@ -46,10 +46,7 @@ export interface CodeAgentInput<TResult = void> extends SpecializedAgentInput {
  *   session,
  * });
  *
- * await agent.consume({
- *   onTextDelta: (d) => process.stdout.write(d.text),
- *   onToolCall:  (d) => console.log(`→ ${d.toolName}`),
- * });
+ * await agent.consume();
  * ```
  */
 export class CodeAgent<TResult = void> extends OffensiveSecurityAgent<TResult> {
@@ -62,7 +59,7 @@ export class CodeAgent<TResult = void> extends OffensiveSecurityAgent<TResult> {
       authConfig,
       onStepFinish,
       abortSignal,
-      callbacks,
+      eventBus,
       stopWhen,
       responseSchema,
       system,
@@ -88,8 +85,7 @@ export class CodeAgent<TResult = void> extends OffensiveSecurityAgent<TResult> {
       authConfig,
       onStepFinish,
       abortSignal,
-      callbacks,
-      subagentCallbacks: callbacks?.subagentCallbacks,
+      eventBus,
       stopWhen: stopWhen ?? stepCountIs(10000),
       activeTools,
       responseSchema,

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import type { Finding, SpecializedAgentInput } from "../../offSecAgent/types";
 import { OffensiveSecurityAgent } from "../../offSecAgent/offensiveSecurityAgent";
 import type { UnifiedSandbox } from "../../offSecAgent/tools/sandbox";
+import { AgentEventBus } from "../../offSecAgent/eventBus";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -223,7 +224,17 @@ function loadFindings(findingsPath: string): Finding[] {
 }
 
 export async function runPentestAgent(input: PentestAgentInput) {
-  const agent = new TargetedPentestAgent(input);
+  const eventBus = input.eventBus ?? (() => {
+    const bus = new AgentEventBus();
+    bus.on("text-delta", (e) => process.stdout.write(e.data.text));
+    bus.on("tool-call", (e) => console.log(`→ calling ${e.data.toolName}`));
+    bus.on("tool-result", (e) =>
+      console.log(`✓ ${e.data.toolName} completed`),
+    );
+    bus.on("error", (e) => console.error("Agent error:", e.error));
+    return bus;
+  })();
+  const agent = new TargetedPentestAgent({ ...input, eventBus });
 
   const { findings, findingsPath, pocsPath } = await agent.consume();
 

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -4,7 +4,6 @@ import { join } from "path";
 import type { Finding, SpecializedAgentInput } from "../../offSecAgent/types";
 import { OffensiveSecurityAgent } from "../../offSecAgent/offensiveSecurityAgent";
 import type { UnifiedSandbox } from "../../offSecAgent/tools/sandbox";
-import { AgentEventBus } from "../../offSecAgent/eventBus";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -223,24 +222,3 @@ function loadFindings(findingsPath: string): Finding[] {
     .filter((f): f is Finding => f !== null);
 }
 
-export async function runPentestAgent(input: PentestAgentInput) {
-  const eventBus = input.eventBus ?? (() => {
-    const bus = new AgentEventBus();
-    bus.on("text-delta", (e) => process.stdout.write(e.data.text));
-    bus.on("tool-call", (e) => console.log(`→ calling ${e.data.toolName}`));
-    bus.on("tool-result", (e) =>
-      console.log(`✓ ${e.data.toolName} completed`),
-    );
-    bus.on("error", (e) => console.error("Agent error:", e.error));
-    return bus;
-  })();
-  const agent = new TargetedPentestAgent({ ...input, eventBus });
-
-  const { findings, findingsPath, pocsPath } = await agent.consume();
-
-  console.log(`\nFound ${findings.length} vulnerabilities`);
-  console.log(`Findings: ${findingsPath}`);
-  console.log(`POCs: ${pocsPath}`);
-
-  return { findings, findingsPath, pocsPath };
-}

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -52,10 +52,7 @@ export interface PentestResult {
  *   session,
  * });
  *
- * const { findings, findingsPath } = await agent.consume({
- *   onTextDelta: (d) => process.stdout.write(d.text),
- *   onToolCall:  (d) => console.log(`→ ${d.toolName}`),
- * });
+ * const { findings, findingsPath } = await agent.consume();
  *
  * console.log(`Found ${findings.length} vulnerabilities`);
  * ```
@@ -80,6 +77,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       session,
       target,
       authConfig,
+      eventBus: opts.eventBus,
       onStepFinish,
       abortSignal,
       sandbox,
@@ -227,12 +225,7 @@ function loadFindings(findingsPath: string): Finding[] {
 export async function runPentestAgent(input: PentestAgentInput) {
   const agent = new TargetedPentestAgent(input);
 
-  const { findings, findingsPath, pocsPath } = await agent.consume({
-    onTextDelta: (d) => process.stdout.write(d.text),
-    onToolCall: (d) => console.log(`→ calling ${d.toolName}`),
-    onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
-    onError: (e) => console.error("Agent error:", e),
-  });
+  const { findings, findingsPath, pocsPath } = await agent.consume();
 
   console.log(`\nFound ${findings.length} vulnerabilities`);
   console.log(`Findings: ${findingsPath}`);

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -221,4 +221,3 @@ function loadFindings(findingsPath: string): Finding[] {
     })
     .filter((f): f is Finding => f !== null);
 }
-

--- a/src/core/agents/specialized/whiteboxAttackSurface/agent.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/agent.ts
@@ -40,10 +40,7 @@ export interface WhiteboxAttackSurfaceAgentInput extends SpecializedAgentInput {
  *   session,
  * });
  *
- * const result = await agent.consume({
- *   onTextDelta: (d) => process.stdout.write(d.text),
- *   onToolCall:  (d) => console.log(`→ ${d.toolName}`),
- * });
+ * const result = await agent.consume();
  *
  * console.log(`Found ${result.summary.totalApiEndpoints} API endpoints`);
  * ```
@@ -57,7 +54,7 @@ export class WhiteboxAttackSurfaceAgent extends OffensiveSecurityAgent<WhiteboxA
       authConfig,
       onStepFinish,
       abortSignal,
-      callbacks,
+      eventBus,
     } = opts;
 
     // Closure variable that the response tool writes to
@@ -84,8 +81,7 @@ This ends the agent run — make sure all data is included.`,
       authConfig,
       onStepFinish,
       abortSignal,
-      callbacks,
-      subagentCallbacks: callbacks?.subagentCallbacks,
+      eventBus,
 
       activeTools: [
         // Filesystem tools — for Phase 1 repo identification

--- a/src/core/api/agentRun.test.ts
+++ b/src/core/api/agentRun.test.ts
@@ -1,15 +1,31 @@
 import { describe, it, expect } from "vitest";
 import { AgentRun } from "./agentRun";
-import type { AgentEventBus } from "../agents/offSecAgent/eventBus";
-import type { AgentEvent } from "../agents/offSecAgent/eventBus";
+import type {
+  AgentEvent,
+  TextDeltaData,
+  ToolCallData,
+} from "../agents/offSecAgent/eventBus";
+
+function makeTextDelta(text: string): TextDeltaData {
+  return { type: "text-delta", id: "td-1", text } as TextDeltaData;
+}
+
+function makeToolCall(toolName: string): ToolCallData {
+  return {
+    type: "tool-call",
+    toolCallId: "tc-1",
+    toolName,
+    args: {},
+  } as unknown as ToolCallData;
+}
 
 describe("AgentRun", () => {
   it("iterates events then resolves result", async () => {
     const events: AgentEvent[] = [];
 
     const run = new AgentRun<string>(async (bus) => {
-      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "hello " } as any });
-      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "world" } as any });
+      bus.emit({ type: "text-delta", data: makeTextDelta("hello ") });
+      bus.emit({ type: "text-delta", data: makeTextDelta("world") });
       return "done";
     });
 
@@ -25,7 +41,7 @@ describe("AgentRun", () => {
 
   it("resolves result without iterating", async () => {
     const run = new AgentRun<number>(async (bus) => {
-      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "ignored" } as any });
+      bus.emit({ type: "text-delta", data: makeTextDelta("ignored") });
       return 42;
     });
 
@@ -38,9 +54,9 @@ describe("AgentRun", () => {
 
     const run = new AgentRun<void>(async (bus) => {
       // Emit several events synchronously
-      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "a" } as any });
-      bus.emit({ type: "tool-call", data: { type: "tool-call", toolName: "test", toolCallId: "1", args: {} } as any });
-      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "b" } as any });
+      bus.emit({ type: "text-delta", data: makeTextDelta("a") });
+      bus.emit({ type: "tool-call", data: makeToolCall("test") });
+      bus.emit({ type: "text-delta", data: makeTextDelta("b") });
     });
 
     for await (const event of run) {
@@ -65,7 +81,7 @@ describe("AgentRun", () => {
     const events: AgentEvent[] = [];
 
     const run = new AgentRun<never>(async (bus) => {
-      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "before error" } as any });
+      bus.emit({ type: "text-delta", data: makeTextDelta("before error") });
       throw new Error("boom");
     });
 
@@ -96,11 +112,11 @@ describe("AgentRun", () => {
     const events: AgentEvent[] = [];
 
     const run = new AgentRun<string>(async (bus) => {
-      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "first" } as any });
+      bus.emit({ type: "text-delta", data: makeTextDelta("first") });
       await new Promise((r) => setTimeout(r, 10));
-      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "second" } as any });
+      bus.emit({ type: "text-delta", data: makeTextDelta("second") });
       await new Promise((r) => setTimeout(r, 10));
-      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "third" } as any });
+      bus.emit({ type: "text-delta", data: makeTextDelta("third") });
       return "complete";
     });
 
@@ -117,8 +133,8 @@ describe("AgentRun", () => {
 
     const run = new AgentRun<void>(async (bus) => {
       const child = bus.child("agent-1");
-      child.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "from child" } as any });
-      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "from parent" } as any });
+      child.emit({ type: "text-delta", data: makeTextDelta("from child") });
+      bus.emit({ type: "text-delta", data: makeTextDelta("from parent") });
     });
 
     for await (const event of run) {

--- a/src/core/api/agentRun.test.ts
+++ b/src/core/api/agentRun.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { AgentRun } from "./agentRun";
+import type { AgentEventBus } from "../agents/offSecAgent/eventBus";
+import type { AgentEvent } from "../agents/offSecAgent/eventBus";
+
+describe("AgentRun", () => {
+  it("iterates events then resolves result", async () => {
+    const events: AgentEvent[] = [];
+
+    const run = new AgentRun<string>(async (bus) => {
+      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "hello " } as any });
+      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "world" } as any });
+      return "done";
+    });
+
+    for await (const event of run) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(2);
+    expect(events[0]!.type).toBe("text-delta");
+    expect(events[1]!.type).toBe("text-delta");
+    expect(await run.result).toBe("done");
+  });
+
+  it("resolves result without iterating", async () => {
+    const run = new AgentRun<number>(async (bus) => {
+      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "ignored" } as any });
+      return 42;
+    });
+
+    const result = await run.result;
+    expect(result).toBe(42);
+  });
+
+  it("buffers events while consumer is processing", async () => {
+    const events: AgentEvent[] = [];
+
+    const run = new AgentRun<void>(async (bus) => {
+      // Emit several events synchronously
+      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "a" } as any });
+      bus.emit({ type: "tool-call", data: { type: "tool-call", toolName: "test", toolCallId: "1", args: {} } as any });
+      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "b" } as any });
+    });
+
+    for await (const event of run) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(3);
+    expect(events[0]!.type).toBe("text-delta");
+    expect(events[1]!.type).toBe("tool-call");
+    expect(events[2]!.type).toBe("text-delta");
+  });
+
+  it("propagates errors from the agent run", async () => {
+    const run = new AgentRun<never>(async () => {
+      throw new Error("agent failed");
+    });
+
+    await expect(run.result).rejects.toThrow("agent failed");
+  });
+
+  it("ends iteration when agent errors", async () => {
+    const events: AgentEvent[] = [];
+
+    const run = new AgentRun<never>(async (bus) => {
+      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "before error" } as any });
+      throw new Error("boom");
+    });
+
+    for await (const event of run) {
+      events.push(event);
+    }
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    await expect(run.result).rejects.toThrow("boom");
+  });
+
+  it("handles empty run (no events)", async () => {
+    const events: AgentEvent[] = [];
+
+    const run = new AgentRun<string>(async () => {
+      return "empty";
+    });
+
+    for await (const event of run) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(0);
+    expect(await run.result).toBe("empty");
+  });
+
+  it("handles async events with delays", async () => {
+    const events: AgentEvent[] = [];
+
+    const run = new AgentRun<string>(async (bus) => {
+      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "first" } as any });
+      await new Promise((r) => setTimeout(r, 10));
+      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "second" } as any });
+      await new Promise((r) => setTimeout(r, 10));
+      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "third" } as any });
+      return "complete";
+    });
+
+    for await (const event of run) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(3);
+    expect(await run.result).toBe("complete");
+  });
+
+  it("preserves subagentId on events from child buses", async () => {
+    const events: AgentEvent[] = [];
+
+    const run = new AgentRun<void>(async (bus) => {
+      const child = bus.child("agent-1");
+      child.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "from child" } as any });
+      bus.emit({ type: "text-delta", data: { type: "text-delta", textDelta: "from parent" } as any });
+    });
+
+    for await (const event of run) {
+      events.push(event);
+    }
+
+    // Child event should have subagentId, parent should not
+    expect(events).toHaveLength(2);
+    expect(events[0]!.subagentId).toBe("agent-1");
+    expect(events[1]!.subagentId).toBeUndefined();
+  });
+});

--- a/src/core/api/agentRun.ts
+++ b/src/core/api/agentRun.ts
@@ -1,0 +1,87 @@
+import { AgentEventBus, type AgentEvent } from "../agents/offSecAgent/eventBus";
+
+/**
+ * Represents a running agent. Async-iterable for streaming events,
+ * with a `.result` promise for the final typed output.
+ *
+ * The internal {@link AgentEventBus} is created and managed automatically —
+ * consumers never need to import or configure it.
+ *
+ * @typeParam TResult - The typed result produced when the agent finishes.
+ *
+ * @example Streaming events
+ * ```ts
+ * const run = runPentestAgent({ target, model, session });
+ * for await (const event of run) {
+ *   if (event.type === "text-delta") process.stdout.write(event.data.text);
+ * }
+ * const result = await run.result;
+ * ```
+ *
+ * @example Result-only (ignore streaming)
+ * ```ts
+ * const { findings } = await runPentestAgent({ target, model, session }).result;
+ * ```
+ */
+export class AgentRun<TResult> implements AsyncIterable<AgentEvent> {
+  /** Resolves to the typed result after the agent finishes. */
+  public readonly result: Promise<TResult>;
+
+  private queue: AgentEvent[] = [];
+  private waiting: ((value: IteratorResult<AgentEvent>) => void) | null = null;
+  private done = false;
+  private error: unknown = undefined;
+
+  constructor(run: (eventBus: AgentEventBus) => Promise<TResult>) {
+    const bus = new AgentEventBus();
+
+    bus.on((event) => {
+      if (this.waiting) {
+        const resolve = this.waiting;
+        this.waiting = null;
+        resolve({ value: event, done: false });
+      } else {
+        this.queue.push(event);
+      }
+    });
+
+    this.result = run(bus)
+      .catch((err) => {
+        this.error = err;
+        throw err;
+      })
+      .finally(() => {
+        this.done = true;
+        if (this.waiting) {
+          const resolve = this.waiting;
+          this.waiting = null;
+          resolve({ value: undefined as never, done: true });
+        }
+      });
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<AgentEvent> {
+    while (true) {
+      while (this.queue.length > 0) {
+        yield this.queue.shift()!;
+      }
+
+      if (this.done) return;
+
+      const next = await new Promise<IteratorResult<AgentEvent>>((resolve) => {
+        if (this.queue.length > 0) {
+          resolve({ value: this.queue.shift()!, done: false });
+          return;
+        }
+        if (this.done) {
+          resolve({ value: undefined as never, done: true });
+          return;
+        }
+        this.waiting = resolve;
+      });
+
+      if (next.done) return;
+      yield next.value;
+    }
+  }
+}

--- a/src/core/api/attackSurface.test.ts
+++ b/src/core/api/attackSurface.test.ts
@@ -1,5 +1,6 @@
 import { runAttackSurfaceAgent } from "./attackSurface";
 import { sessions } from "../session";
+import { AgentEventBus } from "../agents/offSecAgent/eventBus";
 import { describe, it, expect } from "vitest";
 
 const TARGET_URL = "staging-console.pensar.dev";
@@ -15,14 +16,7 @@ describe("Attack Surface", () => {
       model: "claude-haiku-4-5",
       session,
 
-      callbacks: {
-        onToolCall: (d) =>
-          console.log(
-            `\n→ calling ${d.toolName} \n ${JSON.stringify(d.input, null, 2)}`,
-          ),
-        onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
-        onError: (e) => console.error(e),
-      },
+      eventBus: new AgentEventBus(),
     });
     expect(result).toBeDefined();
   });

--- a/src/core/api/attackSurface.test.ts
+++ b/src/core/api/attackSurface.test.ts
@@ -1,6 +1,5 @@
 import { runAttackSurfaceAgent } from "./attackSurface";
 import { sessions } from "../session";
-import { AgentEventBus } from "../agents/offSecAgent/eventBus";
 import { describe, it, expect } from "vitest";
 
 const TARGET_URL = "staging-console.pensar.dev";
@@ -15,9 +14,7 @@ describe("Attack Surface", () => {
       target: TARGET_URL,
       model: "claude-haiku-4-5",
       session,
-
-      eventBus: new AgentEventBus(),
-    });
+    }).result;
     expect(result).toBeDefined();
   });
 });

--- a/src/core/api/attackSurface.ts
+++ b/src/core/api/attackSurface.ts
@@ -5,12 +5,13 @@ import {
 } from "../agents/specialized/attackSurface/blackboxAgent";
 import type { WhiteboxAttackSurfaceResult } from "../agents/specialized/whiteboxAttackSurface";
 import { runWhiteboxAttackSurfaceWorkflow } from "../workflows/whiteboxAttackSurface";
+import { AgentRun } from "./agentRun";
 
 // ---------------------------------------------------------------------------
 // Unified input — accepts both blackbox and whitebox configurations
 // ---------------------------------------------------------------------------
 
-export type AttackSurfaceInput = AttackSurfaceAgentInput;
+export type AttackSurfaceInput = Omit<AttackSurfaceAgentInput, "eventBus">;
 
 // ---------------------------------------------------------------------------
 // Convenience runners
@@ -26,18 +27,21 @@ export type AttackSurfaceInput = AttackSurfaceAgentInput;
  *
  * `target` is always required (the live URL to test against).
  */
-export async function runAttackSurfaceAgent(
-  input: AttackSurfaceAgentInput,
-): Promise<AttackSurfaceResult | WhiteboxAttackSurfaceResult> {
+export function runAttackSurfaceAgent(
+  input: Omit<AttackSurfaceAgentInput, "eventBus">,
+): AgentRun<AttackSurfaceResult | WhiteboxAttackSurfaceResult> {
   const isWhitebox = "cwd" in input && !!input.cwd;
 
   if (isWhitebox) {
-    return runWhiteboxAttackSurface(
-      input as AttackSurfaceAgentInput & { cwd: string },
-    );
+    const whiteboxInput = input as Omit<AttackSurfaceAgentInput, "eventBus"> & { cwd: string };
+    return new AgentRun(async (eventBus) => {
+      return runWhiteboxAttackSurface(whiteboxInput, eventBus);
+    });
   }
 
-  return runBlackboxAttackSurface(input);
+  return new AgentRun(async (eventBus) => {
+    return runBlackboxAttackSurface(input, eventBus);
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -45,17 +49,14 @@ export async function runAttackSurfaceAgent(
 // ---------------------------------------------------------------------------
 
 async function runBlackboxAttackSurface(
-  input: AttackSurfaceAgentInput,
+  input: Omit<AttackSurfaceAgentInput, "eventBus">,
+  eventBus: import("../agents/offSecAgent/eventBus").AgentEventBus,
 ): Promise<AttackSurfaceResult> {
-  const agent = new BlackboxAttackSurfaceAgent(input);
-
-  const { results, targets, resultsPath, assetsPath } = await agent.consume();
-
-  console.log(`\nIdentified ${targets.length} targets for deep testing`);
-  console.log(`Results: ${resultsPath}`);
-  console.log(`Assets: ${assetsPath}`);
-
-  return { results, targets, resultsPath, assetsPath };
+  const agent = new BlackboxAttackSurfaceAgent({
+    ...input,
+    eventBus,
+  } as AttackSurfaceAgentInput);
+  return agent.consume();
 }
 
 // ---------------------------------------------------------------------------
@@ -63,22 +64,15 @@ async function runBlackboxAttackSurface(
 // ---------------------------------------------------------------------------
 
 async function runWhiteboxAttackSurface(
-  input: AttackSurfaceAgentInput & { cwd: string },
+  input: Omit<AttackSurfaceAgentInput, "eventBus"> & { cwd: string },
+  eventBus: import("../agents/offSecAgent/eventBus").AgentEventBus,
 ): Promise<WhiteboxAttackSurfaceResult> {
-  const result = await runWhiteboxAttackSurfaceWorkflow({
+  return runWhiteboxAttackSurfaceWorkflow({
     codebasePath: input.cwd,
     model: input.model,
     session: input.session,
     authConfig: input.authConfig,
     abortSignal: input.abortSignal,
-    eventBus: input.eventBus,
+    eventBus,
   });
-
-  console.log(
-    `\nWhitebox analysis complete: ${result.summary.totalApps} apps, ` +
-      `${result.summary.totalApiEndpoints} API endpoints, ` +
-      `${result.summary.totalPages} pages`,
-  );
-
-  return result;
 }

--- a/src/core/api/attackSurface.ts
+++ b/src/core/api/attackSurface.ts
@@ -33,7 +33,9 @@ export function runAttackSurfaceAgent(
   const isWhitebox = "cwd" in input && !!input.cwd;
 
   if (isWhitebox) {
-    const whiteboxInput = input as Omit<AttackSurfaceAgentInput, "eventBus"> & { cwd: string };
+    const whiteboxInput = input as Omit<AttackSurfaceAgentInput, "eventBus"> & {
+      cwd: string;
+    };
     return new AgentRun(async (eventBus) => {
       return runWhiteboxAttackSurface(whiteboxInput, eventBus);
     });

--- a/src/core/api/attackSurface.ts
+++ b/src/core/api/attackSurface.ts
@@ -49,12 +49,7 @@ async function runBlackboxAttackSurface(
 ): Promise<AttackSurfaceResult> {
   const agent = new BlackboxAttackSurfaceAgent(input);
 
-  const { results, targets, resultsPath, assetsPath } = await agent.consume({
-    onTextDelta: (d) => input.callbacks?.onTextDelta?.(d),
-    onToolCall: (d) => input.callbacks?.onToolCall?.(d),
-    onToolResult: (d) => input.callbacks?.onToolResult?.(d),
-    onError: (e) => input.callbacks?.onError?.(e),
-  });
+  const { results, targets, resultsPath, assetsPath } = await agent.consume();
 
   console.log(`\nIdentified ${targets.length} targets for deep testing`);
   console.log(`Results: ${resultsPath}`);
@@ -76,7 +71,7 @@ async function runWhiteboxAttackSurface(
     session: input.session,
     authConfig: input.authConfig,
     abortSignal: input.abortSignal,
-    callbacks: input.callbacks,
+    eventBus: input.eventBus,
   });
 
   console.log(

--- a/src/core/api/authentication.ts
+++ b/src/core/api/authentication.ts
@@ -1,34 +1,19 @@
 import {
   AuthenticationAgent,
   type AuthenticationAgentInput,
+  type AuthenticationResult,
 } from "../agents/specialized/authenticationAgent/agent";
+import { AgentRun } from "./agentRun";
+
 // ---------------------------------------------------------------------------
 // Convenience runner
 // ---------------------------------------------------------------------------
 
-export async function runAuthenticationAgent(input: AuthenticationAgentInput) {
-  const agent = new AuthenticationAgent(input);
-
-  const {
-    success,
-    summary,
-    exportedCookies,
-    exportedHeaders,
-    strategy,
-    authBarrier,
-    authDataPath,
-  } = await agent.consume();
-
-  console.log(
-    `\nAuthentication ${success ? "succeeded" : "failed"}: ${summary}`,
-  );
-  return {
-    success,
-    summary,
-    exportedCookies,
-    exportedHeaders,
-    strategy,
-    authBarrier,
-    authDataPath,
-  };
+export function runAuthenticationAgent(
+  input: Omit<AuthenticationAgentInput, "eventBus">,
+): AgentRun<AuthenticationResult> {
+  return new AgentRun(async (eventBus) => {
+    const agent = new AuthenticationAgent({ ...input, eventBus });
+    return agent.consume();
+  });
 }

--- a/src/core/api/authentication.ts
+++ b/src/core/api/authentication.ts
@@ -17,13 +17,7 @@ export async function runAuthenticationAgent(input: AuthenticationAgentInput) {
     strategy,
     authBarrier,
     authDataPath,
-  } = await agent.consume({
-    onTextDelta: (d) => input.callbacks?.onTextDelta?.(d),
-    onToolCall: (d) => input.callbacks?.onToolCall?.(d),
-    onToolResult: (d) => input.callbacks?.onToolResult?.(d),
-    onError: (e) => input.callbacks?.onError?.(e),
-    subagentCallbacks: input.callbacks?.subagentCallbacks,
-  });
+  } = await agent.consume();
 
   console.log(
     `\nAuthentication ${success ? "succeeded" : "failed"}: ${summary}`,

--- a/src/core/api/benchmark.ts
+++ b/src/core/api/benchmark.ts
@@ -2,6 +2,7 @@ import {
   BenchmarkComparisonAgent,
   type BenchmarkComparisonAgentInput,
 } from "../agents/specialized/benchmarkComparisonAgent";
+import { AgentEventBus } from "../agents/offSecAgent/eventBus";
 // ---------------------------------------------------------------------------
 // Convenience runner
 // ---------------------------------------------------------------------------
@@ -9,14 +10,10 @@ import {
 export async function runBenchmarkComparisonAgent(
   input: BenchmarkComparisonAgentInput,
 ) {
-  const agent = new BenchmarkComparisonAgent(input);
+  const eventBus = input.eventBus ?? new AgentEventBus();
+  const agent = new BenchmarkComparisonAgent({ ...input, eventBus });
 
-  const { comparison, resultsPath } = await agent.consume({
-    onTextDelta: (d) => process.stdout.write(d.text),
-    onToolCall: (d) => console.log(`→ calling ${d.toolName}`),
-    onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
-    onError: (e) => console.error("Agent error:", e),
-  });
+  const { comparison, resultsPath } = await agent.consume();
 
   if (comparison) {
     console.log(

--- a/src/core/api/benchmark.ts
+++ b/src/core/api/benchmark.ts
@@ -1,37 +1,19 @@
 import {
   BenchmarkComparisonAgent,
   type BenchmarkComparisonAgentInput,
+  type BenchmarkComparisonResult,
 } from "../agents/specialized/benchmarkComparisonAgent";
-import { AgentEventBus } from "../agents/offSecAgent/eventBus";
+import { AgentRun } from "./agentRun";
+
 // ---------------------------------------------------------------------------
 // Convenience runner
 // ---------------------------------------------------------------------------
 
-export async function runBenchmarkComparisonAgent(
-  input: BenchmarkComparisonAgentInput,
-) {
-  const eventBus = input.eventBus ?? (() => {
-    const bus = new AgentEventBus();
-    bus.on("text-delta", (e) => process.stdout.write(e.data.text));
-    bus.on("tool-call", (e) => console.log(`→ calling ${e.data.toolName}`));
-    bus.on("tool-result", (e) =>
-      console.log(`✓ ${e.data.toolName} completed`),
-    );
-    bus.on("error", (e) => console.error("Agent error:", e.error));
-    return bus;
-  })();
-  const agent = new BenchmarkComparisonAgent({ ...input, eventBus });
-
-  const { comparison, resultsPath } = await agent.consume();
-
-  if (comparison) {
-    console.log(
-      `\nComparison: ${comparison.matched.length}/${comparison.totalExpected} matched, ` +
-        `Precision: ${Math.round(comparison.precision * 100)}%, ` +
-        `Recall: ${Math.round(comparison.recall * 100)}%`,
-    );
-  }
-  console.log(`Results: ${resultsPath}`);
-
-  return { comparison, resultsPath };
+export function runBenchmarkComparisonAgent(
+  input: Omit<BenchmarkComparisonAgentInput, "eventBus">,
+): AgentRun<BenchmarkComparisonResult> {
+  return new AgentRun(async (eventBus) => {
+    const agent = new BenchmarkComparisonAgent({ ...input, eventBus });
+    return agent.consume();
+  });
 }

--- a/src/core/api/benchmark.ts
+++ b/src/core/api/benchmark.ts
@@ -10,7 +10,16 @@ import { AgentEventBus } from "../agents/offSecAgent/eventBus";
 export async function runBenchmarkComparisonAgent(
   input: BenchmarkComparisonAgentInput,
 ) {
-  const eventBus = input.eventBus ?? new AgentEventBus();
+  const eventBus = input.eventBus ?? (() => {
+    const bus = new AgentEventBus();
+    bus.on("text-delta", (e) => process.stdout.write(e.data.text));
+    bus.on("tool-call", (e) => console.log(`→ calling ${e.data.toolName}`));
+    bus.on("tool-result", (e) =>
+      console.log(`✓ ${e.data.toolName} completed`),
+    );
+    bus.on("error", (e) => console.error("Agent error:", e.error));
+    return bus;
+  })();
   const agent = new BenchmarkComparisonAgent({ ...input, eventBus });
 
   const { comparison, resultsPath } = await agent.consume();

--- a/src/core/api/blackboxPentest.ts
+++ b/src/core/api/blackboxPentest.ts
@@ -29,7 +29,7 @@ export async function runPentestAgent(
       session: input.session,
       authConfig: input.authConfig,
       abortSignal: input.abortSignal,
-      callbacks: input.callbacks,
+      eventBus: input.eventBus,
     });
 
   console.log(`\nFound ${findings.length} vulnerabilities`);

--- a/src/core/api/blackboxPentest.ts
+++ b/src/core/api/blackboxPentest.ts
@@ -1,9 +1,9 @@
-//
 import {
   runPentestWorkflow,
   type PentestWorkflowInput,
   type PentestWorkflowResult,
 } from "../workflows/pentest";
+import { AgentRun } from "./agentRun";
 
 // ---------------------------------------------------------------------------
 // Convenience runner
@@ -18,24 +18,10 @@ import {
  * Phase 1: Runs attack surface discovery (whitebox workflow or blackbox agent)
  * Phase 2: Spawns targeted pentest agents for each discovered target
  */
-export async function runPentestAgent(
-  input: PentestWorkflowInput,
-): Promise<PentestWorkflowResult> {
-  const { findings, findingsPath, pocsPath, reportPath } =
-    await runPentestWorkflow({
-      target: input.target,
-      cwd: input.cwd,
-      model: input.model,
-      session: input.session,
-      authConfig: input.authConfig,
-      abortSignal: input.abortSignal,
-      eventBus: input.eventBus,
-    });
-
-  console.log(`\nFound ${findings.length} vulnerabilities`);
-  console.log(`Findings: ${findingsPath}`);
-  console.log(`POCs: ${pocsPath}`);
-  if (reportPath) console.log(`Report: ${reportPath}`);
-
-  return { findings, findingsPath, pocsPath, reportPath };
+export function runPentestAgent(
+  input: Omit<PentestWorkflowInput, "eventBus">,
+): AgentRun<PentestWorkflowResult> {
+  return new AgentRun(async (eventBus) => {
+    return runPentestWorkflow({ ...input, eventBus });
+  });
 }

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -1,3 +1,5 @@
+export { AgentRun } from "./agentRun";
+export type { AgentEvent } from "../agents/offSecAgent/eventBus";
 export * from "./attackSurface";
 export * from "./authentication";
 export * from "./benchmark";

--- a/src/core/api/offesecAgent.ts
+++ b/src/core/api/offesecAgent.ts
@@ -5,11 +5,5 @@ export async function runOffensiveSecurityAgent(
   input: OffensiveSecurityAgentInput,
 ) {
   const agent = new OffensiveSecurityAgent(input);
-  return agent.consume({
-    onTextDelta: (d) => input.callbacks?.onTextDelta?.(d),
-    onToolCall: (d) => input.callbacks?.onToolCall?.(d),
-    onToolResult: (d) => input.callbacks?.onToolResult?.(d),
-    onError: (e) => input.callbacks?.onError?.(e),
-    subagentCallbacks: input.callbacks?.subagentCallbacks,
-  });
+  return agent.consume();
 }

--- a/src/core/api/targetedPentest.ts
+++ b/src/core/api/targetedPentest.ts
@@ -5,7 +5,16 @@ import {
 import { AgentEventBus } from "../agents/offSecAgent/eventBus";
 
 export async function runTargetedPentestAgent(input: PentestAgentInput) {
-  const eventBus = input.eventBus ?? new AgentEventBus();
+  const eventBus = input.eventBus ?? (() => {
+    const bus = new AgentEventBus();
+    bus.on("text-delta", (e) => process.stdout.write(e.data.text));
+    bus.on("tool-call", (e) => console.log(`→ calling ${e.data.toolName}`));
+    bus.on("tool-result", (e) =>
+      console.log(`✓ ${e.data.toolName} completed`),
+    );
+    bus.on("error", (e) => console.error("Agent error:", e.error));
+    return bus;
+  })();
   const agent = new TargetedPentestAgent({ ...input, eventBus });
 
   const { findings, findingsPath, pocsPath } = await agent.consume();

--- a/src/core/api/targetedPentest.ts
+++ b/src/core/api/targetedPentest.ts
@@ -2,16 +2,13 @@ import {
   TargetedPentestAgent,
   type PentestAgentInput,
 } from "../agents/specialized/pentest/agent";
+import { AgentEventBus } from "../agents/offSecAgent/eventBus";
 
 export async function runTargetedPentestAgent(input: PentestAgentInput) {
-  const agent = new TargetedPentestAgent(input);
+  const eventBus = input.eventBus ?? new AgentEventBus();
+  const agent = new TargetedPentestAgent({ ...input, eventBus });
 
-  const { findings, findingsPath, pocsPath } = await agent.consume({
-    onTextDelta: (d) => process.stdout.write(d.text),
-    onToolCall: (d) => console.log(`→ calling ${d.toolName}`),
-    onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
-    onError: (e) => console.error("Agent error:", e),
-  });
+  const { findings, findingsPath, pocsPath } = await agent.consume();
 
   console.log(`\nFound ${findings.length} vulnerabilities`);
   console.log(`Findings: ${findingsPath}`);

--- a/src/core/api/targetedPentest.ts
+++ b/src/core/api/targetedPentest.ts
@@ -1,27 +1,15 @@
 import {
   TargetedPentestAgent,
   type PentestAgentInput,
+  type PentestResult,
 } from "../agents/specialized/pentest/agent";
-import { AgentEventBus } from "../agents/offSecAgent/eventBus";
+import { AgentRun } from "./agentRun";
 
-export async function runTargetedPentestAgent(input: PentestAgentInput) {
-  const eventBus = input.eventBus ?? (() => {
-    const bus = new AgentEventBus();
-    bus.on("text-delta", (e) => process.stdout.write(e.data.text));
-    bus.on("tool-call", (e) => console.log(`→ calling ${e.data.toolName}`));
-    bus.on("tool-result", (e) =>
-      console.log(`✓ ${e.data.toolName} completed`),
-    );
-    bus.on("error", (e) => console.error("Agent error:", e.error));
-    return bus;
-  })();
-  const agent = new TargetedPentestAgent({ ...input, eventBus });
-
-  const { findings, findingsPath, pocsPath } = await agent.consume();
-
-  console.log(`\nFound ${findings.length} vulnerabilities`);
-  console.log(`Findings: ${findingsPath}`);
-  console.log(`POCs: ${pocsPath}`);
-
-  return { findings, findingsPath, pocsPath };
+export function runTargetedPentestAgent(
+  input: Omit<PentestAgentInput, "eventBus">,
+): AgentRun<PentestResult> {
+  return new AgentRun(async (eventBus) => {
+    const agent = new TargetedPentestAgent({ ...input, eventBus });
+    return agent.consume();
+  });
 }

--- a/src/core/benchmark/runner.ts
+++ b/src/core/benchmark/runner.ts
@@ -13,6 +13,7 @@ import {
   type BenchmarkComparisonResult,
 } from "../agents/specialized/benchmarkComparisonAgent";
 import { runBenchmarkInDaytona } from "../agents/specialized/benchmark/remote/daytona-wrapper";
+import { AgentEventBus } from "../agents/offSecAgent/eventBus";
 import * as sessions from "../session";
 import { runPentestWorkflow } from "../workflows/pentest";
 import type {
@@ -299,6 +300,33 @@ export async function runSingleBenchmark(
       config.timeoutMinutes * 60 * 1000,
     );
 
+    const benchmarkBus = new AgentEventBus();
+    benchmarkBus.on("text-delta", (e) => process.stdout.write(e.data.text));
+    benchmarkBus.on("tool-call", (e) => {
+      const prefix = e.subagentId
+        ? `[${branch}] [${e.subagentId}]`
+        : `[${branch}]`;
+      console.log(`${prefix} -> ${e.data.toolName}`);
+    });
+    benchmarkBus.on("tool-result", (e) => {
+      const prefix = e.subagentId
+        ? `[${branch}] [${e.subagentId}]`
+        : `[${branch}]`;
+      console.log(`${prefix} <- ${e.data.toolName} done`);
+    });
+    benchmarkBus.on("error", (e) => {
+      const prefix = e.subagentId
+        ? `[${branch}] [${e.subagentId}]`
+        : `[${branch}]`;
+      console.error(`${prefix} Error:`, e.error);
+    });
+    benchmarkBus.on("subagent-spawn", (e) => {
+      console.log(`[${branch}] [${e.subagentId}] spawned`);
+    });
+    benchmarkBus.on("subagent-complete", (e) => {
+      console.log(`[${branch}] [${e.subagentId}] ${e.status}`);
+    });
+
     let pentestResult;
     try {
       pentestResult = await runPentestWorkflow({
@@ -306,25 +334,7 @@ export async function runSingleBenchmark(
         model: config.model,
         session,
         abortSignal: controller.signal,
-        callbacks: {
-          onTextDelta: (d) => process.stdout.write(d.text),
-          onToolCall: (d) => console.log(`[${branch}] -> ${d.toolName}`),
-          onToolResult: (d) => console.log(`[${branch}] <- ${d.toolName} done`),
-          onError: (e) => console.error(`[${branch}] Error:`, e),
-          subagentCallbacks: {
-            onSubagentSpawn: ({ subagentId }) =>
-              console.log(`[${branch}] [${subagentId}] spawned`),
-            onSubagentComplete: ({ subagentId, status }) =>
-              console.log(`[${branch}] [${subagentId}] ${status}`),
-            onToolCall: (d) =>
-              console.log(`[${branch}] [${d.subagentId}] -> ${d.toolName}`),
-            onToolResult: (d) =>
-              console.log(
-                `[${branch}] [${d.subagentId}] <- ${d.toolName} done`,
-              ),
-            onError: (e) => console.error(`[${branch}] [subagent] Error:`, e),
-          },
-        },
+        eventBus: benchmarkBus,
       });
     } finally {
       clearTimeout(timeout);
@@ -355,14 +365,17 @@ export async function runSingleBenchmark(
 
     try {
       console.log(`[${branch}] Running benchmark comparison...`);
+      const compBus = new AgentEventBus();
+      compBus.on("error", (e) =>
+        console.error(`[${branch}] Comparison error:`, e.error),
+      );
       const compAgent = new BenchmarkComparisonAgent({
         repoPath: benchmarkPath,
         model: comparisonModel,
         session,
+        eventBus: compBus,
       });
-      const compResult = await compAgent.consume({
-        onError: (e) => console.error(`[${branch}] Comparison error:`, e),
-      });
+      const compResult = await compAgent.consume();
       comparisonResult = compResult.comparison;
     } catch (e) {
       console.error(

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -5,7 +5,8 @@ import {
   type AttackSurfaceAgentInput,
 } from "../agents/specialized/attackSurface/blackboxAgent";
 import { TargetedPentestAgent } from "../agents/specialized/pentest/agent";
-import type { Finding, ConsumeCallbacks } from "../agents/offSecAgent/types";
+import type { Finding } from "../agents/offSecAgent/types";
+import type { AgentEventBus } from "../agents/offSecAgent/eventBus";
 import type { AIModel } from "../ai";
 import type { AIAuthConfig } from "../ai/utils";
 import type { SessionInfo } from "../session";
@@ -35,7 +36,7 @@ export interface PentestWorkflowInput {
   session: SessionInfo;
   authConfig?: AIAuthConfig;
   abortSignal?: AbortSignal;
-  callbacks?: ConsumeCallbacks;
+  eventBus?: AgentEventBus;
 }
 
 export interface PentestWorkflowResult {
@@ -65,7 +66,7 @@ interface SwarmTarget {
 export async function runPentestWorkflow(
   input: PentestWorkflowInput,
 ): Promise<PentestWorkflowResult> {
-  const { target, cwd, model, session, authConfig, abortSignal, callbacks } =
+  const { target, cwd, model, session, authConfig, abortSignal, eventBus } =
     input;
 
   const mode: "blackbox" | "whitebox" = cwd ? "whitebox" : "blackbox";
@@ -84,7 +85,7 @@ export async function runPentestWorkflow(
       session,
       authConfig,
       abortSignal,
-      callbacks,
+      eventBus,
     });
   } else {
     swarmTargets = await runBlackboxPhase({
@@ -93,7 +94,7 @@ export async function runPentestWorkflow(
       session,
       authConfig,
       abortSignal,
-      callbacks,
+      eventBus,
     });
   }
 
@@ -115,8 +116,10 @@ export async function runPentestWorkflow(
     DEFAULT_CONCURRENCY,
     async (swarmTarget, index) => {
       const subagentId = `pentest-agent-${index + 1}`;
+      const childBus = eventBus?.child(subagentId);
 
-      callbacks?.subagentCallbacks?.onSubagentSpawn?.({
+      eventBus?.emit({
+        type: "subagent-spawn",
         subagentId,
         input: {
           target: swarmTarget.target,
@@ -132,34 +135,14 @@ export async function runPentestWorkflow(
         session,
         authConfig,
         abortSignal,
+        eventBus: childBus,
       });
 
       try {
-        const result = await agent.consume({
-          onError: (e) => callbacks?.onError?.(e),
-          subagentCallbacks: callbacks?.subagentCallbacks
-            ? {
-                onTextDelta: (d) =>
-                  callbacks.subagentCallbacks!.onTextDelta?.({
-                    ...d,
-                    subagentId,
-                  }),
-                onToolCall: (d) =>
-                  callbacks.subagentCallbacks!.onToolCall?.({
-                    ...d,
-                    subagentId,
-                  }),
-                onToolResult: (d) =>
-                  callbacks.subagentCallbacks!.onToolResult?.({
-                    ...d,
-                    subagentId,
-                  }),
-                onError: (e) => callbacks.subagentCallbacks!.onError?.(e),
-              }
-            : undefined,
-        });
+        const result = await agent.consume();
 
-        callbacks?.subagentCallbacks?.onSubagentComplete?.({
+        eventBus?.emit({
+          type: "subagent-complete",
           subagentId,
           input: {
             target: swarmTarget.target,
@@ -170,7 +153,8 @@ export async function runPentestWorkflow(
 
         return result;
       } catch (error) {
-        callbacks?.subagentCallbacks?.onSubagentComplete?.({
+        eventBus?.emit({
+          type: "subagent-complete",
           subagentId,
           input: {
             target: swarmTarget.target,
@@ -209,7 +193,7 @@ async function runWhiteboxPhase(opts: {
   session: SessionInfo;
   authConfig?: AIAuthConfig;
   abortSignal?: AbortSignal;
-  callbacks?: ConsumeCallbacks;
+  eventBus?: AgentEventBus;
 }): Promise<SwarmTarget[]> {
   const workflowInput: WhiteboxAttackSurfaceWorkflowInput = {
     codebasePath: opts.codebasePath,
@@ -217,7 +201,7 @@ async function runWhiteboxPhase(opts: {
     session: opts.session,
     authConfig: opts.authConfig,
     abortSignal: opts.abortSignal,
-    callbacks: opts.callbacks,
+    eventBus: opts.eventBus,
   };
 
   const result = await runWhiteboxAttackSurfaceWorkflow(workflowInput);
@@ -238,7 +222,7 @@ async function runBlackboxPhase(opts: {
   session: SessionInfo;
   authConfig?: AIAuthConfig;
   abortSignal?: AbortSignal;
-  callbacks?: ConsumeCallbacks;
+  eventBus?: AgentEventBus;
 }): Promise<SwarmTarget[]> {
   const agentInput: AttackSurfaceAgentInput = {
     target: opts.target,
@@ -246,18 +230,12 @@ async function runBlackboxPhase(opts: {
     session: opts.session,
     authConfig: opts.authConfig,
     abortSignal: opts.abortSignal,
-    callbacks: opts.callbacks,
+    eventBus: opts.eventBus,
   };
 
   const agent = new BlackboxAttackSurfaceAgent(agentInput);
 
-  const result = await agent.consume({
-    onTextDelta: (d) => opts.callbacks?.onTextDelta?.(d),
-    onToolCall: (d) => opts.callbacks?.onToolCall?.(d),
-    onToolResult: (d) => opts.callbacks?.onToolResult?.(d),
-    onError: (e) => opts.callbacks?.onError?.(e),
-    subagentCallbacks: opts.callbacks?.subagentCallbacks,
-  });
+  const result = await agent.consume();
 
   return result.targets.map((t) => ({
     target: t.target,

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -9,7 +9,7 @@ import {
 import type { AIModel } from "../ai";
 import type { AIAuthConfig } from "../ai/utils";
 import type { SessionInfo } from "../session";
-import type { ConsumeCallbacks } from "../agents/offSecAgent/types";
+import type { AgentEventBus } from "../agents/offSecAgent/eventBus";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -124,7 +124,7 @@ export interface WhiteboxAttackSurfaceWorkflowInput {
   session: SessionInfo;
   authConfig?: AIAuthConfig;
   abortSignal?: AbortSignal;
-  callbacks?: ConsumeCallbacks;
+  eventBus?: AgentEventBus;
 }
 
 // ---------------------------------------------------------------------------
@@ -142,7 +142,7 @@ export interface WhiteboxAttackSurfaceWorkflowInput {
 export async function runWhiteboxAttackSurfaceWorkflow(
   input: WhiteboxAttackSurfaceWorkflowInput,
 ): Promise<WhiteboxAttackSurfaceResult> {
-  const { codebasePath, model, session, authConfig, abortSignal, callbacks } =
+  const { codebasePath, model, session, authConfig, abortSignal, eventBus } =
     input;
 
   // =========================================================================
@@ -157,17 +157,11 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     session,
     authConfig,
     abortSignal,
-    callbacks,
+    eventBus,
     responseSchema: AppsDiscoveryResultSchema,
   });
 
-  const appsResult = await appsAgent.consume({
-    onTextDelta: (d) => callbacks?.onTextDelta?.(d),
-    onToolCall: (d) => callbacks?.onToolCall?.(d),
-    onToolResult: (d) => callbacks?.onToolResult?.(d),
-    onError: (e) => callbacks?.onError?.(e),
-    subagentCallbacks: callbacks?.subagentCallbacks,
-  });
+  const appsResult = await appsAgent.consume();
 
   if (!appsResult || appsResult.apps.length === 0) {
     return {
@@ -202,8 +196,10 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     DEFAULT_CONCURRENCY,
     async (task) => {
       const subagentId = `${task.type}-${task.appInfo.name}`;
+      const childBus = eventBus?.child(subagentId);
 
-      callbacks?.subagentCallbacks?.onSubagentSpawn?.({
+      eventBus?.emit({
+        type: "subagent-spawn",
         subagentId,
         input: { app: task.appInfo.name, type: task.type },
         status: "pending",
@@ -222,36 +218,15 @@ export async function runWhiteboxAttackSurfaceWorkflow(
         session,
         authConfig,
         abortSignal,
-        callbacks,
+        eventBus: childBus,
         responseSchema: EndpointsDiscoveryResultSchema,
       });
 
       try {
-        const result = await agent.consume({
-          onError: (e) => callbacks?.onError?.(e),
-          subagentCallbacks: callbacks?.subagentCallbacks
-            ? {
-                onTextDelta: (d) =>
-                  callbacks.subagentCallbacks!.onTextDelta?.({
-                    ...d,
-                    subagentId,
-                  }),
-                onToolCall: (d) =>
-                  callbacks.subagentCallbacks!.onToolCall?.({
-                    ...d,
-                    subagentId,
-                  }),
-                onToolResult: (d) =>
-                  callbacks.subagentCallbacks!.onToolResult?.({
-                    ...d,
-                    subagentId,
-                  }),
-                onError: (e) => callbacks.subagentCallbacks!.onError?.(e),
-              }
-            : undefined,
-        });
+        const result = await agent.consume();
 
-        callbacks?.subagentCallbacks?.onSubagentComplete?.({
+        eventBus?.emit({
+          type: "subagent-complete",
           subagentId,
           input: { app: task.appInfo.name, type: task.type },
           status: "completed",
@@ -263,7 +238,8 @@ export async function runWhiteboxAttackSurfaceWorkflow(
           endpoints: result?.endpoints ?? [],
         };
       } catch (error) {
-        callbacks?.subagentCallbacks?.onSubagentComplete?.({
+        eventBus?.emit({
+          type: "subagent-complete",
           subagentId,
           input: { app: task.appInfo.name, type: task.type },
           status: "failed",

--- a/src/tests/attackSurface.test.ts
+++ b/src/tests/attackSurface.test.ts
@@ -1,6 +1,5 @@
 import { runAttackSurfaceAgent } from "../core/api/attackSurface";
 import { sessions } from "../core/session";
-import { AgentEventBus } from "../core/agents/offSecAgent/eventBus";
 import { describe, it, expect } from "vitest";
 import { config } from "dotenv";
 
@@ -26,8 +25,7 @@ describe("Attack Surface", () => {
       target: TARGET_URL,
       model: "claude-haiku-4-5",
       session,
-      eventBus: new AgentEventBus(),
-    });
+    }).result;
     expect(result).toBeDefined();
   });
 });

--- a/src/tests/attackSurface.test.ts
+++ b/src/tests/attackSurface.test.ts
@@ -1,5 +1,6 @@
 import { runAttackSurfaceAgent } from "../core/api/attackSurface";
 import { sessions } from "../core/session";
+import { AgentEventBus } from "../core/agents/offSecAgent/eventBus";
 import { describe, it, expect } from "vitest";
 import { config } from "dotenv";
 
@@ -25,15 +26,7 @@ describe("Attack Surface", () => {
       target: TARGET_URL,
       model: "claude-haiku-4-5",
       session,
-      callbacks: {
-        onTextDelta: (d) => process.stdout.write(d.text),
-        onToolCall: (d) =>
-          console.log(
-            `\n→ calling ${d.toolName} \n ${JSON.stringify(d.input, null, 2)}`,
-          ),
-        onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
-        onError: (e) => console.error(e),
-      },
+      eventBus: new AgentEventBus(),
     });
     expect(result).toBeDefined();
   });

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -1,5 +1,6 @@
 import { runAuthenticationAgent } from "../core/api/authentication";
 import { sessions } from "../core/session";
+import { AgentEventBus } from "../core/agents/offSecAgent/eventBus";
 import { describe, it, expect } from "vitest";
 import { config } from "dotenv";
 
@@ -40,15 +41,7 @@ describe("Authentication Agent", () => {
         password,
         loginUrl: `https://${TARGET_URL}/login`,
       },
-      callbacks: {
-        onTextDelta: (d) => process.stdout.write(d.text),
-        onToolCall: (d) =>
-          console.log(
-            `\n→ calling ${d.toolName}\n  ${JSON.stringify(d.input, null, 2)}`,
-          ),
-        onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
-        onError: (e) => console.error("Agent error:", e),
-      },
+      eventBus: new AgentEventBus(),
     });
 
     console.log(
@@ -69,15 +62,7 @@ describe("Authentication Agent", () => {
       target: TARGET_URL,
       model: "claude-haiku-4-5",
       session,
-      callbacks: {
-        onTextDelta: (d) => process.stdout.write(d.text),
-        onToolCall: (d) =>
-          console.log(
-            `\n→ calling ${d.toolName}\n  ${JSON.stringify(d.input, null, 2)}`,
-          ),
-        onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
-        onError: (e) => console.error("Agent error:", e),
-      },
+      eventBus: new AgentEventBus(),
     });
 
     console.log(
@@ -128,15 +113,7 @@ describe("Authentication Agent", () => {
           `https://${TARGET_URL}/dashboard`,
         ],
       },
-      callbacks: {
-        onTextDelta: (d) => process.stdout.write(d.text),
-        onToolCall: (d) =>
-          console.log(
-            `\n→ calling ${d.toolName}\n  ${JSON.stringify(d.input, null, 2)}`,
-          ),
-        onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
-        onError: (e) => console.error("Agent error:", e),
-      },
+      eventBus: new AgentEventBus(),
     });
 
     console.log(

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -1,6 +1,5 @@
 import { runAuthenticationAgent } from "../core/api/authentication";
 import { sessions } from "../core/session";
-import { AgentEventBus } from "../core/agents/offSecAgent/eventBus";
 import { describe, it, expect } from "vitest";
 import { config } from "dotenv";
 
@@ -41,8 +40,7 @@ describe("Authentication Agent", () => {
         password,
         loginUrl: `https://${TARGET_URL}/login`,
       },
-      eventBus: new AgentEventBus(),
-    });
+    }).result;
 
     console.log(
       `\nResult: ${result.success ? "SUCCESS" : "FAILED"} — ${result.summary}`,
@@ -62,8 +60,7 @@ describe("Authentication Agent", () => {
       target: TARGET_URL,
       model: "claude-haiku-4-5",
       session,
-      eventBus: new AgentEventBus(),
-    });
+    }).result;
 
     console.log(
       `\nResult: ${result.success ? "SUCCESS" : "FAILED"} — ${result.summary}`,
@@ -113,8 +110,7 @@ describe("Authentication Agent", () => {
           `https://${TARGET_URL}/dashboard`,
         ],
       },
-      eventBus: new AgentEventBus(),
-    });
+    }).result;
 
     console.log(
       `\nResult: ${result.success ? "SUCCESS" : "FAILED"} — ${result.summary}`,

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -11,7 +11,10 @@ import { useKeyboard } from "@opentui/react";
 
 import { sessions, type SessionInfo } from "../../../core/session";
 import { runOffensiveSecurityAgent } from "../../../core/api/offesecAgent";
-import { ALL_TOOL_NAMES } from "../../../core/agents/offSecAgent";
+import {
+  ALL_TOOL_NAMES,
+  AgentEventBus,
+} from "../../../core/agents/offSecAgent";
 import { useAgent } from "../../context/agent";
 import { useRoute } from "../../context/route";
 import { useConfig } from "../../context/config";
@@ -199,6 +202,43 @@ export default function OperatorDashboard({
         { role: "user", content: prompt, createdAt: new Date() },
       ]);
 
+      const eventBus = new AgentEventBus();
+      const unsubs: Array<() => void> = [];
+
+      unsubs.push(
+        eventBus.on("text-delta", (e) => {
+          setThinking(false);
+          appendText(e.data.text);
+        }),
+      );
+
+      unsubs.push(
+        eventBus.on("tool-call", (e) => {
+          setThinking(false);
+          addToolCall(
+            e.data.toolCallId,
+            e.data.toolName,
+            e.data.input as Record<string, unknown> | undefined,
+          );
+        }),
+      );
+
+      unsubs.push(
+        eventBus.on("tool-result", (e) => {
+          setThinking(true);
+          updateToolResult(e.data.toolCallId, e.data.toolName, e.data.output);
+        }),
+      );
+
+      unsubs.push(
+        eventBus.on("error", (e) => {
+          console.error("Agent error:", e.error);
+          setError(
+            e.error instanceof Error ? e.error.message : "Unknown error",
+          );
+        }),
+      );
+
       try {
         await runOffensiveSecurityAgent({
           system: buildOperatorSystemPrompt(session, operatorState),
@@ -217,28 +257,7 @@ export default function OperatorDashboard({
               ? { baseURL: config.data.localModelUrl }
               : undefined,
           },
-          callbacks: {
-            onTextDelta: (d) => {
-              setThinking(false);
-              appendText(d.text);
-            },
-            onToolCall: (d) => {
-              setThinking(false);
-              addToolCall(
-                d.toolCallId,
-                d.toolName,
-                d.input as Record<string, unknown> | undefined,
-              );
-            },
-            onToolResult: (d) => {
-              setThinking(true);
-              updateToolResult(d.toolCallId, d.toolName, d.output);
-            },
-            onError: (e) => {
-              console.error("Agent error:", e);
-              setError(e instanceof Error ? e.message : "Unknown error");
-            },
-          },
+          eventBus,
         });
       } catch (e) {
         if ((e as Error).name !== "AbortError") {
@@ -254,6 +273,9 @@ export default function OperatorDashboard({
           ]);
         }
       } finally {
+        for (const unsub of unsubs) {
+          unsub();
+        }
         setStatus("idle");
         setThinking(false);
         setIsExecuting(false);

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -6,7 +6,7 @@ import { join } from "path";
 import { exec } from "child_process";
 
 import { sessions, type SessionInfo } from "../../../core/session";
-import { runPentestAgent } from "../../../core/api/blackboxPentest";
+import { runPentestWorkflow } from "../../../core/workflows/pentest";
 import { AgentEventBus } from "../../../core/agents/offSecAgent";
 import { useAgent } from "../../context/agent";
 import { useRoute } from "../../context/route";
@@ -558,7 +558,7 @@ export default function Pentest({ sessionId }: { sessionId: string }) {
       );
 
       try {
-        await runPentestAgent({
+        await runPentestWorkflow({
           target: s.targets[0]!,
           ...(s.config?.cwd ? { cwd: s.config.cwd } : {}),
           session: s,

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -7,6 +7,7 @@ import { exec } from "child_process";
 
 import { sessions, type SessionInfo } from "../../../core/session";
 import { runPentestAgent } from "../../../core/api/blackboxPentest";
+import { AgentEventBus } from "../../../core/agents/offSecAgent";
 import { useAgent } from "../../context/agent";
 import { useRoute } from "../../context/route";
 import { useConfig } from "../../context/config";
@@ -478,6 +479,84 @@ export default function Pentest({ sessionId }: { sessionId: string }) {
       const controller = new AbortController();
       setAbortController(controller);
 
+      const eventBus = new AgentEventBus();
+      const unsubs: Array<() => void> = [];
+
+      unsubs.push(
+        eventBus.on("text-delta", (e) => {
+          setThinking(false);
+          if (!e.subagentId) {
+            appendPanelText("orchestrator", e.data.text);
+          } else if (e.subagentId === "attack-surface-agent") {
+            appendPanelText(e.subagentId, e.data.text);
+          } else {
+            appendPentestText(e.subagentId, e.data.text);
+          }
+        }),
+      );
+
+      unsubs.push(
+        eventBus.on("tool-call", (e) => {
+          setThinking(false);
+          if (!e.subagentId) {
+            if (e.data.toolName === "run_attack_surface") {
+              setPhase("discovery");
+            } else if (e.data.toolName === "spawn_pentest_swarm") {
+              setPhase("pentesting");
+            } else if (e.data.toolName === "generate_report") {
+              setPhase("reporting");
+            }
+            addPanelToolCall(
+              e.data.toolCallId,
+              e.data.toolName,
+              e.data.input as Record<string, unknown> | undefined,
+            );
+          } else if (e.subagentId === "attack-surface-agent") {
+            addPanelToolCall(
+              e.data.toolCallId,
+              e.data.toolName,
+              e.data.input as Record<string, unknown> | undefined,
+            );
+          } else {
+            addPentestToolCall(
+              e.subagentId,
+              e.data.toolCallId,
+              e.data.toolName,
+              e.data.input as Record<string, unknown> | undefined,
+            );
+          }
+        }),
+      );
+
+      unsubs.push(
+        eventBus.on("tool-result", (e) => {
+          setThinking(true);
+          if (!e.subagentId || e.subagentId === "attack-surface-agent") {
+            updatePanelToolResult(
+              e.data.toolCallId,
+              e.data.toolName,
+              e.data.output,
+            );
+          } else {
+            updatePentestToolResult(
+              e.subagentId,
+              e.data.toolCallId,
+              e.data.toolName,
+              e.data.output,
+            );
+          }
+        }),
+      );
+
+      unsubs.push(eventBus.on("subagent-spawn", handleSubagentSpawn));
+      unsubs.push(eventBus.on("subagent-complete", handleSubagentComplete));
+
+      unsubs.push(
+        eventBus.on("error", (e) => {
+          console.error("Agent error:", e.error);
+        }),
+      );
+
       try {
         await runPentestAgent({
           target: s.targets[0]!,
@@ -493,84 +572,7 @@ export default function Pentest({ sessionId }: { sessionId: string }) {
               ? { baseURL: config.data.localModelUrl }
               : undefined,
           },
-          callbacks: {
-            // Orchestrator's own stream events → panel
-            onTextDelta: (d) => {
-              setThinking(false);
-              appendPanelText("orchestrator", d.text);
-            },
-            onToolCall: (d) => {
-              setThinking(false);
-              // Phase tracking
-              if (d.toolName === "run_attack_surface") {
-                setPhase("discovery");
-              } else if (d.toolName === "spawn_pentest_swarm") {
-                setPhase("pentesting");
-              } else if (d.toolName === "generate_report") {
-                setPhase("reporting");
-              }
-              // Add to panel
-              addPanelToolCall(
-                d.toolCallId,
-                d.toolName,
-                d.input as Record<string, unknown> | undefined,
-              );
-            },
-            onToolResult: (d) => {
-              setThinking(true);
-              updatePanelToolResult(d.toolCallId, d.toolName, d.output);
-            },
-
-            // Subagent callbacks — discovery goes to panel, pentest agents go to their own state
-            subagentCallbacks: {
-              onSubagentSpawn: handleSubagentSpawn,
-              onSubagentComplete: handleSubagentComplete,
-              onTextDelta: (d) => {
-                if (!d.subagentId) return;
-                setThinking(false);
-                if (d.subagentId === "attack-surface-agent") {
-                  appendPanelText(d.subagentId, d.text);
-                } else {
-                  appendPentestText(d.subagentId, d.text);
-                }
-              },
-              onToolCall: (d) => {
-                if (!d.subagentId) return;
-                setThinking(false);
-                if (d.subagentId === "attack-surface-agent") {
-                  addPanelToolCall(
-                    d.toolCallId,
-                    d.toolName,
-                    d.input as Record<string, unknown> | undefined,
-                  );
-                } else {
-                  addPentestToolCall(
-                    d.subagentId,
-                    d.toolCallId,
-                    d.toolName,
-                    d.input as Record<string, unknown> | undefined,
-                  );
-                }
-              },
-              onToolResult: (d) => {
-                if (!d.subagentId) return;
-                setThinking(true);
-                if (d.subagentId === "attack-surface-agent") {
-                  updatePanelToolResult(d.toolCallId, d.toolName, d.output);
-                } else {
-                  updatePentestToolResult(
-                    d.subagentId,
-                    d.toolCallId,
-                    d.toolName,
-                    d.output,
-                  );
-                }
-              },
-              onError: (e) => {
-                console.error("Subagent error:", e);
-              },
-            },
-          },
+          eventBus,
         });
 
         setPhase("completed");
@@ -582,6 +584,9 @@ export default function Pentest({ sessionId }: { sessionId: string }) {
           setPhase("error");
         }
       } finally {
+        for (const unsub of unsubs) {
+          unsub();
+        }
         setThinking(false);
         setIsExecuting(false);
       }


### PR DESCRIPTION
Replaces the callback-based event plumbing (`ConsumeCallbacks`, `SubagentConsumeCallbacks`, dual dispatch in `consume()`) with two new primitives:

**AgentEventBus** — an internal typed pub/sub bus that agents `emit()` events onto. The key feature is `child()` buses: when a tool spawns a subagent, it creates `ctx.eventBus.child("agent-id")` and events automatically get tagged with the subagent ID and bubble up to the parent. This eliminates the copy-pasted callback forwarding wrappers that existed in `spawnPentestSwarm`, `runAttackSurface`, `spawnCodingAgent`, and `delegateAuth` — all of which manually constructed subagent callback objects with the same 15-line pattern.

**AgentRun\<T\>** — a public API wrapper that bridges the internal push-based bus to an external pull-based async iterable. Every `run*` function in `src/core/api/` now returns `AgentRun<T>` instead of `Promise<T>`. Clients can stream events with `for await (const event of run) { switch (event.type) { ... } }` or skip streaming entirely with `await run.result`. This is the same pattern used by the Vercel AI SDK's `fullStream` and Claude Code's `Query` — standard async iteration with a discriminated union.

What this deletes:
- `ConsumeCallbacks` and `SubagentConsumeCallbacks` type definitions (~60 lines)
- All callback forwarding wrappers in orchestration tools (~90 lines across 4 files)
- All callback unwrapping in the API layer
- Dual dispatch logic in `consume()` (which fired both the direct callback and the subagent callback for every event)
- `as never` type casts at forwarding boundaries

The `AgentEvent` discriminated union makes new event types additive — add a variant, emit it, handle it in the consumer's switch. No forwarding code to update.

For clients that currently `await` agent functions directly, the migration is appending `.result` to each call site. TypeScript catches every one since the return type changed.

A follow-up PR migrates the TUI components from `.on()` bus subscriptions to the same `for await` pattern the CLI uses, making the TUI just another API client.