### PR TITLE
Sessions command dialog

### DIFF
--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -14,6 +14,7 @@ import { config } from "../core/config";
 export interface AppCommandContext {
   route: Route;
   navigate: (route: Route) => void;
+  openSessionsDialog?: () => void;
 }
 
 /**
@@ -254,6 +255,10 @@ export const commands: CommandConfig[] = [
     description: "Browse previous sessions",
     category: "Pentesting",
     handler: async (args, ctx) => {
+      if (ctx.openSessionsDialog) {
+        ctx.openSessionsDialog();
+        return;
+      }
       ctx.navigate({
         type: "base",
         path: "sessions",

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -45,9 +45,13 @@ export function useCommand(): CommandContextValue {
 
 interface CommandProviderProps {
   children: ReactNode;
+  onOpenSessionsDialog?: () => void;
 }
 
-export function CommandProvider({ children }: CommandProviderProps) {
+export function CommandProvider({
+  children,
+  onOpenSessionsDialog,
+}: CommandProviderProps) {
   const route = useRoute();
   const [skills, setSkills] = useState<Skill[]>([]);
 
@@ -55,9 +59,10 @@ export function CommandProvider({ children }: CommandProviderProps) {
     const ctx: AppCommandContext = {
       route: route.data,
       navigate: route.navigate,
+      openSessionsDialog: onOpenSessionsDialog,
     };
     return ctx;
-  }, [route]);
+  }, [route, onOpenSessionsDialog]);
 
   const refreshSkills = useCallback(async () => {
     const loaded = await loadSkills();

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -65,7 +65,9 @@ function App({ appConfig }: AppProps) {
             <InputProvider>
               <DialogProvider>
                 <AgentProvider>
-                  <CommandProvider>
+                  <CommandProvider
+                    onOpenSessionsDialog={() => setShowSessionsDialog(true)}
+                  >
                     <KeybindingProvider
                       deps={{
                         ctrlCPressTime,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR addresses issue #242 by changing the behavior of the `/sessions` command in the TUI. Previously, `/sessions` navigated to a full-page `SessionsBrowser`. This PR updates the command to directly open the `SessionsDisplay` modal dialog, consistent with the `Ctrl+S` shortcut.

This works by:
1.  Adding an optional `openSessionsDialog` callback to the command context.
2.  Modifying the `/sessions` command to prioritize invoking this callback (with a fallback to the previous route behavior).
3.  Wiring the `CommandProvider` in `index.tsx` to pass the `showSessionsDialog` function as `onOpenSessionsDialog`, ensuring `/sessions` triggers the same dialog as `Ctrl+S`.

### How did you verify your code works?

I verified the changes by:

*   Running automated tests: `bun run test`, `bun run tsc`, and `bun run lint`.
*   Performing a manual TUI verification:
    *   Launched the TUI with `bun run start`.
    *   Typed `/sessions` at the prompt.
    *   Confirmed that the sessions modal dialog overlay appeared directly, rather than a full-page navigation.
    *   Confirmed the dialog could be closed with `esc`.
    *   A video walkthrough of this manual verification was recorded.

---
<p><a href="https://cursor.com/agents/bc-ac58a74d-661e-4c5e-a80d-3fe60893dd7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac58a74d-661e-4c5e-a80d-3fe60893dd7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->