### PR TITLE
feat: command history navigation & subagent display callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensar/apex",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
   "main": "build/index.js",

--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -301,10 +301,8 @@ When to use delegate_to_auth_subagent vs authenticate_session:
 
         const subagentCallbacks = cbs
           ? {
-              onTextDelta: (d: {
-                type: "text-delta";
-                [k: string]: unknown;
-              }) => cbs.onTextDelta?.({ ...d, subagentId } as never),
+              onTextDelta: (d: { type: "text-delta"; [k: string]: unknown }) =>
+                cbs.onTextDelta?.({ ...d, subagentId } as never),
               onToolCall: (d: { type: "tool-call"; [k: string]: unknown }) =>
                 cbs.onToolCall?.({ ...d, subagentId } as never),
               onToolResult: (d: {

--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -215,6 +215,15 @@ When to use delegate_to_auth_subagent vs authenticate_session:
           }
         }
 
+        const subagentId = "auth-agent";
+        const cbs = ctx.subagentCallbacks;
+
+        cbs?.onSubagentSpawn?.({
+          subagentId,
+          input: { target, reason },
+          status: "pending",
+        });
+
         console.log(`\n🔐 Delegating to authentication subagent...`);
         console.log(`   Target: ${target}`);
         console.log(`   Reason: ${reason}`);
@@ -290,6 +299,22 @@ When to use delegate_to_auth_subagent vs authenticate_session:
         const { runAuthenticationAgent } =
           await import("../../../api/authentication");
 
+        const subagentCallbacks = cbs
+          ? {
+              onTextDelta: (d: {
+                type: "text-delta";
+                [k: string]: unknown;
+              }) => cbs.onTextDelta?.({ ...d, subagentId } as never),
+              onToolCall: (d: { type: "tool-call"; [k: string]: unknown }) =>
+                cbs.onToolCall?.({ ...d, subagentId } as never),
+              onToolResult: (d: {
+                type: "tool-result";
+                [k: string]: unknown;
+              }) => cbs.onToolResult?.({ ...d, subagentId } as never),
+              onError: (e: unknown) => cbs.onError?.(e),
+            }
+          : undefined;
+
         const result = await runAuthenticationAgent({
           target,
           session: ctx.session,
@@ -297,7 +322,16 @@ When to use delegate_to_auth_subagent vs authenticate_session:
           model: ctx.model,
           authConfig: ctx.authConfig,
           abortSignal: ctx.abortSignal,
-          callbacks: ctx.callbacks,
+          callbacks: {
+            ...ctx.callbacks,
+            subagentCallbacks,
+          },
+        });
+
+        cbs?.onSubagentComplete?.({
+          subagentId,
+          input: { target, reason },
+          status: result.success ? "completed" : "failed",
         });
 
         if (result.success) {
@@ -361,6 +395,12 @@ When to use delegate_to_auth_subagent vs authenticate_session:
               }`,
         };
       } catch (error: unknown) {
+        ctx.subagentCallbacks?.onSubagentComplete?.({
+          subagentId: "auth-agent",
+          input: { target, reason },
+          status: "failed",
+        });
+
         const errorMessage =
           error instanceof Error ? error.message : String(error);
         return {

--- a/src/core/agents/offSecAgent/tools/runAttackSurface.ts
+++ b/src/core/agents/offSecAgent/tools/runAttackSurface.ts
@@ -65,6 +65,12 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
           }
         : undefined;
 
+      cbs?.onSubagentSpawn?.({
+        subagentId,
+        input: { target, cwd },
+        status: "pending",
+      });
+
       // -----------------------------------------------------------------------
       // Whitebox mode — analyze source code (cwd is the indicator)
       // -----------------------------------------------------------------------
@@ -103,6 +109,12 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
             `\n✓ Whitebox attack surface complete: ${targets.length} targets from ${result.apps.length} apps`,
           );
 
+          cbs?.onSubagentComplete?.({
+            subagentId,
+            input: { target, cwd },
+            status: "completed",
+          });
+
           return {
             success: true,
             mode: "whitebox" as const,
@@ -115,6 +127,13 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
           const errorMsg =
             error instanceof Error ? error.message : String(error);
           console.error(`✗ Whitebox attack surface agent failed: ${errorMsg}`);
+
+          cbs?.onSubagentComplete?.({
+            subagentId,
+            input: { target, cwd },
+            status: "failed",
+          });
+
           return {
             success: false,
             targets: [],
@@ -152,6 +171,12 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
           `\n✓ Blackbox attack surface complete: ${targetCount} targets identified`,
         );
 
+        cbs?.onSubagentComplete?.({
+          subagentId,
+          input: { target },
+          status: "completed",
+        });
+
         return {
           success: true,
           mode: "blackbox" as const,
@@ -170,6 +195,13 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
       } catch (error: unknown) {
         const errorMsg = error instanceof Error ? error.message : String(error);
         console.error(`✗ Blackbox attack surface agent failed: ${errorMsg}`);
+
+        cbs?.onSubagentComplete?.({
+          subagentId,
+          input: { target },
+          status: "failed",
+        });
+
         return {
           success: false,
           targets: [],

--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -1,0 +1,61 @@
+/**
+ * Persistent command history stored at ~/.pensar/command-history.json
+ *
+ * Lazily loads from disk on first access. Writes are fire-and-forget
+ * so callers never block on I/O. The in-memory array is the source
+ * of truth after initial load; disk is kept in sync best-effort.
+ */
+
+import * as Storage from "./storage";
+
+const STORAGE_KEY = ["command-history"];
+const MAX_ENTRIES = 500;
+
+let entries: string[] | null = null;
+let loadPromise: Promise<void> | null = null;
+
+async function ensureLoaded(): Promise<string[]> {
+  if (entries !== null) return entries;
+  if (!loadPromise) {
+    loadPromise = (async () => {
+      try {
+        const data = await Storage.read<string[]>(STORAGE_KEY);
+        entries = Array.isArray(data) ? data : [];
+      } catch {
+        entries = [];
+      }
+    })();
+  }
+  await loadPromise;
+  return entries!;
+}
+
+/**
+ * Load history from disk (or return cached entries).
+ * Call once at startup; subsequent calls return immediately.
+ */
+export async function load(): Promise<string[]> {
+  return ensureLoaded();
+}
+
+/**
+ * Append an entry. Skips consecutive duplicates.
+ * Persists to disk in the background.
+ */
+export async function push(entry: string): Promise<void> {
+  const history = await ensureLoaded();
+  if (history[history.length - 1] === entry) return;
+  history.push(entry);
+  if (history.length > MAX_ENTRIES) {
+    history.splice(0, history.length - MAX_ENTRIES);
+  }
+  Storage.write(STORAGE_KEY, history).catch(() => {});
+}
+
+/**
+ * Synchronous accessor — returns whatever is currently loaded.
+ * Returns an empty array if load() hasn't resolved yet.
+ */
+export function getEntries(): string[] {
+  return entries ?? [];
+}

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -18,9 +18,7 @@ import { useRoute } from "../../context/route";
 import { PromptInput } from "../shared/prompt-input";
 import { useTheme } from "../../theme";
 import { slugify } from "../../../core/skills";
-
-// Persists across re-mounts so history survives navigating away and back
-const homeCommandHistory: string[] = [];
+import * as History from "../../../core/history";
 
 type ViewType = "home" | "config" | "chat";
 
@@ -41,6 +39,13 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
   const { promptRef } = useFocus();
 
   const [hintMessage, setHintMessage] = useState<string | null>(null);
+  const [commandHistory, setCommandHistory] = useState<string[]>(
+    History.getEntries,
+  );
+
+  useEffect(() => {
+    History.load().then(setCommandHistory);
+  }, []);
 
   const launchOperator = useCallback(
     (message: string, options?: { requireApproval?: boolean }) => {
@@ -53,13 +58,8 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
     [route],
   );
 
-  const [, forceUpdate] = useState(0);
-
   const pushHistory = useCallback((entry: string) => {
-    if (homeCommandHistory[homeCommandHistory.length - 1] !== entry) {
-      homeCommandHistory.push(entry);
-      forceUpdate((n) => n + 1);
-    }
+    History.push(entry).then(() => setCommandHistory([...History.getEntries()]));
   }, []);
 
   const handleSubmit = useCallback(
@@ -190,7 +190,7 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
           autocompleteOptions={autocompleteOptions}
           enableCommands={true}
           onCommandExecute={handleCommandExecute}
-          commandHistory={homeCommandHistory}
+          commandHistory={commandHistory}
           showPromptIndicator={true}
         />
 

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -59,7 +59,9 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
   );
 
   const pushHistory = useCallback((entry: string) => {
-    History.push(entry).then(() => setCommandHistory([...History.getEntries()]));
+    History.push(entry).then(() =>
+      setCommandHistory([...History.getEntries()]),
+    );
   }, []);
 
   const handleSubmit = useCallback(

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -19,6 +19,9 @@ import { PromptInput } from "../shared/prompt-input";
 import { useTheme } from "../../theme";
 import { slugify } from "../../../core/skills";
 
+// Persists across re-mounts so history survives navigating away and back
+const homeCommandHistory: string[] = [];
+
 type ViewType = "home" | "config" | "chat";
 
 interface HomeViewProps {
@@ -50,12 +53,22 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
     [route],
   );
 
+  const [, forceUpdate] = useState(0);
+
+  const pushHistory = useCallback((entry: string) => {
+    if (homeCommandHistory[homeCommandHistory.length - 1] !== entry) {
+      homeCommandHistory.push(entry);
+      forceUpdate((n) => n + 1);
+    }
+  }, []);
+
   const handleSubmit = useCallback(
     (value: string) => {
       if (!value.trim()) return;
+      pushHistory(value.trim());
       launchOperator(value.trim());
     },
-    [launchOperator],
+    [launchOperator, pushHistory],
   );
 
   // Auto-clear hint after 3 seconds
@@ -67,7 +80,10 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
 
   const handleCommandExecute = useCallback(
     async (command: string) => {
-      const parts = command.trim().replace(/^\/+/, "").split(/\s+/);
+      const trimmed = command.trim();
+      pushHistory(trimmed);
+
+      const parts = trimmed.replace(/^\/+/, "").split(/\s+/);
       const slug = parts[0]?.toLowerCase() ?? "";
       const args = parts.slice(1);
       const autopilot = args.includes("--autopilot");
@@ -79,7 +95,7 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
       }
       await executeCommand(command);
     },
-    [resolveSkillContent, launchOperator, executeCommand],
+    [resolveSkillContent, launchOperator, executeCommand, pushHistory],
   );
 
   const skillItems = skills.slice(0, 5).map((s) => ({
@@ -174,6 +190,7 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
           autocompleteOptions={autocompleteOptions}
           enableCommands={true}
           onCommandExecute={handleCommandExecute}
+          commandHistory={homeCommandHistory}
           showPromptIndicator={true}
         />
 

--- a/src/tui/components/chat/input-area.tsx
+++ b/src/tui/components/chat/input-area.tsx
@@ -51,6 +51,8 @@ export interface InputAreaProps {
   enableCommands?: boolean;
   /** Handler for slash-command execution */
   onCommandExecute?: (command: string) => Promise<void>;
+  /** Command history for up/down arrow navigation */
+  commandHistory?: string[];
 }
 
 /**
@@ -72,6 +74,7 @@ function NormalInputAreaInner({
   autocompleteOptions = [],
   enableCommands = false,
   onCommandExecute,
+  commandHistory = [],
 }: Omit<
   InputAreaProps,
   "pendingApproval" | "onApprove" | "onAutoApprove" | "lastDeclineNote"
@@ -134,6 +137,7 @@ function NormalInputAreaInner({
           autocompleteOptions={autocompleteOptions}
           enableCommands={enableCommands}
           onCommandExecute={onCommandExecute}
+          commandHistory={commandHistory}
         />
       </box>
 
@@ -200,6 +204,7 @@ export function InputArea(props: InputAreaProps) {
     autocompleteOptions,
     enableCommands,
     onCommandExecute,
+    commandHistory,
     ...normalProps
   } = props;
 
@@ -229,6 +234,7 @@ export function InputArea(props: InputAreaProps) {
         autocompleteOptions={autocompleteOptions}
         enableCommands={enableCommands}
         onCommandExecute={onCommandExecute}
+        commandHistory={commandHistory}
         {...normalProps}
       />
     </InputProvider>

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -45,6 +45,7 @@ import { stepCountIs, type ModelMessage } from "ai";
 import { isTerminalCopyShortcut, shouldHandleOperatorCtrlC } from "./keyboard";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
+import * as History from "../../../core/history";
 
 type DashboardStatus = "idle" | "running" | "waiting" | "done";
 
@@ -111,7 +112,13 @@ export default function OperatorDashboard({
   const conversationRef = useRef<ModelMessage[]>([]);
   // Input state
   const [inputValue, setInputValue] = useState("");
-  const [commandHistory, setCommandHistory] = useState<string[]>([]);
+  const [commandHistory, setCommandHistory] = useState<string[]>(
+    History.getEntries,
+  );
+
+  useEffect(() => {
+    History.load().then(setCommandHistory);
+  }, []);
 
   // Operator state
   const [operatorState, setOperatorState] = useState<OperatorSessionState>(() =>
@@ -608,10 +615,9 @@ export default function OperatorDashboard({
       if (status === "running") return;
 
       const trimmed = value.trim();
-      setCommandHistory((prev) => {
-        if (prev[prev.length - 1] === trimmed) return prev;
-        return [...prev, trimmed];
-      });
+      History.push(trimmed).then(() =>
+        setCommandHistory([...History.getEntries()]),
+      );
       setInputValue("");
       runAgent(trimmed);
     },

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -111,6 +111,7 @@ export default function OperatorDashboard({
   const conversationRef = useRef<ModelMessage[]>([]);
   // Input state
   const [inputValue, setInputValue] = useState("");
+  const [commandHistory, setCommandHistory] = useState<string[]>([]);
 
   // Operator state
   const [operatorState, setOperatorState] = useState<OperatorSessionState>(() =>
@@ -606,8 +607,13 @@ export default function OperatorDashboard({
       // Block submission only when the agent is actively running (not waiting)
       if (status === "running") return;
 
+      const trimmed = value.trim();
+      setCommandHistory((prev) => {
+        if (prev[prev.length - 1] === trimmed) return prev;
+        return [...prev, trimmed];
+      });
       setInputValue("");
-      runAgent(value.trim());
+      runAgent(trimmed);
     },
     [status, runAgent],
   );
@@ -941,6 +947,7 @@ export default function OperatorDashboard({
         autocompleteOptions={autocompleteOptions}
         enableCommands={true}
         onCommandExecute={handleCommandExecute}
+        commandHistory={commandHistory}
       />
     </box>
   );

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -67,6 +67,9 @@ interface PromptInputProps {
   enableCommands?: boolean;
   onCommandExecute?: (command: string) => Promise<void>;
 
+  // Command history (up/down arrow navigation)
+  commandHistory?: string[];
+
   // Visual customization
   showPromptIndicator?: boolean;
 }
@@ -90,6 +93,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       maxSuggestions = 10,
       enableCommands = false,
       onCommandExecute,
+      commandHistory = [],
       showPromptIndicator = false,
     },
     ref,
@@ -99,6 +103,13 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
     const { registerPromptRef } = useFocus();
     const textareaRef = useRef<TextareaRenderable | null>(null);
     const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(-1);
+
+    // Command history navigation state
+    // -1 = not browsing history (showing current input)
+    const [historyIndex, setHistoryIndex] = useState(-1);
+    const savedInputRef = useRef("");
+    const historyRef = useRef(commandHistory);
+    historyRef.current = commandHistory;
 
     // Refs to avoid stale closures in handleSubmit (textarea caches onSubmit)
     const selectedIndexRef = useRef(selectedSuggestionIndex);
@@ -169,38 +180,82 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       return () => registerPromptRef(null);
     }, [registerPromptRef]);
 
-    // Handle keyboard navigation for suggestions (up/down/tab)
+    // Handle keyboard navigation for suggestions and command history
     useKeyboard((key) => {
-      if (!focused || suggestions.length === 0) return;
+      if (!focused) return;
+
+      // When autocomplete suggestions are visible, up/down navigates them
+      if (suggestions.length > 0) {
+        if (key.name === "up") {
+          setSelectedSuggestionIndex((prev) =>
+            prev <= 0 ? suggestions.length - 1 : prev - 1,
+          );
+          return;
+        }
+        if (key.name === "down") {
+          setSelectedSuggestionIndex((prev) =>
+            prev >= suggestions.length - 1 ? 0 : prev + 1,
+          );
+          return;
+        }
+        if (key.name === "tab") {
+          key.preventDefault?.();
+          const currentSelectedIndex = selectedIndexRef.current;
+          if (
+            currentSelectedIndex >= 0 &&
+            currentSelectedIndex < suggestions.length
+          ) {
+            const selected = suggestions[currentSelectedIndex];
+            if (selected) {
+              textareaRef.current?.setText(selected.value);
+              setInputValue(selected.value);
+              setSelectedSuggestionIndex(-1);
+              textareaRef.current?.gotoLineEnd();
+            }
+          }
+          return;
+        }
+        return;
+      }
+
+      // No autocomplete visible — up/down navigates command history
+      const history = historyRef.current;
+      if (history.length === 0) return;
 
       if (key.name === "up") {
-        setSelectedSuggestionIndex((prev) =>
-          prev <= 0 ? suggestions.length - 1 : prev - 1,
-        );
+        setHistoryIndex((prev) => {
+          if (prev === -1) {
+            savedInputRef.current = textareaRef.current?.plainText ?? "";
+          }
+          const next = Math.min(prev + 1, history.length - 1);
+          const entry = history[history.length - 1 - next];
+          if (entry !== undefined) {
+            textareaRef.current?.setText(entry);
+            setInputValue(entry);
+            setTimeout(() => textareaRef.current?.gotoLineEnd(), 0);
+          }
+          return next;
+        });
         return;
       }
       if (key.name === "down") {
-        setSelectedSuggestionIndex((prev) =>
-          prev >= suggestions.length - 1 ? 0 : prev + 1,
-        );
-        return;
-      }
-      // Tab to fill suggestion without running command
-      if (key.name === "tab") {
-        key.preventDefault?.();
-        const currentSelectedIndex = selectedIndexRef.current;
-        if (
-          currentSelectedIndex >= 0 &&
-          currentSelectedIndex < suggestions.length
-        ) {
-          const selected = suggestions[currentSelectedIndex];
-          if (selected) {
-            textareaRef.current?.setText(selected.value);
-            setInputValue(selected.value);
-            setSelectedSuggestionIndex(-1);
-            textareaRef.current?.gotoLineEnd();
+        setHistoryIndex((prev) => {
+          if (prev <= 0) {
+            const saved = savedInputRef.current;
+            textareaRef.current?.setText(saved);
+            setInputValue(saved);
+            setTimeout(() => textareaRef.current?.gotoLineEnd(), 0);
+            return -1;
           }
-        }
+          const next = prev - 1;
+          const entry = history[history.length - 1 - next];
+          if (entry !== undefined) {
+            textareaRef.current?.setText(entry);
+            setInputValue(entry);
+            setTimeout(() => textareaRef.current?.gotoLineEnd(), 0);
+          }
+          return next;
+        });
         return;
       }
     });
@@ -231,16 +286,21 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
         setInputValue("");
         textareaRef.current?.setText("");
         setSelectedSuggestionIndex(-1);
+        setHistoryIndex(-1);
         return;
       }
 
+      setHistoryIndex(-1);
       onSubmitRef.current?.(valueToSubmit);
     };
 
-    // Content change syncs to context
+    // Content change syncs to context and resets history browsing
     const handleContentChange = () => {
       const text = textareaRef.current?.plainText ?? "";
       setInputValue(text);
+      if (historyIndex !== -1) {
+        setHistoryIndex(-1);
+      }
     };
 
     return (

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -110,6 +110,8 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
     const savedInputRef = useRef("");
     const historyRef = useRef(commandHistory);
     historyRef.current = commandHistory;
+    // Guard to prevent handleContentChange from resetting historyIndex during programmatic setText
+    const isNavigatingHistoryRef = useRef(false);
 
     // Refs to avoid stale closures in handleSubmit (textarea caches onSubmit)
     const selectedIndexRef = useRef(selectedSuggestionIndex);
@@ -230,8 +232,10 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
           const next = Math.min(prev + 1, history.length - 1);
           const entry = history[history.length - 1 - next];
           if (entry !== undefined) {
+            isNavigatingHistoryRef.current = true;
             textareaRef.current?.setText(entry);
             setInputValue(entry);
+            isNavigatingHistoryRef.current = false;
             setTimeout(() => textareaRef.current?.gotoLineEnd(), 0);
           }
           return next;
@@ -242,16 +246,20 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
         setHistoryIndex((prev) => {
           if (prev <= 0) {
             const saved = savedInputRef.current;
+            isNavigatingHistoryRef.current = true;
             textareaRef.current?.setText(saved);
             setInputValue(saved);
+            isNavigatingHistoryRef.current = false;
             setTimeout(() => textareaRef.current?.gotoLineEnd(), 0);
             return -1;
           }
           const next = prev - 1;
           const entry = history[history.length - 1 - next];
           if (entry !== undefined) {
+            isNavigatingHistoryRef.current = true;
             textareaRef.current?.setText(entry);
             setInputValue(entry);
+            isNavigatingHistoryRef.current = false;
             setTimeout(() => textareaRef.current?.gotoLineEnd(), 0);
           }
           return next;
@@ -298,7 +306,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
     const handleContentChange = () => {
       const text = textareaRef.current?.plainText ?? "";
       setInputValue(text);
-      if (historyIndex !== -1) {
+      if (historyIndex !== -1 && !isNavigatingHistoryRef.current) {
         setHistoryIndex(-1);
       }
     };

--- a/src/tui/components/shared/tool-registry.ts
+++ b/src/tui/components/shared/tool-registry.ts
@@ -70,6 +70,8 @@ const TOOL_SUMMARY_MAP: Record<string, ToolSummaryFn> = {
     const targets = args.targets as unknown[];
     return `pentest swarm ×${targets?.length ?? "?"}`;
   },
+  delegate_to_auth_subagent: (args) =>
+    `auth ${args.target || ""} — ${args.reason || ""}`,
 
   // Utility tools
   scratchpad: () => "note",

--- a/src/tui/components/shared/tool-registry.ts
+++ b/src/tui/components/shared/tool-registry.ts
@@ -22,7 +22,10 @@ const TOOL_SUMMARY_MAP: Record<string, ToolSummaryFn> = {
   crawl: (args) => `crawl ${args.url || args.target || ""}`,
 
   // Shell/Command tools
-  execute_command: (args) => `$ ${args.command || ""}`,
+  execute_command: (args) => {
+    const cmd = String(args.command || "").split("\n")[0];
+    return cmd.length > 80 ? `$ ${cmd.slice(0, 80)}…` : `$ ${cmd}`;
+  },
 
   // File system tools
   read_file: (args) => `read ${args.path || ""}`,

--- a/src/tui/components/shared/tool-renderer.tsx
+++ b/src/tui/components/shared/tool-renderer.tsx
@@ -18,6 +18,7 @@ const TOOLS_WITH_LOG_WINDOW = new Set([
   "run_attack_surface",
   "spawn_coding_agent",
   "spawn_pentest_swarm",
+  "delegate_to_auth_subagent",
 ]);
 
 interface ToolRendererProps {

--- a/src/tui/context/keybinding.tsx
+++ b/src/tui/context/keybinding.tsx
@@ -9,7 +9,6 @@ import {
   type KeybindingDependencies,
   type KeybindingEntry,
 } from "../keybindings";
-import { useInput } from "./input";
 import { useFocus } from "./focus";
 import { useDialog } from "./dialog";
 
@@ -36,7 +35,6 @@ export function KeybindingProvider({
   deps: ContextDeps;
 }) {
   const { promptRef, refocusPrompt } = useFocus();
-  const { isInputEmpty } = useInput();
   const { setExternalDialogOpen } = useDialog();
 
   const registry = createKeybindings({
@@ -62,7 +60,10 @@ export function KeybindingProvider({
             const isInputFocused =
               textareaRef && !textareaRef.isDestroyed && textareaRef.focused;
 
-            if (!isInputFocused || !isInputEmpty) {
+            const actualValue = promptRef.current?.getValue() ?? "";
+            const isPromptEmpty = actualValue.trim().length === 0;
+
+            if (!isInputFocused || !isPromptEmpty) {
               continue;
             }
           }


### PR DESCRIPTION
## Summary

- **Command history**: Adds persistent command history (`~/.pensar/command-history.json`) with up/down arrow navigation in both the home and operator dashboard prompt inputs. History is lazily loaded, capped at 500 entries, and skips consecutive duplicates.
- **Subagent display callbacks**: Wires `onSubagentSpawn`/`onSubagentComplete` lifecycle callbacks into the `delegate_to_auth_subagent` and `run_attack_surface` tools, and registers `delegate_to_auth_subagent` in the tool summary map and log-window set so the TUI renders it properly.
- **Keybinding fix**: Fixes the `?` help shortcut intercepting keystrokes while the user is typing by reading the prompt value directly from the ref instead of relying on potentially stale context state.

## Changes

| File | What changed |
|------|-------------|
| `src/core/history.ts` | New module — lazy-load, push, and sync command history to disk |
| `src/tui/components/shared/prompt-input.tsx` | Up/down arrow navigates command history when autocomplete is not visible |
| `src/tui/components/chat/home-view.tsx` | Loads history, passes it to `PromptInput`, pushes on submit/command |
| `src/tui/components/operator-dashboard/index.tsx` | Same history integration for the operator dashboard |
| `src/core/agents/offSecAgent/tools/delegateAuth.ts` | Fires subagent spawn/complete callbacks + forwards streaming events |
| `src/core/agents/offSecAgent/tools/runAttackSurface.ts` | Fires subagent spawn/complete callbacks for whitebox & blackbox paths |
| `src/tui/components/shared/tool-registry.ts` | Adds `delegate_to_auth_subagent` summary |
| `src/tui/components/shared/tool-renderer.tsx` | Adds `delegate_to_auth_subagent` to log-window tool set |
| `src/tui/context/keybinding.tsx` | Reads prompt value via ref instead of context to fix `?` shortcut |

## Test plan

- [x] `bun run tsc` — passes
- [x] `bun run lint` — passes
- [x] `bun run test` — 226 passed, 15 skipped


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds persistent local command history and changes how subagent events are surfaced through tool callbacks, which could affect TUI input behavior and agent/tool streaming logs if miswired. No changes to core exploitation logic, but touches auth delegation and recon orchestration instrumentation.
> 
> **Overview**
> **Adds persistent command history** stored in `~/.pensar/command-history.json`, plumbed through `HomeView` and `OperatorDashboard` into `PromptInput` so users can navigate prior commands with up/down arrows (history is lazy-loaded, capped, and avoids consecutive duplicates).
> 
> **Improves subagent observability in the TUI** by emitting `onSubagentSpawn`/`onSubagentComplete` from `delegate_to_auth_subagent` and `run_attack_surface`, forwarding subagent streaming events with a `subagentId`, and updating tool rendering (`tool-registry` summary + log-window support) for `delegate_to_auth_subagent`. Also tightens the `?`/shift keybinding gating by checking the prompt’s actual current value via ref, and truncates `execute_command` tool summaries to a single (possibly shortened) line; bumps version to `0.0.81`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59e03e9d5eff4591042e1a07ef1dac3f8c31854d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->