### PR TITLE
Pensar upgrade command release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,31 @@ jobs:
             artifacts/pensar-linux-x64/pensar-linux-x64.tar.gz
             artifacts/pensar-windows-x64/pensar-windows-x64.zip
           generate_release_notes: true
+          body: |
+            ## Upgrade
+
+            If you already have Pensar installed, upgrade to the latest version:
+            ```bash
+            pensar upgrade
+            ```
+
+            ## Fresh Install
+
+            **macOS / Linux (Quick Install)**
+            ```bash
+            curl -fsSL https://pensarai.com/install.sh | bash
+            ```
+
+            **Homebrew**
+            ```bash
+            brew tap pensarai/tap
+            brew install apex
+            ```
+
+            **npm**
+            ```bash
+            npm install -g @pensar/apex
+            ```
 
   npm:
     needs: release


### PR DESCRIPTION
### What does this PR do?

This PR updates the GitHub Release workflow (`.github/workflows/release.yml`) to include a custom body in the release notes. The custom body prominently features the `pensar upgrade` command for existing users and provides fresh installation instructions (curl, Homebrew, npm) for new users. The `generate_release_notes: true` flag is preserved, ensuring GitHub's auto-generated changelog from merged PRs is still appended.

### How did you verify your code works?

The following checks were performed:
*   `bun run lint` - Passed
*   `bun run tsc` - Passed
*   `bun run test` - Passed (147 passed, 15 skipped)

No manual testing was required as this change only affects the CI workflow YAML and has no impact on UI or runtime code.

---
<p><a href="https://cursor.com/agents/bc-af4ff447-a5d6-4188-aabe-1f26eb48a91a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af4ff447-a5d6-4188-aabe-1f26eb48a91a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that affects GitHub Release text, with no impact on build artifacts or runtime code paths.
> 
> **Overview**
> Adds a custom `body` to the GitHub Release step in `.github/workflows/release.yml`, highlighting `pensar upgrade` for existing users and including fresh install instructions (curl script, Homebrew, npm).
> 
> Keeps `generate_release_notes: true` so GitHub’s auto-generated release notes are still produced alongside the custom text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40cb59490d06aa7675f874d1c4c6076d2340a074. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->