### PR TITLE
Pentest agent: use response tool instead of stopWhen document_finding

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -93,7 +93,6 @@ Severity is determined based on:
 
 Local-only code execution within internal developer tooling does not automatically equate to production remote code execution. Severity classifications reflect the actual deployment context and user exposure of affected components.
 
-
 ## Acknowledgment
 
 We appreciate responsible security research. Valid, in-scope reports will be acknowledged in accordance with this policy. We follow a consistent, process-driven approach to disclosure and do not provide additional recognition beyond our standard acknowledgment process.

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -1,6 +1,6 @@
-import { hasToolCall } from "ai";
 import { existsSync, readdirSync, readFileSync } from "fs";
 import { join } from "path";
+import { z } from "zod";
 import type { Finding, SpecializedAgentInput } from "../../offSecAgent/types";
 import { OffensiveSecurityAgent } from "../../offSecAgent/offensiveSecurityAgent";
 import type { UnifiedSandbox } from "../../offSecAgent/tools/sandbox";
@@ -29,6 +29,28 @@ export interface PentestResult {
   /** Absolute path to the session's POC scripts directory */
   pocsPath: string;
 }
+
+// ---------------------------------------------------------------------------
+// Response schema — the agent calls "response" when done testing
+// ---------------------------------------------------------------------------
+
+const PentestResponseSchema = z.object({
+  summary: z
+    .string()
+    .describe("Brief summary of testing performed and results"),
+  findingsDocumented: z
+    .number()
+    .describe("Number of findings documented via document_finding"),
+  objectivesCovered: z
+    .array(z.string())
+    .describe("Which objectives were tested"),
+  noFindingsReason: z
+    .string()
+    .optional()
+    .describe(
+      "If no findings were documented, explain why (e.g., target not vulnerable, endpoint unreachable)",
+    ),
+});
 
 // ---------------------------------------------------------------------------
 // PentestAgent
@@ -89,9 +111,10 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
         "http_request",
         "document_finding",
         "create_poc",
+        "response",
       ],
 
-      stopWhen: hasToolCall("document_finding"),
+      responseSchema: PentestResponseSchema,
 
       resolveResult: () => ({
         findings: loadFindings(session.findingsPath),
@@ -111,19 +134,23 @@ const PENTEST_SYSTEM_PROMPT = `You are an expert penetration tester performing a
 You are given a specific target and specific objectives. Do NOT perform broad reconnaissance or service/endpoint discovery — that has already been done for you. Your job is to deeply test the provided target against the provided objectives.
 
 Your methodology:
-1. VERIFY — Confirm the target endpoint exists and is reachable. Understand its basic behavior (response format, parameters, auth requirements).
-2. PREPARE — Research applicable payloads and attack techniques for the given objectives. Craft payloads tailored to the target's technology and behavior.
-3. TEST — Execute targeted attacks methodically, one payload/technique at a time. Observe responses carefully for indicators of vulnerability.
-4. EXPLOIT — When a vulnerability is confirmed, create a proof-of-concept script that reliably demonstrates it.
-5. DOCUMENT — Document every confirmed finding with evidence, impact assessment, and remediation steps.
+1. PLAN — Begin by stating the objectives you have been given and outlining your testing plan. For each objective, describe which attack techniques, payloads, and tools you intend to use. Output this plan as text before making any tool calls.
+2. VERIFY — Confirm the target endpoint exists and is reachable. Understand its basic behavior (response format, parameters, auth requirements).
+3. PREPARE — Research applicable payloads and attack techniques for the given objectives. Craft payloads tailored to the target's technology and behavior.
+4. TEST — Execute targeted attacks methodically, one payload/technique at a time. Observe responses carefully for indicators of vulnerability.
+5. EXPLOIT — When a vulnerability is confirmed, create a proof-of-concept script that reliably demonstrates it.
+6. DOCUMENT — Document every confirmed finding with evidence, impact assessment, and remediation steps.
+7. FINISH — After testing ALL objectives, call the response tool to submit your final summary. You may document multiple findings before finishing.
 
 Guidelines:
+- Always start by stating your objectives and plan before executing any tools
 - Stay focused on the provided objectives — do not scan for other services or enumerate additional endpoints
 - Be methodical and thorough — test one payload at a time and observe the response
 - Use execute_command for crafting/running exploit scripts and http_request for targeted web tests
 - Always create POC scripts to confirm vulnerabilities before documenting
-- Document every confirmed finding with document_finding
+- Document every confirmed finding with document_finding — you can document multiple findings in a single run
 - Include clear remediation steps in every finding
+- When you have finished testing ALL objectives, call the response tool with a summary of your results. Do NOT call response until you have completed all testing.
 
 Authentication:
 - If the prompt includes an "Existing Authentication Session" section, USE those cookies/headers on every request. Do NOT attempt to re-authenticate.
@@ -193,11 +220,13 @@ ${authSection}
 ${objectiveList}
 
 ## Instructions
-1. Verify the target endpoint is reachable and understand its baseline behavior
-2. For each objective, research and craft targeted payloads appropriate to the technology
-3. Test systematically — vary payloads, encoding, and bypass techniques
-4. Create POC scripts to reliably demonstrate any confirmed vulnerabilities
-5. Document every confirmed finding with evidence and remediation steps
+1. State the objectives and outline your testing plan — describe which techniques and payloads you will use for each objective before executing any tools
+2. Verify the target endpoint is reachable and understand its baseline behavior
+3. For each objective, research and craft targeted payloads appropriate to the technology
+4. Test systematically — vary payloads, encoding, and bypass techniques
+5. Create POC scripts to reliably demonstrate any confirmed vulnerabilities
+6. Document every confirmed finding with evidence and remediation steps
+7. After testing ALL objectives, call the response tool with your final summary
 
 Do NOT discover or enumerate other endpoints or services. Focus exclusively on the target and objectives above.`;
 }


### PR DESCRIPTION
## Summary

- **Replace `stopWhen: hasToolCall("document_finding")` with a structured `response` tool** — the agent previously stopped after documenting its first finding, meaning it could never report multiple vulnerabilities in a single run. Now it uses the base class's `responseSchema` pattern to signal completion explicitly.
- **Add a PLAN phase to the pentest agent methodology** — the agent now begins each run by stating its objectives and outlining a testing plan (techniques, payloads, tools per objective) as text before making any tool calls, improving transparency and traceability.
- **Define `PentestResponseSchema`** — lightweight Zod schema (`summary`, `findingsDocumented`, `objectivesCovered`, `noFindingsReason`) that the agent fills out when done. The `resolveResult` still loads findings from disk as the source of truth.

## Test plan

- [ ] Run a pentest against a target with multiple known vulnerabilities — verify the agent documents all of them before calling `response`
- [ ] Run a pentest against a hardened target — verify the agent calls `response` with a `noFindingsReason` instead of hanging
- [ ] Verify the agent outputs a testing plan as text before its first tool call
- [ ] TypeScript typechecks cleanly (`tsc --noEmit` passes)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pentest agent termination semantics from stopping on first `document_finding` to requiring an explicit `response` call, which could affect run completion/hanging and overall runtime. Scope is limited to the pentest agent plus a minor `SECURITY.md` formatting tweak.
> 
> **Overview**
> Updates the pentest specialized agent to **stop via an explicit structured `response` tool** instead of `stopWhen: hasToolCall("document_finding")`, enabling multiple findings to be documented in a single run.
> 
> Adds a Zod `PentestResponseSchema` and updates the pentest prompts to include a *PLAN* phase (plan before any tool calls) and a *FINISH* phase (call `response` only after all objectives are tested). Also removes a stray formatting artifact in `SECURITY.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01ac9c571668bab0f67cb31f60bed7720cca38f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->