### PR TITLE
Add blackbox source code prohibition and integrate CVSS 4.0 scoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensar/apex",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
   "main": "build/index.js",

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -3,6 +3,10 @@ import { z } from "zod";
 import { join } from "path";
 import { writeFileSync, appendFileSync } from "fs";
 import type { ToolContext } from "./types";
+import {
+  scoreFindingWithCVSS,
+  type CVSSScorerResult,
+} from "../../specialized/cvssScorer";
 
 export const documentVulnerabilityInputSchema = z.object({
   title: z.string().describe("Finding title"),
@@ -72,11 +76,47 @@ FINDING STRUCTURE:
         }
 
         const timestamp = new Date().toISOString();
+
+        // -- CVSS 4.0 scoring ------------------------------------------------
+        let cvssResult: CVSSScorerResult | undefined;
+        try {
+          cvssResult = await scoreFindingWithCVSS(
+            {
+              finding: {
+                title: finding.title,
+                description: finding.description,
+                impact: finding.impact,
+                evidence: finding.evidence,
+                endpoint: finding.endpoint,
+                remediation: finding.remediation,
+              },
+              agentMessages: [],
+            },
+            ctx.model!,
+            ctx.authConfig,
+          );
+        } catch (err) {
+          console.warn(
+            "CVSS scoring failed, proceeding without score:",
+            err instanceof Error ? err.message : err,
+          );
+        }
+
         const findingWithMeta = {
           ...finding,
           timestamp,
           sessionId: session.id,
           target: session.targets[0],
+          ...(cvssResult && {
+            cvss: {
+              score: cvssResult.score,
+              severity: cvssResult.severity,
+              vectorString: cvssResult.vectorString,
+              metrics: cvssResult.metrics,
+              scoreType: cvssResult.scoreType,
+              reasoning: cvssResult.reasoning,
+            },
+          }),
         };
 
         // Safe filename from title
@@ -97,9 +137,16 @@ FINDING STRUCTURE:
           writeFileSync(jsonPath, JSON.stringify(findingWithMeta, null, 2));
 
           // Write human-readable markdown
+          const cvssLine = cvssResult
+            ? `\n**CVSS 4.0 Score:** ${cvssResult.score} (${cvssResult.severity})  \n**Vector:** \`${cvssResult.vectorString}\`  `
+            : "";
+          const cvssSection = cvssResult
+            ? `\n## CVSS 4.0 Assessment\n\n**Score:** ${cvssResult.score} / 10.0 (${cvssResult.severity})  \n**Vector:** \`${cvssResult.vectorString}\`  \n**Score Type:** ${cvssResult.scoreType}\n\n**Reasoning:** ${cvssResult.reasoning}\n`
+            : "";
+
           const markdown = `# ${finding.title}
 
-**Severity:** ${finding.severity}  
+**Severity:** ${finding.severity}  ${cvssLine}
 **Target:** ${session.targets[0]}  
 **Endpoint:** ${finding.endpoint}  
 **Date:** ${timestamp}  
@@ -112,7 +159,7 @@ ${finding.description}
 ## Impact
 
 ${finding.impact}
-
+${cvssSection}
 ## Evidence
 
 \`\`\`
@@ -138,7 +185,8 @@ ${finding.references ? `## References\n\n${finding.references}` : ""}
 
           // Append to summary
           const summaryPath = join(session.rootPath, "findings-summary.md");
-          const summaryEntry = `- [${finding.severity}] ${finding.title} - \`findings/${mdFilename}\`\n`;
+          const cvssTag = cvssResult ? ` (CVSS ${cvssResult.score})` : "";
+          const summaryEntry = `- [${finding.severity}]${cvssTag} ${finding.title} - \`findings/${mdFilename}\`\n`;
 
           try {
             appendFileSync(summaryPath, summaryEntry);

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -155,6 +155,13 @@ const PENTEST_SYSTEM_PROMPT = `You are an expert penetration tester performing a
 
 You are given a specific target and specific objectives. Do NOT perform broad reconnaissance or service/endpoint discovery — that has already been done for you. Your job is to deeply test the provided target against the provided objectives.
 
+CRITICAL — Source Code Prohibition:
+- You are performing a BLACKBOX penetration test. You must NEVER read, view, access, or analyze source code under any circumstances.
+- Do NOT use execute_command to read files on the local filesystem (no cat, less, more, head, tail, find, ls on source directories, strings, xxd, or any other file-reading command targeting application source code).
+- Do NOT attempt to download, fetch, or retrieve source code from the target server (e.g. via .git exposure, backup files, directory traversal to read source, or source map files) for the purpose of analyzing application logic. If you discover such an exposure, document it as a finding but do NOT read or analyze the contents.
+- Do NOT reference, assume, or reason about internal implementation details. Treat the target as a completely opaque black box — you can only observe its external behavior through HTTP responses, browser rendering, and error messages.
+- Your testing must rely exclusively on external interaction: sending requests, observing responses, and analyzing observable behavior.
+
 Your methodology:
 1. PLAN — Begin by stating the objectives you have been given and outlining your testing plan. For each objective, describe which attack techniques, payloads, and tools you intend to use. Output this plan as text before making any tool calls.
 2. VERIFY — Confirm the target endpoint exists and is reachable. Understand its basic behavior (response format, parameters, auth requirements).

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -141,10 +141,6 @@ const SessionConfigObject = z.object({
   authenticationInstructions: z.string().optional(),
   requestsPerSecond: z.number().optional(),
   operatorSettings: OperatorSettingsObject.optional(),
-  /** Enable CVSS 4.0 scoring for findings (defaults to true if not specified) */
-  enableCvssScoring: z.boolean().optional(),
-  /** Model to use for CVSS scorer subagent (default: claude-4-5-haiku) */
-  cvssModel: z.string().optional(),
   /** Toolset state for controlling which tools are available */
   toolsetState: ToolsetStateSchema.optional(),
   /** Whether to enumerate subdomains during attack surface discovery (default: false) */


### PR DESCRIPTION
## Summary

- **Pentest agent blackbox enforcement:** Adds a "Source Code Prohibition" section to the pentest agent system prompt, preventing the agent from reading, accessing, or reasoning about application source code during blackbox penetration tests.
- **CVSS 4.0 auto-scoring:** Integrates `scoreFindingWithCVSS` into the `documentFinding` tool so every documented vulnerability is automatically scored with CVSS 4.0. The score, severity, vector string, metrics, and reasoning are embedded in the JSON output, markdown report, and findings summary.
- **Config cleanup:** Removes the now-unnecessary `enableCvssScoring` and `cvssModel` session config options — CVSS scoring is always-on.

## Test plan

- [x] Run `bun run test` — all tests pass or are skipped
- [x] Run a pentest session and verify the agent does not attempt to read source code
- [x] Verify documented findings include CVSS 4.0 score, severity, and vector in JSON + markdown output
- [x] Confirm `findings-summary.md` entries include the CVSS score tag
- [x] Verify graceful degradation if CVSS scoring fails (warning logged, finding still saved without score)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 143aebab07040d522336525fccd80334106e6034. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->