### PR TITLE
Fix browser evaluate type error

### DIFF
--- a/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { transformScriptToFunction } from "./playwrightMcp";
+
+describe("transformScriptToFunction", () => {
+  describe("plain expressions", () => {
+    it("wraps simple expression in arrow function", () => {
+      expect(transformScriptToFunction("document.cookie")).toBe(
+        "() => (document.cookie)",
+      );
+    });
+
+    it("wraps complex expression", () => {
+      expect(transformScriptToFunction("localStorage.getItem('token')")).toBe(
+        "() => (localStorage.getItem('token'))",
+      );
+    });
+
+    it("handles expression with whitespace", () => {
+      expect(transformScriptToFunction("  document.title  ")).toBe(
+        "() => (  document.title  )",
+      );
+    });
+  });
+
+  describe("function expressions", () => {
+    it("passes through arrow function", () => {
+      const fn = "() => document.cookie";
+      expect(transformScriptToFunction(fn)).toBe(fn);
+    });
+
+    it("passes through arrow function with body", () => {
+      const fn = "() => { return document.cookie; }";
+      expect(transformScriptToFunction(fn)).toBe(fn);
+    });
+
+    it("passes through async arrow function", () => {
+      const fn = "async () => fetch('/api')";
+      expect(transformScriptToFunction(fn)).toBe(fn);
+    });
+
+    it("passes through function expression", () => {
+      const fn = "function() { return document.cookie; }";
+      expect(transformScriptToFunction(fn)).toBe(fn);
+    });
+
+    it("passes through async function expression", () => {
+      const fn = "async function() { return await fetch('/api'); }";
+      expect(transformScriptToFunction(fn)).toBe(fn);
+    });
+
+    it("handles arrow function with parameters", () => {
+      const fn = "(a, b) => a + b";
+      expect(transformScriptToFunction(fn)).toBe(fn);
+    });
+  });
+
+  describe("IIFEs", () => {
+    it("extracts function from simple arrow IIFE", () => {
+      const iife = "(() => document.cookie)()";
+      expect(transformScriptToFunction(iife)).toBe("() => document.cookie");
+    });
+
+    it("extracts function from arrow IIFE with body", () => {
+      const iife = `(() => {
+  const tokens = {};
+  return tokens;
+})()`;
+      const expected = `() => {
+  const tokens = {};
+  return tokens;
+}`;
+      expect(transformScriptToFunction(iife)).toBe(expected);
+    });
+
+    it("extracts function from complex arrow IIFE (from bug report)", () => {
+      const iife = `(() => {
+  const tokens = {};
+  const keys = ['token', 'access_token', 'accessToken', 'auth_token', 'jwt', 'id_token'];
+  keys.forEach(key => {
+    const lsVal = localStorage.getItem(key);
+    const ssVal = sessionStorage.getItem(key);
+    if (lsVal) tokens[key + '_localStorage'] = lsVal;
+    if (ssVal) tokens[key + '_sessionStorage'] = ssVal;
+  });
+  return JSON.stringify(tokens, null, 2);
+})()
+`;
+      const result = transformScriptToFunction(iife);
+      expect(result).toContain("() => {");
+      expect(result).toContain("const tokens = {};");
+      expect(result).toContain("return JSON.stringify(tokens, null, 2);");
+      expect(result).not.toContain(")()");
+    });
+
+    it("extracts function from async arrow IIFE", () => {
+      const iife = "(async () => await fetch('/api'))()";
+      expect(transformScriptToFunction(iife)).toBe(
+        "async () => await fetch('/api')",
+      );
+    });
+
+    it("extracts function from function IIFE", () => {
+      const iife = "(function() { return document.cookie; })()";
+      expect(transformScriptToFunction(iife)).toBe(
+        "function() { return document.cookie; }",
+      );
+    });
+
+    it("extracts function from async function IIFE", () => {
+      const iife = "(async function() { return await fetch('/api'); })()";
+      expect(transformScriptToFunction(iife)).toBe(
+        "async function() { return await fetch('/api'); }",
+      );
+    });
+
+    it("handles IIFE with trailing semicolon", () => {
+      const iife = "(() => document.cookie)();";
+      expect(transformScriptToFunction(iife)).toBe("() => document.cookie");
+    });
+
+    it("handles IIFE with whitespace in invocation", () => {
+      const iife = "(() => document.cookie)(  )";
+      expect(transformScriptToFunction(iife)).toBe("() => document.cookie");
+    });
+
+    it("handles IIFE with trailing whitespace", () => {
+      const iife = "(() => document.cookie)()   ";
+      expect(transformScriptToFunction(iife)).toBe("() => document.cookie");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles function that returns a function call", () => {
+      const fn = "() => doSomething()";
+      expect(transformScriptToFunction(fn)).toBe(fn);
+    });
+
+    it("does not mis-identify function call as IIFE", () => {
+      const expr = "myFunction()";
+      expect(transformScriptToFunction(expr)).toBe("() => (myFunction())");
+    });
+
+    it("handles JSON stringify in expression", () => {
+      const expr = "JSON.stringify({a: 1})";
+      expect(transformScriptToFunction(expr)).toBe(
+        "() => (JSON.stringify({a: 1}))",
+      );
+    });
+
+    it("handles empty parentheses expression", () => {
+      const expr = "()";
+      expect(transformScriptToFunction(expr)).toBe("()");
+    });
+  });
+});

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -146,6 +146,44 @@ const MCP_CONNECT_TIMEOUT_MS = 30_000;
 const MCP_TOOL_CALL_TIMEOUT_MS = 60_000;
 
 /**
+ * Transform a user-provided script into a function expression for Playwright's browser_evaluate.
+ *
+ * Handles three cases:
+ * 1. Plain expressions: `document.cookie` → `() => (document.cookie)`
+ * 2. Function expressions: `() => document.cookie` → unchanged
+ * 3. IIFEs: `(() => { ... })()` → `() => { ... }`
+ *
+ * IIFEs are problematic because they evaluate to a value, not a function,
+ * causing "result is not a function" errors when Playwright tries to call them.
+ *
+ * @internal Exported for testing
+ */
+export function transformScriptToFunction(script: string): string {
+  const trimmed = script.trim();
+
+  // Detect IIFE pattern: (function...)() or (() => ...)() or (async () => ...)()
+  // Must start with ( followed by (async )?(function or () and end with ()
+  const iifeTrailing = /\(\s*\)\s*;?\s*$/.test(trimmed);
+  const iifeLeading = /^\s*\((?:async\s+)?(?:function|\()/.test(trimmed);
+
+  if (iifeLeading && iifeTrailing) {
+    // This is an IIFE - extract the function without the trailing invocation ()
+    let extracted = trimmed.replace(/\(\s*\)\s*;?\s*$/, "").trim();
+    // Remove the outer wrapping parentheses: (fn) -> fn
+    if (extracted.startsWith("(") && extracted.endsWith(")")) {
+      extracted = extracted.slice(1, -1).trim();
+    }
+    return extracted;
+  }
+
+  // Regular function expression or plain expression
+  const isFunction =
+    /^\s*(async\s+)?\(/.test(script) ||
+    /^\s*(async\s+)?function\s*\(/.test(script);
+  return isFunction ? script : `() => (${script})`;
+}
+
+/**
  * Race a promise against a timeout. Rejects with a descriptive error
  * if the timeout fires first.
  */
@@ -880,13 +918,7 @@ Example workflow:
       toolCallDescription,
     }): Promise<BrowserEvaluateResult> => {
       try {
-        // Playwright MCP's browser_evaluate expects a `function` param with a
-        // function expression like `() => document.cookie`. Wrap raw expressions
-        // that aren't already function-shaped.
-        const isFunction =
-          /^\s*(async\s+)?\(/.test(script) ||
-          /^\s*(async\s+)?function\s*\(/.test(script);
-        const fnScript = isFunction ? script : `() => (${script})`;
+        const fnScript = transformScriptToFunction(script);
 
         const result = await session.callTool(
           "browser_evaluate",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR fixes a bug in the `browser_evaluate` tool where it failed to correctly handle Immediately Invoked Function Expressions (IIFEs) like `(() => { ... })()`. Previously, these were incorrectly identified as regular function expressions, causing Playwright's `page.evaluate()` to receive an already-invoked value and throw a "result is not a function" error when attempting to call it.

The fix involves:
1.  Adding detection for IIFE patterns.
2.  Transforming IIFEs to extract only the function part (e.g., `(() => {...})()` becomes `() => {...}`).
3.  Refactoring the script transformation logic into a new, testable `transformScriptToFunction()` helper function.

This ensures that Playwright's `page.evaluate()` always receives a valid function expression to execute.

### How did you verify your code works?

1.  **Unit Tests:** Added 22 new unit tests for the `transformScriptToFunction()` helper, covering plain expressions, function expressions, and various IIFE formats. All new tests pass.
2.  **Full Test Suite:** Ran the entire existing test suite (169 tests), all passed (15 skipped as expected).
3.  **Type Checking:** Ran TypeScript type checking, which passed.
4.  **Linting:** Ran ESLint, which passed.

---
<p><a href="https://cursor.com/agents/bc-aff0cd04-821e-4beb-afa9-7776f2e70e69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aff0cd04-821e-4beb-afa9-7776f2e70e69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->