### PR TITLE
Command output session storage

### DIFF
--- a/src/core/agents/offSecAgent/tools/createPoc.ts
+++ b/src/core/agents/offSecAgent/tools/createPoc.ts
@@ -10,6 +10,7 @@ import {
   mkdirSync,
 } from "fs";
 import type { ToolContext } from "./types";
+import { persistPocOutput } from "./outputPersistence";
 
 const MAX_POC_ATTEMPTS = 3;
 
@@ -44,6 +45,8 @@ export type CreatePocResult = {
   exitCode?: number;
   error?: string;
   attemptsRemaining?: number;
+  /** Path to persisted POC execution output file */
+  outputPath?: string;
 };
 
 export function createPoc(ctx: ToolContext) {
@@ -127,6 +130,16 @@ async function executeLocalPoc(
       ctx.abortSignal,
     );
 
+    // Always persist POC execution output for evidence
+    const persisted = persistPocOutput(
+      ctx.session,
+      filename,
+      stdout || "(no output)",
+      stderr || "",
+      exitCode,
+      poc.description,
+    );
+
     if (exitCode !== 0) {
       try {
         unlinkSync(pocPath);
@@ -142,6 +155,7 @@ async function executeLocalPoc(
       stderr,
       exitCode,
       attemptsRemaining: MAX_POC_ATTEMPTS - currentAttempts,
+      outputPath: persisted.relativePath,
       error:
         exitCode !== 0
           ? `POC exited with code ${exitCode}. ${MAX_POC_ATTEMPTS - currentAttempts} attempts remaining.`
@@ -207,6 +221,21 @@ async function executeSandboxPoc(
     );
 
     const executionSuccess = result.success || result.exitCode === 0;
+    const rawStdout = result.stdout || "(no output)";
+    const rawStderr = executionSuccess
+      ? result.stderr || "(no errors)"
+      : (result.stderr || "POC execution failed") +
+        "\n\nPOC file has been deleted.";
+
+    // Always persist POC execution output for evidence
+    const persisted = persistPocOutput(
+      ctx.session,
+      filename,
+      rawStdout,
+      result.stderr || "",
+      result.exitCode ?? 1,
+      poc.description,
+    );
 
     if (!executionSuccess) {
       await ctx.sandbox!.execute(`rm -f ${sandboxPocPath}`);
@@ -220,13 +249,11 @@ async function executeSandboxPoc(
     return {
       success: executionSuccess,
       pocPath: executionSuccess ? `pocs/${filename}` : undefined,
-      stdout: result.stdout || "(no output)",
-      stderr: executionSuccess
-        ? result.stderr || "(no errors)"
-        : (result.stderr || "POC execution failed") +
-          "\n\nPOC file has been deleted.",
+      stdout: rawStdout,
+      stderr: rawStderr,
       exitCode: result.exitCode,
       attemptsRemaining: MAX_POC_ATTEMPTS - currentAttempts,
+      outputPath: persisted.relativePath,
       error: !executionSuccess
         ? `POC exited with code ${result.exitCode}. ${MAX_POC_ATTEMPTS - currentAttempts} attempts remaining.`
         : undefined,

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -2,6 +2,11 @@ import { tool } from "ai";
 import { z } from "zod";
 import { spawn } from "child_process";
 import type { ToolContext } from "./types";
+import {
+  persistCommandOutput,
+  shouldPersistOutput,
+  OUTPUT_SIZE_THRESHOLD,
+} from "./outputPersistence";
 
 export const executeCommandInputSchema = z.object({
   command: z.string().describe("The shell command to execute"),
@@ -24,6 +29,8 @@ export type ExecuteCommandResult = {
   stdout: string;
   stderr: string;
   command: string;
+  /** Path to persisted output file when output exceeds threshold */
+  outputPath?: string;
 };
 
 export function executeCommand(ctx: ToolContext) {
@@ -76,14 +83,34 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
           const result = await ctx.sandbox.execute(command, {
             timeout: ssmTimeout,
           });
+
+          const rawStdout = result.stdout || "(no output)";
+          const rawStderr = result.stderr || "";
+
+          // Persist large outputs to file and return path
+          if (shouldPersistOutput(rawStdout, rawStderr)) {
+            const persisted = persistCommandOutput(
+              ctx.session,
+              command,
+              rawStdout,
+              rawStderr,
+              result.success ? 0 : 1,
+            );
+            return {
+              success: result.success,
+              error: !result.success ? rawStderr || "Command failed" : "",
+              stdout: `Output saved to: ${persisted.relativePath}\n\nPreview (first ${OUTPUT_SIZE_THRESHOLD} chars):\n${rawStdout.substring(0, OUTPUT_SIZE_THRESHOLD)}...`,
+              stderr: rawStderr.length > 1000 ? rawStderr.substring(0, 1000) + "..." : rawStderr,
+              command,
+              outputPath: persisted.relativePath,
+            };
+          }
+
           return {
             success: result.success,
-            error: !result.success ? result.stderr || "Command failed" : "",
-            stdout:
-              result.stdout.length > 50000
-                ? `${result.stdout.substring(0, 50000)}...\n\n(truncated) call the command again with grep / tail to paginate`
-                : result.stdout || "(no output)",
-            stderr: result.stderr || "",
+            error: !result.success ? rawStderr || "Command failed" : "",
+            stdout: rawStdout,
+            stderr: rawStderr,
             command,
           };
         } catch (error: unknown) {
@@ -121,6 +148,44 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
           }
         };
 
+        // Helper to resolve with output persistence logic
+        const resolveWithPersistence = (
+          success: boolean,
+          rawStdout: string,
+          rawStderr: string,
+          error: string,
+          exitCode?: number,
+        ) => {
+          const finalStdout = rawStdout || "(no output)";
+          const finalStderr = rawStderr || "";
+
+          if (shouldPersistOutput(finalStdout, finalStderr)) {
+            const persisted = persistCommandOutput(
+              ctx.session,
+              command,
+              finalStdout,
+              finalStderr,
+              exitCode,
+            );
+            safeResolve({
+              success,
+              stdout: `Output saved to: ${persisted.relativePath}\n\nPreview (first ${OUTPUT_SIZE_THRESHOLD} chars):\n${finalStdout.substring(0, OUTPUT_SIZE_THRESHOLD)}...`,
+              stderr: finalStderr.length > 1000 ? finalStderr.substring(0, 1000) + "..." : finalStderr,
+              command,
+              error,
+              outputPath: persisted.relativePath,
+            });
+          } else {
+            safeResolve({
+              success,
+              stdout: finalStdout,
+              stderr: finalStderr,
+              command,
+              error,
+            });
+          }
+        };
+
         const killProcess = () => {
           if (killed) return;
           killed = true;
@@ -150,16 +215,13 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
               // Process may have already exited
             }
 
-            safeResolve({
-              success: false,
-              stdout:
-                stdout.length > 50000
-                  ? `${stdout.substring(0, 50000)}...\n\n(truncated)`
-                  : stdout || "(no output)",
-              stderr: stderr || "",
-              command,
-              error: "Command killed (did not exit after SIGTERM)",
-            });
+            resolveWithPersistence(
+              false,
+              stdout,
+              stderr,
+              "Command killed (did not exit after SIGTERM)",
+              1,
+            );
           }, 5000);
         };
 
@@ -175,31 +237,22 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
 
         child.on("close", (code) => {
           clearTimeout(timeoutTimer);
-          safeResolve({
-            success: code === 0 && !killed,
-            stdout:
-              stdout.length > 50000
-                ? `${stdout.substring(0, 50000)}...\n\n(truncated) call the command again with grep / tail to paginate`
-                : stdout || "(no output)",
-            stderr: stderr || "",
-            command,
-            error: killed
+          resolveWithPersistence(
+            code === 0 && !killed,
+            stdout,
+            stderr,
+            killed
               ? "Command timed out"
               : code !== 0
                 ? `Exit code: ${code}`
                 : "",
-          });
+            code ?? 1,
+          );
         });
 
         child.on("error", (err) => {
           clearTimeout(timeoutTimer);
-          safeResolve({
-            success: false,
-            error: err.message,
-            stdout,
-            stderr,
-            command,
-          });
+          resolveWithPersistence(false, stdout, stderr, err.message, 1);
         });
 
         // Wire up abort signal

--- a/src/core/agents/offSecAgent/tools/outputPersistence.ts
+++ b/src/core/agents/offSecAgent/tools/outputPersistence.ts
@@ -1,0 +1,210 @@
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import type { SessionInfo } from "../../../session";
+
+/**
+ * Threshold in characters above which command output is persisted to file
+ * and a file path is returned instead of inline output.
+ */
+export const OUTPUT_SIZE_THRESHOLD = 10000;
+
+/**
+ * Result of persisting output to a file
+ */
+export interface PersistedOutput {
+  /** Absolute path to the output file */
+  filePath: string;
+  /** Relative path from session root for display */
+  relativePath: string;
+}
+
+/**
+ * Generate a unique filename for command output
+ */
+function generateOutputFilename(command: string, suffix?: string): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const sanitizedCmd = command
+    .split(/\s+/)[0]
+    .replace(/[^a-zA-Z0-9_-]/g, "_")
+    .substring(0, 30);
+  const suffixPart = suffix ? `_${suffix}` : "";
+  return `${timestamp}_${sanitizedCmd}${suffixPart}.txt`;
+}
+
+/**
+ * Persist command output to the terminals directory.
+ * Creates the directory if it doesn't exist.
+ *
+ * @param session - The session containing the terminalsPath
+ * @param command - The command that was executed (used for filename)
+ * @param stdout - Standard output from the command
+ * @param stderr - Standard error from the command
+ * @param exitCode - Exit code of the command (optional)
+ * @returns The persisted output info with file paths
+ */
+export function persistCommandOutput(
+  session: SessionInfo,
+  command: string,
+  stdout: string,
+  stderr: string,
+  exitCode?: number,
+): PersistedOutput {
+  const terminalsPath = session.terminalsPath;
+
+  if (!existsSync(terminalsPath)) {
+    mkdirSync(terminalsPath, { recursive: true });
+  }
+
+  const filename = generateOutputFilename(command);
+  const filePath = join(terminalsPath, filename);
+
+  const content = formatOutputContent(command, stdout, stderr, exitCode);
+  writeFileSync(filePath, content);
+
+  return {
+    filePath,
+    relativePath: `terminals/${filename}`,
+  };
+}
+
+/**
+ * Persist POC execution output to a file alongside the POC.
+ * The output file is named similarly to the POC with a .output.txt suffix.
+ *
+ * @param session - The session containing paths
+ * @param pocFilename - The POC filename (e.g., poc_my_script.sh)
+ * @param stdout - Standard output from POC execution
+ * @param stderr - Standard error from POC execution
+ * @param exitCode - Exit code of the POC
+ * @param description - Description of what the POC does
+ * @returns The persisted output info with file paths
+ */
+export function persistPocOutput(
+  session: SessionInfo,
+  pocFilename: string,
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  description?: string,
+): PersistedOutput {
+  const terminalsPath = session.terminalsPath;
+
+  if (!existsSync(terminalsPath)) {
+    mkdirSync(terminalsPath, { recursive: true });
+  }
+
+  const baseName = pocFilename.replace(/\.[^.]+$/, "");
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `${baseName}_${timestamp}.output.txt`;
+  const filePath = join(terminalsPath, filename);
+
+  const content = formatPocOutputContent(
+    pocFilename,
+    stdout,
+    stderr,
+    exitCode,
+    description,
+  );
+  writeFileSync(filePath, content);
+
+  return {
+    filePath,
+    relativePath: `terminals/${filename}`,
+  };
+}
+
+/**
+ * Format command output content for persistence
+ */
+function formatOutputContent(
+  command: string,
+  stdout: string,
+  stderr: string,
+  exitCode?: number,
+): string {
+  const lines: string[] = [
+    "=" .repeat(80),
+    "COMMAND EXECUTION OUTPUT",
+    "=" .repeat(80),
+    "",
+    `Timestamp: ${new Date().toISOString()}`,
+    `Command: ${command}`,
+  ];
+
+  if (exitCode !== undefined) {
+    lines.push(`Exit Code: ${exitCode}`);
+  }
+
+  lines.push("");
+  lines.push("-".repeat(80));
+  lines.push("STDOUT:");
+  lines.push("-".repeat(80));
+  lines.push(stdout || "(no output)");
+  lines.push("");
+
+  if (stderr) {
+    lines.push("-".repeat(80));
+    lines.push("STDERR:");
+    lines.push("-".repeat(80));
+    lines.push(stderr);
+    lines.push("");
+  }
+
+  lines.push("=".repeat(80));
+
+  return lines.join("\n");
+}
+
+/**
+ * Format POC output content for persistence
+ */
+function formatPocOutputContent(
+  pocFilename: string,
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  description?: string,
+): string {
+  const lines: string[] = [
+    "=".repeat(80),
+    "POC EXECUTION OUTPUT",
+    "=".repeat(80),
+    "",
+    `Timestamp: ${new Date().toISOString()}`,
+    `POC File: ${pocFilename}`,
+    `Exit Code: ${exitCode}`,
+    `Success: ${exitCode === 0 ? "Yes" : "No"}`,
+  ];
+
+  if (description) {
+    lines.push(`Description: ${description}`);
+  }
+
+  lines.push("");
+  lines.push("-".repeat(80));
+  lines.push("STDOUT:");
+  lines.push("-".repeat(80));
+  lines.push(stdout || "(no output)");
+  lines.push("");
+
+  if (stderr) {
+    lines.push("-".repeat(80));
+    lines.push("STDERR:");
+    lines.push("-".repeat(80));
+    lines.push(stderr);
+    lines.push("");
+  }
+
+  lines.push("=".repeat(80));
+
+  return lines.join("\n");
+}
+
+/**
+ * Check if output should be persisted based on size threshold.
+ * Returns true if the combined output exceeds the threshold.
+ */
+export function shouldPersistOutput(stdout: string, stderr: string): boolean {
+  const totalLength = (stdout?.length || 0) + (stderr?.length || 0);
+  return totalLength > OUTPUT_SIZE_THRESHOLD;
+}

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -180,6 +180,8 @@ export interface ExecutionSession {
   logsPath: string;
   /** Path for proof-of-concept scripts (~/.pensar/executions/{id}/pocs) */
   pocsPath: string;
+  /** Path for terminal/command output logs (~/.pensar/executions/{id}/terminals) */
+  terminalsPath: string;
   /** Target URL or system being tested */
   target: string;
   /** Testing objective description */
@@ -251,6 +253,7 @@ export async function createExecution(
   await Storage.createDir(["executions", session.id, "scratchpad"]);
   await Storage.createDir(["executions", session.id, "logs"]);
   await Storage.createDir(["executions", session.id, "pocs"]);
+  await Storage.createDir(["executions", session.id, "terminals"]);
 
   const startTime = new Date().toISOString();
 
@@ -278,6 +281,7 @@ function generateSessionReadme(session: SessionInfo): string {
 - \`scratchpad/\` - Notes and temporary data during testing
 - \`logs/\` - Execution logs and command outputs
 - \`pocs/\` - Proof-of-concept exploit scripts
+- \`terminals/\` - Command and POC execution output logs
 - \`session.json\` - Session metadata
 
 ## Findings
@@ -354,6 +358,8 @@ export const SessionInfoObject = z.object({
   findingsPath: z.string(),
   scratchpadPath: z.string(),
   pocsPath: z.string(),
+  /** Path for terminal/command output logs (~/.pensar/executions/{id}/terminals) */
+  terminalsPath: z.string(),
 });
 
 export type SessionInfo = z.output<typeof SessionInfoObject> & {
@@ -383,6 +389,7 @@ export async function create(input: CreateInputProps) {
   const scratchpadPath = path.join(rootPath, "scratchpad");
   const logsPath = path.join(rootPath, "logs");
   const pocsPath = path.join(rootPath, "pocs");
+  const terminalsPath = path.join(rootPath, "terminals");
 
   const rateLimiter = new RateLimiter({
     requestsPerSecond: input.config?.requestsPerSecond,
@@ -429,6 +436,7 @@ export async function create(input: CreateInputProps) {
     pocsPath,
     scratchpadPath,
     findingsPath,
+    terminalsPath,
   };
 
   console.info("created session", result);


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<p><a href="https://cursor.com/agents/bc-79b87d03-cfb0-4fce-8059-b60a2e18c70a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79b87d03-cfb0-4fce-8059-b60a2e18c70a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes execution-tool outputs and session metadata by persisting results to disk and returning file paths, which could impact downstream consumers and increase disk usage. Risk is moderate due to new persisted artifacts and altered stdout/stderr truncation behavior.
> 
> **Overview**
> Adds a new per-session `terminals/` artifact directory (`terminalsPath`) and ensures it is created during session setup and documented in the session README.
> 
> Introduces `outputPersistence.ts` and updates `executeCommand` to persist *large* stdout/stderr to `terminals/` (returning an `outputPath` plus a short preview) instead of inline truncation.
> 
> Updates `createPoc` to always persist POC execution output to `terminals/` for evidence and returns the persisted `outputPath` alongside the normal execution result.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58d000f0ff7348a191b2e995380c4f676faebfdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->