### PR TITLE
Operator mode skills

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensar/apex",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
   "main": "build/index.js",

--- a/src/core/skills/index.ts
+++ b/src/core/skills/index.ts
@@ -1,0 +1,150 @@
+import os from "os";
+import path from "path";
+import fs from "fs/promises";
+import type { Skill, SkillFrontmatter } from "./types";
+
+export type { Skill, SkillFrontmatter };
+
+const SKILLS_DIR = path.join(os.homedir(), ".pensar", "skills");
+
+/** Ensure the skills directory exists. */
+async function ensureSkillsDir(): Promise<void> {
+  await fs.mkdir(SKILLS_DIR, { recursive: true });
+}
+
+/**
+ * Parse simple YAML-style frontmatter from a markdown string.
+ * Returns the parsed key-value pairs and the body after the frontmatter.
+ */
+function parseFrontmatter(raw: string): {
+  meta: SkillFrontmatter;
+  body: string;
+} {
+  const trimmed = raw.trimStart();
+  if (!trimmed.startsWith("---")) {
+    return { meta: {}, body: raw };
+  }
+
+  const endIdx = trimmed.indexOf("---", 3);
+  if (endIdx === -1) {
+    return { meta: {}, body: raw };
+  }
+
+  const frontmatterBlock = trimmed.slice(3, endIdx).trim();
+  const body = trimmed.slice(endIdx + 3).trim();
+  const meta: Record<string, string> = {};
+
+  for (const line of frontmatterBlock.split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const value = line.slice(colonIdx + 1).trim();
+    meta[key] = value;
+  }
+
+  return { meta: meta as SkillFrontmatter, body };
+}
+
+/** Serialize a skill into a markdown string with frontmatter. */
+function serializeSkill(skill: Skill): string {
+  const lines = [
+    "---",
+    `name: ${skill.name}`,
+    `description: ${skill.description}`,
+    "---",
+    "",
+    skill.content,
+  ];
+  return lines.join("\n");
+}
+
+/** Convert a display name to a filename-safe slug. */
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** Load all skills from ~/.pensar/skills/ */
+export async function loadSkills(): Promise<Skill[]> {
+  await ensureSkillsDir();
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(SKILLS_DIR);
+  } catch {
+    return [];
+  }
+
+  const skills: Skill[] = [];
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".md")) continue;
+
+    const filePath = path.join(SKILLS_DIR, entry);
+    try {
+      const raw = await fs.readFile(filePath, "utf-8");
+      const { meta, body } = parseFrontmatter(raw);
+      const slug = entry.replace(/\.md$/, "");
+
+      skills.push({
+        name: meta.name || slug,
+        description: meta.description || "",
+        content: body,
+      });
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  skills.sort((a, b) => a.name.localeCompare(b.name));
+  return skills;
+}
+
+/** Load a single skill by slug. */
+export async function loadSkill(slug: string): Promise<Skill | null> {
+  const filePath = path.join(SKILLS_DIR, `${slug}.md`);
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const { meta, body } = parseFrontmatter(raw);
+    return {
+      name: meta.name || slug,
+      description: meta.description || "",
+      content: body,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Save a skill to ~/.pensar/skills/{slug}.md */
+export async function saveSkill(skill: Skill): Promise<string> {
+  await ensureSkillsDir();
+  const slug = slugify(skill.name);
+  const filePath = path.join(SKILLS_DIR, `${slug}.md`);
+  await fs.writeFile(filePath, serializeSkill(skill), "utf-8");
+  return slug;
+}
+
+/** Delete a skill by slug. */
+export async function deleteSkill(slug: string): Promise<boolean> {
+  const filePath = path.join(SKILLS_DIR, `${slug}.md`);
+  try {
+    await fs.unlink(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Check if a skill slug already exists. */
+export async function skillExists(slug: string): Promise<boolean> {
+  const filePath = path.join(SKILLS_DIR, `${slug}.md`);
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/core/skills/skills.test.ts
+++ b/src/core/skills/skills.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import os from "os";
 import path from "path";
 import fs from "fs/promises";

--- a/src/core/skills/skills.test.ts
+++ b/src/core/skills/skills.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import os from "os";
+import path from "path";
+import fs from "fs/promises";
+import {
+  loadSkills,
+  loadSkill,
+  saveSkill,
+  deleteSkill,
+  skillExists,
+  slugify,
+} from "./index";
+
+const SKILLS_DIR = path.join(os.homedir(), ".pensar", "skills");
+
+describe("Skills Module", () => {
+  const testSkillFiles: string[] = [];
+
+  afterEach(async () => {
+    for (const f of testSkillFiles) {
+      try {
+        await fs.unlink(f);
+      } catch {
+        // ignore
+      }
+    }
+    testSkillFiles.length = 0;
+  });
+
+  describe("slugify", () => {
+    it("converts a name to a slug", () => {
+      expect(slugify("SQL Injection Test")).toBe("sql-injection-test");
+    });
+
+    it("strips leading/trailing dashes", () => {
+      expect(slugify("--Hello World--")).toBe("hello-world");
+    });
+
+    it("replaces special characters", () => {
+      expect(slugify("OWASP Top 10 (2025)")).toBe("owasp-top-10-2025");
+    });
+
+    it("handles empty string", () => {
+      expect(slugify("")).toBe("");
+    });
+  });
+
+  describe("saveSkill / loadSkill", () => {
+    it("saves and loads a skill with frontmatter", async () => {
+      const skill = {
+        name: "test-save-load",
+        description: "A test skill",
+        content: "Do the thing.\nLine 2.",
+      };
+      const slug = await saveSkill(skill);
+      testSkillFiles.push(path.join(SKILLS_DIR, `${slug}.md`));
+
+      expect(slug).toBe("test-save-load");
+
+      const loaded = await loadSkill(slug);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.name).toBe("test-save-load");
+      expect(loaded!.description).toBe("A test skill");
+      expect(loaded!.content).toBe("Do the thing.\nLine 2.");
+    });
+  });
+
+  describe("loadSkills", () => {
+    it("returns all skills sorted by name", async () => {
+      await saveSkill({
+        name: "zzz-skill",
+        description: "Z",
+        content: "z content",
+      });
+      testSkillFiles.push(path.join(SKILLS_DIR, "zzz-skill.md"));
+
+      await saveSkill({
+        name: "aaa-skill",
+        description: "A",
+        content: "a content",
+      });
+      testSkillFiles.push(path.join(SKILLS_DIR, "aaa-skill.md"));
+
+      const skills = await loadSkills();
+      const names = skills.map((s) => s.name);
+      expect(names).toContain("aaa-skill");
+      expect(names).toContain("zzz-skill");
+
+      const aIdx = names.indexOf("aaa-skill");
+      const zIdx = names.indexOf("zzz-skill");
+      expect(aIdx).toBeLessThan(zIdx);
+    });
+  });
+
+  describe("skillExists", () => {
+    it("returns true for existing skill", async () => {
+      await saveSkill({
+        name: "existence-check",
+        description: "",
+        content: "x",
+      });
+      testSkillFiles.push(path.join(SKILLS_DIR, "existence-check.md"));
+
+      expect(await skillExists("existence-check")).toBe(true);
+    });
+
+    it("returns false for non-existing skill", async () => {
+      expect(await skillExists("does-not-exist-123")).toBe(false);
+    });
+  });
+
+  describe("deleteSkill", () => {
+    it("deletes an existing skill", async () => {
+      await saveSkill({
+        name: "to-delete",
+        description: "",
+        content: "bye",
+      });
+      expect(await skillExists("to-delete")).toBe(true);
+
+      const deleted = await deleteSkill("to-delete");
+      expect(deleted).toBe(true);
+      expect(await skillExists("to-delete")).toBe(false);
+    });
+
+    it("returns false for non-existing skill", async () => {
+      const deleted = await deleteSkill("never-existed-456");
+      expect(deleted).toBe(false);
+    });
+  });
+});

--- a/src/core/skills/types.ts
+++ b/src/core/skills/types.ts
@@ -1,0 +1,17 @@
+export interface Skill {
+  /** Unique slug used as the slash-command name (e.g. "sql-injection") */
+  name: string;
+  /** Short human-readable description shown in autocomplete */
+  description: string;
+  /** The prompt / workflow content injected when the skill is invoked */
+  content: string;
+}
+
+/**
+ * Frontmatter extracted from a skill markdown file.
+ * The remainder of the file becomes `content`.
+ */
+export interface SkillFrontmatter {
+  name?: string;
+  description?: string;
+}

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -371,6 +371,18 @@ export const commands: CommandConfig[] = [
     },
   },
 
+  {
+    name: "create-skill",
+    description: "Create a new operator skill",
+    category: "Skills",
+    handler: async (args, ctx) => {
+      ctx.navigate({
+        type: "base",
+        path: "create-skill",
+      });
+    },
+  },
+
   // Add more commands here...
   // Example:
   // {

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -87,6 +87,7 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
         {[
           { cmd: "/pentest", desc: "autonomous pentest" },
           { cmd: "/operator", desc: "interactive operator" },
+          { cmd: "/auth", desc: "login to Pensar" },
           { cmd: "/models", desc: "select AI model" },
           { cmd: "/providers", desc: "manage API keys" },
         ].map(({ cmd, desc }) => (

--- a/src/tui/components/chat/input-area.tsx
+++ b/src/tui/components/chat/input-area.tsx
@@ -43,6 +43,14 @@ export interface InputAreaProps {
   onAutoApprove?: () => void;
   /** Last decline note */
   lastDeclineNote?: string | null;
+  /** Enable autocomplete suggestions (e.g. slash commands, skills) */
+  enableAutocomplete?: boolean;
+  /** Autocomplete options to show */
+  autocompleteOptions?: import("../shared/prompt-input").AutocompleteOption[];
+  /** Enable slash-command handling */
+  enableCommands?: boolean;
+  /** Handler for slash-command execution */
+  onCommandExecute?: (command: string) => Promise<void>;
 }
 
 /**
@@ -60,6 +68,10 @@ function NormalInputAreaInner({
   operatorMode,
   verboseMode = false,
   expandedLogs = false,
+  enableAutocomplete = false,
+  autocompleteOptions = [],
+  enableCommands = false,
+  onCommandExecute,
 }: Omit<
   InputAreaProps,
   "pendingApproval" | "onApprove" | "onAutoApprove" | "lastDeclineNote"
@@ -118,6 +130,10 @@ function NormalInputAreaInner({
           focused={focused && !isDisabled}
           placeholder={isDisabled ? "Processing..." : placeholder}
           onSubmit={handleSubmit}
+          enableAutocomplete={enableAutocomplete}
+          autocompleteOptions={autocompleteOptions}
+          enableCommands={enableCommands}
+          onCommandExecute={onCommandExecute}
         />
       </box>
 
@@ -134,6 +150,7 @@ function NormalInputAreaInner({
           {operatorMode === "manual" && (
             <text fg={colors.textMuted}>{"MANUAL"}</text>
           )}
+          <text fg={colors.textMuted}>/ commands</text>
           <text fg={verboseMode ? colors.primary : colors.textMuted}>
             {verboseMode ? "verbose:on" : "verbose"}
           </text>
@@ -179,6 +196,10 @@ export function InputArea(props: InputAreaProps) {
     value,
     onChange,
     onSubmit,
+    enableAutocomplete,
+    autocompleteOptions,
+    enableCommands,
+    onCommandExecute,
     ...normalProps
   } = props;
 
@@ -204,6 +225,10 @@ export function InputArea(props: InputAreaProps) {
         value={value}
         onChange={onChange}
         onSubmit={onSubmit}
+        enableAutocomplete={enableAutocomplete}
+        autocompleteOptions={autocompleteOptions}
+        enableCommands={enableCommands}
+        onCommandExecute={onCommandExecute}
         {...normalProps}
       />
     </InputProvider>

--- a/src/tui/components/chat/message-list.tsx
+++ b/src/tui/components/chat/message-list.tsx
@@ -123,19 +123,12 @@ export function MessageList({
           <box flexDirection="column" gap={0} marginTop={1}>
             <text fg={colors.text}>Tips:</text>
             <box flexDirection="row">
-              <text fg={colors.primary}>/auth</text>
-              <text fg={colors.textMuted}> - Configure authentication</text>
+              <text fg={colors.primary}>/</text>
+              <text fg={colors.textMuted}> - Create or use skills</text>
             </box>
             <box flexDirection="row">
               <text fg={colors.primary}>Shift+Tab</text>
-              <text fg={colors.textMuted}>
-                {" "}
-                - Cycle modes (plan/manual/auto)
-              </text>
-            </box>
-            <box flexDirection="row">
-              <text fg={colors.primary}>Ctrl+S</text>
-              <text fg={colors.textMuted}> - Change stage</text>
+              <text fg={colors.textMuted}> - Cycle approval on/off</text>
             </box>
           </box>
         </box>

--- a/src/tui/components/commands/create-skill-wizard.tsx
+++ b/src/tui/components/commands/create-skill-wizard.tsx
@@ -1,0 +1,297 @@
+import { useState } from "react";
+import { useKeyboard } from "@opentui/react";
+import Input from "../input";
+import { useRoute } from "../../context/route";
+import { useTheme } from "../../theme";
+import { saveSkill, slugify, skillExists } from "../../../core/skills";
+import type { Skill } from "../../../core/skills";
+
+type WizardStep = "name" | "description" | "content" | "confirm" | "saving";
+
+export default function CreateSkillWizard() {
+  const { colors } = useTheme();
+  const route = useRoute();
+
+  const [step, setStep] = useState<WizardStep>("name");
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [content, setContent] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [confirmFocused, setConfirmFocused] = useState(0);
+
+  const slug = slugify(name);
+
+  async function handleSave() {
+    if (!name.trim() || !content.trim()) return;
+
+    setStep("saving");
+    setError(null);
+
+    try {
+      if (await skillExists(slug)) {
+        setError(`A skill with the slug "${slug}" already exists.`);
+        setStep("confirm");
+        return;
+      }
+
+      const skill: Skill = {
+        name: name.trim(),
+        description: description.trim(),
+        content: content.trim(),
+      };
+
+      await saveSkill(skill);
+      route.navigate({ type: "base", path: "home" });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save skill");
+      setStep("confirm");
+    }
+  }
+
+  useKeyboard((key) => {
+    if (key.name === "escape") {
+      if (step === "saving") return;
+      if (step === "confirm") {
+        setStep("content");
+        return;
+      }
+      if (step === "content") {
+        setStep("description");
+        return;
+      }
+      if (step === "description") {
+        setStep("name");
+        return;
+      }
+      route.navigate({ type: "base", path: "home" });
+      return;
+    }
+
+    if (step === "name") {
+      if (key.name === "return" && name.trim()) {
+        setStep("description");
+      }
+      return;
+    }
+
+    if (step === "description") {
+      if (key.name === "return") {
+        setStep("content");
+      }
+      return;
+    }
+
+    if (step === "content") {
+      if (key.name === "return" && !key.shift && content.trim()) {
+        setStep("confirm");
+      }
+      return;
+    }
+
+    if (step === "confirm") {
+      if (key.name === "up" || (key.name === "tab" && key.shift)) {
+        setConfirmFocused((p) => Math.max(0, p - 1));
+        return;
+      }
+      if (key.name === "down" || key.name === "tab") {
+        setConfirmFocused((p) => Math.min(1, p + 1));
+        return;
+      }
+      if (key.name === "return") {
+        if (confirmFocused === 0) {
+          handleSave();
+        } else {
+          route.navigate({ type: "base", path: "home" });
+        }
+      }
+    }
+  });
+
+  if (step === "saving") {
+    return (
+      <box
+        flexDirection="column"
+        width="100%"
+        height="100%"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <text fg={colors.primary}>Saving skill...</text>
+      </box>
+    );
+  }
+
+  if (step === "name") {
+    return (
+      <box width="100%" flexDirection="column" gap={2} paddingLeft={4}>
+        <text fg={colors.text}>Create Skill</text>
+        <text fg={colors.textMuted}>
+          Skills are reusable prompts / workflows available via / commands
+        </text>
+
+        {error && <text fg={colors.error}>Error: {error}</text>}
+
+        <Input
+          label="Skill Name"
+          description='A short name (e.g. "SQL Injection Test")'
+          placeholder="My Custom Skill"
+          value={name}
+          onInput={setName}
+          focused={true}
+        />
+
+        {name.trim() && (
+          <text fg={colors.textMuted}>Slash command: /{slug}</text>
+        )}
+
+        <box flexDirection="column" gap={0} marginTop={1}>
+          <text>
+            <span fg={colors.primary}>█ </span>
+            <span fg={colors.textMuted}>Press </span>
+            <span fg={colors.text}>[Enter]</span>
+            <span fg={colors.textMuted}> to continue</span>
+          </text>
+          <text>
+            <span fg={colors.primary}>█ </span>
+            <span fg={colors.textMuted}>Press </span>
+            <span fg={colors.text}>[ESC]</span>
+            <span fg={colors.textMuted}> to cancel</span>
+          </text>
+        </box>
+      </box>
+    );
+  }
+
+  if (step === "description") {
+    return (
+      <box width="100%" flexDirection="column" gap={2} paddingLeft={4}>
+        <text fg={colors.text}>Create Skill — Description</text>
+        <text fg={colors.textMuted}>
+          Skill: {name} (/{slug})
+        </text>
+
+        <Input
+          label="Description"
+          description="One-line description shown in autocomplete (optional)"
+          placeholder="Test for SQL injection vulnerabilities"
+          value={description}
+          onInput={setDescription}
+          focused={true}
+        />
+
+        <box flexDirection="column" gap={0} marginTop={1}>
+          <text>
+            <span fg={colors.primary}>█ </span>
+            <span fg={colors.textMuted}>Press </span>
+            <span fg={colors.text}>[Enter]</span>
+            <span fg={colors.textMuted}> to continue</span>
+          </text>
+          <text>
+            <span fg={colors.primary}>█ </span>
+            <span fg={colors.textMuted}>Press </span>
+            <span fg={colors.text}>[ESC]</span>
+            <span fg={colors.textMuted}> to go back</span>
+          </text>
+        </box>
+      </box>
+    );
+  }
+
+  if (step === "content") {
+    return (
+      <box width="100%" flexDirection="column" gap={2} paddingLeft={4}>
+        <text fg={colors.text}>Create Skill — Prompt Content</text>
+        <text fg={colors.textMuted}>
+          Skill: {name} (/{slug})
+        </text>
+
+        <Input
+          label="Prompt Content"
+          description="The directive / prompt that will be sent to the agent"
+          placeholder="Test the target for SQL injection vulnerabilities..."
+          value={content}
+          onInput={setContent}
+          focused={true}
+        />
+
+        <box flexDirection="column" gap={0} marginTop={1}>
+          <text>
+            <span fg={colors.primary}>█ </span>
+            <span fg={colors.textMuted}>Press </span>
+            <span fg={colors.text}>[Enter]</span>
+            <span fg={colors.textMuted}> to review</span>
+          </text>
+          <text>
+            <span fg={colors.primary}>█ </span>
+            <span fg={colors.textMuted}>Press </span>
+            <span fg={colors.text}>[ESC]</span>
+            <span fg={colors.textMuted}> to go back</span>
+          </text>
+        </box>
+      </box>
+    );
+  }
+
+  // Confirm step
+  return (
+    <box width="100%" flexDirection="column" gap={1} paddingLeft={4}>
+      <text fg={colors.text}>Create Skill — Review</text>
+
+      {error && <text fg={colors.error}>Error: {error}</text>}
+
+      <box flexDirection="column" marginTop={1} gap={1}>
+        <box flexDirection="row" gap={1}>
+          <text fg={colors.textMuted}>Name:</text>
+          <text fg={colors.text}>{name}</text>
+        </box>
+        <box flexDirection="row" gap={1}>
+          <text fg={colors.textMuted}>Command:</text>
+          <text fg={colors.primary}>/{slug}</text>
+        </box>
+        {description && (
+          <box flexDirection="row" gap={1}>
+            <text fg={colors.textMuted}>Description:</text>
+            <text fg={colors.text}>{description}</text>
+          </box>
+        )}
+        <box flexDirection="column" marginTop={1}>
+          <text fg={colors.textMuted}>Prompt:</text>
+          <box paddingLeft={2} marginTop={0}>
+            <text fg={colors.text}>{content}</text>
+          </box>
+        </box>
+      </box>
+
+      <box flexDirection="column" marginTop={2} gap={0}>
+        {/* Save button */}
+        <box flexDirection="row" gap={1}>
+          <text fg={confirmFocused === 0 ? colors.primary : colors.textMuted}>
+            {confirmFocused === 0 ? "▸" : " "}
+          </text>
+          <text fg={confirmFocused === 0 ? colors.primary : colors.textMuted}>
+            {confirmFocused === 0 ? "[" : " "}Save Skill
+            {confirmFocused === 0 ? "]" : " "}
+          </text>
+        </box>
+
+        {/* Cancel button */}
+        <box flexDirection="row" gap={1}>
+          <text fg={confirmFocused === 1 ? colors.primary : colors.textMuted}>
+            {confirmFocused === 1 ? "▸" : " "}
+          </text>
+          <text fg={confirmFocused === 1 ? colors.textMuted : colors.textMuted}>
+            {confirmFocused === 1 ? "[" : " "}Cancel
+            {confirmFocused === 1 ? "]" : " "}
+          </text>
+        </box>
+      </box>
+
+      <box flexDirection="column" gap={0} marginTop={2}>
+        <text fg={colors.textMuted}>
+          ↑/↓ navigate | Enter select | ESC back
+        </text>
+        <text fg={colors.textMuted}>Saved to ~/.pensar/skills/{slug}.md</text>
+      </box>
+    </box>
+  );
+}

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -16,6 +16,7 @@ import { ALL_TOOL_NAMES } from "../../../core/agents/offSecAgent";
 import { useAgent } from "../../context/agent";
 import { useRoute } from "../../context/route";
 import { useConfig } from "../../context/config";
+import { useCommand } from "../../context/command";
 import { MessageList } from "../chat/message-list";
 import { InputArea } from "../chat/input-area";
 import { useTheme } from "../../theme";
@@ -48,6 +49,8 @@ export default function OperatorDashboard({
   const route = useRoute();
   const config = useConfig();
   const { model, setThinking, setIsExecuting } = useAgent();
+  const { autocompleteOptions, executeCommand, resolveSkillContent } =
+    useCommand();
 
   // Session state
   const [session, setSession] = useState<SessionInfo | null>(null);
@@ -384,6 +387,20 @@ export default function OperatorDashboard({
     [status, runAgent],
   );
 
+  const handleCommandExecute = useCallback(
+    async (command: string) => {
+      // Check if this matches a skill — if so, inject its content as a directive
+      const skillContent = resolveSkillContent(command);
+      if (skillContent) {
+        handleSubmit(skillContent);
+        return;
+      }
+      // Otherwise, delegate to the standard command router
+      await executeCommand(command);
+    },
+    [resolveSkillContent, handleSubmit, executeCommand],
+  );
+
   const handleAbort = useCallback(() => {
     if (abortControllerRef.current) {
       // Increment generation to prevent the aborted run's cleanup from firing
@@ -570,7 +587,7 @@ export default function OperatorDashboard({
             ? "Agent is working..."
             : status === "waiting"
               ? "Type to redirect agent, or Y/A to approve..."
-              : "Enter directive (e.g., 'Explore the attack surface')..."
+              : "Enter directive or / for commands & skills..."
         }
         focused={status !== "running"}
         status={status === "waiting" ? "running" : status}
@@ -581,6 +598,10 @@ export default function OperatorDashboard({
         pendingApproval={currentPending}
         onApprove={handleApprove}
         onAutoApprove={handleAutoApprove}
+        enableAutocomplete={true}
+        autocompleteOptions={autocompleteOptions}
+        enableCommands={true}
+        onCommandExecute={handleCommandExecute}
       />
     </box>
   );

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -6,7 +6,7 @@
  * Reuses MessageList and InputArea from the shared/chat components.
  */
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useKeyboard } from "@opentui/react";
 
 import { sessions, type SessionInfo } from "../../../core/session";
@@ -23,6 +23,7 @@ import { useTheme } from "../../theme";
 import type { DisplayMessage } from "../agent-display";
 import { isToolMessage } from "../shared/type-guards";
 import type { OperatorMode, PendingApproval } from "../../../core/operator";
+import { slugify } from "../../../core/skills";
 import {
   ApprovalGate,
   createInitialOperatorState,
@@ -49,8 +50,19 @@ export default function OperatorDashboard({
   const route = useRoute();
   const config = useConfig();
   const { model, setThinking, setIsExecuting } = useAgent();
-  const { autocompleteOptions, executeCommand, resolveSkillContent } =
-    useCommand();
+  const {
+    autocompleteOptions: allAutocompleteOptions,
+    executeCommand,
+    resolveSkillContent,
+    skills,
+  } = useCommand();
+
+  const autocompleteOptions = useMemo(() => {
+    const skillSlugs = new Set(skills.map((s) => `/${slugify(s.name)}`));
+    return allAutocompleteOptions.filter(
+      (opt) => opt.value === "/create-skill" || skillSlugs.has(opt.value),
+    );
+  }, [allAutocompleteOptions, skills]);
 
   // Session state
   const [session, setSession] = useState<SessionInfo | null>(null);

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -58,9 +58,10 @@ export default function OperatorDashboard({
   } = useCommand();
 
   const autocompleteOptions = useMemo(() => {
+    const allowedCommands = new Set(["/create-skill"]);
     const skillSlugs = new Set(skills.map((s) => `/${slugify(s.name)}`));
     return allAutocompleteOptions.filter(
-      (opt) => opt.value === "/create-skill" || skillSlugs.has(opt.value),
+      (opt) => allowedCommands.has(opt.value) || skillSlugs.has(opt.value),
     );
   }, [allAutocompleteOptions, skills]);
 

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -1,4 +1,11 @@
-import { createContext, useContext, useMemo, useCallback } from "react";
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useCallback,
+  useState,
+  useEffect,
+} from "react";
 import type { ReactNode } from "react";
 import { CommandRouter } from "../command-router";
 import {
@@ -8,12 +15,22 @@ import {
 } from "../command-registry";
 import type { AutocompleteOption } from "../components/shared/prompt-input";
 import { useRoute } from "./route";
+import { loadSkills, slugify, type Skill } from "../../core/skills";
 
 interface CommandContextValue {
   router: CommandRouter<AppCommandContext>;
   autocompleteOptions: AutocompleteOption[];
   executeCommand: (input: string) => Promise<boolean>;
   commands: typeof commands;
+  /** Available operator skills loaded from ~/.pensar/skills/ */
+  skills: Skill[];
+  /** Reload skills from disk (e.g. after creating a new one) */
+  refreshSkills: () => Promise<void>;
+  /**
+   * Resolve a slash-command input to skill content.
+   * Returns the skill's prompt content if the input matches a skill, else null.
+   */
+  resolveSkillContent: (input: string) => string | null;
 }
 
 const CommandContext = createContext<CommandContextValue | null>(null);
@@ -32,6 +49,7 @@ interface CommandProviderProps {
 
 export function CommandProvider({ children }: CommandProviderProps) {
   const route = useRoute();
+  const [skills, setSkills] = useState<Skill[]>([]);
 
   const ctx = useMemo(() => {
     const ctx: AppCommandContext = {
@@ -40,6 +58,16 @@ export function CommandProvider({ children }: CommandProviderProps) {
     };
     return ctx;
   }, [route]);
+
+  const refreshSkills = useCallback(async () => {
+    const loaded = await loadSkills();
+    setSkills(loaded);
+  }, []);
+
+  // Load skills on mount and whenever we return to home
+  useEffect(() => {
+    refreshSkills();
+  }, [route.data]);
 
   // Create router with context - initialized once
   const router = useMemo(() => {
@@ -53,22 +81,34 @@ export function CommandProvider({ children }: CommandProviderProps) {
     return router;
   }, []);
 
-  // Generate autocomplete options from router commands
+  // Build a slug-to-content map for fast skill resolution
+  const skillSlugMap = useMemo(() => {
+    const map = new Map<string, Skill>();
+    for (const skill of skills) {
+      map.set(slugify(skill.name), skill);
+    }
+    return map;
+  }, [skills]);
+
+  const resolveSkillContent = useCallback(
+    (input: string): string | null => {
+      const trimmed = input.trim().replace(/^\/+/, "").toLowerCase();
+      const skill = skillSlugMap.get(trimmed);
+      return skill?.content ?? null;
+    },
+    [skillSlugMap],
+  );
+
+  // Generate autocomplete options from router commands + skills
   const autocompleteOptions = useMemo((): AutocompleteOption[] => {
     const routerCommands = router.getAllCommands();
     const options: AutocompleteOption[] = [];
 
     for (const cmd of routerCommands) {
-      // Find the original command config to get options
       const cmdConfig = commands.find((c) => c.name === cmd.name);
-
-      // Skip hidden commands (they still work, just don't show in menu)
       if (cmdConfig?.hidden) continue;
 
-      // Build description with options hint
       const description = cmd.description || "";
-
-      // Add main command (aliases hidden but still work via router)
       options.push({
         value: `/${cmd.name}`,
         label: `/${cmd.name}`,
@@ -76,8 +116,18 @@ export function CommandProvider({ children }: CommandProviderProps) {
       });
     }
 
+    // Append skill-based slash commands
+    for (const skill of skills) {
+      const slug = slugify(skill.name);
+      options.push({
+        value: `/${slug}`,
+        label: `/${slug}`,
+        description: skill.description || "Skill",
+      });
+    }
+
     return options;
-  }, [router]);
+  }, [router, skills]);
 
   const executeCommand = useCallback(
     async (input: string): Promise<boolean> => {
@@ -92,8 +142,18 @@ export function CommandProvider({ children }: CommandProviderProps) {
       autocompleteOptions,
       executeCommand,
       commands,
+      skills,
+      refreshSkills,
+      resolveSkillContent,
     }),
-    [router, autocompleteOptions, executeCommand],
+    [
+      router,
+      autocompleteOptions,
+      executeCommand,
+      skills,
+      refreshSkills,
+      resolveSkillContent,
+    ],
   );
 
   return (

--- a/src/tui/context/route.tsx
+++ b/src/tui/context/route.tsx
@@ -22,7 +22,8 @@ export type RoutePath =
   | "sessions"
   | "theme"
   | "auth"
-  | "credits";
+  | "credits"
+  | "create-skill";
 
 export interface WebCommandOptions {
   auto?: boolean;

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -37,6 +37,7 @@ import { KeybindingProvider } from "./context/keybinding";
 import Pentest from "./components/pentest/pentest";
 import OperatorDashboard from "./components/operator-dashboard";
 import ThemePicker from "./components/commands/theme-picker";
+import CreateSkillWizard from "./components/commands/create-skill-wizard";
 import { ThemeProvider, useTheme, type ColorMode } from "./theme";
 import { registerBuiltinThemes } from "./theme/themes";
 import { detectTerminalMode } from "./theme/detect-mode";
@@ -319,6 +320,9 @@ function CommandDisplay({
           </RouteSwitch.Case>
           <RouteSwitch.Case when="credits">
             <CreditsFlow />
+          </RouteSwitch.Case>
+          <RouteSwitch.Case when="create-skill">
+            <CreateSkillWizard />
           </RouteSwitch.Case>
         </RouteSwitch>
       </box>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR introduces the ability for operators to create and use custom "skills" via slash commands, extending the functionality with preset prompting/workflows.

*   **Issue:** Operators lacked a mechanism to define and quickly invoke custom prompts or workflows, similar to `/` commands in other tools.
*   **Changes:**
    *   Added a `/create-skill` command, which launches a multi-step wizard to guide users through defining a new skill (name, description, prompt content).
    *   Skills are stored as Markdown files with YAML frontmatter in `~/.pensar/skills/`.
    *   Implemented a core `skills` module for CRUD operations (load, save, delete, list) on these skill files.
    *   Integrated skills into the `CommandProvider` so that all available skills are dynamically loaded and appear as suggestions when `/` is typed in operator mode.
    *   Modified `InputArea` and `OperatorDashboard` to enable slash command parsing and execution. When a skill command is selected, its prompt content is submitted as an agent directive; built-in commands execute normally.
*   **Why it works:** This system provides a structured, user-friendly way for operators to define, store, and invoke custom prompts. By integrating skills directly into the command input and autocomplete, it makes them easily discoverable and accessible, significantly enhancing the extensibility and customizability of the operator mode.

### How did you verify your code works?

*   `bun run tsc`: Passed with no type errors.
*   `bun run lint`: Passed with no lint issues.
*   `bun run format:check`: All files passed Prettier checks.
*   `bun run test`: 179 tests passed (including 10 new unit tests for the skills module), 15 integration tests were skipped.
*   `bun run build`: Successful bundle.
*   No manual GUI testing was performed as the TUI requires a real terminal and operator mode requires an AI provider API key. Verification relies on static analysis and comprehensive unit tests.

---
<p><a href="https://cursor.com/agents/bc-7b74aa18-6b50-4d55-acae-f1e0feafb7e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b74aa18-6b50-4d55-acae-f1e0feafb7e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->