### PR TITLE
Mercury 2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@ai-sdk/anthropic": "^3.0.50",
         "@ai-sdk/google": "^3.0.37",
         "@ai-sdk/openai": "^3.0.37",
+        "@ai-sdk/openai-compatible": "^2.0.33",
         "@daytonaio/sdk": "^0.112.1",
         "@googleapis/gmail": "^16.1.1",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -59,9 +60,11 @@
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.59", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.16", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MbtheWHgEFV/8HL1Z6E3hOAsmP73zZlNFg0F0nJAD0Adnjp4J/plqNK00Y896d+dWTw+r0OXzyov9/2wCFjH0Q=="],
 
-    "@ai-sdk/google": ["@ai-sdk/google@3.0.37", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.17" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hZ7nO55+GfQEWJe2B5XRoLNeEubMTuk6OjJJUDS+XCtjKLCd973rRkc62vS86rHw5VuCGITwn3gUZRhSbuX5vw=="],
+    "@ai-sdk/google": ["@ai-sdk/google@3.0.43", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-NGCgP5g8HBxrNdxvF8Dhww+UKfqAkZAmyYBvbu9YLoBkzAmGKDBGhVptN/oXPB5Vm0jggMdoLycZ8JReQM8Zqg=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.37", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.16" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bcYjT3/58i/C0DN3AnrjiGsAb0kYivZLWWUtgTjsBurHSht/LTEy+w3dw5XQe3FmZwX7Z/mUQCiA3wB/5Kf7ow=="],
+
+    "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.33", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.17" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HwptqeUS4vtDyjSSjmKCQExjoQMwPVq0C4pHH18i7c+3CQ0QN81HLvz3BdpULo0n/UtdQwTNISRqx3G5miPZhw=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
@@ -1315,7 +1318,9 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
-    "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.17", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oyCeFINTYK0B8ZGUBiQc05G5vytPlKSmTTtm19xfJuUgoi8zkvvRcoPQci4mSnyfpPn2XSFFDfsALG8uGcapfg=="],
+    "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.19", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg=="],
+
+    "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.17", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oyCeFINTYK0B8ZGUBiQc05G5vytPlKSmTTtm19xfJuUgoi8zkvvRcoPQci4mSnyfpPn2XSFFDfsALG8uGcapfg=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@ai-sdk/anthropic": "^3.0.50",
     "@ai-sdk/google": "^3.0.37",
     "@ai-sdk/openai": "^3.0.37",
+    "@ai-sdk/openai-compatible": "^2.0.33",
     "@daytonaio/sdk": "^0.112.1",
     "@googleapis/gmail": "^16.1.1",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -31,6 +31,7 @@ export type AIModelProvider =
   | "openrouter"
   | "bedrock"
   | "pensar"
+  | "inception"
   | "local";
 
 function checkIfRateLimitError(error: unknown): boolean {

--- a/src/core/ai/models/inception.ts
+++ b/src/core/ai/models/inception.ts
@@ -1,0 +1,11 @@
+import type { ModelInfo } from "../ai";
+
+export const INCEPTION_MODELS: ModelInfo[] = [
+    {
+        id: "mercury-2",
+        name: "Mercury 2",
+        provider: "inception",
+        contextLength: 128_000
+    }
+];
+

--- a/src/core/ai/models/inception.ts
+++ b/src/core/ai/models/inception.ts
@@ -1,11 +1,10 @@
 import type { ModelInfo } from "../ai";
 
 export const INCEPTION_MODELS: ModelInfo[] = [
-    {
-        id: "mercury-2",
-        name: "Mercury 2",
-        provider: "inception",
-        contextLength: 128_000
-    }
+  {
+    id: "mercury-2",
+    name: "Mercury 2",
+    provider: "inception",
+    contextLength: 128_000,
+  },
 ];
-

--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -10,6 +10,7 @@ import { BEDROCK_MODELS } from "./bedrock";
 // OpenRouter — curated manually (SDK doesn't enumerate models).
 import { OPENROUTER_MODELS } from "./openrouter";
 import { PENSAR_MODELS } from "./pensar";
+import { INCEPTION_MODELS } from "./inception";
 
 export const AVAILABLE_MODELS: ModelInfo[] = [
   ...ANTHROPIC_MODELS,
@@ -18,6 +19,7 @@ export const AVAILABLE_MODELS: ModelInfo[] = [
   ...BEDROCK_MODELS,
   ...OPENROUTER_MODELS,
   ...PENSAR_MODELS,
+  ...INCEPTION_MODELS,
 ];
 
 export function getModelInfo(model: AIModel): ModelInfo {

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -2,6 +2,7 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { streamResponse, type AIModel, type StreamResponseOpts } from "./ai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { getModelInfo } from "./models";
@@ -23,6 +24,7 @@ export type AIAuthConfig = {
   anthropicAPIKey?: string;
   googleAPIKey?: string;
   openRouterAPIKey?: string;
+  inceptionAPIKey?: string;
   pensarAPIKey?: string;
   pensarApiUrl?: string;
   // WorkOS CLI auth
@@ -96,6 +98,7 @@ export function getProviderModel(
   const bedrockSessionToken =
     authConfig?.bedrock?.sessionToken || process.env.AWS_SESSION_TOKEN;
   const bedrockRegion = authConfig?.bedrock?.region || process.env.AWS_REGION;
+  const inceptionApiKey = authConfig?.inceptionAPIKey || process.env.INCEPTION_API_KEY;
   const localBaseURL =
     authConfig?.local?.baseURL ||
     process.env.LOCAL_MODEL_URL ||
@@ -117,6 +120,16 @@ export function getProviderModel(
         apiKey: openRouterAPIKey,
       });
       providerModel = openrouter(model);
+      break;
+    }
+
+    case "inception": {
+      const inception = createOpenAICompatible({
+        name: "inception",
+        apiKey: inceptionApiKey,
+        baseURL: "https://api.inceptionlabs.ai/v1"
+      });
+      providerModel = inception("mercury-2");
       break;
     }
 

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -98,7 +98,8 @@ export function getProviderModel(
   const bedrockSessionToken =
     authConfig?.bedrock?.sessionToken || process.env.AWS_SESSION_TOKEN;
   const bedrockRegion = authConfig?.bedrock?.region || process.env.AWS_REGION;
-  const inceptionApiKey = authConfig?.inceptionAPIKey || process.env.INCEPTION_API_KEY;
+  const inceptionApiKey =
+    authConfig?.inceptionAPIKey || process.env.INCEPTION_API_KEY;
   const localBaseURL =
     authConfig?.local?.baseURL ||
     process.env.LOCAL_MODEL_URL ||
@@ -127,7 +128,7 @@ export function getProviderModel(
       const inception = createOpenAICompatible({
         name: "inception",
         apiKey: inceptionApiKey,
-        baseURL: "https://api.inceptionlabs.ai/v1"
+        baseURL: "https://api.inceptionlabs.ai/v1",
       });
       providerModel = inception("mercury-2");
       break;

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -53,6 +53,7 @@ export function buildAuthConfig(cfg: {
   openAiAPIKey?: string | null;
   googleAPIKey?: string | null;
   openRouterAPIKey?: string | null;
+  inceptionAPIKey?: string | null;
   pensarAPIKey?: string | null;
   pensarApiUrl?: string | null;
   accessToken?: string | null;
@@ -66,6 +67,7 @@ export function buildAuthConfig(cfg: {
     openAiAPIKey: cfg.openAiAPIKey ?? undefined,
     googleAPIKey: cfg.googleAPIKey ?? undefined,
     openRouterAPIKey: cfg.openRouterAPIKey ?? undefined,
+    inceptionAPIKey: cfg.inceptionAPIKey ?? undefined,
     pensarAPIKey: cfg.pensarAPIKey ?? undefined,
     pensarApiUrl: cfg.pensarApiUrl ?? undefined,
     accessToken: cfg.accessToken ?? undefined,

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -13,6 +13,7 @@ export interface Config {
   anthropicAPIKey?: string | null;
   googleAPIKey?: string | null;
   openRouterAPIKey?: string | null;
+  inceptionAPIKey?: string | null;
   bedrockAPIKey?: string | null;
   pensarAPIKey?: string | null;
   pensarApiUrl?: string | null;
@@ -84,6 +85,8 @@ export async function get(): Promise<Config> {
       process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? parsedConfig.googleAPIKey,
     openRouterAPIKey:
       process.env.OPENROUTER_API_KEY ?? parsedConfig.openRouterAPIKey,
+    inceptionAPIKey:
+      process.env.INCEPTION_API_KEY ?? parsedConfig.inceptionAPIKey,
     bedrockAPIKey: process.env.BEDROCK_API_KEY ?? parsedConfig.bedrockAPIKey,
     pensarAPIKey: process.env.PENSAR_API_KEY ?? parsedConfig.pensarAPIKey,
     pensarApiUrl: process.env.PENSAR_API_URL ?? parsedConfig.pensarApiUrl,

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -4,6 +4,7 @@ export type ProviderType =
   | "google"
   | "bedrock"
   | "openrouter"
+  | "inception"
   | "pensar"
   | "local";
 
@@ -43,6 +44,12 @@ export const AVAILABLE_PROVIDERS: Provider[] = [
     id: "openrouter",
     name: "OpenRouter",
     description: "Access multiple AI models through one API",
+    requiresAPIKey: true,
+  },
+  {
+    id: "inception",
+    name: "Inception",
+    description: "Mercury and other Inception models",
     requiresAPIKey: true,
   },
   {

--- a/src/core/providers/utils.ts
+++ b/src/core/providers/utils.ts
@@ -31,6 +31,8 @@ export function isProviderConfigured(
       return !!config.googleAPIKey;
     case "openrouter":
       return !!config.openRouterAPIKey;
+    case "inception":
+      return !!config.inceptionAPIKey;
     case "bedrock":
       return !!config.bedrockAPIKey;
     case "local":
@@ -52,6 +54,7 @@ export function hasAnyProviderConfigured(config: Config): boolean {
     !!config.openAiAPIKey ||
     !!config.googleAPIKey ||
     !!config.openRouterAPIKey ||
+    !!config.inceptionAPIKey ||
     !!config.bedrockAPIKey ||
     !!config.localModelUrl ||
     !!config.localModelName ||


### PR DESCRIPTION
Adds Inception Labds provider to support using the Mercury-2 diffusion LLM. https://www.inceptionlabs.ai/blog/introducing-mercury-2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new third-party LLM provider path and new persisted/env API key handling, which could affect model selection and runtime request routing if misconfigured.
> 
> **Overview**
> Adds support for the **Inception Labs** provider by introducing the `inception` provider type and registering the `mercury-2` model in the available model list.
> 
> Wires provider selection to route `inception` models through `@ai-sdk/openai-compatible` against `https://api.inceptionlabs.ai/v1`, and extends config/auth handling to persist/load `inceptionAPIKey` (and `INCEPTION_API_KEY`) plus provider-configured checks.
> 
> Updates dependencies/lockfile to include `@ai-sdk/openai-compatible` and bumps `@ai-sdk/google` in `bun.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1abcf9359d93647776280930cac5049ae5b62c79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->