### PR TITLE
Escape key help popup

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -17,6 +17,7 @@ import { useAgent } from "../../context/agent";
 import { useRoute } from "../../context/route";
 import { useConfig } from "../../context/config";
 import { useCommand } from "../../context/command";
+import { useDialog } from "../../context/dialog";
 import { MessageList } from "../chat/message-list";
 import { InputArea } from "../chat/input-area";
 import { useTheme } from "../../theme";
@@ -56,6 +57,7 @@ export default function OperatorDashboard({
     resolveSkillContent,
     skills,
   } = useCommand();
+  const { stack, externalDialogOpen } = useDialog();
 
   const autocompleteOptions = useMemo(() => {
     const allowedCommands = new Set(["/create-skill"]);
@@ -449,6 +451,9 @@ export default function OperatorDashboard({
 
   // Keyboard shortcuts
   useKeyboard((key) => {
+    // Skip local shortcuts when dialogs are open (e.g. shortcuts popup)
+    if (stack.length > 0 || externalDialogOpen) return;
+
     if (key.ctrl && key.name === "c") {
       if (status === "running" || status === "waiting") {
         handleAbort();

--- a/src/tui/keybindings/registry.ts
+++ b/src/tui/keybindings/registry.ts
@@ -2,6 +2,7 @@ import { useRenderer } from "@opentui/react";
 import { useRoute } from "../context/route";
 import { useFocus } from "../context/focus";
 import { useInput } from "../context/input";
+import { useDialog } from "../context/dialog";
 
 export interface KeybindingEntry {
   combo: string;
@@ -45,6 +46,7 @@ export function createKeybindings(
   const renderer = useRenderer();
   const { promptRef } = useFocus();
   const { inputValue, setInputValue, clearInput } = useInput();
+  const { stack, externalDialogOpen } = useDialog();
 
   return [
     {
@@ -75,11 +77,16 @@ export function createKeybindings(
       combo: "escape",
       description: "Return to home",
       fn: async () => {
+        if (stack.length > 0 || externalDialogOpen) {
+          return;
+        }
+
         const isHome = route.data.type === "base" && route.data.path === "home";
         const isWeb = route.data.type === "base" && route.data.path === "web";
         const isOperator =
           route.data.type === "base" && route.data.path === "operator";
-        const isSession = route.data.type === "pentest";
+        const isSession =
+          route.data.type === "pentest" || route.data.type === "operator";
 
         if (!isHome && !isWeb && !isOperator && !isSession) {
           route.navigate({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR fixes a bug where pressing `Esc` in operator mode, after opening the `?` shortcuts popup, would terminate the entire session instead of just closing the popup.

The changes ensure that:
1.  Global `Esc` handling is guarded, preventing it from routing away when a dialog is open or when the user is in an operator session.
2.  The operator dashboard's keyboard handling ignores session-level `Esc` shortcuts when any dialog is active, giving precedence to dialog-specific `Esc` actions.

This resolves the conflict by ensuring that `Esc` correctly dismisses the active dialog without affecting the underlying operator session.

### How did you verify your code works?

*   **Automated Tests:**
    *   `bun run test` (all tests passed)
    *   `bun run tsc` (type checks passed)
    *   `bun run lint` (lint checks passed)
*   **Manual TUI Validation:**
    *   Entered operator mode.
    *   Pressed `?` to open the shortcuts popup.
    *   Pressed `Esc` once.
    *   Confirmed that the popup closed and the operator session remained active.
    *   A demo video and screenshots were captured to confirm this behavior.

---
<p><a href="https://cursor.com/agents/bc-f484ecf6-f43a-435d-af97-d72705ee33ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f484ecf6-f43a-435d-af97-d72705ee33ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->