### PR TITLE
Sandbox playwright support

### DIFF
--- a/scripts/test-sandbox-playwright.ts
+++ b/scripts/test-sandbox-playwright.ts
@@ -1,0 +1,381 @@
+/**
+ * Live integration test for sandbox Playwright browser tools.
+ *
+ * Uses the Daytona REST API directly (not the SDK) to create a sandbox,
+ * wraps it as a UnifiedSandbox, then exercises the full sandbox Playwright
+ * lifecycle:
+ *   1. Check / install Playwright
+ *   2. Launch Chromium via CDP
+ *   3. Run browser tools (navigate, snapshot, click, evaluate, cookies, screenshot)
+ *
+ * Usage:
+ *   DAYTONA_API_KEY=<key> bun run scripts/test-sandbox-playwright.ts
+ */
+
+import type {
+  UnifiedSandbox,
+  SandboxExecuteOptions,
+  SandboxExecutionResult,
+} from "../src/core/agents/offSecAgent/tools/sandbox";
+import {
+  checkSandboxPlaywright,
+  installSandboxPlaywright,
+  ensureSandboxPlaywright,
+  ensureSandboxBrowser,
+  createSandboxBrowserTools,
+} from "../src/core/agents/offSecAgent/tools/sandboxPlaywright";
+import type { ToolContext } from "../src/core/agents/offSecAgent/tools/types";
+import { mkdirSync } from "fs";
+import { join } from "path";
+
+// ---------------------------------------------------------------------------
+// Daytona REST API helpers
+// ---------------------------------------------------------------------------
+
+const API_BASE = "https://app.daytona.io/api";
+const API_KEY = process.env.DAYTONA_API_KEY!;
+
+const headers = {
+  Authorization: `Bearer ${API_KEY}`,
+  "Content-Type": "application/json",
+};
+
+interface DaytonaSandboxInfo {
+  id: string;
+  state: string;
+  toolboxProxyUrl?: string;
+}
+
+async function createDaytonaSandbox(): Promise<DaytonaSandboxInfo> {
+  const res = await fetch(`${API_BASE}/sandbox`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      image: "daytona/node:20-slim",
+      resources: { cpu: 2, memory: 4, disk: 10 },
+      public: true,
+      autoStopInterval: 0,
+    }),
+  });
+  if (!res.ok) throw new Error(`Create sandbox failed: ${res.status} ${await res.text()}`);
+  return (await res.json()) as DaytonaSandboxInfo;
+}
+
+async function waitForSandboxReady(id: string, timeoutMs = 60000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const res = await fetch(`${API_BASE}/sandbox/${id}`, { headers });
+    if (res.ok) {
+      const info = (await res.json()) as DaytonaSandboxInfo;
+      if (info.state === "started") return;
+      if (info.state === "error") throw new Error(`Sandbox in error state`);
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error(`Sandbox not ready within ${timeoutMs}ms`);
+}
+
+const TOOLBOX_PROXY = "https://proxy.app.daytona.io/toolbox";
+
+async function execInSandbox(
+  id: string,
+  command: string,
+  timeout?: number,
+): Promise<{ exitCode: number; result: string }> {
+  const res = await fetch(`${TOOLBOX_PROXY}/${id}/process/execute`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ command, timeout }),
+    signal: timeout ? AbortSignal.timeout((timeout + 30) * 1000) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Exec failed: ${res.status} ${text}`);
+  }
+  return (await res.json()) as { exitCode: number; result: string };
+}
+
+async function deleteSandbox(id: string): Promise<void> {
+  await fetch(`${API_BASE}/sandbox/${id}`, { method: "DELETE", headers });
+}
+
+// ---------------------------------------------------------------------------
+// UnifiedSandbox wrapper
+// ---------------------------------------------------------------------------
+
+function makeSandbox(id: string): UnifiedSandbox {
+  return {
+    type: "linux",
+    async execute(
+      command: string,
+      opts?: SandboxExecuteOptions,
+    ): Promise<SandboxExecutionResult> {
+      try {
+        // Daytona toolbox API doesn't run commands in a shell by default.
+        // Base64-encode the entire command and pipe through bash to avoid
+        // all quoting / escaping issues with nested quotes. We need bash
+        // to handle the pipes, so wrap in bash -c (base64 is pipe-safe).
+        const b64 = Buffer.from(command).toString("base64");
+        const wrapped = `bash -c "echo ${b64} | base64 -d | bash"`;
+        const result = await execInSandbox(id, wrapped, opts?.timeout);
+        return {
+          stdout: result.result ?? "",
+          stderr: "",
+          exitCode: result.exitCode ?? 0,
+          success: result.exitCode === 0,
+        };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        return { stdout: "", stderr: msg, exitCode: 1, success: false };
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+let passCount = 0;
+let failCount = 0;
+
+function log(label: string, msg: string) {
+  console.log(`[${label}] ${msg}`);
+}
+
+function pass(name: string) {
+  passCount++;
+  console.log(`  ✅ ${name}`);
+}
+
+function fail(name: string, err: unknown) {
+  failCount++;
+  console.error(
+    `  ❌ ${name}: ${err instanceof Error ? err.message : String(err)}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  if (!API_KEY) {
+    console.error("DAYTONA_API_KEY is required");
+    process.exit(1);
+  }
+
+  let sandboxId: string | undefined;
+
+  try {
+    // ---- Create sandbox ----------------------------------------------------
+    log("setup", "Creating Daytona sandbox...");
+    const info = await createDaytonaSandbox();
+    sandboxId = info.id;
+    log("setup", `Sandbox created: ${sandboxId} (state: ${info.state})`);
+
+    if (info.state !== "started") {
+      log("setup", "Waiting for sandbox to start...");
+      await waitForSandboxReady(sandboxId);
+    }
+    pass("Sandbox is ready");
+
+    const sandbox = makeSandbox(sandboxId);
+
+    // Verify base environment
+    const nodeCheck = await sandbox.execute("node --version");
+    log("setup", `Node.js: ${nodeCheck.stdout.trim()}`);
+    pass(`Node.js available: ${nodeCheck.stdout.trim()}`);
+
+    // ---- Step 1: Check Playwright (should be false) ------------------------
+    log("test", "Step 1: checkSandboxPlaywright (expect false)");
+    const before = await checkSandboxPlaywright(sandbox);
+    if (!before) {
+      pass("Playwright not yet installed (expected)");
+    } else {
+      fail("check should be false before install", "got true");
+    }
+
+    // ---- Step 2: Install Playwright ----------------------------------------
+    log("test", "Step 2: installSandboxPlaywright (may take 1-3 min)...");
+    const t0 = Date.now();
+    await installSandboxPlaywright(sandbox);
+    pass(`Playwright installed in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+
+    // ---- Step 3: Check again (should be true) ------------------------------
+    log("test", "Step 3: checkSandboxPlaywright (expect true)");
+
+    // Debug: check what's in the sandbox
+    const debugLs = await sandbox.execute("ls /tmp/sandbox-playwright/node_modules/ 2>&1");
+    log("debug", `node_modules: ${debugLs.stdout.trim()}`);
+    const debugCheck = await sandbox.execute("cd /tmp/sandbox-playwright && echo 'console.log(\"PW_OK\")' > /tmp/dbg.js && node /tmp/dbg.js 2>&1");
+    log("debug", `simple script: ${debugCheck.stdout.trim()} (exit: ${debugCheck.exitCode})`);
+    const debugReq = await sandbox.execute("cd /tmp/sandbox-playwright && echo 'try{require(\"playwright\");console.log(\"PW_OK\")}catch(e){console.log(\"FAIL:\"+e.message)}' > /tmp/dbg2.js && node /tmp/dbg2.js 2>&1");
+    log("debug", `require test: ${debugReq.stdout.trim()} (exit: ${debugReq.exitCode})`);
+
+    const after = await checkSandboxPlaywright(sandbox);
+    if (after) {
+      pass("Playwright verified installed");
+    } else {
+      fail("check should be true after install", "got false");
+    }
+
+    // ---- Step 4: Launch browser --------------------------------------------
+    log("test", "Step 4: ensureSandboxBrowser (launch Chromium)...");
+    const t1 = Date.now();
+    await ensureSandboxBrowser(sandbox);
+    pass(`Chromium launched in ${((Date.now() - t1) / 1000).toFixed(1)}s`);
+
+    // Verify CDP
+    const cdpCheck = await sandbox.execute(
+      "curl -sf http://127.0.0.1:9222/json/version",
+    );
+    if (cdpCheck.success) {
+      pass("Chromium CDP endpoint responding");
+    } else {
+      fail("CDP check", cdpCheck.stderr);
+    }
+
+    // ---- Step 5: Test browser tools ----------------------------------------
+    log("test", "Step 5: Testing browser tools end-to-end");
+
+    const testDir = join(process.cwd(), ".pensar", "test-sandbox-pw");
+    mkdirSync(join(testDir, "evidence"), { recursive: true });
+    mkdirSync(join(testDir, "logs"), { recursive: true });
+    mkdirSync(join(testDir, "pocs"), { recursive: true });
+    mkdirSync(join(testDir, "findings"), { recursive: true });
+    mkdirSync(join(testDir, "scratchpad"), { recursive: true });
+
+    const ctx: ToolContext = {
+      session: {
+        id: "test-sandbox-pw",
+        version: "0.0.1",
+        targets: ["example.com"],
+        name: "Test Sandbox PW",
+        time: { created: Date.now(), updated: Date.now() },
+        config: {
+          mode: "auto" as const,
+          offensiveHeaders: { mode: "default" as const, headers: {} },
+          outcomeGuidance: "test",
+        },
+        rootPath: testDir,
+        logsPath: join(testDir, "logs"),
+        pocsPath: join(testDir, "pocs"),
+        scratchpadPath: join(testDir, "scratchpad"),
+        findingsPath: join(testDir, "findings"),
+      } as ToolContext["session"],
+      target: "https://example.com",
+      sandbox,
+    };
+
+    const tools = createSandboxBrowserTools(ctx);
+    const callOpts = { toolCallId: "t", messages: [] as never[], abortSignal: undefined as never };
+
+    // 5a: browser_navigate
+    log("tool", "browser_navigate → https://example.com");
+    const nav = (await tools.browser_navigate.execute!(
+      { url: "https://example.com", toolCallDescription: "test" },
+      callOpts,
+    )) as { success: boolean; url?: string; title?: string; error?: string };
+    if (nav.success) {
+      pass(`navigate: url=${nav.url}, title="${nav.title}"`);
+    } else {
+      fail("navigate", nav.error);
+    }
+
+    // 5b: browser_evaluate
+    log("tool", "browser_evaluate → document.title");
+    const evalR = (await tools.browser_evaluate.execute!(
+      { script: "document.title", toolCallDescription: "test" },
+      callOpts,
+    )) as { success: boolean; result?: unknown; error?: string };
+    if (evalR.success) {
+      pass(`evaluate: title = "${evalR.result}"`);
+    } else {
+      fail("evaluate", evalR.error);
+    }
+
+    // 5c: browser_snapshot
+    log("tool", "browser_snapshot");
+    const snap = (await tools.browser_snapshot.execute!(
+      { toolCallDescription: "test" },
+      callOpts,
+    )) as { success: boolean; snapshot?: string; error?: string };
+    if (snap.success && snap.snapshot) {
+      console.log("  snapshot (first 400 chars):\n" + snap.snapshot.substring(0, 400));
+      pass(`snapshot: ${snap.snapshot.length} chars`);
+    } else {
+      fail("snapshot", snap.error);
+    }
+
+    // 5d: browser_get_cookies
+    log("tool", "browser_get_cookies");
+    const cookies = (await tools.browser_get_cookies.execute!(
+      { toolCallDescription: "test" },
+      callOpts,
+    )) as { success: boolean; cookies?: unknown[]; error?: string };
+    if (cookies.success) {
+      pass(`cookies: ${cookies.cookies?.length ?? 0} cookie(s)`);
+    } else {
+      fail("cookies", cookies.error);
+    }
+
+    // 5e: browser_screenshot
+    log("tool", "browser_screenshot");
+    const ss = (await tools.browser_screenshot.execute!(
+      { filename: "test_example_com", toolCallDescription: "test" },
+      callOpts,
+    )) as { success: boolean; path?: string; error?: string };
+    if (ss.success) {
+      pass(`screenshot: ${ss.path}`);
+    } else {
+      fail("screenshot", ss.error);
+    }
+
+    // 5f: browser_console
+    log("tool", "browser_console");
+    const cons = (await tools.browser_console.execute!(
+      { toolCallDescription: "test" },
+      callOpts,
+    )) as { success: boolean; messages?: unknown[]; error?: string };
+    if (cons.success) {
+      pass(`console: ${cons.messages?.length ?? 0} message(s)`);
+    } else {
+      fail("console", cons.error);
+    }
+
+    // ---- Summary -----------------------------------------------------------
+    console.log("\n" + "=".repeat(60));
+    console.log(`Results: ${passCount} passed, ${failCount} failed`);
+    if (failCount === 0) {
+      console.log("🎉 All tests passed!");
+    } else {
+      console.log("⚠️  Some tests failed.");
+    }
+    console.log("=".repeat(60));
+  } catch (error) {
+    console.error(
+      "\n❌ Fatal error:",
+      error instanceof Error ? error.message : String(error),
+    );
+    if (error instanceof Error && error.stack) {
+      console.error(error.stack);
+    }
+    process.exitCode = 1;
+  } finally {
+    if (sandboxId) {
+      log("cleanup", "Deleting sandbox...");
+      try {
+        await deleteSandbox(sandboxId);
+        log("cleanup", "Sandbox deleted.");
+      } catch (err) {
+        console.error(
+          "Cleanup failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+  }
+}
+
+main();

--- a/scripts/test-sandbox-playwright.ts
+++ b/scripts/test-sandbox-playwright.ts
@@ -57,11 +57,15 @@ async function createDaytonaSandbox(): Promise<DaytonaSandboxInfo> {
       autoStopInterval: 0,
     }),
   });
-  if (!res.ok) throw new Error(`Create sandbox failed: ${res.status} ${await res.text()}`);
+  if (!res.ok)
+    throw new Error(`Create sandbox failed: ${res.status} ${await res.text()}`);
   return (await res.json()) as DaytonaSandboxInfo;
 }
 
-async function waitForSandboxReady(id: string, timeoutMs = 60000): Promise<void> {
+async function waitForSandboxReady(
+  id: string,
+  timeoutMs = 60000,
+): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     const res = await fetch(`${API_BASE}/sandbox/${id}`, { headers });
@@ -206,12 +210,24 @@ async function main() {
     log("test", "Step 3: checkSandboxPlaywright (expect true)");
 
     // Debug: check what's in the sandbox
-    const debugLs = await sandbox.execute("ls /tmp/sandbox-playwright/node_modules/ 2>&1");
+    const debugLs = await sandbox.execute(
+      "ls /tmp/sandbox-playwright/node_modules/ 2>&1",
+    );
     log("debug", `node_modules: ${debugLs.stdout.trim()}`);
-    const debugCheck = await sandbox.execute("cd /tmp/sandbox-playwright && echo 'console.log(\"PW_OK\")' > /tmp/dbg.js && node /tmp/dbg.js 2>&1");
-    log("debug", `simple script: ${debugCheck.stdout.trim()} (exit: ${debugCheck.exitCode})`);
-    const debugReq = await sandbox.execute("cd /tmp/sandbox-playwright && echo 'try{require(\"playwright\");console.log(\"PW_OK\")}catch(e){console.log(\"FAIL:\"+e.message)}' > /tmp/dbg2.js && node /tmp/dbg2.js 2>&1");
-    log("debug", `require test: ${debugReq.stdout.trim()} (exit: ${debugReq.exitCode})`);
+    const debugCheck = await sandbox.execute(
+      "cd /tmp/sandbox-playwright && echo 'console.log(\"PW_OK\")' > /tmp/dbg.js && node /tmp/dbg.js 2>&1",
+    );
+    log(
+      "debug",
+      `simple script: ${debugCheck.stdout.trim()} (exit: ${debugCheck.exitCode})`,
+    );
+    const debugReq = await sandbox.execute(
+      'cd /tmp/sandbox-playwright && echo \'try{require("playwright");console.log("PW_OK")}catch(e){console.log("FAIL:"+e.message)}\' > /tmp/dbg2.js && node /tmp/dbg2.js 2>&1',
+    );
+    log(
+      "debug",
+      `require test: ${debugReq.stdout.trim()} (exit: ${debugReq.exitCode})`,
+    );
 
     const after = await checkSandboxPlaywright(sandbox);
     if (after) {
@@ -269,7 +285,11 @@ async function main() {
     };
 
     const tools = createSandboxBrowserTools(ctx);
-    const callOpts = { toolCallId: "t", messages: [] as never[], abortSignal: undefined as never };
+    const callOpts = {
+      toolCallId: "t",
+      messages: [] as never[],
+      abortSignal: undefined as never,
+    };
 
     // 5a: browser_navigate
     log("tool", "browser_navigate → https://example.com");
@@ -302,7 +322,9 @@ async function main() {
       callOpts,
     )) as { success: boolean; snapshot?: string; error?: string };
     if (snap.success && snap.snapshot) {
-      console.log("  snapshot (first 400 chars):\n" + snap.snapshot.substring(0, 400));
+      console.log(
+        "  snapshot (first 400 chars):\n" + snap.snapshot.substring(0, 400),
+      );
       pass(`snapshot: ${snap.snapshot.length} chars`);
     } else {
       fail("snapshot", snap.error);

--- a/src/core/agents/offSecAgent/tools/browserTools.ts
+++ b/src/core/agents/offSecAgent/tools/browserTools.ts
@@ -21,6 +21,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import { join } from "path";
 import { createBrowserTools } from "./playwrightMcp";
+import { createSandboxBrowserTools } from "./sandboxPlaywright";
 import type { ToolContext } from "./types";
 
 /**
@@ -42,23 +43,27 @@ export type BrowserToolName = (typeof BROWSER_TOOL_NAMES)[number];
 /**
  * Create the full set of browser automation tools from a {@link ToolContext}.
  *
- * Uses `"operator"` mode by default for the most general-purpose descriptions.
+ * When `ctx.sandbox` is set, browser tools run inside the sandbox via direct
+ * Playwright execution (no MCP). Playwright and Chromium are installed
+ * on-demand in the sandbox on the first browser tool call.
+ *
+ * Otherwise, uses `"operator"` mode with the local Playwright MCP server.
  * The evidence directory is derived from `session.rootPath + "/evidence"`.
  *
  * When `ctx.credentialManager` is set, `browser_fill` is replaced with a
  * credential-aware wrapper that resolves secrets from IDs at execution time.
  */
 export function createBrowserToolset(ctx: ToolContext) {
-  const evidenceDir = join(ctx.session.rootPath, "evidence");
-  const targetUrl = ctx.target ?? "";
-
-  const tools = createBrowserTools(
-    targetUrl,
-    evidenceDir,
-    "operator",
-    undefined,
-    ctx.abortSignal,
-  );
+  // Sandbox mode: use direct Playwright execution inside the sandbox
+  const tools = ctx.sandbox
+    ? createSandboxBrowserTools(ctx)
+    : createBrowserTools(
+        ctx.target ?? "",
+        join(ctx.session.rootPath, "evidence"),
+        "operator",
+        undefined,
+        ctx.abortSignal,
+      );
 
   if (!ctx.credentialManager) {
     return tools;

--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -10,6 +10,14 @@ export {
 export { createBrowserToolset, BROWSER_TOOL_NAMES } from "./browserTools";
 export type { BrowserToolName } from "./browserTools";
 
+// Sandbox Playwright helpers (check / install Playwright in a sandbox)
+export {
+  checkSandboxPlaywright,
+  installSandboxPlaywright,
+  ensureSandboxPlaywright,
+  ensureSandboxBrowser,
+} from "./sandboxPlaywright";
+
 // Core pentest tools
 export { executeCommand } from "./executeCommand";
 export { httpRequest } from "./httpRequest";

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -41,6 +41,7 @@ const SANDBOX_PW_DIR = "/opt/sandbox-playwright";
 const SANDBOX_EVIDENCE_DIR = "/tmp/evidence";
 const SANDBOX_REFS_FILE = "/tmp/pw-refs.json";
 const SANDBOX_URL_FILE = "/tmp/pw-current-url";
+const SANDBOX_CONSOLE_FILE = "/tmp/pw-console-log.json";
 
 /** Marker pair used to extract JSON results from script stdout. */
 const RESULT_START = "__PW_RESULT__";
@@ -245,6 +246,7 @@ const fs = require('fs');
   }
 
   let context;
+  const __consoleMessages = [];
   try {
     context = await chromium.launchPersistentContext('/tmp/pw-user-data', {
       headless: true,
@@ -253,6 +255,10 @@ const fs = require('fs');
     });
     const pages = context.pages();
     const page = pages.length > 0 ? pages[pages.length - 1] : await context.newPage();
+
+    page.on('console', msg => {
+      __consoleMessages.push({ type: msg.type(), text: msg.text() });
+    });
 
     // Restore the last-visited URL so page state persists across tool calls.
     if (page.url() === 'about:blank') {
@@ -267,6 +273,16 @@ const fs = require('fs');
   } catch (error) {
     resolve({ success: false, error: error.message || String(error) });
   } finally {
+    if (__consoleMessages.length > 0) {
+      try {
+        const fs = require('fs');
+        let existing = [];
+        try { existing = JSON.parse(fs.readFileSync('${SANDBOX_CONSOLE_FILE}', 'utf-8')); } catch {}
+        existing.push(...__consoleMessages);
+        if (existing.length > 200) existing = existing.slice(-200);
+        fs.writeFileSync('${SANDBOX_CONSOLE_FILE}', JSON.stringify(existing));
+      } catch {}
+    }
     if (context) {
       try { await context.close(); } catch {}
     }
@@ -439,20 +455,6 @@ Target base URL: ${targetUrl}`,
     require('fs').writeFileSync('${SANDBOX_URL_FILE}', page.url());
     const title = await page.title();
 
-    // Inject console interceptor for later retrieval
-    await page.evaluate(() => {
-      if (!window.__pw_console) {
-        window.__pw_console = [];
-        for (const m of ['log', 'warn', 'error', 'info', 'debug']) {
-          const orig = console[m];
-          console[m] = function(...args) {
-            window.__pw_console.push({ type: m, text: args.map(String).join(' ') });
-            orig.apply(console, args);
-          };
-        }
-      }
-    });
-
     resolve({ success: true, url: page.url(), title });
           `,
           60,
@@ -550,9 +552,45 @@ Example workflow:
     // Playwright versions and doesn't depend on the deprecated
     // page.accessibility.snapshot() API.
     const treeData = await page.evaluate(() => {
+      function tagToAriaRole(el) {
+        const tag = el.tagName.toLowerCase();
+        switch (tag) {
+          case 'a': return el.hasAttribute('href') ? 'link' : 'generic';
+          case 'button': return 'button';
+          case 'input': {
+            const t = (el.getAttribute('type') || 'text').toLowerCase();
+            if (t === 'button' || t === 'submit' || t === 'reset' || t === 'image') return 'button';
+            if (t === 'checkbox') return 'checkbox';
+            if (t === 'radio') return 'radio';
+            if (t === 'range') return 'slider';
+            if (t === 'number') return 'spinbutton';
+            if (t === 'search') return 'searchbox';
+            return 'textbox';
+          }
+          case 'select': return el.hasAttribute('multiple') ? 'listbox' : 'combobox';
+          case 'textarea': return 'textbox';
+          case 'img': return 'img';
+          case 'h1': case 'h2': case 'h3': case 'h4': case 'h5': case 'h6': return 'heading';
+          case 'table': return 'table';
+          case 'form': return 'form';
+          case 'nav': return 'navigation';
+          case 'main': return 'main';
+          case 'header': return 'banner';
+          case 'footer': return 'contentinfo';
+          case 'aside': return 'complementary';
+          case 'article': return 'article';
+          case 'ul': case 'ol': return 'list';
+          case 'li': return 'listitem';
+          case 'dialog': return 'dialog';
+          case 'progress': return 'progressbar';
+          case 'option': return 'option';
+          case 'fieldset': return 'group';
+          case 'output': return 'status';
+          default: return tag;
+        }
+      }
       function walk(el, depth) {
-        const role = el.getAttribute('role')
-          || el.tagName.toLowerCase();
+        const role = el.getAttribute('role') || tagToAriaRole(el);
         const name = el.getAttribute('aria-label')
           || el.getAttribute('name')
           || el.getAttribute('placeholder')
@@ -629,13 +667,23 @@ IMPORTANT: For reliable clicking, first call browser_snapshot to get element ref
     const ref = ${JSON.stringify(ref || "")};
     const element = ${JSON.stringify(element)};
 
+    const TAG_TO_ROLE = {
+      a:'link',input:'textbox',select:'combobox',textarea:'textbox',
+      img:'img',h1:'heading',h2:'heading',h3:'heading',h4:'heading',
+      h5:'heading',h6:'heading',nav:'navigation',main:'main',
+      header:'banner',footer:'contentinfo',aside:'complementary',
+      article:'article',ul:'list',ol:'list',li:'listitem',
+      dialog:'dialog',progress:'progressbar',option:'option',
+      fieldset:'group',output:'status',button:'button',form:'form',table:'table'
+    };
+
     if (ref) {
-      // Use stored ref mapping for precise targeting
       try {
         const refData = JSON.parse(require('fs').readFileSync(${JSON.stringify(SANDBOX_REFS_FILE)}, 'utf-8'));
         const info = refData[ref];
         if (info && info.role && info.name) {
-          await page.getByRole(info.role, { name: info.name }).first().click({ timeout: 10000 });
+          const role = TAG_TO_ROLE[info.role] || info.role;
+          await page.getByRole(role, { name: info.name }).first().click({ timeout: 10000 });
           resolve({ success: true, element, result: 'Clicked via ref ' + ref });
           return;
         }
@@ -698,12 +746,23 @@ IMPORTANT: For reliable form filling, first call browser_snapshot to get element
     const element = ${JSON.stringify(element)};
     const value = ${JSON.stringify(value)};
 
+    const TAG_TO_ROLE = {
+      a:'link',input:'textbox',select:'combobox',textarea:'textbox',
+      img:'img',h1:'heading',h2:'heading',h3:'heading',h4:'heading',
+      h5:'heading',h6:'heading',nav:'navigation',main:'main',
+      header:'banner',footer:'contentinfo',aside:'complementary',
+      article:'article',ul:'list',ol:'list',li:'listitem',
+      dialog:'dialog',progress:'progressbar',option:'option',
+      fieldset:'group',output:'status',button:'button',form:'form',table:'table'
+    };
+
     if (ref) {
       try {
         const refData = JSON.parse(require('fs').readFileSync(${JSON.stringify(SANDBOX_REFS_FILE)}, 'utf-8'));
         const info = refData[ref];
         if (info && info.role && info.name) {
-          await page.getByRole(info.role, { name: info.name }).first().fill(value, { timeout: 10000 });
+          const role = TAG_TO_ROLE[info.role] || info.role;
+          await page.getByRole(role, { name: info.name }).first().fill(value, { timeout: 10000 });
           resolve({ success: true, element, result: 'Filled via ref ' + ref });
           return;
         }
@@ -806,8 +865,13 @@ Use this to check for:
         const result = (await runPlaywrightScript(
           sandbox,
           `
-    const messages = await page.evaluate(() => window.__pw_console || []);
-    resolve({ success: true, messages, result: messages });
+    const fs = require('fs');
+    let persisted = [];
+    try { persisted = JSON.parse(fs.readFileSync('${SANDBOX_CONSOLE_FILE}', 'utf-8')); } catch {}
+    const allMessages = [...persisted, ...__consoleMessages];
+    try { fs.writeFileSync('${SANDBOX_CONSOLE_FILE}', '[]'); } catch {}
+    __consoleMessages.length = 0;
+    resolve({ success: true, messages: allMessages, result: allMessages });
           `,
           15,
         )) as BrowserConsoleResult;

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -92,9 +92,7 @@ export async function installSandboxPlaywright(
 ): Promise<void> {
   await sandbox.execute(`mkdir -p ${SANDBOX_PW_DIR}`, { timeout: 10 });
 
-  const isAlpine = (
-    await sandbox.execute("which apk", { timeout: 5 })
-  ).success;
+  const isAlpine = (await sandbox.execute("which apk", { timeout: 5 })).success;
 
   const initResult = await sandbox.execute(
     `cd ${SANDBOX_PW_DIR} && npm init -y --silent 2>/dev/null`,

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -37,7 +37,7 @@ import type {
 // Constants
 // ---------------------------------------------------------------------------
 
-const SANDBOX_PW_DIR = "/tmp/sandbox-playwright";
+const SANDBOX_PW_DIR = "/opt/sandbox-playwright";
 const SANDBOX_EVIDENCE_DIR = "/tmp/evidence";
 const SANDBOX_REFS_FILE = "/tmp/pw-refs.json";
 const SANDBOX_URL_FILE = "/tmp/pw-current-url";
@@ -79,12 +79,22 @@ export async function checkSandboxPlaywright(
 /**
  * Install Playwright and the Chromium browser inside the sandbox.
  *
- * Requires `node` and `npm` (or compatible) to be available in the sandbox.
+ * When Playwright + Chromium have already been baked into the Daytona image
+ * snapshot (via `createSandbox({ installPlaywright: true })`), this function
+ * is never called because {@link checkSandboxPlaywright} will return `true`
+ * and {@link ensureSandboxPlaywright} will skip it.
+ *
+ * As a fallback this handles both Alpine (system Chromium via `apk`) and
+ * Debian (Playwright's own installer).
  */
 export async function installSandboxPlaywright(
   sandbox: UnifiedSandbox,
 ): Promise<void> {
   await sandbox.execute(`mkdir -p ${SANDBOX_PW_DIR}`, { timeout: 10 });
+
+  const isAlpine = (
+    await sandbox.execute("which apk", { timeout: 5 })
+  ).success;
 
   const initResult = await sandbox.execute(
     `cd ${SANDBOX_PW_DIR} && npm init -y --silent 2>/dev/null`,
@@ -96,40 +106,53 @@ export async function installSandboxPlaywright(
     );
   }
 
-  const installResult = await sandbox.execute(
-    `cd ${SANDBOX_PW_DIR} && npm install playwright 2>&1`,
-    { timeout: 300 },
-  );
+  // On Alpine, skip Playwright's bundled browser download — we install
+  // system Chromium via apk instead.
+  const npmInstallCmd = isAlpine
+    ? `cd ${SANDBOX_PW_DIR} && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install playwright 2>&1`
+    : `cd ${SANDBOX_PW_DIR} && npm install playwright 2>&1`;
+
+  const installResult = await sandbox.execute(npmInstallCmd, { timeout: 300 });
   if (!installResult.success) {
     throw new Error(
       `Failed to install Playwright in sandbox: ${installResult.stderr || installResult.stdout}`,
     );
   }
 
-  // Remove broken Yarn apt repo (common on Daytona node images) before
-  // installing Chromium system deps, otherwise apt-get update fails.
-  await sandbox.execute(
-    `(sudo rm -f /etc/apt/sources.list.d/yarn.list /etc/apt/sources.list.d/yarn.sources 2>/dev/null || rm -f /etc/apt/sources.list.d/yarn.list /etc/apt/sources.list.d/yarn.sources 2>/dev/null || true)`,
-    { timeout: 10 },
-  );
-
-  // Install Chromium + system deps. Retry up to 3 times because browser
-  // binary downloads can hit transient network errors (ECONNRESET, etc.).
-  let browserResult;
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    browserResult = await sandbox.execute(
-      `cd ${SANDBOX_PW_DIR} && npx playwright install chromium --with-deps 2>&1`,
-      { timeout: 300 },
+  if (isAlpine) {
+    const apkResult = await sandbox.execute(
+      "apk add --no-cache chromium nss freetype harfbuzz ca-certificates ttf-freefont 2>&1",
+      { timeout: 120 },
     );
-    if (browserResult.success) break;
-    if (attempt < 3) {
-      await new Promise((r) => setTimeout(r, 3000));
+    if (!apkResult.success) {
+      throw new Error(
+        `Failed to install Chromium via apk: ${apkResult.stderr || apkResult.stdout}`,
+      );
     }
-  }
-  if (!browserResult!.success) {
-    throw new Error(
-      `Failed to install Chromium in sandbox: ${browserResult!.stderr || browserResult!.stdout}`,
+  } else {
+    // Debian/Ubuntu: use Playwright's own installer.
+    // Remove broken Yarn apt repo before installing system deps.
+    await sandbox.execute(
+      `(sudo rm -f /etc/apt/sources.list.d/yarn.list /etc/apt/sources.list.d/yarn.sources 2>/dev/null || rm -f /etc/apt/sources.list.d/yarn.list /etc/apt/sources.list.d/yarn.sources 2>/dev/null || true)`,
+      { timeout: 10 },
     );
+
+    let browserResult;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      browserResult = await sandbox.execute(
+        `cd ${SANDBOX_PW_DIR} && npx playwright install chromium --with-deps 2>&1`,
+        { timeout: 300 },
+      );
+      if (browserResult.success) break;
+      if (attempt < 3) {
+        await new Promise((r) => setTimeout(r, 3000));
+      }
+    }
+    if (!browserResult!.success) {
+      throw new Error(
+        `Failed to install Chromium in sandbox: ${browserResult!.stderr || browserResult!.stdout}`,
+      );
+    }
   }
 }
 
@@ -210,23 +233,30 @@ async function runPlaywrightScript(
 ): Promise<unknown> {
   const script = `
 const { chromium } = require('playwright');
+const fs = require('fs');
 
 (async () => {
   function resolve(value) {
     process.stdout.write('${RESULT_START}' + JSON.stringify(value) + '${RESULT_END}');
   }
 
+  // Prefer system Chromium (Alpine apk install) over Playwright's bundled binary.
+  let executablePath;
+  for (const p of ['/usr/bin/chromium-browser', '/usr/bin/chromium']) {
+    try { fs.accessSync(p, fs.constants.X_OK); executablePath = p; break; } catch {}
+  }
+
   let context;
   try {
     context = await chromium.launchPersistentContext('/tmp/pw-user-data', {
       headless: true,
+      ...(executablePath ? { executablePath } : {}),
       args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--disable-gpu'],
     });
     const pages = context.pages();
     const page = pages.length > 0 ? pages[pages.length - 1] : await context.newPage();
 
     // Restore the last-visited URL so page state persists across tool calls.
-    const fs = require('fs');
     if (page.url() === 'about:blank') {
       try {
         const savedUrl = fs.readFileSync('${SANDBOX_URL_FILE}', 'utf-8').trim();

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -1,0 +1,860 @@
+/**
+ * Sandbox Playwright Browser Tools
+ *
+ * When running in a sandbox environment, browser tools use Playwright directly
+ * via {@link UnifiedSandbox.execute} instead of the local MCP server. This
+ * avoids the need for MCP plumbing in the sandbox — Playwright scripts are
+ * written to the sandbox filesystem, executed with Node.js, and results are
+ * parsed from stdout.
+ *
+ * Architecture:
+ *   1. On first browser tool call, check/install Playwright + Chromium in the sandbox.
+ *   2. Launch a persistent headless Chromium via its CLI with `--remote-debugging-port`.
+ *   3. Each tool call writes a short Node.js script that connects via CDP,
+ *      performs the action, and prints a JSON result to stdout.
+ *   4. The host parses the JSON result and returns it to the agent.
+ *
+ * Browser state (pages, cookies, localStorage) persists across tool calls
+ * because the Chromium process stays alive between connections.
+ */
+
+import { tool } from "ai";
+import { z } from "zod";
+import { join, dirname } from "path";
+import { mkdirSync, existsSync, writeFileSync } from "fs";
+import type { UnifiedSandbox } from "./sandbox";
+import type { ToolContext } from "./types";
+import type {
+  BrowserNavigateResult,
+  BrowserScreenshotResult,
+  BrowserClickResult,
+  BrowserFillResult,
+  BrowserEvaluateResult,
+  BrowserConsoleResult,
+} from "./playwrightMcp";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SANDBOX_CDP_PORT = 9222;
+const SANDBOX_PW_DIR = "/tmp/sandbox-playwright";
+const SANDBOX_EVIDENCE_DIR = "/tmp/evidence";
+const SANDBOX_REFS_FILE = "/tmp/pw-refs.json";
+
+/** Marker pair used to extract JSON results from script stdout. */
+const RESULT_START = "__PW_RESULT__";
+const RESULT_END = "__PW_END__";
+
+// ---------------------------------------------------------------------------
+// Installation check / install
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-sandbox installation promise cache. Prevents duplicate installs when
+ * multiple browser tools fire concurrently on the same sandbox.
+ */
+const installationCache = new WeakMap<UnifiedSandbox, Promise<void>>();
+
+/**
+ * Check whether the `playwright` package is importable inside the sandbox.
+ */
+export async function checkSandboxPlaywright(
+  sandbox: UnifiedSandbox,
+): Promise<boolean> {
+  const result = await sandbox.execute(
+    `cd ${SANDBOX_PW_DIR} 2>/dev/null && node -e "try { require('playwright'); console.log('OK'); } catch(e) { process.exit(1); }"`,
+    { timeout: 30 },
+  );
+  return result.success && result.stdout.includes("OK");
+}
+
+/**
+ * Install Playwright and the Chromium browser inside the sandbox.
+ *
+ * Requires `node` and `npm` (or compatible) to be available in the sandbox.
+ */
+export async function installSandboxPlaywright(
+  sandbox: UnifiedSandbox,
+): Promise<void> {
+  await sandbox.execute(`mkdir -p ${SANDBOX_PW_DIR}`, { timeout: 10 });
+
+  const initResult = await sandbox.execute(
+    `cd ${SANDBOX_PW_DIR} && npm init -y --silent 2>/dev/null`,
+    { timeout: 30 },
+  );
+  if (!initResult.success) {
+    throw new Error(
+      `Failed to init npm project in sandbox: ${initResult.stderr || initResult.stdout}`,
+    );
+  }
+
+  const installResult = await sandbox.execute(
+    `cd ${SANDBOX_PW_DIR} && npm install playwright 2>&1`,
+    { timeout: 300 },
+  );
+  if (!installResult.success) {
+    throw new Error(
+      `Failed to install Playwright in sandbox: ${installResult.stderr || installResult.stdout}`,
+    );
+  }
+
+  const browserResult = await sandbox.execute(
+    `cd ${SANDBOX_PW_DIR} && npx playwright install chromium --with-deps 2>&1`,
+    { timeout: 300 },
+  );
+  if (!browserResult.success) {
+    throw new Error(
+      `Failed to install Chromium in sandbox: ${browserResult.stderr || browserResult.stdout}`,
+    );
+  }
+}
+
+/**
+ * Ensure Playwright is available in the sandbox, installing on-demand if
+ * needed. The result is cached per-sandbox so repeated calls are free.
+ */
+export async function ensureSandboxPlaywright(
+  sandbox: UnifiedSandbox,
+): Promise<void> {
+  let cached = installationCache.get(sandbox);
+  if (cached) return cached;
+
+  cached = (async () => {
+    const installed = await checkSandboxPlaywright(sandbox);
+    if (!installed) {
+      await installSandboxPlaywright(sandbox);
+    }
+  })();
+
+  installationCache.set(sandbox, cached);
+
+  try {
+    await cached;
+  } catch (error) {
+    installationCache.delete(sandbox);
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Browser lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure a headless Chromium is running in the sandbox with CDP enabled.
+ * Waits until the browser accepts connections before returning.
+ */
+export async function ensureSandboxBrowser(
+  sandbox: UnifiedSandbox,
+): Promise<void> {
+  const check = await sandbox.execute(
+    `curl -sf http://127.0.0.1:${SANDBOX_CDP_PORT}/json/version 2>/dev/null`,
+    { timeout: 10 },
+  );
+
+  if (check.success && check.stdout.includes("webSocketDebuggerUrl")) {
+    return;
+  }
+
+  // Resolve the Chromium binary path that Playwright installed.
+  const chromePath = await sandbox.execute(
+    `cd ${SANDBOX_PW_DIR} && node -e "console.log(require('playwright').chromium.executablePath())"`,
+    { timeout: 15 },
+  );
+
+  const chromeBin = chromePath.stdout?.trim();
+  if (!chromeBin || !chromePath.success) {
+    throw new Error(
+      "Could not determine Chromium path in sandbox. Is Playwright installed?",
+    );
+  }
+
+  await sandbox.execute(`mkdir -p ${SANDBOX_EVIDENCE_DIR}`, { timeout: 5 });
+
+  await sandbox.execute(
+    `nohup "${chromeBin}" ` +
+      `--headless --no-sandbox --disable-setuid-sandbox ` +
+      `--disable-dev-shm-usage --disable-gpu ` +
+      `--remote-debugging-address=0.0.0.0 ` +
+      `--remote-debugging-port=${SANDBOX_CDP_PORT} ` +
+      `--user-data-dir=/tmp/pw-user-data ` +
+      `> /tmp/pw-browser.log 2>&1 &`,
+    { timeout: 10 },
+  );
+
+  for (let i = 0; i < 30; i++) {
+    const ready = await sandbox.execute(
+      `curl -sf http://127.0.0.1:${SANDBOX_CDP_PORT}/json/version 2>/dev/null`,
+      { timeout: 5 },
+    );
+
+    if (ready.success && ready.stdout.includes("webSocketDebuggerUrl")) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  const logs = await sandbox.execute("cat /tmp/pw-browser.log 2>/dev/null", {
+    timeout: 5,
+  });
+  throw new Error(
+    `Chromium failed to start in sandbox within 30 s. Logs:\n${logs.stdout || logs.stderr || "(empty)"}`,
+  );
+}
+
+/**
+ * Full setup: install Playwright if needed, then ensure browser is running.
+ */
+async function ensureSandboxReady(sandbox: UnifiedSandbox): Promise<void> {
+  await ensureSandboxPlaywright(sandbox);
+  await ensureSandboxBrowser(sandbox);
+}
+
+// ---------------------------------------------------------------------------
+// Script execution helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a Playwright Node.js script to the sandbox, execute it, and parse
+ * the JSON result from between the {@link RESULT_START}/{@link RESULT_END}
+ * markers in stdout.
+ *
+ * @param sandbox  - The sandbox to execute in
+ * @param body     - The *body* of the async IIFE (everything between
+ *                   `try {` and the closing `}`). Has `browser`, `context`,
+ *                   and `page` in scope. Must call `resolve(jsonValue)` to
+ *                   return a result.
+ * @param timeout  - Sandbox execution timeout in seconds (default 60)
+ */
+async function runPlaywrightScript(
+  sandbox: UnifiedSandbox,
+  body: string,
+  timeout = 60,
+): Promise<unknown> {
+  const script = `
+const { chromium } = require('playwright');
+
+(async () => {
+  function resolve(value) {
+    process.stdout.write('${RESULT_START}' + JSON.stringify(value) + '${RESULT_END}');
+  }
+
+  let browser;
+  try {
+    browser = await chromium.connectOverCDP('http://127.0.0.1:${SANDBOX_CDP_PORT}');
+    const contexts = browser.contexts();
+    const context = contexts[0] || await browser.newContext();
+    const pages = context.pages();
+    const page = pages.length > 0 ? pages[pages.length - 1] : await context.newPage();
+
+    ${body}
+
+  } catch (error) {
+    resolve({ success: false, error: error.message || String(error) });
+  } finally {
+    if (browser) {
+      try { browser.disconnect(); } catch {}
+    }
+  }
+})();
+`;
+
+  const b64 = Buffer.from(script).toString("base64");
+  const result = await sandbox.execute(
+    `echo "${b64}" | base64 -d > /tmp/pw_action.js && cd ${SANDBOX_PW_DIR} && node /tmp/pw_action.js`,
+    { timeout },
+  );
+
+  const stdout = result.stdout || "";
+  const match = stdout.match(
+    new RegExp(
+      `${RESULT_START.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}([\\s\\S]*?)${RESULT_END.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+    ),
+  );
+
+  if (!match) {
+    if (!result.success) {
+      throw new Error(
+        `Playwright script failed: ${result.stderr || stdout || "unknown error"}`,
+      );
+    }
+    throw new Error(
+      `No result marker in script output: ${stdout.substring(0, 500)}`,
+    );
+  }
+
+  try {
+    return JSON.parse(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Input schemas (mirrors playwrightMcp.ts – kept local for decoupling)
+// ---------------------------------------------------------------------------
+
+const BrowserNavigateInput = z.object({
+  url: z.string().describe("Full URL to navigate to"),
+  toolCallDescription: z
+    .string()
+    .describe("Why you are navigating to this URL"),
+});
+
+const BrowserScreenshotInput = z.object({
+  filename: z
+    .string()
+    .describe("Descriptive filename for screenshot (without extension)"),
+  toolCallDescription: z
+    .string()
+    .describe("What evidence this screenshot captures"),
+});
+
+const BrowserSnapshotInput = z.object({
+  toolCallDescription: z
+    .string()
+    .describe("Why you need to get the page snapshot"),
+});
+
+const BrowserClickInput = z.object({
+  element: z
+    .string()
+    .describe(
+      "Description of element to click, e.g., 'Submit button' or 'Login link'",
+    ),
+  ref: z
+    .string()
+    .optional()
+    .describe(
+      "Element reference from browser_snapshot (e.g., 'e5'). If provided, uses exact element reference for precise clicking.",
+    ),
+  toolCallDescription: z.string().describe("Why you are clicking this element"),
+});
+
+const BrowserFillInput = z.object({
+  element: z
+    .string()
+    .describe(
+      "Description of form field, e.g., 'Username field' or 'Search input'",
+    ),
+  ref: z
+    .string()
+    .optional()
+    .describe(
+      "Element reference from browser_snapshot (e.g., 'e3'). If provided, uses exact element reference for precise filling.",
+    ),
+  value: z.string().describe("Value to fill into the field"),
+  toolCallDescription: z
+    .string()
+    .describe("Why you are filling this field with this value"),
+});
+
+const BrowserEvaluateInput = z.object({
+  script: z.string().describe("JavaScript code to execute in browser"),
+  toolCallDescription: z
+    .string()
+    .describe("What you are testing with this script"),
+});
+
+const BrowserConsoleInput = z.object({
+  toolCallDescription: z
+    .string()
+    .describe("Why you need to check console messages"),
+});
+
+const BrowserGetCookiesInput = z.object({
+  urls: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Optional list of URLs to get cookies for. If not provided, gets all cookies.",
+    ),
+  toolCallDescription: z
+    .string()
+    .describe("Why you need to extract cookies from the browser"),
+});
+
+// ---------------------------------------------------------------------------
+// Sandbox browser tools factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the full set of browser tools that run inside a
+ * {@link UnifiedSandbox} via direct Playwright execution (no MCP).
+ *
+ * The factory lazily installs Playwright and launches Chromium in the sandbox
+ * on the first tool invocation.
+ */
+export function createSandboxBrowserTools(ctx: ToolContext) {
+  const sandbox = ctx.sandbox!;
+  const evidenceDir = join(ctx.session.rootPath, "evidence");
+  const targetUrl = ctx.target ?? "";
+
+  if (!existsSync(evidenceDir)) {
+    mkdirSync(evidenceDir, { recursive: true });
+  }
+
+  // Shared setup gate — only runs once per sandbox.
+  let setupPromise: Promise<void> | null = null;
+  function setup(): Promise<void> {
+    if (!setupPromise) {
+      setupPromise = ensureSandboxReady(sandbox);
+    }
+    return setupPromise;
+  }
+
+  // ------- browser_navigate -------------------------------------------------
+
+  const browser_navigate = tool({
+    description: `Navigate the browser to a URL to load and render a page.
+
+Use this to load SPAs, JavaScript-heavy pages, or any page that requires full browser rendering.
+The page will be fully loaded and JavaScript executed before returning.
+
+Target base URL: ${targetUrl}`,
+    inputSchema: BrowserNavigateInput,
+    execute: async ({ url }): Promise<BrowserNavigateResult> => {
+      try {
+        await setup();
+        const result = (await runPlaywrightScript(
+          sandbox,
+          `
+    await page.goto(${JSON.stringify(url)}, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    const title = await page.title();
+
+    // Inject console interceptor for later retrieval
+    await page.evaluate(() => {
+      if (!window.__pw_console) {
+        window.__pw_console = [];
+        for (const m of ['log', 'warn', 'error', 'info', 'debug']) {
+          const orig = console[m];
+          console[m] = function(...args) {
+            window.__pw_console.push({ type: m, text: args.map(String).join(' ') });
+            orig.apply(console, args);
+          };
+        }
+      }
+    });
+
+    resolve({ success: true, url: page.url(), title });
+          `,
+          60,
+        )) as BrowserNavigateResult;
+        return result;
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { success: false, url, error: message };
+      }
+    },
+  });
+
+  // ------- browser_screenshot -----------------------------------------------
+
+  const browser_screenshot = tool({
+    description: `Take a screenshot of the current page for evidence/documentation.
+
+Use this to document:
+- Exposed admin panels or sensitive pages
+- Interesting error pages or debug information
+- Visual proof of discovered vulnerabilities
+- Login pages and authentication flows`,
+    inputSchema: BrowserScreenshotInput,
+    execute: async ({ filename }): Promise<BrowserScreenshotResult> => {
+      try {
+        await setup();
+        const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+        const screenshotFilename = `${filename}_${timestamp}.png`;
+        const sandboxPath = `${SANDBOX_EVIDENCE_DIR}/${screenshotFilename}`;
+
+        const result = (await runPlaywrightScript(
+          sandbox,
+          `
+    const buf = await page.screenshot({ fullPage: false });
+    const b64 = buf.toString('base64');
+    require('fs').mkdirSync(${JSON.stringify(SANDBOX_EVIDENCE_DIR)}, { recursive: true });
+    require('fs').writeFileSync(${JSON.stringify(sandboxPath)}, buf);
+    resolve({ success: true, data: b64, sandboxPath: ${JSON.stringify(sandboxPath)} });
+          `,
+          30,
+        )) as {
+          success: boolean;
+          data?: string;
+          sandboxPath?: string;
+          error?: string;
+        };
+
+        if (result.success && result.data) {
+          const localPath = join(evidenceDir, screenshotFilename);
+          const dir = dirname(localPath);
+          if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true });
+          }
+          writeFileSync(localPath, Buffer.from(result.data, "base64"));
+          return {
+            success: true,
+            path: localPath,
+            message: `Screenshot saved to ${localPath}`,
+          };
+        }
+
+        return { success: false, error: result.error || "No screenshot data" };
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { success: false, error: message };
+      }
+    },
+  });
+
+  // ------- browser_snapshot -------------------------------------------------
+
+  const browser_snapshot = tool({
+    description: `Get the accessibility snapshot of the current page.
+
+IMPORTANT: Call this BEFORE using browser_click or browser_fill to get element references (refs).
+The snapshot returns an accessibility tree with elements marked like [ref=e5].
+Use these refs in browser_click and browser_fill for precise element targeting.
+
+Example workflow:
+1. Call browser_snapshot to get the page structure
+2. Find the element you need (e.g., "textbox 'Email'" with [ref=e3])
+3. Call browser_fill with ref="e3" to fill that specific element`,
+    inputSchema: BrowserSnapshotInput,
+    execute: async (): Promise<{
+      success: boolean;
+      snapshot?: string;
+      error?: string;
+    }> => {
+      try {
+        await setup();
+        const result = (await runPlaywrightScript(
+          sandbox,
+          `
+    const snapshot = await page.accessibility.snapshot();
+    const refMap = {};
+    let refId = 0;
+
+    function formatNode(node, depth) {
+      if (!node) return '';
+      const ref = 'e' + (refId++);
+      const lines = [];
+      const indent = '  '.repeat(depth);
+      let desc = indent + '[ref=' + ref + '] ' + (node.role || 'unknown');
+      if (node.name) desc += ' "' + node.name.substring(0, 80) + '"';
+      if (node.value) desc += ' value="' + String(node.value).substring(0, 40) + '"';
+      lines.push(desc);
+
+      refMap[ref] = { role: node.role, name: node.name || '' };
+
+      if (node.children) {
+        for (const child of node.children) {
+          const childText = formatNode(child, depth + 1);
+          if (childText) lines.push(childText);
+        }
+      }
+      return lines.join('\\n');
+    }
+
+    const text = formatNode(snapshot, 0);
+    require('fs').writeFileSync(${JSON.stringify(SANDBOX_REFS_FILE)}, JSON.stringify(refMap));
+    resolve({ success: true, snapshot: text });
+          `,
+          30,
+        )) as { success: boolean; snapshot?: string; error?: string };
+
+        return result;
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { success: false, error: message };
+      }
+    },
+  });
+
+  // ------- browser_click ----------------------------------------------------
+
+  const browser_click = tool({
+    description: `Click on an element in the page by describing it.
+
+Use this to:
+- Navigate through multi-step flows
+- Expand collapsed menus or sections
+- Click buttons, links, or interactive elements
+- Submit forms
+
+IMPORTANT: For reliable clicking, first call browser_snapshot to get element refs, then pass the ref parameter.`,
+    inputSchema: BrowserClickInput,
+    execute: async ({ element, ref }): Promise<BrowserClickResult> => {
+      try {
+        await setup();
+        const result = (await runPlaywrightScript(
+          sandbox,
+          `
+    const ref = ${JSON.stringify(ref || "")};
+    const element = ${JSON.stringify(element)};
+
+    if (ref) {
+      // Use stored ref mapping for precise targeting
+      try {
+        const refData = JSON.parse(require('fs').readFileSync(${JSON.stringify(SANDBOX_REFS_FILE)}, 'utf-8'));
+        const info = refData[ref];
+        if (info && info.role && info.name) {
+          await page.getByRole(info.role, { name: info.name }).first().click({ timeout: 10000 });
+          resolve({ success: true, element, result: 'Clicked via ref ' + ref });
+          return;
+        }
+      } catch {}
+    }
+
+    // Fallback: use text / role heuristic matching
+    try {
+      await page.getByRole('button', { name: element }).first().click({ timeout: 5000 });
+      resolve({ success: true, element, result: 'Clicked button matching: ' + element });
+      return;
+    } catch {}
+
+    try {
+      await page.getByRole('link', { name: element }).first().click({ timeout: 5000 });
+      resolve({ success: true, element, result: 'Clicked link matching: ' + element });
+      return;
+    } catch {}
+
+    try {
+      await page.getByText(element).first().click({ timeout: 5000 });
+      resolve({ success: true, element, result: 'Clicked text matching: ' + element });
+      return;
+    } catch {}
+
+    // Last resort: broad locator
+    await page.locator('text=' + element).first().click({ timeout: 10000 });
+    resolve({ success: true, element, result: 'Clicked via text locator: ' + element });
+          `,
+          30,
+        )) as BrowserClickResult;
+
+        return result;
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { success: false, error: message };
+      }
+    },
+  });
+
+  // ------- browser_fill -----------------------------------------------------
+
+  const browser_fill = tool({
+    description: `Fill a form field with a value.
+
+Use this to:
+- Enter credentials for authenticated reconnaissance
+- Fill search boxes or input fields
+- Enter test data into forms
+
+IMPORTANT: For reliable form filling, first call browser_snapshot to get element refs, then pass the ref parameter.`,
+    inputSchema: BrowserFillInput,
+    execute: async ({ element, ref, value }): Promise<BrowserFillResult> => {
+      try {
+        await setup();
+        const result = (await runPlaywrightScript(
+          sandbox,
+          `
+    const ref = ${JSON.stringify(ref || "")};
+    const element = ${JSON.stringify(element)};
+    const value = ${JSON.stringify(value)};
+
+    if (ref) {
+      try {
+        const refData = JSON.parse(require('fs').readFileSync(${JSON.stringify(SANDBOX_REFS_FILE)}, 'utf-8'));
+        const info = refData[ref];
+        if (info && info.role && info.name) {
+          await page.getByRole(info.role, { name: info.name }).first().fill(value, { timeout: 10000 });
+          resolve({ success: true, element, result: 'Filled via ref ' + ref });
+          return;
+        }
+      } catch {}
+    }
+
+    // Fallback: try label, placeholder, or role matching
+    try {
+      await page.getByLabel(element).first().fill(value, { timeout: 5000 });
+      resolve({ success: true, element, result: 'Filled by label: ' + element });
+      return;
+    } catch {}
+
+    try {
+      await page.getByPlaceholder(element).first().fill(value, { timeout: 5000 });
+      resolve({ success: true, element, result: 'Filled by placeholder: ' + element });
+      return;
+    } catch {}
+
+    try {
+      await page.getByRole('textbox', { name: element }).first().fill(value, { timeout: 5000 });
+      resolve({ success: true, element, result: 'Filled textbox matching: ' + element });
+      return;
+    } catch {}
+
+    // Last resort
+    await page.locator('[placeholder*="' + element.replace(/"/g, '') + '" i]').first().fill(value, { timeout: 10000 });
+    resolve({ success: true, element, result: 'Filled via placeholder locator: ' + element });
+          `,
+          30,
+        )) as BrowserFillResult;
+
+        return result;
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { success: false, error: message };
+      }
+    },
+  });
+
+  // ------- browser_evaluate -------------------------------------------------
+
+  const browser_evaluate = tool({
+    description: `Execute JavaScript in the browser context to extract information.
+
+CRITICAL for SPA reconnaissance - use this to extract:
+- React Router routes: window.__REACT_ROUTER_VERSION__
+- Next.js data: window.__NEXT_DATA__ (reveals all page routes and API endpoints)
+- Vue Router routes: window.__VUE_ROUTER__?.options?.routes
+- API configuration: window.API_URL, window.API_BASE_URL, window.config
+- Application state: window.__REDUX_STATE__, window.__INITIAL_STATE__
+- All links on page: Array.from(document.querySelectorAll('a')).map(a => a.href)
+- Service worker routes: navigator.serviceWorker?.controller
+
+The JavaScript is executed in the page context and the result is returned.`,
+    inputSchema: BrowserEvaluateInput,
+    execute: async ({ script }): Promise<BrowserEvaluateResult> => {
+      try {
+        await setup();
+
+        const isFunction =
+          /^\s*(async\s+)?\(/.test(script) ||
+          /^\s*(async\s+)?function\s*\(/.test(script);
+        const fnScript = isFunction ? script : `() => (${script})`;
+
+        const result = (await runPlaywrightScript(
+          sandbox,
+          `
+    const fn = ${JSON.stringify(fnScript)};
+    const evalResult = await page.evaluate(fn);
+    resolve({ success: true, script: ${JSON.stringify(script)}, result: evalResult });
+          `,
+          30,
+        )) as BrowserEvaluateResult;
+
+        return result;
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { success: false, error: message };
+      }
+    },
+  });
+
+  // ------- browser_console --------------------------------------------------
+
+  const browser_console = tool({
+    description: `Get console messages from the browser.
+
+Use this to check for:
+- Leaked API keys or secrets in console output
+- Debug messages revealing internal URLs or endpoints
+- Error messages exposing application structure
+- Warnings about deprecated endpoints
+- Network request failures revealing API patterns`,
+    inputSchema: BrowserConsoleInput,
+    execute: async (): Promise<BrowserConsoleResult> => {
+      try {
+        await setup();
+        const result = (await runPlaywrightScript(
+          sandbox,
+          `
+    const messages = await page.evaluate(() => window.__pw_console || []);
+    resolve({ success: true, messages, result: messages });
+          `,
+          15,
+        )) as BrowserConsoleResult;
+
+        return result;
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { success: false, error: message };
+      }
+    },
+  });
+
+  // ------- browser_get_cookies ----------------------------------------------
+
+  const browser_get_cookies = tool({
+    description: `Extract cookies from the browser context, including httpOnly cookies.
+
+CRITICAL: Use this after successful browser authentication to get session cookies that can be used in HTTP requests.
+
+Returns all cookies including:
+- Session cookies (often httpOnly, not accessible via document.cookie)
+- Authentication tokens
+- CSRF tokens
+
+The returned cookies can be formatted as a Cookie header for use with http_request tool.`,
+    inputSchema: BrowserGetCookiesInput,
+    execute: async ({
+      urls,
+    }): Promise<{
+      success: boolean;
+      cookies?: Array<{
+        name: string;
+        value: string;
+        domain: string;
+        path: string;
+        httpOnly: boolean;
+        secure: boolean;
+      }>;
+      cookieHeader?: string;
+      error?: string;
+    }> => {
+      try {
+        await setup();
+        const result = (await runPlaywrightScript(
+          sandbox,
+          `
+    const urls = ${JSON.stringify(urls || [])};
+    const cookies = urls.length > 0
+      ? await context.cookies(urls)
+      : await context.cookies();
+    const cookieHeader = cookies.map(c => c.name + '=' + c.value).join('; ');
+    resolve({ success: true, cookies, cookieHeader });
+          `,
+          15,
+        )) as {
+          success: boolean;
+          cookies?: Array<{
+            name: string;
+            value: string;
+            domain: string;
+            path: string;
+            httpOnly: boolean;
+            secure: boolean;
+          }>;
+          cookieHeader?: string;
+          error?: string;
+        };
+
+        return result;
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { success: false, error: message };
+      }
+    },
+  });
+
+  return {
+    browser_navigate,
+    browser_snapshot,
+    browser_screenshot,
+    browser_click,
+    browser_fill,
+    browser_evaluate,
+    browser_console,
+    browser_get_cookies,
+  };
+}

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -37,10 +37,10 @@ import type {
 // Constants
 // ---------------------------------------------------------------------------
 
-const SANDBOX_CDP_PORT = 9222;
 const SANDBOX_PW_DIR = "/tmp/sandbox-playwright";
 const SANDBOX_EVIDENCE_DIR = "/tmp/evidence";
 const SANDBOX_REFS_FILE = "/tmp/pw-refs.json";
+const SANDBOX_URL_FILE = "/tmp/pw-current-url";
 
 /** Marker pair used to extract JSON results from script stdout. */
 const RESULT_START = "__PW_RESULT__";
@@ -62,10 +62,17 @@ const installationCache = new WeakMap<UnifiedSandbox, Promise<void>>();
 export async function checkSandboxPlaywright(
   sandbox: UnifiedSandbox,
 ): Promise<boolean> {
-  const result = await sandbox.execute(
-    `cd ${SANDBOX_PW_DIR} 2>/dev/null && node -e "try { require('playwright'); console.log('OK'); } catch(e) { process.exit(1); }"`,
-    { timeout: 30 },
+  // Write the check script inside the PW dir so require() can resolve
+  // node_modules relative to the script's __dirname.
+  const script = `try{require("playwright");console.log("OK")}catch(e){process.exit(1)}`;
+  const b64 = Buffer.from(script).toString("base64");
+  await sandbox.execute(
+    `mkdir -p ${SANDBOX_PW_DIR} && echo "${b64}" | base64 -d > ${SANDBOX_PW_DIR}/pw_check.js`,
+    { timeout: 10 },
   );
+  const result = await sandbox.execute(`node ${SANDBOX_PW_DIR}/pw_check.js`, {
+    timeout: 30,
+  });
   return result.success && result.stdout.includes("OK");
 }
 
@@ -99,13 +106,29 @@ export async function installSandboxPlaywright(
     );
   }
 
-  const browserResult = await sandbox.execute(
-    `cd ${SANDBOX_PW_DIR} && npx playwright install chromium --with-deps 2>&1`,
-    { timeout: 300 },
+  // Remove broken Yarn apt repo (common on Daytona node images) before
+  // installing Chromium system deps, otherwise apt-get update fails.
+  await sandbox.execute(
+    `(sudo rm -f /etc/apt/sources.list.d/yarn.list /etc/apt/sources.list.d/yarn.sources 2>/dev/null || rm -f /etc/apt/sources.list.d/yarn.list /etc/apt/sources.list.d/yarn.sources 2>/dev/null || true)`,
+    { timeout: 10 },
   );
-  if (!browserResult.success) {
+
+  // Install Chromium + system deps. Retry up to 3 times because browser
+  // binary downloads can hit transient network errors (ECONNRESET, etc.).
+  let browserResult;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    browserResult = await sandbox.execute(
+      `cd ${SANDBOX_PW_DIR} && npx playwright install chromium --with-deps 2>&1`,
+      { timeout: 300 },
+    );
+    if (browserResult.success) break;
+    if (attempt < 3) {
+      await new Promise((r) => setTimeout(r, 3000));
+    }
+  }
+  if (!browserResult!.success) {
     throw new Error(
-      `Failed to install Chromium in sandbox: ${browserResult.stderr || browserResult.stdout}`,
+      `Failed to install Chromium in sandbox: ${browserResult!.stderr || browserResult!.stdout}`,
     );
   }
 }
@@ -142,70 +165,20 @@ export async function ensureSandboxPlaywright(
 // ---------------------------------------------------------------------------
 
 /**
- * Ensure a headless Chromium is running in the sandbox with CDP enabled.
- * Waits until the browser accepts connections before returning.
+ * Verify that Playwright can launch Chromium in the sandbox.
+ * This is a lightweight smoke-test — the actual browser is launched per-script
+ * via `launchPersistentContext` so no long-running process is needed.
  */
 export async function ensureSandboxBrowser(
   sandbox: UnifiedSandbox,
 ): Promise<void> {
-  const check = await sandbox.execute(
-    `curl -sf http://127.0.0.1:${SANDBOX_CDP_PORT}/json/version 2>/dev/null`,
-    { timeout: 10 },
-  );
-
-  if (check.success && check.stdout.includes("webSocketDebuggerUrl")) {
-    return;
-  }
-
-  // Resolve the Chromium binary path that Playwright installed.
-  const chromePath = await sandbox.execute(
-    `cd ${SANDBOX_PW_DIR} && node -e "console.log(require('playwright').chromium.executablePath())"`,
-    { timeout: 15 },
-  );
-
-  const chromeBin = chromePath.stdout?.trim();
-  if (!chromeBin || !chromePath.success) {
-    throw new Error(
-      "Could not determine Chromium path in sandbox. Is Playwright installed?",
-    );
-  }
-
-  await sandbox.execute(`mkdir -p ${SANDBOX_EVIDENCE_DIR}`, { timeout: 5 });
-
-  await sandbox.execute(
-    `nohup "${chromeBin}" ` +
-      `--headless --no-sandbox --disable-setuid-sandbox ` +
-      `--disable-dev-shm-usage --disable-gpu ` +
-      `--remote-debugging-address=0.0.0.0 ` +
-      `--remote-debugging-port=${SANDBOX_CDP_PORT} ` +
-      `--user-data-dir=/tmp/pw-user-data ` +
-      `> /tmp/pw-browser.log 2>&1 &`,
-    { timeout: 10 },
-  );
-
-  for (let i = 0; i < 30; i++) {
-    const ready = await sandbox.execute(
-      `curl -sf http://127.0.0.1:${SANDBOX_CDP_PORT}/json/version 2>/dev/null`,
-      { timeout: 5 },
-    );
-
-    if (ready.success && ready.stdout.includes("webSocketDebuggerUrl")) {
-      return;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  }
-
-  const logs = await sandbox.execute("cat /tmp/pw-browser.log 2>/dev/null", {
+  await sandbox.execute(`mkdir -p ${SANDBOX_EVIDENCE_DIR} /tmp/pw-user-data`, {
     timeout: 5,
   });
-  throw new Error(
-    `Chromium failed to start in sandbox within 30 s. Logs:\n${logs.stdout || logs.stderr || "(empty)"}`,
-  );
 }
 
 /**
- * Full setup: install Playwright if needed, then ensure browser is running.
+ * Full setup: install Playwright if needed, then prepare directories.
  */
 async function ensureSandboxReady(sandbox: UnifiedSandbox): Promise<void> {
   await ensureSandboxPlaywright(sandbox);
@@ -221,11 +194,13 @@ async function ensureSandboxReady(sandbox: UnifiedSandbox): Promise<void> {
  * the JSON result from between the {@link RESULT_START}/{@link RESULT_END}
  * markers in stdout.
  *
+ * Each script launches a persistent browser context (with a shared user-data
+ * dir) so that cookies, localStorage, and other state survive across calls.
+ * The browser is closed when the script exits.
+ *
  * @param sandbox  - The sandbox to execute in
- * @param body     - The *body* of the async IIFE (everything between
- *                   `try {` and the closing `}`). Has `browser`, `context`,
- *                   and `page` in scope. Must call `resolve(jsonValue)` to
- *                   return a result.
+ * @param body     - The *body* of the async IIFE. Has `context` and `page`
+ *                   in scope. Must call `resolve(jsonValue)` to return a result.
  * @param timeout  - Sandbox execution timeout in seconds (default 60)
  */
 async function runPlaywrightScript(
@@ -241,21 +216,31 @@ const { chromium } = require('playwright');
     process.stdout.write('${RESULT_START}' + JSON.stringify(value) + '${RESULT_END}');
   }
 
-  let browser;
+  let context;
   try {
-    browser = await chromium.connectOverCDP('http://127.0.0.1:${SANDBOX_CDP_PORT}');
-    const contexts = browser.contexts();
-    const context = contexts[0] || await browser.newContext();
+    context = await chromium.launchPersistentContext('/tmp/pw-user-data', {
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--disable-gpu'],
+    });
     const pages = context.pages();
     const page = pages.length > 0 ? pages[pages.length - 1] : await context.newPage();
+
+    // Restore the last-visited URL so page state persists across tool calls.
+    const fs = require('fs');
+    if (page.url() === 'about:blank') {
+      try {
+        const savedUrl = fs.readFileSync('${SANDBOX_URL_FILE}', 'utf-8').trim();
+        if (savedUrl) await page.goto(savedUrl, { waitUntil: 'domcontentloaded', timeout: 20000 });
+      } catch {}
+    }
 
     ${body}
 
   } catch (error) {
     resolve({ success: false, error: error.message || String(error) });
   } finally {
-    if (browser) {
-      try { browser.disconnect(); } catch {}
+    if (context) {
+      try { await context.close(); } catch {}
     }
   }
 })();
@@ -263,7 +248,7 @@ const { chromium } = require('playwright');
 
   const b64 = Buffer.from(script).toString("base64");
   const result = await sandbox.execute(
-    `echo "${b64}" | base64 -d > /tmp/pw_action.js && cd ${SANDBOX_PW_DIR} && node /tmp/pw_action.js`,
+    `echo "${b64}" | base64 -d > ${SANDBOX_PW_DIR}/pw_action.js && node ${SANDBOX_PW_DIR}/pw_action.js`,
     { timeout },
   );
 
@@ -422,6 +407,8 @@ Target base URL: ${targetUrl}`,
           sandbox,
           `
     await page.goto(${JSON.stringify(url)}, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    // Persist current URL so subsequent tool calls can restore the page
+    require('fs').writeFileSync('${SANDBOX_URL_FILE}', page.url());
     const title = await page.title();
 
     // Inject console interceptor for later retrieval
@@ -531,7 +518,28 @@ Example workflow:
         const result = (await runPlaywrightScript(
           sandbox,
           `
-    const snapshot = await page.accessibility.snapshot();
+    // Build accessibility snapshot via page.evaluate — works on all
+    // Playwright versions and doesn't depend on the deprecated
+    // page.accessibility.snapshot() API.
+    const treeData = await page.evaluate(() => {
+      function walk(el, depth) {
+        const role = el.getAttribute('role')
+          || el.tagName.toLowerCase();
+        const name = el.getAttribute('aria-label')
+          || el.getAttribute('name')
+          || el.getAttribute('placeholder')
+          || (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' ? el.getAttribute('type') || '' : '')
+          || el.textContent?.trim().substring(0, 60) || '';
+        const value = el.value !== undefined && el.value !== '' ? el.value : undefined;
+        const children = [];
+        for (const child of el.children) {
+          children.push(walk(child, depth + 1));
+        }
+        return { role, name, value, children, depth };
+      }
+      return walk(document.body, 0);
+    });
+
     const refMap = {};
     let refId = 0;
 
@@ -556,7 +564,7 @@ Example workflow:
       return lines.join('\\n');
     }
 
-    const text = formatNode(snapshot, 0);
+    const text = formatNode(treeData, 0);
     require('fs').writeFileSync(${JSON.stringify(SANDBOX_REFS_FILE)}, JSON.stringify(refMap));
     resolve({ success: true, snapshot: text });
           `,
@@ -736,7 +744,8 @@ The JavaScript is executed in the page context and the result is returned.`,
         const result = (await runPlaywrightScript(
           sandbox,
           `
-    const fn = ${JSON.stringify(fnScript)};
+    const fnStr = ${JSON.stringify(fnScript)};
+    const fn = new Function('return (' + fnStr + ')')();
     const evalResult = await page.evaluate(fn);
     resolve({ success: true, script: ${JSON.stringify(script)}, result: evalResult });
           `,

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -125,10 +125,13 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
         "document_vulnerability",
         "create_poc",
         "response",
-        // Browser tools for visual evidence collection
+        // Browser tools — navigate/snapshot/screenshot for evidence collection,
+        // click/fill for interactive form testing (e.g. login, XSS via inputs)
         "browser_navigate",
         "browser_snapshot",
         "browser_screenshot",
+        "browser_click",
+        "browser_fill",
         // Email tools (filtered out by base class when no inboxes configured)
         "email_list_inboxes",
         "email_list_messages",
@@ -193,8 +196,9 @@ CRITICAL — document_vulnerability usage rules:
 - If you were unable to confirm or exploit a vulnerability, do NOT document it — instead describe it in your final response summary
 - It is completely acceptable to finish a test with zero documented vulnerabilities if none were found
 
-Screenshot Evidence:
-- Use browser_navigate + browser_screenshot to capture visual evidence of vulnerabilities
+Browser Interaction:
+- Use browser_navigate to load pages, browser_snapshot to inspect the DOM, and browser_screenshot for visual evidence
+- Use browser_click and browser_fill to interact with forms, buttons, and input fields — essential for testing login flows, search fields, and other interactive elements
 - Take screenshots of: successful XSS execution, error pages revealing sensitive info, authentication bypass results, anomalous server responses
 - Take a screenshot when you encounter unexpected errors to document the failure state
 - Use descriptive filenames that indicate what the screenshot captures (e.g. "xss-alert-fired", "sql-error-disclosure", "auth-bypass-admin-panel")


### PR DESCRIPTION
### What does this PR do?

This PR adds support for browser tools within a sandbox environment, enabling agents to use Playwright directly inside a Daytona sandbox.

The issue addressed is the lack of a mechanism for browser-based interactions when an agent is operating within a sandbox. Previously, browser tools relied on an external Playwright MCP (Managed Control Plane) server, which is not suitable for sandbox execution.

The solution involves:
1.  **Introducing `sandboxPlaywright.ts`**: A new module that provides sandbox-native browser tools. These tools execute Playwright scripts directly within the sandbox using `sandbox.execute()`, completely bypassing the MCP.
2.  **Conditional Toolset Loading**: `browserTools.ts` is updated to dynamically load either the standard browser tools or the new sandbox-specific tools based on the presence of a `ctx.sandbox` instance.
3.  **Exporting Sandbox Functions**: `index.ts` is updated to export necessary functions for checking, installing, and ensuring Playwright and Chromium are available in the sandbox.

This approach works by:
*   **On-demand installation**: Playwright and Chromium are installed directly into the sandbox on the first tool invocation.
*   **Persistent Context**: Instead of CDP, `launchPersistentContext()` is used, ensuring browser state (cookies, user data, and navigated URL) persists across tool calls.
*   **Robust Script Execution**: Playwright scripts are written to temporary files within the sandbox and then executed, avoiding complex shell escaping issues with inline `node -e` commands.
*   **Ref-based Element Targeting**: A custom DOM traversal is implemented for `browser_snapshot` to create an accessibility tree with `[ref=eN]` markers, which `browser_click` and `browser_fill` can then use via `page.getByRole()`.

### How did you verify your code works?

*   **Unit Tests**: All 145 existing unit tests pass (`bun vitest run`).
*   **Type Checking**: `bun run tsc` passes without errors.
*   **Linting**: `bun run lint` passes without errors.
*   **Live Integration Test**: A dedicated integration test script (`scripts/test-sandbox-playwright.ts`) was developed and executed against a live Daytona sandbox. This test:
    *   Creates a new Daytona sandbox.
    *   Installs Playwright and Chromium within the sandbox.
    *   Launches a persistent Chromium instance.
    *   Exercises all 8 browser tools (`navigate`, `evaluate`, `snapshot`, `click`, `fill`, `screenshot`, `console`, `cookies`) against `https://example.com/`.
    *   All browser tools were verified to function correctly, including URL persistence, cookie management, DOM interaction, and screenshot capture.

---
<p><a href="https://cursor.com/agents/bc-c187289e-9856-4f9d-9355-983f209fc624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c187289e-9856-4f9d-9355-983f209fc624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit d7fc1073732e27b20e2e11d1639b2e41efa49a68. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->