### PR TITLE
Apex.yaml deploy error

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -35,10 +35,7 @@ import {
   type OperatorSessionState,
 } from "../../../core/operator";
 import { stepCountIs, type ModelMessage } from "ai";
-import {
-  isTerminalCopyShortcut,
-  shouldHandleOperatorCtrlC,
-} from "./keyboard";
+import { isTerminalCopyShortcut, shouldHandleOperatorCtrlC } from "./keyboard";
 
 type DashboardStatus = "idle" | "running" | "waiting" | "done";
 

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -35,6 +35,10 @@ import {
   type OperatorSessionState,
 } from "../../../core/operator";
 import { stepCountIs, type ModelMessage } from "ai";
+import {
+  isTerminalCopyShortcut,
+  shouldHandleOperatorCtrlC,
+} from "./keyboard";
 
 type DashboardStatus = "idle" | "running" | "waiting" | "done";
 
@@ -495,7 +499,14 @@ export default function OperatorDashboard({
     // Skip local shortcuts when dialogs are open (e.g. shortcuts popup)
     if (stack.length > 0 || externalDialogOpen) return;
 
-    if (key.ctrl && key.name === "c") {
+    // Let terminal-native copy shortcuts pass through so selected output text
+    // in operator mode can still be copied.
+    if (isTerminalCopyShortcut(key)) {
+      return;
+    }
+
+    if (shouldHandleOperatorCtrlC(key, status, inputValue)) {
+      key.preventDefault?.();
       if (status === "running" || status === "waiting") {
         handleAbort();
       } else if (inputValue.trim()) {

--- a/src/tui/components/operator-dashboard/keyboard.test.ts
+++ b/src/tui/components/operator-dashboard/keyboard.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  isTerminalCopyShortcut,
-  shouldHandleOperatorCtrlC,
-} from "./keyboard";
+import { isTerminalCopyShortcut, shouldHandleOperatorCtrlC } from "./keyboard";
 
 describe("operator dashboard keyboard helpers", () => {
   it("detects terminal copy shortcuts", () => {

--- a/src/tui/components/operator-dashboard/keyboard.test.ts
+++ b/src/tui/components/operator-dashboard/keyboard.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  isTerminalCopyShortcut,
+  shouldHandleOperatorCtrlC,
+} from "./keyboard";
+
+describe("operator dashboard keyboard helpers", () => {
+  it("detects terminal copy shortcuts", () => {
+    expect(
+      isTerminalCopyShortcut({
+        name: "c",
+        ctrl: false,
+        meta: true,
+        super: false,
+      }),
+    ).toBe(true);
+    expect(
+      isTerminalCopyShortcut({
+        name: "c",
+        ctrl: false,
+        meta: false,
+        super: true,
+      }),
+    ).toBe(true);
+    expect(
+      isTerminalCopyShortcut({
+        name: "c",
+        ctrl: true,
+        meta: false,
+        super: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("handles Ctrl+C while running or waiting", () => {
+    const ctrlC = { name: "c", ctrl: true, meta: false, super: false };
+    expect(shouldHandleOperatorCtrlC(ctrlC, "running", "")).toBe(true);
+    expect(shouldHandleOperatorCtrlC(ctrlC, "waiting", "")).toBe(true);
+  });
+
+  it("handles Ctrl+C for clearing non-empty input", () => {
+    const ctrlC = { name: "c", ctrl: true, meta: false, super: false };
+    expect(shouldHandleOperatorCtrlC(ctrlC, "idle", "has text")).toBe(true);
+  });
+
+  it("does not handle Ctrl+C when idle with empty input", () => {
+    const ctrlC = { name: "c", ctrl: true, meta: false, super: false };
+    expect(shouldHandleOperatorCtrlC(ctrlC, "idle", "")).toBe(false);
+    expect(shouldHandleOperatorCtrlC(ctrlC, "idle", "   ")).toBe(false);
+  });
+
+  it("never handles command/super copy chords", () => {
+    expect(
+      shouldHandleOperatorCtrlC(
+        { name: "c", ctrl: false, meta: true, super: false },
+        "running",
+        "text",
+      ),
+    ).toBe(false);
+    expect(
+      shouldHandleOperatorCtrlC(
+        { name: "c", ctrl: false, meta: false, super: true },
+        "waiting",
+        "text",
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/tui/components/operator-dashboard/keyboard.ts
+++ b/src/tui/components/operator-dashboard/keyboard.ts
@@ -1,0 +1,27 @@
+import type { ParsedKey } from "@opentui/core";
+
+export type OperatorDashboardStatus = "idle" | "running" | "waiting" | "done";
+
+type KeyboardKey = Pick<ParsedKey, "name" | "ctrl" | "meta" | "super">;
+
+/**
+ * Terminal copy shortcuts (Cmd+C on macOS / Super+C variants) should not be
+ * hijacked by operator-level Ctrl+C handling.
+ */
+export function isTerminalCopyShortcut(key: KeyboardKey): boolean {
+  return (Boolean(key.meta) || Boolean(key.super)) && key.name === "c";
+}
+
+/**
+ * Operator dashboard should only consume Ctrl+C when it maps to an operator
+ * action (stop active run or clear non-empty input).
+ */
+export function shouldHandleOperatorCtrlC(
+  key: KeyboardKey,
+  status: OperatorDashboardStatus,
+  inputValue: string,
+): boolean {
+  if (isTerminalCopyShortcut(key)) return false;
+  if (!key.ctrl || key.name !== "c") return false;
+  return status === "running" || status === "waiting" || inputValue.trim() !== "";
+}

--- a/src/tui/components/operator-dashboard/keyboard.ts
+++ b/src/tui/components/operator-dashboard/keyboard.ts
@@ -23,5 +23,7 @@ export function shouldHandleOperatorCtrlC(
 ): boolean {
   if (isTerminalCopyShortcut(key)) return false;
   if (!key.ctrl || key.name !== "c") return false;
-  return status === "running" || status === "waiting" || inputValue.trim() !== "";
+  return (
+    status === "running" || status === "waiting" || inputValue.trim() !== ""
+  );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR fixes issue #265 where users could not copy highlighted text in operator mode because the TUI was intercepting copy shortcuts.

The changes introduce a new `keyboard.ts` module with helper functions to differentiate between operator control keys (`Ctrl+C` for stop/clear) and terminal copy shortcuts (`Cmd/Super+C`). The `operator-dashboard`'s keyboard handling now uses these helpers to:
1. Preserve `Ctrl+C` functionality for operator actions (stopping agents, clearing non-empty input).
2. Explicitly allow `Cmd/Super+C` and other copy shortcuts to pass through to the terminal, enabling native text copying.

This works by selectively consuming key events: `Ctrl+C` is handled by the operator only when it's intended for control, while other copy-related key combinations are ignored by the operator to allow the terminal to process them.

### How did you verify your code works?

- ✅ `bun run lint`
- ✅ `bun run test` (including new unit tests for `isCopyShortcut` and `shouldHandleOperatorKey` to cover copy-shortcut detection and `Ctrl+C` routing)
- ✅ `bun run tsc`
- ✅ Manual TUI smoke walkthrough:
    - Verified `Ctrl+C` still clears populated input.
    - Confirmed normal operator messaging works.
    - Confirmed assistant response in operator mode.
- ⚠️ Direct macOS `Cmd+C` chord injection was not available in the Linux VM; the `Cmd/Super+C` fix path was validated via the new unit tests and overall operator-mode keyboard behavior.

---
<p><a href="https://cursor.com/agents/bc-a2c08820-4957-4ed2-91e9-82e51bde35a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2c08820-4957-4ed2-91e9-82e51bde35a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->