### PR TITLE
Operator command approval flow

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -10,6 +10,8 @@ import type { OffensiveSecurityAgentInput, ConsumeCallbacks } from "./types";
 import { createAllTools, EMAIL_TOOL_NAMES_ACTIVE } from "./tools";
 import { createResponseTool, RESPONSE_TOOL_NAME } from "./tools/response";
 import { DEFAULT_SYSTEM_PROMPT } from "./prompt";
+import type { ApprovalGate } from "../../operator";
+import { ApprovalDeniedError } from "../../operator";
 
 /**
  * General-purpose offensive security agent harness.
@@ -79,6 +81,11 @@ export class OffensiveSecurityAgent<TResult = void> {
     let tools: ToolSet = input.extraTools
       ? { ...builtinTools, ...input.extraTools }
       : { ...builtinTools };
+
+    // -- Approval gate wrapping -----------------------------------------------
+    if (input.approvalGate) {
+      tools = wrapToolsWithApprovalGate(tools, input.approvalGate);
+    }
 
     // -- Response schema → auto capture / stop / resolve ----------------------
     let capturedResponse: TResult | null = null;
@@ -231,4 +238,50 @@ export class OffensiveSecurityAgent<TResult = void> {
   get response() {
     return this.streamResult.response;
   }
+}
+
+/**
+ * Wrap every tool's execute function with the approval gate so that
+ * tool calls are held until the operator approves them.
+ */
+function wrapToolsWithApprovalGate(
+  tools: ToolSet,
+  gate: ApprovalGate,
+): ToolSet {
+  const wrapped: ToolSet = {};
+
+  for (const [name, coreTool] of Object.entries(tools)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const t = coreTool as any;
+
+    if (!t.execute) {
+      wrapped[name] = coreTool;
+      continue;
+    }
+
+    const originalExecute = t.execute;
+
+    wrapped[name] = {
+      ...t,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      execute: async (args: Record<string, unknown>, options: any) => {
+        const toolCallId =
+          args.toolCallId ??
+          `tc_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+        try {
+          await gate.check(name, String(toolCallId), args);
+        } catch (err) {
+          if (err instanceof ApprovalDeniedError) {
+            return { blocked: true, reason: "Denied by operator" };
+          }
+          throw err;
+        }
+
+        return originalExecute(args, options);
+      },
+    };
+  }
+
+  return wrapped;
 }

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -13,6 +13,7 @@ import type { AIAuthConfig } from "../../ai/utils";
 import type { CredentialManager } from "../../credentials";
 import type { FindingsRegistry } from "../../findings/registry";
 import type { SessionInfo } from "../../session";
+import type { ApprovalGate } from "../../operator";
 import type { ToolName } from "./tools";
 import type { UnifiedSandbox } from "./tools/sandbox";
 import { z } from "zod";
@@ -169,6 +170,13 @@ export type OffensiveSecurityAgentInput<TResult = void> = {
    * `activeTools` to get typed structured output from `consume()`.
    */
   responseSchema?: z.ZodSchema;
+
+  /**
+   * When provided, each tool call is gated through the approval gate.
+   * The gate will pause execution until the operator approves or denies
+   * the call (when `requireApproval` is enabled on the gate).
+   */
+  approvalGate?: ApprovalGate;
 };
 
 /**

--- a/src/core/api/offesecAgent.ts
+++ b/src/core/api/offesecAgent.ts
@@ -1,15 +1,18 @@
 import type { OffensiveSecurityAgentInput } from "../agents/offSecAgent";
+import type { StreamTextResult, ToolSet } from "ai";
 
 import { OffensiveSecurityAgent } from "../agents/offSecAgent/offensiveSecurityAgent";
+
 export async function runOffensiveSecurityAgent(
   input: OffensiveSecurityAgentInput,
-) {
+): Promise<StreamTextResult<ToolSet, never>> {
   const agent = new OffensiveSecurityAgent(input);
-  return agent.consume({
+  await agent.consume({
     onTextDelta: (d) => input.callbacks?.onTextDelta?.(d),
     onToolCall: (d) => input.callbacks?.onToolCall?.(d),
     onToolResult: (d) => input.callbacks?.onToolResult?.(d),
     onError: (e) => input.callbacks?.onError?.(e),
     subagentCallbacks: input.callbacks?.subagentCallbacks,
   });
+  return agent.streamResult;
 }

--- a/src/core/operator/approvalGate.ts
+++ b/src/core/operator/approvalGate.ts
@@ -1,27 +1,17 @@
 import { EventEmitter } from "events";
 import { randomBytes } from "crypto";
 import type {
-  OperatorMode,
-  OperatorStage,
-  PermissionTier,
   PendingApproval,
   ApprovalDecision,
   ActionHistoryEntry,
   OperatorEvent,
 } from "./types";
-import { classifyToolCall } from "./toolClassifier";
-import { checkPermission, shouldBlockAction } from "./permissionPolicy";
 
 /**
- * Approval gate configuration
+ * Approval gate configuration — simple boolean toggle.
  */
 export interface ApprovalGateConfig {
-  mode: OperatorMode;
-  autoApproveTier: PermissionTier;
-  /** Current operator stage - used for stage-aware auto-approval */
-  currentStage?: OperatorStage;
-  /** Tools to auto-approve in test/validate stages (offensive mode) */
-  offensiveStageTools?: string[];
+  requireApproval: boolean;
 }
 
 /**
@@ -34,7 +24,11 @@ interface DeferredApproval {
 }
 
 /**
- * ApprovalGate intercepts tool calls and manages the approval workflow
+ * ApprovalGate intercepts tool calls and manages the approval workflow.
+ *
+ * When `requireApproval` is true every tool call is held until the
+ * operator explicitly approves or denies it.  When false, all calls
+ * are auto-approved immediately.
  */
 export class ApprovalGate extends EventEmitter {
   private config: ApprovalGateConfig;
@@ -46,120 +40,64 @@ export class ApprovalGate extends EventEmitter {
     this.config = config;
   }
 
-  /**
-   * Update the gate configuration (e.g., when mode changes)
-   */
   updateConfig(config: Partial<ApprovalGateConfig>): void {
     this.config = { ...this.config, ...config };
     this.emit("config-changed", this.config);
   }
 
-  /**
-   * Get current configuration
-   */
   getConfig(): ApprovalGateConfig {
     return { ...this.config };
   }
 
-  /**
-   * Get pending approvals
-   */
   getPendingApprovals(): PendingApproval[] {
     return Array.from(this.pendingApprovals.values()).map((d) => d.approval);
   }
 
-  /**
-   * Get action history
-   */
   getActionHistory(): ActionHistoryEntry[] {
     return [...this.actionHistory];
   }
 
   /**
-   * Check if a tool call is allowed and handle approval if needed
-   * Returns a promise that resolves when approved or rejects when denied/blocked
+   * Check whether a tool call should proceed.
+   *
+   * If approval is required the call is held until the operator acts.
+   * Otherwise it is auto-approved immediately.
    */
   async check(
     toolName: string,
     toolCallId: string,
     args: Record<string, unknown>,
   ): Promise<ApprovalDecision> {
-    const tier = classifyToolCall({ toolName, args });
-
-    // Check if action should be blocked entirely (plan mode)
-    if (shouldBlockAction(tier, this.config.mode)) {
-      const entry = this.recordAction(toolName, toolCallId, tier, "denied");
-      this.emitEvent({ type: "action-completed", entry });
-      throw new ApprovalBlockedError(
-        `Action blocked in plan mode (tier ${tier})`,
-        tier,
-      );
-    }
-
-    // Stage-aware auto-approval: Auto-approve offensive tools in test/validate stages
-    const isOffensiveStage = ["test", "validate"].includes(
-      this.config.currentStage || "",
-    );
-    const isOffensiveTool = this.config.offensiveStageTools?.includes(toolName);
-    if (isOffensiveStage && isOffensiveTool && tier <= 3) {
-      const entry = this.recordAction(
-        toolName,
-        toolCallId,
-        tier,
-        "auto-approved",
-      );
+    if (!this.config.requireApproval) {
+      const entry = this.recordAction(toolName, toolCallId, "auto-approved");
       this.emitEvent({ type: "action-completed", entry });
       return "auto-approved";
     }
 
-    // Check permission policy
-    const result = checkPermission(tier, this.config);
-
-    if (result.autoApproved) {
-      const entry = this.recordAction(
-        toolName,
-        toolCallId,
-        tier,
-        "auto-approved",
-      );
-      this.emitEvent({ type: "action-completed", entry });
-      return "auto-approved";
-    }
-
-    // Need manual approval - create pending approval
-    return this.requestApproval(toolName, toolCallId, args, tier);
+    return this.requestApproval(toolName, toolCallId, args);
   }
 
-  /**
-   * Request manual approval for a tool call
-   */
   private requestApproval(
     toolName: string,
     toolCallId: string,
     args: Record<string, unknown>,
-    tier: PermissionTier,
   ): Promise<ApprovalDecision> {
     const approval: PendingApproval = {
       id: `apr_${Date.now()}_${randomBytes(4).toString("hex")}`,
       toolName,
       toolCallId,
       args,
-      tier,
+      tier: 1,
       timestamp: Date.now(),
     };
 
     return new Promise((resolve, reject) => {
       const deferred: DeferredApproval = { approval, resolve, reject };
       this.pendingApprovals.set(approval.id, deferred);
-
-      // Emit event for UI to show approval prompt
       this.emitEvent({ type: "approval-needed", approval });
     });
   }
 
-  /**
-   * Approve a pending approval
-   */
   approve(approvalId: string): void {
     const deferred = this.pendingApprovals.get(approvalId);
     if (!deferred) {
@@ -170,7 +108,6 @@ export class ApprovalGate extends EventEmitter {
     const entry = this.recordAction(
       deferred.approval.toolName,
       deferred.approval.toolCallId,
-      deferred.approval.tier,
       "approved",
     );
 
@@ -180,24 +117,17 @@ export class ApprovalGate extends EventEmitter {
       decision: "approved",
     });
     this.emitEvent({ type: "action-completed", entry });
-
     deferred.resolve("approved");
   }
 
-  /**
-   * Deny a pending approval
-   */
   deny(approvalId: string): void {
     const deferred = this.pendingApprovals.get(approvalId);
-    if (!deferred) {
-      return; // Already resolved or doesn't exist - no-op
-    }
+    if (!deferred) return;
 
     this.pendingApprovals.delete(approvalId);
     const entry = this.recordAction(
       deferred.approval.toolName,
       deferred.approval.toolCallId,
-      deferred.approval.tier,
       "denied",
     );
 
@@ -207,13 +137,9 @@ export class ApprovalGate extends EventEmitter {
       decision: "denied",
     });
     this.emitEvent({ type: "action-completed", entry });
-
     deferred.reject(new ApprovalDeniedError("Action denied by user"));
   }
 
-  /**
-   * Batch approve multiple pending approvals
-   */
   batchApprove(approvalIds: string[]): void {
     for (const id of approvalIds) {
       if (this.pendingApprovals.has(id)) {
@@ -222,47 +148,27 @@ export class ApprovalGate extends EventEmitter {
     }
   }
 
-  /**
-   * Approve all pending approvals up to a certain tier
-   */
-  approveUpToTier(maxTier: PermissionTier): void {
-    for (const [id, deferred] of this.pendingApprovals) {
-      if (deferred.approval.tier <= maxTier) {
-        this.approve(id);
-      }
-    }
-  }
-
-  /**
-   * Deny all pending approvals
-   */
   denyAll(): void {
     for (const id of this.pendingApprovals.keys()) {
       this.deny(id);
     }
   }
 
-  /**
-   * Record an action in the history
-   */
   private recordAction(
     toolName: string,
     toolCallId: string,
-    tier: PermissionTier,
     decision: ApprovalDecision,
   ): ActionHistoryEntry {
     const entry: ActionHistoryEntry = {
       id: `act_${Date.now()}_${randomBytes(4).toString("hex")}`,
       toolName,
       toolCallId,
-      tier,
+      tier: 1,
       decision,
       timestamp: Date.now(),
     };
 
     this.actionHistory.push(entry);
-
-    // Keep history bounded (last 100 entries)
     if (this.actionHistory.length > 100) {
       this.actionHistory.shift();
     }
@@ -270,31 +176,19 @@ export class ApprovalGate extends EventEmitter {
     return entry;
   }
 
-  /**
-   * Emit a typed Operator event
-   */
   private emitEvent(event: OperatorEvent): void {
     this.emit(event.type, event);
     this.emit("operator-event", event);
   }
 }
 
-/**
- * Error thrown when an action is blocked (e.g., in plan mode)
- */
 export class ApprovalBlockedError extends Error {
-  tier: PermissionTier;
-
-  constructor(message: string, tier: PermissionTier) {
+  constructor(message: string) {
     super(message);
     this.name = "ApprovalBlockedError";
-    this.tier = tier;
   }
 }
 
-/**
- * Error thrown when an action is denied by the user
- */
 export class ApprovalDeniedError extends Error {
   constructor(message: string) {
     super(message);
@@ -303,7 +197,10 @@ export class ApprovalDeniedError extends Error {
 }
 
 /**
- * Create a tool wrapper that integrates with the approval gate
+ * Wrap a tool's execute function with approval-gate logic.
+ *
+ * When the gate requires approval the wrapped function will block
+ * until the operator approves the call.
  */
 export function wrapToolWithApproval<
   TArgs extends Record<string, unknown>,
@@ -318,10 +215,7 @@ export function wrapToolWithApproval<
       args.toolCallId || `tc_${Date.now()}_${randomBytes(4).toString("hex")}`;
     const { toolCallId: _, ...toolArgs } = args;
 
-    // Check approval
     await gate.check(toolName, toolCallId, toolArgs as Record<string, unknown>);
-
-    // Execute the tool
     return originalTool(toolArgs as TArgs);
   };
 }

--- a/src/core/operator/index.ts
+++ b/src/core/operator/index.ts
@@ -41,7 +41,6 @@ export {
 // Permission Policy
 export {
   checkPermission,
-  shouldBlockAction,
   shouldAutoApprove,
   getApprovalRequirement,
   getPolicySummary,

--- a/src/core/operator/permissionPolicy.ts
+++ b/src/core/operator/permissionPolicy.ts
@@ -1,141 +1,49 @@
-import type { OperatorMode, PermissionTier } from "./types";
-
 /**
- * Permission policy configuration
+ * Permission policy — simplified to a single boolean toggle.
+ *
+ * When `requireApproval` is true every tool call needs manual approval.
+ * When false, all calls are auto-approved.
  */
+
 export interface PermissionPolicyConfig {
-  mode: OperatorMode;
-  autoApproveTier: PermissionTier;
+  requireApproval: boolean;
 }
 
-/**
- * Result of a permission check
- */
 export interface PermissionCheckResult {
   allowed: boolean;
   autoApproved: boolean;
   reason: string;
 }
 
-/**
- * Check if a tool call should be auto-approved based on policy
- */
 export function checkPermission(
-  tier: PermissionTier,
   config: PermissionPolicyConfig,
 ): PermissionCheckResult {
-  const { mode, autoApproveTier } = config;
-
-  // Plan mode: block all network actions (tier > 1)
-  if (mode === "plan") {
-    if (tier === 1) {
-      return {
-        allowed: true,
-        autoApproved: true,
-        reason: "Passive operations allowed in plan mode",
-      };
-    }
-    return {
-      allowed: false,
-      autoApproved: false,
-      reason: "Plan mode - network actions blocked",
-    };
-  }
-
-  // Manual mode: require approval for everything except tier 1
-  if (mode === "manual") {
-    if (tier === 1) {
-      return {
-        allowed: true,
-        autoApproved: true,
-        reason: "Passive operations auto-approved",
-      };
-    }
+  if (config.requireApproval) {
     return {
       allowed: true,
       autoApproved: false,
-      reason: `Tier ${tier} requires manual approval`,
+      reason: "Command approval is required",
     };
   }
-
-  // Auto mode: auto-approve up to configured tier
-  if (mode === "auto") {
-    if (tier <= autoApproveTier) {
-      return {
-        allowed: true,
-        autoApproved: true,
-        reason: `Tier ${tier} auto-approved (within T${autoApproveTier})`,
-      };
-    }
-    return {
-      allowed: true,
-      autoApproved: false,
-      reason: `Tier ${tier} exceeds auto-approve threshold (T${autoApproveTier})`,
-    };
-  }
-
-  // Fallback - shouldn't reach here
   return {
     allowed: true,
-    autoApproved: false,
-    reason: "Unknown mode - requiring approval",
+    autoApproved: true,
+    reason: "Command approval is disabled",
   };
 }
 
-/**
- * Check if an action should be blocked entirely (not just requiring approval)
- */
-export function shouldBlockAction(
-  tier: PermissionTier,
-  mode: OperatorMode,
-): boolean {
-  // Only plan mode blocks actions (tier > 1)
-  return mode === "plan" && tier > 1;
+export function shouldAutoApprove(config: PermissionPolicyConfig): boolean {
+  return !config.requireApproval;
 }
 
-/**
- * Check if an action should be auto-approved
- */
-export function shouldAutoApprove(
-  tier: PermissionTier,
-  mode: OperatorMode,
-  autoApproveTier: PermissionTier,
-): boolean {
-  const result = checkPermission(tier, { mode, autoApproveTier });
-  return result.allowed && result.autoApproved;
-}
-
-/**
- * Get the effective approval requirement for a tier given current policy
- */
 export function getApprovalRequirement(
-  tier: PermissionTier,
   config: PermissionPolicyConfig,
-): "auto" | "manual" | "blocked" {
-  const result = checkPermission(tier, config);
-
-  if (!result.allowed) {
-    return "blocked";
-  }
-  if (result.autoApproved) {
-    return "auto";
-  }
-  return "manual";
+): "auto" | "manual" {
+  return config.requireApproval ? "manual" : "auto";
 }
 
-/**
- * Get a summary of what tiers are auto-approved vs manual for current config
- */
 export function getPolicySummary(config: PermissionPolicyConfig): string {
-  const { mode, autoApproveTier } = config;
-
-  if (mode === "plan") {
-    return "Plan mode: Only passive (T1) operations allowed";
-  }
-
-  if (mode === "manual") {
-    return "Manual mode: T1 auto-approved, T2-T5 require approval";
-  }
-
-  return `Auto mode: T1-T${autoApproveTier} auto-approved, T${autoApproveTier + 1}-T5 require approval`;
+  return config.requireApproval
+    ? "Command approval enabled — every tool call requires approval"
+    : "Command approval disabled — tool calls execute automatically";
 }

--- a/src/core/operator/types.ts
+++ b/src/core/operator/types.ts
@@ -205,7 +205,7 @@ export interface StageProgress {
 export interface OperatorSessionState {
   mode: OperatorMode;
   currentStage: OperatorStage;
-  autoApproveTier: PermissionTier;
+  requireApproval: boolean;
   pendingApprovals: PendingApproval[];
   actionHistory: ActionHistoryEntry[];
   stageProgress: Record<OperatorStage, StageProgress>;
@@ -213,7 +213,7 @@ export interface OperatorSessionState {
 
 export function createInitialOperatorState(
   initialMode: OperatorMode = "manual",
-  autoApproveTier: PermissionTier = 2,
+  requireApproval: boolean = true,
 ): OperatorSessionState {
   const stageProgress = {} as Record<OperatorStage, StageProgress>;
   for (const stage of Object.keys(OPERATOR_STAGES) as OperatorStage[]) {
@@ -222,7 +222,7 @@ export function createInitialOperatorState(
   return {
     mode: initialMode,
     currentStage: "setup",
-    autoApproveTier,
+    requireApproval,
     pendingApprovals: [],
     actionHistory: [],
     stageProgress,
@@ -232,7 +232,7 @@ export function createInitialOperatorState(
 /** Operator settings for session config */
 export const OperatorSettingsObject = z.object({
   initialMode: z.enum(["plan", "manual", "auto"]).default("manual"),
-  autoApproveTier: z.number().min(1).max(5).default(2),
+  requireApproval: z.boolean().default(true),
 });
 
 export type OperatorSettings = z.infer<typeof OperatorSettingsObject>;

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -79,7 +79,7 @@ export type OffensiveHeadersConfig = z.infer<
 
 const OperatorSettingsObject = z.object({
   initialMode: z.enum(["plan", "manual", "auto"]).default("manual"),
-  autoApproveTier: z.number().min(1).max(5).default(2),
+  requireApproval: z.boolean().default(true),
   enableSuggestions: z.boolean().default(true),
 });
 
@@ -530,8 +530,8 @@ export const removeMessage = async (input: z.output<typeof RemoveMsgInput>) => {
 export interface OperatorSessionState {
   /** Operator mode: plan, manual, auto */
   mode: string;
-  /** Auto-approve tier level */
-  autoApproveTier: number;
+  /** Whether commands require user approval before execution */
+  requireApproval: boolean;
   /** Current stage: setup, recon, foothold, etc. */
   currentStage: string;
   /** Chat messages history */
@@ -614,7 +614,7 @@ export async function updateOperatorSettings(
     if (!session.config.operatorSettings) {
       session.config.operatorSettings = {
         initialMode: "manual",
-        autoApproveTier: 2,
+        requireApproval: true,
         enableSuggestions: true,
       };
     }
@@ -623,9 +623,9 @@ export async function updateOperatorSettings(
     if (settings.initialMode !== undefined) {
       session.config.operatorSettings.initialMode = settings.initialMode;
     }
-    if (settings.autoApproveTier !== undefined) {
-      session.config.operatorSettings.autoApproveTier =
-        settings.autoApproveTier;
+    if (settings.requireApproval !== undefined) {
+      session.config.operatorSettings.requireApproval =
+        settings.requireApproval;
     }
     if (settings.enableSuggestions !== undefined) {
       session.config.operatorSettings.enableSuggestions =

--- a/src/tui/components/chat/approval-inline.tsx
+++ b/src/tui/components/chat/approval-inline.tsx
@@ -5,7 +5,7 @@
  * Provides visual context for pending approvals.
  */
 
-import { useTheme, getTierColor } from "../../theme";
+import { useTheme } from "../../theme";
 import { getToolSummary } from "../shared/tool-registry";
 import type { PendingApproval } from "../../../core/operator";
 
@@ -14,17 +14,12 @@ interface InlineApprovalPromptProps {
 }
 
 /**
- * Inline approval prompt - shows pending tool call with tier info.
- * Displayed in the chat flow.
+ * Inline approval prompt — shows pending tool call awaiting approval.
  */
 export function InlineApprovalPrompt({ approval }: InlineApprovalPromptProps) {
   const { colors } = useTheme();
-  const tierColor = getTierColor(colors, approval.tier);
 
-  // Get the description if provided
   const description = approval.args?.toolCallDescription as string | undefined;
-
-  // Get tool summary from registry
   const summary = getToolSummary(approval.toolName, approval.args || {});
 
   return (
@@ -33,17 +28,15 @@ export function InlineApprovalPrompt({ approval }: InlineApprovalPromptProps) {
       <text fg={colors.warning}>{"  │ "}</text>
 
       <box flexDirection="column">
-        {/* Description from agent if available */}
         {description && (
           <box flexDirection="row" marginBottom={1}>
             <text fg={colors.text} content={description} />
           </box>
         )}
 
-        {/* Approval line with tier indicator */}
+        {/* Approval line */}
         <box flexDirection="row" gap={1}>
           <text fg={colors.warning} content="?" />
-          <text fg={tierColor} content={`[T${approval.tier}]`} />
           <text fg={colors.info} content={summary} />
         </box>
 
@@ -52,7 +45,7 @@ export function InlineApprovalPrompt({ approval }: InlineApprovalPromptProps) {
           <text fg={colors.primary}>Y</text>
           <text fg={colors.textMuted}>approve</text>
           <text fg={colors.secondary}>A</text>
-          <text fg={colors.textMuted}>auto-approve</text>
+          <text fg={colors.textMuted}>approve all</text>
           <text fg={colors.textMuted}>or type to redirect</text>
         </box>
       </box>

--- a/src/tui/components/chat/header.tsx
+++ b/src/tui/components/chat/header.tsx
@@ -5,12 +5,8 @@
  * Layout: MODE | target URL | endpoints found | findings documented | tokens | tool calls
  */
 
-import { useTheme, getTierColor } from "../../theme";
-import type {
-  OperatorMode,
-  OperatorStage,
-  PermissionTier,
-} from "../../../core/operator";
+import { useTheme } from "../../theme";
+import type { OperatorMode, OperatorStage } from "../../../core/operator";
 
 export interface HeaderProps {
   /** Session mode */
@@ -27,8 +23,8 @@ export interface HeaderProps {
   operatorMode?: OperatorMode;
   /** Operator-specific: current stage */
   currentStage?: OperatorStage;
-  /** Operator-specific: auto-approve tier */
-  autoApproveTier?: PermissionTier;
+  /** Whether command approval is enabled */
+  requireApproval?: boolean;
   /** Operator-specific: approval stats */
   stats?: { approved: number; denied: number };
   /** Number of endpoints discovered */
@@ -51,7 +47,7 @@ export function Header({
   tokenUsage,
   operatorMode,
   currentStage,
-  autoApproveTier,
+  requireApproval,
   stats,
   endpointsCount = 0,
   findingsCount = 0,
@@ -118,12 +114,12 @@ export function Header({
           </>
         )}
 
-        {/* Auto-approve tier indicator */}
-        {autoApproveTier && mode === "operator" && (
+        {/* Approval status indicator */}
+        {requireApproval !== undefined && mode === "operator" && (
           <>
             <text fg={colors.textMuted}>│</text>
-            <text fg={getTierColor(colors, autoApproveTier)}>
-              T{autoApproveTier}
+            <text fg={requireApproval ? colors.warning : colors.primary}>
+              {requireApproval ? "approval:on" : "approval:off"}
             </text>
           </>
         )}

--- a/src/tui/components/chat/index.tsx
+++ b/src/tui/components/chat/index.tsx
@@ -110,7 +110,7 @@ export function ChatApp({
         },
         operatorSettings: {
           initialMode: "manual",
-          autoApproveTier: 2,
+          requireApproval: true,
           enableSuggestions: true,
         },
       },

--- a/src/tui/components/chat/input-area.tsx
+++ b/src/tui/components/chat/input-area.tsx
@@ -9,7 +9,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useKeyboard } from "@opentui/react";
-import { useTheme, getTierColor } from "../../theme";
+import { useTheme } from "../../theme";
 import { PromptInput, type PromptInputRef } from "../shared/prompt-input";
 import { InputProvider, useInput } from "../../context/input";
 import type { PendingApproval, OperatorMode } from "../../../core/operator";
@@ -234,7 +234,6 @@ function ApprovalInputArea({
 }: ApprovalInputAreaProps) {
   const { colors } = useTheme();
   const [focusedElement, setFocusedElement] = useState(0); // 0=Yes, 1=Auto, 2=Input
-  const tierColor = getTierColor(colors, approval.tier);
 
   useKeyboard((key) => {
     // Navigation
@@ -293,7 +292,7 @@ function ApprovalInputArea({
         />
         <text
           fg={focusedElement === 1 ? colors.text : colors.textMuted}
-          content={`[A] Auto-approve T1-T${approval.tier} from now`}
+          content="[A] Auto-approve all commands from now"
         />
       </box>
 

--- a/src/tui/components/commands/operator-wizard.tsx
+++ b/src/tui/components/commands/operator-wizard.tsx
@@ -7,8 +7,8 @@ import { useAgent } from "../../context/agent";
 import { sessions, type SessionConfig } from "../../../core/session";
 import { SpinnerDots } from "../sprites";
 import { generateRandomName } from "../../../util/name";
-import type { OperatorMode, PermissionTier } from "../../../core/operator";
-import { OPERATOR_MODES, PERMISSION_TIERS } from "../../../core/operator";
+import type { OperatorMode } from "../../../core/operator";
+import { OPERATOR_MODES } from "../../../core/operator";
 import type { ModelInfo } from "../../../core/ai";
 import { getAvailableModels } from "../../../core/providers/utils";
 import { useTheme } from "../../theme";
@@ -19,7 +19,7 @@ interface WizardState {
   name: string;
   target: string;
   mode: OperatorMode;
-  autoApproveTier: PermissionTier;
+  requireApproval: boolean;
   scope: {
     allowedHosts: string[];
     strictScope: boolean;
@@ -30,7 +30,7 @@ interface HITLWizardProps {
   initialTarget?: string;
   initialMode?: string;
   initialName?: string;
-  initialTier?: number;
+  initialRequireApproval?: boolean;
   initialAuthUrl?: string;
   initialAuthUser?: string;
   initialAuthPass?: string;
@@ -75,7 +75,7 @@ export default function HITLWizard(props: HITLWizardProps) {
     initialTarget,
     initialMode,
     initialName,
-    initialTier,
+    initialRequireApproval,
     initialHosts,
     initialStrict,
     initialModel,
@@ -89,7 +89,6 @@ export default function HITLWizard(props: HITLWizardProps) {
 
   const [currentStep, setCurrentStep] = useState<WizardStep>(initialStep);
   const [state, setState] = useState<WizardState>(() => {
-    // Auto-parse host from target URL if provided
     const hostsFromTarget: string[] = [];
     if (initialTarget) {
       const parsedHost = parseHostFromUrl(initialTarget);
@@ -97,7 +96,6 @@ export default function HITLWizard(props: HITLWizardProps) {
         hostsFromTarget.push(parsedHost);
       }
     }
-    // Combine with any explicitly provided hosts (avoiding duplicates)
     const combinedHosts = [
       ...new Set([...hostsFromTarget, ...(initialHosts || [])]),
     ];
@@ -106,7 +104,7 @@ export default function HITLWizard(props: HITLWizardProps) {
       name: initialName || generateRandomName(),
       target: initialTarget || "",
       mode: (initialMode as OperatorMode) || "manual",
-      autoApproveTier: (initialTier || 2) as PermissionTier,
+      requireApproval: initialRequireApproval ?? true,
       scope: {
         allowedHosts: combinedHosts,
         strictScope: initialStrict || false,
@@ -132,7 +130,6 @@ export default function HITLWizard(props: HITLWizardProps) {
       const models = getAvailableModels(config.data);
       setAvailableModels(models);
       if (models.length > 0) {
-        // If initialModel was provided, try to set it
         if (initialModel) {
           const targetModel = models.find((m) => m.id === initialModel);
           if (targetModel) {
@@ -192,7 +189,7 @@ export default function HITLWizard(props: HITLWizardProps) {
         mode: "operator",
         operatorSettings: {
           initialMode: state.mode,
-          autoApproveTier: state.autoApproveTier,
+          requireApproval: state.requireApproval,
           enableSuggestions: true,
         },
       };
@@ -220,9 +217,7 @@ export default function HITLWizard(props: HITLWizardProps) {
     }
   }
 
-  // Helper to transition to mode step and auto-parse host from target
   const goToModeStep = () => {
-    // Auto-parse host from target URL if not already in scope
     const targetHost = parseHostFromUrl(state.target);
     if (targetHost && !state.scope.allowedHosts.includes(targetHost)) {
       setState((prev) => ({
@@ -236,16 +231,14 @@ export default function HITLWizard(props: HITLWizardProps) {
     setCurrentStep("mode");
   };
 
-  // Calculate max field index (5 normally, 4 if plan mode hides tier selector)
-  const maxField = state.mode === "plan" ? 4 : 5;
-
-  // Adjust field index mapping when in plan mode (skip tier field)
-  const getActualField = (field: number): number => {
-    if (state.mode === "plan" && field >= 1) {
-      return field + 1; // Skip tier field (1) in plan mode
-    }
-    return field;
-  };
+  // Mode step fields:
+  // 0: Mode selection
+  // 1: Require approval toggle
+  // 2: Add allowed host input
+  // 3: Strict scope toggle
+  // 4: Model selection
+  // 5: Submit button
+  const maxField = 5;
 
   useKeyboard((key) => {
     if (key.name === "escape") {
@@ -289,9 +282,6 @@ export default function HITLWizard(props: HITLWizardProps) {
     }
 
     if (currentStep === "mode") {
-      const actualField = getActualField(modeFocusedField);
-
-      // Up/down navigation between fields
       if (key.name === "up") {
         setModeFocusedField((prev) => Math.max(0, prev - 1));
         return;
@@ -309,12 +299,11 @@ export default function HITLWizard(props: HITLWizardProps) {
         return;
       }
 
-      // Left/right to change values within a field
       if (key.name === "left" || key.name === "right") {
         const delta = key.name === "left" ? -1 : 1;
 
         // Mode selection (field 0)
-        if (actualField === 0) {
+        if (modeFocusedField === 0) {
           const modes: OperatorMode[] = ["plan", "manual", "auto"];
           const idx = modes.indexOf(state.mode);
           const newIdx = (idx + delta + modes.length) % modes.length;
@@ -322,17 +311,17 @@ export default function HITLWizard(props: HITLWizardProps) {
           return;
         }
 
-        // Tier selection (field 1, only in non-plan mode)
-        if (actualField === 1) {
-          const tiers: PermissionTier[] = [1, 2, 3, 4, 5];
-          const idx = tiers.indexOf(state.autoApproveTier);
-          const newIdx = Math.max(0, Math.min(4, idx + delta));
-          setState((prev) => ({ ...prev, autoApproveTier: tiers[newIdx] }));
+        // Require approval toggle (field 1)
+        if (modeFocusedField === 1) {
+          setState((prev) => ({
+            ...prev,
+            requireApproval: !prev.requireApproval,
+          }));
           return;
         }
 
         // Strict scope toggle (field 3)
-        if (actualField === 3) {
+        if (modeFocusedField === 3) {
           setState((prev) => ({
             ...prev,
             scope: { ...prev.scope, strictScope: !prev.scope.strictScope },
@@ -341,7 +330,7 @@ export default function HITLWizard(props: HITLWizardProps) {
         }
 
         // Model selection (field 4)
-        if (actualField === 4 && visibleModels.length > 0) {
+        if (modeFocusedField === 4 && visibleModels.length > 0) {
           const currentIdx = visibleModels.findIndex((m) => m.id === model.id);
           const newIdx = Math.max(
             0,
@@ -353,10 +342,18 @@ export default function HITLWizard(props: HITLWizardProps) {
         }
       }
 
-      // Enter to activate/submit
       if (key.name === "return") {
+        // Require approval toggle (field 1)
+        if (modeFocusedField === 1) {
+          setState((prev) => ({
+            ...prev,
+            requireApproval: !prev.requireApproval,
+          }));
+          return;
+        }
+
         // Add host if typing (field 2)
-        if (actualField === 2 && hostInput.trim()) {
+        if (modeFocusedField === 2 && hostInput.trim()) {
           setState((prev) => ({
             ...prev,
             scope: {
@@ -369,7 +366,7 @@ export default function HITLWizard(props: HITLWizardProps) {
         }
 
         // Toggle strict scope (field 3)
-        if (actualField === 3) {
+        if (modeFocusedField === 3) {
           setState((prev) => ({
             ...prev,
             scope: { ...prev.scope, strictScope: !prev.scope.strictScope },
@@ -378,7 +375,7 @@ export default function HITLWizard(props: HITLWizardProps) {
         }
 
         // Submit button (field 5)
-        if (actualField === 5) {
+        if (modeFocusedField === 5) {
           createSessionAndNavigate();
         }
         return;
@@ -459,18 +456,7 @@ export default function HITLWizard(props: HITLWizardProps) {
     );
   }
 
-  // Mode step - field indices:
-  // 0: Mode selection
-  // 1: Auto-approve tier (hidden in plan mode)
-  // 2: Add allowed host input
-  // 3: Strict scope toggle
-  // 4: Model selection
-  // 5: Submit button
-  // In plan mode, fields shift: 0, 2, 3, 4, 5 become indices 0, 1, 2, 3, 4
-
-  const actualField = getActualField(modeFocusedField);
   const modeDef = OPERATOR_MODES[state.mode];
-  const tierDef = PERMISSION_TIERS[state.autoApproveTier];
 
   return (
     <box width="100%" flexDirection="column" gap={1} paddingLeft={4}>
@@ -481,45 +467,47 @@ export default function HITLWizard(props: HITLWizardProps) {
 
       {/* Mode Selection - Field 0 */}
       <box flexDirection="row" gap={1}>
-        <text fg={actualField === 0 ? colors.primary : colors.textMuted}>
-          {actualField === 0 ? "▸" : " "}
+        <text fg={modeFocusedField === 0 ? colors.primary : colors.textMuted}>
+          {modeFocusedField === 0 ? "▸" : " "}
         </text>
-        <text fg={actualField === 0 ? colors.text : colors.textMuted}>
+        <text fg={modeFocusedField === 0 ? colors.text : colors.textMuted}>
           Mode:
         </text>
         <text fg={modeColor}>{modeDef.name}</text>
         <text fg={colors.textMuted}>- {modeDef.description}</text>
-        {actualField === 0 && <text fg={colors.textMuted}>(←/→)</text>}
+        {modeFocusedField === 0 && <text fg={colors.textMuted}>(←/→)</text>}
       </box>
 
-      {/* Auto-approve Tier - Field 1 (hidden in plan mode) */}
-      {state.mode !== "plan" && (
-        <box flexDirection="row" gap={1}>
-          <text fg={actualField === 1 ? colors.primary : colors.textMuted}>
-            {actualField === 1 ? "▸" : " "}
-          </text>
-          <text fg={actualField === 1 ? colors.text : colors.textMuted}>
-            Auto-approve:
-          </text>
-          <text fg={colors.primary}>
-            T{state.autoApproveTier} - {tierDef.name}
-          </text>
-          <text fg={colors.textMuted}>
-            ({tierDef.examples.slice(0, 2).join(", ")})
-          </text>
-          {actualField === 1 && <text fg={colors.textMuted}>(←/→)</text>}
-        </box>
-      )}
+      {/* Require Approval Toggle - Field 1 */}
+      <box flexDirection="row" gap={1}>
+        <text fg={modeFocusedField === 1 ? colors.primary : colors.textMuted}>
+          {modeFocusedField === 1 ? "▸" : " "}
+        </text>
+        <text fg={modeFocusedField === 1 ? colors.text : colors.textMuted}>
+          Require command approval:
+        </text>
+        <text fg={state.requireApproval ? colors.warning : colors.primary}>
+          {state.requireApproval ? "Enabled" : "Disabled"}
+        </text>
+        <text fg={colors.textMuted}>
+          {state.requireApproval
+            ? "- approve each command before execution"
+            : "- commands execute automatically"}
+        </text>
+        {modeFocusedField === 1 && (
+          <text fg={colors.textMuted}>(Enter/←/→)</text>
+        )}
+      </box>
 
       {/* Add Allowed Host - Field 2 */}
       <box flexDirection="row" gap={1}>
-        <text fg={actualField === 2 ? colors.primary : colors.textMuted}>
-          {actualField === 2 ? "▸" : " "}
+        <text fg={modeFocusedField === 2 ? colors.primary : colors.textMuted}>
+          {modeFocusedField === 2 ? "▸" : " "}
         </text>
-        <text fg={actualField === 2 ? colors.text : colors.textMuted}>
+        <text fg={modeFocusedField === 2 ? colors.text : colors.textMuted}>
           Add host:
         </text>
-        {actualField === 2 ? (
+        {modeFocusedField === 2 ? (
           <input
             width={30}
             value={hostInput}
@@ -533,7 +521,9 @@ export default function HITLWizard(props: HITLWizardProps) {
         ) : (
           <text fg={colors.textMuted}>{hostInput || "example.com"}</text>
         )}
-        {actualField === 2 && <text fg={colors.textMuted}>(Enter to add)</text>}
+        {modeFocusedField === 2 && (
+          <text fg={colors.textMuted}>(Enter to add)</text>
+        )}
       </box>
 
       {/* Show added hosts */}
@@ -550,43 +540,45 @@ export default function HITLWizard(props: HITLWizardProps) {
 
       {/* Strict Scope - Field 3 */}
       <box flexDirection="row" gap={1}>
-        <text fg={actualField === 3 ? colors.primary : colors.textMuted}>
-          {actualField === 3 ? "▸" : " "}
+        <text fg={modeFocusedField === 3 ? colors.primary : colors.textMuted}>
+          {modeFocusedField === 3 ? "▸" : " "}
         </text>
-        <text fg={actualField === 3 ? colors.text : colors.textMuted}>
+        <text fg={modeFocusedField === 3 ? colors.text : colors.textMuted}>
           Strict scope:
         </text>
         <text fg={state.scope.strictScope ? colors.primary : colors.textMuted}>
           {state.scope.strictScope ? "Enabled" : "Disabled"}
         </text>
-        {actualField === 3 && <text fg={colors.textMuted}>(Enter/←/→)</text>}
+        {modeFocusedField === 3 && (
+          <text fg={colors.textMuted}>(Enter/←/→)</text>
+        )}
       </box>
 
       {/* Model Selection - Field 4 */}
       <box flexDirection="row" gap={1}>
-        <text fg={actualField === 4 ? colors.primary : colors.textMuted}>
-          {actualField === 4 ? "▸" : " "}
+        <text fg={modeFocusedField === 4 ? colors.primary : colors.textMuted}>
+          {modeFocusedField === 4 ? "▸" : " "}
         </text>
-        <text fg={actualField === 4 ? colors.text : colors.textMuted}>
+        <text fg={modeFocusedField === 4 ? colors.text : colors.textMuted}>
           Model:
         </text>
         <text fg={colors.primary}>{model.name}</text>
-        {actualField === 4 && <text fg={colors.textMuted}>(←/→)</text>}
+        {modeFocusedField === 4 && <text fg={colors.textMuted}>(←/→)</text>}
       </box>
 
       {/* Submit Button - Field 5 */}
       <box flexDirection="row" gap={1} marginTop={1}>
-        <text fg={actualField === 5 ? colors.primary : colors.textMuted}>
-          {actualField === 5 ? "▸" : " "}
+        <text fg={modeFocusedField === 5 ? colors.primary : colors.textMuted}>
+          {modeFocusedField === 5 ? "▸" : " "}
         </text>
-        <text fg={actualField === 5 ? colors.primary : colors.textMuted}>
-          {actualField === 5 ? "[" : " "}
+        <text fg={modeFocusedField === 5 ? colors.primary : colors.textMuted}>
+          {modeFocusedField === 5 ? "[" : " "}
         </text>
-        <text fg={actualField === 5 ? colors.text : colors.textMuted}>
+        <text fg={modeFocusedField === 5 ? colors.text : colors.textMuted}>
           Start Session
         </text>
-        <text fg={actualField === 5 ? colors.primary : colors.textMuted}>
-          {actualField === 5 ? "]" : " "}
+        <text fg={modeFocusedField === 5 ? colors.primary : colors.textMuted}>
+          {modeFocusedField === 5 ? "]" : " "}
         </text>
       </box>
 

--- a/src/tui/components/commands/operator-wizard.tsx
+++ b/src/tui/components/commands/operator-wizard.tsx
@@ -273,9 +273,7 @@ export default function HITLWizard(props: HITLWizardProps) {
           <input
             width={30}
             value={state.name}
-            onInput={(v: string) =>
-              setState((prev) => ({ ...prev, name: v }))
-            }
+            onInput={(v: string) => setState((prev) => ({ ...prev, name: v }))}
             focused={true}
             placeholder="swift-falcon"
             textColor={colors.text}
@@ -303,9 +301,7 @@ export default function HITLWizard(props: HITLWizardProps) {
             ? "- approve each command before execution"
             : "- commands execute automatically"}
         </text>
-        {focusedField === 1 && (
-          <text fg={colors.textMuted}>(Enter/←/→)</text>
-        )}
+        {focusedField === 1 && <text fg={colors.textMuted}>(Enter/←/→)</text>}
       </box>
 
       {/* Model Selection - Field 2 */}

--- a/src/tui/components/commands/operator-wizard.tsx
+++ b/src/tui/components/commands/operator-wizard.tsx
@@ -1,42 +1,31 @@
 import { useState, useEffect, useMemo } from "react";
 import { useKeyboard } from "@opentui/react";
-import Input from "../input";
 import { useRoute } from "../../context/route";
 import { useConfig } from "../../context/config";
 import { useAgent } from "../../context/agent";
 import { sessions, type SessionConfig } from "../../../core/session";
 import { SpinnerDots } from "../sprites";
 import { generateRandomName } from "../../../util/name";
-import type { OperatorMode } from "../../../core/operator";
-import { OPERATOR_MODES } from "../../../core/operator";
 import type { ModelInfo } from "../../../core/ai";
 import { getAvailableModels } from "../../../core/providers/utils";
 import { useTheme } from "../../theme";
 
-type WizardStep = "target" | "mode" | "creating";
+type WizardStep = "config" | "creating";
 
 interface WizardState {
   name: string;
   target: string;
-  mode: OperatorMode;
   requireApproval: boolean;
-  scope: {
-    allowedHosts: string[];
-    strictScope: boolean;
-  };
 }
 
 interface HITLWizardProps {
   initialTarget?: string;
-  initialMode?: string;
   initialName?: string;
   initialRequireApproval?: boolean;
   initialAuthUrl?: string;
   initialAuthUser?: string;
   initialAuthPass?: string;
   initialAuthInstructions?: string;
-  initialHosts?: string[];
-  initialStrict?: boolean;
   initialHeadersMode?: "none" | "default" | "custom";
   initialCustomHeaders?: Record<string, string>;
   initialModel?: string;
@@ -50,71 +39,23 @@ const providerNames: Record<string, string> = {
 };
 const providerOrder = ["anthropic", "openai", "openrouter", "bedrock"];
 
-/**
- * Parse host from a URL string (includes port if present)
- * e.g., http://localhost:3001 -> localhost:3001
- */
-function parseHostFromUrl(url: string): string | null {
-  try {
-    const parsed = new URL(url);
-    return parsed.host; // host includes port, hostname does not
-  } catch {
-    // Try adding protocol if missing
-    try {
-      const parsed = new URL(`https://${url}`);
-      return parsed.host;
-    } catch {
-      return null;
-    }
-  }
-}
-
 export default function HITLWizard(props: HITLWizardProps) {
   const { colors } = useTheme();
-  const {
-    initialTarget,
-    initialMode,
-    initialName,
-    initialRequireApproval,
-    initialHosts,
-    initialStrict,
-    initialModel,
-  } = props;
+  const { initialTarget, initialName, initialRequireApproval, initialModel } =
+    props;
 
   const route = useRoute();
   const config = useConfig();
   const { model, setModel, isModelUserSelected } = useAgent();
 
-  const initialStep: WizardStep = initialTarget ? "mode" : "target";
+  const [currentStep, setCurrentStep] = useState<WizardStep>("config");
+  const [state, setState] = useState<WizardState>(() => ({
+    name: initialName || generateRandomName(),
+    target: initialTarget || "",
+    requireApproval: initialRequireApproval ?? true,
+  }));
 
-  const [currentStep, setCurrentStep] = useState<WizardStep>(initialStep);
-  const [state, setState] = useState<WizardState>(() => {
-    const hostsFromTarget: string[] = [];
-    if (initialTarget) {
-      const parsedHost = parseHostFromUrl(initialTarget);
-      if (parsedHost) {
-        hostsFromTarget.push(parsedHost);
-      }
-    }
-    const combinedHosts = [
-      ...new Set([...hostsFromTarget, ...(initialHosts || [])]),
-    ];
-
-    return {
-      name: initialName || generateRandomName(),
-      target: initialTarget || "",
-      mode: (initialMode as OperatorMode) || "manual",
-      requireApproval: initialRequireApproval ?? true,
-      scope: {
-        allowedHosts: combinedHosts,
-        strictScope: initialStrict || false,
-      },
-    };
-  });
-
-  const [targetFocusedField, setTargetFocusedField] = useState(0);
-  const [modeFocusedField, setModeFocusedField] = useState(0);
-  const [hostInput, setHostInput] = useState("");
+  const [focusedField, setFocusedField] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
   // Model picker state
@@ -124,7 +65,6 @@ export default function HITLWizard(props: HITLWizardProps) {
     new Set(["anthropic"]),
   );
 
-  // Load available models
   useEffect(() => {
     if (config.data) {
       const models = getAvailableModels(config.data);
@@ -146,7 +86,6 @@ export default function HITLWizard(props: HITLWizardProps) {
     }
   }, [config.data, model.id, initialModel]);
 
-  // Group and filter models
   const groupedModels = useMemo(() => {
     const groups: Record<string, ModelInfo[]> = {};
     const query = modelSearchQuery.toLowerCase().trim();
@@ -164,7 +103,6 @@ export default function HITLWizard(props: HITLWizardProps) {
     return groups;
   }, [availableModels, modelSearchQuery]);
 
-  // Visible models for navigation
   const visibleModels = useMemo(() => {
     const result: ModelInfo[] = [];
     for (const provider of providerOrder) {
@@ -178,8 +116,6 @@ export default function HITLWizard(props: HITLWizardProps) {
   }, [groupedModels, expandedProviders]);
 
   async function createSessionAndNavigate() {
-    if (!state.target.trim()) return;
-
     setCurrentStep("creating");
     setError(null);
 
@@ -188,21 +124,15 @@ export default function HITLWizard(props: HITLWizardProps) {
         sessionType: "web-app",
         mode: "operator",
         operatorSettings: {
-          initialMode: state.mode,
+          initialMode: "auto",
           requireApproval: state.requireApproval,
           enableSuggestions: true,
         },
       };
 
-      if (state.scope.allowedHosts.length > 0) {
-        sessionConfig.scopeConstraints = {
-          allowedHosts: state.scope.allowedHosts,
-          strictScope: state.scope.strictScope,
-        };
-      }
-
+      const targets = state.target.trim() ? [state.target] : [];
       const session = await sessions.create({
-        targets: [state.target],
+        targets,
         name: state.name,
         config: sessionConfig,
       });
@@ -213,106 +143,51 @@ export default function HITLWizard(props: HITLWizardProps) {
       });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create session");
-      setCurrentStep(initialTarget ? "mode" : "target");
+      setCurrentStep("config");
     }
   }
 
-  const goToModeStep = () => {
-    const targetHost = parseHostFromUrl(state.target);
-    if (targetHost && !state.scope.allowedHosts.includes(targetHost)) {
-      setState((prev) => ({
-        ...prev,
-        scope: {
-          ...prev.scope,
-          allowedHosts: [targetHost, ...prev.scope.allowedHosts],
-        },
-      }));
-    }
-    setCurrentStep("mode");
-  };
-
-  // Mode step fields:
-  // 0: Mode selection
+  // Config step fields:
+  // 0: Session name
   // 1: Require approval toggle
-  // 2: Add allowed host input
-  // 3: Strict scope toggle
-  // 4: Model selection
-  // 5: Submit button
-  const maxField = 5;
+  // 2: Model selection
+  // 3: Submit button
+  const maxField = 3;
 
   useKeyboard((key) => {
     if (key.name === "escape") {
       if (currentStep === "creating") return;
-      if (currentStep === "mode") {
-        if (initialTarget) {
-          route.navigate({ type: "base", path: "home" });
-        } else {
-          setCurrentStep("target");
-        }
-        return;
-      }
       route.navigate({ type: "base", path: "home" });
       return;
     }
 
     if (currentStep === "creating") return;
 
-    if (currentStep === "target") {
-      if (key.name === "tab" || key.name === "down") {
-        if (key.shift) {
-          setTargetFocusedField((prev) => Math.max(0, prev - 1));
-        } else {
-          if (targetFocusedField === 1 && state.target.trim()) {
-            goToModeStep();
-          } else {
-            setTargetFocusedField((prev) => Math.min(1, prev + 1));
-          }
-        }
-        return;
-      }
-      if (key.name === "up") {
-        setTargetFocusedField((prev) => Math.max(0, prev - 1));
-        return;
-      }
-      if (key.name === "return" && state.target.trim()) {
-        goToModeStep();
-        return;
-      }
-      return;
-    }
+    if (currentStep === "config") {
+      const isEditingText = focusedField === 0;
 
-    if (currentStep === "mode") {
       if (key.name === "up") {
-        setModeFocusedField((prev) => Math.max(0, prev - 1));
+        setFocusedField((prev) => Math.max(0, prev - 1));
         return;
       }
       if (key.name === "down") {
-        setModeFocusedField((prev) => Math.min(maxField, prev + 1));
+        setFocusedField((prev) => Math.min(maxField, prev + 1));
         return;
       }
       if (key.name === "tab") {
         if (key.shift) {
-          setModeFocusedField((prev) => Math.max(0, prev - 1));
+          setFocusedField((prev) => Math.max(0, prev - 1));
         } else {
-          setModeFocusedField((prev) => Math.min(maxField, prev + 1));
+          setFocusedField((prev) => Math.min(maxField, prev + 1));
         }
         return;
       }
 
-      if (key.name === "left" || key.name === "right") {
+      if (!isEditingText && (key.name === "left" || key.name === "right")) {
         const delta = key.name === "left" ? -1 : 1;
 
-        // Mode selection (field 0)
-        if (modeFocusedField === 0) {
-          const modes: OperatorMode[] = ["plan", "manual", "auto"];
-          const idx = modes.indexOf(state.mode);
-          const newIdx = (idx + delta + modes.length) % modes.length;
-          setState((prev) => ({ ...prev, mode: modes[newIdx] }));
-          return;
-        }
-
         // Require approval toggle (field 1)
-        if (modeFocusedField === 1) {
+        if (focusedField === 1) {
           setState((prev) => ({
             ...prev,
             requireApproval: !prev.requireApproval,
@@ -320,17 +195,8 @@ export default function HITLWizard(props: HITLWizardProps) {
           return;
         }
 
-        // Strict scope toggle (field 3)
-        if (modeFocusedField === 3) {
-          setState((prev) => ({
-            ...prev,
-            scope: { ...prev.scope, strictScope: !prev.scope.strictScope },
-          }));
-          return;
-        }
-
-        // Model selection (field 4)
-        if (modeFocusedField === 4 && visibleModels.length > 0) {
+        // Model selection (field 2)
+        if (focusedField === 2 && visibleModels.length > 0) {
           const currentIdx = visibleModels.findIndex((m) => m.id === model.id);
           const newIdx = Math.max(
             0,
@@ -343,8 +209,14 @@ export default function HITLWizard(props: HITLWizardProps) {
       }
 
       if (key.name === "return") {
+        // Session name (field 0) — advance to next field
+        if (focusedField === 0) {
+          setFocusedField(1);
+          return;
+        }
+
         // Require approval toggle (field 1)
-        if (modeFocusedField === 1) {
+        if (focusedField === 1) {
           setState((prev) => ({
             ...prev,
             requireApproval: !prev.requireApproval,
@@ -352,43 +224,14 @@ export default function HITLWizard(props: HITLWizardProps) {
           return;
         }
 
-        // Add host if typing (field 2)
-        if (modeFocusedField === 2 && hostInput.trim()) {
-          setState((prev) => ({
-            ...prev,
-            scope: {
-              ...prev.scope,
-              allowedHosts: [...prev.scope.allowedHosts, hostInput.trim()],
-            },
-          }));
-          setHostInput("");
-          return;
-        }
-
-        // Toggle strict scope (field 3)
-        if (modeFocusedField === 3) {
-          setState((prev) => ({
-            ...prev,
-            scope: { ...prev.scope, strictScope: !prev.scope.strictScope },
-          }));
-          return;
-        }
-
-        // Submit button (field 5)
-        if (modeFocusedField === 5) {
+        // Submit button (field 3)
+        if (focusedField === 3) {
           createSessionAndNavigate();
         }
         return;
       }
     }
   });
-
-  const modeColor =
-    state.mode === "plan"
-      ? colors.warning
-      : state.mode === "auto"
-        ? colors.primary
-        : colors.accent;
 
   if (currentStep === "creating") {
     return (
@@ -401,89 +244,55 @@ export default function HITLWizard(props: HITLWizardProps) {
         flexGrow={1}
         gap={2}
       >
-        <SpinnerDots label="Creating HITL session..." fg={colors.primary} />
-        <text fg={colors.textMuted}>Target: {state.target}</text>
-        <text fg={modeColor}>Mode: {OPERATOR_MODES[state.mode].name}</text>
+        <SpinnerDots label="Creating operator session..." fg={colors.primary} />
+        <text fg={colors.textMuted}>Session: {state.name}</text>
       </box>
     );
   }
-
-  if (currentStep === "target") {
-    return (
-      <box width="100%" flexDirection="column" gap={2} paddingLeft={4}>
-        <text fg={colors.text}>Interactive Pentesting (Operator Mode)</text>
-        <text fg={colors.textMuted}>
-          Human-in-the-Loop - Approval gates for risky actions
-        </text>
-
-        {error && <text fg={colors.error}>Error: {error}</text>}
-
-        <Input
-          label="Session Name"
-          description="Auto-generated, edit if desired"
-          placeholder="swift-falcon"
-          value={state.name}
-          onInput={(v) => setState((prev) => ({ ...prev, name: v }))}
-          focused={targetFocusedField === 0}
-        />
-
-        <Input
-          label="Target URL"
-          description="e.g., https://example.com"
-          placeholder="https://example.com"
-          value={state.target}
-          onInput={(v) => setState((prev) => ({ ...prev, target: v }))}
-          focused={targetFocusedField === 1}
-        />
-
-        <box flexDirection="column" gap={0} marginTop={1}>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={colors.textMuted}>Press </span>
-            <span fg={colors.text}>[Enter]</span>
-            <span fg={colors.textMuted}> or </span>
-            <span fg={colors.text}>[Tab]</span>
-            <span fg={colors.textMuted}> to configure mode</span>
-          </text>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={colors.textMuted}>Press </span>
-            <span fg={colors.text}>[ESC]</span>
-            <span fg={colors.textMuted}> to cancel</span>
-          </text>
-        </box>
-      </box>
-    );
-  }
-
-  const modeDef = OPERATOR_MODES[state.mode];
 
   return (
     <box width="100%" flexDirection="column" gap={1} paddingLeft={4}>
       <box flexDirection="column" marginBottom={1}>
-        <text fg={colors.text}>Configure Operator Mode</text>
-        <text fg={colors.textMuted}>Target: {state.target}</text>
+        <text fg={colors.text}>Interactive Pentesting (Operator Mode)</text>
+        <text fg={colors.textMuted}>
+          Human-in-the-Loop - Approval gates for risky actions
+        </text>
       </box>
 
-      {/* Mode Selection - Field 0 */}
+      {error && <text fg={colors.error}>Error: {error}</text>}
+
+      {/* Session Name - Field 0 */}
       <box flexDirection="row" gap={1}>
-        <text fg={modeFocusedField === 0 ? colors.primary : colors.textMuted}>
-          {modeFocusedField === 0 ? "▸" : " "}
+        <text fg={focusedField === 0 ? colors.primary : colors.textMuted}>
+          {focusedField === 0 ? "▸" : " "}
         </text>
-        <text fg={modeFocusedField === 0 ? colors.text : colors.textMuted}>
-          Mode:
+        <text fg={focusedField === 0 ? colors.text : colors.textMuted}>
+          Session:
         </text>
-        <text fg={modeColor}>{modeDef.name}</text>
-        <text fg={colors.textMuted}>- {modeDef.description}</text>
-        {modeFocusedField === 0 && <text fg={colors.textMuted}>(←/→)</text>}
+        {focusedField === 0 ? (
+          <input
+            width={30}
+            value={state.name}
+            onInput={(v: string) =>
+              setState((prev) => ({ ...prev, name: v }))
+            }
+            focused={true}
+            placeholder="swift-falcon"
+            textColor={colors.text}
+            backgroundColor="transparent"
+            cursorColor={colors.textMuted}
+          />
+        ) : (
+          <text fg={colors.text}>{state.name}</text>
+        )}
       </box>
 
       {/* Require Approval Toggle - Field 1 */}
       <box flexDirection="row" gap={1}>
-        <text fg={modeFocusedField === 1 ? colors.primary : colors.textMuted}>
-          {modeFocusedField === 1 ? "▸" : " "}
+        <text fg={focusedField === 1 ? colors.primary : colors.textMuted}>
+          {focusedField === 1 ? "▸" : " "}
         </text>
-        <text fg={modeFocusedField === 1 ? colors.text : colors.textMuted}>
+        <text fg={focusedField === 1 ? colors.text : colors.textMuted}>
           Require command approval:
         </text>
         <text fg={state.requireApproval ? colors.warning : colors.primary}>
@@ -494,91 +303,36 @@ export default function HITLWizard(props: HITLWizardProps) {
             ? "- approve each command before execution"
             : "- commands execute automatically"}
         </text>
-        {modeFocusedField === 1 && (
+        {focusedField === 1 && (
           <text fg={colors.textMuted}>(Enter/←/→)</text>
         )}
       </box>
 
-      {/* Add Allowed Host - Field 2 */}
+      {/* Model Selection - Field 2 */}
       <box flexDirection="row" gap={1}>
-        <text fg={modeFocusedField === 2 ? colors.primary : colors.textMuted}>
-          {modeFocusedField === 2 ? "▸" : " "}
+        <text fg={focusedField === 2 ? colors.primary : colors.textMuted}>
+          {focusedField === 2 ? "▸" : " "}
         </text>
-        <text fg={modeFocusedField === 2 ? colors.text : colors.textMuted}>
-          Add host:
-        </text>
-        {modeFocusedField === 2 ? (
-          <input
-            width={30}
-            value={hostInput}
-            onInput={setHostInput}
-            focused={true}
-            placeholder="example.com"
-            textColor={colors.text}
-            backgroundColor="transparent"
-            cursorColor={colors.textMuted}
-          />
-        ) : (
-          <text fg={colors.textMuted}>{hostInput || "example.com"}</text>
-        )}
-        {modeFocusedField === 2 && (
-          <text fg={colors.textMuted}>(Enter to add)</text>
-        )}
-      </box>
-
-      {/* Show added hosts */}
-      {state.scope.allowedHosts.length > 0 && (
-        <box flexDirection="column" paddingLeft={3}>
-          {state.scope.allowedHosts.map((h, i) => (
-            <text key={i} fg={colors.textMuted}>
-              {" "}
-              • {h}
-            </text>
-          ))}
-        </box>
-      )}
-
-      {/* Strict Scope - Field 3 */}
-      <box flexDirection="row" gap={1}>
-        <text fg={modeFocusedField === 3 ? colors.primary : colors.textMuted}>
-          {modeFocusedField === 3 ? "▸" : " "}
-        </text>
-        <text fg={modeFocusedField === 3 ? colors.text : colors.textMuted}>
-          Strict scope:
-        </text>
-        <text fg={state.scope.strictScope ? colors.primary : colors.textMuted}>
-          {state.scope.strictScope ? "Enabled" : "Disabled"}
-        </text>
-        {modeFocusedField === 3 && (
-          <text fg={colors.textMuted}>(Enter/←/→)</text>
-        )}
-      </box>
-
-      {/* Model Selection - Field 4 */}
-      <box flexDirection="row" gap={1}>
-        <text fg={modeFocusedField === 4 ? colors.primary : colors.textMuted}>
-          {modeFocusedField === 4 ? "▸" : " "}
-        </text>
-        <text fg={modeFocusedField === 4 ? colors.text : colors.textMuted}>
+        <text fg={focusedField === 2 ? colors.text : colors.textMuted}>
           Model:
         </text>
         <text fg={colors.primary}>{model.name}</text>
-        {modeFocusedField === 4 && <text fg={colors.textMuted}>(←/→)</text>}
+        {focusedField === 2 && <text fg={colors.textMuted}>(←/→)</text>}
       </box>
 
-      {/* Submit Button - Field 5 */}
+      {/* Submit Button - Field 3 */}
       <box flexDirection="row" gap={1} marginTop={1}>
-        <text fg={modeFocusedField === 5 ? colors.primary : colors.textMuted}>
-          {modeFocusedField === 5 ? "▸" : " "}
+        <text fg={focusedField === 3 ? colors.primary : colors.textMuted}>
+          {focusedField === 3 ? "▸" : " "}
         </text>
-        <text fg={modeFocusedField === 5 ? colors.primary : colors.textMuted}>
-          {modeFocusedField === 5 ? "[" : " "}
+        <text fg={focusedField === 3 ? colors.primary : colors.textMuted}>
+          {focusedField === 3 ? "[" : " "}
         </text>
-        <text fg={modeFocusedField === 5 ? colors.text : colors.textMuted}>
+        <text fg={focusedField === 3 ? colors.text : colors.textMuted}>
           Start Session
         </text>
-        <text fg={modeFocusedField === 5 ? colors.primary : colors.textMuted}>
-          {modeFocusedField === 5 ? "]" : " "}
+        <text fg={focusedField === 3 ? colors.primary : colors.textMuted}>
+          {focusedField === 3 ? "]" : " "}
         </text>
       </box>
 

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -23,6 +23,7 @@ import type { DisplayMessage } from "../agent-display";
 import { isToolMessage } from "../shared/type-guards";
 import type { OperatorMode, PendingApproval } from "../../../core/operator";
 import {
+  ApprovalGate,
   createInitialOperatorState,
   type OperatorSessionState,
 } from "../../../core/operator";
@@ -66,14 +67,51 @@ export default function OperatorDashboard({
 
   // Operator state
   const [operatorState, setOperatorState] = useState<OperatorSessionState>(() =>
-    createInitialOperatorState("manual", 2),
+    createInitialOperatorState("manual", true),
   );
-  const [pendingApprovals] = useState<PendingApproval[]>([]);
-  const [lastApprovedAction] = useState<string | null>(null);
+
+  // Approval gate — created once and updated when config changes
+  const approvalGateRef = useRef<ApprovalGate>(
+    new ApprovalGate({ requireApproval: true }),
+  );
+  const [pendingApprovals, setPendingApprovals] = useState<PendingApproval[]>(
+    [],
+  );
+  const [lastApprovedAction, setLastApprovedAction] = useState<string | null>(
+    null,
+  );
 
   // Display options
   const [verboseMode, setVerboseMode] = useState(false);
   const [expandedLogs, setExpandedLogs] = useState(false);
+
+  // Subscribe to approval gate events
+  useEffect(() => {
+    const gate = approvalGateRef.current;
+
+    const onApprovalNeeded = () => {
+      setPendingApprovals(gate.getPendingApprovals());
+      setStatus("waiting");
+    };
+
+    const onApprovalResolved = (event: { id: string; decision: string }) => {
+      setPendingApprovals(gate.getPendingApprovals());
+      if (event.decision === "approved") {
+        setLastApprovedAction(event.id);
+      }
+      if (gate.getPendingApprovals().length === 0) {
+        setStatus("running");
+      }
+    };
+
+    gate.on("approval-needed", onApprovalNeeded);
+    gate.on("approval-resolved", onApprovalResolved);
+
+    return () => {
+      gate.off("approval-needed", onApprovalNeeded);
+      gate.off("approval-resolved", onApprovalResolved);
+    };
+  }, []);
 
   // Load session on mount
   useEffect(() => {
@@ -88,17 +126,18 @@ export default function OperatorDashboard({
           if (hasState) {
             const savedState = await sessions.loadOperatorState(sessionId);
             if (savedState) {
-              // Map persisted state to runtime operator state
               setOperatorState((prev) => ({
                 ...prev,
                 mode: (savedState.mode as OperatorMode) || prev.mode,
-                autoApproveTier:
-                  (savedState.autoApproveTier as 1 | 2 | 3 | 4 | 5) ||
-                  prev.autoApproveTier,
+                requireApproval:
+                  savedState.requireApproval ?? prev.requireApproval,
                 currentStage:
                   (savedState.currentStage as OperatorSessionState["currentStage"]) ||
                   prev.currentStage,
               }));
+              approvalGateRef.current.updateConfig({
+                requireApproval: savedState.requireApproval ?? true,
+              });
             }
           }
         }
@@ -106,11 +145,13 @@ export default function OperatorDashboard({
         // Initialize operator state from session config (only if not resuming)
         if (!isResume && s.config?.operatorSettings) {
           const settings = s.config.operatorSettings;
+          const requireApproval = settings.requireApproval ?? true;
           const initialState = createInitialOperatorState(
             (settings.initialMode as OperatorMode) || "manual",
-            (settings.autoApproveTier as 1 | 2 | 3 | 4 | 5) || 2,
+            requireApproval,
           );
           setOperatorState(initialState);
+          approvalGateRef.current.updateConfig({ requireApproval });
         }
       } catch (e) {
         setError(e instanceof Error ? e.message : "Failed to load session");
@@ -178,6 +219,29 @@ export default function OperatorDashboard({
   );
 
   // ---------------------------------------------------------------------------
+  // Approval handlers
+  // ---------------------------------------------------------------------------
+
+  const handleApprove = useCallback(() => {
+    const pending = approvalGateRef.current.getPendingApprovals();
+    if (pending.length > 0) {
+      approvalGateRef.current.approve(pending[0].id);
+    }
+  }, []);
+
+  const handleAutoApprove = useCallback(() => {
+    // Disable approval for the rest of the session
+    approvalGateRef.current.updateConfig({ requireApproval: false });
+    setOperatorState((prev) => ({ ...prev, requireApproval: false }));
+
+    // Approve all currently pending
+    const pending = approvalGateRef.current.getPendingApprovals();
+    for (const p of pending) {
+      approvalGateRef.current.approve(p.id);
+    }
+  }, []);
+
+  // ---------------------------------------------------------------------------
   // Run agent
   // ---------------------------------------------------------------------------
 
@@ -211,6 +275,7 @@ export default function OperatorDashboard({
           activeTools: [...ALL_TOOL_NAMES],
           abortSignal: controller.signal,
           authConfig: buildAuthConfig(config.data),
+          approvalGate: approvalGateRef.current,
           callbacks: {
             onTextDelta: (d) => {
               setThinking(false);
@@ -269,7 +334,18 @@ export default function OperatorDashboard({
 
   const handleSubmit = useCallback(
     (value: string) => {
-      if (!value.trim() || status === "running") return;
+      if (!value.trim()) return;
+
+      // If there's a pending approval and the user types, deny and redirect
+      const pending = approvalGateRef.current.getPendingApprovals();
+      if (pending.length > 0) {
+        for (const p of pending) {
+          approvalGateRef.current.deny(p.id);
+        }
+      }
+
+      if (status === "running") return;
+
       setInputValue("");
       runAgent(value.trim());
     },
@@ -283,6 +359,10 @@ export default function OperatorDashboard({
       setStatus("idle");
       setThinking(false);
       setIsExecuting(false);
+
+      // Deny all pending approvals on abort
+      approvalGateRef.current.denyAll();
+
       setMessages((prev) => [
         ...prev,
         {
@@ -294,11 +374,19 @@ export default function OperatorDashboard({
     }
   }, [setThinking, setIsExecuting]);
 
+  // Toggle approval requirement at runtime
+  const toggleApproval = useCallback(() => {
+    setOperatorState((prev) => {
+      const newVal = !prev.requireApproval;
+      approvalGateRef.current.updateConfig({ requireApproval: newVal });
+      return { ...prev, requireApproval: newVal };
+    });
+  }, []);
+
   // Keyboard shortcuts
   useKeyboard((key) => {
-    // Ctrl+C - abort or clear input
     if (key.ctrl && key.name === "c") {
-      if (status === "running") {
+      if (status === "running" || status === "waiting") {
         handleAbort();
       } else if (inputValue.trim()) {
         setInputValue("");
@@ -306,8 +394,7 @@ export default function OperatorDashboard({
       return;
     }
 
-    // Escape - go home
-    if (key.name === "escape" && status !== "running") {
+    if (key.name === "escape" && status !== "running" && status !== "waiting") {
       route.navigate({ type: "base", path: "home" });
       return;
     }
@@ -324,14 +411,29 @@ export default function OperatorDashboard({
       return;
     }
 
-    // Shift+Tab - cycle operator mode
+    // Shift+Tab - toggle command approval on/off
     if (key.name === "tab" && key.shift) {
-      setOperatorState((prev) => {
-        const modes: OperatorMode[] = ["plan", "manual", "auto"];
-        const idx = modes.indexOf(prev.mode);
-        const nextIdx = (idx + 1) % modes.length;
-        return { ...prev, mode: modes[nextIdx] };
-      });
+      toggleApproval();
+      return;
+    }
+
+    // Y/y to approve pending
+    if (
+      status === "waiting" &&
+      pendingApprovals.length > 0 &&
+      (key.name === "y" || key.raw === "Y")
+    ) {
+      handleApprove();
+      return;
+    }
+
+    // A/a to auto-approve (disable approval)
+    if (
+      status === "waiting" &&
+      pendingApprovals.length > 0 &&
+      (key.name === "a" || key.raw === "A")
+    ) {
+      handleAutoApprove();
       return;
     }
   });
@@ -351,7 +453,6 @@ export default function OperatorDashboard({
     );
   }
 
-  // Error state (session failed to load)
   if (!session) {
     return (
       <box
@@ -368,6 +469,10 @@ export default function OperatorDashboard({
       </box>
     );
   }
+
+  // Determine the current pending approval for the input area
+  const currentPending =
+    pendingApprovals.length > 0 ? pendingApprovals[0] : undefined;
 
   return (
     <box flexDirection="column" width="100%" height="100%" flexGrow={1}>
@@ -394,15 +499,9 @@ export default function OperatorDashboard({
         </box>
         <box flexDirection="row" gap={2}>
           <text
-            fg={
-              operatorState.mode === "auto"
-                ? colors.primary
-                : operatorState.mode === "plan"
-                  ? colors.warning
-                  : colors.info
-            }
+            fg={operatorState.requireApproval ? colors.warning : colors.primary}
           >
-            {operatorState.mode.toUpperCase()}
+            {operatorState.requireApproval ? "APPROVAL ON" : "APPROVAL OFF"}
           </text>
           <text fg={colors.textMuted}>{model.name}</text>
         </box>
@@ -418,7 +517,7 @@ export default function OperatorDashboard({
       {/* Message display */}
       <MessageList
         messages={messages}
-        isRunning={status === "running"}
+        isRunning={status === "running" || status === "waiting"}
         variant="operator"
         focused={true}
         verbose={verboseMode}
@@ -435,14 +534,19 @@ export default function OperatorDashboard({
         placeholder={
           status === "running"
             ? "Agent is working..."
-            : "Enter directive (e.g., 'Explore the attack surface')..."
+            : status === "waiting"
+              ? "Type to redirect agent, or Y/A to approve..."
+              : "Enter directive (e.g., 'Explore the attack surface')..."
         }
         focused={status !== "running"}
-        status={status}
+        status={status === "waiting" ? "running" : status}
         mode="operator"
         operatorMode={operatorState.mode}
         verboseMode={verboseMode}
         expandedLogs={expandedLogs}
+        pendingApproval={currentPending}
+        onApprove={handleApprove}
+        onAutoApprove={handleAutoApprove}
       />
     </box>
   );
@@ -456,20 +560,15 @@ function buildOperatorSystemPrompt(
   operatorState: OperatorSessionState,
 ): string {
   const target = session.targets[0] || "unknown";
-  const mode = operatorState.mode;
 
   return `You are an offensive security agent operating in interactive operator mode.
 
 Target: ${target}
-Mode: ${mode}
 Stage: ${operatorState.currentStage}
+Command approval: ${operatorState.requireApproval ? "enabled — the operator will approve each tool call" : "disabled — tool calls execute automatically"}
 
 You are tasked with performing security testing on the target system. The human operator
 will guide your actions through directives. Follow their instructions carefully.
-
-${mode === "plan" ? "PLAN MODE: You should only propose actions and explain your reasoning. Do not execute any tools." : ""}
-${mode === "manual" ? "MANUAL MODE: Execute the requested actions. The operator will approve individual tool calls." : ""}
-${mode === "auto" ? "AUTO MODE: Execute actions autonomously within the approved tier level." : ""}
 
 Guidelines:
 - Be thorough and methodical in your testing approach

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -57,6 +57,7 @@ export default function OperatorDashboard({
   // Agent/status state
   const [status, setStatus] = useState<DashboardStatus>("idle");
   const abortControllerRef = useRef<AbortController | null>(null);
+  const generationRef = useRef(0);
 
   // Messages — same pattern as pentest component
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
@@ -251,6 +252,14 @@ export default function OperatorDashboard({
     async (prompt: string) => {
       if (!session) return;
 
+      // Abort any previous run before starting a new one
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+        abortControllerRef.current = null;
+      }
+
+      const gen = ++generationRef.current;
+
       setStatus("running");
       setThinking(true);
       setIsExecuting(true);
@@ -312,13 +321,14 @@ export default function OperatorDashboard({
         // Persist full conversation for next turn
         try {
           const response = await streamResult.response;
-          if (response.messages) {
+          if (gen === generationRef.current && response.messages) {
             conversationRef.current = response.messages as ModelMessage[];
           }
         } catch {
           // Stream may have been aborted; conversation stays as-is
         }
       } catch (e) {
+        if (gen !== generationRef.current) return;
         if ((e as Error).name !== "AbortError") {
           const errorMsg = e instanceof Error ? e.message : "Agent failed";
           setError(errorMsg);
@@ -332,10 +342,12 @@ export default function OperatorDashboard({
           ]);
         }
       } finally {
-        setStatus("idle");
-        setThinking(false);
-        setIsExecuting(false);
-        abortControllerRef.current = null;
+        if (gen === generationRef.current) {
+          setStatus("idle");
+          setThinking(false);
+          setIsExecuting(false);
+          abortControllerRef.current = null;
+        }
       }
     },
     [
@@ -363,6 +375,7 @@ export default function OperatorDashboard({
         }
       }
 
+      // Block submission only when the agent is actively running (not waiting)
       if (status === "running") return;
 
       setInputValue("");
@@ -373,6 +386,8 @@ export default function OperatorDashboard({
 
   const handleAbort = useCallback(() => {
     if (abortControllerRef.current) {
+      // Increment generation to prevent the aborted run's cleanup from firing
+      generationRef.current++;
       abortControllerRef.current.abort();
       abortControllerRef.current = null;
       setStatus("idle");

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -27,7 +27,7 @@ import {
   createInitialOperatorState,
   type OperatorSessionState,
 } from "../../../core/operator";
-import { stepCountIs } from "ai";
+import { stepCountIs, type ModelMessage } from "ai";
 
 interface OperatorDashboardProps {
   sessionId: string;
@@ -61,6 +61,8 @@ export default function OperatorDashboard({
   // Messages — same pattern as pentest component
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
   const textRef = useRef("");
+  // AI SDK conversation history for multi-turn continuity
+  const conversationRef = useRef<ModelMessage[]>([]);
 
   // Input state
   const [inputValue, setInputValue] = useState("");
@@ -264,12 +266,19 @@ export default function OperatorDashboard({
         { role: "user", content: prompt, createdAt: new Date() },
       ]);
 
+      // Build messages array — append user turn to conversation history
+      const nextMessages: ModelMessage[] = [
+        ...conversationRef.current,
+        { role: "user", content: prompt },
+      ];
+
       try {
-        await runOffensiveSecurityAgent({
+        const streamResult = await runOffensiveSecurityAgent({
           system: buildOperatorSystemPrompt(session, operatorState),
           prompt,
           model: model.id,
           session,
+          messages: nextMessages,
           stopWhen: [stepCountIs(10000)],
           target: session.targets[0],
           activeTools: [...ALL_TOOL_NAMES],
@@ -299,6 +308,16 @@ export default function OperatorDashboard({
             },
           },
         });
+
+        // Persist full conversation for next turn
+        try {
+          const response = await streamResult.response;
+          if (response.messages) {
+            conversationRef.current = response.messages as ModelMessage[];
+          }
+        } catch {
+          // Stream may have been aborted; conversation stays as-is
+        }
       } catch (e) {
         if ((e as Error).name !== "AbortError") {
           const errorMsg = e instanceof Error ? e.message : "Agent failed";

--- a/src/tui/components/shared/approval-prompt.tsx
+++ b/src/tui/components/shared/approval-prompt.tsx
@@ -2,12 +2,11 @@
  * Unified Approval Prompt Components
  *
  * Single implementation for approval UI used in both operator and chat views.
- * Replaces 2 duplicate implementations.
  */
 
 import { useState } from "react";
 import { useKeyboard } from "@opentui/react";
-import { useTheme, getTierColor } from "../../theme";
+import { useTheme } from "../../theme";
 import { getToolSummary } from "./tool-registry";
 import type { PendingApproval } from "../../../core/operator";
 
@@ -16,22 +15,17 @@ interface InlineApprovalPromptProps {
 }
 
 /**
- * Inline approval prompt - shows pending tool call with tier info.
+ * Inline approval prompt - shows pending tool call.
  * Displayed in the chat flow.
  */
 export function InlineApprovalPrompt({ approval }: InlineApprovalPromptProps) {
   const { colors } = useTheme();
-  const tierColor = getTierColor(colors, approval.tier);
 
-  // Get the description if provided
   const description = approval.args?.toolCallDescription as string | undefined;
-
-  // Get tool summary from registry
   const summary = getToolSummary(approval.toolName, approval.args || {});
 
   return (
     <box flexDirection="column" marginTop={2}>
-      {/* Description from agent if available */}
       {description && (
         <box flexDirection="row" marginBottom={1}>
           <text fg={colors.primary} content="| " />
@@ -39,10 +33,8 @@ export function InlineApprovalPrompt({ approval }: InlineApprovalPromptProps) {
         </box>
       )}
 
-      {/* Approval line */}
       <box flexDirection="row" gap={1} marginLeft={2}>
         <text fg={colors.warning} content="?" />
-        <text fg={tierColor} content={`[T${approval.tier}]`} />
         <text fg={colors.info} content={summary} />
       </box>
     </box>
@@ -73,10 +65,9 @@ export function ApprovalInputArea({
   lastDeclineNote,
 }: ApprovalInputAreaProps) {
   const { colors } = useTheme();
-  const [focusedElement, setFocusedElement] = useState(0); // 0=Yes, 1=Auto, 2=Input
+  const [focusedElement, setFocusedElement] = useState(0);
 
   useKeyboard((key) => {
-    // Navigation
     if (key.name === "up") {
       setFocusedElement((prev) => Math.max(0, prev - 1));
       return;
@@ -90,7 +81,6 @@ export function ApprovalInputArea({
       return;
     }
 
-    // Enter to select
     if (key.name === "return") {
       if (focusedElement === 0) {
         onApprove();
@@ -131,7 +121,7 @@ export function ApprovalInputArea({
         />
         <text
           fg={focusedElement === 1 ? colors.text : colors.textMuted}
-          content={`Auto - auto-approve T1-T${approval.tier} from now`}
+          content="Auto - approve all commands from now"
         />
       </box>
 
@@ -158,7 +148,6 @@ export function ApprovalInputArea({
         />
       </box>
 
-      {/* Last decline note */}
       {lastDeclineNote && (
         <box marginTop={1} marginLeft={2}>
           <text

--- a/src/tui/context/route.tsx
+++ b/src/tui/context/route.tsx
@@ -30,7 +30,7 @@ export interface WebCommandOptions {
   name?: string;
   swarm?: boolean;
   mode?: "plan" | "manual" | "auto";
-  tier?: number;
+  requireApproval?: boolean;
   authUrl?: string;
   authUser?: string;
   authPass?: string;

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -274,11 +274,8 @@ function CommandDisplay({
           <RouteSwitch.Case when="operator">
             <HITLWizard
               initialTarget={route.data.options?.target}
-              initialMode={route.data.options?.mode}
               initialName={route.data.options?.name}
               initialRequireApproval={route.data.options?.requireApproval}
-              initialHosts={route.data.options?.hosts}
-              initialStrict={route.data.options?.strict}
               initialModel={route.data.options?.model}
             />
           </RouteSwitch.Case>

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -276,7 +276,7 @@ function CommandDisplay({
               initialTarget={route.data.options?.target}
               initialMode={route.data.options?.mode}
               initialName={route.data.options?.name}
-              initialTier={route.data.options?.tier}
+              initialRequireApproval={route.data.options?.requireApproval}
               initialHosts={route.data.options?.hosts}
               initialStrict={route.data.options?.strict}
               initialModel={route.data.options?.model}

--- a/src/tui/utils/command-flags.ts
+++ b/src/tui/utils/command-flags.ts
@@ -11,7 +11,7 @@ import {
   type SessionInfo,
 } from "../../core/session";
 import { generateRandomName } from "../../util/name";
-import type { OperatorMode, PermissionTier } from "../../core/operator";
+import type { OperatorMode } from "../../core/operator";
 import { createToolsetState } from "../../core/toolset";
 
 // ============================================================================
@@ -124,7 +124,7 @@ export interface WebCommandFlags {
 
   // Operator mode options (ignored if swarm)
   mode?: OperatorMode;
-  tier?: number;
+  requireApproval?: boolean;
 
   // Auth options
   authUrl?: string;
@@ -153,7 +153,8 @@ const webFlagSchema: FlagSchema = {
   name: { type: "string", aliases: ["n"] },
   swarm: { type: "boolean" },
   mode: { type: "string", aliases: ["m"] },
-  tier: { type: "string" },
+  "require-approval": { type: "boolean" },
+  "no-approval": { type: "boolean" },
   "auth-url": { type: "string" },
   "auth-user": { type: "string" },
   "auth-pass": { type: "string" },
@@ -187,12 +188,8 @@ export function parseWebFlags(args: string[]): WebCommandFlags {
       flags.mode = mode as OperatorMode;
     }
   }
-  if (raw.tier) {
-    const tier = parseInt(String(raw.tier), 10);
-    if (tier >= 1 && tier <= 5) {
-      flags.tier = tier;
-    }
-  }
+  if (raw.requireApproval) flags.requireApproval = true;
+  if (raw.noApproval) flags.requireApproval = false;
 
   // Auth options
   if (raw.authUrl) flags.authUrl = String(raw.authUrl);
@@ -259,7 +256,7 @@ export function hasEnoughFlagsToSkipWizard(flags: WebCommandFlags): boolean {
     // Operator mode - skip wizard if any additional config is provided
     return !!(
       flags.mode ||
-      flags.tier ||
+      flags.requireApproval !== undefined ||
       flags.authUrl ||
       flags.authUser ||
       flags.hosts ||
@@ -284,7 +281,7 @@ export async function createOperatorSessionFromFlags(
     mode: "operator",
     operatorSettings: {
       initialMode: flags.mode || "manual",
-      autoApproveTier: (flags.tier || 2) as PermissionTier,
+      requireApproval: flags.requireApproval ?? true,
       enableSuggestions: true,
     },
     // Initialize toolset with full web-pentest tools


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR refactors the `/operator mode` command approval flow from a complex, partially implemented tier-based system (T1-T5) to a simplified boolean `requireApproval` setting.

The changes include:
- **Core Logic:** Replaced `PermissionTier` and `autoApproveTier` with a `requireApproval: boolean` flag in `src/core/operator/types.ts`, `approvalGate.ts`, `permissionPolicy.ts`, and `index.ts`.
- **Agent Integration:** Wired the `ApprovalGate` into the `OffensiveSecurityAgent` by conditionally wrapping tool executions based on the `requireApproval` setting.
- **UI/CLI Updates:**
    - The operator setup wizard (`operator-wizard.tsx`) now presents a simple "Require command approval: Enabled/Disabled" toggle.
    - The operator dashboard (`operator-dashboard/index.tsx`) manages pending approvals and handles keyboard shortcuts (Y/A/Shift+Tab) for the new approval flow.
    - Session configuration (`session/index.ts`) and CLI flags (`command-flags.ts`) now use `requireApproval` instead of tier-based settings.
    - Approval UI components (`approval-inline.tsx`, `approval-prompt.tsx`, `input-area.tsx`, `header.tsx`) have been updated to reflect the simplified approve/deny prompts without tier indicators.

This works by simplifying the approval mechanism to a single boolean, which directly controls whether the `ApprovalGate` intercepts and prompts for user confirmation before an agent executes a tool. The UI and configuration are updated to reflect this direct control.

### How did you verify your code works?
- ✅ `bun run tsc` — type check passes
- ✅ `bun run lint` — ESLint passes
- ✅ `bun run format:check` — Prettier passes
- ✅ `bun run test` — 147 tests passed, 15 skipped (integration tests requiring API keys)
- ✅ `bun run build` — build succeeds
- No manual GUI testing was performed due to the environment limitations (requires interactive terminal and AI provider API keys).

---
<p><a href="https://cursor.com/agents/bc-5cffd2ef-6722-4b65-a866-864458434648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cffd2ef-6722-4b65-a866-864458434648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->