### PR TITLE
Add doctor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,31 +20,9 @@
 
 ### Prerequisites
 
-- **nmap** (required for network scanning)
 - **API Key** for your chosen AI provider
 
-#### Install nmap
-
-macOS:
-
-```bash
-brew install nmap
-```
-
-Debian/Ubuntu:
-
-```bash
-sudo apt-get update && sudo apt-get install -y nmap
-```
-
-Fedora/RHEL:
-
-```bash
-sudo dnf install -y nmap
-```
-
-Windows:
-Download installer from `https://nmap.org/download.html` and ensure `nmap` is on your PATH.
+After installing, run `pensar doctor` to check for optional dependencies (like nmap) and install them.
 
 ### Install Apex
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensar/apex",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
   "main": "build/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,6 +59,7 @@ function showHelp() {
   );
   console.log(
     "  pensar upgrade                      Update pensar to the latest version",
+    "  pensar doctor                      Check dependencies and install missing tools",
   );
   console.log("  pensar help                         Show this help message");
   console.log("  pensar version                      Show version number");
@@ -235,6 +236,9 @@ if (command === "version" || command === "--version" || command === "-v") {
   await runPentest();
 } else if (command === "targeted-pentest") {
   await runTargetedPentest();
+} else if (command === "doctor") {
+  const { runDoctor } = await import("./core/doctor");
+  await runDoctor();
 } else if (args.length === 0) {
   await import("./tui/index.tsx");
 } else {

--- a/src/core/agents/specialized/utils.ts
+++ b/src/core/agents/specialized/utils.ts
@@ -46,7 +46,7 @@ function detectDocker(): boolean {
   return false;
 }
 
-function toolExists(commandName: string): boolean {
+export function toolExists(commandName: string): boolean {
   try {
     // Prefer a POSIX-compliant lookup via the shell builtin
     execSync(`command -v ${commandName} >/dev/null 2>&1`, {

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -1,25 +1,6 @@
 import { execSync, spawnSync } from "child_process";
 import readline from "readline";
-
-function toolExists(commandName: string): boolean {
-  try {
-    execSync(`command -v ${commandName} >/dev/null 2>&1`, {
-      stdio: "ignore",
-      shell: "/bin/bash",
-    });
-    return true;
-  } catch {
-    try {
-      execSync(`which ${commandName} >/dev/null 2>&1`, {
-        stdio: "ignore",
-        shell: "/bin/bash",
-      });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-}
+import { toolExists } from "./agents/specialized/utils.js";
 
 function detectPackageManager(): { name: string; installCmd: string } | null {
   const platform = process.platform;
@@ -45,7 +26,7 @@ function detectPackageManager(): { name: string; installCmd: string } | null {
 function prompt(question: string): Promise<string> {
   const rl = readline.createInterface({
     input: process.stdin,
-    output: process.stderr,
+    output: process.stdout,
   });
   return new Promise((resolve) => {
     rl.question(question, (answer) => {

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -85,9 +85,10 @@ export async function runDoctor(): Promise<void> {
   if (nmapInstalled) {
     let version = "";
     try {
-      version = execSync("nmap --version", { encoding: "utf-8" })
-        .split("\n")[0]
-        ?.trim() ?? "";
+      version =
+        execSync("nmap --version", { encoding: "utf-8" })
+          .split("\n")[0]
+          ?.trim() ?? "";
     } catch {
       // ignore
     }
@@ -144,7 +145,9 @@ export async function runDoctor(): Promise<void> {
         console.log("  Skipped nmap installation.");
       }
     } else {
-      console.log("  No supported package manager found. Install nmap manually:");
+      console.log(
+        "  No supported package manager found. Install nmap manually:",
+      );
       console.log("    https://nmap.org/download.html");
     }
     console.log();

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -1,0 +1,152 @@
+import { execSync, spawnSync } from "child_process";
+import readline from "readline";
+
+function toolExists(commandName: string): boolean {
+  try {
+    execSync(`command -v ${commandName} >/dev/null 2>&1`, {
+      stdio: "ignore",
+      shell: "/bin/bash",
+    });
+    return true;
+  } catch {
+    try {
+      execSync(`which ${commandName} >/dev/null 2>&1`, {
+        stdio: "ignore",
+        shell: "/bin/bash",
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+function detectPackageManager(): { name: string; installCmd: string } | null {
+  const platform = process.platform;
+
+  if (platform === "darwin" && toolExists("brew")) {
+    return { name: "Homebrew", installCmd: "brew install nmap" };
+  }
+  if (toolExists("apt-get")) {
+    return {
+      name: "apt",
+      installCmd: "sudo apt-get update && sudo apt-get install -y nmap",
+    };
+  }
+  if (toolExists("dnf")) {
+    return { name: "dnf", installCmd: "sudo dnf install -y nmap" };
+  }
+  if (toolExists("pacman")) {
+    return { name: "pacman", installCmd: "sudo pacman -S --noconfirm nmap" };
+  }
+  return null;
+}
+
+function prompt(question: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+function checkApiKeys(): { provider: string; configured: boolean }[] {
+  const keys: { provider: string; env: string }[] = [
+    { provider: "Anthropic", env: "ANTHROPIC_API_KEY" },
+    { provider: "OpenAI", env: "OPENAI_API_KEY" },
+    { provider: "OpenRouter", env: "OPENROUTER_API_KEY" },
+    { provider: "AWS Bedrock", env: "BEDROCK_API_KEY" },
+    { provider: "AWS IAM", env: "AWS_ACCESS_KEY_ID" },
+    { provider: "vLLM (local)", env: "LOCAL_MODEL_URL" },
+  ];
+
+  return keys.map(({ provider, env }) => ({
+    provider,
+    configured: Boolean(process.env[env]),
+  }));
+}
+
+export async function runDoctor(): Promise<void> {
+  console.log();
+  console.log("Pensar Doctor");
+  console.log("=============");
+  console.log();
+
+  // --- nmap check ---
+  console.log("System Tools");
+  console.log("------------");
+
+  const nmapInstalled = toolExists("nmap");
+  if (nmapInstalled) {
+    let version = "";
+    try {
+      version = execSync("nmap --version", { encoding: "utf-8" })
+        .split("\n")[0]
+        ?.trim() ?? "";
+    } catch {
+      // ignore
+    }
+    console.log(`  ✓ nmap ${version ? `(${version})` : "installed"}`);
+  } else {
+    console.log("  ✗ nmap — not found (recommended for network scanning)");
+  }
+
+  console.log();
+
+  // --- API key check ---
+  console.log("AI Providers");
+  console.log("------------");
+
+  const apiKeys = checkApiKeys();
+  const anyConfigured = apiKeys.some((k) => k.configured);
+
+  for (const key of apiKeys) {
+    const icon = key.configured ? "✓" : "·";
+    console.log(`  ${icon} ${key.provider}`);
+  }
+
+  if (!anyConfigured) {
+    console.log();
+    console.log(
+      "  No AI provider configured. Set at least one API key to get started:",
+    );
+    console.log("    export ANTHROPIC_API_KEY=your-key-here");
+  }
+
+  console.log();
+
+  // --- Offer to install nmap ---
+  if (!nmapInstalled) {
+    const pm = detectPackageManager();
+    if (pm) {
+      const answer = await prompt(
+        `Install nmap via ${pm.name}? (${pm.installCmd}) [y/N] `,
+      );
+      if (/^y(es)?$/i.test(answer)) {
+        console.log();
+        const result = spawnSync(pm.installCmd, {
+          stdio: "inherit",
+          shell: true,
+        });
+        console.log();
+        if (result.status === 0) {
+          console.log("✓ nmap installed successfully!");
+        } else {
+          console.log("✗ Installation failed. You can install manually:");
+          console.log(`    ${pm.installCmd}`);
+        }
+      } else {
+        console.log("  Skipped nmap installation.");
+      }
+    } else {
+      console.log("  No supported package manager found. Install nmap manually:");
+      console.log("    https://nmap.org/download.html");
+    }
+    console.log();
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Implements a doctor command to check for / install `nmap`

Can extended to support other tools we want to sidecar in the future

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new interactive CLI path that can execute privileged package-manager install commands (`sudo ... install nmap`), so failures or unexpected environments could impact user machines.
> 
> **Overview**
> Adds a new `pensar doctor` command that reports whether `nmap` is installed (including version when available) and whether any supported AI provider environment variables are configured.
> 
> When `nmap` is missing, the command can *interactively* install it by detecting a supported package manager (Homebrew/apt/dnf/pacman) and running the appropriate install command. Documentation is updated to point users to `pensar doctor`, `toolExists` is exported for reuse, and the package version is bumped to `0.0.69`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c62b3d7416758c0eca70381e3134e35a7ff826e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->