### PR TITLE
Severity CVSS source

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -3,14 +3,11 @@ import { z } from "zod";
 import { join } from "path";
 import { writeFileSync, appendFileSync } from "fs";
 import type { ToolContext } from "./types";
-import {
-  scoreFindingWithCVSS,
-  type CVSSScorerResult,
-} from "../../specialized/cvssScorer";
+import { scoreFindingWithCVSS } from "../../specialized/cvssScorer";
+import type { Finding } from "../types";
 
 export const documentVulnerabilityInputSchema = z.object({
   title: z.string().describe("Finding title"),
-  severity: z.enum(["CRITICAL", "HIGH", "MEDIUM", "LOW"]),
   description: z.string().describe("Detailed description of the finding"),
   impact: z.string().describe("Potential impact if exploited"),
   evidence: z.string().describe("Evidence/proof of the vulnerability"),
@@ -42,24 +39,45 @@ CRITICAL RULES — READ BEFORE CALLING:
 - You MUST have a working PoC script (created via create_poc) that reliably demonstrates the vulnerability BEFORE calling this tool
 - Do NOT use this tool for: positive/negative observations, informational notes, testing limitations, authentication issues, rate-limiting, infrastructure notes, or anything that is not a exploitable security vulnerability
 - If you could not exploit a vulnerability, do NOT document it — mention it in your final response summary instead
-
-SEVERITY LEVELS:
-- CRITICAL: Immediate risk of system compromise (RCE, auth bypass, SQL injection with data access)
-- HIGH: Significant security risk (XSS, CSRF, sensitive data exposure, privilege escalation)
-- MEDIUM: Security weakness that could be exploited (information disclosure, weak configs)
-- LOW: Minor security concern (missing headers, verbose errors)
+- Severity is automatically determined from CVSS 4.0 scoring — you do NOT need to specify it
 
 FINDING STRUCTURE:
 - Title: Clear, concise description of the vulnerability
-- Severity: Use CVSS if applicable
 - Description: Detailed technical explanation of the vulnerability
 - Impact: Business and technical consequences if exploited
 - Evidence: Commands run, responses received, proof of exploitation
 - Remediation: Specific, actionable steps to fix
 - References: CVE, CWE, OWASP, or security advisories`,
     inputSchema: documentVulnerabilityInputSchema,
-    execute: async (finding) => {
+    execute: async (input) => {
       try {
+        const timestamp = new Date().toISOString();
+
+        // -- CVSS 4.0 scoring (determines severity) --------------------------
+        const cvssResult = await scoreFindingWithCVSS(
+          {
+            finding: {
+              title: input.title,
+              description: input.description,
+              impact: input.impact,
+              evidence: input.evidence,
+              endpoint: input.endpoint,
+              remediation: input.remediation,
+            },
+            agentMessages: [],
+          },
+          ctx.model!,
+          ctx.authConfig,
+        );
+
+        const severity =
+          cvssResult.severity === "NONE" ? "LOW" : cvssResult.severity;
+
+        const finding: Finding = {
+          ...input,
+          severity: severity as Finding["severity"],
+        };
+
         // -- Dedup check (when a shared registry is available) ----------------
         if (ctx.findingsRegistry) {
           const check = await ctx.findingsRegistry.register(finding);
@@ -75,48 +93,19 @@ FINDING STRUCTURE:
           }
         }
 
-        const timestamp = new Date().toISOString();
-
-        // -- CVSS 4.0 scoring ------------------------------------------------
-        let cvssResult: CVSSScorerResult | undefined;
-        try {
-          cvssResult = await scoreFindingWithCVSS(
-            {
-              finding: {
-                title: finding.title,
-                description: finding.description,
-                impact: finding.impact,
-                evidence: finding.evidence,
-                endpoint: finding.endpoint,
-                remediation: finding.remediation,
-              },
-              agentMessages: [],
-            },
-            ctx.model!,
-            ctx.authConfig,
-          );
-        } catch (err) {
-          console.warn(
-            "CVSS scoring failed, proceeding without score:",
-            err instanceof Error ? err.message : err,
-          );
-        }
-
         const findingWithMeta = {
           ...finding,
           timestamp,
           sessionId: session.id,
           target: session.targets[0],
-          ...(cvssResult && {
-            cvss: {
-              score: cvssResult.score,
-              severity: cvssResult.severity,
-              vectorString: cvssResult.vectorString,
-              metrics: cvssResult.metrics,
-              scoreType: cvssResult.scoreType,
-              reasoning: cvssResult.reasoning,
-            },
-          }),
+          cvss: {
+            score: cvssResult.score,
+            severity: cvssResult.severity,
+            vectorString: cvssResult.vectorString,
+            metrics: cvssResult.metrics,
+            scoreType: cvssResult.scoreType,
+            reasoning: cvssResult.reasoning,
+          },
         };
 
         // Safe filename from title
@@ -137,16 +126,11 @@ FINDING STRUCTURE:
           writeFileSync(jsonPath, JSON.stringify(findingWithMeta, null, 2));
 
           // Write human-readable markdown
-          const cvssLine = cvssResult
-            ? `\n**CVSS 4.0 Score:** ${cvssResult.score} (${cvssResult.severity})  \n**Vector:** \`${cvssResult.vectorString}\`  `
-            : "";
-          const cvssSection = cvssResult
-            ? `\n## CVSS 4.0 Assessment\n\n**Score:** ${cvssResult.score} / 10.0 (${cvssResult.severity})  \n**Vector:** \`${cvssResult.vectorString}\`  \n**Score Type:** ${cvssResult.scoreType}\n\n**Reasoning:** ${cvssResult.reasoning}\n`
-            : "";
-
           const markdown = `# ${finding.title}
 
-**Severity:** ${finding.severity}  ${cvssLine}
+**Severity:** ${finding.severity}  
+**CVSS 4.0 Score:** ${cvssResult.score} (${cvssResult.severity})  
+**Vector:** \`${cvssResult.vectorString}\`  
 **Target:** ${session.targets[0]}  
 **Endpoint:** ${finding.endpoint}  
 **Date:** ${timestamp}  
@@ -159,7 +143,15 @@ ${finding.description}
 ## Impact
 
 ${finding.impact}
-${cvssSection}
+
+## CVSS 4.0 Assessment
+
+**Score:** ${cvssResult.score} / 10.0 (${cvssResult.severity})  
+**Vector:** \`${cvssResult.vectorString}\`  
+**Score Type:** ${cvssResult.scoreType}
+
+**Reasoning:** ${cvssResult.reasoning}
+
 ## Evidence
 
 \`\`\`
@@ -185,8 +177,7 @@ ${finding.references ? `## References\n\n${finding.references}` : ""}
 
           // Append to summary
           const summaryPath = join(session.rootPath, "findings-summary.md");
-          const cvssTag = cvssResult ? ` (CVSS ${cvssResult.score})` : "";
-          const summaryEntry = `- [${finding.severity}]${cvssTag} ${finding.title} - \`findings/${mdFilename}\`\n`;
+          const summaryEntry = `- [${finding.severity}] (CVSS ${cvssResult.score}) ${finding.title} - \`findings/${mdFilename}\`\n`;
 
           try {
             appendFileSync(summaryPath, summaryEntry);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR modifies the `documentVulnerability` tool to derive the finding's severity directly from the CVSS 4.0 score, rather than having the agent provide it.

Key changes include:
- Removed `severity` from `documentVulnerabilityInputSchema`.
- CVSS scoring now occurs before the dedup check, ensuring the `Finding` object has a CVSS-derived severity for registry fingerprinting.
- The finding's severity is mapped from `cvssResult.severity` (with "NONE" mapped to "LOW").
- The CVSS result is always present on persisted findings, and the markdown/summary output consistently includes the CVSS assessment section.
- The tool description has been updated to reflect that severity is automatically determined.

This change ensures that severity is consistently linked to and influenced by the CVSS score.

### How did you verify your code works?

The following checks were performed:
- ✅ `bun run tsc` — type check passes
- ✅ `bun run lint` — no lint errors
- ✅ `bun run format:check` — formatting passes
- ✅ `bun run test` — 179 passed, 15 skipped (all skipped tests are integration tests requiring live services)

No manual testing was performed as this is a backend tool schema change with no UI component; correctness is verified by the type checker and existing tests.

---
<p><a href="https://cursor.com/agents/bc-e6f97f5c-e581-489b-8aae-d253834f6d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6f97f5c-e581-489b-8aae-d253834f6d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->