### PR TITLE
add exfil mode

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@
 import packageJson from "../package.json";
 import { getCurrentVersion, upgrade } from "./core/installation";
 import { buildAuthConfig } from "./core/ai/utils";
+import { resolvePentestMode } from "./core/cli/pentestMode";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -107,7 +108,11 @@ async function runPentest() {
   const cwd = getArg("--cwd");
   const mode = getArg("--mode");
   const model = (getArg("--model") ?? "claude-sonnet-4-5") as AIModel;
-  const exfilMode = mode === "exfil";
+  const { exfilMode, warning: modeWarning } = resolvePentestMode(mode);
+
+  if (modeWarning) {
+    console.warn(modeWarning);
+  }
 
   console.log("=".repeat(60));
   console.log("PENTEST ORCHESTRATION");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,6 +70,9 @@ function showHelp() {
   console.log(
     "  --cwd <path>       Source code path — enables whitebox attack surface",
   );
+  console.log(
+    "  --mode <mode>      Pentest mode: exfil (pivoting & flag extraction)",
+  );
   console.log("  --model <model>    AI model (default: claude-sonnet-4-5)");
   console.log();
   console.log("targeted-pentest options:");
@@ -102,13 +105,16 @@ async function runPentest() {
 
   const target = getArgRequired("--target");
   const cwd = getArg("--cwd");
+  const mode = getArg("--mode");
   const model = (getArg("--model") ?? "claude-sonnet-4-5") as AIModel;
+  const exfilMode = mode === "exfil";
 
   console.log("=".repeat(60));
   console.log("PENTEST ORCHESTRATION");
   console.log("=".repeat(60));
   console.log(`Target:  ${target}`);
   if (cwd) console.log(`Cwd:     ${cwd} (whitebox)`);
+  if (exfilMode) console.log(`Mode:    exfil`);
   console.log(`Model:   ${model}`);
   console.log();
 
@@ -117,7 +123,10 @@ async function runPentest() {
   const session = await sessions.create({
     name: cwd ? "Whitebox Pentest" : "Blackbox Pentest",
     targets: [target],
-    ...(cwd ? { config: { cwd } } : {}),
+    config: {
+      ...(cwd ? { cwd } : {}),
+      ...(exfilMode ? { exfilMode: true } : {}),
+    },
   });
 
   const { findings, findingsPath, pocsPath, reportPath } =

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -104,12 +104,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
 
     super({
       system: buildSystemPrompt(session),
-      prompt: buildPrompt(
-        target,
-        objectives,
-        session,
-        findingsRegistry,
-      ),
+      prompt: buildPrompt(target, objectives, session, findingsRegistry),
       model,
       session,
       target,
@@ -241,7 +236,9 @@ Authentication:
 - For execute_command (curl): include -H "Cookie: ..." and/or -H "Authorization: ..." flags.
 - If a request returns 401/403, the session may have expired — note it in your findings but do not try to log in again.`;
 
-function buildSystemPrompt(session: { config?: { exfilMode?: boolean } }): string {
+function buildSystemPrompt(session: {
+  config?: { exfilMode?: boolean };
+}): string {
   return session.config?.exfilMode
     ? PENTEST_SYSTEM_PROMPT_EXFIL
     : PENTEST_SYSTEM_PROMPT_BASE;
@@ -250,7 +247,10 @@ function buildSystemPrompt(session: { config?: { exfilMode?: boolean } }): strin
 function buildPrompt(
   target: string,
   objectives: string[],
-  session: { rootPath: string; config?: { exfilMode?: boolean; outcomeGuidance?: string } },
+  session: {
+    rootPath: string;
+    config?: { exfilMode?: boolean; outcomeGuidance?: string };
+  },
   findingsRegistry?: FindingsRegistry,
 ): string {
   const sessionRootPath = session.rootPath;

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -103,11 +103,11 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
     } = opts;
 
     super({
-      system: PENTEST_SYSTEM_PROMPT,
+      system: buildSystemPrompt(session),
       prompt: buildPrompt(
         target,
         objectives,
-        session.rootPath,
+        session,
         findingsRegistry,
       ),
       model,
@@ -154,7 +154,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
 // Prompts
 // ---------------------------------------------------------------------------
 
-const PENTEST_SYSTEM_PROMPT = `You are an expert penetration tester performing a targeted security assessment.
+const PENTEST_SYSTEM_PROMPT_BASE = `You are an expert penetration tester performing a targeted security assessment.
 
 You are given a specific target and specific objectives. Do NOT perform broad reconnaissance or service/endpoint discovery — that has already been done for you. Your job is to deeply test the provided target against the provided objectives.
 
@@ -210,12 +210,52 @@ Authentication:
 - For execute_command (curl): include -H "Cookie: ..." and/or -H "Authorization: ..." flags.
 - If a request returns 401/403, the session may have expired — note it in your findings but do not try to log in again.`;
 
+const PENTEST_SYSTEM_PROMPT_EXFIL = `You are an expert penetration tester performing a targeted security assessment with the goal of demonstrating full exploit impact.
+
+You are given a specific target and specific objectives. Your job is to deeply test the provided target, and when vulnerabilities are confirmed, pivot through them to discover and extract sensitive data.
+
+Your methodology:
+1. PLAN — Begin by stating the objectives you have been given and outlining your testing plan. For each objective, describe which attack techniques, payloads, and tools you intend to use. Output this plan as text before making any tool calls.
+2. VERIFY — Confirm the target endpoint exists and is reachable. Understand its basic behavior (response format, parameters, auth requirements).
+3. PREPARE — Research applicable payloads and attack techniques for the given objectives. Craft payloads tailored to the target's technology and behavior.
+4. TEST — Execute targeted attacks methodically, one payload/technique at a time. Observe responses carefully for indicators of vulnerability.
+5. EXPLOIT — When a vulnerability is confirmed, create a proof-of-concept script that reliably demonstrates it.
+6. PIVOT — When a vulnerability grants access to internal resources (e.g. SSRF, RCE, LFI), use it to discover and map what's accessible. Reason about what internal services, APIs, and data stores may exist behind the vulnerability — consider common internal hostnames, ports, and paths (e.g. internal DNS names in Docker/Kubernetes environments, common service ports, admin endpoints). Actively explore through the vulnerability to find reachable services.
+7. EXTRACT — The primary goal is to locate and extract a flag, secret, or sensitive data. Don't stop at proving the vulnerability exists — demonstrate full impact by retrieving the target data through the confirmed attack vector.
+8. DOCUMENT — Document every confirmed finding with evidence, impact assessment, and remediation steps. You can document multiple findings before finishing.
+9. FINISH — After testing ALL objectives and completing extraction, call the response tool to submit your final summary. Do NOT call response until you have completed all testing and extraction.
+
+Guidelines:
+- Always start by stating your objectives and plan before executing any tools
+- When you confirm a vulnerability that provides internal access, think through what lies behind it and actively explore through the vulnerability to maximize impact
+- Be methodical and thorough — test one payload at a time and observe the response
+- Use execute_command for crafting/running exploit scripts and http_request for targeted web tests
+- Always create POC scripts to confirm vulnerabilities before documenting
+- Document every confirmed vulnerability with document_vulnerability — you can document multiple vulnerabilities in a single run
+- Include clear remediation steps in every finding
+- When you have finished testing ALL objectives and extracting data, call the response tool with a summary of your results. Do NOT call response until you have completed all testing and extraction.
+
+Authentication:
+- If the prompt includes an "Existing Authentication Session" section, USE those cookies/headers on every request. Do NOT attempt to re-authenticate.
+- For http_request: include the provided Cookie and Authorization headers in every call.
+- For execute_command (curl): include -H "Cookie: ..." and/or -H "Authorization: ..." flags.
+- If a request returns 401/403, the session may have expired — note it in your findings but do not try to log in again.`;
+
+function buildSystemPrompt(session: { config?: { exfilMode?: boolean } }): string {
+  return session.config?.exfilMode
+    ? PENTEST_SYSTEM_PROMPT_EXFIL
+    : PENTEST_SYSTEM_PROMPT_BASE;
+}
+
 function buildPrompt(
   target: string,
   objectives: string[],
-  sessionRootPath: string,
+  session: { rootPath: string; config?: { exfilMode?: boolean; outcomeGuidance?: string } },
   findingsRegistry?: FindingsRegistry,
 ): string {
+  const sessionRootPath = session.rootPath;
+  const exfilMode = session.config?.exfilMode ?? false;
+  const outcomeGuidance = session.config?.outcomeGuidance;
   const objectiveList = objectives.map((o, i) => `${i + 1}. ${o}`).join("\n");
 
   let authSection = "";
@@ -277,17 +317,24 @@ The following vulnerabilities have already been documented. Do NOT re-test or re
 ${existing}`;
   }
 
-  return `# Testing Assignment
+  const outcomeSection = outcomeGuidance
+    ? `\n## Outcome Guidance\n${outcomeGuidance}\n`
+    : "";
 
-## Target
-- **URL:** ${target}
-${authSection}
-${knownFindingsSection}
-
-## Objectives
-${objectiveList}
+  const instructions = exfilMode
+    ? `## Goal
+Your target is a flag with the format FLAG{...}. Locate and extract it.
 
 ## Instructions
+1. State the objectives and outline your testing plan — describe which techniques and payloads you will use for each objective before executing any tools
+2. Verify the target endpoint is reachable and understand its baseline behavior
+3. For each objective, research and craft targeted payloads appropriate to the technology
+4. Test systematically — vary payloads, encoding, and bypass techniques
+5. Create POC scripts to reliably demonstrate any confirmed vulnerabilities
+6. When a vulnerability provides internal access, pivot through it to discover reachable services and extract sensitive data
+7. Document every confirmed vulnerability (using document_vulnerability) with evidence and remediation steps
+8. After testing ALL objectives and extracting the flag, call the response tool with your final summary. Do NOT call response until you have completed all testing and extraction.`
+    : `## Instructions
 1. State the objectives and outline your testing plan — describe which techniques and payloads you will use for each objective before executing any tools
 2. Verify the target endpoint is reachable and understand its baseline behavior
 3. For each objective, research and craft targeted payloads appropriate to the technology
@@ -297,6 +344,18 @@ ${objectiveList}
 7. After testing ALL objectives, call the response tool with your final summary
 
 Do NOT discover or enumerate other endpoints or services. Focus exclusively on the target and objectives above.`;
+
+  return `# Testing Assignment
+
+## Target
+- **URL:** ${target}
+${authSection}
+${knownFindingsSection}
+
+## Objectives
+${objectiveList}
+${outcomeSection}
+${instructions}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/benchmark/runner.ts
+++ b/src/core/benchmark/runner.ts
@@ -284,8 +284,9 @@ export async function runSingleBenchmark(
       targets: [targetUrl],
       prefix: `benchmark-${branch}-`,
       config: {
-        outcomeGuidance: sessions.BENCHMARK_OUTCOME_GUIDANCE,
+        outcomeGuidance: sessions.EXFIL_OUTCOME_GUIDANCE,
         mode: "auto",
+        exfilMode: true,
       },
     });
 

--- a/src/core/cli/pentestMode.test.ts
+++ b/src/core/cli/pentestMode.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { resolvePentestMode } from "./pentestMode";
+
+describe("resolvePentestMode", () => {
+  it("enables exfil mode for exfil", () => {
+    expect(resolvePentestMode("exfil")).toEqual({ exfilMode: true });
+  });
+
+  it("defaults to standard mode when mode is omitted", () => {
+    expect(resolvePentestMode(undefined)).toEqual({ exfilMode: false });
+  });
+
+  it("warns and falls back when mode is unsupported", () => {
+    const resolution = resolvePentestMode("exfiltrate");
+
+    expect(resolution.exfilMode).toBe(false);
+    expect(resolution.warning).toContain(
+      'Warning: Unsupported --mode value "exfiltrate".',
+    );
+    expect(resolution.warning).toContain("Supported values: exfil");
+    expect(resolution.warning).toContain("Continuing in default mode.");
+  });
+});

--- a/src/core/cli/pentestMode.ts
+++ b/src/core/cli/pentestMode.ts
@@ -1,0 +1,23 @@
+export interface PentestModeResolution {
+  exfilMode: boolean;
+  warning?: string;
+}
+
+const SUPPORTED_PENTEST_MODES = ["exfil"] as const;
+
+export function resolvePentestMode(
+  mode: string | undefined,
+): PentestModeResolution {
+  if (!mode) {
+    return { exfilMode: false };
+  }
+
+  if (mode === "exfil") {
+    return { exfilMode: true };
+  }
+
+  return {
+    exfilMode: false,
+    warning: `Warning: Unsupported --mode value "${mode}". Supported values: ${SUPPORTED_PENTEST_MODES.join(", ")}. Continuing in default mode.`,
+  };
+}

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -23,9 +23,9 @@ export const DEFAULT_OUTCOME_GUIDANCE =
   "Create proof-of-concept exploits that demonstrate the vulnerability exists without causing damage.";
 
 /**
- * Benchmark outcome guidance (extract flags)
+ * Exfil-mode outcome guidance (extract flags / sensitive data)
  */
-export const BENCHMARK_OUTCOME_GUIDANCE =
+export const EXFIL_OUTCOME_GUIDANCE =
   "Exfiltrate data to extract the flag value. " +
   "Create proof-of-concept exploits that successfully extract the flag from the target system.";
 
@@ -149,6 +149,8 @@ const SessionConfigObject = z.object({
   cwd: z.string().optional(),
   /** Email inboxes available to the agent for monitoring/reading email */
   emailIntegration: EmailIntegrationConfigObject.optional(),
+  /** Enable exfiltration mode — allows internal pivoting and flag extraction through confirmed vulnerabilities */
+  exfilMode: z.boolean().optional(),
 });
 
 export type SessionConfig = z.infer<typeof SessionConfigObject>;
@@ -416,7 +418,10 @@ export async function create(input: CreateInputProps) {
         },
       },
       outcomeGuidance:
-        input.config?.outcomeGuidance || DEFAULT_OUTCOME_GUIDANCE,
+        input.config?.outcomeGuidance ||
+        (input.config?.exfilMode
+          ? EXFIL_OUTCOME_GUIDANCE
+          : DEFAULT_OUTCOME_GUIDANCE),
     },
     _rateLimiter: rateLimiter,
     credentialManager,
@@ -682,7 +687,7 @@ export const sessions = {
   getExecutionRoot,
   getOffensiveHeaders,
   DEFAULT_OUTCOME_GUIDANCE,
-  BENCHMARK_OUTCOME_GUIDANCE,
+  EXFIL_OUTCOME_GUIDANCE,
   create,
   get,
   update,


### PR DESCRIPTION
### What does this PR do?

Adds `exfilMode` flag to apex `pentest` command - exfiltration mode instructs the agent to extract canary flags,  sensitive data, etc. to maximally demonstrate impact of detected vuln.

Gated behind flag instead of default behavior to allow for user opt-in of potentially dangerous behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pentest agent prompting and session defaults to encourage data extraction/pivoting when enabled, which can materially alter runtime behavior and test impact. Risk is mitigated by being opt-in via CLI flag and explicit session config.
> 
> **Overview**
> Adds an opt-in **exfiltration mode** to `pensar pentest` via `--mode exfil`, persisting `config.exfilMode` into the created session and printing the selected mode.
> 
> When `exfilMode` is set, the targeted pentest agent switches to a new exfil-focused system prompt and augments the assignment prompt with flag/extraction-oriented instructions (including pivoting through confirmed vulns) plus an optional *Outcome Guidance* section. Benchmarks are updated to run in exfil mode by default, and session config/schema is extended so `exfilMode` also selects a more aggressive default `outcomeGuidance` (`EXFIL_OUTCOME_GUIDANCE`, renamed from the prior benchmark constant).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 543966ce0745b17a6098ddbae3ccc4d6e6963e5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->