### PR TITLE
fix: use ConfigProvider for model persistence, derive isModelUserSelected

### DIFF
--- a/src/core/config/config.test.ts
+++ b/src/core/config/config.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import * as config from "./config";
+import { getAvailableModels } from "../providers/utils";
+
+// ---------------------------------------------------------------------------
+// Helpers — redirect config I/O to a temp directory via HOME env var
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "config-test-"));
+  originalHome = process.env.HOME;
+  process.env.HOME = tmpDir;
+});
+
+afterEach(() => {
+  process.env.HOME = originalHome;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Write a config JSON directly to the temp config path (simulates cold start) */
+function writeConfigToDisk(data: Record<string, unknown>) {
+  const configDir = join(tmpDir, ".pensar");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, "config.json"), JSON.stringify(data));
+}
+
+// ---------------------------------------------------------------------------
+// Config persistence layer
+// ---------------------------------------------------------------------------
+
+describe("config persistence", () => {
+  it("returns default config when no file exists", async () => {
+    const cfg = await config.get();
+    expect(cfg.responsibleUseAccepted).toBe(false);
+    expect(cfg.selectedModelId).toBeUndefined();
+  });
+
+  it("persists selectedModelId to disk", async () => {
+    await config.init();
+    await config.update({
+      selectedModelId: "pensar:anthropic.claude-sonnet-4-5-20250929-v1:0",
+    });
+    const cfg = await config.get();
+    expect(cfg.selectedModelId).toBe(
+      "pensar:anthropic.claude-sonnet-4-5-20250929-v1:0",
+    );
+  });
+
+  it("merges without losing existing fields", async () => {
+    await config.init();
+    await config.update({ anthropicAPIKey: "sk-test-123" });
+    await config.update({
+      selectedModelId: "claude-haiku-4-5",
+    });
+    const cfg = await config.get();
+    expect(cfg.anthropicAPIKey).toBe("sk-test-123");
+    expect(cfg.selectedModelId).toBe("claude-haiku-4-5");
+  });
+
+  it("can clear selectedModelId by setting it to null", async () => {
+    await config.init();
+    await config.update({
+      selectedModelId: "pensar:anthropic.claude-opus-4-20250514-v1:0",
+    });
+    await config.update({ selectedModelId: null });
+    const cfg = await config.get();
+    expect(cfg.selectedModelId).toBeNull();
+  });
+
+  it("reads persisted model selection from disk (cold start)", async () => {
+    writeConfigToDisk({
+      responsibleUseAccepted: true,
+      selectedModelId: "pensar:anthropic.claude-opus-4-20250514-v1:0",
+      pensarAPIKey: "pk_test",
+    });
+
+    const cfg = await config.get();
+    expect(cfg.selectedModelId).toBe(
+      "pensar:anthropic.claude-opus-4-20250514-v1:0",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Model resolution on startup
+// ---------------------------------------------------------------------------
+
+describe("model resolution from config", () => {
+  it("finds persisted model in available models", async () => {
+    const cfg = {
+      responsibleUseAccepted: true,
+      pensarAPIKey: "pk_test",
+      selectedModelId: "pensar:anthropic.claude-sonnet-4-5-20250929-v1:0",
+    } satisfies Partial<config.Config> as config.Config;
+
+    const available = getAvailableModels(cfg);
+    const saved = available.find((m) => m.id === cfg.selectedModelId);
+    expect(saved).toBeDefined();
+    expect(saved!.provider).toBe("pensar");
+  });
+
+  it("returns undefined when persisted model provider is no longer configured", async () => {
+    const cfg = {
+      responsibleUseAccepted: true,
+      // No pensarAPIKey or accessToken
+      selectedModelId: "pensar:anthropic.claude-sonnet-4-5-20250929-v1:0",
+    } satisfies Partial<config.Config> as config.Config;
+
+    const available = getAvailableModels(cfg);
+    const saved = available.find((m) => m.id === cfg.selectedModelId);
+    expect(saved).toBeUndefined();
+  });
+
+  it("returns undefined when persisted model ID does not exist", async () => {
+    const cfg = {
+      responsibleUseAccepted: true,
+      pensarAPIKey: "pk_test",
+      selectedModelId: "pensar:nonexistent-model-2099",
+    } satisfies Partial<config.Config> as config.Config;
+
+    const available = getAvailableModels(cfg);
+    const saved = available.find((m) => m.id === cfg.selectedModelId);
+    expect(saved).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end persistence across simulated restart
+// ---------------------------------------------------------------------------
+
+describe("model persistence across restart", () => {
+  it("persists non-default model across simulated restart", async () => {
+    // Session 1: user selects a non-default model
+    await config.init();
+    await config.update({ pensarAPIKey: "pk_test" });
+    const nonDefaultModel = "pensar:anthropic.claude-opus-4-1-20250805-v1:0";
+    await config.update({ selectedModelId: nonDefaultModel });
+
+    // Session 2: cold start — read config and check model is restorable
+    const cfg = await config.get();
+    expect(cfg.selectedModelId).toBe(nonDefaultModel);
+
+    const available = getAvailableModels(cfg);
+    const restored = available.find((m) => m.id === cfg.selectedModelId);
+    expect(restored).toBeDefined();
+    expect(restored!.name).toContain("Opus");
+  });
+
+  it("switching models multiple times persists only the latest", async () => {
+    await config.init();
+    await config.update({ pensarAPIKey: "pk_test" });
+    await config.update({
+      selectedModelId: "pensar:anthropic.claude-haiku-4-5-20251001-v1:0",
+    });
+    await config.update({
+      selectedModelId: "pensar:anthropic.claude-sonnet-4-5-20250929-v1:0",
+    });
+    await config.update({
+      selectedModelId: "pensar:anthropic.claude-opus-4-1-20250805-v1:0",
+    });
+
+    const cfg = await config.get();
+    expect(cfg.selectedModelId).toBe(
+      "pensar:anthropic.claude-opus-4-1-20250805-v1:0",
+    );
+  });
+
+  it("persisted model survives adding a new provider", async () => {
+    // User had Anthropic model selected
+    await config.init();
+    await config.update({
+      anthropicAPIKey: "sk-test",
+      selectedModelId: "claude-haiku-4-5",
+    });
+
+    // Then adds Pensar — the persisted model should NOT be overwritten
+    await config.update({ pensarAPIKey: "pk_test" });
+
+    const cfg = await config.get();
+    expect(cfg.selectedModelId).toBe("claude-haiku-4-5");
+  });
+});

--- a/src/core/config/config.test.ts
+++ b/src/core/config/config.test.ts
@@ -5,10 +5,6 @@ import { tmpdir } from "os";
 import * as config from "./config";
 import { getAvailableModels } from "../providers/utils";
 
-// ---------------------------------------------------------------------------
-// Helpers — redirect config I/O to a temp directory via HOME env var
-// ---------------------------------------------------------------------------
-
 let tmpDir: string;
 let originalHome: string | undefined;
 
@@ -29,10 +25,6 @@ function writeConfigToDisk(data: Record<string, unknown>) {
   mkdirSync(configDir, { recursive: true });
   writeFileSync(join(configDir, "config.json"), JSON.stringify(data));
 }
-
-// ---------------------------------------------------------------------------
-// Config persistence layer
-// ---------------------------------------------------------------------------
 
 describe("config persistence", () => {
   it("returns default config when no file exists", async () => {
@@ -87,10 +79,6 @@ describe("config persistence", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Model resolution on startup
-// ---------------------------------------------------------------------------
-
 describe("model resolution from config", () => {
   it("finds persisted model in available models", async () => {
     const cfg = {
@@ -129,10 +117,6 @@ describe("model resolution from config", () => {
     expect(saved).toBeUndefined();
   });
 });
-
-// ---------------------------------------------------------------------------
-// End-to-end persistence across simulated restart
-// ---------------------------------------------------------------------------
 
 describe("model persistence across restart", () => {
   it("persists non-default model across simulated restart", async () => {

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -23,6 +23,8 @@ export interface Config {
   // Local LLM
   localModelUrl?: string | null;
   localModelName?: string | null;
+  // Model preference
+  selectedModelId?: string | null;
   // Theme preferences
   theme?: string;
   themeMode?: "dark" | "light" | "auto";

--- a/src/tui/context/__tests__/agent.test.tsx
+++ b/src/tui/context/__tests__/agent.test.tsx
@@ -1,0 +1,723 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ModelInfo } from "../../../core/ai";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const FAKE_MODELS: ModelInfo[] = [
+  {
+    id: "claude-haiku-4-5",
+    name: "Claude Haiku 4.5",
+    provider: "anthropic",
+    contextLength: 200000,
+  },
+  {
+    id: "pensar:anthropic.claude-haiku-4-5-20251001-v1:0",
+    name: "Claude Haiku 4.5 (Pensar)",
+    provider: "pensar",
+    contextLength: 200000,
+  },
+  {
+    id: "gpt-4o-mini",
+    name: "GPT-4o Mini",
+    provider: "openai",
+    contextLength: 128000,
+  },
+  {
+    id: "openrouter:mixtral",
+    name: "Mixtral (OpenRouter)",
+    provider: "openrouter",
+    contextLength: 32000,
+  },
+  {
+    id: "bedrock:titan",
+    name: "Titan (Bedrock)",
+    provider: "bedrock",
+    contextLength: 100000,
+  },
+  {
+    id: "claude-sonnet-4",
+    name: "Claude Sonnet 4",
+    provider: "anthropic",
+    contextLength: 200000,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Shared mock state — written to by vi.mock factories, read by tests
+// ---------------------------------------------------------------------------
+
+// Captured from the React mocks so tests can invoke component internals
+let capturedEffect: (() => void) | null = null;
+let capturedSetModel: ((m: ModelInfo) => void) | null = null;
+let capturedContextValue: Record<string, unknown> | null = null;
+
+// Spies for assertions
+const setModelInternalSpy = vi.fn();
+let mockConfigData: Record<string, unknown> = {};
+const mockConfigUpdate = vi.fn<
+  (data: Record<string, unknown>) => Promise<void>
+>(() => Promise.resolve());
+const mockWriteErrorLog = vi.fn();
+const mockGetAvailableModels = vi.fn<
+  (config: Record<string, unknown>) => ModelInfo[]
+>(() => []);
+
+// ---------------------------------------------------------------------------
+// Module mocks (hoisted)
+// ---------------------------------------------------------------------------
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useState: vi.fn((init: unknown) => {
+      // The first useState call with a ModelInfo-shaped object is the model state
+      if (
+        typeof init === "object" &&
+        init !== null &&
+        "id" in (init as Record<string, unknown>)
+      ) {
+        return [init, setModelInternalSpy];
+      }
+      return [init, vi.fn()];
+    }),
+    useEffect: vi.fn((cb: () => void) => {
+      capturedEffect = cb;
+    }),
+    useCallback: vi.fn((cb: unknown) => {
+      // The first useCallback with a function that takes a ModelInfo is setModel
+      // We capture it so tests can invoke it directly
+      const fn = cb as (...args: unknown[]) => unknown;
+      if (fn.length === 1 && !capturedSetModel) {
+        capturedSetModel = fn as (m: ModelInfo) => void;
+      }
+      return cb;
+    }),
+    useMemo: vi.fn((factory: () => unknown) => {
+      const val = factory();
+      // Capture the context value (object with model, setModel, isModelUserSelected, etc.)
+      if (
+        typeof val === "object" &&
+        val !== null &&
+        "isModelUserSelected" in (val as Record<string, unknown>)
+      ) {
+        capturedContextValue = val as Record<string, unknown>;
+      }
+      return val;
+    }),
+    useContext: vi.fn(),
+    createContext: vi.fn(() => ({
+      Provider: ({ children }: { children: unknown }) => children,
+    })),
+  };
+});
+
+vi.mock("../config", () => ({
+  useConfig: vi.fn(() => ({
+    data: mockConfigData,
+    update: mockConfigUpdate,
+  })),
+}));
+
+vi.mock("../../../core/ai/models", () => ({
+  AVAILABLE_MODELS: FAKE_MODELS,
+}));
+
+vi.mock("../../../core/providers/utils", () => ({
+  getAvailableModels: (...args: unknown[]) =>
+    mockGetAvailableModels(args[0] as Record<string, unknown>),
+}));
+
+vi.mock("../../../core/logger", () => ({
+  writeErrorLog: (...args: unknown[]) => mockWriteErrorLog(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-import and invoke AgentProvider with fresh mock state.
+ * Returns helpers to run the captured useEffect and invoke setModel.
+ */
+async function renderProvider(configData: Record<string, unknown> = {}) {
+  capturedEffect = null;
+  capturedSetModel = null;
+  capturedContextValue = null;
+  setModelInternalSpy.mockClear();
+  mockConfigUpdate.mockClear();
+  mockWriteErrorLog.mockClear();
+  mockConfigData = configData;
+
+  vi.resetModules();
+
+  // Re-apply mocks after resetModules (hoisted mocks are cleared)
+  vi.doMock("react", async () => {
+    const actual = await vi.importActual<typeof import("react")>("react");
+    return {
+      ...actual,
+      useState: vi.fn((init: unknown) => {
+        if (
+          typeof init === "object" &&
+          init !== null &&
+          "id" in (init as Record<string, unknown>)
+        ) {
+          return [init, setModelInternalSpy];
+        }
+        return [init, vi.fn()];
+      }),
+      useEffect: vi.fn((cb: () => void) => {
+        capturedEffect = cb;
+      }),
+      useCallback: vi.fn((cb: unknown) => {
+        const fn = cb as (...args: unknown[]) => unknown;
+        if (fn.length === 1 && !capturedSetModel) {
+          capturedSetModel = fn as (m: ModelInfo) => void;
+        }
+        return cb;
+      }),
+      useMemo: vi.fn((factory: () => unknown) => {
+        const val = factory();
+        if (
+          typeof val === "object" &&
+          val !== null &&
+          "isModelUserSelected" in (val as Record<string, unknown>)
+        ) {
+          capturedContextValue = val as Record<string, unknown>;
+        }
+        return val;
+      }),
+      useContext: vi.fn(),
+      createContext: vi.fn(() => ({
+        Provider: ({ children }: { children: unknown }) => children,
+      })),
+    };
+  });
+
+  vi.doMock("../config", () => ({
+    useConfig: vi.fn(() => ({
+      data: mockConfigData,
+      update: mockConfigUpdate,
+    })),
+  }));
+
+  vi.doMock("../../../core/ai/models", () => ({
+    AVAILABLE_MODELS: FAKE_MODELS,
+  }));
+
+  vi.doMock("../../../core/providers/utils", () => ({
+    getAvailableModels: (...args: unknown[]) =>
+      mockGetAvailableModels(args[0] as Record<string, unknown>),
+  }));
+
+  vi.doMock("../../../core/logger", () => ({
+    writeErrorLog: (...args: unknown[]) => mockWriteErrorLog(...args),
+  }));
+
+  const mod = await import("../agent");
+  mod.AgentProvider({ children: null });
+
+  return {
+    runEffect() {
+      if (capturedEffect) capturedEffect();
+    },
+    /** The real setModel callback from the component */
+    getSetModel() {
+      return capturedSetModel;
+    },
+    /** The context value produced by useMemo */
+    getContextValue() {
+      return capturedContextValue;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockGetAvailableModels.mockReset();
+  mockConfigUpdate.mockReset().mockResolvedValue(undefined);
+  mockWriteErrorLog.mockReset();
+  setModelInternalSpy.mockClear();
+});
+
+describe("AgentProvider model selection", () => {
+  // -----------------------------------------------------------------------
+  // 1. Restoring a persisted model
+  // -----------------------------------------------------------------------
+  describe("restoring a persisted model", () => {
+    it("sets the persisted model when it matches an available model", async () => {
+      const persistedId = "gpt-4o-mini";
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { runEffect } = await renderProvider({
+        selectedModelId: persistedId,
+      });
+      runEffect();
+
+      expect(setModelInternalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: persistedId }),
+      );
+      expect(mockConfigUpdate).not.toHaveBeenCalled();
+    });
+
+    it("restores the exact ModelInfo object from available models", async () => {
+      const persistedId = "pensar:anthropic.claude-haiku-4-5-20251001-v1:0";
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { runEffect } = await renderProvider({
+        selectedModelId: persistedId,
+      });
+      runEffect();
+
+      const calledWith = setModelInternalSpy.mock.calls[0]![0] as ModelInfo;
+      expect(calledWith.id).toBe(persistedId);
+      expect(calledWith.provider).toBe("pensar");
+      expect(calledWith.name).toBe("Claude Haiku 4.5 (Pensar)");
+    });
+
+    it("returns early without selecting a smart default", async () => {
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { runEffect } = await renderProvider({
+        selectedModelId: "claude-haiku-4-5",
+      });
+      runEffect();
+
+      // Only called once — for the persisted model, not a smart default
+      expect(setModelInternalSpy).toHaveBeenCalledTimes(1);
+      expect(setModelInternalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "claude-haiku-4-5" }),
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. Cleaning up a stale persisted model
+  // -----------------------------------------------------------------------
+  describe("cleaning up a stale persisted model", () => {
+    it("clears selectedModelId when persisted model is not in available list", async () => {
+      mockGetAvailableModels.mockReturnValue([FAKE_MODELS[0]!]);
+
+      const { runEffect } = await renderProvider({
+        selectedModelId: "nonexistent-model-id",
+      });
+      runEffect();
+
+      expect(mockConfigUpdate).toHaveBeenCalledWith({
+        selectedModelId: null,
+      });
+    });
+
+    it("falls through to smart defaults after clearing stale model", async () => {
+      const anthropicOnly = FAKE_MODELS.filter(
+        (m) => m.provider === "anthropic",
+      );
+      mockGetAvailableModels.mockReturnValue(anthropicOnly);
+
+      const { runEffect } = await renderProvider({
+        selectedModelId: "nonexistent-model-id",
+      });
+      runEffect();
+
+      // Cleared the stale model
+      expect(mockConfigUpdate).toHaveBeenCalledWith({
+        selectedModelId: null,
+      });
+
+      // Then selected via smart defaults
+      expect(setModelInternalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "claude-haiku-4-5" }),
+      );
+    });
+
+    it("logs error when config.update rejects during stale cleanup", async () => {
+      const error = new Error("disk full");
+      mockConfigUpdate.mockRejectedValue(error);
+      mockGetAvailableModels.mockReturnValue([FAKE_MODELS[0]!]);
+
+      const { runEffect } = await renderProvider({
+        selectedModelId: "stale-model",
+      });
+      runEffect();
+
+      await vi.waitFor(() => {
+        expect(mockWriteErrorLog).toHaveBeenCalledWith(error, "CONFIG");
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. Smart default selection
+  // -----------------------------------------------------------------------
+  describe("smart default selection (no persisted model)", () => {
+    it("selects pensar preferred default when pensar models are available", async () => {
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { runEffect } = await renderProvider({});
+      runEffect();
+
+      expect(setModelInternalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "pensar:anthropic.claude-haiku-4-5-20251001-v1:0",
+        }),
+      );
+    });
+
+    it("selects anthropic preferred default when pensar is unavailable", async () => {
+      const noPensar = FAKE_MODELS.filter((m) => m.provider !== "pensar");
+      mockGetAvailableModels.mockReturnValue(noPensar);
+
+      const { runEffect } = await renderProvider({});
+      runEffect();
+
+      expect(setModelInternalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "claude-haiku-4-5" }),
+      );
+    });
+
+    it("selects openai preferred default when pensar and anthropic are unavailable", async () => {
+      const openaiAndRest = FAKE_MODELS.filter(
+        (m) => m.provider !== "pensar" && m.provider !== "anthropic",
+      );
+      mockGetAvailableModels.mockReturnValue(openaiAndRest);
+
+      const { runEffect } = await renderProvider({});
+      runEffect();
+
+      expect(setModelInternalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "gpt-4o-mini" }),
+      );
+    });
+
+    it("selects first openrouter model when higher-priority providers are unavailable", async () => {
+      const openrouterAndBedrock = FAKE_MODELS.filter(
+        (m) =>
+          m.provider !== "pensar" &&
+          m.provider !== "anthropic" &&
+          m.provider !== "openai",
+      );
+      mockGetAvailableModels.mockReturnValue(openrouterAndBedrock);
+
+      const { runEffect } = await renderProvider({});
+      runEffect();
+
+      expect(setModelInternalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "openrouter:mixtral",
+          provider: "openrouter",
+        }),
+      );
+    });
+
+    it("selects first bedrock model when only bedrock is available", async () => {
+      const bedrockOnly = FAKE_MODELS.filter((m) => m.provider === "bedrock");
+      mockGetAvailableModels.mockReturnValue(bedrockOnly);
+
+      const { runEffect } = await renderProvider({});
+      runEffect();
+
+      expect(setModelInternalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "bedrock:titan",
+          provider: "bedrock",
+        }),
+      );
+    });
+
+    it("falls back to first model from provider when preferred default is missing", async () => {
+      const anthropicNonPreferred: ModelInfo[] = [
+        {
+          id: "claude-sonnet-4",
+          name: "Claude Sonnet 4",
+          provider: "anthropic",
+          contextLength: 200000,
+        },
+      ];
+      mockGetAvailableModels.mockReturnValue(anthropicNonPreferred);
+
+      const { runEffect } = await renderProvider({});
+      runEffect();
+
+      expect(setModelInternalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "claude-sonnet-4" }),
+      );
+    });
+
+    it("respects full provider preference order", async () => {
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { runEffect } = await renderProvider({});
+      runEffect();
+
+      const selectedModel = setModelInternalSpy.mock.calls[0]![0] as ModelInfo;
+      expect(selectedModel.provider).toBe("pensar");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. isModelUserSelected derivation
+  // -----------------------------------------------------------------------
+  describe("isModelUserSelected derivation", () => {
+    it("is true when config.data.selectedModelId is a non-empty string", async () => {
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { getContextValue } = await renderProvider({
+        selectedModelId: "claude-haiku-4-5",
+      });
+
+      expect(getContextValue()?.isModelUserSelected).toBe(true);
+    });
+
+    it("is false when config.data.selectedModelId is null", async () => {
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { getContextValue } = await renderProvider({
+        selectedModelId: null,
+      });
+
+      expect(getContextValue()?.isModelUserSelected).toBe(false);
+    });
+
+    it("is false when config.data.selectedModelId is undefined", async () => {
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { getContextValue } = await renderProvider({});
+
+      expect(getContextValue()?.isModelUserSelected).toBe(false);
+    });
+
+    it("is false when config.data.selectedModelId is empty string", async () => {
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { getContextValue } = await renderProvider({
+        selectedModelId: "",
+      });
+
+      expect(getContextValue()?.isModelUserSelected).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 5. setModel persists to config
+  // -----------------------------------------------------------------------
+  describe("setModel persists to config", () => {
+    it("calls setModelInternal and config.update when invoked", async () => {
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { getSetModel } = await renderProvider({});
+      const setModel = getSetModel();
+      expect(setModel).toBeTruthy();
+
+      const newModel: ModelInfo = {
+        id: "gpt-4o-mini",
+        name: "GPT-4o Mini",
+        provider: "openai",
+      };
+
+      setModel!(newModel);
+
+      expect(setModelInternalSpy).toHaveBeenCalledWith(newModel);
+      expect(mockConfigUpdate).toHaveBeenCalledWith({
+        selectedModelId: "gpt-4o-mini",
+      });
+    });
+
+    it("persists the model id, not the full ModelInfo object", async () => {
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { getSetModel } = await renderProvider({});
+      const setModel = getSetModel()!;
+
+      setModel({
+        id: "pensar:anthropic.claude-haiku-4-5-20251001-v1:0",
+        name: "Claude Haiku 4.5 (Pensar)",
+        provider: "pensar",
+        contextLength: 200000,
+      });
+
+      expect(mockConfigUpdate).toHaveBeenCalledWith({
+        selectedModelId: "pensar:anthropic.claude-haiku-4-5-20251001-v1:0",
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 6. Error logging on config write failure
+  // -----------------------------------------------------------------------
+  describe("error logging on config write failure", () => {
+    it("calls writeErrorLog when config.update rejects in setModel", async () => {
+      const error = new Error("write failed");
+      mockConfigUpdate.mockRejectedValueOnce(error);
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { getSetModel } = await renderProvider({});
+      const setModel = getSetModel()!;
+
+      setModel({
+        id: "gpt-4o-mini",
+        name: "GPT-4o Mini",
+        provider: "openai",
+      });
+
+      await vi.waitFor(() => {
+        expect(mockWriteErrorLog).toHaveBeenCalledWith(error, "CONFIG");
+      });
+    });
+
+    it("does not throw when config.update rejects in setModel", async () => {
+      mockConfigUpdate.mockRejectedValueOnce(new Error("boom"));
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { getSetModel } = await renderProvider({});
+      const setModel = getSetModel()!;
+
+      // Should not throw — error is caught by .catch()
+      expect(() =>
+        setModel({
+          id: "gpt-4o-mini",
+          name: "GPT-4o Mini",
+          provider: "openai",
+        }),
+      ).not.toThrow();
+    });
+
+    it("calls writeErrorLog when config.update rejects during stale model cleanup", async () => {
+      const error = new Error("cleanup failed");
+      mockConfigUpdate.mockRejectedValue(error);
+      mockGetAvailableModels.mockReturnValue([FAKE_MODELS[0]!]);
+
+      const { runEffect } = await renderProvider({
+        selectedModelId: "stale-model",
+      });
+      runEffect();
+
+      await vi.waitFor(() => {
+        expect(mockWriteErrorLog).toHaveBeenCalledWith(error, "CONFIG");
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 7. No model available
+  // -----------------------------------------------------------------------
+  describe("no model available", () => {
+    it("does not change model when getAvailableModels returns empty array", async () => {
+      mockGetAvailableModels.mockReturnValue([]);
+
+      const { runEffect } = await renderProvider({});
+      runEffect();
+
+      expect(setModelInternalSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not attempt to clear persisted model when no models available", async () => {
+      mockGetAvailableModels.mockReturnValue([]);
+
+      const { runEffect } = await renderProvider({
+        selectedModelId: "some-model",
+      });
+      runEffect();
+
+      expect(mockConfigUpdate).not.toHaveBeenCalled();
+    });
+
+    it("initial model state defaults to AVAILABLE_MODELS[0]", async () => {
+      mockGetAvailableModels.mockReturnValue([]);
+
+      const { getContextValue } = await renderProvider({});
+
+      // The useMemo factory receives the model from useState initial value,
+      // which is AVAILABLE_MODELS[0] (= FAKE_MODELS[0])
+      const ctx = getContextValue();
+      expect(ctx?.model).toEqual(
+        expect.objectContaining({ id: "claude-haiku-4-5" }),
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Edge cases
+  // -----------------------------------------------------------------------
+  describe("edge cases", () => {
+    it("handles provider with no entry in PREFERRED_DEFAULTS (bedrock)", async () => {
+      const bedrockOnly = FAKE_MODELS.filter((m) => m.provider === "bedrock");
+      mockGetAvailableModels.mockReturnValue(bedrockOnly);
+
+      const { runEffect } = await renderProvider({});
+      runEffect();
+
+      expect(setModelInternalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: "bedrock" }),
+      );
+    });
+
+    it("does not select model when only local provider models are available", async () => {
+      const localModel: ModelInfo = {
+        id: "custom:my-model",
+        name: "Custom Model",
+        provider: "local",
+      };
+      mockGetAvailableModels.mockReturnValue([localModel]);
+
+      const { runEffect } = await renderProvider({});
+      runEffect();
+
+      // "local" is not in PROVIDER_PREFERENCE, so nothing is selected
+      expect(setModelInternalSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not call config.update when persisted model is still available", async () => {
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { runEffect } = await renderProvider({
+        selectedModelId: "claude-haiku-4-5",
+      });
+      runEffect();
+
+      expect(mockConfigUpdate).not.toHaveBeenCalled();
+    });
+
+    it("picks preferred default over non-preferred model from same provider", async () => {
+      const twoAnthropicModels = FAKE_MODELS.filter(
+        (m) => m.provider === "anthropic",
+      );
+      mockGetAvailableModels.mockReturnValue(twoAnthropicModels);
+
+      const { runEffect } = await renderProvider({});
+      runEffect();
+
+      expect(setModelInternalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "claude-haiku-4-5" }),
+      );
+    });
+
+    it("passes config.data to getAvailableModels", async () => {
+      const configData = { anthropicAPIKey: "sk-test" };
+      mockGetAvailableModels.mockReturnValue([]);
+
+      const { runEffect } = await renderProvider(configData);
+      runEffect();
+
+      expect(mockGetAvailableModels).toHaveBeenCalledWith(configData);
+    });
+
+    it("handles persisted model matching when multiple providers have the same model id", async () => {
+      // If persisted id matches, the first match in available models is used
+      mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
+
+      const { runEffect } = await renderProvider({
+        selectedModelId: "claude-sonnet-4",
+      });
+      runEffect();
+
+      const selected = setModelInternalSpy.mock.calls[0]![0] as ModelInfo;
+      expect(selected.id).toBe("claude-sonnet-4");
+      expect(selected.provider).toBe("anthropic");
+    });
+  });
+});

--- a/src/tui/context/agent.test.tsx
+++ b/src/tui/context/agent.test.tsx
@@ -70,6 +70,7 @@ vi.mock("react", async () => {
       }
       return [init, vi.fn()];
     }),
+    useRef: vi.fn((init: unknown) => ({ current: init })),
     useEffect: vi.fn((cb: () => void) => {
       capturedEffect = cb;
     }),
@@ -147,6 +148,7 @@ async function renderProvider(configData: Record<string, unknown> = {}) {
         }
         return [init, vi.fn()];
       }),
+      useRef: vi.fn((init: unknown) => ({ current: init })),
       useEffect: vi.fn((cb: () => void) => {
         capturedEffect = cb;
       }),

--- a/src/tui/context/agent.test.tsx
+++ b/src/tui/context/agent.test.tsx
@@ -1,9 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ModelInfo } from "../../../core/ai";
-
-// ---------------------------------------------------------------------------
-// Test fixtures
-// ---------------------------------------------------------------------------
+import type { ModelInfo } from "../../core/ai";
 
 const FAKE_MODELS: ModelInfo[] = [
   {
@@ -44,11 +40,6 @@ const FAKE_MODELS: ModelInfo[] = [
   },
 ];
 
-// ---------------------------------------------------------------------------
-// Shared mock state — written to by vi.mock factories, read by tests
-// ---------------------------------------------------------------------------
-
-// Captured from the React mocks so tests can invoke component internals
 let capturedEffect: (() => void) | null = null;
 let capturedSetModel: ((m: ModelInfo) => void) | null = null;
 let capturedContextValue: Record<string, unknown> | null = null;
@@ -63,10 +54,6 @@ const mockWriteErrorLog = vi.fn();
 const mockGetAvailableModels = vi.fn<
   (config: Record<string, unknown>) => ModelInfo[]
 >(() => []);
-
-// ---------------------------------------------------------------------------
-// Module mocks (hoisted)
-// ---------------------------------------------------------------------------
 
 vi.mock("react", async () => {
   const actual = await vi.importActual<typeof import("react")>("react");
@@ -114,34 +101,26 @@ vi.mock("react", async () => {
   };
 });
 
-vi.mock("../config", () => ({
+vi.mock("./config", () => ({
   useConfig: vi.fn(() => ({
     data: mockConfigData,
     update: mockConfigUpdate,
   })),
 }));
 
-vi.mock("../../../core/ai/models", () => ({
+vi.mock("../../core/ai/models", () => ({
   AVAILABLE_MODELS: FAKE_MODELS,
 }));
 
-vi.mock("../../../core/providers/utils", () => ({
+vi.mock("../../core/providers/utils", () => ({
   getAvailableModels: (...args: unknown[]) =>
     mockGetAvailableModels(args[0] as Record<string, unknown>),
 }));
 
-vi.mock("../../../core/logger", () => ({
+vi.mock("../../core/logger", () => ({
   writeErrorLog: (...args: unknown[]) => mockWriteErrorLog(...args),
 }));
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Re-import and invoke AgentProvider with fresh mock state.
- * Returns helpers to run the captured useEffect and invoke setModel.
- */
 async function renderProvider(configData: Record<string, unknown> = {}) {
   capturedEffect = null;
   capturedSetModel = null;
@@ -196,27 +175,27 @@ async function renderProvider(configData: Record<string, unknown> = {}) {
     };
   });
 
-  vi.doMock("../config", () => ({
+  vi.doMock("./config", () => ({
     useConfig: vi.fn(() => ({
       data: mockConfigData,
       update: mockConfigUpdate,
     })),
   }));
 
-  vi.doMock("../../../core/ai/models", () => ({
+  vi.doMock("../../core/ai/models", () => ({
     AVAILABLE_MODELS: FAKE_MODELS,
   }));
 
-  vi.doMock("../../../core/providers/utils", () => ({
+  vi.doMock("../../core/providers/utils", () => ({
     getAvailableModels: (...args: unknown[]) =>
       mockGetAvailableModels(args[0] as Record<string, unknown>),
   }));
 
-  vi.doMock("../../../core/logger", () => ({
+  vi.doMock("../../core/logger", () => ({
     writeErrorLog: (...args: unknown[]) => mockWriteErrorLog(...args),
   }));
 
-  const mod = await import("../agent");
+  const mod = await import("./agent");
   mod.AgentProvider({ children: null });
 
   return {
@@ -234,10 +213,6 @@ async function renderProvider(configData: Record<string, unknown> = {}) {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 beforeEach(() => {
   mockGetAvailableModels.mockReset();
   mockConfigUpdate.mockReset().mockResolvedValue(undefined);
@@ -246,9 +221,6 @@ beforeEach(() => {
 });
 
 describe("AgentProvider model selection", () => {
-  // -----------------------------------------------------------------------
-  // 1. Restoring a persisted model
-  // -----------------------------------------------------------------------
   describe("restoring a persisted model", () => {
     it("sets the persisted model when it matches an available model", async () => {
       const persistedId = "gpt-4o-mini";
@@ -296,9 +268,6 @@ describe("AgentProvider model selection", () => {
     });
   });
 
-  // -----------------------------------------------------------------------
-  // 2. Cleaning up a stale persisted model
-  // -----------------------------------------------------------------------
   describe("cleaning up a stale persisted model", () => {
     it("clears selectedModelId when persisted model is not in available list", async () => {
       mockGetAvailableModels.mockReturnValue([FAKE_MODELS[0]!]);
@@ -351,9 +320,6 @@ describe("AgentProvider model selection", () => {
     });
   });
 
-  // -----------------------------------------------------------------------
-  // 3. Smart default selection
-  // -----------------------------------------------------------------------
   describe("smart default selection (no persisted model)", () => {
     it("selects pensar preferred default when pensar models are available", async () => {
       mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
@@ -459,9 +425,6 @@ describe("AgentProvider model selection", () => {
     });
   });
 
-  // -----------------------------------------------------------------------
-  // 4. isModelUserSelected derivation
-  // -----------------------------------------------------------------------
   describe("isModelUserSelected derivation", () => {
     it("is true when config.data.selectedModelId is a non-empty string", async () => {
       mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
@@ -502,9 +465,6 @@ describe("AgentProvider model selection", () => {
     });
   });
 
-  // -----------------------------------------------------------------------
-  // 5. setModel persists to config
-  // -----------------------------------------------------------------------
   describe("setModel persists to config", () => {
     it("calls setModelInternal and config.update when invoked", async () => {
       mockGetAvailableModels.mockReturnValue(FAKE_MODELS);
@@ -546,9 +506,6 @@ describe("AgentProvider model selection", () => {
     });
   });
 
-  // -----------------------------------------------------------------------
-  // 6. Error logging on config write failure
-  // -----------------------------------------------------------------------
   describe("error logging on config write failure", () => {
     it("calls writeErrorLog when config.update rejects in setModel", async () => {
       const error = new Error("write failed");
@@ -602,9 +559,6 @@ describe("AgentProvider model selection", () => {
     });
   });
 
-  // -----------------------------------------------------------------------
-  // 7. No model available
-  // -----------------------------------------------------------------------
   describe("no model available", () => {
     it("does not change model when getAvailableModels returns empty array", async () => {
       mockGetAvailableModels.mockReturnValue([]);
@@ -640,9 +594,6 @@ describe("AgentProvider model selection", () => {
     });
   });
 
-  // -----------------------------------------------------------------------
-  // Edge cases
-  // -----------------------------------------------------------------------
   describe("edge cases", () => {
     it("handles provider with no entry in PREFERRED_DEFAULTS (bedrock)", async () => {
       const bedrockOnly = FAKE_MODELS.filter((m) => m.provider === "bedrock");

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -9,8 +9,9 @@ import {
 } from "react";
 import { type ModelInfo } from "../../core/ai";
 import { AVAILABLE_MODELS } from "../../core/ai/models";
-import { get as getConfig } from "../../core/config/config";
+import { writeErrorLog } from "../../core/logger";
 import { getAvailableModels } from "../../core/providers/utils";
+import { useConfig } from "./config";
 
 // Preferred defaults by provider (fast + cheap models)
 const PREFERRED_DEFAULTS: Record<string, string> = {
@@ -64,9 +65,8 @@ interface AgentProviderProps {
 }
 
 export function AgentProvider({ children }: AgentProviderProps) {
+  const config = useConfig();
   const [model, setModelInternal] = useState<ModelInfo>(AVAILABLE_MODELS[0]!);
-  const [isModelUserSelected, setIsModelUserSelected] =
-    useState<boolean>(false);
   const [tokenUsage, setTokenUsage] = useState<TokenUsage>({
     inputTokens: 0,
     outputTokens: 0,
@@ -76,58 +76,76 @@ export function AgentProvider({ children }: AgentProviderProps) {
   const [thinking, setThinking] = useState<boolean>(false);
   const [isExecuting, setIsExecuting] = useState<boolean>(false);
 
-  // Wrapper that marks model as user-selected
-  const setModel = useCallback((newModel: ModelInfo) => {
-    setModelInternal(newModel);
-    setIsModelUserSelected(true);
-  }, []);
+  // Derived from config — true when the user has explicitly selected a model
+  const isModelUserSelected = !!config.data.selectedModelId;
+
+  // Persist model selection to config
+  const setModel = useCallback(
+    (newModel: ModelInfo) => {
+      setModelInternal(newModel);
+      config.update({ selectedModelId: newModel.id }).catch((err) => {
+        writeErrorLog(err, "CONFIG");
+      });
+    },
+    [config],
+  );
 
   // Smart default model selection:
-  // 1. Prefer Pensar Haiku 4.5 if connected to Pensar Console
-  // 2. Fall back to Claude Haiku 4.5 if Anthropic is configured
-  // 3. Fall back to GPT-4o Mini if OpenAI is configured
-  // 4. Otherwise use first available model
+  // 1. Restore persisted user selection if still available
+  // 2. Prefer Pensar Haiku 4.5 if connected to Pensar Console
+  // 3. Fall back to Claude Haiku 4.5 if Anthropic is configured
+  // 4. Fall back to GPT-4o Mini if OpenAI is configured
+  // 5. Otherwise use first available model
   useEffect(() => {
-    getConfig()
-      .then((config) => {
-        const available = getAvailableModels(config);
-        if (available.length === 0) return;
+    const available = getAvailableModels(config.data);
+    if (available.length === 0) return;
 
-        // Group available models by provider
-        const byProvider = new Map<string, ModelInfo[]>();
-        for (const m of available) {
-          const list = byProvider.get(m.provider) || [];
-          list.push(m);
-          byProvider.set(m.provider, list);
-        }
+    // Restore persisted model selection
+    const persistedId = config.data.selectedModelId;
+    if (persistedId) {
+      const persisted = available.find((m) => m.id === persistedId);
+      if (persisted) {
+        setModelInternal(persisted);
+        return;
+      }
+      // Persisted model is stale — clean it up
+      config.update({ selectedModelId: null }).catch((err) => {
+        writeErrorLog(err, "CONFIG");
+      });
+    }
 
-        // Find best default based on provider preference
-        let selectedModel: ModelInfo | null = null;
-        for (const provider of PROVIDER_PREFERENCE) {
-          const models = byProvider.get(provider);
-          if (!models || models.length === 0) continue;
+    // Group available models by provider
+    const byProvider = new Map<string, ModelInfo[]>();
+    for (const m of available) {
+      const list = byProvider.get(m.provider) || [];
+      list.push(m);
+      byProvider.set(m.provider, list);
+    }
 
-          // Try to find the preferred model for this provider
-          const preferredId = PREFERRED_DEFAULTS[provider];
-          if (preferredId) {
-            const preferred = models.find((m) => m.id === preferredId);
-            if (preferred) {
-              selectedModel = preferred;
-              break;
-            }
-          }
-          // Fall back to first model from this provider
-          selectedModel = models[0]!;
+    // Find best default based on provider preference
+    let selectedModel: ModelInfo | null = null;
+    for (const provider of PROVIDER_PREFERENCE) {
+      const models = byProvider.get(provider);
+      if (!models || models.length === 0) continue;
+
+      // Try to find the preferred model for this provider
+      const preferredId = PREFERRED_DEFAULTS[provider];
+      if (preferredId) {
+        const preferred = models.find((m) => m.id === preferredId);
+        if (preferred) {
+          selectedModel = preferred;
           break;
         }
+      }
+      // Fall back to first model from this provider
+      selectedModel = models[0]!;
+      break;
+    }
 
-        if (selectedModel) {
-          setModelInternal(selectedModel);
-          // Don't mark as user-selected since this is auto-default
-        }
-      })
-      .catch(() => {});
-  }, []);
+    if (selectedModel) {
+      setModelInternal(selectedModel);
+    }
+  }, [config.data]);
 
   const addTokenUsage = useCallback((input: number, output: number) => {
     setHasExecuted(true);

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useCallback,
   useEffect,
+  useRef,
   type ReactNode,
 } from "react";
 import { type ModelInfo } from "../../core/ai";
@@ -90,6 +91,10 @@ export function AgentProvider({ children }: AgentProviderProps) {
     [config],
   );
 
+  // Track stale model IDs we've already attempted to clean up to avoid
+  // infinite loops if the disk write keeps failing and rolling back.
+  const cleanedStaleIds = useRef<Set<string>>(new Set());
+
   // Smart default model selection:
   // 1. Restore persisted user selection if still available
   // 2. Prefer Pensar Haiku 4.5 if connected to Pensar Console
@@ -108,10 +113,13 @@ export function AgentProvider({ children }: AgentProviderProps) {
         setModelInternal(persisted);
         return;
       }
-      // Persisted model is stale — clean it up
-      config.update({ selectedModelId: null }).catch((err) => {
-        writeErrorLog(err, "CONFIG");
-      });
+      // Persisted model is stale — clean it up (only attempt once per ID)
+      if (!cleanedStaleIds.current.has(persistedId)) {
+        cleanedStaleIds.current.add(persistedId);
+        config.update({ selectedModelId: null }).catch((err) => {
+          writeErrorLog(err, "CONFIG");
+        });
+      }
     }
 
     // Group available models by provider

--- a/src/tui/context/config.tsx
+++ b/src/tui/context/config.tsx
@@ -28,11 +28,14 @@ export function ConfigProvider({ children, config }: ConfigProviderProps) {
     () => ({
       data: appConfig,
       update: async (newConfig: Partial<Config>) => {
-        setAppConfig({
-          ...appConfig,
-          ...newConfig,
-        });
-        await _config.update(newConfig);
+        const prev = appConfig;
+        setAppConfig({ ...prev, ...newConfig });
+        try {
+          await _config.update(newConfig);
+        } catch (err) {
+          setAppConfig(prev);
+          throw err;
+        }
       },
       reload: async () => {
         const freshConfig = await _config.get();

--- a/src/tui/context/config.tsx
+++ b/src/tui/context/config.tsx
@@ -28,11 +28,11 @@ export function ConfigProvider({ children, config }: ConfigProviderProps) {
     () => ({
       data: appConfig,
       update: async (newConfig: Partial<Config>) => {
-        await _config.update(newConfig);
         setAppConfig({
           ...appConfig,
           ...newConfig,
         });
+        await _config.update(newConfig);
       },
       reload: async () => {
         const freshConfig = await _config.get();

--- a/src/tui/context/config.tsx
+++ b/src/tui/context/config.tsx
@@ -28,8 +28,14 @@ export function ConfigProvider({ children, config }: ConfigProviderProps) {
     () => ({
       data: appConfig,
       update: async (newConfig: Partial<Config>) => {
-        setAppConfig({ ...appConfig, ...newConfig });
-        await _config.update(newConfig);
+        const prev = appConfig;
+        setAppConfig({ ...prev, ...newConfig });
+        try {
+          await _config.update(newConfig);
+        } catch (err) {
+          setAppConfig(prev);
+          throw err;
+        }
       },
       reload: async () => {
         const freshConfig = await _config.get();

--- a/src/tui/context/config.tsx
+++ b/src/tui/context/config.tsx
@@ -28,14 +28,8 @@ export function ConfigProvider({ children, config }: ConfigProviderProps) {
     () => ({
       data: appConfig,
       update: async (newConfig: Partial<Config>) => {
-        const prev = appConfig;
-        setAppConfig({ ...prev, ...newConfig });
-        try {
-          await _config.update(newConfig);
-        } catch (err) {
-          setAppConfig(prev);
-          throw err;
-        }
+        setAppConfig({ ...appConfig, ...newConfig });
+        await _config.update(newConfig);
       },
       reload: async () => {
         const freshConfig = await _config.get();


### PR DESCRIPTION
## Summary
- **Remove redundant disk read**: `AgentProvider` was calling `getConfig()` directly, bypassing the already-loaded `ConfigProvider` state. Now uses `config.data` from `useConfig()`
- **Derive `isModelUserSelected`**: Replaced independent `useState<boolean>` with `!!config.data.selectedModelId` — eliminates state drift between the flag and persisted config
- **Log config write errors**: Replaced silent `.catch(() => {})` with `writeErrorLog(err, "CONFIG")` so config persistence failures are visible in error logs

## Test plan
- [x] 31 new unit tests covering model restoration, stale cleanup, smart defaults, `isModelUserSelected` derivation, persistence, and error logging
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bun run test` — 243 tests pass (260 total, 17 skipped)
- [x] `bun run lint --fix && bun run format` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit a6b2006c55079a0b93d5b9b5c8a92505030ad998. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->