### PR TITLE
Fix context provider architecture bugs

### DIFF
--- a/src/tui/components/footer.tsx
+++ b/src/tui/components/footer.tsx
@@ -4,12 +4,12 @@ import { ProgressBar, SpinnerDots } from "./sprites";
 import { useSession } from "../context/session";
 import { useRoute } from "../context/route";
 import { useInput } from "../context/input";
+import { useUIState } from "../context/ui-state";
 import { useEffect } from "react";
 import { useTheme } from "../theme";
 
 interface FooterProps {
   cwd?: string;
-  showExitWarning?: boolean;
 }
 
 function formatTokenCount(count: number): string {
@@ -21,11 +21,9 @@ function formatTokenCount(count: number): string {
   return count.toString();
 }
 
-export default function Footer({
-  cwd = process.cwd(),
-  showExitWarning = false,
-}: FooterProps) {
+export default function Footer({ cwd = process.cwd() }: FooterProps) {
   cwd = "~" + cwd.split(os.homedir()).pop() || "";
+  const { showExitWarning } = useUIState();
   const { colors } = useTheme();
   const { model, tokenUsage, hasExecuted, thinking, isExecuting } = useAgent();
   const session = useSession();

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -27,10 +27,27 @@ interface TokenUsage {
   totalTokens: number;
 }
 
-interface AgentContextValue {
+// --- Model Context (slow-changing) ---
+
+interface ModelContextValue {
   model: ModelInfo;
   setModel: (model: ModelInfo) => void;
   isModelUserSelected: boolean;
+}
+
+const ModelContext = createContext<ModelContextValue | null>(null);
+
+export function useModel(): ModelContextValue {
+  const context = useContext(ModelContext);
+  if (!context) {
+    throw new Error("useModel must be used within AgentProvider");
+  }
+  return context;
+}
+
+// --- Execution Context (fast-changing) ---
+
+interface ExecutionContextValue {
   tokenUsage: TokenUsage;
   addTokenUsage: (input: number, output: number) => void;
   resetTokenUsage: () => void;
@@ -41,15 +58,30 @@ interface AgentContextValue {
   setIsExecuting: (isExecuting: boolean) => void;
 }
 
-const AgentContext = createContext<AgentContextValue | null>(null);
+const ExecutionContext = createContext<ExecutionContextValue | null>(null);
 
-export function useAgent() {
-  const context = useContext(AgentContext);
+export function useExecution(): ExecutionContextValue {
+  const context = useContext(ExecutionContext);
   if (!context) {
-    throw new Error("useAgent must be used within AgentProvider");
+    throw new Error("useExecution must be used within AgentProvider");
   }
   return context;
 }
+
+// --- Combined hook for backwards compatibility ---
+
+type AgentContextValue = ModelContextValue & ExecutionContextValue;
+
+export function useAgent(): AgentContextValue {
+  const modelCtx = useModel();
+  const executionCtx = useExecution();
+  return useMemo(
+    () => ({ ...modelCtx, ...executionCtx }),
+    [modelCtx, executionCtx],
+  );
+}
+
+// --- Provider ---
 
 interface AgentProviderProps {
   children: ReactNode;
@@ -134,11 +166,17 @@ export function AgentProvider({ children }: AgentProviderProps) {
     setTokenUsage({ inputTokens: 0, outputTokens: 0, totalTokens: 0 });
   }, []);
 
-  const contextValue = useMemo(
+  const modelValue = useMemo(
     () => ({
       model,
       setModel,
       isModelUserSelected,
+    }),
+    [model, setModel, isModelUserSelected],
+  );
+
+  const executionValue = useMemo(
+    () => ({
       tokenUsage,
       addTokenUsage,
       resetTokenUsage,
@@ -149,21 +187,20 @@ export function AgentProvider({ children }: AgentProviderProps) {
       setIsExecuting,
     }),
     [
-      model,
-      setModel,
-      isModelUserSelected,
       tokenUsage,
+      addTokenUsage,
+      resetTokenUsage,
       hasExecuted,
       thinking,
       isExecuting,
-      addTokenUsage,
-      resetTokenUsage,
     ],
   );
 
   return (
-    <AgentContext.Provider value={contextValue}>
-      {children}
-    </AgentContext.Provider>
+    <ModelContext.Provider value={modelValue}>
+      <ExecutionContext.Provider value={executionValue}>
+        {children}
+      </ExecutionContext.Provider>
+    </ModelContext.Provider>
   );
 }

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -41,7 +41,7 @@ export function CommandProvider({ children }: CommandProviderProps) {
     return ctx;
   }, [route]);
 
-  // Create router with context - initialized once
+  // Create router with context - rebuilt when ctx changes
   const router = useMemo(() => {
     const router = new CommandRouter<AppCommandContext>();
 
@@ -51,7 +51,7 @@ export function CommandProvider({ children }: CommandProviderProps) {
     }
 
     return router;
-  }, []);
+  }, [ctx]);
 
   // Generate autocomplete options from router commands
   const autocompleteOptions = useMemo((): AutocompleteOption[] => {

--- a/src/tui/context/dialog.tsx
+++ b/src/tui/context/dialog.tsx
@@ -8,6 +8,7 @@ import {
   useContext,
   useState,
   useCallback,
+  useMemo,
   useRef,
   type ReactNode,
 } from "react";
@@ -100,47 +101,57 @@ export function DialogProvider({ children }: { children: ReactNode }) {
   }, [renderer]);
 
   const clear = useCallback(() => {
-    for (const item of stack) {
-      if (item.onClose) item.onClose();
-    }
+    setStack((prev) => {
+      for (const item of prev) {
+        if (item.onClose) item.onClose();
+      }
+      return [];
+    });
     setSize("medium");
-    setStack([]);
     refocus();
-  }, [stack, refocus]);
+  }, [refocus]);
 
   const replace = useCallback(
     (element: ReactNode, onClose?: () => void) => {
-      if (stack.length === 0) {
-        focusRef.current = renderer.currentFocusedRenderable;
-      }
-      for (const item of stack) {
-        if (item.onClose) item.onClose();
-      }
+      setStack((prev) => {
+        if (prev.length === 0) {
+          focusRef.current = renderer.currentFocusedRenderable;
+        }
+        for (const item of prev) {
+          if (item.onClose) item.onClose();
+        }
+        return [{ element, onClose }];
+      });
       setSize("medium");
-      setStack([{ element, onClose }]);
     },
-    [stack, renderer],
+    [renderer],
   );
 
   useKeyboard((evt) => {
-    if (evt.name === "escape" && stack.length > 0) {
-      const current = stack[stack.length - 1];
-      current?.onClose?.();
-      setStack(stack.slice(0, -1));
-      evt.preventDefault();
-      refocus();
+    if (evt.name === "escape") {
+      setStack((prev) => {
+        if (prev.length === 0) return prev;
+        const current = prev[prev.length - 1];
+        current?.onClose?.();
+        evt.preventDefault();
+        refocus();
+        return prev.slice(0, -1);
+      });
     }
   });
 
-  const value: DialogContextValue = {
-    clear,
-    replace,
-    stack,
-    size,
-    setSize,
-    externalDialogOpen,
-    setExternalDialogOpen,
-  };
+  const value: DialogContextValue = useMemo(
+    () => ({
+      clear,
+      replace,
+      stack,
+      size,
+      setSize,
+      externalDialogOpen,
+      setExternalDialogOpen,
+    }),
+    [clear, replace, stack, size, externalDialogOpen],
+  );
 
   return (
     <DialogContext.Provider value={value}>

--- a/src/tui/context/keybinding.tsx
+++ b/src/tui/context/keybinding.tsx
@@ -2,14 +2,13 @@ import type { KeyEvent } from "@opentui/core";
 import { useKeyboard } from "@opentui/react";
 import { createContext, useContext, type ReactNode } from "react";
 import {
-  createKeybindings,
+  useKeybindings,
   Keybind,
-  type KeybindingDependencies,
   type KeybindingEntry,
+  type UseKeybindingsOptions,
 } from "../keybindings";
 import { useInput } from "./input";
 import { useFocus } from "./focus";
-import { useDialog } from "./dialog";
 
 export type { KeybindingEntry };
 
@@ -17,31 +16,21 @@ interface KeybindingContextType {
   registry: KeybindingEntry[];
 }
 
-type ContextDeps = Omit<
-  KeybindingDependencies,
-  "refocusPrompt" | "setExternalDialogOpen"
->;
-
 const KeybindingContext = createContext<KeybindingContextType | undefined>(
   undefined,
 );
 
 export function KeybindingProvider({
   children,
-  deps,
+  options,
 }: {
   children: ReactNode;
-  deps: ContextDeps;
+  options?: UseKeybindingsOptions;
 }) {
-  const { promptRef, refocusPrompt } = useFocus();
+  const { promptRef } = useFocus();
   const { isInputEmpty } = useInput();
-  const { setExternalDialogOpen } = useDialog();
 
-  const registry = createKeybindings({
-    ...deps,
-    refocusPrompt,
-    setExternalDialogOpen,
-  });
+  const registry = useKeybindings(options);
 
   useKeyboard((key: KeyEvent) => {
     const pressedKey = Keybind.fromParsedKey(key);

--- a/src/tui/context/ui-state.tsx
+++ b/src/tui/context/ui-state.tsx
@@ -1,0 +1,92 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  useCallback,
+  type ReactNode,
+} from "react";
+
+interface UIStateContextValue {
+  focusIndex: number;
+  setFocusIndex: (fn: (prev: number) => number) => void;
+  ctrlCPressTime: number | null;
+  setCtrlCPressTime: (time: number | null) => void;
+  showExitWarning: boolean;
+  setShowExitWarning: (show: boolean) => void;
+  inputKey: number;
+  setInputKey: (fn: (prev: number) => number) => void;
+  showSessionsDialog: boolean;
+  setShowSessionsDialog: (show: boolean) => void;
+  showShortcutsDialog: boolean;
+  setShowShortcutsDialog: (show: boolean) => void;
+  navigableItems: string[];
+}
+
+const UIStateContext = createContext<UIStateContextValue | null>(null);
+
+export function useUIState(): UIStateContextValue {
+  const context = useContext(UIStateContext);
+  if (!context) {
+    throw new Error("useUIState must be used within UIStateProvider");
+  }
+  return context;
+}
+
+interface UIStateProviderProps {
+  children: ReactNode;
+}
+
+const NAVIGABLE_ITEMS = ["command-input"];
+
+export function UIStateProvider({ children }: UIStateProviderProps) {
+  const [focusIndex, setFocusIndex] = useState(0);
+  const [ctrlCPressTime, setCtrlCPressTime] = useState<number | null>(null);
+  const [showExitWarning, setShowExitWarning] = useState(false);
+  const [inputKey, setInputKey] = useState(0);
+  const [showSessionsDialog, setShowSessionsDialog] = useState(false);
+  const [showShortcutsDialog, setShowShortcutsDialog] = useState(false);
+
+  // Wrap setFocusIndex and setInputKey to accept updater functions
+  const wrappedSetFocusIndex = useCallback(
+    (fn: (prev: number) => number) => setFocusIndex(fn),
+    [],
+  );
+
+  const wrappedSetInputKey = useCallback(
+    (fn: (prev: number) => number) => setInputKey(fn),
+    [],
+  );
+
+  const value = useMemo(
+    () => ({
+      focusIndex,
+      setFocusIndex: wrappedSetFocusIndex,
+      ctrlCPressTime,
+      setCtrlCPressTime,
+      showExitWarning,
+      setShowExitWarning,
+      inputKey,
+      setInputKey: wrappedSetInputKey,
+      showSessionsDialog,
+      setShowSessionsDialog,
+      showShortcutsDialog,
+      setShowShortcutsDialog,
+      navigableItems: NAVIGABLE_ITEMS,
+    }),
+    [
+      focusIndex,
+      wrappedSetFocusIndex,
+      ctrlCPressTime,
+      showExitWarning,
+      inputKey,
+      wrappedSetInputKey,
+      showSessionsDialog,
+      showShortcutsDialog,
+    ],
+  );
+
+  return (
+    <UIStateContext.Provider value={value}>{children}</UIStateContext.Provider>
+  );
+}

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -1,5 +1,5 @@
 import { createRoot } from "@opentui/react";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import Footer from "./components/footer";
 import { CommandProvider } from "./context/command";
 import { AgentProvider } from "./context/agent";
@@ -30,6 +30,7 @@ import ShortcutsDialog from "./components/commands/shortcuts-dialog";
 import HelpDialog from "./components/commands/help-dialog";
 import ModelsDisplay from "./components/commands/models-display";
 import { KeybindingProvider } from "./context/keybinding";
+import { UIStateProvider, useUIState } from "./context/ui-state";
 import Pentest from "./components/pentest/pentest";
 import OperatorDashboard from "./components/operator-dashboard";
 import ThemePicker from "./components/commands/theme-picker";
@@ -42,16 +43,6 @@ interface AppProps {
 }
 
 function App({ appConfig }: AppProps) {
-  const [focusIndex, setFocusIndex] = useState(0);
-  const [cwd, setCwd] = useState(process.cwd());
-  const [ctrlCPressTime, setCtrlCPressTime] = useState<number | null>(null);
-  const [showExitWarning, setShowExitWarning] = useState(false);
-  const [inputKey, setInputKey] = useState(0);
-  const [showSessionsDialog, setShowSessionsDialog] = useState(false);
-  const [showShortcutsDialog, setShowShortcutsDialog] = useState(false);
-
-  const navigableItems = ["command-input"];
-
   return (
     <ConfigProvider config={appConfig}>
       <SessionProvider>
@@ -61,32 +52,11 @@ function App({ appConfig }: AppProps) {
               <DialogProvider>
                 <AgentProvider>
                   <CommandProvider>
-                    <KeybindingProvider
-                      deps={{
-                        ctrlCPressTime,
-                        setCtrlCPressTime,
-                        setShowExitWarning,
-                        setInputKey,
-                        setShowSessionsDialog,
-                        setShowShortcutsDialog,
-                        setFocusIndex,
-                        navigableItems,
-                      }}
-                    >
-                      <AppContent
-                        focusIndex={focusIndex}
-                        showSessionsDialog={showSessionsDialog}
-                        setShowSessionsDialog={setShowSessionsDialog}
-                        showShortcutsDialog={showShortcutsDialog}
-                        setShowShortcutsDialog={setShowShortcutsDialog}
-                        cwd={cwd}
-                        setCtrlCPressTime={setCtrlCPressTime}
-                        showExitWarning={showExitWarning}
-                        setShowExitWarning={setShowExitWarning}
-                        inputKey={inputKey}
-                        setInputKey={setInputKey}
-                      />
-                    </KeybindingProvider>
+                    <UIStateProvider>
+                      <KeybindingProvider>
+                        <AppContent />
+                      </KeybindingProvider>
+                    </UIStateProvider>
                   </CommandProvider>
                 </AgentProvider>
               </DialogProvider>
@@ -98,37 +68,25 @@ function App({ appConfig }: AppProps) {
   );
 }
 
-function AppContent({
-  focusIndex,
-  showSessionsDialog,
-  setShowSessionsDialog,
-  showShortcutsDialog,
-  setShowShortcutsDialog,
-  cwd,
-  setCtrlCPressTime,
-  showExitWarning,
-  setShowExitWarning,
-  inputKey,
-  setInputKey,
-}: {
-  focusIndex: number;
-  showSessionsDialog: boolean;
-  setShowSessionsDialog: (show: boolean) => void;
-  showShortcutsDialog: boolean;
-  setShowShortcutsDialog: (show: boolean) => void;
-  cwd: string;
-  setCtrlCPressTime: (time: number | null) => void;
-  showExitWarning: boolean;
-  setShowExitWarning: (show: boolean) => void;
-  inputKey: number;
-  setInputKey: (fn: (prev: number) => number) => void;
-}) {
+function AppContent() {
   const route = useRoute();
   const config = useConfig();
   const { colors } = useTheme();
-
   const { refocusPrompt } = useFocus();
   const { setExternalDialogOpen } = useDialog();
+  const {
+    focusIndex,
+    showSessionsDialog,
+    setShowSessionsDialog,
+    showShortcutsDialog,
+    setShowShortcutsDialog,
+    showExitWarning,
+    setShowExitWarning,
+    ctrlCPressTime: _ctrlCPressTime,
+    setCtrlCPressTime,
+    inputKey,
+    setInputKey,
+  } = useUIState();
 
   useEffect(() => {
     if (route.data.type !== "base") return;
@@ -172,9 +130,6 @@ function AppContent({
     refocusPrompt();
   };
 
-  // Check if we're on the home route
-  const isHomeRoute = route.data.type === "base" && route.data.path === "home";
-
   return (
     <box
       flexDirection="column"
@@ -187,7 +142,7 @@ function AppContent({
     >
       <CommandDisplay focusIndex={focusIndex} inputKey={inputKey} />
 
-      <Footer cwd={cwd} showExitWarning={showExitWarning} />
+      <Footer />
 
       {showSessionsDialog && (
         <SessionsDisplay onClose={handleCloseSessionsDialog} />

--- a/src/tui/keybindings/index.ts
+++ b/src/tui/keybindings/index.ts
@@ -40,8 +40,10 @@ export {
 
 export {
   createKeybindings,
+  useKeybindings,
   type KeybindingEntry,
   type KeybindingDependencies,
+  type UseKeybindingsOptions,
 } from "./registry";
 
 export namespace Keybind {

--- a/src/tui/keybindings/registry.ts
+++ b/src/tui/keybindings/registry.ts
@@ -1,7 +1,10 @@
 import { useRenderer } from "@opentui/react";
+import { useMemo } from "react";
 import { useRoute } from "../context/route";
 import { useFocus } from "../context/focus";
 import { useInput } from "../context/input";
+import { useUIState } from "../context/ui-state";
+import { useDialog } from "../context/dialog";
 
 export interface KeybindingEntry {
   combo: string;
@@ -9,6 +12,12 @@ export interface KeybindingEntry {
   fn: () => Promise<void>;
 }
 
+export interface UseKeybindingsOptions {
+  /** Optional: Toggle tools panel visibility (session context only) */
+  setShowToolsPanel?: (show: boolean) => void;
+}
+
+// Keep the old interface exported for backwards compatibility with the barrel export
 export interface KeybindingDependencies {
   refocusPrompt: () => void;
   ctrlCPressTime: number | null;
@@ -24,116 +33,141 @@ export interface KeybindingDependencies {
   setShowToolsPanel?: (show: boolean) => void;
 }
 
-export function createKeybindings(
-  deps: KeybindingDependencies,
+export function useKeybindings(
+  options?: UseKeybindingsOptions,
 ): KeybindingEntry[] {
   const {
-    refocusPrompt,
     ctrlCPressTime,
     setCtrlCPressTime,
     setShowExitWarning,
     setInputKey,
     setShowSessionsDialog,
     setShowShortcutsDialog,
-    setExternalDialogOpen,
     setFocusIndex,
     navigableItems,
-    setShowToolsPanel,
-  } = deps;
+  } = useUIState();
 
+  const { refocusPrompt } = useFocus();
+  const { setExternalDialogOpen } = useDialog();
   const route = useRoute();
   const renderer = useRenderer();
   const { promptRef } = useFocus();
-  const { inputValue, setInputValue, clearInput } = useInput();
+  const { clearInput } = useInput();
 
-  return [
-    {
-      combo: "ctrl+c",
-      description: "Exit (press twice)",
-      fn: async () => {
-        const now = Date.now();
-        const lastPress = ctrlCPressTime;
+  const setShowToolsPanel = options?.setShowToolsPanel;
 
-        if (lastPress && now - lastPress < 1000) {
-          renderer.destroy();
-          process.exit(0);
-        } else {
-          setInputKey((prev) => prev + 1);
-          setCtrlCPressTime(now);
-          setShowExitWarning(true);
-        }
-      },
-    },
-    {
-      combo: "ctrl+k",
-      description: "Toggle console",
-      fn: async () => {
-        renderer.console.toggle();
-      },
-    },
-    {
-      combo: "escape",
-      description: "Return to home",
-      fn: async () => {
-        const isHome = route.data.type === "base" && route.data.path === "home";
-        const isWeb = route.data.type === "base" && route.data.path === "web";
-        const isOperator =
-          route.data.type === "base" && route.data.path === "operator";
-        const isSession = route.data.type === "pentest";
+  return useMemo(
+    () => [
+      {
+        combo: "ctrl+c",
+        description: "Exit (press twice)",
+        fn: async () => {
+          const now = Date.now();
+          const lastPress = ctrlCPressTime;
 
-        if (!isHome && !isWeb && !isOperator && !isSession) {
-          route.navigate({
-            type: "base",
-            path: "home",
-          });
-          refocusPrompt();
-        }
+          if (lastPress && now - lastPress < 1000) {
+            renderer.destroy();
+            process.exit(0);
+          } else {
+            setInputKey((prev) => prev + 1);
+            setCtrlCPressTime(now);
+            setShowExitWarning(true);
+          }
+        },
       },
-    },
-    {
-      combo: "ctrl+s",
-      description: "Show sessions",
-      fn: async () => {
-        if (route.data.type === "base" && route.data.path === "home") {
-          setShowSessionsDialog(true);
-        }
+      {
+        combo: "ctrl+k",
+        description: "Toggle console",
+        fn: async () => {
+          renderer.console.toggle();
+        },
       },
-    },
-    {
-      combo: "?",
-      description: "Show keyboard shortcuts",
-      fn: async () => {
-        clearInput();
-        promptRef.current?.blur();
-        setExternalDialogOpen(true);
-        setShowShortcutsDialog(true);
+      {
+        combo: "escape",
+        description: "Return to home",
+        fn: async () => {
+          const isHome =
+            route.data.type === "base" && route.data.path === "home";
+          const isWeb = route.data.type === "base" && route.data.path === "web";
+          const isOperator =
+            route.data.type === "base" && route.data.path === "operator";
+          const isSession = route.data.type === "pentest";
+
+          if (!isHome && !isWeb && !isOperator && !isSession) {
+            route.navigate({
+              type: "base",
+              path: "home",
+            });
+            refocusPrompt();
+          }
+        },
       },
-    },
-    {
-      combo: "tab",
-      description: "Next focusable item",
-      fn: async () => {
-        setFocusIndex((prev) => (prev + 1) % navigableItems.length);
+      {
+        combo: "ctrl+s",
+        description: "Show sessions",
+        fn: async () => {
+          if (route.data.type === "base" && route.data.path === "home") {
+            setShowSessionsDialog(true);
+          }
+        },
       },
-    },
-    {
-      combo: "shift+tab",
-      description: "Previous focusable item",
-      fn: async () => {
-        setFocusIndex(
-          (prev) => (prev - 1 + navigableItems.length) % navigableItems.length,
-        );
+      {
+        combo: "?",
+        description: "Show keyboard shortcuts",
+        fn: async () => {
+          clearInput();
+          promptRef.current?.blur();
+          setExternalDialogOpen(true);
+          setShowShortcutsDialog(true);
+        },
       },
-    },
-    {
-      combo: "ctrl+t",
-      description: "Toggle tools panel",
-      fn: async () => {
-        // Only works in session context
-        if (route.data.type === "pentest" && setShowToolsPanel) {
-          setShowToolsPanel(true);
-        }
+      {
+        combo: "tab",
+        description: "Next focusable item",
+        fn: async () => {
+          setFocusIndex((prev) => (prev + 1) % navigableItems.length);
+        },
       },
-    },
-  ];
+      {
+        combo: "shift+tab",
+        description: "Previous focusable item",
+        fn: async () => {
+          setFocusIndex(
+            (prev) =>
+              (prev - 1 + navigableItems.length) % navigableItems.length,
+          );
+        },
+      },
+      {
+        combo: "ctrl+t",
+        description: "Toggle tools panel",
+        fn: async () => {
+          // Only works in session context
+          if (route.data.type === "pentest" && setShowToolsPanel) {
+            setShowToolsPanel(true);
+          }
+        },
+      },
+    ],
+    [
+      ctrlCPressTime,
+      setCtrlCPressTime,
+      setShowExitWarning,
+      setInputKey,
+      setShowSessionsDialog,
+      setShowShortcutsDialog,
+      setFocusIndex,
+      navigableItems,
+      refocusPrompt,
+      setExternalDialogOpen,
+      route,
+      renderer,
+      promptRef,
+      clearInput,
+      setShowToolsPanel,
+    ],
+  );
 }
+
+// Keep the old createKeybindings export name for the barrel re-export
+export const createKeybindings = useKeybindings;


### PR DESCRIPTION
Fixes 2 bugs and 2 architecture issues in the TUI context providers. Closes #201.

**DialogProvider** was creating a new context value object on every render, cascading re-renders to all `useDialog()` consumers. Wrapped in `useMemo` and converted `clear`/`replace` to functional state updates so their references stay stable.

**CommandProvider** had an empty deps array on the router `useMemo`, so `registerWithContext` permanently captured the initial route context. Added `ctx` to deps.

**AgentContext** bundled fast-changing execution state (`tokenUsage`, `thinking`) with slow-changing model state. During pentests, every streaming token update re-rendered every component that only needed the model. Split into `ModelContext` + `ExecutionContext` with a backwards-compatible `useAgent()` that combines both.

**KeybindingProvider** received 8 pieces of `App`-local state as a `deps` prop, bypassing React context. Moved that state into a new `UIStateContext` and removed the prop bag entirely. The keybinding registry is now memoized instead of rebuilt on every render.