### PR TITLE
Manual model preference

### DIFF
--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -26,6 +26,8 @@ export interface Config {
   // Theme preferences
   theme?: string;
   themeMode?: "dark" | "light" | "auto";
+  // Model preference
+  selectedModelId?: string | null;
   // WorkOS CLI auth (replaces pensarAPIKey for new auth flow)
   accessToken?: string | null;
   refreshToken?: string | null;

--- a/src/tui/components/commands/operator-wizard.tsx
+++ b/src/tui/components/commands/operator-wizard.tsx
@@ -73,7 +73,7 @@ export default function HITLWizard(props: HITLWizardProps) {
         if (initialModel) {
           const targetModel = models.find((m) => m.id === initialModel);
           if (targetModel) {
-            setModel(targetModel);
+            setModel(targetModel, false);
             setExpandedProviders(new Set([targetModel.provider]));
             return;
           }

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -154,7 +154,7 @@ export default function WebWizard({
       if (initialModel) {
         const targetModel = models.find((m) => m.id === initialModel);
         if (targetModel) {
-          setModel(targetModel);
+          setModel(targetModel, false);
           const newIndex = models.findIndex((m) => m.id === targetModel.id);
           if (newIndex >= 0) {
             setSelectedModelIndex(newIndex);

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -14,6 +14,7 @@ import {
   update as updateConfig,
 } from "../../core/config/config";
 import { getAvailableModels } from "../../core/providers/utils";
+import { writeErrorLog } from "../../core/logger";
 
 // Preferred defaults by provider (fast + cheap models)
 const PREFERRED_DEFAULTS: Record<string, string> = {
@@ -84,7 +85,9 @@ export function AgentProvider({ children }: AgentProviderProps) {
     setModelInternal(newModel);
     setIsModelUserSelected(true);
     // Persist user's model preference to config
-    updateConfig({ selectedModelId: newModel.id }).catch(() => {});
+    updateConfig({ selectedModelId: newModel.id }).catch((err) => {
+      writeErrorLog(err, "AGENT_CONTEXT");
+    });
   }, []);
 
   // Smart default model selection:
@@ -145,7 +148,9 @@ export function AgentProvider({ children }: AgentProviderProps) {
           // Don't mark as user-selected since this is auto-default
         }
       })
-      .catch(() => {});
+      .catch((err) => {
+        writeErrorLog(err, "AGENT_CONTEXT");
+      });
   }, []);
 
   const addTokenUsage = useCallback((input: number, output: number) => {

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -9,7 +9,10 @@ import {
 } from "react";
 import { type ModelInfo } from "../../core/ai";
 import { AVAILABLE_MODELS } from "../../core/ai/models";
-import { get as getConfig, update as updateConfig } from "../../core/config/config";
+import {
+  get as getConfig,
+  update as updateConfig,
+} from "../../core/config/config";
 import { getAvailableModels } from "../../core/providers/utils";
 
 // Preferred defaults by provider (fast + cheap models)
@@ -98,7 +101,9 @@ export function AgentProvider({ children }: AgentProviderProps) {
 
         // Priority 1: Check if user has a saved model preference
         if (config.selectedModelId) {
-          const savedModel = available.find((m) => m.id === config.selectedModelId);
+          const savedModel = available.find(
+            (m) => m.id === config.selectedModelId,
+          );
           if (savedModel) {
             setModelInternal(savedModel);
             setIsModelUserSelected(true);

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -41,7 +41,12 @@ interface TokenUsage {
 
 interface AgentContextValue {
   model: ModelInfo;
-  setModel: (model: ModelInfo) => void;
+  /**
+   * Update the active model.
+   * Pass `persist = false` for programmatic/initialization calls that should
+   * not overwrite the user's saved preference on disk.
+   */
+  setModel: (model: ModelInfo, persist?: boolean) => void;
   isModelUserSelected: boolean;
   tokenUsage: TokenUsage;
   addTokenUsage: (input: number, output: number) => void;
@@ -80,14 +85,17 @@ export function AgentProvider({ children }: AgentProviderProps) {
   const [thinking, setThinking] = useState<boolean>(false);
   const [isExecuting, setIsExecuting] = useState<boolean>(false);
 
-  // Wrapper that marks model as user-selected and persists to config
-  const setModel = useCallback((newModel: ModelInfo) => {
+  // Wrapper that marks model as user-selected and persists to config.
+  // Pass `persist = false` for programmatic/initialization calls so the
+  // user's previously saved preference is not silently overwritten.
+  const setModel = useCallback((newModel: ModelInfo, persist = true) => {
     setModelInternal(newModel);
-    setIsModelUserSelected(true);
-    // Persist user's model preference to config
-    updateConfig({ selectedModelId: newModel.id }).catch((err) => {
-      writeErrorLog(err, "AGENT_CONTEXT");
-    });
+    if (persist) {
+      setIsModelUserSelected(true);
+      updateConfig({ selectedModelId: newModel.id }).catch((err) => {
+        writeErrorLog(err, "AGENT_CONTEXT");
+      });
+    }
   }, []);
 
   // Smart default model selection:

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { type ModelInfo } from "../../core/ai";
 import { AVAILABLE_MODELS } from "../../core/ai/models";
-import { get as getConfig } from "../../core/config/config";
+import { get as getConfig, update as updateConfig } from "../../core/config/config";
 import { getAvailableModels } from "../../core/providers/utils";
 
 // Preferred defaults by provider (fast + cheap models)
@@ -76,23 +76,37 @@ export function AgentProvider({ children }: AgentProviderProps) {
   const [thinking, setThinking] = useState<boolean>(false);
   const [isExecuting, setIsExecuting] = useState<boolean>(false);
 
-  // Wrapper that marks model as user-selected
+  // Wrapper that marks model as user-selected and persists to config
   const setModel = useCallback((newModel: ModelInfo) => {
     setModelInternal(newModel);
     setIsModelUserSelected(true);
+    // Persist user's model preference to config
+    updateConfig({ selectedModelId: newModel.id }).catch(() => {});
   }, []);
 
   // Smart default model selection:
-  // 1. Prefer Pensar Haiku 4.5 if connected to Pensar Console
-  // 2. Fall back to Claude Haiku 4.5 if Anthropic is configured
-  // 3. Fall back to GPT-4o Mini if OpenAI is configured
-  // 4. Otherwise use first available model
+  // 1. Use user's saved model preference if it still exists
+  // 2. Prefer Pensar Haiku 4.5 if connected to Pensar Console
+  // 3. Fall back to Claude Haiku 4.5 if Anthropic is configured
+  // 4. Fall back to GPT-4o Mini if OpenAI is configured
+  // 5. Otherwise use first available model
   useEffect(() => {
     getConfig()
       .then((config) => {
         const available = getAvailableModels(config);
         if (available.length === 0) return;
 
+        // Priority 1: Check if user has a saved model preference
+        if (config.selectedModelId) {
+          const savedModel = available.find((m) => m.id === config.selectedModelId);
+          if (savedModel) {
+            setModelInternal(savedModel);
+            setIsModelUserSelected(true);
+            return;
+          }
+        }
+
+        // Priority 2: Use auto-default logic
         // Group available models by provider
         const byProvider = new Map<string, ModelInfo[]>();
         for (const m of available) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR addresses an issue where manually selected AI models were not persisted across sessions, causing the application to revert to default models (e.g., Pensar models if authenticated) on restart.

The changes introduce persistence for the user's `selectedModelId` in the application configuration. When a user manually selects a model, its ID is now saved to disk. On startup, the application first checks for a saved `selectedModelId` and prioritizes it over the default model selection logic, ensuring that manual choices are respected.

### How did you verify your code works?

I verified the code works through:

*   **Unit Tests:** All existing unit tests passed.
*   **Type Checking & Linting:** Passed without errors.
*   **Manual Testing:**
    1.  Started the TUI and noted the default model.
    2.  Used the `/models` command to manually select a different model.
    3.  Confirmed that the `selectedModelId` was correctly saved in the configuration file.
    4.  Exited and relaunched the TUI.
    5.  Verified that the previously selected model was still active, confirming persistence across sessions.

---
<p><a href="https://cursor.com/agents/bc-c51d86df-1b13-469f-9973-a720f8564c53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c51d86df-1b13-469f-9973-a720f8564c53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->