### PR TITLE
feat: add Claude Opus 4.6 model across all providers

### DIFF
--- a/src/core/ai/models/anthropic.ts
+++ b/src/core/ai/models/anthropic.ts
@@ -13,6 +13,12 @@ export const ANTHROPIC_MODELS: ModelInfo[] = [
     contextLength: 200000,
   },
   {
+    id: "claude-opus-4-6",
+    name: "Claude Opus 4.6",
+    provider: "anthropic",
+    contextLength: 200000,
+  },
+  {
     id: "claude-opus-4-5",
     name: "Claude Opus 4.5",
     provider: "anthropic",

--- a/src/core/ai/models/bedrock.ts
+++ b/src/core/ai/models/bedrock.ts
@@ -117,6 +117,12 @@ export const BEDROCK_MODELS: ModelInfo[] = [
     provider: "bedrock",
     contextLength: 200000,
   },
+  {
+    id: "anthropic.claude-opus-4-6-v1:0",
+    name: "Claude Opus 4.6 (Bedrock)",
+    provider: "bedrock",
+    contextLength: 200000,
+  },
 
   // Cohere Models
   {
@@ -339,6 +345,12 @@ export const BEDROCK_MODELS: ModelInfo[] = [
     provider: "bedrock",
     contextLength: 200000,
   },
+  {
+    id: "us.anthropic.claude-opus-4-6-v1:0",
+    name: "Claude Opus 4.6 (US)",
+    provider: "bedrock",
+    contextLength: 200000,
+  },
 
   // US Region - Meta Llama Models
   {
@@ -422,6 +434,12 @@ export const BEDROCK_MODELS: ModelInfo[] = [
   {
     id: "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
     name: "Claude Sonnet 4.5 (Global)",
+    provider: "bedrock",
+    contextLength: 200000,
+  },
+  {
+    id: "global.anthropic.claude-opus-4-6-v1:0",
+    name: "Claude Opus 4.6 (Global)",
     provider: "bedrock",
     contextLength: 200000,
   },

--- a/src/core/ai/models/openrouter.ts
+++ b/src/core/ai/models/openrouter.ts
@@ -26,6 +26,12 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
     contextLength: 200000,
   },
   {
+    id: "anthropic/claude-opus-4.6",
+    name: "Claude Opus 4.6 (OpenRouter)",
+    provider: "openrouter",
+    contextLength: 200000,
+  },
+  {
     id: "anthropic/claude-opus-4.5",
     name: "Claude Opus 4.5 (OpenRouter)",
     provider: "openrouter",


### PR DESCRIPTION
Add Opus 4.6 to Anthropic, Bedrock (base, US, global), and OpenRouter model lists so it appears in the TUI model picker.

Made-with: Cursor

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a data-only change that adds new model IDs/names to static model registries without altering request/response logic.
> 
> **Overview**
> Adds **Claude Opus 4.6** to the selectable model lists for `anthropic`, `bedrock`, and `openrouter`.
> 
> For Bedrock, the model is added for the base catalog plus `us.` and `global.` region-prefixed IDs so it appears in pickers across regions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d3478d5d8b3cf7b90346734e4a1b72e83ab2929. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->