### PR TITLE
Shortcut dialog session kill

### DIFF
--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -188,7 +188,9 @@ function AppContent({
 
   const handleCloseShortcutsDialog = () => {
     setShowShortcutsDialog(false);
-    setExternalDialogOpen(false);
+    setTimeout(() => {
+      setExternalDialogOpen(false);
+    }, 0);
     setInputKey((prev) => prev + 1);
     refocusPrompt();
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR fixes a bug where pressing `escape` to close the shortcuts dialog would also terminate the operator session.

The issue arose because multiple keyboard handlers processed the `escape` event. The shortcuts dialog's handler synchronously set `externalDialogOpen` to `false`. By the time the operator dashboard's handler checked this flag, it was already `false`, causing it to incorrectly bypass its dialog-open check and kill the session.

The fix defers the `setExternalDialogOpen(false)` call using `setTimeout(..., 0)` in the shortcuts dialog's close handler. This ensures that all other keyboard handlers check `externalDialogOpen` while it is still `true`, allowing them to correctly skip processing the `escape` event when a dialog is open.

### How did you verify your code works?

- Manual testing confirmed that the operator session remains active after closing the shortcuts dialog with `escape`.
- All unit tests passed (203 passed, 15 skipped).
- Linting and type checking passed.
- A video demonstration was recorded.

---
<p><a href="https://cursor.com/agents/bc-2a4f7286-eb0d-457e-a03f-707c0efcbc6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a4f7286-eb0d-457e-a03f-707c0efcbc6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->