### PR TITLE
Fix broken CLI by including src/core/installation in published package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,9 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: Smoke test published package
+        run: |
+          npm pack
+          npm install -g ./pensar-apex-*.tgz
+          pensar --version

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "files": [
     "build",
     "bin",
+    "src/core/installation",
     "pensar.svg",
     "LICENSE"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensar/apex",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
   "main": "build/index.js",


### PR DESCRIPTION
`bin/pensar.js` imports from `../src/core/installation/index.ts`, but the `files` array in `package.json` didn't include `src/`, so the published tarball was missing it. Every command failed with "Cannot find module" on v0.0.70.

Added `src/core/installation` to `files` and a CI smoke test that packs the tarball and runs `pensar --version` from it, so this can't regress.

Fixes #210

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: packaging/CI-only changes, but they affect what gets published and will fail builds if `npm pack` output or install behavior changes.
> 
> **Overview**
> Fixes a broken published CLI by **including `src/core/installation` in the npm package** via the `files` allowlist in `package.json`, and bumps the version to `0.0.71`.
> 
> Adds a CI step in `.github/workflows/build.yml` to **smoke test the actual packed tarball** (`npm pack` → global install → `pensar --version`) to prevent future publish regressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0ca9e3988267b55a48c39f251056a7e7cbbfcbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->