### PR TITLE
feat: application-centric threat model agent

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,9 @@ function showHelp() {
   console.log(
     "  pensar targeted-pentest [options]   Run a targeted pentest on a single target",
   );
+  console.log(
+    "  pensar threat-model [options]       Run an application-centric threat model",
+  );
   console.log("  pensar help                         Show this help message");
   console.log("  pensar version                      Show version number");
   console.log();
@@ -70,6 +73,14 @@ function showHelp() {
   console.log("  --target <url>          (required) Target URL / domain / IP");
   console.log(
     "  --objective <text>      (required, repeatable) Testing objective",
+  );
+  console.log(
+    "  --model <model>         AI model (default: claude-sonnet-4-5)",
+  );
+  console.log();
+  console.log("threat-model options:");
+  console.log(
+    "  --cwd <path>            (required) Local codebase path for whitebox analysis",
   );
   console.log(
     "  --model <model>         AI model (default: claude-sonnet-4-5)",
@@ -236,6 +247,85 @@ async function runTargetedPentest() {
   console.log(`POCs:      ${pocsPath}`);
 }
 
+async function runThreatModel() {
+  const { config } = await import("dotenv");
+  config();
+
+  const { runThreatModelAgent } = await import("./core/api/threatModel");
+  const { sessions } = await import("./core/session");
+  const { config: appConfig } = await import("./core/config");
+  type AIModel = import("./core/ai").AIModel;
+
+  const cwd = getArgRequired("--cwd");
+  const model = (getArg("--model") ?? "claude-sonnet-4-5") as AIModel;
+
+  console.log("=".repeat(60));
+  console.log("THREAT MODEL");
+  console.log("=".repeat(60));
+  console.log(`Codebase: ${cwd}`);
+  console.log(`Model:    ${model}`);
+  console.log();
+
+  const pensarConfig = await appConfig.get();
+
+  const session = await sessions.create({
+    name: "Threat Model",
+    targets: [cwd],
+  });
+
+  const run = runThreatModelAgent({
+    cwd,
+    session,
+    model,
+    authConfig: {
+      anthropicAPIKey: pensarConfig.anthropicAPIKey ?? undefined,
+      openAiAPIKey: pensarConfig.openAiAPIKey ?? undefined,
+      openRouterAPIKey: pensarConfig.openRouterAPIKey ?? undefined,
+      local: pensarConfig.localModelUrl
+        ? { baseURL: pensarConfig.localModelUrl }
+        : undefined,
+    },
+  });
+
+  for await (const event of run) {
+    switch (event.type) {
+      case "text-delta":
+        process.stdout.write(event.data.text);
+        break;
+      case "tool-call":
+        console.log(`\n→ ${event.data.toolName}`);
+        break;
+      case "tool-result":
+        console.log(`✓ ${event.data.toolName} completed`);
+        break;
+      case "subagent-spawn":
+        console.log(`\n▸ Phase: ${event.subagentId}`);
+        break;
+      case "subagent-complete":
+        console.log(`✓ Phase: ${event.subagentId} ${event.status}`);
+        break;
+      case "error":
+        console.error("Error:", event.error);
+        break;
+    }
+  }
+
+  const result = await run.result;
+
+  console.log();
+  console.log("=".repeat(60));
+  console.log("RESULTS");
+  console.log("=".repeat(60));
+  console.log(`Attack Paths: ${result.summary.totalAttackPaths}`);
+  console.log(`  Critical: ${result.summary.bySeverity.critical}`);
+  console.log(`  High:     ${result.summary.bySeverity.high}`);
+  console.log(`  Medium:   ${result.summary.bySeverity.medium}`);
+  console.log(`  Low:      ${result.summary.bySeverity.low}`);
+  console.log();
+  console.log(`Markdown: ${result.files.markdownPath}`);
+  console.log(`JSON:     ${result.files.jsonPath}`);
+}
+
 // ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
@@ -248,6 +338,8 @@ if (command === "version" || command === "--version" || command === "-v") {
   await runPentest();
 } else if (command === "targeted-pentest") {
   await runTargetedPentest();
+} else if (command === "threat-model") {
+  await runThreatModel();
 } else if (args.length === 0) {
   await import("./tui/index.tsx");
 } else {

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -18,6 +18,9 @@ export interface PentestAgentInput extends SpecializedAgentInput {
 
   /** When set, tools execute inside this sandbox instead of locally */
   sandbox?: UnifiedSandbox;
+
+  /** Path to a threat model markdown file — when set, the agent is instructed to grep it for relevant attack paths */
+  threatModelPath?: string;
 }
 
 /** The typed result returned by `PentestAgent.consume()`. */
@@ -68,11 +71,17 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       onStepFinish,
       abortSignal,
       sandbox,
+      threatModelPath,
     } = opts;
 
     super({
-      system: PENTEST_SYSTEM_PROMPT,
-      prompt: buildPrompt(target, objectives, session.rootPath),
+      system: buildSystemPrompt(threatModelPath),
+      prompt: buildPrompt(
+        target,
+        objectives,
+        session.rootPath,
+        threatModelPath,
+      ),
       model,
       session,
       target,
@@ -104,7 +113,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
 // Prompts
 // ---------------------------------------------------------------------------
 
-const PENTEST_SYSTEM_PROMPT = `You are an expert penetration tester performing a targeted security assessment.
+const PENTEST_SYSTEM_PROMPT_BASE = `You are an expert penetration tester performing a targeted security assessment.
 
 You are given a specific target and specific objectives. Do NOT perform broad reconnaissance or service/endpoint discovery — that has already been done for you. Your job is to deeply test the provided target against the provided objectives.
 
@@ -129,10 +138,24 @@ Authentication:
 - For execute_command (curl): include -H "Cookie: ..." and/or -H "Authorization: ..." flags.
 - If a request returns 401/403, the session may have expired — note it in your findings but do not try to log in again.`;
 
+function buildSystemPrompt(threatModelPath?: string): string {
+  if (!threatModelPath) return PENTEST_SYSTEM_PROMPT_BASE;
+
+  return `${PENTEST_SYSTEM_PROMPT_BASE}
+
+## Threat Model
+A threat model is available at: ${threatModelPath}
+Use the \`grep\` tool (via execute_command) to search for attack paths relevant to your target.
+Look for entries matching your target URL, endpoint path, or feature name.
+Focus on "attack paths" — these describe specific attacker techniques grounded in the application's architecture.
+Use the threat model to prioritize your testing and discover additional attack vectors beyond the stated objectives.`;
+}
+
 function buildPrompt(
   target: string,
   objectives: string[],
   sessionRootPath: string,
+  threatModelPath?: string,
 ): string {
   const objectiveList = objectives.map((o, i) => `${i + 1}. ${o}`).join("\n");
 
@@ -181,6 +204,18 @@ function buildPrompt(
     }
   }
 
+  let threatModelSection = "";
+  if (threatModelPath) {
+    threatModelSection = `
+
+## Threat Model Reference
+A threat model has been generated for this application and is available at: \`${threatModelPath}\`
+Before testing, use \`grep\` (via execute_command) to search the threat model for attack paths relevant to your target.
+Look for entries matching your target URL, endpoint path, or feature name.
+Focus on "attack paths" — these describe specific attacker techniques grounded in the application's architecture.
+Use any relevant attack paths to guide and prioritize your testing.`;
+  }
+
   return `# Testing Assignment
 
 ## Target
@@ -189,6 +224,7 @@ ${authSection}
 
 ## Objectives
 ${objectiveList}
+${threatModelSection}
 
 ## Instructions
 1. Verify the target endpoint is reachable and understand its baseline behavior

--- a/src/core/agents/specialized/threatModel/index.ts
+++ b/src/core/agents/specialized/threatModel/index.ts
@@ -1,0 +1,37 @@
+// Schemas
+export {
+  DeploymentContextSchema,
+  SecurityControlSchema,
+  SecurityControlsResultSchema,
+  ComponentSchema,
+  TrustBoundarySchema,
+  DataFlowSchema,
+  SystemArchitectureSchema,
+  ApplicationIdentitySchema,
+  ApplicationFeatureSchema,
+  ApplicationTrustBoundarySchema,
+  AttackerProfileSchema,
+  ApplicationContextSchema,
+  AttackPathSchema,
+  AttackPathsResultSchema,
+} from "./types.js";
+
+// Types
+export type {
+  DeploymentContext,
+  SecurityControl,
+  SecurityControlsResult,
+  Component,
+  TrustBoundary,
+  DataFlow,
+  SystemArchitecture,
+  ApplicationIdentity,
+  ApplicationFeature,
+  ApplicationTrustBoundary,
+  AttackerProfile,
+  ApplicationContext,
+  AttackPath,
+  AttackPathsResult,
+  ThreatModelResult,
+  ThreatModel,
+} from "./types.js";

--- a/src/core/agents/specialized/threatModel/prompts.ts
+++ b/src/core/agents/specialized/threatModel/prompts.ts
@@ -1,0 +1,418 @@
+import { join } from "path";
+import type { DeploymentContext } from "./types";
+
+// ---------------------------------------------------------------------------
+// System Prompts
+// ---------------------------------------------------------------------------
+
+export const WHITEBOX_CODE_AGENT_SYSTEM_PROMPT = `You are an expert source-code analyst with direct filesystem access. You will be given a specific objective — focus exclusively on completing it.
+
+Your focus is on **deployed applications and services** — APIs, web apps, microservices — that listen on a port and serve traffic. Ignore libraries, shared packages, SDKs, CLI tools, build scripts, and test suites unless they are part of a deployable service.
+
+# Tool Usage Guide
+
+## read_file
+Read the contents of any file. You can read the whole file or a specific line range.
+- When a file is large, read it in chunks using startLine / endLine to stay focused.
+- Follow imports and references — when you see an interesting function call, read its source.
+
+## list_files
+List files and directories. Use this to orient yourself in the codebase.
+- Start by listing the project root or relevant subdirectory to understand the structure.
+- Use recursive=true sparingly on targeted subdirectories to avoid flooding context.
+
+## grep
+Search file contents by pattern. This is your most powerful navigation tool.
+- Use it to find route definitions, middleware, controllers, endpoint registrations, etc.
+- Use -i for case-insensitive searches.
+- Use --include="*.ext" to narrow to relevant file types.
+- Use -C 3 or -C 5 to get context around matches.
+- Use -rn (default for directories) for recursive search with line numbers.
+- Use -l to get just file paths when you need a broad overview of where something appears.
+
+## execute_command
+Run shell commands when needed.
+- Use for build tools, git operations, package managers, linters, etc.
+
+## document_asset
+**Use this to document every significant asset you discover.** Each call persists a JSON record to the session's assets directory.
+
+## response
+When your objective includes structured output, call \`response\` with your final results once you are done. This ends your run — make sure all data is included.
+
+# Working Approach
+1. **Orient first** — list files and read key entry points to understand the structure.
+2. **Ignore submodules** — check for a \`.gitmodules\` file or run \`git submodule status\`. Any directories that are git submodules are external dependencies and must be **completely excluded** from your analysis.
+3. **Search, then read** — use grep to locate what you need, then read the relevant files.
+4. **Document as you go** — call document_asset for every significant asset you discover.
+5. **Follow the trail** — trace through imports, function calls, and references to build full understanding.
+6. **Be thorough** — don't stop at the first match. Cover everything relevant to the objective.
+`;
+
+export const DATA_SYNTHESIS_AGENT_SYSTEM_PROMPT = `You are an expert security analyst synthesizing structured analysis data into threat model artifacts. You are NOT exploring source code — you are reading structured JSON analysis files that were produced by earlier phases.
+
+# Tool Usage Guide
+
+## read_file
+Read JSON data files from the session directory. These files contain structured analysis results — read them in full to understand the data.
+
+## grep
+Use grep to cross-reference data across files when needed — e.g. searching for a specific endpoint or component name across multiple JSON files.
+
+## response
+When your objective is complete, call \`response\` with your final structured results. This ends your run — make sure all data is included.
+
+# Working Approach
+1. **Read the data files** specified in your objective — these contain all the information you need.
+2. **Cross-reference** data across files to build a complete picture.
+3. **Focus on deployed endpoints** (paths, methods, parameters) — not source file paths.
+4. **Be thorough** — ensure your output covers all relevant data from the input files.
+`;
+
+// ---------------------------------------------------------------------------
+// Phase 0: Application Context Discovery
+// ---------------------------------------------------------------------------
+
+export function buildApplicationContextObjective(
+  codebasePath: string,
+  applicationIdentity?: string,
+): string {
+  const identityHint = applicationIdentity
+    ? `\n## Application Identity Hint\nThe user describes this application as: "${applicationIdentity}"\nUse this as a starting point but verify and expand upon it through code analysis.\n`
+    : "";
+
+  return `# Discover Application Context
+
+## Codebase
+- **Path:** ${codebasePath}
+${identityHint}
+## Task
+Analyze the codebase to understand what this application IS — its nature, domain, capabilities, and security-relevant characteristics. This context will drive threat identification, so focus on what makes this application unique from a security perspective.
+
+### What to Determine
+
+1. **Application Identity** — Determine:
+   - **Type:** Is this a library, framework, service, platform, CLI tool, or something else?
+   - **Domain:** What domain does it operate in? (e.g. browser automation, e-commerce, fintech, CI/CD, AI/ML)
+   - **Description:** One clear paragraph explaining what it does
+   - **Users:** Who uses this? (developers integrating it, end users, operators, other services)
+   - **Core Capabilities:** What are the key things it can DO that have security implications? (e.g. "executes arbitrary browser actions", "processes credit card payments", "manages infrastructure")
+
+2. **Features & Capabilities** — For each security-relevant feature, determine:
+   - What the feature does
+   - Why it matters for security (what could go wrong)
+   - What privileged operations it can perform (file access, network requests, code execution, data access)
+   - What sensitive data it handles (credentials, PII, tokens, secrets)
+
+3. **Application-Specific Trust Boundaries** — Identify where untrusted data enters and what sensitive context it reaches:
+   - These should be specific to this application, NOT generic zones like "DMZ" or "internal network"
+   - Example for a browser automation framework: "web page content → agent instruction parser" is a trust boundary because malicious page content could influence agent behavior
+   - Example for an API gateway: "upstream request headers → routing logic" is a trust boundary
+   - For each boundary: what are the input sources, and what sensitive context does the input cross into?
+
+4. **Attacker Profiles** — Define realistic attacker profiles specific to this application:
+   - Who would attack this application and why?
+   - What do they control? (e.g. a website's HTML content, an npm package, API inputs)
+   - What are their goals? (data exfiltration, code execution, denial of service, privilege escalation)
+   - What skill level is required?
+   - Do NOT include generic attacker profiles — each should be grounded in how this specific application could be abused
+
+### Approach
+1. Read the project README, package.json, and main entry points to understand what the application does
+2. Explore the source code to identify core features and capabilities
+3. Look for where external/untrusted data enters the system
+4. Trace how that data flows through to privileged operations
+5. Think about who would want to attack this and what they'd gain
+
+### Output
+Call the \`response\` tool with the structured application context when done.`;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1b: Deployment Context Discovery
+// ---------------------------------------------------------------------------
+
+export function buildDeploymentContextObjective(
+  codebasePath: string,
+): string {
+  return `# Extract Deployment and Infrastructure Context
+
+## Codebase
+- **Path:** ${codebasePath}
+
+## Task
+Analyze the repository to extract deployment and infrastructure context. This information will be used to build a threat model, so be thorough and precise.
+
+### What to Find
+
+1. **Cloud Provider & Services** — Look for:
+   - AWS SDK imports, \`aws-cdk\`, \`@aws-sdk/*\`, boto3, Azure SDK, GCP client libraries
+   - Cloud-specific config files (samconfig.toml, cdk.json, app.yaml)
+   - Environment variables referencing cloud services (AWS_REGION, GOOGLE_CLOUD_PROJECT)
+
+2. **Containers & Orchestration** — Look for:
+   - Dockerfiles, docker-compose.yml/yaml
+   - Kubernetes manifests (deployments, services, ingress) in k8s/, kubernetes/, deploy/ directories
+   - Helm charts (Chart.yaml)
+   - ECS task definitions
+
+3. **Infrastructure as Code** — Look for:
+   - Terraform (.tf files), CDK (cdk.json + lib/), Pulumi (Pulumi.yaml), CloudFormation templates
+   - Record the tool name and config file path
+
+4. **CI/CD** — Look for:
+   - .github/workflows/*.yml (GitHub Actions)
+   - .gitlab-ci.yml (GitLab CI)
+   - Jenkinsfile, .circleci/config.yml, bitbucket-pipelines.yml
+   - buildspec.yml (AWS CodeBuild)
+
+5. **Databases** — Look for:
+   - ORM configurations (Prisma schema, TypeORM config, Sequelize, SQLAlchemy, Django settings)
+   - Database connection strings in config files or environment variables
+   - Database client imports (pg, mysql2, mongodb, redis, ioredis)
+   - Determine the database type and version if possible
+
+6. **Message Queues** — Look for:
+   - RabbitMQ, SQS, Kafka, Bull/BullMQ, Redis pub/sub imports and configuration
+
+7. **Reverse Proxy** — Look for:
+   - nginx.conf, Caddyfile, traefik.yml
+   - Reverse proxy configuration in docker-compose or k8s ingress
+
+8. **Environment Files** — Look for:
+   - .env, .env.example, .env.local, .env.production
+   - Do NOT read the actual values — just record the file paths
+
+### Output
+Call the \`response\` tool with the structured deployment context when done.`;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1c: Security Controls Discovery
+// ---------------------------------------------------------------------------
+
+export function buildSecurityControlsObjective(
+  codebasePath: string,
+  deploymentContext: DeploymentContext,
+  sessionRootPath: string,
+): string {
+  const dbTypes =
+    deploymentContext.databases?.map((d) => d.type).join(", ") ?? "unknown";
+  const attackSurfacePath = join(
+    sessionRootPath,
+    "attack-surface-results.json",
+  );
+
+  return `# Extract Security Controls and Middleware
+
+## Codebase
+- **Path:** ${codebasePath}
+- **Databases:** ${dbTypes}
+
+## Attack Surface Data
+The attack surface analysis (apps, endpoints, frameworks) is available at:
+- **File:** ${attackSurfacePath}
+
+Read this file to understand the application structure, frameworks in use, and known apps/endpoints. Use this context to guide your security controls discovery.
+
+## Task
+Analyze the codebase to find ALL security controls, authentication mechanisms, and authorization models. For each control, assess its effectiveness and identify gaps.
+
+### What to Find
+
+1. **Authentication Middleware** — Look for:
+   - JWT verification (jsonwebtoken, jose, passport-jwt)
+   - Session middleware (express-session, cookie-session)
+   - OAuth/OIDC (passport, openid-client, next-auth)
+   - API key validation
+   - Where it's applied (all routes, specific route groups, individual routes)
+
+2. **Authorization / Access Control** — Look for:
+   - Role-based checks (RBAC middleware, role decorators)
+   - Attribute-based access control (ABAC)
+   - Permission checks, guards, policies
+   - Owner-only checks (comparing user ID to resource owner)
+
+3. **Input Validation** — Look for:
+   - Validation libraries (zod, joi, yup, class-validator, express-validator)
+   - Manual input sanitization or validation
+   - Schema validation on request bodies
+   - Parameterized queries vs raw SQL
+
+4. **Output Encoding** — Look for:
+   - Template engine auto-escaping settings
+   - React JSX (auto-escapes by default)
+   - dangerouslySetInnerHTML or equivalent unsafe patterns
+   - Manual HTML encoding
+
+5. **Security Headers** — Look for:
+   - helmet.js or manual security header configuration
+   - Content-Security-Policy (CSP) configuration
+   - CORS configuration (cors npm package, manual headers)
+   - X-Frame-Options, X-Content-Type-Options, Strict-Transport-Security
+
+6. **Rate Limiting** — Look for:
+   - express-rate-limit, rate-limiter-flexible, or similar
+   - Where rate limiting is applied (all routes, auth routes only, etc.)
+   - Rate limit values and configuration
+
+7. **CSRF Protection** — Look for:
+   - csurf, csrf-csrf, or similar CSRF middleware
+   - SameSite cookie attributes
+   - Custom CSRF token implementation
+
+8. **Encryption** — Look for:
+   - TLS/SSL configuration
+   - Data encryption at rest (field-level encryption, encrypted columns)
+   - Password hashing (bcrypt, argon2, scrypt)
+
+9. **Logging & Monitoring** — Look for:
+   - Security event logging (failed auth attempts, authorization failures)
+   - Audit logging
+   - Error logging that might leak sensitive data
+
+10. **Secrets Management** — Look for:
+    - Hardcoded secrets, API keys in source code
+    - Environment variable usage for secrets
+    - Secrets manager integration (AWS Secrets Manager, Vault, etc.)
+
+### For Each Control, Determine:
+- **type**: The control type (auth_middleware, cors, csp, rate_limiter, etc.)
+- **name**: A descriptive name
+- **implementation**: How it's implemented (library, custom code)
+- **scope**: What it applies to (all routes, specific routes, etc.)
+- **effectiveness**: strong (well-implemented, comprehensive), moderate (covers most cases but has gaps), weak (easily bypassed or incomplete), unknown
+- **gaps**: Any weaknesses or missing coverage
+
+### Output
+Call the \`response\` tool with the structured security controls when done.`;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: Architecture Synthesis
+// ---------------------------------------------------------------------------
+
+export function buildArchitectureSynthesisObjective(
+  sessionRootPath: string,
+): string {
+  const attackSurfacePath = join(
+    sessionRootPath,
+    "attack-surface-results.json",
+  );
+  const deploymentContextPath = join(
+    sessionRootPath,
+    "deployment-context.json",
+  );
+
+  return `# Model System Architecture
+
+## Data Files
+Read these files to understand the system:
+- **Attack Surface:** ${attackSurfacePath}
+- **Deployment Context:** ${deploymentContextPath}
+
+## Instructions
+
+1. **Read both data files** in full to understand the application structure and deployment context.
+
+2. **Define system components** — based on the deployment context and attack surface, model all components (apps, databases, caches, proxies, CDNs, etc.):
+   - Assign a unique ID (comp-1, comp-2, ...) and a trust boundary
+   - Include the technology stack for each component
+
+3. **Define trust boundaries** — group components into trust boundaries:
+   - external (internet), dmz (edge/proxy), internal (app tier), data (databases/caches)
+   - Each component belongs to exactly one boundary
+   - Assign unique IDs (tb-external, tb-dmz, etc.)
+
+4. **Define data flows** — model how data moves between components:
+   - Include protocol, data classification, and whether the flow is authenticated/encrypted
+   - Assign unique IDs (df-1, df-2, ...)
+
+## Output
+Call the \`response\` tool with the structured system architecture when done.`;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Attack Path Synthesis (application-centric)
+// ---------------------------------------------------------------------------
+
+export function buildAttackPathSynthesisObjective(
+  sessionRootPath: string,
+): string {
+  const applicationContextPath = join(
+    sessionRootPath,
+    "application-context.json",
+  );
+  const attackSurfacePath = join(
+    sessionRootPath,
+    "attack-surface-results.json",
+  );
+  const deploymentContextPath = join(
+    sessionRootPath,
+    "deployment-context.json",
+  );
+  const securityControlsPath = join(
+    sessionRootPath,
+    "security-controls.json",
+  );
+  const systemArchitecturePath = join(
+    sessionRootPath,
+    "system-architecture.json",
+  );
+
+  return `# Identify Application-Specific Attack Paths
+
+## Data Files
+Read ALL of these files before generating attack paths:
+- **Application Context:** ${applicationContextPath} — Start here. This describes what the application IS, its features, trust boundaries, and attacker profiles.
+- **Attack Surface:** ${attackSurfacePath}
+- **Deployment Context:** ${deploymentContextPath}
+- **Security Controls:** ${securityControlsPath}
+- **System Architecture:** ${systemArchitecturePath}
+
+## Approach
+
+You are generating attack paths that are SPECIFIC to this application. Do NOT use STRIDE categories as your generative framework. Instead:
+
+1. **Start from the application context** — read it first to understand what the application does, who would attack it, and what the application-specific trust boundaries are.
+2. **For each attacker profile**, consider what attacks they could mount given what they control and what their goals are.
+3. **For each application-specific trust boundary**, consider how untrusted input could cross into sensitive context.
+4. **Cross-reference with the attack surface** to ground each attack path in real endpoints, features, and parameters.
+5. **Check security controls** to determine what defenses exist and where gaps remain.
+6. **Include deployment context** to make attack paths technology-specific.
+
+## Signal vs. Noise
+
+SKIP generic threats that are not specific to what this application does. For example:
+- If this is NOT a web application with cookie-based sessions, skip CSRF threats
+- If this is a library/framework (not a deployed service), skip server configuration threats
+- If this application doesn't serve HTML pages, skip XSS/clickjacking
+- Focus on threats that arise FROM the application's unique capabilities and trust boundaries
+
+PRIORITIZE threats that are unique to this application's domain. For example:
+- For a browser automation framework: prompt injection via web page content, data exfiltration through agent actions
+- For a payment processor: transaction manipulation, race conditions in balance updates
+- For an AI service: model manipulation, training data poisoning, inference-time attacks
+
+## Attack Path Structure
+
+Each attack path must trace a concrete path through the system:
+- **Entry Point:** Where the attack starts (a specific feature, input, endpoint)
+- **Mechanism:** Step-by-step how the attack flows through the system (array of steps)
+- **Impact:** What happens if the attack succeeds
+- **Attacker Profile:** Which attacker profile would execute this (must reference a profile from the application context)
+- **Affected Features:** Which features are impacted
+
+## Quality Standards
+
+- **Every attack path must be grounded in the application context** — reference specific features, trust boundaries, and attacker profiles
+- **Mechanisms must be concrete** — not "attacker exploits vulnerability" but "attacker embeds malicious instruction in page title → agent reads page title as context → agent executes attacker-controlled action"
+- **Preconditions must be specific** — conditions tied to this application's behavior, not generic statements
+- **Control gaps must identify what's missing** — not just "no mitigation" but what specific control would prevent this
+- **Pentest guidance must be actionable** — specific techniques a pentester could use to test this attack path
+
+Assign unique IDs: AP-001, AP-002, etc. Use severity levels: critical, high, medium, low.
+
+## Output
+Call the \`response\` tool with the structured attack paths when done.`;
+}

--- a/src/core/agents/specialized/threatModel/prompts.ts
+++ b/src/core/agents/specialized/threatModel/prompts.ts
@@ -132,9 +132,7 @@ Call the \`response\` tool with the structured application context when done.`;
 // Phase 1b: Deployment Context Discovery
 // ---------------------------------------------------------------------------
 
-export function buildDeploymentContextObjective(
-  codebasePath: string,
-): string {
+export function buildDeploymentContextObjective(codebasePath: string): string {
   return `# Extract Deployment and Infrastructure Context
 
 ## Codebase
@@ -351,10 +349,7 @@ export function buildAttackPathSynthesisObjective(
     sessionRootPath,
     "deployment-context.json",
   );
-  const securityControlsPath = join(
-    sessionRootPath,
-    "security-controls.json",
-  );
+  const securityControlsPath = join(sessionRootPath, "security-controls.json");
   const systemArchitecturePath = join(
     sessionRootPath,
     "system-architecture.json",

--- a/src/core/agents/specialized/threatModel/serialize.ts
+++ b/src/core/agents/specialized/threatModel/serialize.ts
@@ -1,0 +1,499 @@
+import type {
+  ThreatModel,
+  Component,
+  DataFlow,
+  AttackPath,
+  ApplicationContext,
+  SecurityControlsResult,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Markdown serializer
+// ---------------------------------------------------------------------------
+
+const SEVERITY_LABELS: Record<string, string> = {
+  critical: "CRITICAL",
+  high: "HIGH",
+  medium: "MEDIUM",
+  low: "LOW",
+};
+
+/**
+ * Serialize a threat model to a structured markdown document
+ * optimized for LLM agent consumption via `read_file` and `grep`.
+ */
+export function serializeThreatModelToMarkdown(model: ThreatModel): string {
+  const sections: string[] = [];
+
+  // =========================================================================
+  // Header
+  // =========================================================================
+
+  sections.push(`# Threat Model
+
+**Generated:** ${model.metadata.generatedAt}
+**Codebase:** ${model.metadata.codebasePath}
+**Repo Type:** ${model.metadata.repoType}
+**Package Manager:** ${model.metadata.packageManager}
+
+---`);
+
+  // =========================================================================
+  // Application Context
+  // =========================================================================
+
+  sections.push(renderApplicationContextSection(model.applicationContext));
+
+  // =========================================================================
+  // Deployment Model
+  // =========================================================================
+
+  sections.push(renderDeploymentSection(model));
+
+  // =========================================================================
+  // System Components
+  // =========================================================================
+
+  sections.push(renderComponentsSection(model.components));
+
+  // =========================================================================
+  // Trust Boundaries (system-level)
+  // =========================================================================
+
+  sections.push(renderTrustBoundariesSection(model));
+
+  // =========================================================================
+  // Data Flows
+  // =========================================================================
+
+  sections.push(renderDataFlowsSection(model.dataFlows));
+
+  // =========================================================================
+  // Security Controls
+  // =========================================================================
+
+  sections.push(renderSecurityControlsSection(model.securityControls));
+
+  // =========================================================================
+  // Attack Paths
+  // =========================================================================
+
+  sections.push(renderAttackPathsSection(model.attackPaths));
+
+  // =========================================================================
+  // Summary
+  // =========================================================================
+
+  sections.push(renderSummarySection(model));
+
+  return sections.join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// Section renderers
+// ---------------------------------------------------------------------------
+
+function renderApplicationContextSection(ctx: ApplicationContext): string {
+  const lines: string[] = ["## Application Context"];
+
+  // Identity
+  lines.push("");
+  lines.push("### Identity");
+  lines.push(`- **Type:** ${capitalize(ctx.identity.type)}`);
+  lines.push(`- **Domain:** ${ctx.identity.domain}`);
+  lines.push(`- **Description:** ${ctx.identity.description}`);
+  lines.push(`- **Users:** ${ctx.identity.users.join(", ")}`);
+  lines.push(
+    `- **Core Capabilities:** ${ctx.identity.coreCapabilities.join(", ")}`,
+  );
+
+  // Features & Capabilities
+  lines.push("");
+  lines.push("### Features & Capabilities");
+  lines.push("");
+  lines.push(
+    "| Feature | Security Relevance | Privileged Operations | Data Handled |",
+  );
+  lines.push(
+    "|---------|-------------------|----------------------|--------------|",
+  );
+  for (const f of ctx.features) {
+    lines.push(
+      `| **${f.name}** — ${f.description} | ${f.securityRelevance} | ${f.privilegedOperations.join("; ") || "—"} | ${f.dataHandled.join("; ") || "—"} |`,
+    );
+  }
+
+  // Application-Specific Trust Boundaries
+  lines.push("");
+  lines.push("### Trust Boundaries (Application-Specific)");
+  for (const tb of ctx.trustBoundaries) {
+    lines.push("");
+    lines.push(`#### ${tb.name}`);
+    lines.push(`${tb.description}`);
+    lines.push(`- **Input Sources:** ${tb.inputSources.join(", ")}`);
+    lines.push(`- **Crosses To:** ${tb.crossesTo}`);
+  }
+
+  // Attacker Profiles
+  lines.push("");
+  lines.push("### Attacker Profiles");
+  for (const ap of ctx.attackerProfiles) {
+    lines.push("");
+    lines.push(`#### ${ap.name}`);
+    lines.push(`${ap.description}`);
+    lines.push(`- **Skill Level:** ${capitalize(ap.skillLevel)}`);
+    lines.push(`- **Controls:** ${ap.controls.join(", ")}`);
+    lines.push(`- **Goals:** ${ap.goals.join(", ")}`);
+  }
+
+  return lines.join("\n");
+}
+
+function renderDeploymentSection(model: ThreatModel): string {
+  const d = model.deployment;
+  const lines: string[] = ["## Deployment Model"];
+
+  // Cloud
+  if (d.cloud) {
+    lines.push("");
+    lines.push("### Cloud");
+    if (d.cloud.provider) {
+      const region = d.cloud.region ? ` (${d.cloud.region})` : "";
+      lines.push(`- **Provider:** ${d.cloud.provider}${region}`);
+    }
+    if (d.cloud.services && d.cloud.services.length > 0) {
+      lines.push(`- **Services:** ${d.cloud.services.join(", ")}`);
+    }
+  }
+
+  // Containers
+  if (d.containers) {
+    lines.push("");
+    lines.push("### Containers");
+    if (d.containers.runtime)
+      lines.push(`- **Runtime:** ${d.containers.runtime}`);
+    if (d.containers.orchestration)
+      lines.push(`- **Orchestration:** ${d.containers.orchestration}`);
+    lines.push(
+      `- **Dockerfile:** ${d.containers.hasDockerfile ? "Yes" : "No"}`,
+    );
+    lines.push(
+      `- **Docker Compose:** ${d.containers.hasDockerCompose ? "Yes" : "No"}`,
+    );
+    lines.push(
+      `- **Kubernetes:** ${d.containers.hasKubernetes ? "Yes" : "No"}`,
+    );
+  }
+
+  // Infrastructure as Code
+  if (d.iac && d.iac.length > 0) {
+    lines.push("");
+    lines.push("### Infrastructure as Code");
+    lines.push("| Tool | Config Path |");
+    lines.push("|------|------------|");
+    for (const entry of d.iac) {
+      lines.push(`| ${entry.tool} | ${entry.configPath} |`);
+    }
+  }
+
+  // CI/CD
+  if (d.cicd && d.cicd.length > 0) {
+    lines.push("");
+    lines.push("### CI/CD");
+    for (const ci of d.cicd) {
+      lines.push(`- ${ci}`);
+    }
+  }
+
+  // Databases
+  if (d.databases && d.databases.length > 0) {
+    lines.push("");
+    lines.push("### Databases");
+    for (const db of d.databases) {
+      const ver = db.version ? ` ${db.version}` : "";
+      lines.push(`- ${db.type}${ver}`);
+    }
+  }
+
+  // Message Queues
+  if (d.messageQueues && d.messageQueues.length > 0) {
+    lines.push("");
+    lines.push("### Message Queues");
+    for (const mq of d.messageQueues) {
+      lines.push(`- ${mq}`);
+    }
+  }
+
+  // Reverse Proxy
+  if (d.reverseProxy) {
+    lines.push("");
+    lines.push("### Reverse Proxy");
+    lines.push(`- ${d.reverseProxy}`);
+  }
+
+  // Environment Files
+  if (d.environmentFiles && d.environmentFiles.length > 0) {
+    lines.push("");
+    lines.push("### Environment Files");
+    for (const ef of d.environmentFiles) {
+      lines.push(`- ${ef}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function renderComponentsSection(components: Component[]): string {
+  const lines: string[] = ["## System Components", ""];
+  lines.push("| ID | Name | Type | Technology | Trust Boundary |");
+  lines.push("|----|------|------|------------|----------------|");
+  for (const c of components) {
+    lines.push(
+      `| ${c.id} | ${c.name} | ${formatType(c.type)} | ${c.technology} | ${c.trustBoundary} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function renderTrustBoundariesSection(model: ThreatModel): string {
+  const lines: string[] = ["## Trust Boundaries"];
+
+  const componentMap = new Map(model.components.map((c) => [c.id, c]));
+
+  for (const tb of model.trustBoundaries) {
+    lines.push("");
+    const levelLabel = formatTrustLevel(tb.level);
+    lines.push(`### ${tb.name} (${tb.id})`);
+    lines.push(`**Level:** ${levelLabel}`);
+    const componentNames = tb.componentIds
+      .map((id) => {
+        const comp = componentMap.get(id);
+        return comp ? `${comp.id} (${comp.name})` : id;
+      })
+      .join(", ");
+    lines.push(`**Components:** ${componentNames}`);
+  }
+
+  return lines.join("\n");
+}
+
+function renderDataFlowsSection(dataFlows: DataFlow[]): string {
+  const lines: string[] = ["## Data Flows", ""];
+  lines.push(
+    "| ID | From | To | Protocol | Data Classification | Authenticated | Encrypted |",
+  );
+  lines.push(
+    "|----|------|----|----------|-------------------|---------------|-----------|",
+  );
+  for (const df of dataFlows) {
+    lines.push(
+      `| ${df.id} | ${df.from} | ${df.to} | ${df.protocol} | ${capitalize(df.dataClassification)} | ${df.authenticated ? "Yes" : "No"} | ${df.encrypted ? "Yes" : "No"} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function renderSecurityControlsSection(sc: SecurityControlsResult): string {
+  const lines: string[] = ["## Security Controls"];
+
+  for (let i = 0; i < sc.controls.length; i++) {
+    const ctrl = sc.controls[i]!;
+    lines.push("");
+    lines.push(`### SC-${i + 1}: ${ctrl.name}`);
+    lines.push(`- **Type:** ${ctrl.type}`);
+    lines.push(`- **Effectiveness:** ${capitalize(ctrl.effectiveness)}`);
+    lines.push(`- **Scope:** ${ctrl.scope}`);
+    lines.push(`- **Implementation:** ${ctrl.implementation}`);
+    if (ctrl.gaps) {
+      lines.push(`- **Gaps:** ${ctrl.gaps}`);
+    }
+  }
+
+  // Authentication Mechanism
+  if (sc.authenticationMechanism) {
+    const auth = sc.authenticationMechanism;
+    lines.push("");
+    lines.push("### Authentication Mechanism");
+    lines.push(`- **Type:** ${auth.type}`);
+    lines.push(`- **Implementation:** ${auth.implementation}`);
+    lines.push(`- **Session Storage:** ${auth.sessionStorage}`);
+    if (auth.mfa) {
+      lines.push(`- **MFA:** ${auth.mfa}`);
+    }
+  }
+
+  // Authorization Model
+  if (sc.authorizationModel) {
+    const authz = sc.authorizationModel;
+    lines.push("");
+    lines.push("### Authorization Model");
+    lines.push(`- **Type:** ${authz.type}`);
+    lines.push(`- **Implementation:** ${authz.implementation}`);
+    if (authz.roles && authz.roles.length > 0) {
+      lines.push(`- **Roles:** ${authz.roles.join(", ")}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function renderAttackPathsSection(attackPaths: AttackPath[]): string {
+  const lines: string[] = ["## Attack Paths"];
+
+  for (const ap of attackPaths) {
+    const sevLabel = SEVERITY_LABELS[ap.severity] ?? ap.severity;
+
+    lines.push("");
+    lines.push(`### ${ap.id}: ${ap.title} [${sevLabel}]`);
+    lines.push("");
+    lines.push(`**Attacker Profile:** ${ap.attackerProfile}`);
+    lines.push(`**Entry Point:** ${ap.entryPoint}`);
+    lines.push(`**Severity:** ${capitalize(ap.severity)}`);
+    lines.push(`**Affected Features:** ${ap.affectedFeatures.join(", ")}`);
+
+    // Mechanism
+    lines.push("");
+    lines.push("**Mechanism:**");
+    for (let i = 0; i < ap.mechanism.length; i++) {
+      lines.push(`${i + 1}. ${ap.mechanism[i]}`);
+    }
+
+    // Impact
+    lines.push("");
+    lines.push(`**Impact:** ${ap.impact}`);
+
+    // Preconditions
+    lines.push("");
+    lines.push("#### Preconditions");
+    if (ap.preconditions.length === 0) {
+      lines.push("- None");
+    } else {
+      for (const pre of ap.preconditions) {
+        lines.push(`- ${pre}`);
+      }
+    }
+
+    // Existing Controls
+    lines.push("");
+    lines.push("#### Existing Controls");
+    if (ap.existingControls.length === 0) {
+      lines.push("- None identified");
+    } else {
+      for (const ctrl of ap.existingControls) {
+        lines.push(`- ${ctrl}`);
+      }
+    }
+
+    // Control Gaps
+    lines.push("");
+    lines.push("#### Control Gaps");
+    if (ap.controlGaps.length === 0) {
+      lines.push("- None identified");
+    } else {
+      for (const gap of ap.controlGaps) {
+        lines.push(`- ${gap}`);
+      }
+    }
+
+    // Pentest Guidance
+    lines.push("");
+    lines.push("#### Pentest Guidance");
+
+    lines.push("**Objectives:**");
+    for (let i = 0; i < ap.pentestGuidance.objectives.length; i++) {
+      lines.push(`${i + 1}. ${ap.pentestGuidance.objectives[i]}`);
+    }
+
+    if (ap.pentestGuidance.techniques.length > 0) {
+      lines.push("");
+      lines.push("**Techniques:**");
+      for (const tech of ap.pentestGuidance.techniques) {
+        lines.push(`- ${tech}`);
+      }
+    }
+
+    if (ap.pentestGuidance.deploymentConsiderations.length > 0) {
+      lines.push("");
+      lines.push("**Deployment Considerations:**");
+      for (const dc of ap.pentestGuidance.deploymentConsiderations) {
+        lines.push(`- ${dc}`);
+      }
+    }
+
+    if (ap.pentestGuidance.prerequisites.length > 0) {
+      lines.push("");
+      lines.push("**Prerequisites:**");
+      for (const pr of ap.pentestGuidance.prerequisites) {
+        lines.push(`- ${pr}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function renderSummarySection(model: ThreatModel): string {
+  const s = model.summary;
+  const lines: string[] = [
+    "---",
+    "",
+    "## Summary",
+    "",
+    "| Metric | Count |",
+    "|--------|-------|",
+    `| Total Components | ${s.totalComponents} |`,
+    `| Total Data Flows | ${s.totalDataFlows} |`,
+    `| Total Attack Paths | ${s.totalAttackPaths} |`,
+    "",
+    "### Attack Paths by Severity",
+    "| Severity | Count |",
+    "|----------|-------|",
+    `| Critical | ${s.attackPathsBySeverity.critical} |`,
+    `| High | ${s.attackPathsBySeverity.high} |`,
+    `| Medium | ${s.attackPathsBySeverity.medium} |`,
+    `| Low | ${s.attackPathsBySeverity.low} |`,
+  ];
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// JSON serializer
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a threat model to pretty-printed JSON for programmatic use.
+ */
+export function serializeThreatModelToJson(model: ThreatModel): string {
+  return JSON.stringify(model, null, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function formatType(type: string): string {
+  return type
+    .split("_")
+    .map((w) => capitalize(w))
+    .join(" ");
+}
+
+function formatTrustLevel(level: string): string {
+  switch (level) {
+    case "external":
+      return "External/Internet";
+    case "dmz":
+      return "DMZ/Edge";
+    case "internal":
+      return "Internal/Application";
+    case "data":
+      return "Data Tier";
+    default:
+      return capitalize(level);
+  }
+}

--- a/src/core/agents/specialized/threatModel/types.ts
+++ b/src/core/agents/specialized/threatModel/types.ts
@@ -1,0 +1,521 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Deployment Context
+// ---------------------------------------------------------------------------
+
+export const DeploymentContextSchema = z.object({
+  cloud: z
+    .object({
+      provider: z
+        .string()
+        .optional()
+        .describe("Cloud provider (e.g. AWS, GCP, Azure, DigitalOcean)"),
+      region: z.string().optional().describe("Deployment region"),
+      services: z
+        .array(z.string())
+        .optional()
+        .describe("Cloud services in use (e.g. ECS, RDS, S3, CloudFront)"),
+    })
+    .optional(),
+  containers: z
+    .object({
+      runtime: z
+        .string()
+        .optional()
+        .describe("Container runtime (e.g. Docker, Podman)"),
+      orchestration: z
+        .string()
+        .optional()
+        .describe(
+          "Orchestration platform (e.g. Kubernetes, ECS, Docker Compose)",
+        ),
+      hasDockerfile: z.boolean().optional(),
+      hasDockerCompose: z.boolean().optional(),
+      hasKubernetes: z.boolean().optional(),
+    })
+    .optional(),
+  iac: z
+    .array(
+      z.object({
+        tool: z
+          .string()
+          .describe(
+            "IaC tool (e.g. Terraform, CDK, Pulumi, CloudFormation)",
+          ),
+        configPath: z.string().describe("Path to the IaC configuration"),
+      }),
+    )
+    .describe("Infrastructure as Code tools detected (empty array if none)"),
+  cicd: z
+    .array(z.string())
+    .describe(
+      "CI/CD platforms detected (e.g. GitHub Actions, GitLab CI, Jenkins). Empty array if none",
+    ),
+  databases: z
+    .array(
+      z.object({
+        type: z
+          .string()
+          .describe(
+            "Database type (e.g. PostgreSQL, MySQL, MongoDB, Redis)",
+          ),
+        version: z.string().optional().describe("Version if determinable"),
+      }),
+    )
+    .describe("Databases discovered (empty array if none)"),
+  messageQueues: z
+    .array(z.string())
+    .describe(
+      "Message queues/brokers (e.g. RabbitMQ, SQS, Kafka). Empty array if none",
+    ),
+  reverseProxy: z
+    .string()
+    .describe(
+      "Reverse proxy (e.g. nginx, Caddy, Traefik). Empty string if none",
+    ),
+  environmentFiles: z
+    .array(z.string())
+    .describe(
+      "Environment file paths discovered (e.g. .env, .env.example). Empty array if none",
+    ),
+});
+
+export type DeploymentContext = z.infer<typeof DeploymentContextSchema>;
+
+// ---------------------------------------------------------------------------
+// Security Controls
+// ---------------------------------------------------------------------------
+
+export const SecurityControlSchema = z.object({
+  type: z
+    .enum([
+      "waf",
+      "cdn",
+      "cors",
+      "csp",
+      "rate_limiter",
+      "auth_middleware",
+      "authorization",
+      "input_validation",
+      "output_encoding",
+      "csrf_protection",
+      "encryption",
+      "logging",
+      "secrets_management",
+      "security_headers",
+      "other",
+    ])
+    .describe("Type of security control"),
+  name: z.string().describe("Descriptive name for this control"),
+  implementation: z
+    .string()
+    .describe(
+      "How the control is implemented (library, custom code, etc.)",
+    ),
+  scope: z
+    .string()
+    .describe(
+      "What the control applies to (e.g. all routes, /api/* only)",
+    ),
+  effectiveness: z
+    .enum(["strong", "moderate", "weak", "unknown"])
+    .describe("Assessed effectiveness of the control"),
+  gaps: z
+    .string()
+    .describe(
+      "Known gaps or weaknesses in the control. Empty string if none identified",
+    ),
+});
+
+export type SecurityControl = z.infer<typeof SecurityControlSchema>;
+
+export const SecurityControlsResultSchema = z.object({
+  controls: z
+    .array(SecurityControlSchema)
+    .describe("All security controls discovered in the codebase"),
+  authenticationMechanism: z
+    .object({
+      type: z
+        .string()
+        .describe(
+          "Auth type (e.g. JWT Bearer, Session Cookie, OAuth2, API Key)",
+        ),
+      implementation: z.string().describe("Library or approach used"),
+      sessionStorage: z
+        .string()
+        .describe(
+          "How sessions are stored (stateless, Redis, DB, etc.)",
+        ),
+      mfa: z.string().optional().describe("MFA support status"),
+    })
+    .optional()
+    .describe("Primary authentication mechanism"),
+  authorizationModel: z
+    .object({
+      type: z
+        .string()
+        .describe(
+          "Authorization model (e.g. RBAC, ABAC, ACL, custom)",
+        ),
+      implementation: z
+        .string()
+        .describe("How authorization is enforced"),
+      roles: z
+        .array(z.string())
+        .optional()
+        .describe("Defined roles if RBAC"),
+    })
+    .optional()
+    .describe("Authorization model"),
+});
+
+export type SecurityControlsResult = z.infer<
+  typeof SecurityControlsResultSchema
+>;
+
+// ---------------------------------------------------------------------------
+// System Architecture: Components, Trust Boundaries, Data Flows
+// ---------------------------------------------------------------------------
+
+export const ComponentSchema = z.object({
+  id: z.string().describe("Unique component ID (e.g. comp-1)"),
+  name: z.string().describe("Component name (e.g. user-api)"),
+  type: z
+    .enum([
+      "web_app",
+      "api_service",
+      "database",
+      "cache",
+      "queue",
+      "cdn",
+      "gateway",
+      "reverse_proxy",
+      "storage",
+      "identity_provider",
+      "other",
+    ])
+    .describe("Component type"),
+  technology: z
+    .string()
+    .describe(
+      "Technology stack (e.g. Express.js on Node 20, PostgreSQL 15)",
+    ),
+  trustBoundary: z
+    .string()
+    .describe(
+      "Name of the trust boundary this component belongs to",
+    ),
+});
+
+export type Component = z.infer<typeof ComponentSchema>;
+
+export const TrustBoundarySchema = z.object({
+  id: z.string().describe("Unique boundary ID (e.g. tb-external)"),
+  name: z.string().describe("Human-readable boundary name"),
+  level: z
+    .enum(["external", "dmz", "internal", "data"])
+    .describe("Trust level of this boundary"),
+  componentIds: z
+    .array(z.string())
+    .describe("IDs of components within this boundary"),
+});
+
+export type TrustBoundary = z.infer<typeof TrustBoundarySchema>;
+
+export const DataFlowSchema = z.object({
+  id: z.string().describe("Unique data flow ID (e.g. df-1)"),
+  from: z.string().describe("Source component name"),
+  to: z.string().describe("Destination component name"),
+  protocol: z
+    .string()
+    .describe(
+      "Protocol used (e.g. HTTPS, SQL/TLS, Redis, gRPC)",
+    ),
+  dataClassification: z
+    .enum(["public", "internal", "confidential", "restricted"])
+    .describe("Data sensitivity classification"),
+  authenticated: z
+    .boolean()
+    .describe("Whether the flow requires authentication"),
+  encrypted: z
+    .boolean()
+    .describe("Whether the flow is encrypted in transit"),
+});
+
+export type DataFlow = z.infer<typeof DataFlowSchema>;
+
+/** System architecture: components, trust boundaries, and data flows */
+export const SystemArchitectureSchema = z.object({
+  components: z.array(ComponentSchema).describe("System components"),
+  trustBoundaries: z
+    .array(TrustBoundarySchema)
+    .describe("Trust boundaries"),
+  dataFlows: z
+    .array(DataFlowSchema)
+    .describe("Data flows between components"),
+});
+
+export type SystemArchitecture = z.infer<typeof SystemArchitectureSchema>;
+
+// ---------------------------------------------------------------------------
+// Application Context
+// ---------------------------------------------------------------------------
+
+export const ApplicationIdentitySchema = z.object({
+  type: z
+    .enum([
+      "library",
+      "framework",
+      "service",
+      "platform",
+      "cli",
+      "other",
+    ])
+    .describe("What kind of software this is"),
+  description: z
+    .string()
+    .describe("One-paragraph summary of what the application does"),
+  domain: z
+    .string()
+    .describe(
+      "Application domain (e.g. browser automation, e-commerce, fintech, CI/CD)",
+    ),
+  users: z
+    .array(z.string())
+    .describe(
+      "Who uses this application (e.g. developers, end users, operators)",
+    ),
+  coreCapabilities: z
+    .array(z.string())
+    .describe(
+      "Key capabilities with security implications (e.g. executes browser actions, processes payments)",
+    ),
+});
+
+export type ApplicationIdentity = z.infer<typeof ApplicationIdentitySchema>;
+
+export const ApplicationFeatureSchema = z.object({
+  name: z
+    .string()
+    .describe("Feature name (e.g. page navigation, form fill)"),
+  description: z.string().describe("What the feature does"),
+  securityRelevance: z
+    .string()
+    .describe("Why this feature matters for security"),
+  privilegedOperations: z
+    .array(z.string())
+    .describe(
+      "Privileged operations this feature can perform (e.g. file system access, network requests)",
+    ),
+  dataHandled: z
+    .array(z.string())
+    .describe(
+      "Sensitive data this feature handles (e.g. user credentials, page content, cookies)",
+    ),
+});
+
+export type ApplicationFeature = z.infer<typeof ApplicationFeatureSchema>;
+
+export const ApplicationTrustBoundarySchema = z.object({
+  name: z
+    .string()
+    .describe(
+      "Boundary name (e.g. web page -> agent, user prompt -> browser action)",
+    ),
+  description: z
+    .string()
+    .describe("What crosses this boundary and why it matters"),
+  inputSources: z
+    .array(z.string())
+    .describe("Where untrusted input comes from"),
+  crossesTo: z
+    .string()
+    .describe("What sensitive context the input reaches"),
+});
+
+export type ApplicationTrustBoundary = z.infer<
+  typeof ApplicationTrustBoundarySchema
+>;
+
+export const AttackerProfileSchema = z.object({
+  name: z
+    .string()
+    .describe(
+      "Profile name (e.g. malicious website operator, compromised dependency author)",
+    ),
+  description: z
+    .string()
+    .describe("Who this attacker is and their motivation"),
+  controls: z
+    .array(z.string())
+    .describe(
+      "What the attacker controls (e.g. web page content, npm package)",
+    ),
+  goals: z
+    .array(z.string())
+    .describe(
+      "What the attacker wants to achieve (e.g. exfiltrate data, execute arbitrary code)",
+    ),
+  skillLevel: z
+    .enum(["low", "medium", "high", "expert"])
+    .describe("Expected attacker skill level"),
+});
+
+export type AttackerProfile = z.infer<typeof AttackerProfileSchema>;
+
+export const ApplicationContextSchema = z.object({
+  identity: ApplicationIdentitySchema.describe("What the application is"),
+  features: z
+    .array(ApplicationFeatureSchema)
+    .describe("Security-relevant features and capabilities"),
+  trustBoundaries: z
+    .array(ApplicationTrustBoundarySchema)
+    .describe(
+      "Application-specific trust boundaries where untrusted data enters sensitive context",
+    ),
+  attackerProfiles: z
+    .array(AttackerProfileSchema)
+    .describe(
+      "Realistic attacker profiles based on the application's nature",
+    ),
+});
+
+export type ApplicationContext = z.infer<typeof ApplicationContextSchema>;
+
+// ---------------------------------------------------------------------------
+// Attack Paths
+// ---------------------------------------------------------------------------
+
+export const AttackPathSchema = z.object({
+  id: z.string().describe("Unique attack path ID (e.g. AP-001)"),
+  title: z.string().describe("Short descriptive title"),
+  severity: z
+    .enum(["critical", "high", "medium", "low"])
+    .describe("Severity of the attack path"),
+  attackerProfile: z
+    .string()
+    .describe(
+      "Name of the attacker profile that would execute this attack",
+    ),
+  entryPoint: z
+    .string()
+    .describe(
+      "Specific feature, input, or endpoint where the attack begins",
+    ),
+  mechanism: z
+    .array(z.string())
+    .describe(
+      "Step-by-step array showing how the attack flows through the system",
+    ),
+  impact: z
+    .string()
+    .describe("What happens if the attack succeeds"),
+  affectedFeatures: z
+    .array(z.string())
+    .describe("Features affected by this attack path"),
+  preconditions: z
+    .array(z.string())
+    .describe(
+      "Conditions that must be true for this attack to work",
+    ),
+  existingControls: z
+    .array(z.string())
+    .describe(
+      "Existing controls that partially or fully mitigate this attack",
+    ),
+  controlGaps: z
+    .array(z.string())
+    .describe(
+      "Missing or insufficient controls that make this attack viable",
+    ),
+  pentestGuidance: z.object({
+    objectives: z
+      .array(z.string())
+      .describe("Specific pentest objectives for this attack path"),
+    techniques: z
+      .array(z.string())
+      .describe("Recommended testing techniques and tools"),
+    deploymentConsiderations: z
+      .array(z.string())
+      .describe(
+        "Deployment-specific details that affect testing. Empty array if none",
+      ),
+    prerequisites: z
+      .array(z.string())
+      .describe(
+        "Prerequisites before testing (e.g. authenticated session). Empty array if none",
+      ),
+  }),
+});
+
+export type AttackPath = z.infer<typeof AttackPathSchema>;
+
+export const AttackPathsResultSchema = z.object({
+  attackPaths: z
+    .array(AttackPathSchema)
+    .describe("Attack paths identified"),
+});
+
+export type AttackPathsResult = z.infer<typeof AttackPathsResultSchema>;
+
+// ---------------------------------------------------------------------------
+// Top-level Threat Model Result (returned from the threat model command)
+// ---------------------------------------------------------------------------
+
+export interface ThreatModelResult {
+  metadata: {
+    mode: "whitebox";
+    target: string;
+    generatedAt: string;
+    modelUsed: string;
+    schemaVersion: string;
+    repoType: string;
+    packageManager: string;
+  };
+  applicationContext: ApplicationContext;
+  deployment: DeploymentContext;
+  architecture: SystemArchitecture;
+  securityControls: SecurityControlsResult;
+  attackPaths: AttackPath[];
+  summary: {
+    totalAttackPaths: number;
+    bySeverity: Record<"critical" | "high" | "medium" | "low", number>;
+    topRisks: string[];
+  };
+  files: {
+    markdownPath: string;
+    jsonPath: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Threat Model (for serialization, without file paths)
+// ---------------------------------------------------------------------------
+
+export interface ThreatModel {
+  metadata: {
+    generatedAt: string;
+    codebasePath: string;
+    repoType: string;
+    packageManager: string;
+  };
+  applicationContext: ApplicationContext;
+  deployment: DeploymentContext;
+  components: Component[];
+  trustBoundaries: TrustBoundary[];
+  dataFlows: DataFlow[];
+  securityControls: SecurityControlsResult;
+  attackPaths: AttackPath[];
+  summary: {
+    totalComponents: number;
+    totalDataFlows: number;
+    totalAttackPaths: number;
+    attackPathsBySeverity: {
+      critical: number;
+      high: number;
+      medium: number;
+      low: number;
+    };
+  };
+}

--- a/src/core/agents/specialized/threatModel/types.ts
+++ b/src/core/agents/specialized/threatModel/types.ts
@@ -40,9 +40,7 @@ export const DeploymentContextSchema = z.object({
       z.object({
         tool: z
           .string()
-          .describe(
-            "IaC tool (e.g. Terraform, CDK, Pulumi, CloudFormation)",
-          ),
+          .describe("IaC tool (e.g. Terraform, CDK, Pulumi, CloudFormation)"),
         configPath: z.string().describe("Path to the IaC configuration"),
       }),
     )
@@ -57,9 +55,7 @@ export const DeploymentContextSchema = z.object({
       z.object({
         type: z
           .string()
-          .describe(
-            "Database type (e.g. PostgreSQL, MySQL, MongoDB, Redis)",
-          ),
+          .describe("Database type (e.g. PostgreSQL, MySQL, MongoDB, Redis)"),
         version: z.string().optional().describe("Version if determinable"),
       }),
     )
@@ -110,14 +106,10 @@ export const SecurityControlSchema = z.object({
   name: z.string().describe("Descriptive name for this control"),
   implementation: z
     .string()
-    .describe(
-      "How the control is implemented (library, custom code, etc.)",
-    ),
+    .describe("How the control is implemented (library, custom code, etc.)"),
   scope: z
     .string()
-    .describe(
-      "What the control applies to (e.g. all routes, /api/* only)",
-    ),
+    .describe("What the control applies to (e.g. all routes, /api/* only)"),
   effectiveness: z
     .enum(["strong", "moderate", "weak", "unknown"])
     .describe("Assessed effectiveness of the control"),
@@ -144,9 +136,7 @@ export const SecurityControlsResultSchema = z.object({
       implementation: z.string().describe("Library or approach used"),
       sessionStorage: z
         .string()
-        .describe(
-          "How sessions are stored (stateless, Redis, DB, etc.)",
-        ),
+        .describe("How sessions are stored (stateless, Redis, DB, etc.)"),
       mfa: z.string().optional().describe("MFA support status"),
     })
     .optional()
@@ -155,16 +145,9 @@ export const SecurityControlsResultSchema = z.object({
     .object({
       type: z
         .string()
-        .describe(
-          "Authorization model (e.g. RBAC, ABAC, ACL, custom)",
-        ),
-      implementation: z
-        .string()
-        .describe("How authorization is enforced"),
-      roles: z
-        .array(z.string())
-        .optional()
-        .describe("Defined roles if RBAC"),
+        .describe("Authorization model (e.g. RBAC, ABAC, ACL, custom)"),
+      implementation: z.string().describe("How authorization is enforced"),
+      roles: z.array(z.string()).optional().describe("Defined roles if RBAC"),
     })
     .optional()
     .describe("Authorization model"),
@@ -198,14 +181,10 @@ export const ComponentSchema = z.object({
     .describe("Component type"),
   technology: z
     .string()
-    .describe(
-      "Technology stack (e.g. Express.js on Node 20, PostgreSQL 15)",
-    ),
+    .describe("Technology stack (e.g. Express.js on Node 20, PostgreSQL 15)"),
   trustBoundary: z
     .string()
-    .describe(
-      "Name of the trust boundary this component belongs to",
-    ),
+    .describe("Name of the trust boundary this component belongs to"),
 });
 
 export type Component = z.infer<typeof ComponentSchema>;
@@ -229,18 +208,14 @@ export const DataFlowSchema = z.object({
   to: z.string().describe("Destination component name"),
   protocol: z
     .string()
-    .describe(
-      "Protocol used (e.g. HTTPS, SQL/TLS, Redis, gRPC)",
-    ),
+    .describe("Protocol used (e.g. HTTPS, SQL/TLS, Redis, gRPC)"),
   dataClassification: z
     .enum(["public", "internal", "confidential", "restricted"])
     .describe("Data sensitivity classification"),
   authenticated: z
     .boolean()
     .describe("Whether the flow requires authentication"),
-  encrypted: z
-    .boolean()
-    .describe("Whether the flow is encrypted in transit"),
+  encrypted: z.boolean().describe("Whether the flow is encrypted in transit"),
 });
 
 export type DataFlow = z.infer<typeof DataFlowSchema>;
@@ -248,12 +223,8 @@ export type DataFlow = z.infer<typeof DataFlowSchema>;
 /** System architecture: components, trust boundaries, and data flows */
 export const SystemArchitectureSchema = z.object({
   components: z.array(ComponentSchema).describe("System components"),
-  trustBoundaries: z
-    .array(TrustBoundarySchema)
-    .describe("Trust boundaries"),
-  dataFlows: z
-    .array(DataFlowSchema)
-    .describe("Data flows between components"),
+  trustBoundaries: z.array(TrustBoundarySchema).describe("Trust boundaries"),
+  dataFlows: z.array(DataFlowSchema).describe("Data flows between components"),
 });
 
 export type SystemArchitecture = z.infer<typeof SystemArchitectureSchema>;
@@ -264,14 +235,7 @@ export type SystemArchitecture = z.infer<typeof SystemArchitectureSchema>;
 
 export const ApplicationIdentitySchema = z.object({
   type: z
-    .enum([
-      "library",
-      "framework",
-      "service",
-      "platform",
-      "cli",
-      "other",
-    ])
+    .enum(["library", "framework", "service", "platform", "cli", "other"])
     .describe("What kind of software this is"),
   description: z
     .string()
@@ -296,9 +260,7 @@ export const ApplicationIdentitySchema = z.object({
 export type ApplicationIdentity = z.infer<typeof ApplicationIdentitySchema>;
 
 export const ApplicationFeatureSchema = z.object({
-  name: z
-    .string()
-    .describe("Feature name (e.g. page navigation, form fill)"),
+  name: z.string().describe("Feature name (e.g. page navigation, form fill)"),
   description: z.string().describe("What the feature does"),
   securityRelevance: z
     .string()
@@ -329,9 +291,7 @@ export const ApplicationTrustBoundarySchema = z.object({
   inputSources: z
     .array(z.string())
     .describe("Where untrusted input comes from"),
-  crossesTo: z
-    .string()
-    .describe("What sensitive context the input reaches"),
+  crossesTo: z.string().describe("What sensitive context the input reaches"),
 });
 
 export type ApplicationTrustBoundary = z.infer<
@@ -344,9 +304,7 @@ export const AttackerProfileSchema = z.object({
     .describe(
       "Profile name (e.g. malicious website operator, compromised dependency author)",
     ),
-  description: z
-    .string()
-    .describe("Who this attacker is and their motivation"),
+  description: z.string().describe("Who this attacker is and their motivation"),
   controls: z
     .array(z.string())
     .describe(
@@ -376,9 +334,7 @@ export const ApplicationContextSchema = z.object({
     ),
   attackerProfiles: z
     .array(AttackerProfileSchema)
-    .describe(
-      "Realistic attacker profiles based on the application's nature",
-    ),
+    .describe("Realistic attacker profiles based on the application's nature"),
 });
 
 export type ApplicationContext = z.infer<typeof ApplicationContextSchema>;
@@ -395,40 +351,28 @@ export const AttackPathSchema = z.object({
     .describe("Severity of the attack path"),
   attackerProfile: z
     .string()
-    .describe(
-      "Name of the attacker profile that would execute this attack",
-    ),
+    .describe("Name of the attacker profile that would execute this attack"),
   entryPoint: z
     .string()
-    .describe(
-      "Specific feature, input, or endpoint where the attack begins",
-    ),
+    .describe("Specific feature, input, or endpoint where the attack begins"),
   mechanism: z
     .array(z.string())
     .describe(
       "Step-by-step array showing how the attack flows through the system",
     ),
-  impact: z
-    .string()
-    .describe("What happens if the attack succeeds"),
+  impact: z.string().describe("What happens if the attack succeeds"),
   affectedFeatures: z
     .array(z.string())
     .describe("Features affected by this attack path"),
   preconditions: z
     .array(z.string())
-    .describe(
-      "Conditions that must be true for this attack to work",
-    ),
+    .describe("Conditions that must be true for this attack to work"),
   existingControls: z
     .array(z.string())
-    .describe(
-      "Existing controls that partially or fully mitigate this attack",
-    ),
+    .describe("Existing controls that partially or fully mitigate this attack"),
   controlGaps: z
     .array(z.string())
-    .describe(
-      "Missing or insufficient controls that make this attack viable",
-    ),
+    .describe("Missing or insufficient controls that make this attack viable"),
   pentestGuidance: z.object({
     objectives: z
       .array(z.string())
@@ -452,9 +396,7 @@ export const AttackPathSchema = z.object({
 export type AttackPath = z.infer<typeof AttackPathSchema>;
 
 export const AttackPathsResultSchema = z.object({
-  attackPaths: z
-    .array(AttackPathSchema)
-    .describe("Attack paths identified"),
+  attackPaths: z.array(AttackPathSchema).describe("Attack paths identified"),
 });
 
 export type AttackPathsResult = z.infer<typeof AttackPathsResultSchema>;

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -18,10 +18,7 @@ export { runAuthenticationAgent } from "./authentication";
 export { runBenchmarkComparisonAgent } from "./benchmark";
 export { runPentestAgent } from "./blackboxPentest";
 export { runTargetedPentestAgent } from "./targetedPentest";
-export {
-  runThreatModelAgent,
-  type ThreatModelInput,
-} from "./threatModel";
+export { runThreatModelAgent, type ThreatModelInput } from "./threatModel";
 export * from "./operator";
 
 // ---------------------------------------------------------------------------

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -18,6 +18,10 @@ export { runAuthenticationAgent } from "./authentication";
 export { runBenchmarkComparisonAgent } from "./benchmark";
 export { runPentestAgent } from "./blackboxPentest";
 export { runTargetedPentestAgent } from "./targetedPentest";
+export {
+  runThreatModelAgent,
+  type ThreatModelInput,
+} from "./threatModel";
 export * from "./operator";
 
 // ---------------------------------------------------------------------------
@@ -29,6 +33,7 @@ export type { AuthenticationResult } from "../agents/specialized/authenticationA
 export type { PentestResult } from "../agents/specialized/pentest/agent";
 export type { PentestWorkflowResult } from "../workflows/pentest";
 export type { BenchmarkComparisonResult } from "../agents/specialized/benchmarkComparisonAgent";
+export type { ThreatModelResult } from "../agents/specialized/threatModel/types";
 
 // ---------------------------------------------------------------------------
 // Input types — accepted by agent runners
@@ -63,6 +68,24 @@ export type {
   AuthFlowHints,
   AuthMethod,
 } from "../agents/specialized/authenticationAgent/types";
+
+// Threat model
+export type {
+  ApplicationContext,
+  ApplicationIdentity,
+  ApplicationFeature,
+  ApplicationTrustBoundary,
+  AttackerProfile,
+  AttackPath,
+  AttackPathsResult,
+  SystemArchitecture,
+  Component,
+  TrustBoundary,
+  DataFlow,
+  DeploymentContext,
+  SecurityControl,
+  SecurityControlsResult,
+} from "../agents/specialized/threatModel/types";
 
 // AI model
 export type { AIModel } from "../ai";

--- a/src/core/api/threatModel.ts
+++ b/src/core/api/threatModel.ts
@@ -1,0 +1,35 @@
+import {
+  runThreatModelWorkflow,
+  type ThreatModelWorkflowInput,
+} from "../workflows/threatModel";
+import type { ThreatModelResult } from "../agents/specialized/threatModel/types";
+import { AgentRun } from "./agentRun";
+
+// ---------------------------------------------------------------------------
+// Input type
+// ---------------------------------------------------------------------------
+
+export type ThreatModelInput = Omit<ThreatModelWorkflowInput, "eventBus">;
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the application-centric threat model workflow.
+ *
+ * Phase 0: Application Context Discovery
+ * Phase 1a: Attack Surface Reconnaissance
+ * Phase 1b: Deployment Context
+ * Phase 1c: Security Controls
+ * Phase 2: Architecture Synthesis
+ * Phase 3: Attack Path Synthesis
+ * Phase 4: Assembly + Serialization
+ */
+export function runThreatModelAgent(
+  input: ThreatModelInput,
+): AgentRun<ThreatModelResult> {
+  return new AgentRun(async (eventBus) => {
+    return runThreatModelWorkflow({ ...input, eventBus });
+  });
+}

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -14,6 +14,7 @@ import {
   runWhiteboxAttackSurfaceWorkflow,
   type WhiteboxAttackSurfaceWorkflowInput,
 } from "./whiteboxAttackSurface";
+import { runThreatModelWorkflow } from "./threatModel";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -50,6 +51,7 @@ export interface PentestWorkflowResult {
 interface SwarmTarget {
   target: string;
   objectives: string[];
+  threatModelPath?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -108,6 +110,34 @@ export async function runPentestWorkflow(
   }
 
   // =========================================================================
+  // Phase 1.5: Threat model generation (whitebox only, best-effort)
+  // =========================================================================
+
+  let threatModelPath: string | undefined;
+  if (mode === "whitebox") {
+    try {
+      const tmResult = await runThreatModelWorkflow({
+        cwd: cwd!,
+        model,
+        session,
+        authConfig,
+        abortSignal,
+        eventBus: eventBus?.child("threat-model"),
+      });
+      threatModelPath = tmResult.files.markdownPath;
+    } catch {
+      // Best-effort: continue without threat model
+    }
+  }
+
+  // Attach threat model path to each swarm target
+  if (threatModelPath) {
+    for (const st of swarmTargets) {
+      st.threatModelPath = threatModelPath;
+    }
+  }
+
+  // =========================================================================
   // Phase 2: Spawn pentest swarm
   // =========================================================================
 
@@ -131,6 +161,7 @@ export async function runPentestWorkflow(
       const agent = new TargetedPentestAgent({
         target: swarmTarget.target,
         objectives: swarmTarget.objectives,
+        threatModelPath: swarmTarget.threatModelPath,
         model,
         session,
         authConfig,

--- a/src/core/workflows/threatModel.ts
+++ b/src/core/workflows/threatModel.ts
@@ -1,0 +1,334 @@
+import { mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { CodeAgent } from "../agents/specialized/codeAgent/agent";
+import {
+  ApplicationContextSchema,
+  AttackPathsResultSchema,
+  DeploymentContextSchema,
+  SecurityControlsResultSchema,
+  SystemArchitectureSchema,
+  type ApplicationContext,
+  type AttackPathsResult,
+  type DeploymentContext,
+  type SecurityControlsResult,
+  type SystemArchitecture,
+  type ThreatModel,
+  type ThreatModelResult,
+} from "../agents/specialized/threatModel/types";
+import {
+  WHITEBOX_CODE_AGENT_SYSTEM_PROMPT,
+  DATA_SYNTHESIS_AGENT_SYSTEM_PROMPT,
+  buildApplicationContextObjective,
+  buildDeploymentContextObjective,
+  buildSecurityControlsObjective,
+  buildArchitectureSynthesisObjective,
+  buildAttackPathSynthesisObjective,
+} from "../agents/specialized/threatModel/prompts";
+import {
+  serializeThreatModelToMarkdown,
+  serializeThreatModelToJson,
+} from "../agents/specialized/threatModel/serialize";
+import {
+  runWhiteboxAttackSurfaceWorkflow,
+  type WhiteboxAttackSurfaceWorkflowInput,
+} from "./whiteboxAttackSurface";
+import type { AgentEventBus } from "../agents/offSecAgent/eventBus";
+import type { AIModel } from "../ai";
+import type { AIAuthConfig } from "../ai/utils";
+import type { SessionInfo } from "../session";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ThreatModelWorkflowInput {
+  /** Local codebase path (absolute) */
+  cwd: string;
+
+  model: AIModel;
+  session: SessionInfo;
+
+  /** Optional user hint about what the app is */
+  applicationIdentity?: string;
+
+  authConfig?: AIAuthConfig;
+  abortSignal?: AbortSignal;
+  eventBus?: AgentEventBus;
+}
+
+// ---------------------------------------------------------------------------
+// Workflow
+// ---------------------------------------------------------------------------
+
+/**
+ * Deterministic threat model workflow.
+ *
+ * Phase 0: Application Context Discovery (CodeAgent reads source code)
+ * Phase 1a: Attack Surface Reconnaissance (reuses whitebox workflow)
+ * Phase 1b: Deployment Context (CodeAgent reads source code)
+ * Phase 1c: Security Controls (CodeAgent reads source code + attack surface data)
+ * Phase 2: Architecture Synthesis (CodeAgent reads JSON data files)
+ * Phase 3: Attack Path Synthesis (CodeAgent reads JSON data files)
+ * Phase 4: Assembly + Serialization (deterministic, no LLM)
+ */
+export async function runThreatModelWorkflow(
+  input: ThreatModelWorkflowInput,
+): Promise<ThreatModelResult> {
+  const {
+    cwd,
+    model,
+    session,
+    applicationIdentity,
+    authConfig,
+    abortSignal,
+    eventBus,
+  } = input;
+
+  const threatModelDir = join(session.rootPath, "threat-model");
+  mkdirSync(threatModelDir, { recursive: true });
+
+  const baseAgentInput = { model, session, authConfig, abortSignal };
+
+  // =========================================================================
+  // Phase 0: Application Context Discovery
+  // =========================================================================
+
+  emitPhase(eventBus, "application-context", "pending");
+
+  const agent0 = new CodeAgent<ApplicationContext>({
+    codebasePath: cwd,
+    objective: buildApplicationContextObjective(cwd, applicationIdentity),
+    system: WHITEBOX_CODE_AGENT_SYSTEM_PROMPT,
+    responseSchema: ApplicationContextSchema,
+    ...baseAgentInput,
+    eventBus: eventBus?.child("application-context"),
+  });
+  const applicationContext = await agent0.consume();
+
+  if (!applicationContext) {
+    throw new Error("Phase 0 failed: no application context returned");
+  }
+
+  writeJSON(threatModelDir, "application-context.json", applicationContext);
+  emitPhase(eventBus, "application-context", "completed");
+
+  // =========================================================================
+  // Phase 1a: Attack Surface Reconnaissance (reuses existing workflow)
+  // =========================================================================
+
+  emitPhase(eventBus, "attack-surface", "pending");
+
+  const attackSurfaceInput: WhiteboxAttackSurfaceWorkflowInput = {
+    codebasePath: cwd,
+    ...baseAgentInput,
+    eventBus: eventBus?.child("attack-surface"),
+  };
+
+  const attackSurfaceResult =
+    await runWhiteboxAttackSurfaceWorkflow(attackSurfaceInput);
+
+  // Persist for downstream phases that read JSON data files
+  writeJSON(
+    session.rootPath,
+    "attack-surface-results.json",
+    attackSurfaceResult,
+  );
+  emitPhase(eventBus, "attack-surface", "completed");
+
+  // =========================================================================
+  // Phase 1b: Deployment Context
+  // =========================================================================
+
+  emitPhase(eventBus, "deployment-context", "pending");
+
+  const agent1b = new CodeAgent<DeploymentContext>({
+    codebasePath: cwd,
+    objective: buildDeploymentContextObjective(cwd),
+    responseSchema: DeploymentContextSchema,
+    ...baseAgentInput,
+    eventBus: eventBus?.child("deployment-context"),
+  });
+  const deployment = (await agent1b.consume()) ?? emptyDeploymentContext();
+
+  writeJSON(threatModelDir, "deployment-context.json", deployment);
+  // Also write to session root for architecture synthesis prompt paths
+  writeJSON(session.rootPath, "deployment-context.json", deployment);
+  emitPhase(eventBus, "deployment-context", "completed");
+
+  // =========================================================================
+  // Phase 1c: Security Controls
+  // =========================================================================
+
+  emitPhase(eventBus, "security-controls", "pending");
+
+  const agent1c = new CodeAgent<SecurityControlsResult>({
+    codebasePath: cwd,
+    objective: buildSecurityControlsObjective(
+      cwd,
+      deployment,
+      session.rootPath,
+    ),
+    responseSchema: SecurityControlsResultSchema,
+    ...baseAgentInput,
+    eventBus: eventBus?.child("security-controls"),
+  });
+  const securityControls = (await agent1c.consume()) ?? { controls: [] };
+
+  writeJSON(threatModelDir, "security-controls.json", securityControls);
+  // Also write to session root for attack path synthesis prompt paths
+  writeJSON(session.rootPath, "security-controls.json", securityControls);
+  emitPhase(eventBus, "security-controls", "completed");
+
+  // =========================================================================
+  // Phase 2: Architecture Synthesis
+  // =========================================================================
+
+  emitPhase(eventBus, "architecture-synthesis", "pending");
+
+  const agent2 = new CodeAgent<SystemArchitecture>({
+    codebasePath: session.rootPath,
+    objective: buildArchitectureSynthesisObjective(session.rootPath),
+    system: DATA_SYNTHESIS_AGENT_SYSTEM_PROMPT,
+    responseSchema: SystemArchitectureSchema,
+    ...baseAgentInput,
+    eventBus: eventBus?.child("architecture-synthesis"),
+  });
+  const architecture = (await agent2.consume()) ?? {
+    components: [],
+    trustBoundaries: [],
+    dataFlows: [],
+  };
+
+  writeJSON(threatModelDir, "system-architecture.json", architecture);
+  // Also write to session root for attack path synthesis prompt paths
+  writeJSON(session.rootPath, "system-architecture.json", architecture);
+  emitPhase(eventBus, "architecture-synthesis", "completed");
+
+  // =========================================================================
+  // Phase 3: Attack Path Synthesis
+  // =========================================================================
+
+  emitPhase(eventBus, "attack-path-synthesis", "pending");
+
+  const agent3 = new CodeAgent<AttackPathsResult>({
+    codebasePath: session.rootPath,
+    objective: buildAttackPathSynthesisObjective(session.rootPath),
+    system: DATA_SYNTHESIS_AGENT_SYSTEM_PROMPT,
+    responseSchema: AttackPathsResultSchema,
+    ...baseAgentInput,
+    eventBus: eventBus?.child("attack-path-synthesis"),
+  });
+  const attackPathsResult = (await agent3.consume()) ?? { attackPaths: [] };
+
+  writeJSON(threatModelDir, "attack-paths.json", attackPathsResult);
+  emitPhase(eventBus, "attack-path-synthesis", "completed");
+
+  // =========================================================================
+  // Phase 4: Assembly (deterministic, no LLM)
+  // =========================================================================
+
+  const bySeverity = { critical: 0, high: 0, medium: 0, low: 0 };
+  for (const ap of attackPathsResult.attackPaths) {
+    bySeverity[ap.severity]++;
+  }
+
+  const severityOrder = ["critical", "high", "medium", "low"] as const;
+  const sorted = [...attackPathsResult.attackPaths].sort(
+    (a, b) =>
+      severityOrder.indexOf(a.severity) - severityOrder.indexOf(b.severity),
+  );
+
+  const threatModelResult: Omit<ThreatModelResult, "files"> = {
+    metadata: {
+      mode: "whitebox",
+      target: cwd,
+      generatedAt: new Date().toISOString(),
+      modelUsed: model,
+      schemaVersion: "2.0.0",
+      repoType: attackSurfaceResult.repoType,
+      packageManager: attackSurfaceResult.packageManager,
+    },
+    applicationContext,
+    deployment,
+    architecture,
+    securityControls,
+    attackPaths: attackPathsResult.attackPaths,
+    summary: {
+      totalAttackPaths: attackPathsResult.attackPaths.length,
+      bySeverity,
+      topRisks: sorted.slice(0, 10).map((ap) => ap.id),
+    },
+  };
+
+  // Build serialization model
+  const threatModel: ThreatModel = {
+    metadata: {
+      generatedAt: threatModelResult.metadata.generatedAt,
+      codebasePath: cwd,
+      repoType: attackSurfaceResult.repoType,
+      packageManager: attackSurfaceResult.packageManager,
+    },
+    applicationContext,
+    deployment,
+    components: architecture.components,
+    trustBoundaries: architecture.trustBoundaries,
+    dataFlows: architecture.dataFlows,
+    securityControls,
+    attackPaths: attackPathsResult.attackPaths,
+    summary: {
+      totalComponents: architecture.components.length,
+      totalDataFlows: architecture.dataFlows.length,
+      totalAttackPaths: attackPathsResult.attackPaths.length,
+      attackPathsBySeverity: bySeverity,
+    },
+  };
+
+  const jsonPath = join(threatModelDir, "threat-model.json");
+  const mdPath = join(threatModelDir, "threat-model.md");
+  writeFileSync(jsonPath, serializeThreatModelToJson(threatModel));
+  writeFileSync(mdPath, serializeThreatModelToMarkdown(threatModel));
+
+  return { ...threatModelResult, files: { markdownPath: mdPath, jsonPath } };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function emitPhase(
+  eventBus: AgentEventBus | undefined,
+  phase: string,
+  status: "pending" | "completed" | "failed",
+): void {
+  if (!eventBus) return;
+  if (status === "pending") {
+    eventBus.emit({
+      type: "subagent-spawn",
+      subagentId: phase,
+      input: { phase },
+      status: "pending",
+    });
+  } else {
+    eventBus.emit({
+      type: "subagent-complete",
+      subagentId: phase,
+      input: { phase },
+      status,
+    });
+  }
+}
+
+function writeJSON(dir: string, filename: string, data: unknown): void {
+  writeFileSync(join(dir, filename), JSON.stringify(data, null, 2));
+}
+
+function emptyDeploymentContext(): DeploymentContext {
+  return {
+    iac: [],
+    cicd: [],
+    databases: [],
+    messageQueues: [],
+    reverseProxy: "",
+    environmentFiles: [],
+  };
+}

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -2,10 +2,12 @@ import type { CommandDefinition } from "./command-router";
 import type { Route } from "./context/route";
 import {
   parseWebFlags,
+  parseThreatModelFlags,
   hasEnoughFlagsToSkipWizard,
   createOperatorSessionFromFlags,
   createSwarmSessionFromFlags,
 } from "./utils/command-flags";
+import { sessions } from "../core/session";
 import { getAllThemeNames } from "./theme";
 import { config } from "../core/config";
 
@@ -203,6 +205,36 @@ export const commands: CommandConfig[] = [
         path: "operator",
         options: flags as Record<string, unknown>,
       });
+    },
+  },
+  {
+    name: "threat-model",
+    aliases: ["threatmodel", "tm"],
+    description: "Generate application-centric threat model",
+    category: "Analysis",
+    options: [
+      {
+        name: "--cwd",
+        valueHint: "<path>",
+        description: "Codebase path to analyze",
+      },
+      {
+        name: "--model",
+        valueHint: "<model>",
+        description: "AI model to use",
+      },
+    ],
+    handler: async (args, ctx) => {
+      const flags = parseThreatModelFlags(args);
+      const cwd = flags.cwd || process.cwd();
+
+      const session = await sessions.create({
+        name: "Threat Model",
+        targets: [cwd],
+        config: { cwd },
+      });
+
+      ctx.navigate({ type: "threat-model", sessionId: session.id });
     },
   },
   {

--- a/src/tui/components/threat-model/threat-model.tsx
+++ b/src/tui/components/threat-model/threat-model.tsx
@@ -1,0 +1,401 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useKeyboard } from "@opentui/react";
+import { exec } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+
+import { sessions, type SessionInfo } from "../../../core/session";
+import { runThreatModelAgent, type ThreatModelResult } from "../../../core/api";
+import { useAgent } from "../../context/agent";
+import { useRoute } from "../../context/route";
+import { useConfig } from "../../context/config";
+import { useTheme } from "../../theme";
+import { SpinnerDots } from "../sprites";
+
+// ---------------------------------------------------------------------------
+// Phase definitions
+// ---------------------------------------------------------------------------
+
+const PHASE_NAMES: Record<string, string> = {
+  "application-context": "Application Context Discovery",
+  "attack-surface": "Attack Surface Discovery",
+  "deployment-context": "Deployment Context Analysis",
+  "security-controls": "Security Controls Analysis",
+  "architecture-synthesis": "Architecture Synthesis",
+  "attack-path-synthesis": "Attack Path Synthesis",
+};
+
+const PHASE_ORDER = [
+  "application-context",
+  "attack-surface",
+  "deployment-context",
+  "security-controls",
+  "architecture-synthesis",
+  "attack-path-synthesis",
+] as const;
+
+type PhaseId = (typeof PHASE_ORDER)[number];
+type PhaseStatus = "pending" | "active" | "completed" | "failed";
+
+type OverallPhase = "loading" | "running" | "completed" | "error";
+
+// ---------------------------------------------------------------------------
+// ThreatModel component
+// ---------------------------------------------------------------------------
+
+export default function ThreatModel({ sessionId }: { sessionId: string }) {
+  const { colors } = useTheme();
+  const route = useRoute();
+  const config = useConfig();
+  const { model, setThinking, setIsExecuting } = useAgent();
+
+  // Session state
+  const [session, setSession] = useState<SessionInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [overallPhase, setOverallPhase] = useState<OverallPhase>("loading");
+
+  // Phase tracking
+  const [phaseStatuses, setPhaseStatuses] = useState<
+    Record<PhaseId, PhaseStatus>
+  >(() => {
+    const initial: Record<string, PhaseStatus> = {};
+    for (const id of PHASE_ORDER) {
+      initial[id] = "pending";
+    }
+    return initial as Record<PhaseId, PhaseStatus>;
+  });
+
+  // Result
+  const [result, setResult] = useState<ThreatModelResult | null>(null);
+
+  // Abort
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  // -------------------------------------------------------------------------
+  // Load session
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const s = await sessions.get(sessionId);
+        if (!s) {
+          setError(`Session not found: ${sessionId}`);
+          setOverallPhase("error");
+          return;
+        }
+        setSession(s);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to load session");
+        setOverallPhase("error");
+      }
+    }
+    load();
+  }, [sessionId]);
+
+  // -------------------------------------------------------------------------
+  // Cleanup
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Run threat model
+  // -------------------------------------------------------------------------
+
+  const startThreatModel = useCallback(
+    async (s: SessionInfo) => {
+      setOverallPhase("running");
+      setIsExecuting(true);
+      setThinking(true);
+
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      const cwd = s.config?.cwd || s.targets[0] || process.cwd();
+
+      const run = runThreatModelAgent({
+        cwd,
+        session: s,
+        model: model.id,
+        abortSignal: controller.signal,
+        authConfig: {
+          anthropicAPIKey: config.data.anthropicAPIKey ?? undefined,
+          openAiAPIKey: config.data.openAiAPIKey ?? undefined,
+          openRouterAPIKey: config.data.openRouterAPIKey ?? undefined,
+          local: config.data.localModelUrl
+            ? { baseURL: config.data.localModelUrl }
+            : undefined,
+        },
+      });
+
+      try {
+        for await (const event of run) {
+          switch (event.type) {
+            case "subagent-spawn": {
+              const phaseId = event.subagentId as PhaseId;
+              if (phaseId in PHASE_NAMES) {
+                setPhaseStatuses((prev) => ({
+                  ...prev,
+                  [phaseId]: "active",
+                }));
+              }
+              break;
+            }
+            case "subagent-complete": {
+              const phaseId = event.subagentId as PhaseId;
+              if (phaseId in PHASE_NAMES) {
+                setPhaseStatuses((prev) => ({
+                  ...prev,
+                  [phaseId]:
+                    event.status === "completed" ? "completed" : "failed",
+                }));
+              }
+              break;
+            }
+            case "error":
+              console.error("Threat model error:", event.error);
+              break;
+          }
+        }
+
+        const threatModelResult = await run.result;
+        setResult(threatModelResult);
+        setOverallPhase("completed");
+      } catch (e) {
+        if (e instanceof Error && e.name === "AbortError") {
+          // User aborted
+        } else {
+          setError(e instanceof Error ? e.message : "Unknown error");
+          setOverallPhase("error");
+        }
+      } finally {
+        setThinking(false);
+        setIsExecuting(false);
+      }
+    },
+    [model.id, config.data, setThinking, setIsExecuting],
+  );
+
+  // -------------------------------------------------------------------------
+  // Auto-start when session loads
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (session && overallPhase === "loading") {
+      startThreatModel(session);
+    }
+  }, [session, overallPhase, startThreatModel]);
+
+  // -------------------------------------------------------------------------
+  // Keyboard
+  // -------------------------------------------------------------------------
+
+  useKeyboard((key) => {
+    if (key.name === "escape") {
+      abortControllerRef.current?.abort();
+      route.navigate({ type: "base", path: "home" });
+      return;
+    }
+
+    if (key.name === "return" && overallPhase === "completed") {
+      openReport();
+      return;
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Open report
+  // -------------------------------------------------------------------------
+
+  const openReport = useCallback(() => {
+    if (!session) return;
+    const mdPath = join(session.rootPath, "threat-model", "threat-model.md");
+    if (existsSync(mdPath)) {
+      exec(`open "${mdPath}"`);
+    } else {
+      exec(`open "${session.rootPath}"`);
+    }
+  }, [session]);
+
+  // -------------------------------------------------------------------------
+  // Render: Loading
+  // -------------------------------------------------------------------------
+
+  if (overallPhase === "loading" && !session) {
+    return (
+      <box
+        flexDirection="column"
+        width="100%"
+        height="100%"
+        alignItems="center"
+        justifyContent="center"
+        backgroundColor={colors.background}
+      >
+        <SpinnerDots label="Loading session..." />
+      </box>
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Render: Error
+  // -------------------------------------------------------------------------
+
+  if (overallPhase === "error") {
+    return (
+      <box
+        flexDirection="column"
+        width="100%"
+        height="100%"
+        alignItems="center"
+        justifyContent="center"
+        backgroundColor={colors.background}
+        gap={1}
+      >
+        <text fg={colors.error} content="Threat Model Failed" />
+        {error && <text fg={colors.textMuted} content={error} />}
+        <text fg={colors.textMuted} content="Press ESC to go back" />
+      </box>
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Render: Running / Completed
+  // -------------------------------------------------------------------------
+
+  return (
+    <box
+      flexDirection="column"
+      width="100%"
+      height="100%"
+      backgroundColor={colors.background}
+      paddingLeft={2}
+      paddingRight={2}
+      paddingTop={1}
+      gap={1}
+    >
+      {/* Title */}
+      <box flexDirection="row" gap={1}>
+        <text fg={colors.primary} content="Threat Model" />
+        {session && (
+          <text
+            fg={colors.textMuted}
+            content={`- ${session.config?.cwd || session.targets[0] || "unknown"}`}
+          />
+        )}
+      </box>
+
+      {/* Phase list */}
+      <box flexDirection="column" gap={0}>
+        {PHASE_ORDER.map((phaseId) => (
+          <PhaseRow
+            key={phaseId}
+            phaseId={phaseId}
+            status={phaseStatuses[phaseId]}
+          />
+        ))}
+      </box>
+
+      {/* Completion banner */}
+      {overallPhase === "completed" && result && (
+        <CompletionBanner result={result} />
+      )}
+
+      {/* Footer hint */}
+      <box flexDirection="row" gap={1} marginTop={1}>
+        {overallPhase === "completed" ? (
+          <text
+            fg={colors.textMuted}
+            content="Press ENTER to open report | ESC to go back"
+          />
+        ) : (
+          <text fg={colors.textMuted} content="Press ESC to abort" />
+        )}
+      </box>
+    </box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PhaseRow — single phase with status indicator
+// ---------------------------------------------------------------------------
+
+function PhaseRow({
+  phaseId,
+  status,
+}: {
+  phaseId: PhaseId;
+  status: PhaseStatus;
+}) {
+  const { colors } = useTheme();
+  const label = PHASE_NAMES[phaseId] || phaseId;
+
+  if (status === "completed") {
+    return (
+      <box flexDirection="row" gap={1}>
+        <text fg={colors.success} content="  [done]" />
+        <text fg={colors.text} content={label} />
+      </box>
+    );
+  }
+
+  if (status === "active") {
+    return (
+      <box flexDirection="row" gap={1}>
+        <SpinnerDots label={label} />
+      </box>
+    );
+  }
+
+  if (status === "failed") {
+    return (
+      <box flexDirection="row" gap={1}>
+        <text fg={colors.error} content="  [fail]" />
+        <text fg={colors.error} content={label} />
+      </box>
+    );
+  }
+
+  // pending
+  return (
+    <box flexDirection="row" gap={1}>
+      <text fg={colors.textMuted} content="  [ -- ]" />
+      <text fg={colors.textMuted} content={label} />
+    </box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CompletionBanner
+// ---------------------------------------------------------------------------
+
+function CompletionBanner({ result }: { result: ThreatModelResult }) {
+  const { colors } = useTheme();
+  const { summary } = result;
+  const { bySeverity, totalAttackPaths } = summary;
+
+  const parts: string[] = [];
+  if (bySeverity.critical > 0) parts.push(`${bySeverity.critical} critical`);
+  if (bySeverity.high > 0) parts.push(`${bySeverity.high} high`);
+  if (bySeverity.medium > 0) parts.push(`${bySeverity.medium} medium`);
+  if (bySeverity.low > 0) parts.push(`${bySeverity.low} low`);
+
+  const breakdown = parts.length > 0 ? parts.join(", ") : "none";
+  const bannerText = `Threat Model Complete -- ${totalAttackPaths} attack paths: ${breakdown}`;
+
+  return (
+    <box
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={colors.success}
+      paddingLeft={1}
+      paddingRight={1}
+    >
+      <text fg={colors.success} content={bannerText} />
+    </box>
+  );
+}

--- a/src/tui/context/route.tsx
+++ b/src/tui/context/route.tsx
@@ -58,6 +58,10 @@ export type Route =
   | {
       type: "operator";
       sessionId: string;
+    }
+  | {
+      type: "threat-model";
+      sessionId: string;
     };
 
 type RouteContext = {

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -32,6 +32,7 @@ import ModelsDisplay from "./components/commands/models-display";
 import { KeybindingProvider } from "./context/keybinding";
 import Pentest from "./components/pentest/pentest";
 import OperatorDashboard from "./components/operator-dashboard";
+import ThreatModel from "./components/threat-model/threat-model";
 import ThemePicker from "./components/commands/theme-picker";
 import { ThemeProvider, useTheme, type ColorMode } from "./theme";
 import { registerBuiltinThemes } from "./theme/themes";
@@ -311,6 +312,10 @@ function CommandDisplay({
 
   if (route.data.type === "pentest") {
     return <Pentest sessionId={route.data.sessionId} />;
+  }
+
+  if (route.data.type === "threat-model") {
+    return <ThreatModel sessionId={route.data.sessionId} />;
   }
 
   return null;

--- a/src/tui/utils/command-flags.ts
+++ b/src/tui/utils/command-flags.ts
@@ -245,6 +245,28 @@ export function parseWebFlags(args: string[]): WebCommandFlags {
   return flags;
 }
 
+// ============================================================================
+// Threat Model Command Specific Types and Parsing
+// ============================================================================
+
+export interface ThreatModelCommandFlags {
+  cwd?: string;
+  model?: string;
+}
+
+const threatModelFlagSchema: FlagSchema = {
+  cwd: { type: "string" },
+  model: { type: "string" },
+};
+
+export function parseThreatModelFlags(args: string[]): ThreatModelCommandFlags {
+  const raw = parseFlags(args, threatModelFlagSchema);
+  const flags: ThreatModelCommandFlags = {};
+  if (raw.cwd) flags.cwd = String(raw.cwd);
+  if (raw.model) flags.model = String(raw.model);
+  return flags;
+}
+
 /**
  * Check if flags have enough information to skip the wizard
  * Requires at least a target to skip wizard


### PR DESCRIPTION
First pass at a threat modeling agent that analyzes source code to produce domain-specific attack paths — grounded in the application's nature, trust boundaries, and attacker profiles rather than generic STRIDE enumeration. This gets the full pipeline wired up end-to-end; we'll iterate on prompt quality, output format, and UX once we can run it against real repos.

Based on Kerem's work on `origin/threat-model` (schemas, prompts, serialization), ported to the event-driven agent API.

**Pipeline:** 7-phase workflow orchestrated in `src/core/workflows/threatModel.ts`:
- Phase 0: Application Context Discovery — understands *what the app is* (identity, features, trust boundaries, attacker profiles)
- Phase 1a: Attack Surface Recon (reuses existing whitebox workflow)
- Phase 1b: Deployment Context
- Phase 1c: Security Controls
- Phase 2: Architecture Synthesis (reads JSON from earlier phases)
- Phase 3: Attack Path Synthesis (reads all data files, explicitly avoids STRIDE categories)
- Phase 4: Deterministic assembly + markdown/JSON serialization

**Integration points:**
- API: `runThreatModelAgent()` → `AgentRun<ThreatModelResult>` with all domain types exported from barrel
- TUI: `/threat-model` command (aliases: `threatmodel`, `tm`) with 6-phase progress visualization
- CLI: `pensar threat-model --cwd <path> [--model <model>]`
- Pentest: best-effort threat model generation in whitebox pentest flow — passes attack paths to each pentest agent for context-aware testing