### PR TITLE
Tui cli upgrade command

### DIFF
--- a/bin/pensar.js
+++ b/bin/pensar.js
@@ -71,7 +71,7 @@ if (command === "benchmark") {
   console.log(`Current version: v${currentVersion}`);
   console.log("Checking for updates...");
 
-  const result = await upgrade();
+  const result = await upgrade({ interactive: true });
   console.log();
   console.log(result.message);
 

--- a/bin/pensar.js
+++ b/bin/pensar.js
@@ -65,6 +65,19 @@ if (command === "benchmark") {
 
   // Import and run auth
   await import(authPath);
+} else if (command === "upgrade" || command === "update") {
+  // Run upgrade
+  const { Installation } = await import("../src/core/installation/index.ts");
+
+  const currentVersion = Installation.getCurrentVersion();
+  console.log(`Current version: v${currentVersion}`);
+  console.log("Checking for updates...");
+
+  const result = await Installation.upgrade();
+  console.log();
+  console.log(result.message);
+
+  process.exit(result.success ? 0 : 1);
 } else if (
   command === "version" ||
   command === "--version" ||
@@ -78,6 +91,7 @@ if (command === "benchmark") {
   console.log();
   console.log("Usage:");
   console.log("  pensar              Launch the TUI (Terminal User Interface)");
+  console.log("  pensar upgrade      Update pensar to the latest version");
   console.log("  pensar help         Show this help message");
   console.log("  pensar version      Show version number");
   console.log("  pensar benchmark    Run the benchmark CLI");

--- a/bin/pensar.js
+++ b/bin/pensar.js
@@ -14,6 +14,7 @@ import { dirname, join } from "path";
 
 // Import package.json directly so Bun can embed it at compile time
 import packageJson from "../package.json";
+import { getCurrentVersion, upgrade } from "../src/core/installation/index.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -66,9 +67,6 @@ if (command === "benchmark") {
   // Import and run auth
   await import(authPath);
 } else if (command === "upgrade" || command === "update") {
-  // Run upgrade
-  const { getCurrentVersion, upgrade } = await import("../src/core/installation/index.ts");
-
   const currentVersion = getCurrentVersion();
   console.log(`Current version: v${currentVersion}`);
   console.log("Checking for updates...");

--- a/bin/pensar.js
+++ b/bin/pensar.js
@@ -67,13 +67,13 @@ if (command === "benchmark") {
   await import(authPath);
 } else if (command === "upgrade" || command === "update") {
   // Run upgrade
-  const { Installation } = await import("../src/core/installation/index.ts");
+  const { getCurrentVersion, upgrade } = await import("../src/core/installation/index.ts");
 
-  const currentVersion = Installation.getCurrentVersion();
+  const currentVersion = getCurrentVersion();
   console.log(`Current version: v${currentVersion}`);
   console.log("Checking for updates...");
 
-  const result = await Installation.upgrade();
+  const result = await upgrade();
   console.log();
   console.log(result.message);
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,7 @@ export default tseslint.config(
     rules: {
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-unused-vars": "off",
-      "@typescript-eslint/no-namespace": "off",
+      "@typescript-eslint/no-namespace": "error",
       "@typescript-eslint/no-require-imports": "off",
       "no-unused-vars": "off",
       "unused-imports/no-unused-imports": "error",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensar/apex",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
   "main": "build/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@
  */
 
 import packageJson from "../package.json";
+import { getCurrentVersion, upgrade } from "./core/installation";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -209,8 +210,6 @@ async function runTargetedPentest() {
 }
 
 async function runUpgrade() {
-  const { getCurrentVersion, upgrade } = await import("./core/installation");
-
   const currentVersion = getCurrentVersion();
   console.log(`Current version: v${currentVersion}`);
   console.log("Checking for updates...");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,9 @@ function showHelp() {
   console.log(
     "  pensar targeted-pentest [options]   Run a targeted pentest on a single target",
   );
+  console.log(
+    "  pensar upgrade                      Update pensar to the latest version",
+  );
   console.log("  pensar help                         Show this help message");
   console.log("  pensar version                      Show version number");
   console.log();
@@ -205,6 +208,20 @@ async function runTargetedPentest() {
   console.log(`POCs:      ${pocsPath}`);
 }
 
+async function runUpgrade() {
+  const { Installation } = await import("./core/installation");
+
+  const currentVersion = Installation.getCurrentVersion();
+  console.log(`Current version: v${currentVersion}`);
+  console.log("Checking for updates...");
+
+  const result = await Installation.upgrade();
+  console.log();
+  console.log(result.message);
+
+  process.exit(result.success ? 0 : 1);
+}
+
 // ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
@@ -213,6 +230,8 @@ if (command === "version" || command === "--version" || command === "-v") {
   console.log(`v${version}`);
 } else if (command === "help" || command === "--help" || command === "-h") {
   showHelp();
+} else if (command === "upgrade" || command === "update") {
+  await runUpgrade();
 } else if (command === "pentest") {
   await runPentest();
 } else if (command === "targeted-pentest") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -214,7 +214,7 @@ async function runUpgrade() {
   console.log(`Current version: v${currentVersion}`);
   console.log("Checking for updates...");
 
-  const result = await upgrade();
+  const result = await upgrade({ interactive: true });
   console.log();
   console.log(result.message);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -209,13 +209,13 @@ async function runTargetedPentest() {
 }
 
 async function runUpgrade() {
-  const { Installation } = await import("./core/installation");
+  const { getCurrentVersion, upgrade } = await import("./core/installation");
 
-  const currentVersion = Installation.getCurrentVersion();
+  const currentVersion = getCurrentVersion();
   console.log(`Current version: v${currentVersion}`);
   console.log("Checking for updates...");
 
-  const result = await Installation.upgrade();
+  const result = await upgrade();
   console.log();
   console.log(result.message);
 

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -1,7 +1,7 @@
 import os from "os";
 import path from "path";
 import fs from "fs/promises";
-import { Installation } from "../installation";
+import { getVersion } from "../installation";
 
 const DEFAULT_CONFIG: Config = {
   responsibleUseAccepted: false,
@@ -44,7 +44,7 @@ export async function init() {
     await fs.writeFile(file, JSON.stringify(DEFAULT_CONFIG));
   }
 
-  const version = await Installation.getVersion();
+  const version = await getVersion();
   return { ...DEFAULT_CONFIG, version };
 }
 
@@ -62,7 +62,7 @@ export async function get(): Promise<Config> {
 
   const parsedConfig = JSON.parse(config);
 
-  const version = await Installation.getVersion();
+  const version = await getVersion();
 
   return {
     ...parsedConfig,

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -1,7 +1,7 @@
 import os from "os";
 import path from "path";
 import fs from "fs/promises";
-import { getVersion } from "../installation";
+import { getCurrentVersion } from "../installation";
 
 const DEFAULT_CONFIG: Config = {
   responsibleUseAccepted: false,
@@ -44,7 +44,7 @@ export async function init() {
     await fs.writeFile(file, JSON.stringify(DEFAULT_CONFIG));
   }
 
-  const version = await getVersion();
+  const version = getCurrentVersion();
   return { ...DEFAULT_CONFIG, version };
 }
 
@@ -62,7 +62,7 @@ export async function get(): Promise<Config> {
 
   const parsedConfig = JSON.parse(config);
 
-  const version = await getVersion();
+  const version = getCurrentVersion();
 
   return {
     ...parsedConfig,

--- a/src/core/id/id.ts
+++ b/src/core/id/id.ts
@@ -30,11 +30,11 @@ export function descending(prefix: IdentifierPrefix, given?: string) {
 
 function generateID(
   prefix: IdentifierPrefix,
-  desc: boolean,
+  descending: boolean,
   given?: string,
 ): string {
   if (!given) {
-    return create(prefix, desc);
+    return create(prefix, descending);
   }
 
   if (!given.startsWith(prefixes[prefix])) {
@@ -56,7 +56,7 @@ function randomBase62(length: number): string {
 
 export function create(
   prefix: IdentifierPrefix,
-  desc: boolean,
+  descending: boolean,
   timestamp?: number,
 ): string {
   const currentTimestamp = timestamp ?? Date.now();
@@ -69,7 +69,7 @@ export function create(
 
   let now = BigInt(currentTimestamp) * BigInt(0x1000) + BigInt(counter);
 
-  now = desc ? ~now : now;
+  now = descending ? ~now : now;
 
   const timeBytes = Buffer.alloc(6);
   for (let i = 0; i < 6; i++) {

--- a/src/core/id/id.ts
+++ b/src/core/id/id.ts
@@ -1,86 +1,85 @@
 import z from "zod";
 import { randomBytes } from "crypto";
 
-export namespace Identifier {
-  const prefixes = {
-    session: "ses",
-    message: "msg",
-    permission: "per",
-    user: "usr",
-    part: "prt",
-  } as const;
+const prefixes = {
+  session: "ses",
+  message: "msg",
+  permission: "per",
+  user: "usr",
+  part: "prt",
+} as const;
 
-  export function schema(prefix: keyof typeof prefixes) {
-    return z.string().startsWith(prefixes[prefix]);
+export type IdentifierPrefix = keyof typeof prefixes;
+
+export function schema(prefix: IdentifierPrefix) {
+  return z.string().startsWith(prefixes[prefix]);
+}
+
+const LENGTH = 26;
+
+let lastTimestamp = 0;
+let counter = 0;
+
+export function ascending(prefix: IdentifierPrefix, given?: string) {
+  return generateID(prefix, false, given);
+}
+
+export function descending(prefix: IdentifierPrefix, given?: string) {
+  return generateID(prefix, true, given);
+}
+
+function generateID(
+  prefix: IdentifierPrefix,
+  desc: boolean,
+  given?: string,
+): string {
+  if (!given) {
+    return create(prefix, desc);
   }
 
-  const LENGTH = 26;
+  if (!given.startsWith(prefixes[prefix])) {
+    throw new Error(`ID ${given} does not start with ${prefixes[prefix]}`);
+  }
+  return given;
+}
 
-  // State for monotonic ID generation
-  let lastTimestamp = 0;
-  let counter = 0;
+function randomBase62(length: number): string {
+  const chars =
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  let result = "";
+  const bytes = randomBytes(length);
+  for (let i = 0; i < length; i++) {
+    result += chars[bytes[i] % 62];
+  }
+  return result;
+}
 
-  export function ascending(prefix: keyof typeof prefixes, given?: string) {
-    return generateID(prefix, false, given);
+export function create(
+  prefix: IdentifierPrefix,
+  desc: boolean,
+  timestamp?: number,
+): string {
+  const currentTimestamp = timestamp ?? Date.now();
+
+  if (currentTimestamp !== lastTimestamp) {
+    lastTimestamp = currentTimestamp;
+    counter = 0;
+  }
+  counter++;
+
+  let now = BigInt(currentTimestamp) * BigInt(0x1000) + BigInt(counter);
+
+  now = desc ? ~now : now;
+
+  const timeBytes = Buffer.alloc(6);
+  for (let i = 0; i < 6; i++) {
+    timeBytes[i] = Number((now >> BigInt(40 - 8 * i)) & BigInt(0xff));
   }
 
-  export function descending(prefix: keyof typeof prefixes, given?: string) {
-    return generateID(prefix, true, given);
-  }
-
-  function generateID(
-    prefix: keyof typeof prefixes,
-    descending: boolean,
-    given?: string,
-  ): string {
-    if (!given) {
-      return create(prefix, descending);
-    }
-
-    if (!given.startsWith(prefixes[prefix])) {
-      throw new Error(`ID ${given} does not start with ${prefixes[prefix]}`);
-    }
-    return given;
-  }
-
-  function randomBase62(length: number): string {
-    const chars =
-      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-    let result = "";
-    const bytes = randomBytes(length);
-    for (let i = 0; i < length; i++) {
-      result += chars[bytes[i] % 62];
-    }
-    return result;
-  }
-
-  export function create(
-    prefix: keyof typeof prefixes,
-    descending: boolean,
-    timestamp?: number,
-  ): string {
-    const currentTimestamp = timestamp ?? Date.now();
-
-    if (currentTimestamp !== lastTimestamp) {
-      lastTimestamp = currentTimestamp;
-      counter = 0;
-    }
-    counter++;
-
-    let now = BigInt(currentTimestamp) * BigInt(0x1000) + BigInt(counter);
-
-    now = descending ? ~now : now;
-
-    const timeBytes = Buffer.alloc(6);
-    for (let i = 0; i < 6; i++) {
-      timeBytes[i] = Number((now >> BigInt(40 - 8 * i)) & BigInt(0xff));
-    }
-
-    return (
-      prefixes[prefix] +
-      "_" +
-      timeBytes.toString("hex") +
-      randomBase62(LENGTH - 12)
-    );
-  }
+  return (
+    prefixes[prefix] +
+    "_" +
+    timeBytes.toString("hex") +
+    randomBase62(LENGTH - 12)
+  );
 }

--- a/src/core/installation/index.ts
+++ b/src/core/installation/index.ts
@@ -1,3 +1,15 @@
+import { spawnSync } from "child_process";
+import packageJson from "../../../package.json";
+
+export type InstallMethod = "npm" | "homebrew" | "binary";
+
+export interface UpgradeResult {
+  success: boolean;
+  message: string;
+  fromVersion: string;
+  toVersion: string;
+}
+
 export namespace Installation {
   export async function getVersion() {
     if (process.env["APEX_VERSION"]) return process.env["APEX_VERSION"];
@@ -9,7 +21,138 @@ export namespace Installation {
       const data = (await res.json()) as Record<string, unknown>;
       return String(data.version);
     });
-    // .then((data: any) => {console.log(data); return data.version});
     return version;
+  }
+
+  export function getCurrentVersion(): string {
+    return packageJson.version;
+  }
+
+  export async function getLatestVersion(): Promise<string> {
+    const res = await fetch(
+      "https://registry.npmjs.org/@pensar/apex/latest",
+    );
+    if (!res.ok) throw new Error(`Failed to fetch latest version: ${res.statusText}`);
+    const data = (await res.json()) as Record<string, unknown>;
+    return String(data.version);
+  }
+
+  export function detectInstallMethod(): InstallMethod {
+    const execPath = process.execPath;
+    const argv1 = process.argv[1] ?? "";
+
+    if (
+      execPath.includes("homebrew") ||
+      execPath.includes("Cellar") ||
+      execPath.includes("linuxbrew") ||
+      argv1.includes("homebrew") ||
+      argv1.includes("Cellar")
+    ) {
+      return "homebrew";
+    }
+
+    if (
+      argv1.includes("node_modules") ||
+      argv1.includes(".npm") ||
+      argv1.includes("npx")
+    ) {
+      return "npm";
+    }
+
+    const npmCheck = spawnSync("npm", ["list", "-g", "@pensar/apex", "--depth=0"], {
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+    if (npmCheck.status === 0 && npmCheck.stdout?.includes("@pensar/apex")) {
+      return "npm";
+    }
+
+    return "binary";
+  }
+
+  function getUpgradeCommand(method: InstallMethod): { cmd: string; args: string[] } {
+    switch (method) {
+      case "npm":
+        return { cmd: "npm", args: ["install", "-g", "@pensar/apex@latest"] };
+      case "homebrew":
+        return { cmd: "brew", args: ["upgrade", "pensarai/apex/apex"] };
+      case "binary":
+        return { cmd: "bash", args: ["-c", "curl -fsSL https://pensarai.com/install.sh | bash"] };
+    }
+  }
+
+  export function getUpgradeCommandString(method: InstallMethod): string {
+    const { cmd, args } = getUpgradeCommand(method);
+    return `${cmd} ${args.join(" ")}`;
+  }
+
+  export function runUpgrade(method: InstallMethod): UpgradeResult {
+    const currentVersion = getCurrentVersion();
+    const { cmd, args } = getUpgradeCommand(method);
+
+    const result = spawnSync(cmd, args, {
+      encoding: "utf-8",
+      timeout: 120000,
+      stdio: "pipe",
+    });
+
+    if (result.status !== 0) {
+      const stderr = result.stderr?.trim() || "Unknown error";
+      return {
+        success: false,
+        message: `Upgrade failed: ${stderr}`,
+        fromVersion: currentVersion,
+        toVersion: currentVersion,
+      };
+    }
+
+    return {
+      success: true,
+      message: "Upgrade successful. Please restart pensar to use the new version.",
+      fromVersion: currentVersion,
+      toVersion: "latest",
+    };
+  }
+
+  export async function upgrade(): Promise<UpgradeResult> {
+    const currentVersion = getCurrentVersion();
+    let latestVersion: string;
+
+    try {
+      latestVersion = await getLatestVersion();
+    } catch {
+      return {
+        success: false,
+        message: "Failed to check for updates. Please check your internet connection.",
+        fromVersion: currentVersion,
+        toVersion: currentVersion,
+      };
+    }
+
+    if (currentVersion === latestVersion) {
+      return {
+        success: true,
+        message: `Already on the latest version (v${currentVersion}).`,
+        fromVersion: currentVersion,
+        toVersion: latestVersion,
+      };
+    }
+
+    const method = detectInstallMethod();
+    const result = runUpgrade(method);
+
+    if (result.success) {
+      return {
+        ...result,
+        toVersion: latestVersion,
+        message: `Upgraded from v${currentVersion} to v${latestVersion}. Please restart pensar.`,
+      };
+    }
+
+    return {
+      ...result,
+      toVersion: latestVersion,
+      message: `${result.message}\n\nYou can upgrade manually by running:\n  ${getUpgradeCommandString(method)}`,
+    };
   }
 }

--- a/src/core/installation/index.ts
+++ b/src/core/installation/index.ts
@@ -27,6 +27,23 @@ export function getCurrentVersion(): string {
   return packageJson.version;
 }
 
+/**
+ * Returns true if `latest` is strictly greater than `current` by semver.
+ * Only compares major.minor.patch; pre-release suffixes are ignored.
+ */
+export function isNewerVersion(current: string, latest: string): boolean {
+  const parse = (v: string) => v.split(".").map((n) => parseInt(n, 10) || 0);
+  const c = parse(current);
+  const l = parse(latest);
+  for (let i = 0; i < Math.max(c.length, l.length); i++) {
+    const cv = c[i] ?? 0;
+    const lv = l[i] ?? 0;
+    if (lv > cv) return true;
+    if (lv < cv) return false;
+  }
+  return false;
+}
+
 export async function getLatestVersion(): Promise<string> {
   const res = await fetch("https://registry.npmjs.org/@pensar/apex/latest");
   if (!res.ok)
@@ -111,7 +128,7 @@ export async function checkForUpdate(): Promise<CheckUpdateResult> {
   }
 
   return {
-    updateAvailable: currentVersion !== latestVersion,
+    updateAvailable: isNewerVersion(currentVersion, latestVersion),
     currentVersion,
     latestVersion,
   };
@@ -170,7 +187,7 @@ export async function upgrade(options?: {
     };
   }
 
-  if (currentVersion === latestVersion) {
+  if (!isNewerVersion(currentVersion, latestVersion)) {
     return {
       success: true,
       message: `Already on the latest version (v${currentVersion}).`,

--- a/src/core/installation/index.ts
+++ b/src/core/installation/index.ts
@@ -10,149 +10,158 @@ export interface UpgradeResult {
   toVersion: string;
 }
 
-export namespace Installation {
-  export async function getVersion() {
-    if (process.env["APEX_VERSION"]) return process.env["APEX_VERSION"];
+export async function getVersion() {
+  if (process.env["APEX_VERSION"]) return process.env["APEX_VERSION"];
 
-    const version = await fetch(
-      "https://registry.npmjs.org/@pensar/apex/latest",
-    ).then(async (res) => {
-      if (!res.ok) throw new Error(res.statusText);
-      const data = (await res.json()) as Record<string, unknown>;
-      return String(data.version);
-    });
-    return version;
-  }
-
-  export function getCurrentVersion(): string {
-    return packageJson.version;
-  }
-
-  export async function getLatestVersion(): Promise<string> {
-    const res = await fetch(
-      "https://registry.npmjs.org/@pensar/apex/latest",
-    );
-    if (!res.ok) throw new Error(`Failed to fetch latest version: ${res.statusText}`);
+  const version = await fetch(
+    "https://registry.npmjs.org/@pensar/apex/latest",
+  ).then(async (res) => {
+    if (!res.ok) throw new Error(res.statusText);
     const data = (await res.json()) as Record<string, unknown>;
     return String(data.version);
+  });
+  return version;
+}
+
+export function getCurrentVersion(): string {
+  return packageJson.version;
+}
+
+export async function getLatestVersion(): Promise<string> {
+  const res = await fetch("https://registry.npmjs.org/@pensar/apex/latest");
+  if (!res.ok)
+    throw new Error(`Failed to fetch latest version: ${res.statusText}`);
+  const data = (await res.json()) as Record<string, unknown>;
+  return String(data.version);
+}
+
+export function detectInstallMethod(): InstallMethod {
+  const execPath = process.execPath;
+  const argv1 = process.argv[1] ?? "";
+
+  if (
+    execPath.includes("homebrew") ||
+    execPath.includes("Cellar") ||
+    execPath.includes("linuxbrew") ||
+    argv1.includes("homebrew") ||
+    argv1.includes("Cellar")
+  ) {
+    return "homebrew";
   }
 
-  export function detectInstallMethod(): InstallMethod {
-    const execPath = process.execPath;
-    const argv1 = process.argv[1] ?? "";
+  if (
+    argv1.includes("node_modules") ||
+    argv1.includes(".npm") ||
+    argv1.includes("npx")
+  ) {
+    return "npm";
+  }
 
-    if (
-      execPath.includes("homebrew") ||
-      execPath.includes("Cellar") ||
-      execPath.includes("linuxbrew") ||
-      argv1.includes("homebrew") ||
-      argv1.includes("Cellar")
-    ) {
-      return "homebrew";
-    }
-
-    if (
-      argv1.includes("node_modules") ||
-      argv1.includes(".npm") ||
-      argv1.includes("npx")
-    ) {
-      return "npm";
-    }
-
-    const npmCheck = spawnSync("npm", ["list", "-g", "@pensar/apex", "--depth=0"], {
+  const npmCheck = spawnSync(
+    "npm",
+    ["list", "-g", "@pensar/apex", "--depth=0"],
+    {
       encoding: "utf-8",
       timeout: 10000,
-    });
-    if (npmCheck.status === 0 && npmCheck.stdout?.includes("@pensar/apex")) {
-      return "npm";
-    }
-
-    return "binary";
+    },
+  );
+  if (npmCheck.status === 0 && npmCheck.stdout?.includes("@pensar/apex")) {
+    return "npm";
   }
 
-  function getUpgradeCommand(method: InstallMethod): { cmd: string; args: string[] } {
-    switch (method) {
-      case "npm":
-        return { cmd: "npm", args: ["install", "-g", "@pensar/apex@latest"] };
-      case "homebrew":
-        return { cmd: "brew", args: ["upgrade", "pensarai/apex/apex"] };
-      case "binary":
-        return { cmd: "bash", args: ["-c", "curl -fsSL https://pensarai.com/install.sh | bash"] };
-    }
-  }
+  return "binary";
+}
 
-  export function getUpgradeCommandString(method: InstallMethod): string {
-    const { cmd, args } = getUpgradeCommand(method);
-    return `${cmd} ${args.join(" ")}`;
-  }
-
-  export function runUpgrade(method: InstallMethod): UpgradeResult {
-    const currentVersion = getCurrentVersion();
-    const { cmd, args } = getUpgradeCommand(method);
-
-    const result = spawnSync(cmd, args, {
-      encoding: "utf-8",
-      timeout: 120000,
-      stdio: "pipe",
-    });
-
-    if (result.status !== 0) {
-      const stderr = result.stderr?.trim() || "Unknown error";
+function getUpgradeCommand(method: InstallMethod): {
+  cmd: string;
+  args: string[];
+} {
+  switch (method) {
+    case "npm":
+      return { cmd: "npm", args: ["install", "-g", "@pensar/apex@latest"] };
+    case "homebrew":
+      return { cmd: "brew", args: ["upgrade", "pensarai/apex/apex"] };
+    case "binary":
       return {
-        success: false,
-        message: `Upgrade failed: ${stderr}`,
-        fromVersion: currentVersion,
-        toVersion: currentVersion,
+        cmd: "bash",
+        args: ["-c", "curl -fsSL https://pensarai.com/install.sh | bash"],
       };
-    }
+  }
+}
 
+export function getUpgradeCommandString(method: InstallMethod): string {
+  const { cmd, args } = getUpgradeCommand(method);
+  return `${cmd} ${args.join(" ")}`;
+}
+
+export function runUpgrade(method: InstallMethod): UpgradeResult {
+  const currentVersion = getCurrentVersion();
+  const { cmd, args } = getUpgradeCommand(method);
+
+  const result = spawnSync(cmd, args, {
+    encoding: "utf-8",
+    timeout: 120000,
+    stdio: "pipe",
+  });
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim() || "Unknown error";
     return {
-      success: true,
-      message: "Upgrade successful. Please restart pensar to use the new version.",
+      success: false,
+      message: `Upgrade failed: ${stderr}`,
       fromVersion: currentVersion,
-      toVersion: "latest",
+      toVersion: currentVersion,
     };
   }
 
-  export async function upgrade(): Promise<UpgradeResult> {
-    const currentVersion = getCurrentVersion();
-    let latestVersion: string;
+  return {
+    success: true,
+    message:
+      "Upgrade successful. Please restart pensar to use the new version.",
+    fromVersion: currentVersion,
+    toVersion: "latest",
+  };
+}
 
-    try {
-      latestVersion = await getLatestVersion();
-    } catch {
-      return {
-        success: false,
-        message: "Failed to check for updates. Please check your internet connection.",
-        fromVersion: currentVersion,
-        toVersion: currentVersion,
-      };
-    }
+export async function upgrade(): Promise<UpgradeResult> {
+  const currentVersion = getCurrentVersion();
+  let latestVersion: string;
 
-    if (currentVersion === latestVersion) {
-      return {
-        success: true,
-        message: `Already on the latest version (v${currentVersion}).`,
-        fromVersion: currentVersion,
-        toVersion: latestVersion,
-      };
-    }
+  try {
+    latestVersion = await getLatestVersion();
+  } catch {
+    return {
+      success: false,
+      message:
+        "Failed to check for updates. Please check your internet connection.",
+      fromVersion: currentVersion,
+      toVersion: currentVersion,
+    };
+  }
 
-    const method = detectInstallMethod();
-    const result = runUpgrade(method);
+  if (currentVersion === latestVersion) {
+    return {
+      success: true,
+      message: `Already on the latest version (v${currentVersion}).`,
+      fromVersion: currentVersion,
+      toVersion: latestVersion,
+    };
+  }
 
-    if (result.success) {
-      return {
-        ...result,
-        toVersion: latestVersion,
-        message: `Upgraded from v${currentVersion} to v${latestVersion}. Please restart pensar.`,
-      };
-    }
+  const method = detectInstallMethod();
+  const result = runUpgrade(method);
 
+  if (result.success) {
     return {
       ...result,
       toVersion: latestVersion,
-      message: `${result.message}\n\nYou can upgrade manually by running:\n  ${getUpgradeCommandString(method)}`,
+      message: `Upgraded from v${currentVersion} to v${latestVersion}. Please restart pensar.`,
     };
   }
+
+  return {
+    ...result,
+    toVersion: latestVersion,
+    message: `${result.message}\n\nYou can upgrade manually by running:\n  ${getUpgradeCommandString(method)}`,
+  };
 }

--- a/src/core/installation/index.ts
+++ b/src/core/installation/index.ts
@@ -124,7 +124,11 @@ export async function checkForUpdate(): Promise<CheckUpdateResult> {
   try {
     latestVersion = await getLatestVersion();
   } catch {
-    return { updateAvailable: false, currentVersion, latestVersion: currentVersion };
+    return {
+      updateAvailable: false,
+      currentVersion,
+      latestVersion: currentVersion,
+    };
   }
 
   return {

--- a/src/core/installation/index.ts
+++ b/src/core/installation/index.ts
@@ -94,18 +94,47 @@ export function getUpgradeCommandString(method: InstallMethod): string {
   return `${cmd} ${args.join(" ")}`;
 }
 
-export function runUpgrade(method: InstallMethod): UpgradeResult {
+export interface CheckUpdateResult {
+  updateAvailable: boolean;
+  currentVersion: string;
+  latestVersion: string;
+}
+
+export async function checkForUpdate(): Promise<CheckUpdateResult> {
+  const currentVersion = getCurrentVersion();
+  let latestVersion: string;
+
+  try {
+    latestVersion = await getLatestVersion();
+  } catch {
+    return { updateAvailable: false, currentVersion, latestVersion: currentVersion };
+  }
+
+  return {
+    updateAvailable: currentVersion !== latestVersion,
+    currentVersion,
+    latestVersion,
+  };
+}
+
+export function runUpgrade(
+  method: InstallMethod,
+  options?: { interactive?: boolean },
+): UpgradeResult {
   const currentVersion = getCurrentVersion();
   const { cmd, args } = getUpgradeCommand(method);
+  const interactive = options?.interactive ?? false;
 
   const result = spawnSync(cmd, args, {
     encoding: "utf-8",
     timeout: 120000,
-    stdio: "pipe",
+    stdio: interactive ? "inherit" : "pipe",
   });
 
   if (result.status !== 0) {
-    const stderr = result.stderr?.trim() || "Unknown error";
+    const stderr =
+      (typeof result.stderr === "string" ? result.stderr.trim() : "") ||
+      "Unknown error";
     return {
       success: false,
       message: `Upgrade failed: ${stderr}`,
@@ -123,7 +152,9 @@ export function runUpgrade(method: InstallMethod): UpgradeResult {
   };
 }
 
-export async function upgrade(): Promise<UpgradeResult> {
+export async function upgrade(options?: {
+  interactive?: boolean;
+}): Promise<UpgradeResult> {
   const currentVersion = getCurrentVersion();
   let latestVersion: string;
 
@@ -149,7 +180,7 @@ export async function upgrade(): Promise<UpgradeResult> {
   }
 
   const method = detectInstallMethod();
-  const result = runUpgrade(method);
+  const result = runUpgrade(method, options);
 
   if (result.success) {
     return {

--- a/src/core/installation/index.ts
+++ b/src/core/installation/index.ts
@@ -10,17 +10,9 @@ export interface UpgradeResult {
   toVersion: string;
 }
 
-export async function getVersion() {
+export async function resolveVersion(): Promise<string> {
   if (process.env["APEX_VERSION"]) return process.env["APEX_VERSION"];
-
-  const version = await fetch(
-    "https://registry.npmjs.org/@pensar/apex/latest",
-  ).then(async (res) => {
-    if (!res.ok) throw new Error(res.statusText);
-    const data = (await res.json()) as Record<string, unknown>;
-    return String(data.version);
-  });
-  return version;
+  return getLatestVersion();
 }
 
 export function getCurrentVersion(): string {

--- a/src/core/installation/installation.test.ts
+++ b/src/core/installation/installation.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   getCurrentVersion,
   getLatestVersion,
-  getVersion,
+  resolveVersion,
   isNewerVersion,
   detectInstallMethod,
   getUpgradeCommandString,
@@ -32,10 +32,10 @@ describe("getCurrentVersion", () => {
 });
 
 // ---------------------------------------------------------------------------
-// getVersion
+// resolveVersion
 // ---------------------------------------------------------------------------
 
-describe("getVersion", () => {
+describe("resolveVersion", () => {
   const originalEnv = process.env["APEX_VERSION"];
 
   afterEach(() => {
@@ -49,18 +49,18 @@ describe("getVersion", () => {
 
   it("returns APEX_VERSION env var when set", async () => {
     process.env["APEX_VERSION"] = "1.2.3-custom";
-    const version = await getVersion();
+    const version = await resolveVersion();
     expect(version).toBe("1.2.3-custom");
   });
 
-  it("fetches version from npm registry when env var is not set", async () => {
+  it("delegates to getLatestVersion when env var is not set", async () => {
     delete process.env["APEX_VERSION"];
     const mockFetch = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(
         new Response(JSON.stringify({ version: "9.9.9" }), { status: 200 }),
       );
-    const version = await getVersion();
+    const version = await resolveVersion();
     expect(version).toBe("9.9.9");
     expect(mockFetch).toHaveBeenCalledWith(
       "https://registry.npmjs.org/@pensar/apex/latest",
@@ -175,6 +175,53 @@ describe("detectInstallMethod", () => {
     });
     process.argv[1] = "/home/user/.npm/_npx/abc/node_modules/.bin/pensar";
     expect(detectInstallMethod()).toBe("npm");
+  });
+
+  it("detects npm via spawnSync fallback when path heuristics miss", async () => {
+    Object.defineProperty(process, "execPath", {
+      value: "/usr/local/bin/node",
+      writable: true,
+    });
+    process.argv[1] = "/usr/local/bin/pensar";
+
+    const { spawnSync } = await import("child_process");
+    const mockedSpawnSync = vi.mocked(spawnSync);
+    mockedSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: "└── @pensar/apex@0.1.0",
+      stderr: "",
+      pid: 0,
+      output: [],
+      signal: null,
+    });
+
+    expect(detectInstallMethod()).toBe("npm");
+    expect(mockedSpawnSync).toHaveBeenCalledWith(
+      "npm",
+      ["list", "-g", "@pensar/apex", "--depth=0"],
+      expect.objectContaining({ encoding: "utf-8" }),
+    );
+  });
+
+  it("returns binary when all heuristics fail", async () => {
+    Object.defineProperty(process, "execPath", {
+      value: "/usr/local/bin/node",
+      writable: true,
+    });
+    process.argv[1] = "/usr/local/bin/pensar";
+
+    const { spawnSync } = await import("child_process");
+    const mockedSpawnSync = vi.mocked(spawnSync);
+    mockedSpawnSync.mockReturnValue({
+      status: 1,
+      stdout: "",
+      stderr: "",
+      pid: 0,
+      output: [],
+      signal: null,
+    });
+
+    expect(detectInstallMethod()).toBe("binary");
   });
 });
 

--- a/src/core/installation/installation.test.ts
+++ b/src/core/installation/installation.test.ts
@@ -53,9 +53,11 @@ describe("getVersion", () => {
 
   it("fetches version from npm registry when env var is not set", async () => {
     delete process.env["APEX_VERSION"];
-    const mockFetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ version: "9.9.9" }), { status: 200 }),
-    );
+    const mockFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ version: "9.9.9" }), { status: 200 }),
+      );
     const version = await getVersion();
     expect(version).toBe("9.9.9");
     expect(mockFetch).toHaveBeenCalledWith(
@@ -96,7 +98,10 @@ describe("detectInstallMethod", () => {
   const origArgv = [...process.argv];
 
   afterEach(() => {
-    Object.defineProperty(process, "execPath", { value: origExecPath, writable: true });
+    Object.defineProperty(process, "execPath", {
+      value: origExecPath,
+      writable: true,
+    });
     process.argv = [...origArgv];
     vi.restoreAllMocks();
   });
@@ -181,9 +186,7 @@ describe("upgrade", () => {
   });
 
   it("returns failure when version check fails", async () => {
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(
-      new Error("network error"),
-    );
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network error"));
 
     const result = await upgrade();
     expect(result.success).toBe(false);

--- a/src/core/installation/installation.test.ts
+++ b/src/core/installation/installation.test.ts
@@ -5,6 +5,7 @@ import {
   getVersion,
   detectInstallMethod,
   getUpgradeCommandString,
+  checkForUpdate,
   upgrade,
 } from "./index";
 import packageJson from "../../../package.json";
@@ -166,6 +167,44 @@ describe("getUpgradeCommandString", () => {
 });
 
 // ---------------------------------------------------------------------------
+// checkForUpdate
+// ---------------------------------------------------------------------------
+
+describe("checkForUpdate", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("reports no update when versions match", async () => {
+    const current = getCurrentVersion();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: current }), { status: 200 }),
+    );
+
+    const result = await checkForUpdate();
+    expect(result.updateAvailable).toBe(false);
+    expect(result.currentVersion).toBe(current);
+    expect(result.latestVersion).toBe(current);
+  });
+
+  it("reports update available when versions differ", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "99.99.99" }), { status: 200 }),
+    );
+
+    const result = await checkForUpdate();
+    expect(result.updateAvailable).toBe(true);
+    expect(result.currentVersion).toBe(getCurrentVersion());
+    expect(result.latestVersion).toBe("99.99.99");
+  });
+
+  it("returns no update on network failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+
+    const result = await checkForUpdate();
+    expect(result.updateAvailable).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // upgrade (integration of version check + upgrade logic)
 // ---------------------------------------------------------------------------
 
@@ -214,6 +253,56 @@ describe("upgrade", () => {
     expect(result.fromVersion).toBe(getCurrentVersion());
     expect(result.toVersion).toBe("99.99.99");
     expect(result.message).toContain("Upgraded from");
+  });
+
+  it("uses stdio inherit when interactive is true", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "99.99.99" }), { status: 200 }),
+    );
+
+    const { spawnSync } = await import("child_process");
+    const mockedSpawnSync = vi.mocked(spawnSync);
+    mockedSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: "",
+      stderr: "",
+      pid: 0,
+      output: [],
+      signal: null,
+    });
+
+    await upgrade({ interactive: true });
+
+    expect(mockedSpawnSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+  });
+
+  it("uses stdio pipe when interactive is false", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "99.99.99" }), { status: 200 }),
+    );
+
+    const { spawnSync } = await import("child_process");
+    const mockedSpawnSync = vi.mocked(spawnSync);
+    mockedSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: "",
+      stderr: "",
+      pid: 0,
+      output: [],
+      signal: null,
+    });
+
+    await upgrade({ interactive: false });
+
+    expect(mockedSpawnSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ stdio: "pipe" }),
+    );
   });
 
   it("includes manual command on upgrade failure", async () => {

--- a/src/core/installation/installation.test.ts
+++ b/src/core/installation/installation.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  getCurrentVersion,
+  getLatestVersion,
+  getVersion,
+  detectInstallMethod,
+  getUpgradeCommandString,
+  upgrade,
+} from "./index";
+import packageJson from "../../../package.json";
+
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  return { ...actual, spawnSync: vi.fn(actual.spawnSync) };
+});
+
+// ---------------------------------------------------------------------------
+// getCurrentVersion
+// ---------------------------------------------------------------------------
+
+describe("getCurrentVersion", () => {
+  it("returns the version from package.json", () => {
+    expect(getCurrentVersion()).toBe(packageJson.version);
+  });
+
+  it("returns a valid semver-like string", () => {
+    const version = getCurrentVersion();
+    expect(version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getVersion
+// ---------------------------------------------------------------------------
+
+describe("getVersion", () => {
+  const originalEnv = process.env["APEX_VERSION"];
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env["APEX_VERSION"] = originalEnv;
+    } else {
+      delete process.env["APEX_VERSION"];
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("returns APEX_VERSION env var when set", async () => {
+    process.env["APEX_VERSION"] = "1.2.3-custom";
+    const version = await getVersion();
+    expect(version).toBe("1.2.3-custom");
+  });
+
+  it("fetches version from npm registry when env var is not set", async () => {
+    delete process.env["APEX_VERSION"];
+    const mockFetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "9.9.9" }), { status: 200 }),
+    );
+    const version = await getVersion();
+    expect(version).toBe("9.9.9");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/@pensar/apex/latest",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getLatestVersion
+// ---------------------------------------------------------------------------
+
+describe("getLatestVersion", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns the latest version from npm registry", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "1.0.0" }), { status: 200 }),
+    );
+    const version = await getLatestVersion();
+    expect(version).toBe("1.0.0");
+  });
+
+  it("throws on non-ok response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("not found", { status: 404, statusText: "Not Found" }),
+    );
+    await expect(getLatestVersion()).rejects.toThrow("Not Found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectInstallMethod
+// ---------------------------------------------------------------------------
+
+describe("detectInstallMethod", () => {
+  const origExecPath = process.execPath;
+  const origArgv = [...process.argv];
+
+  afterEach(() => {
+    Object.defineProperty(process, "execPath", { value: origExecPath, writable: true });
+    process.argv = [...origArgv];
+    vi.restoreAllMocks();
+  });
+
+  it("detects homebrew from execPath", () => {
+    Object.defineProperty(process, "execPath", {
+      value: "/opt/homebrew/bin/bun",
+      writable: true,
+    });
+    expect(detectInstallMethod()).toBe("homebrew");
+  });
+
+  it("detects homebrew from Cellar in execPath", () => {
+    Object.defineProperty(process, "execPath", {
+      value: "/opt/homebrew/Cellar/apex/0.1.0/bin/pensar",
+      writable: true,
+    });
+    expect(detectInstallMethod()).toBe("homebrew");
+  });
+
+  it("detects npm from node_modules in argv[1]", () => {
+    Object.defineProperty(process, "execPath", {
+      value: "/usr/local/bin/node",
+      writable: true,
+    });
+    process.argv[1] = "/usr/local/lib/node_modules/@pensar/apex/bin/pensar.js";
+    expect(detectInstallMethod()).toBe("npm");
+  });
+
+  it("detects npm from npx in argv[1]", () => {
+    Object.defineProperty(process, "execPath", {
+      value: "/usr/local/bin/node",
+      writable: true,
+    });
+    process.argv[1] = "/home/user/.npm/_npx/abc/node_modules/.bin/pensar";
+    expect(detectInstallMethod()).toBe("npm");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getUpgradeCommandString
+// ---------------------------------------------------------------------------
+
+describe("getUpgradeCommandString", () => {
+  it("returns npm install command for npm method", () => {
+    expect(getUpgradeCommandString("npm")).toBe(
+      "npm install -g @pensar/apex@latest",
+    );
+  });
+
+  it("returns brew upgrade command for homebrew method", () => {
+    expect(getUpgradeCommandString("homebrew")).toBe(
+      "brew upgrade pensarai/apex/apex",
+    );
+  });
+
+  it("returns curl command for binary method", () => {
+    const cmd = getUpgradeCommandString("binary");
+    expect(cmd).toContain("curl");
+    expect(cmd).toContain("pensarai.com/install.sh");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upgrade (integration of version check + upgrade logic)
+// ---------------------------------------------------------------------------
+
+describe("upgrade", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("reports already up to date when versions match", async () => {
+    const current = getCurrentVersion();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: current }), { status: 200 }),
+    );
+
+    const result = await upgrade();
+    expect(result.success).toBe(true);
+    expect(result.fromVersion).toBe(current);
+    expect(result.toVersion).toBe(current);
+    expect(result.message).toContain("Already on the latest version");
+  });
+
+  it("returns failure when version check fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new Error("network error"),
+    );
+
+    const result = await upgrade();
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Failed to check for updates");
+  });
+
+  it("attempts upgrade when a newer version is available", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "99.99.99" }), { status: 200 }),
+    );
+
+    const { spawnSync } = await import("child_process");
+    const mockedSpawnSync = vi.mocked(spawnSync);
+    mockedSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: "upgraded successfully",
+      stderr: "",
+      pid: 0,
+      output: [],
+      signal: null,
+    });
+
+    const result = await upgrade();
+    expect(result.success).toBe(true);
+    expect(result.fromVersion).toBe(getCurrentVersion());
+    expect(result.toVersion).toBe("99.99.99");
+    expect(result.message).toContain("Upgraded from");
+  });
+
+  it("includes manual command on upgrade failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "99.99.99" }), { status: 200 }),
+    );
+
+    const { spawnSync } = await import("child_process");
+    const mockedSpawnSync = vi.mocked(spawnSync);
+    mockedSpawnSync.mockReturnValue({
+      status: 1,
+      stdout: "",
+      stderr: "permission denied",
+      pid: 0,
+      output: [],
+      signal: null,
+    });
+
+    const result = await upgrade();
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("permission denied");
+    expect(result.message).toContain("You can upgrade manually");
+  });
+});

--- a/src/core/installation/installation.test.ts
+++ b/src/core/installation/installation.test.ts
@@ -3,6 +3,7 @@ import {
   getCurrentVersion,
   getLatestVersion,
   getVersion,
+  isNewerVersion,
   detectInstallMethod,
   getUpgradeCommandString,
   checkForUpdate,
@@ -87,6 +88,41 @@ describe("getLatestVersion", () => {
       new Response("not found", { status: 404, statusText: "Not Found" }),
     );
     await expect(getLatestVersion()).rejects.toThrow("Not Found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isNewerVersion
+// ---------------------------------------------------------------------------
+
+describe("isNewerVersion", () => {
+  it("returns true when latest has higher patch", () => {
+    expect(isNewerVersion("0.0.66", "0.0.67")).toBe(true);
+  });
+
+  it("returns true when latest has higher minor", () => {
+    expect(isNewerVersion("0.1.0", "0.2.0")).toBe(true);
+  });
+
+  it("returns true when latest has higher major", () => {
+    expect(isNewerVersion("1.0.0", "2.0.0")).toBe(true);
+  });
+
+  it("returns false when versions are equal", () => {
+    expect(isNewerVersion("0.0.67", "0.0.67")).toBe(false);
+  });
+
+  it("returns false when current is newer than latest", () => {
+    expect(isNewerVersion("0.0.67", "0.0.66")).toBe(false);
+  });
+
+  it("returns false when current major is higher", () => {
+    expect(isNewerVersion("2.0.0", "1.9.9")).toBe(false);
+  });
+
+  it("handles versions with different segment counts", () => {
+    expect(isNewerVersion("1.0", "1.0.1")).toBe(true);
+    expect(isNewerVersion("1.0.1", "1.0")).toBe(false);
   });
 });
 
@@ -185,7 +221,7 @@ describe("checkForUpdate", () => {
     expect(result.latestVersion).toBe(current);
   });
 
-  it("reports update available when versions differ", async () => {
+  it("reports update available when latest is greater", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ version: "99.99.99" }), { status: 200 }),
     );
@@ -194,6 +230,16 @@ describe("checkForUpdate", () => {
     expect(result.updateAvailable).toBe(true);
     expect(result.currentVersion).toBe(getCurrentVersion());
     expect(result.latestVersion).toBe("99.99.99");
+  });
+
+  it("reports no update when current is newer than latest", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "0.0.1" }), { status: 200 }),
+    );
+
+    const result = await checkForUpdate();
+    expect(result.updateAvailable).toBe(false);
+    expect(result.latestVersion).toBe("0.0.1");
   });
 
   it("returns no update on network failure", async () => {

--- a/src/core/messages/index.ts
+++ b/src/core/messages/index.ts
@@ -1,72 +1,67 @@
 import fs from "fs";
 import { z } from "zod";
 import type { ToolMessage, Message } from "./types";
-import { Identifier } from "../id/id";
-import { Storage } from "../storage";
+import * as Identifier from "../id/id";
+import * as Storage from "../storage";
 import { type SessionInfo } from "../session";
 
-export namespace Messages {
-  const StreamInput = z.object({
-    sessionId: Identifier.schema("session"),
-  });
+const StreamInput = z.object({
+  sessionId: Identifier.schema("session"),
+});
 
-  export async function* stream(input: z.output<typeof StreamInput>) {
-    const list = await Array.fromAsync(
-      await Storage.list(["message", input.sessionId]),
-    );
-    for (let i = list.length - 1; i >= 0; i--) {
-      yield await get({
-        sessionId: input.sessionId,
-        messageId: list[i][2],
-      });
-    }
+export async function* stream(input: z.output<typeof StreamInput>) {
+  const list = await Array.fromAsync(
+    await Storage.list(["message", input.sessionId]),
+  );
+  for (let i = list.length - 1; i >= 0; i--) {
+    yield await get({
+      sessionId: input.sessionId,
+      messageId: list[i][2],
+    });
+  }
+}
+
+const GetInput = z.object({
+  sessionId: Identifier.schema("session"),
+  messageId: Identifier.schema("message"),
+});
+
+export const get = async (input: z.output<typeof GetInput>) => {
+  return await Storage.read<Message>([
+    "message",
+    input.sessionId,
+    input.messageId,
+  ]);
+};
+
+export function save(session: SessionInfo, messages: Message[]) {
+  fs.writeFileSync(
+    session.rootPath + "/messages.json",
+    JSON.stringify(messages, null, 2),
+  );
+}
+
+export function saveSubagentMessages(
+  orchestratorSession: SessionInfo,
+  subagentId: string,
+  messages: Message[],
+) {
+  const subagentDir = `${orchestratorSession.rootPath}/subagents/${subagentId}`;
+
+  if (!fs.existsSync(`${orchestratorSession.rootPath}/subagents`)) {
+    fs.mkdirSync(`${orchestratorSession.rootPath}/subagents`, {
+      recursive: true,
+    });
   }
 
-  const GetInput = z.object({
-    sessionId: Identifier.schema("session"),
-    messageId: Identifier.schema("message"),
-  });
-
-  export const get = async (input: z.output<typeof GetInput>) => {
-    return await Storage.read<Message>([
-      "message",
-      input.sessionId,
-      input.messageId,
-    ]);
-  };
-
-  export function save(session: SessionInfo, messages: Message[]) {
-    fs.writeFileSync(
-      session.rootPath + "/messages.json",
-      JSON.stringify(messages, null, 2),
-    );
+  if (!fs.existsSync(subagentDir)) {
+    fs.mkdirSync(subagentDir, { recursive: true });
   }
 
-  export function saveSubagentMessages(
-    orchestratorSession: SessionInfo,
-    subagentId: string,
-    messages: Message[],
-  ) {
-    const subagentDir = `${orchestratorSession.rootPath}/subagents/${subagentId}`;
-
-    // Create subagents directory if it doesn't exist
-    if (!fs.existsSync(`${orchestratorSession.rootPath}/subagents`)) {
-      fs.mkdirSync(`${orchestratorSession.rootPath}/subagents`, {
-        recursive: true,
-      });
-    }
-
-    // Create subagent-specific directory if it doesn't exist
-    if (!fs.existsSync(subagentDir)) {
-      fs.mkdirSync(subagentDir, { recursive: true });
-    }
-
-    // Save messages
-    fs.writeFileSync(
-      `${subagentDir}/messages.json`,
-      JSON.stringify(messages, null, 2),
-    );
-  }
+  fs.writeFileSync(
+    `${subagentDir}/messages.json`,
+    JSON.stringify(messages, null, 2),
+  );
 }
 
 export function mapMessages(messages: Message[]): Message[] {

--- a/src/core/messages/types.ts
+++ b/src/core/messages/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { Identifier } from "../id/id";
+import * as Identifier from "../id/id";
 
 const Base = z.object({
   sessionId: Identifier.schema("session"),

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -3,7 +3,7 @@ import path from "path";
 import os from "os";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { Identifier } from "../id/id";
-import { Installation } from "../installation";
+import { getVersion } from "../installation";
 import { Storage } from "../storage";
 import type { Message } from "../messages/types";
 import { Messages } from "../messages";
@@ -337,7 +337,7 @@ export async function create(input: CreateInputProps) {
 
   const result: SessionInfo = {
     id: id,
-    version: (await Installation.getVersion()) ?? "unknown",
+    version: (await getVersion()) ?? "unknown",
     targets: input.targets,
     name: input.name,
     time: {

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -3,7 +3,7 @@ import path from "path";
 import os from "os";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import * as Identifier from "../id/id";
-import { getVersion } from "../installation";
+import { getCurrentVersion } from "../installation";
 import * as Storage from "../storage";
 import type { Message } from "../messages/types";
 import * as Messages from "../messages";
@@ -337,7 +337,7 @@ export async function create(input: CreateInputProps) {
 
   const result: SessionInfo = {
     id: id,
-    version: (await getVersion()) ?? "unknown",
+    version: getCurrentVersion(),
     targets: input.targets,
     name: input.name,
     time: {

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -2,11 +2,11 @@ import z from "zod";
 import path from "path";
 import os from "os";
 import { existsSync, readFileSync, writeFileSync } from "fs";
-import { Identifier } from "../id/id";
+import * as Identifier from "../id/id";
 import { getVersion } from "../installation";
-import { Storage } from "../storage";
+import * as Storage from "../storage";
 import type { Message } from "../messages/types";
-import { Messages } from "../messages";
+import * as Messages from "../messages";
 import { RateLimiter } from "../services/rateLimiter";
 import {
   ToolsetStateSchema,

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -5,157 +5,143 @@ import { readdir } from "fs/promises";
 
 import z from "zod";
 import { NamedError } from "../../util/errors";
-import { Lock } from "../../util/lock";
+import * as Lock from "../../util/lock";
 
-export namespace Storage {
-  export const NotFoundError = NamedError.create(
-    "NotFoundError",
-    z.object({
-      message: z.string(),
-    }),
-  );
+export const NotFoundError = NamedError.create(
+  "NotFoundError",
+  z.object({
+    message: z.string(),
+  }),
+);
 
-  export async function remove(key: string[]) {
-    const dir = path.join(os.homedir(), ".pensar");
-    const target = path.join(dir, ...key) + ".json";
-    return withErrorHandling(async () => {
-      await fs.unlink(target).catch(() => {});
-    });
-  }
+export async function remove(key: string[]) {
+  const dir = path.join(os.homedir(), ".pensar");
+  const target = path.join(dir, ...key) + ".json";
+  return withErrorHandling(async () => {
+    await fs.unlink(target).catch(() => {});
+  });
+}
 
-  export async function locate(key: string[], ext?: string) {
-    const dir = path.join(os.homedir(), ".pensar");
-    const target = path.join(dir, ...key) + (ext ? ext : ".json");
-    return target;
-  }
+export async function locate(key: string[], ext?: string) {
+  const dir = path.join(os.homedir(), ".pensar");
+  const target = path.join(dir, ...key) + (ext ? ext : ".json");
+  return target;
+}
 
-  export async function write<T>(key: string[], content: T, ext?: string) {
-    const dir = path.join(os.homedir(), ".pensar");
-    const target = path.join(dir, ...key) + (ext ? ext : ".json");
-    return withErrorHandling(async () => {
-      using _ = await Lock.write(target);
-      // Ensure parent directory exists
-      await fs.mkdir(path.dirname(target), { recursive: true });
-      await fs.writeFile(target, JSON.stringify(content, null, 2), "utf-8");
-    });
-  }
+export async function write<T>(key: string[], content: T, ext?: string) {
+  const dir = path.join(os.homedir(), ".pensar");
+  const target = path.join(dir, ...key) + (ext ? ext : ".json");
+  return withErrorHandling(async () => {
+    using _ = await Lock.write(target);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, JSON.stringify(content, null, 2), "utf-8");
+  });
+}
 
-  export async function createDir(key: string[]) {
-    const dir = path.join(os.homedir(), ".pensar");
-    const target = path.join(dir, ...key);
-    return withErrorHandling(async () => {
-      using _ = await Lock.write(target);
-      await fs.mkdir(target, { recursive: true });
-    });
-  }
+export async function createDir(key: string[]) {
+  const dir = path.join(os.homedir(), ".pensar");
+  const target = path.join(dir, ...key);
+  return withErrorHandling(async () => {
+    using _ = await Lock.write(target);
+    await fs.mkdir(target, { recursive: true });
+  });
+}
 
-  /**
-   * Write raw content (non-JSON) to a file within the .pensar directory
-   * @param key Path segments relative to .pensar
-   * @param content Raw string content to write
-   */
-  export async function writeRaw(key: string[], content: string) {
-    const dir = path.join(os.homedir(), ".pensar");
-    const target = path.join(dir, ...key);
-    return withErrorHandling(async () => {
-      using _ = await Lock.write(target);
-      // Ensure parent directory exists
-      const parentDir = path.dirname(target);
-      await fs.mkdir(parentDir, { recursive: true });
-      await fs.writeFile(target, content, "utf-8");
-    });
-  }
+/**
+ * Write raw content (non-JSON) to a file within the .pensar directory
+ */
+export async function writeRaw(key: string[], content: string) {
+  const dir = path.join(os.homedir(), ".pensar");
+  const target = path.join(dir, ...key);
+  return withErrorHandling(async () => {
+    using _ = await Lock.write(target);
+    const parentDir = path.dirname(target);
+    await fs.mkdir(parentDir, { recursive: true });
+    await fs.writeFile(target, content, "utf-8");
+  });
+}
 
-  /**
-   * Append raw content to a file within the .pensar directory
-   * @param key Path segments relative to .pensar
-   * @param content Raw string content to append
-   */
-  export async function appendRaw(key: string[], content: string) {
-    const dir = path.join(os.homedir(), ".pensar");
-    const target = path.join(dir, ...key);
-    return withErrorHandling(async () => {
-      using _ = await Lock.write(target);
-      // Ensure parent directory exists
-      const parentDir = path.dirname(target);
-      await fs.mkdir(parentDir, { recursive: true });
-      await fs.appendFile(target, content);
-    });
-  }
+/**
+ * Append raw content to a file within the .pensar directory
+ */
+export async function appendRaw(key: string[], content: string) {
+  const dir = path.join(os.homedir(), ".pensar");
+  const target = path.join(dir, ...key);
+  return withErrorHandling(async () => {
+    using _ = await Lock.write(target);
+    const parentDir = path.dirname(target);
+    await fs.mkdir(parentDir, { recursive: true });
+    await fs.appendFile(target, content);
+  });
+}
 
-  export async function read<T>(key: string[], ext?: string) {
-    const dir = path.join(os.homedir(), ".pensar");
-    const target = path.join(dir, ...key) + (ext ? ext : ".json");
-    return withErrorHandling(async () => {
-      using _ = await Lock.read(target);
-      const text = await fs.readFile(target, "utf-8");
-      const result = ext ? text : JSON.parse(text);
-      return result as T;
-    });
-  }
+export async function read<T>(key: string[], ext?: string) {
+  const dir = path.join(os.homedir(), ".pensar");
+  const target = path.join(dir, ...key) + (ext ? ext : ".json");
+  return withErrorHandling(async () => {
+    using _ = await Lock.read(target);
+    const text = await fs.readFile(target, "utf-8");
+    const result = ext ? text : JSON.parse(text);
+    return result as T;
+  });
+}
 
-  export async function update<T>(
-    key: string[],
-    fn: (draft: T) => void,
-    ext?: string,
-  ) {
-    const dir = path.join(os.homedir(), ".pensar");
-    const target = path.join(dir, ...key) + (ext ? ext : ".json");
-    return withErrorHandling(async () => {
-      using _ = await Lock.write(target);
-      const text = await fs.readFile(target, "utf-8");
-      const content = ext ? text : JSON.parse(text);
-      fn(content);
-      await fs.writeFile(target, JSON.stringify(content, null, 2), "utf-8");
-      return content as T;
-    });
-  }
+export async function update<T>(
+  key: string[],
+  fn: (draft: T) => void,
+  ext?: string,
+) {
+  const dir = path.join(os.homedir(), ".pensar");
+  const target = path.join(dir, ...key) + (ext ? ext : ".json");
+  return withErrorHandling(async () => {
+    using _ = await Lock.write(target);
+    const text = await fs.readFile(target, "utf-8");
+    const content = ext ? text : JSON.parse(text);
+    fn(content);
+    await fs.writeFile(target, JSON.stringify(content, null, 2), "utf-8");
+    return content as T;
+  });
+}
 
-  async function withErrorHandling<T>(body: () => Promise<T>) {
-    return body().catch((e) => {
-      if (!(e instanceof Error)) throw e;
-      const errnoExcpetion = e as NodeJS.ErrnoException;
-      if (errnoExcpetion.code === "ENOENT") {
-        throw new NotFoundError({
-          message: `Resource not found: ${errnoExcpetion.path}`,
-        });
-      }
-      throw e;
-    });
-  }
-
-  /**
-   * Recursively list all files in a directory
-   */
-  async function listFilesRecursively(dir: string): Promise<string[]> {
-    const entries = await readdir(dir, { withFileTypes: true });
-    const files: string[] = [];
-    for (const entry of entries) {
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        files.push(...(await listFilesRecursively(fullPath)));
-      } else {
-        files.push(fullPath);
-      }
-    }
-    return files;
-  }
-
-  export async function list(prefix: string[]) {
-    const dir = path.join(os.homedir(), ".pensar");
-    const targetDir = path.join(dir, ...prefix);
-    try {
-      const files = await listFilesRecursively(targetDir);
-      // Convert absolute paths to relative paths and split into key segments
-      // Remove the .json extension (last 5 chars) and split by path separator
-      const result = files.map((filePath) => {
-        const relativePath = path.relative(targetDir, filePath);
-        return [...prefix, ...relativePath.slice(0, -5).split(path.sep)];
+async function withErrorHandling<T>(body: () => Promise<T>) {
+  return body().catch((e) => {
+    if (!(e instanceof Error)) throw e;
+    const errnoExcpetion = e as NodeJS.ErrnoException;
+    if (errnoExcpetion.code === "ENOENT") {
+      throw new NotFoundError({
+        message: `Resource not found: ${errnoExcpetion.path}`,
       });
-      result.sort();
-      return result;
-    } catch {
-      return [];
     }
+    throw e;
+  });
+}
+
+async function listFilesRecursively(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFilesRecursively(fullPath)));
+    } else {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+export async function list(prefix: string[]) {
+  const dir = path.join(os.homedir(), ".pensar");
+  const targetDir = path.join(dir, ...prefix);
+  try {
+    const files = await listFilesRecursively(targetDir);
+    const result = files.map((filePath) => {
+      const relativePath = path.relative(targetDir, filePath);
+      return [...prefix, ...relativePath.slice(0, -5).split(path.sep)];
+    });
+    result.sort();
+    return result;
+  } catch {
+    return [];
   }
 }

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -8,7 +8,11 @@ import {
 } from "./utils/command-flags";
 import { getAllThemeNames } from "./theme";
 import { config } from "../core/config";
-import { getCurrentVersion, upgrade } from "../core/installation";
+import {
+  checkForUpdate,
+  getUpgradeCommandString,
+  detectInstallMethod,
+} from "../core/installation";
 
 import type { ToastVariant } from "./context/toast";
 
@@ -348,23 +352,23 @@ export const commands: CommandConfig[] = [
     description: "Update pensar to the latest version",
     category: "General",
     handler: async (_args, ctx) => {
-      const currentVersion = getCurrentVersion();
-      ctx.toast(`Current version: v${currentVersion} — checking for updates…`);
+      ctx.toast("Checking for updates…");
 
-      const result = await upgrade();
+      const { updateAvailable, currentVersion, latestVersion } =
+        await checkForUpdate();
 
-      if (result.success && result.fromVersion !== result.toVersion) {
-        ctx.toast(
-          `Upgraded to v${result.toVersion}. Restarting…`,
-          "default",
-          3000,
-        );
-        setTimeout(() => process.kill(process.pid, "SIGINT"), 2000);
-      } else if (result.success) {
-        ctx.toast(result.message);
-      } else {
-        ctx.toast(result.message, "error", 6000);
+      if (!updateAvailable) {
+        ctx.toast(`Already on the latest version (v${currentVersion}).`);
+        return;
       }
+
+      const method = detectInstallMethod();
+      const cmd = getUpgradeCommandString(method);
+      ctx.toast(
+        `Update available: v${currentVersion} → v${latestVersion}. Run: ${cmd}`,
+        "warn",
+        8000,
+      );
     },
   },
   {

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -8,6 +8,7 @@ import {
 } from "./utils/command-flags";
 import { getAllThemeNames } from "./theme";
 import { config } from "../core/config";
+import { Installation } from "../core/installation";
 
 /**
  * Define your application's CommandContext type with specific methods
@@ -338,6 +339,24 @@ export const commands: CommandConfig[] = [
     },
   },
 
+  {
+    name: "upgrade",
+    aliases: ["update"],
+    description: "Update pensar to the latest version",
+    category: "General",
+    handler: async () => {
+      const currentVersion = Installation.getCurrentVersion();
+      console.log(`\nCurrent version: v${currentVersion}`);
+      console.log("Checking for updates...\n");
+
+      const result = await Installation.upgrade();
+      console.log(result.message);
+
+      if (result.success && result.fromVersion !== result.toVersion) {
+        setTimeout(() => process.kill(process.pid, "SIGINT"), 1500);
+      }
+    },
+  },
   {
     name: "exit",
     aliases: ["quit", "q"],

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -8,21 +8,12 @@ import {
 } from "./utils/command-flags";
 import { getAllThemeNames } from "./theme";
 import { config } from "../core/config";
-import {
-  checkForUpdate,
-  getUpgradeCommandString,
-  detectInstallMethod,
-} from "../core/installation";
-
-import type { ToastVariant } from "./context/toast";
-
 /**
  * Define your application's CommandContext type with specific methods
  */
 export interface AppCommandContext {
   route: Route;
   navigate: (route: Route) => void;
-  toast: (message: string, variant?: ToastVariant, duration?: number) => void;
 }
 
 /**
@@ -346,31 +337,6 @@ export const commands: CommandConfig[] = [
     },
   },
 
-  {
-    name: "upgrade",
-    aliases: ["update"],
-    description: "Update pensar to the latest version",
-    category: "General",
-    handler: async (_args, ctx) => {
-      ctx.toast("Checking for updates…");
-
-      const { updateAvailable, currentVersion, latestVersion } =
-        await checkForUpdate();
-
-      if (!updateAvailable) {
-        ctx.toast(`Already on the latest version (v${currentVersion}).`);
-        return;
-      }
-
-      const method = detectInstallMethod();
-      const cmd = getUpgradeCommandString(method);
-      ctx.toast(
-        `Update available: v${currentVersion} → v${latestVersion}. Run: ${cmd}`,
-        "warn",
-        8000,
-      );
-    },
-  },
   {
     name: "exit",
     aliases: ["quit", "q"],

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -8,7 +8,7 @@ import {
 } from "./utils/command-flags";
 import { getAllThemeNames } from "./theme";
 import { config } from "../core/config";
-import { Installation } from "../core/installation";
+import { getCurrentVersion, upgrade } from "../core/installation";
 
 /**
  * Define your application's CommandContext type with specific methods
@@ -345,11 +345,11 @@ export const commands: CommandConfig[] = [
     description: "Update pensar to the latest version",
     category: "General",
     handler: async () => {
-      const currentVersion = Installation.getCurrentVersion();
+      const currentVersion = getCurrentVersion();
       console.log(`\nCurrent version: v${currentVersion}`);
       console.log("Checking for updates...\n");
 
-      const result = await Installation.upgrade();
+      const result = await upgrade();
       console.log(result.message);
 
       if (result.success && result.fromVersion !== result.toVersion) {

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -10,12 +10,15 @@ import { getAllThemeNames } from "./theme";
 import { config } from "../core/config";
 import { getCurrentVersion, upgrade } from "../core/installation";
 
+import type { ToastVariant } from "./context/toast";
+
 /**
  * Define your application's CommandContext type with specific methods
  */
 export interface AppCommandContext {
   route: Route;
   navigate: (route: Route) => void;
+  toast: (message: string, variant?: ToastVariant, duration?: number) => void;
 }
 
 /**
@@ -344,16 +347,23 @@ export const commands: CommandConfig[] = [
     aliases: ["update"],
     description: "Update pensar to the latest version",
     category: "General",
-    handler: async () => {
+    handler: async (_args, ctx) => {
       const currentVersion = getCurrentVersion();
-      console.log(`\nCurrent version: v${currentVersion}`);
-      console.log("Checking for updates...\n");
+      ctx.toast(`Current version: v${currentVersion} — checking for updates…`);
 
       const result = await upgrade();
-      console.log(result.message);
 
       if (result.success && result.fromVersion !== result.toVersion) {
-        setTimeout(() => process.kill(process.pid, "SIGINT"), 1500);
+        ctx.toast(
+          `Upgraded to v${result.toVersion}. Restarting…`,
+          "default",
+          3000,
+        );
+        setTimeout(() => process.kill(process.pid, "SIGINT"), 2000);
+      } else if (result.success) {
+        ctx.toast(result.message);
+      } else {
+        ctx.toast(result.message, "error", 6000);
       }
     },
   },

--- a/src/tui/components/commands/sessions-browser.tsx
+++ b/src/tui/components/commands/sessions-browser.tsx
@@ -12,7 +12,7 @@ import { scrollToIndex } from "../../utils/scroll";
 import { useRoute } from "../../context/route";
 import { useSession } from "../../context/session";
 import { useFocus } from "../../context/focus";
-import { Storage } from "../../../core/storage";
+import * as Storage from "../../../core/storage";
 import {
   useSessionsList,
   formatRelativeTime,

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -6,7 +6,7 @@ import { useRoute } from "../../context/route";
 import { useSession } from "../../context/session";
 import { useFocus } from "../../context/focus";
 import { sessions, type SessionInfo } from "../../../core/session";
-import { Storage } from "../../../core/storage";
+import * as Storage from "../../../core/storage";
 import { Dialog } from "../../context/dialog";
 import { ScrollBoxRenderable } from "@opentui/core";
 import { scrollToIndex } from "../../utils/scroll";

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -8,7 +8,6 @@ import {
 } from "../command-registry";
 import type { AutocompleteOption } from "../components/shared/prompt-input";
 import { useRoute } from "./route";
-import { useToast } from "./toast";
 
 interface CommandContextValue {
   router: CommandRouter<AppCommandContext>;
@@ -33,16 +32,14 @@ interface CommandProviderProps {
 
 export function CommandProvider({ children }: CommandProviderProps) {
   const route = useRoute();
-  const { toast } = useToast();
 
   const ctx = useMemo(() => {
     const ctx: AppCommandContext = {
       route: route.data,
       navigate: route.navigate,
-      toast,
     };
     return ctx;
-  }, [route, toast]);
+  }, [route]);
 
   // Create router with context - initialized once
   const router = useMemo(() => {

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -8,6 +8,7 @@ import {
 } from "../command-registry";
 import type { AutocompleteOption } from "../components/shared/prompt-input";
 import { useRoute } from "./route";
+import { useToast } from "./toast";
 
 interface CommandContextValue {
   router: CommandRouter<AppCommandContext>;
@@ -32,14 +33,16 @@ interface CommandProviderProps {
 
 export function CommandProvider({ children }: CommandProviderProps) {
   const route = useRoute();
+  const { toast } = useToast();
 
   const ctx = useMemo(() => {
     const ctx: AppCommandContext = {
       route: route.data,
       navigate: route.navigate,
+      toast,
     };
     return ctx;
-  }, [route]);
+  }, [route, toast]);
 
   // Create router with context - initialized once
   const router = useMemo(() => {

--- a/src/tui/context/keybinding.tsx
+++ b/src/tui/context/keybinding.tsx
@@ -3,7 +3,9 @@ import { useKeyboard } from "@opentui/react";
 import { createContext, useContext, type ReactNode } from "react";
 import {
   createKeybindings,
-  Keybind,
+  fromParsedKey,
+  parseKeybind,
+  matchesKeybind,
   type KeybindingDependencies,
   type KeybindingEntry,
 } from "../keybindings";
@@ -44,13 +46,13 @@ export function KeybindingProvider({
   });
 
   useKeyboard((key: KeyEvent) => {
-    const pressedKey = Keybind.fromParsedKey(key);
+    const pressedKey = fromParsedKey(key);
 
     for (const binding of registry) {
-      const parsedCombos = Keybind.parse(binding.combo);
+      const parsedCombos = parseKeybind(binding.combo);
 
       for (const combo of parsedCombos) {
-        if (Keybind.matches(pressedKey, combo)) {
+        if (matchesKeybind(pressedKey, combo)) {
           // If combo starts with "shift", require input to be focused and empty
           if (
             binding.combo.toLowerCase().startsWith("shift") ||

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -27,11 +27,7 @@ import { ToastContainer } from "./components/toast";
 import { ErrorBoundary } from "./components/error-boundary";
 import { useToast } from "./context/toast";
 import { writeErrorLog } from "../core/logger";
-import {
-  checkForUpdate,
-  detectInstallMethod,
-  getUpgradeCommandString,
-} from "../core/installation";
+import { checkForUpdate } from "../core/installation";
 import ShortcutsDialog from "./components/commands/shortcuts-dialog";
 import HelpDialog from "./components/commands/help-dialog";
 import ModelsDisplay from "./components/commands/models-display";
@@ -140,10 +136,8 @@ function AppContent({
   useEffect(() => {
     checkForUpdate().then(({ updateAvailable, currentVersion, latestVersion }) => {
       if (!updateAvailable) return;
-      const method = detectInstallMethod();
-      const cmd = getUpgradeCommandString(method);
       toast(
-        `Update available: v${currentVersion} → v${latestVersion}. Run: ${cmd}`,
+        `Update available: v${currentVersion} → v${latestVersion}. Run: pensar upgrade`,
         "warn",
         8000,
       );

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -25,7 +25,13 @@ import { DialogProvider, useDialog } from "./context/dialog";
 import { ToastProvider } from "./context/toast";
 import { ToastContainer } from "./components/toast";
 import { ErrorBoundary } from "./components/error-boundary";
+import { useToast } from "./context/toast";
 import { writeErrorLog } from "../core/logger";
+import {
+  checkForUpdate,
+  detectInstallMethod,
+  getUpgradeCommandString,
+} from "../core/installation";
 import ShortcutsDialog from "./components/commands/shortcuts-dialog";
 import HelpDialog from "./components/commands/help-dialog";
 import ModelsDisplay from "./components/commands/models-display";
@@ -126,9 +132,23 @@ function AppContent({
   const route = useRoute();
   const config = useConfig();
   const { colors } = useTheme();
+  const { toast } = useToast();
 
   const { refocusPrompt } = useFocus();
   const { setExternalDialogOpen } = useDialog();
+
+  useEffect(() => {
+    checkForUpdate().then(({ updateAvailable, currentVersion, latestVersion }) => {
+      if (!updateAvailable) return;
+      const method = detectInstallMethod();
+      const cmd = getUpgradeCommandString(method);
+      toast(
+        `Update available: v${currentVersion} → v${latestVersion}. Run: ${cmd}`,
+        "warn",
+        8000,
+      );
+    });
+  }, []);
 
   useEffect(() => {
     if (route.data.type !== "base") return;

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -134,14 +134,16 @@ function AppContent({
   const { setExternalDialogOpen } = useDialog();
 
   useEffect(() => {
-    checkForUpdate().then(({ updateAvailable, currentVersion, latestVersion }) => {
-      if (!updateAvailable) return;
-      toast(
-        `Update available: v${currentVersion} → v${latestVersion}. Run: pensar upgrade`,
-        "warn",
-        8000,
-      );
-    });
+    checkForUpdate().then(
+      ({ updateAvailable, currentVersion, latestVersion }) => {
+        if (!updateAvailable) return;
+        toast(
+          `Update available: v${currentVersion} → v${latestVersion}. Run: pensar upgrade`,
+          "warn",
+          8000,
+        );
+      },
+    );
   }, []);
 
   useEffect(() => {

--- a/src/tui/keybindings/index.ts
+++ b/src/tui/keybindings/index.ts
@@ -44,126 +44,121 @@ export {
   type KeybindingDependencies,
 } from "./registry";
 
-export namespace Keybind {
-  export type Info = Pick<
-    ParsedKey,
-    "name" | "ctrl" | "meta" | "shift" | "super"
-  > & {
-    sequence?: string;
+export type KeybindInfo = Pick<
+  ParsedKey,
+  "name" | "ctrl" | "meta" | "shift" | "super"
+> & {
+  sequence?: string;
+};
+
+export function fromParsedKey(key: ParsedKey, _leader = false): KeybindInfo {
+  return {
+    name: key.name,
+    ctrl: key.ctrl,
+    meta: key.meta,
+    shift: key.shift,
+    super: key.super ?? false,
+    sequence: key.sequence,
   };
+}
 
-  export function fromParsedKey(key: ParsedKey, leader = false): Info {
-    return {
-      name: key.name,
-      ctrl: key.ctrl,
-      meta: key.meta,
-      shift: key.shift,
-      super: key.super ?? false,
-      sequence: key.sequence,
+export function keybindToString(info: KeybindInfo | undefined): string {
+  if (!info) return "";
+  const parts: string[] = [];
+
+  if (info.ctrl) parts.push("ctrl");
+  if (info.meta) parts.push("alt");
+  if (info.super) parts.push("super");
+  if (info.shift) parts.push("shift");
+  if (info.name) {
+    if (info.name === "delete") parts.push("del");
+    else parts.push(info.name);
+  }
+
+  const result = parts.join("+");
+
+  return result;
+}
+
+export function parseKeybind(key: string): KeybindInfo[] {
+  if (key === "none") return [];
+
+  return key.split(",").map((c) => {
+    const parts = c.split("+");
+
+    const info: KeybindInfo = {
+      ctrl: false,
+      meta: false,
+      shift: false,
+      name: "",
+      sequence: undefined,
     };
-  }
 
-  export function toString(info: Info | undefined): string {
-    if (!info) return "";
-    const parts: string[] = [];
-
-    if (info.ctrl) parts.push("ctrl");
-    if (info.meta) parts.push("alt");
-    if (info.super) parts.push("super");
-    if (info.shift) parts.push("shift");
-    if (info.name) {
-      if (info.name === "delete") parts.push("del");
-      else parts.push(info.name);
-    }
-
-    const result = parts.join("+");
-
-    return result;
-  }
-
-  export function parse(key: string): Info[] {
-    if (key === "none") return [];
-
-    return key.split(",").map((c) => {
-      const parts = c.split("+");
-
-      const info: Info = {
-        ctrl: false,
-        meta: false,
-        shift: false,
-        name: "",
-        sequence: undefined,
-      };
-
-      for (const part of parts) {
-        const lowerPart = part.toLowerCase();
-        switch (lowerPart) {
-          case "ctrl":
-            info.ctrl = true;
-            break;
-          case "alt":
-          case "meta":
-          case "option":
-            info.meta = true;
-            break;
-          case "super":
-            info.super = true;
-            break;
-          case "shift":
-            info.shift = true;
-            break;
-          case "esc":
-            info.name = "escape";
-            break;
-          default:
-            // If it's a single character that differs from lowercase, treat as sequence
-            // e.g., "?" or "!" - these are produced by shift+key combos
-            if (part.length === 1 && part !== lowerPart) {
-              info.sequence = part;
-            } else {
-              info.name = lowerPart;
-            }
-            break;
-        }
-      }
-
-      return info;
-    });
-  }
-
-  export function matches(pressed: Info, combo: Info): boolean {
-    // If combo has a sequence defined, match by sequence
-    if (combo.sequence) {
-      return (
-        pressed.sequence === combo.sequence &&
-        pressed.ctrl === combo.ctrl &&
-        pressed.meta === combo.meta &&
-        (pressed.super ?? false) === (combo.super ?? false)
-      );
-    }
-
-    // Handle control character sequences (e.g., "\x03" for Ctrl+C)
-    if (combo.ctrl && combo.name && pressed.sequence) {
-      const charCode = pressed.sequence.charCodeAt(0);
-      // Control characters are ASCII 1-26, corresponding to Ctrl+A through Ctrl+Z
-      if (charCode >= 1 && charCode <= 26) {
-        const expectedChar = String.fromCharCode(charCode + 96); // 1 -> 'a', 2 -> 'b', etc.
-        if (combo.name === expectedChar) {
-          return (
-            pressed.meta === combo.meta &&
-            (pressed.super ?? false) === (combo.super ?? false)
-          );
-        }
+    for (const part of parts) {
+      const lowerPart = part.toLowerCase();
+      switch (lowerPart) {
+        case "ctrl":
+          info.ctrl = true;
+          break;
+        case "alt":
+        case "meta":
+        case "option":
+          info.meta = true;
+          break;
+        case "super":
+          info.super = true;
+          break;
+        case "shift":
+          info.shift = true;
+          break;
+        case "esc":
+          info.name = "escape";
+          break;
+        default:
+          if (part.length === 1 && part !== lowerPart) {
+            info.sequence = part;
+          } else {
+            info.name = lowerPart;
+          }
+          break;
       }
     }
 
-    // Otherwise match by name and modifiers
+    return info;
+  });
+}
+
+export function matchesKeybind(
+  pressed: KeybindInfo,
+  combo: KeybindInfo,
+): boolean {
+  if (combo.sequence) {
     return (
-      pressed.name === combo.name &&
+      pressed.sequence === combo.sequence &&
       pressed.ctrl === combo.ctrl &&
       pressed.meta === combo.meta &&
-      pressed.shift === combo.shift &&
       (pressed.super ?? false) === (combo.super ?? false)
     );
   }
+
+  if (combo.ctrl && combo.name && pressed.sequence) {
+    const charCode = pressed.sequence.charCodeAt(0);
+    if (charCode >= 1 && charCode <= 26) {
+      const expectedChar = String.fromCharCode(charCode + 96);
+      if (combo.name === expectedChar) {
+        return (
+          pressed.meta === combo.meta &&
+          (pressed.super ?? false) === (combo.super ?? false)
+        );
+      }
+    }
+  }
+
+  return (
+    pressed.name === combo.name &&
+    pressed.ctrl === combo.ctrl &&
+    pressed.meta === combo.meta &&
+    pressed.shift === combo.shift &&
+    (pressed.super ?? false) === (combo.super ?? false)
+  );
 }

--- a/src/util/lock.ts
+++ b/src/util/lock.ts
@@ -1,103 +1,98 @@
-export namespace Lock {
-  const locks = new Map<
-    string,
-    {
-      readers: number;
-      writer: boolean;
-      waitingReaders: (() => void)[];
-      waitingWriters: (() => void)[];
-    }
-  >();
+const locks = new Map<
+  string,
+  {
+    readers: number;
+    writer: boolean;
+    waitingReaders: (() => void)[];
+    waitingWriters: (() => void)[];
+  }
+>();
 
-  function get(key: string) {
-    if (!locks.has(key)) {
-      locks.set(key, {
-        readers: 0,
-        writer: false,
-        waitingReaders: [],
-        waitingWriters: [],
+function getLock(key: string) {
+  if (!locks.has(key)) {
+    locks.set(key, {
+      readers: 0,
+      writer: false,
+      waitingReaders: [],
+      waitingWriters: [],
+    });
+  }
+  return locks.get(key)!;
+}
+
+function processQueue(key: string) {
+  const lock = locks.get(key);
+  if (!lock || lock.writer || lock.readers > 0) return;
+
+  if (lock.waitingWriters.length > 0) {
+    const nextWriter = lock.waitingWriters.shift()!;
+    nextWriter();
+    return;
+  }
+
+  while (lock.waitingReaders.length > 0) {
+    const nextReader = lock.waitingReaders.shift()!;
+    nextReader();
+  }
+
+  if (
+    lock.readers === 0 &&
+    !lock.writer &&
+    lock.waitingReaders.length === 0 &&
+    lock.waitingWriters.length === 0
+  ) {
+    locks.delete(key);
+  }
+}
+
+export async function read(key: string): Promise<Disposable> {
+  const lock = getLock(key);
+
+  return new Promise((resolve) => {
+    if (!lock.writer && lock.waitingWriters.length === 0) {
+      lock.readers++;
+      resolve({
+        [Symbol.dispose]: () => {
+          lock.readers--;
+          processQueue(key);
+        },
       });
-    }
-    return locks.get(key)!;
-  }
-
-  function process(key: string) {
-    const lock = locks.get(key);
-    if (!lock || lock.writer || lock.readers > 0) return;
-
-    // Prioritize writers to prevent starvation
-    if (lock.waitingWriters.length > 0) {
-      const nextWriter = lock.waitingWriters.shift()!;
-      nextWriter();
-      return;
-    }
-
-    // Wake up all waiting readers
-    while (lock.waitingReaders.length > 0) {
-      const nextReader = lock.waitingReaders.shift()!;
-      nextReader();
-    }
-
-    // Clean up empty locks
-    if (
-      lock.readers === 0 &&
-      !lock.writer &&
-      lock.waitingReaders.length === 0 &&
-      lock.waitingWriters.length === 0
-    ) {
-      locks.delete(key);
-    }
-  }
-
-  export async function read(key: string): Promise<Disposable> {
-    const lock = get(key);
-
-    return new Promise((resolve) => {
-      if (!lock.writer && lock.waitingWriters.length === 0) {
+    } else {
+      lock.waitingReaders.push(() => {
         lock.readers++;
         resolve({
           [Symbol.dispose]: () => {
             lock.readers--;
-            process(key);
+            processQueue(key);
           },
         });
-      } else {
-        lock.waitingReaders.push(() => {
-          lock.readers++;
-          resolve({
-            [Symbol.dispose]: () => {
-              lock.readers--;
-              process(key);
-            },
-          });
-        });
-      }
-    });
-  }
+      });
+    }
+  });
+}
 
-  export async function write(key: string): Promise<Disposable> {
-    const lock = get(key);
+export async function write(key: string): Promise<Disposable> {
+  const lock = getLock(key);
 
-    return new Promise((resolve) => {
-      if (!lock.writer && lock.readers === 0) {
+  return new Promise((resolve) => {
+    if (!lock.writer && lock.readers === 0) {
+      lock.writer = true;
+      resolve({
+        [Symbol.dispose]: () => {
+          lock.writer = false;
+          processQueue(key);
+        },
+      });
+    } else {
+      lock.waitingWriters.push(() => {
         lock.writer = true;
         resolve({
           [Symbol.dispose]: () => {
             lock.writer = false;
-            process(key);
+            processQueue(key);
           },
         });
-      } else {
-        lock.waitingWriters.push(() => {
-          lock.writer = true;
-          resolve({
-            [Symbol.dispose]: () => {
-              lock.writer = false;
-              process(key);
-            },
-          });
-        });
-      }
-    });
-  }
+      });
+    }
+  });
 }


### PR DESCRIPTION
## What does this PR do?

Adds the ability for users to update pensar to the latest version:

- **CLI**: `pensar upgrade` / `pensar update` — runs the upgrade interactively, supporting sudo prompts for npm/binary installs
- **TUI**: Automatically checks for updates on startup and shows a toast notification if a newer version is available (e.g. "Update available: v0.0.66 → v0.0.67. Run: pensar upgrade")

### Core upgrade logic (`src/core/installation/index.ts`)

- `getCurrentVersion()` — reads version from `package.json`
- `getLatestVersion()` — fetches the latest published version from the npm registry
- `isNewerVersion()` — proper semver comparison (major.minor.patch) so a local dev version newer than the published one does not trigger a false update
- `detectInstallMethod()` — auto-detects npm, Homebrew, or binary install from exec path and argv
- `checkForUpdate()` — async version check without running any subprocess (used by TUI)
- `upgrade({ interactive })` — full upgrade flow: checks version, runs the appropriate install command (`npm install -g`, `brew upgrade`, or curl install script)
  - `interactive: true` (CLI) uses `stdio: "inherit"` so sudo/password prompts work
  - `interactive: false` (default) uses `stdio: "pipe"` for non-interactive use

### CLI changes

- Added `pensar upgrade` / `pensar update` subcommand to both `src/cli.ts` (compiled binary) and `bin/pensar.js` (npm entrypoint)
- Updated help text in both entrypoints

### TUI changes

- On app startup, `AppContent` runs an async update check via `useEffect`
- If a newer version exists, a warning toast appears for 8 seconds: "Update available: v{current} → v{latest}. Run: pensar upgrade"
- No subprocess is spawned from the TUI — it only checks and informs

### Other changes

- Enabled `@typescript-eslint/no-namespace` lint rule (`"error"`)
- Removed all TypeScript namespaces (`Installation`, `Identifier`, `Messages`, `Storage`, `Lock`, `Keybind`) and converted to plain named exports
- Updated all consumer imports across the codebase

## How was this verified?

- TypeScript type checks pass (`tsc --noEmit`)
- ESLint passes with the new no-namespace rule enforced
- 30 vitest tests covering `getCurrentVersion`, `getVersion`, `getLatestVersion`, `isNewerVersion`, `detectInstallMethod`, `getUpgradeCommandString`, `checkForUpdate`, and `upgrade` (including interactive stdio behavior and failure fallbacks)