### PR TITLE
Issue 264 bug

### DIFF
--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -270,9 +270,18 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
                 name: "return",
               },
               {
+                action: "submit",
+                name: "linefeed",
+              },
+              {
                 action: "newline",
                 meta: true,
                 name: "return",
+              },
+              {
+                action: "newline",
+                meta: true,
+                name: "linefeed",
               },
             ]}
             onContentChange={handleContentChange}

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -275,12 +275,12 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
               },
               {
                 action: "newline",
-                meta: true,
+                shift: true,
                 name: "return",
               },
               {
                 action: "newline",
-                meta: true,
+                shift: true,
                 name: "linefeed",
               },
             ]}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR fixes issue #264 where submit functionality broke after textarea blur/refocus in operator mode. The `PromptInput` textarea bindings were hardened to correctly handle both `return` and `linefeed` events for submit/newline behavior, ensuring that Enter submission consistently works after focus transitions.

### How did you verify your code works?

- Ran `bun run tsc && bun run test`, which passed successfully.
- Performed manual UI validation:
    - In operator mode, submitted input.
    - Defocused and refocused the input area using `?` (shortcuts) and `Esc`.
    - Successfully submitted input again, confirming the fix.

---
<p><a href="https://cursor.com/agents/bc-77568393-f11b-4e03-b28e-8c342b299325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77568393-f11b-4e03-b28e-8c342b299325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->