### PR TITLE
Responsive pentest agent card grid

### DIFF
--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -132,8 +132,7 @@ export default function Pentest({ sessionId }: { sessionId: string }) {
   // Responsive grid columns
   const { width: termWidth } = useTerminalDimensions();
   const gridAvailableWidth = showOrchestratorPanel
-    ? // Expanded: both panel and grid are flexGrow=1, parent has padding=1 + gap=2
-      Math.floor((termWidth - 4) / 2) - GRID_OUTER_PADDING
+    ? Math.floor((termWidth - 4) / 2) - 2
     : termWidth - ORCHESTRATOR_PANEL_WIDTH - GRID_OUTER_PADDING;
   const gridColumns = Math.max(
     1,

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
-import { useKeyboard } from "@opentui/react";
+import { useKeyboard, useTerminalDimensions } from "@opentui/react";
 import { RGBA } from "@opentui/core";
 import { existsSync, readdirSync, readFileSync } from "fs";
 import { join } from "path";
@@ -43,6 +43,11 @@ type AgentState = {
 };
 
 type ViewMode = "overview" | "detail";
+
+const ORCHESTRATOR_PANEL_WIDTH = 32;
+const GRID_GAP = 1;
+const GRID_OUTER_PADDING = 6; // row padding (2) + outer gap (2) + borders (2)
+const CARD_MIN_WIDTH = 40;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -121,6 +126,16 @@ export default function Pentest({ sessionId }: { sessionId: string }) {
   const selectedAgent = useMemo(
     () => (selectedAgentId ? (pentestAgents[selectedAgentId] ?? null) : null),
     [pentestAgents, selectedAgentId],
+  );
+
+  // Responsive grid columns
+  const { width: termWidth } = useTerminalDimensions();
+  const gridColumns = Math.max(
+    1,
+    Math.floor(
+      (termWidth - ORCHESTRATOR_PANEL_WIDTH - GRID_OUTER_PADDING + GRID_GAP) /
+        (CARD_MIN_WIDTH + GRID_GAP),
+    ),
   );
 
   // -------------------------------------------------------------------------
@@ -710,11 +725,11 @@ export default function Pentest({ sessionId }: { sessionId: string }) {
         return;
       }
       if (key.name === "down") {
-        setFocusedIndex((p) => Math.min(p + 2, count - 1));
+        setFocusedIndex((p) => Math.min(p + gridColumns, count - 1));
         return;
       }
       if (key.name === "up") {
-        setFocusedIndex((p) => Math.max(p - 2, 0));
+        setFocusedIndex((p) => Math.max(p - gridColumns, 0));
         return;
       }
 
@@ -855,6 +870,7 @@ export default function Pentest({ sessionId }: { sessionId: string }) {
           ) : (
             <AgentCardGrid
               agents={pentestAgentList}
+              gridColumns={gridColumns}
               focusedIndex={focusedIndex}
               onSelectAgent={(id) => {
                 setSelectedAgentId(id);
@@ -1032,7 +1048,7 @@ function OrchestratorPanel({
   // Collapsed panel — sidebar
   return (
     <box
-      width={32}
+      width={ORCHESTRATOR_PANEL_WIDTH}
       border
       borderColor={isRunning ? colors.primary : colors.textMuted}
       backgroundColor={colors.backgroundElement}
@@ -1131,23 +1147,25 @@ function riskColor(colors: ThemeColors, level: string): RGBA {
 
 interface AgentCardGridProps {
   agents: AgentState[];
+  gridColumns: number;
   focusedIndex: number;
   onSelectAgent: (id: string) => void;
 }
 
 function AgentCardGrid({
   agents,
+  gridColumns,
   focusedIndex,
   onSelectAgent,
 }: AgentCardGridProps) {
   const { colors } = useTheme();
   const rows = useMemo(() => {
     const result: AgentState[][] = [];
-    for (let i = 0; i < agents.length; i += 2) {
-      result.push(agents.slice(i, i + 2));
+    for (let i = 0; i < agents.length; i += gridColumns) {
+      result.push(agents.slice(i, i + gridColumns));
     }
     return result;
-  }, [agents]);
+  }, [agents, gridColumns]);
 
   return (
     <scrollbox
@@ -1161,7 +1179,7 @@ function AgentCardGrid({
       {rows.map((row, ri) => (
         <box key={ri} flexDirection="row" gap={1} width="100%">
           {row.map((agent, ci) => {
-            const flatIdx = ri * 2 + ci;
+            const flatIdx = ri * gridColumns + ci;
             return (
               <AgentCard
                 key={agent.id}
@@ -1171,7 +1189,15 @@ function AgentCardGrid({
               />
             );
           })}
-          {row.length === 1 && <box flexGrow={1} flexBasis={0} minWidth={40} />}
+          {row.length < gridColumns &&
+            Array.from({ length: gridColumns - row.length }, (_, i) => (
+              <box
+                key={`spacer-${i}`}
+                flexGrow={1}
+                flexBasis={0}
+                minWidth={CARD_MIN_WIDTH}
+              />
+            ))}
         </box>
       ))}
     </scrollbox>
@@ -1220,7 +1246,7 @@ function AgentCard({
     <box
       flexGrow={1}
       flexBasis={0}
-      minWidth={40}
+      minWidth={CARD_MIN_WIDTH}
       border
       borderColor={focused ? colors.primary : colors.textMuted}
       backgroundColor={colors.backgroundElement}

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useKeyboard, useTerminalDimensions } from "@opentui/react";
-import { RGBA } from "@opentui/core";
+import { RGBA, ScrollBoxRenderable } from "@opentui/core";
 import { existsSync, readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { exec } from "child_process";
@@ -19,6 +19,7 @@ import { useDialog } from "../../context/dialog";
 import { useTheme, type ThemeColors } from "../../theme";
 import AgentDisplay, { type DisplayMessage } from "../agent-display";
 import { SpinnerDots } from "../sprites";
+import { scrollToChild } from "../../utils/scroll";
 import type { DocumentedAssetRecord } from "../../../core/agents/specialized/attackSurface/schemas";
 
 // ---------------------------------------------------------------------------
@@ -130,12 +131,13 @@ export default function Pentest({ sessionId }: { sessionId: string }) {
 
   // Responsive grid columns
   const { width: termWidth } = useTerminalDimensions();
+  const gridAvailableWidth = showOrchestratorPanel
+    ? // Expanded: both panel and grid are flexGrow=1, parent has padding=1 + gap=2
+      Math.floor((termWidth - 4) / 2) - GRID_OUTER_PADDING
+    : termWidth - ORCHESTRATOR_PANEL_WIDTH - GRID_OUTER_PADDING;
   const gridColumns = Math.max(
     1,
-    Math.floor(
-      (termWidth - ORCHESTRATOR_PANEL_WIDTH - GRID_OUTER_PADDING + GRID_GAP) /
-        (CARD_MIN_WIDTH + GRID_GAP),
-    ),
+    Math.floor((gridAvailableWidth + GRID_GAP) / (CARD_MIN_WIDTH + GRID_GAP)),
   );
 
   // -------------------------------------------------------------------------
@@ -1159,6 +1161,13 @@ function AgentCardGrid({
   onSelectAgent,
 }: AgentCardGridProps) {
   const { colors } = useTheme();
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+
+  useEffect(() => {
+    const agent = agents[focusedIndex];
+    if (agent) scrollToChild(scrollRef.current, agent.id);
+  }, [focusedIndex, agents]);
+
   const rows = useMemo(() => {
     const result: AgentState[][] = [];
     for (let i = 0; i < agents.length; i += gridColumns) {
@@ -1169,6 +1178,7 @@ function AgentCardGrid({
 
   return (
     <scrollbox
+      ref={scrollRef}
       style={{
         rootOptions: { flexGrow: 1, width: "100%" },
         contentOptions: { flexDirection: "column", gap: 1 },
@@ -1244,6 +1254,7 @@ function AgentCard({
 
   return (
     <box
+      id={agent.id}
       flexGrow={1}
       flexBasis={0}
       minWidth={CARD_MIN_WIDTH}

--- a/src/tui/utils/scroll.ts
+++ b/src/tui/utils/scroll.ts
@@ -40,6 +40,32 @@ export function scrollToIndex<T>(
   }
 }
 
+/**
+ * Scrolls a ScrollBox only if the child with the given ID is not fully visible.
+ * Unlike `scrollToIndex`, this has no first/last index shortcuts — it purely
+ * checks visibility, making it suitable for grid layouts.
+ */
+export function scrollToChild(
+  scrollBox: ScrollBoxRenderable | null,
+  id: string,
+) {
+  if (!scrollBox) return;
+
+  const target = findChildById(scrollBox, id);
+  if (!target) return;
+
+  const viewportY = scrollBox.viewport.y;
+  const viewportHeight = scrollBox.viewport.height;
+  const targetTop = target.y - viewportY;
+  const targetBottom = targetTop + (target.height || 1);
+
+  if (targetBottom > viewportHeight) {
+    scrollBox.scrollBy(targetBottom - viewportHeight);
+  } else if (targetTop < 0) {
+    scrollBox.scrollBy(targetTop);
+  }
+}
+
 function findChildById(
   scrollBox: ScrollBoxRenderable,
   id: string,


### PR DESCRIPTION
Makes the pentest grid compute columns dynamically from terminal width instead of hardcoding 2. Extracts magic numbers into named constants and updates keyboard navigation (up/down arrows) to match the computed column count.

Also fix the scrolling behavior so that when you select, if you move to a sub-agent card that is off screen, it automatically scrolls it into view. 

Side note, this can probably be improved a little bit because sometimes it scrolls a little bit even when the next agent card is completely within view. We only want it to be scrolled when the selected agent (if it was previously not completely in view) is brought completely into the view. 

https://github.com/user-attachments/assets/30c77f36-aed5-4d33-9567-0a7232fdb486

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core TUI navigation/layout math and scroll behavior; likely safe but could introduce edge-case focus/scroll glitches on unusual terminal sizes or when toggling the orchestrator panel.
> 
> **Overview**
> Makes the pentest overview agent cards **responsive to terminal width** by computing `gridColumns` dynamically and replacing hardcoded 2-column layout assumptions (including up/down keyboard navigation).
> 
> Improves usability by adding **auto-scroll-to-focused-card** behavior in the grid via a new `scrollToChild` helper, and replaces various layout “magic numbers” with named constants (e.g., `ORCHESTRATOR_PANEL_WIDTH`, `CARD_MIN_WIDTH`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d205862908959cbe01f835564dcd8a41884122f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->