### PR TITLE
feat: AI-generated session names + decouple session creation from TUI

### DIFF
--- a/src/core/agents/offSecAgent/index.ts
+++ b/src/core/agents/offSecAgent/index.ts
@@ -4,6 +4,7 @@
 export { OffensiveSecurityAgent } from "./offensiveSecurityAgent";
 export type {
   OffensiveSecurityAgentInput,
+  CreateAgentInput,
   SpecializedAgentInput,
   ConsumeCallbacks,
 } from "./types";

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -7,13 +7,18 @@ import type {
   ToolSet,
 } from "ai";
 import { hasToolCall } from "ai";
-import type { OffensiveSecurityAgentInput, ConsumeCallbacks } from "./types";
+import type {
+  OffensiveSecurityAgentInput,
+  CreateAgentInput,
+  ConsumeCallbacks,
+} from "./types";
 import { createAllTools, EMAIL_TOOL_NAMES_ACTIVE } from "./tools";
 import { createResponseTool, RESPONSE_TOOL_NAME } from "./tools/response";
 import { PersistentShell } from "./tools/persistentShell";
 import { DEFAULT_SYSTEM_PROMPT } from "./prompt";
 import type { ApprovalGate } from "../../operator";
 import { ApprovalDeniedError } from "../../operator";
+import { create as createSession, type SessionInfo } from "../../session";
 import { join } from "path";
 import { writeFileSync, mkdirSync, existsSync } from "fs";
 
@@ -65,7 +70,39 @@ export class OffensiveSecurityAgent<TResult = void> {
   /** Persistent shell for local-mode command execution; disposed on consume() completion. */
   private readonly persistentShell?: PersistentShell;
 
+  /** The session this agent is operating within. */
+  private readonly _session: SessionInfo;
+
+  /**
+   * Async factory that creates a session when one is not provided,
+   * then constructs the agent. Use this instead of `new` when you
+   * want the agent to own session lifecycle.
+   *
+   * Pass an existing `session` to reuse one (console integration,
+   * subagent spawning, etc.).
+   */
+  static async create<TResult = void>(
+    input: CreateAgentInput<TResult>,
+  ): Promise<OffensiveSecurityAgent<TResult>> {
+    let session = input.session;
+    if (!session) {
+      session = await createSession({
+        targets: input.target ? [input.target] : [],
+        config: input.sessionConfig,
+        model: input.model,
+        authConfig: input.authConfig,
+      });
+    }
+    return new OffensiveSecurityAgent({ ...input, session });
+  }
+
+  /** The session this agent is operating within. */
+  get session(): SessionInfo {
+    return this._session;
+  }
+
   constructor(input: OffensiveSecurityAgentInput<TResult>) {
+    this._session = input.session;
     this.subagentId = input.subagentId;
 
     // -- Persistent shell (local mode only) -----------------------------------

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -91,9 +91,14 @@ export class OffensiveSecurityAgent<TResult = void> {
         config: input.sessionConfig,
         model: input.model,
         authConfig: input.authConfig,
+        userMessage: input.prompt,
+        onNameGenerated: input.onNameGenerated,
       });
     }
-    return new OffensiveSecurityAgent({ ...input, session });
+    const system = input.buildSystem
+      ? input.buildSystem(session)
+      : (input.system ?? DEFAULT_SYSTEM_PROMPT);
+    return new OffensiveSecurityAgent({ ...input, session, system });
   }
 
   /** The session this agent is operating within. */

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -12,7 +12,7 @@ import type { AIModel } from "../../ai";
 import type { AIAuthConfig } from "../../ai/utils";
 import type { CredentialManager } from "../../credentials";
 import type { FindingsRegistry } from "../../findings/registry";
-import type { SessionInfo } from "../../session";
+import type { SessionInfo, SessionConfig } from "../../session";
 import type { ApprovalGate } from "../../operator";
 import type { ToolName } from "./tools";
 import type { UnifiedSandbox } from "./tools/sandbox";
@@ -293,4 +293,24 @@ export type SubagentConsumeCallbacks = {
     },
   ) => void;
   onError?: (error: unknown) => void;
+};
+
+/**
+ * Input for the `OffensiveSecurityAgent.create()` async factory.
+ *
+ * Identical to {@link OffensiveSecurityAgentInput} except `session` is
+ * optional. When omitted, the factory creates a new session automatically
+ * using the remaining fields.
+ *
+ * Pass an existing `session` to reuse one (e.g. from the console API or
+ * when spawning subagents).
+ */
+export type CreateAgentInput<TResult = void> = Omit<
+  OffensiveSecurityAgentInput<TResult>,
+  "session"
+> & {
+  /** Existing session to reuse. When omitted a new one is created. */
+  session?: SessionInfo;
+  /** Session config used when auto-creating a session (ignored when `session` is provided). */
+  sessionConfig?: SessionConfig;
 };

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -307,10 +307,23 @@ export type SubagentConsumeCallbacks = {
  */
 export type CreateAgentInput<TResult = void> = Omit<
   OffensiveSecurityAgentInput<TResult>,
-  "session"
+  "session" | "system"
 > & {
   /** Existing session to reuse. When omitted a new one is created. */
   session?: SessionInfo;
   /** Session config used when auto-creating a session (ignored when `session` is provided). */
   sessionConfig?: SessionConfig;
+  /**
+   * Static system prompt. Used when `session` is provided.
+   * When omitted and `buildSystem` is set, the factory builds the prompt
+   * after creating the session.
+   */
+  system?: string;
+  /**
+   * Called with the created/resolved session to build the system prompt.
+   * Takes precedence over `system` when a session is auto-created.
+   */
+  buildSystem?: (session: SessionInfo) => string;
+  /** Called when the async AI name generation resolves with a name. */
+  onNameGenerated?: (name: string) => void;
 };

--- a/src/core/api/offesecAgent.ts
+++ b/src/core/api/offesecAgent.ts
@@ -1,12 +1,25 @@
-import type { OffensiveSecurityAgentInput } from "../agents/offSecAgent";
+import type {
+  OffensiveSecurityAgentInput,
+  CreateAgentInput,
+} from "../agents/offSecAgent";
 import type { StreamTextResult, ToolSet } from "ai";
 
 import { OffensiveSecurityAgent } from "../agents/offSecAgent/offensiveSecurityAgent";
 
+/**
+ * Run the offensive security agent, consuming its stream to completion.
+ *
+ * Accepts either a full {@link OffensiveSecurityAgentInput} (with a
+ * pre-existing session) or a {@link CreateAgentInput} where `session`
+ * is optional and will be auto-created.
+ */
 export async function runOffensiveSecurityAgent(
-  input: OffensiveSecurityAgentInput,
+  input: OffensiveSecurityAgentInput | CreateAgentInput,
 ): Promise<StreamTextResult<ToolSet, never>> {
-  const agent = new OffensiveSecurityAgent(input);
+  const agent = input.session
+    ? new OffensiveSecurityAgent(input as OffensiveSecurityAgentInput)
+    : await OffensiveSecurityAgent.create(input as CreateAgentInput);
+
   await agent.consume({
     onTextDelta: (d) => input.callbacks?.onTextDelta?.(d),
     onToolCall: (d) => input.callbacks?.onToolCall?.(d),

--- a/src/core/api/offesecAgent.ts
+++ b/src/core/api/offesecAgent.ts
@@ -3,8 +3,14 @@ import type {
   CreateAgentInput,
 } from "../agents/offSecAgent";
 import type { StreamTextResult, ToolSet } from "ai";
+import type { SessionInfo } from "../session";
 
 import { OffensiveSecurityAgent } from "../agents/offSecAgent/offensiveSecurityAgent";
+
+export interface RunAgentResult {
+  streamResult: StreamTextResult<ToolSet, never>;
+  session: SessionInfo;
+}
 
 /**
  * Run the offensive security agent, consuming its stream to completion.
@@ -12,10 +18,13 @@ import { OffensiveSecurityAgent } from "../agents/offSecAgent/offensiveSecurityA
  * Accepts either a full {@link OffensiveSecurityAgentInput} (with a
  * pre-existing session) or a {@link CreateAgentInput} where `session`
  * is optional and will be auto-created.
+ *
+ * Returns the stream result **and** the session so callers can access a
+ * session that was auto-created by the factory.
  */
 export async function runOffensiveSecurityAgent(
   input: OffensiveSecurityAgentInput | CreateAgentInput,
-): Promise<StreamTextResult<ToolSet, never>> {
+): Promise<RunAgentResult> {
   const agent = input.session
     ? new OffensiveSecurityAgent(input as OffensiveSecurityAgentInput)
     : await OffensiveSecurityAgent.create(input as CreateAgentInput);
@@ -27,5 +36,5 @@ export async function runOffensiveSecurityAgent(
     onError: (e) => input.callbacks?.onError?.(e),
     subagentCallbacks: input.callbacks?.subagentCallbacks,
   });
-  return agent.streamResult;
+  return { streamResult: agent.streamResult, session: agent.session };
 }

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -375,6 +375,10 @@ export interface CreateInputProps {
   model?: AIModel;
   /** Auth config for the AI provider (optional). */
   authConfig?: AIAuthConfig;
+  /** User objective / first prompt — used as context for AI name generation. */
+  userMessage?: string;
+  /** Called when the async AI name generation resolves with a name. */
+  onNameGenerated?: (name: string) => void;
 }
 
 export async function create(input: CreateInputProps) {
@@ -451,13 +455,16 @@ export async function create(input: CreateInputProps) {
   if (!input.name && input.model) {
     generateSessionName({
       targets: input.targets,
+      userMessage: input.userMessage,
       model: input.model,
       authConfig: input.authConfig,
     }).then((aiName) => {
       if (aiName) {
+        result.name = aiName;
         update(result.id, (s) => {
           s.name = aiName;
         }).catch(() => {});
+        input.onNameGenerated?.(aiName);
       }
     });
   }

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -341,7 +341,7 @@ export function getOffensiveHeaders(
 
 export const SessionInfoObject = z.object({
   id: Identifier.schema("session"),
-  name: z.string(),
+  name: z.string().optional(),
   version: z.string(),
   targets: z.array(z.string()),
   config: SessionConfigObject.optional(),
@@ -378,19 +378,7 @@ export interface CreateInputProps {
 }
 
 export async function create(input: CreateInputProps) {
-  let name = input.name;
-  if (!name) {
-    if (input.model) {
-      name =
-        (await generateSessionName({
-          targets: input.targets,
-          model: input.model,
-          authConfig: input.authConfig,
-        })) ?? generateRandomName();
-    } else {
-      name = generateRandomName();
-    }
-  }
+  const name = input.name ?? generateRandomName();
 
   const id =
     `${input.prefix ? input.prefix : ""}` +
@@ -458,6 +446,22 @@ export async function create(input: CreateInputProps) {
   const { _rateLimiter, credentialManager: _cm, ...sessionData } = result;
   await createSessionDirs({ session: result });
   await Storage.write(["sessions", result.id, "session"], sessionData);
+
+  // Fire-and-forget AI name generation — updates persisted session in the background
+  if (!input.name && input.model) {
+    generateSessionName({
+      targets: input.targets,
+      model: input.model,
+      authConfig: input.authConfig,
+    }).then((aiName) => {
+      if (aiName) {
+        update(result.id, (s) => {
+          s.name = aiName;
+        }).catch(() => {});
+      }
+    });
+  }
+
   return result;
 }
 

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -14,6 +14,9 @@ import {
   type ToolsetState,
   toggleTool as toolsetToggle,
 } from "../toolset";
+import type { AIModel } from "../ai/ai";
+import type { AIAuthConfig } from "../ai/utils";
+import { generateRandomName, generateSessionName } from "../../util/name";
 
 /**
  * Default outcome guidance (safe, non-destructive)
@@ -360,17 +363,35 @@ export type SessionInfo = z.output<typeof SessionInfoObject> & {
   tokensOut?: number;
 };
 
-interface CreateInputProps {
+export interface CreateInputProps {
   id?: string;
   targets: string[];
-  name: string;
+  /** Explicit session name. When omitted, an AI-generated name is attempted
+   *  (requires `model` + `authConfig`), falling back to a random name. */
+  name?: string;
   prefix?: string;
   config?: SessionConfig;
-  // offensiveHeaders?: OffensiveHeadersConfig;
-  // outcomeGuidance?: string;
+  /** AI model for session name generation (optional). */
+  model?: AIModel;
+  /** Auth config for the AI provider (optional). */
+  authConfig?: AIAuthConfig;
 }
 
 export async function create(input: CreateInputProps) {
+  let name = input.name;
+  if (!name) {
+    if (input.model) {
+      name =
+        (await generateSessionName({
+          targets: input.targets,
+          model: input.model,
+          authConfig: input.authConfig,
+        })) ?? generateRandomName();
+    } else {
+      name = generateRandomName();
+    }
+  }
+
   const id =
     `${input.prefix ? input.prefix : ""}` +
     Identifier.descending("session", input.id);
@@ -402,7 +423,7 @@ export async function create(input: CreateInputProps) {
     id: id,
     version: getCurrentVersion(),
     targets: input.targets,
-    name: input.name,
+    name,
     time: {
       created: Date.now(),
       updated: Date.now(),

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -3,8 +3,8 @@ import type { Route } from "./context/route";
 import {
   parseWebFlags,
   hasEnoughFlagsToSkipWizard,
-  createOperatorSessionFromFlags,
-  createSwarmSessionFromFlags,
+  buildOperatorSessionConfig,
+  buildSwarmSessionConfig,
 } from "./utils/command-flags";
 import { getAllThemeNames } from "./theme";
 import { config } from "../core/config";
@@ -105,14 +105,13 @@ export const commands: CommandConfig[] = [
 
       // Pentest command always uses swarm mode
       if (flags.target && hasEnoughFlagsToSkipWizard(flags)) {
-        try {
-          const session = await createSwarmSessionFromFlags(flags);
-          ctx.navigate({ type: "pentest", sessionId: session.id });
-          return;
-        } catch (e) {
-          // Fall through to wizard on error
-          console.error("Failed to create session:", e);
-        }
+        const params = buildSwarmSessionConfig(flags);
+        ctx.navigate({
+          type: "pentest",
+          targets: params.targets,
+          sessionConfig: params.config,
+        });
+        return;
       }
       // Navigate to WebWizard (swarm wizard) for target input
       ctx.navigate({
@@ -184,12 +183,14 @@ export const commands: CommandConfig[] = [
     ],
     handler: async (args, ctx) => {
       const flags = parseWebFlags(args);
-      try {
-        const session = await createOperatorSessionFromFlags(flags);
-        ctx.navigate({ type: "operator", sessionId: session.id });
-      } catch (e) {
-        console.error("Failed to create operator session:", e);
-      }
+      const params = buildOperatorSessionConfig(flags);
+      ctx.navigate({
+        type: "operator",
+        initialConfig: {
+          requireApproval: flags.requireApproval ?? true,
+          target: flags.target,
+        },
+      });
     },
   },
   {

--- a/src/tui/components/commands/init-wizard.tsx
+++ b/src/tui/components/commands/init-wizard.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useKeyboard } from "@opentui/react";
 import Input from "../input";
 import { useRoute } from "../../context/route";
-import { sessions, type SessionConfig } from "../../../core/session";
+import type { SessionConfig } from "../../../core/session";
 import { SpinnerDots } from "../sprites";
 import { useTheme } from "../../theme";
 
@@ -116,23 +116,10 @@ export default function InitWizard() {
         };
       }
 
-      // Create session
-      // const session = await Session.createSessionDirs({
-      //   target: state.target,
-      //   objective: `Pentest: ${state.target}`,
-      //   prefix: state.name || undefined,
-      //   config: sessionConfig,
-      // });
-
-      const session = await sessions.create({
-        targets: [state.target],
-        config: sessionConfig,
-      });
-
-      // Navigate to session route - SessionView will handle execution
       route.navigate({
         type: "pentest",
-        sessionId: session.id,
+        targets: [state.target],
+        sessionConfig,
       });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create session");

--- a/src/tui/components/commands/init-wizard.tsx
+++ b/src/tui/components/commands/init-wizard.tsx
@@ -4,7 +4,6 @@ import Input from "../input";
 import { useRoute } from "../../context/route";
 import { sessions, type SessionConfig } from "../../../core/session";
 import { SpinnerDots } from "../sprites";
-import { generateRandomName } from "../../../util/name";
 import { useTheme } from "../../theme";
 
 // Simplified wizard step types
@@ -127,7 +126,6 @@ export default function InitWizard() {
 
       const session = await sessions.create({
         targets: [state.target],
-        name: generateRandomName(),
         config: sessionConfig,
       });
 

--- a/src/tui/components/commands/init-wizard.tsx
+++ b/src/tui/components/commands/init-wizard.tsx
@@ -12,7 +12,6 @@ type WizardStep = "target" | "configure" | "creating";
 
 // Simplified wizard state interface
 interface WizardState {
-  name: string;
   target: string;
   auth: {
     loginUrl: string;
@@ -38,7 +37,6 @@ export default function InitWizard() {
   // Wizard state
   const [currentStep, setCurrentStep] = useState<WizardStep>("target");
   const [state, setState] = useState<WizardState>(() => ({
-    name: generateRandomName(),
     target: "",
     auth: {
       loginUrl: "",
@@ -129,7 +127,7 @@ export default function InitWizard() {
 
       const session = await sessions.create({
         targets: [state.target],
-        name: state.name,
+        name: generateRandomName(),
         config: sessionConfig,
       });
 
@@ -167,16 +165,9 @@ export default function InitWizard() {
 
     // Target step: Enter to start, Tab to navigate/configure
     if (currentStep === "target") {
-      // Tab navigation between name and target fields
       if (key.name === "tab") {
-        if (key.shift) {
-          setTargetFocusedField((prev) => Math.max(0, prev - 1));
-        } else {
-          if (targetFocusedField === 1 && state.target.trim()) {
-            setCurrentStep("configure");
-          } else {
-            setTargetFocusedField((prev) => Math.min(1, prev + 1));
-          }
+        if (!key.shift && targetFocusedField === 0 && state.target.trim()) {
+          setCurrentStep("configure");
         }
         return;
       }
@@ -331,21 +322,12 @@ export default function InitWizard() {
         {error && <text fg={colors.error}>Error: {error}</text>}
 
         <Input
-          label="Session Name"
-          description="Auto-generated, edit if desired"
-          placeholder="swift-falcon"
-          value={state.name}
-          onInput={(v) => setState((prev) => ({ ...prev, name: v }))}
-          focused={targetFocusedField === 0}
-        />
-
-        <Input
           label="Target URL"
           description="e.g., https://example.com"
           placeholder="https://example.com"
           value={state.target}
           onInput={(v) => setState((prev) => ({ ...prev, target: v }))}
-          focused={targetFocusedField === 1}
+          focused={targetFocusedField === 0}
         />
 
         <box flexDirection="column" gap={0} marginTop={1}>

--- a/src/tui/components/commands/operator-wizard.tsx
+++ b/src/tui/components/commands/operator-wizard.tsx
@@ -5,8 +5,8 @@ import { useConfig } from "../../context/config";
 import { useAgent } from "../../context/agent";
 import { sessions, type SessionConfig } from "../../../core/session";
 import { SpinnerDots } from "../sprites";
-import { generateRandomName } from "../../../util/name";
 import type { ModelInfo } from "../../../core/ai";
+import { buildAuthConfig } from "../../../core/ai/utils";
 import { getAvailableModels } from "../../../core/providers/utils";
 import { useTheme } from "../../theme";
 
@@ -130,8 +130,9 @@ export default function HITLWizard(props: HITLWizardProps) {
       const targets = state.target.trim() ? [state.target] : [];
       const session = await sessions.create({
         targets,
-        name: generateRandomName(),
         config: sessionConfig,
+        model: model.id,
+        authConfig: buildAuthConfig(config.data),
       });
 
       route.navigate({

--- a/src/tui/components/commands/operator-wizard.tsx
+++ b/src/tui/components/commands/operator-wizard.tsx
@@ -3,10 +3,8 @@ import { useKeyboard } from "@opentui/react";
 import { useRoute } from "../../context/route";
 import { useConfig } from "../../context/config";
 import { useAgent } from "../../context/agent";
-import { sessions, type SessionConfig } from "../../../core/session";
 import { SpinnerDots } from "../sprites";
 import type { ModelInfo } from "../../../core/ai";
-import { buildAuthConfig } from "../../../core/ai/utils";
 import { getAvailableModels } from "../../../core/providers/utils";
 import { useTheme } from "../../theme";
 
@@ -112,37 +110,14 @@ export default function HITLWizard(props: HITLWizardProps) {
     return result;
   }, [groupedModels, expandedProviders]);
 
-  async function createSessionAndNavigate() {
-    setCurrentStep("creating");
-    setError(null);
-
-    try {
-      const sessionConfig: SessionConfig = {
-        sessionType: "web-app",
-        mode: "operator",
-        operatorSettings: {
-          initialMode: "auto",
-          requireApproval: state.requireApproval,
-          enableSuggestions: true,
-        },
-      };
-
-      const targets = state.target.trim() ? [state.target] : [];
-      const session = await sessions.create({
-        targets,
-        config: sessionConfig,
-        model: model.id,
-        authConfig: buildAuthConfig(config.data),
-      });
-
-      route.navigate({
-        type: "operator",
-        sessionId: session.id,
-      });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to create session");
-      setCurrentStep("config");
-    }
+  function createSessionAndNavigate() {
+    route.navigate({
+      type: "operator",
+      initialConfig: {
+        requireApproval: state.requireApproval,
+        target: state.target.trim() || undefined,
+      },
+    });
   }
 
   // Config step fields:

--- a/src/tui/components/commands/operator-wizard.tsx
+++ b/src/tui/components/commands/operator-wizard.tsx
@@ -13,7 +13,6 @@ import { useTheme } from "../../theme";
 type WizardStep = "config" | "creating";
 
 interface WizardState {
-  name: string;
   target: string;
   requireApproval: boolean;
 }
@@ -41,8 +40,7 @@ const providerOrder = ["anthropic", "openai", "openrouter", "bedrock"];
 
 export default function HITLWizard(props: HITLWizardProps) {
   const { colors } = useTheme();
-  const { initialTarget, initialName, initialRequireApproval, initialModel } =
-    props;
+  const { initialTarget, initialRequireApproval, initialModel } = props;
 
   const route = useRoute();
   const config = useConfig();
@@ -50,12 +48,11 @@ export default function HITLWizard(props: HITLWizardProps) {
 
   const [currentStep, setCurrentStep] = useState<WizardStep>("config");
   const [state, setState] = useState<WizardState>(() => ({
-    name: initialName || generateRandomName(),
     target: initialTarget || "",
     requireApproval: initialRequireApproval ?? true,
   }));
 
-  const [focusedField, setFocusedField] = useState(0);
+  const [focusedField, setFocusedField] = useState(0); // 0=approval, 1=model, 2=submit
   const [error, setError] = useState<string | null>(null);
 
   // Model picker state
@@ -133,7 +130,7 @@ export default function HITLWizard(props: HITLWizardProps) {
       const targets = state.target.trim() ? [state.target] : [];
       const session = await sessions.create({
         targets,
-        name: state.name,
+        name: generateRandomName(),
         config: sessionConfig,
       });
 
@@ -148,11 +145,10 @@ export default function HITLWizard(props: HITLWizardProps) {
   }
 
   // Config step fields:
-  // 0: Session name
-  // 1: Require approval toggle
-  // 2: Model selection
-  // 3: Submit button
-  const maxField = 3;
+  // 0: Require approval toggle
+  // 1: Model selection
+  // 2: Submit button
+  const maxField = 2;
 
   useKeyboard((key) => {
     if (key.name === "escape") {
@@ -164,8 +160,6 @@ export default function HITLWizard(props: HITLWizardProps) {
     if (currentStep === "creating") return;
 
     if (currentStep === "config") {
-      const isEditingText = focusedField === 0;
-
       if (key.name === "up") {
         setFocusedField((prev) => Math.max(0, prev - 1));
         return;
@@ -183,11 +177,11 @@ export default function HITLWizard(props: HITLWizardProps) {
         return;
       }
 
-      if (!isEditingText && (key.name === "left" || key.name === "right")) {
+      if (key.name === "left" || key.name === "right") {
         const delta = key.name === "left" ? -1 : 1;
 
-        // Require approval toggle (field 1)
-        if (focusedField === 1) {
+        // Require approval toggle (field 0)
+        if (focusedField === 0) {
           setState((prev) => ({
             ...prev,
             requireApproval: !prev.requireApproval,
@@ -195,8 +189,8 @@ export default function HITLWizard(props: HITLWizardProps) {
           return;
         }
 
-        // Model selection (field 2)
-        if (focusedField === 2 && visibleModels.length > 0) {
+        // Model selection (field 1)
+        if (focusedField === 1 && visibleModels.length > 0) {
           const currentIdx = visibleModels.findIndex((m) => m.id === model.id);
           const newIdx = Math.max(
             0,
@@ -209,14 +203,8 @@ export default function HITLWizard(props: HITLWizardProps) {
       }
 
       if (key.name === "return") {
-        // Session name (field 0) — advance to next field
+        // Require approval toggle (field 0)
         if (focusedField === 0) {
-          setFocusedField(1);
-          return;
-        }
-
-        // Require approval toggle (field 1)
-        if (focusedField === 1) {
           setState((prev) => ({
             ...prev,
             requireApproval: !prev.requireApproval,
@@ -224,8 +212,8 @@ export default function HITLWizard(props: HITLWizardProps) {
           return;
         }
 
-        // Submit button (field 3)
-        if (focusedField === 3) {
+        // Submit button (field 2)
+        if (focusedField === 2) {
           createSessionAndNavigate();
         }
         return;
@@ -245,7 +233,6 @@ export default function HITLWizard(props: HITLWizardProps) {
         gap={2}
       >
         <SpinnerDots label="Creating operator session..." fg={colors.primary} />
-        <text fg={colors.textMuted}>Session: {state.name}</text>
       </box>
     );
   }
@@ -261,36 +248,12 @@ export default function HITLWizard(props: HITLWizardProps) {
 
       {error && <text fg={colors.error}>Error: {error}</text>}
 
-      {/* Session Name - Field 0 */}
+      {/* Require Approval Toggle - Field 0 */}
       <box flexDirection="row" gap={1}>
         <text fg={focusedField === 0 ? colors.primary : colors.textMuted}>
           {focusedField === 0 ? "▸" : " "}
         </text>
         <text fg={focusedField === 0 ? colors.text : colors.textMuted}>
-          Session:
-        </text>
-        {focusedField === 0 ? (
-          <input
-            width={30}
-            value={state.name}
-            onInput={(v: string) => setState((prev) => ({ ...prev, name: v }))}
-            focused={true}
-            placeholder="swift-falcon"
-            textColor={colors.text}
-            backgroundColor="transparent"
-            cursorColor={colors.textMuted}
-          />
-        ) : (
-          <text fg={colors.text}>{state.name}</text>
-        )}
-      </box>
-
-      {/* Require Approval Toggle - Field 1 */}
-      <box flexDirection="row" gap={1}>
-        <text fg={focusedField === 1 ? colors.primary : colors.textMuted}>
-          {focusedField === 1 ? "▸" : " "}
-        </text>
-        <text fg={focusedField === 1 ? colors.text : colors.textMuted}>
           Require command approval:
         </text>
         <text fg={state.requireApproval ? colors.warning : colors.primary}>
@@ -301,34 +264,34 @@ export default function HITLWizard(props: HITLWizardProps) {
             ? "- approve each command before execution"
             : "- commands execute automatically"}
         </text>
-        {focusedField === 1 && <text fg={colors.textMuted}>(Enter/←/→)</text>}
+        {focusedField === 0 && <text fg={colors.textMuted}>(Enter/←/→)</text>}
       </box>
 
-      {/* Model Selection - Field 2 */}
+      {/* Model Selection - Field 1 */}
       <box flexDirection="row" gap={1}>
-        <text fg={focusedField === 2 ? colors.primary : colors.textMuted}>
-          {focusedField === 2 ? "▸" : " "}
+        <text fg={focusedField === 1 ? colors.primary : colors.textMuted}>
+          {focusedField === 1 ? "▸" : " "}
         </text>
-        <text fg={focusedField === 2 ? colors.text : colors.textMuted}>
+        <text fg={focusedField === 1 ? colors.text : colors.textMuted}>
           Model:
         </text>
         <text fg={colors.primary}>{model.name}</text>
-        {focusedField === 2 && <text fg={colors.textMuted}>(←/→)</text>}
+        {focusedField === 1 && <text fg={colors.textMuted}>(←/→)</text>}
       </box>
 
-      {/* Submit Button - Field 3 */}
+      {/* Submit Button - Field 2 */}
       <box flexDirection="row" gap={1} marginTop={1}>
-        <text fg={focusedField === 3 ? colors.primary : colors.textMuted}>
-          {focusedField === 3 ? "▸" : " "}
+        <text fg={focusedField === 2 ? colors.primary : colors.textMuted}>
+          {focusedField === 2 ? "▸" : " "}
         </text>
-        <text fg={focusedField === 3 ? colors.primary : colors.textMuted}>
-          {focusedField === 3 ? "[" : " "}
+        <text fg={focusedField === 2 ? colors.primary : colors.textMuted}>
+          {focusedField === 2 ? "[" : " "}
         </text>
-        <text fg={focusedField === 3 ? colors.text : colors.textMuted}>
+        <text fg={focusedField === 2 ? colors.text : colors.textMuted}>
           Start Session
         </text>
-        <text fg={focusedField === 3 ? colors.primary : colors.textMuted}>
-          {focusedField === 3 ? "]" : " "}
+        <text fg={focusedField === 2 ? colors.primary : colors.textMuted}>
+          {focusedField === 2 ? "]" : " "}
         </text>
       </box>
 

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -6,8 +6,8 @@ import { useConfig } from "../../context/config";
 import { useAgent } from "../../context/agent";
 import { sessions, type SessionConfig } from "../../../core/session";
 import { SpinnerDots } from "../sprites";
-import { generateRandomName } from "../../../util/name";
 import { type ModelInfo } from "../../../core/ai";
+import { buildAuthConfig } from "../../../core/ai/utils";
 import { getAvailableModels } from "../../../core/providers/utils";
 import { useTheme } from "../../theme";
 
@@ -283,8 +283,9 @@ export default function WebWizard({
 
       const session = await sessions.create({
         targets: [state.target],
-        name: generateRandomName(),
         config: sessionConfig,
+        model: model.id,
+        authConfig: buildAuthConfig(config.data),
       });
 
       // Navigate to session route - SessionView will handle execution based on mode

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -16,7 +16,6 @@ type WizardStep = "target" | "configure" | "creating";
 
 // Wizard state interface
 interface WizardState {
-  name: string;
   target: string;
   sourceCodeAccess: boolean;
   cwd: string;
@@ -185,7 +184,6 @@ export default function WebWizard({
   // Wizard state
   const [currentStep, setCurrentStep] = useState<WizardStep>(initialStep);
   const [state, setState] = useState<WizardState>(() => ({
-    name: initialName || generateRandomName(),
     target: initialTarget || "",
     sourceCodeAccess: false,
     cwd: process.cwd(),
@@ -208,7 +206,7 @@ export default function WebWizard({
   }));
 
   // UI state for target step
-  const [targetFocusedField, setTargetFocusedField] = useState(0); // 0=name, 1=target, 2=source code access
+  const [targetFocusedField, setTargetFocusedField] = useState(0); // 0=target, 1=source code access, 2=cwd (if enabled)
 
   // UI state for configure step
   const [focusedSection, setFocusedSection] = useState(0); // 0=auth, 1=scope, 2=headers
@@ -285,7 +283,7 @@ export default function WebWizard({
 
       const session = await sessions.create({
         targets: [state.target],
-        name: state.name,
+        name: generateRandomName(),
         config: sessionConfig,
       });
 
@@ -328,7 +326,7 @@ export default function WebWizard({
 
     // Target step: Enter to start, Tab to navigate/configure
     if (currentStep === "target") {
-      const maxTargetField = state.sourceCodeAccess ? 3 : 2; // 0=name, 1=target, 2=toggle, 3=cwd (if enabled)
+      const maxTargetField = state.sourceCodeAccess ? 2 : 1; // 0=target, 1=toggle, 2=cwd (if enabled)
       // Tab navigation
       if (key.name === "tab") {
         if (key.shift) {
@@ -344,7 +342,7 @@ export default function WebWizard({
       }
       // Up/Down to toggle source code access when focused
       if (
-        targetFocusedField === 2 &&
+        targetFocusedField === 1 &&
         (key.name === "up" || key.name === "down")
       ) {
         setState((prev) => ({
@@ -611,27 +609,18 @@ export default function WebWizard({
         {error && <text fg={colors.error}>Error: {error}</text>}
 
         <Input
-          label="Session Name"
-          description="Auto-generated, edit if desired"
-          placeholder="swift-falcon"
-          value={state.name}
-          onInput={(v) => setState((prev) => ({ ...prev, name: v }))}
-          focused={targetFocusedField === 0}
-        />
-
-        <Input
           label="Target URL"
           description="e.g., https://example.com"
           placeholder="https://example.com"
           value={state.target}
           onInput={(v) => setState((prev) => ({ ...prev, target: v }))}
-          focused={targetFocusedField === 1}
+          focused={targetFocusedField === 0}
         />
 
         <box flexDirection="column" gap={1}>
           <box flexDirection="row" gap={1}>
             <text
-              fg={targetFocusedField === 2 ? colors.primary : colors.textMuted}
+              fg={targetFocusedField === 1 ? colors.primary : colors.textMuted}
             >
               Source Code Access:
             </text>
@@ -640,7 +629,7 @@ export default function WebWizard({
             >
               {state.sourceCodeAccess ? "● Enabled" : "○ Disabled"}
             </text>
-            {targetFocusedField === 2 && (
+            {targetFocusedField === 1 && (
               <text fg={colors.textMuted}>(↑/↓ to toggle)</text>
             )}
           </box>
@@ -651,7 +640,7 @@ export default function WebWizard({
               placeholder={process.cwd()}
               value={state.cwd}
               onInput={(v) => setState((prev) => ({ ...prev, cwd: v }))}
-              focused={targetFocusedField === 3}
+              focused={targetFocusedField === 2}
             />
           )}
         </box>

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -4,10 +4,9 @@ import Input from "../input";
 import { useRoute } from "../../context/route";
 import { useConfig } from "../../context/config";
 import { useAgent } from "../../context/agent";
-import { sessions, type SessionConfig } from "../../../core/session";
+import type { SessionConfig } from "../../../core/session";
 import { SpinnerDots } from "../sprites";
 import { type ModelInfo } from "../../../core/ai";
-import { buildAuthConfig } from "../../../core/ai/utils";
 import { getAvailableModels } from "../../../core/providers/utils";
 import { useTheme } from "../../theme";
 
@@ -281,17 +280,10 @@ export default function WebWizard({
         };
       }
 
-      const session = await sessions.create({
-        targets: [state.target],
-        config: sessionConfig,
-        model: model.id,
-        authConfig: buildAuthConfig(config.data),
-      });
-
-      // Navigate to session route - SessionView will handle execution based on mode
       route.navigate({
         type: "pentest",
-        sessionId: session.id,
+        targets: [state.target],
+        sessionConfig,
       });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create session");

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -15,7 +15,6 @@ import {
   type SessionConfig,
 } from "../../../core/session";
 import { runOffensiveSecurityAgent } from "../../../core/api/offesecAgent";
-import { generateRandomName, generateSessionName } from "../../../util/name";
 import { buildAuthConfig } from "../../../core/ai/utils";
 import { ALL_TOOL_NAMES } from "../../../core/agents/offSecAgent";
 import {
@@ -122,8 +121,6 @@ export default function OperatorDashboard({
   const textRef = useRef("");
   // AI SDK conversation history for multi-turn continuity
   const conversationRef = useRef<ModelMessage[]>([]);
-  // Track whether we've already kicked off AI session name generation
-  const nameGenTriggeredRef = useRef(false);
   // Input state
   const [inputValue, setInputValue] = useState("");
   const [commandHistory, setCommandHistory] = useState<string[]>(
@@ -208,8 +205,9 @@ export default function OperatorDashboard({
           };
           s = await sessions.create({
             targets: [],
-            name: generateRandomName(),
             config: sessionConfig,
+            model: model.id,
+            authConfig: buildAuthConfig(config.data),
           });
 
           const state = createInitialOperatorState("auto", requireApproval);
@@ -242,7 +240,6 @@ export default function OperatorDashboard({
                 Array.isArray(savedState.messages) &&
                 savedState.messages.length > 0
               ) {
-                nameGenTriggeredRef.current = true;
                 const modelMsgs = savedState.messages;
                 conversationRef.current = modelMsgs;
 
@@ -628,24 +625,6 @@ export default function OperatorDashboard({
           }
         } catch {
           // Stream may have been aborted; conversation stays as-is
-        }
-
-        // Fire-and-forget AI session name generation on first successful exchange
-        if (!nameGenTriggeredRef.current && session) {
-          nameGenTriggeredRef.current = true;
-          generateSessionName({
-            targets: session.targets,
-            userMessage: prompt,
-            model: model.id,
-            authConfig: buildAuthConfig(config.data),
-          }).then((name) => {
-            if (name) {
-              sessions.update(session.id, (s) => {
-                s.name = name;
-              });
-              setSession((prev) => (prev ? { ...prev, name } : prev));
-            }
-          });
         }
       } catch (e) {
         if (gen !== generationRef.current) return;

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -16,7 +16,10 @@ import {
 } from "../../../core/session";
 import { runOffensiveSecurityAgent } from "../../../core/api/offesecAgent";
 import { buildAuthConfig } from "../../../core/ai/utils";
-import { ALL_TOOL_NAMES } from "../../../core/agents/offSecAgent";
+import {
+  ALL_TOOL_NAMES,
+  type ConsumeCallbacks,
+} from "../../../core/agents/offSecAgent";
 import {
   convertModelMessagesToUI,
   type UIMessage,
@@ -48,7 +51,6 @@ import { stepCountIs, type ModelMessage } from "ai";
 import { isTerminalCopyShortcut, shouldHandleOperatorCtrlC } from "./keyboard";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-import * as History from "../../../core/history";
 
 type DashboardStatus = "idle" | "running" | "waiting" | "done";
 
@@ -103,6 +105,8 @@ export default function OperatorDashboard({
   const [session, setSession] = useState<SessionInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Captures an AI-generated name that arrives before the session is stored in state
+  const pendingNameRef = useRef<string | null>(null);
 
   // Agent/status state
   const [status, setStatus] = useState<DashboardStatus>("idle");
@@ -123,13 +127,6 @@ export default function OperatorDashboard({
   const conversationRef = useRef<ModelMessage[]>([]);
   // Input state
   const [inputValue, setInputValue] = useState("");
-  const [commandHistory, setCommandHistory] = useState<string[]>(
-    History.getEntries,
-  );
-
-  useEffect(() => {
-    History.load().then(setCommandHistory);
-  }, []);
 
   // Operator state
   const [operatorState, setOperatorState] = useState<OperatorSessionState>(() =>
@@ -184,42 +181,15 @@ export default function OperatorDashboard({
     };
   }, []);
 
-  // Load or create session on mount
+  // Load existing session or initialise operator state for a new one.
+  // New sessions are created lazily by the agent on the first runAgent call.
   useEffect(() => {
     async function loadSession() {
       try {
-        let s: SessionInfo;
-
         if (sessionId) {
-          s = await sessions.get(sessionId);
-        } else {
-          const requireApproval = initialConfig?.requireApproval ?? true;
-          const target = initialConfig?.target;
-          const sessionConfig: SessionConfig = {
-            sessionType: "web-app",
-            mode: "operator",
-            operatorSettings: {
-              initialMode: "auto",
-              requireApproval,
-              enableSuggestions: true,
-            },
-          };
-          s = await sessions.create({
-            targets: target ? [target] : [],
-            config: sessionConfig,
-            model: model.id,
-            authConfig: buildAuthConfig(config.data),
-          });
+          const s = await sessions.get(sessionId);
+          setSession(s);
 
-          const state = createInitialOperatorState("auto", requireApproval);
-          setOperatorState(state);
-          approvalGateRef.current.updateConfig({ requireApproval });
-        }
-
-        setSession(s);
-
-        // For existing sessions, attempt to load saved operator state
-        if (sessionId) {
           const hasState = sessions.hasOperatorState(s);
           if (hasState) {
             const savedState = await sessions.loadOperatorState(sessionId);
@@ -269,6 +239,13 @@ export default function OperatorDashboard({
             setOperatorState(initialState);
             approvalGateRef.current.updateConfig({ requireApproval });
           }
+        } else {
+          // New session — just set up operator config; the agent creates the
+          // session on the first runAgent call.
+          const requireApproval = initialConfig?.requireApproval ?? true;
+          const state = createInitialOperatorState("auto", requireApproval);
+          setOperatorState(state);
+          approvalGateRef.current.updateConfig({ requireApproval });
         }
       } catch (e) {
         setError(e instanceof Error ? e.message : "Failed to load session");
@@ -477,8 +454,6 @@ export default function OperatorDashboard({
 
   const runAgent = useCallback(
     async (prompt: string) => {
-      if (!session) return;
-
       // Abort any previous run before starting a new one
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
@@ -510,114 +485,159 @@ export default function OperatorDashboard({
       ];
       conversationRef.current = nextMessages;
 
+      const onStepFinish = (event: {
+        usage?: { inputTokens?: number; outputTokens?: number };
+      }) => {
+        const inputTokens = event.usage?.inputTokens ?? 0;
+        const outputTokens = event.usage?.outputTokens ?? 0;
+        if (inputTokens <= 0 && outputTokens <= 0) return;
+
+        const nextUsage = {
+          inputTokens: tokenUsageRef.current.inputTokens + inputTokens,
+          outputTokens: tokenUsageRef.current.outputTokens + outputTokens,
+          totalTokens:
+            tokenUsageRef.current.totalTokens + inputTokens + outputTokens,
+        };
+        tokenUsageRef.current = nextUsage;
+
+        addTokenUsage(inputTokens, outputTokens);
+        if (session) {
+          try {
+            writeExecutionMetrics({
+              sessionRootPath: session.rootPath,
+              tokenUsage: nextUsage,
+            });
+          } catch {
+            // Best effort: token metrics should not interrupt operator runs.
+          }
+        }
+      };
+
+      const callbacks = {
+        onTextDelta: (d) => {
+          setThinking(false);
+          appendText(d.text);
+        },
+        onToolCall: (d) => {
+          setThinking(false);
+          commandCancelledRef.current = false;
+          addToolCall(
+            d.toolCallId,
+            d.toolName,
+            d.input as Record<string, unknown> | undefined,
+          );
+        },
+        onToolResult: (d) => {
+          flushCommandOutput();
+          if (cmdFlushTimerRef.current) {
+            clearInterval(cmdFlushTimerRef.current);
+            cmdFlushTimerRef.current = null;
+          }
+          setThinking(true);
+          updateToolResult(d.toolCallId, d.toolName, d.output);
+        },
+        onCommandOutput,
+        onError: (e) => {
+          console.error("Agent error:", e);
+          setError(e instanceof Error ? e.message : "Unknown error");
+        },
+        subagentCallbacks: {
+          onSubagentSpawn: ({ subagentId }) => {
+            appendLogToActiveTool(`▸ ${subagentId} started`);
+          },
+          onSubagentComplete: ({ subagentId, status }) => {
+            const icon = status === "completed" ? "✓" : "✗";
+            appendLogToActiveTool(`${icon} ${subagentId} ${status}`);
+          },
+          onTextDelta: (d) => {
+            if (!d.subagentId) return;
+            onCommandOutput(d.text);
+          },
+          onToolCall: (d) => {
+            if (!d.subagentId) return;
+            const args =
+              ((d as Record<string, unknown>).input as Record<
+                string,
+                unknown
+              >) ?? {};
+            const summary = getToolSummary(d.toolName, args);
+            appendLogToActiveTool(summary);
+          },
+          onToolResult: (d) => {
+            if (!d.subagentId) return;
+            const args =
+              ((d as Record<string, unknown>).args as Record<
+                string,
+                unknown
+              >) ?? {};
+            const summary = getToolSummary(d.toolName, args);
+            appendLogToActiveTool(`✓ ${summary}`);
+          },
+          onError: (e) => {
+            const msg = e instanceof Error ? e.message : "subagent error";
+            appendLogToActiveTool(`✗ ${msg}`);
+          },
+        },
+      } satisfies ConsumeCallbacks;
+
+      const commonInput = {
+        prompt,
+        model: model.id,
+        messages: nextMessages,
+        stopWhen: [stepCountIs(10000)],
+        target: initialConfig?.target,
+        activeTools: [...ALL_TOOL_NAMES] as string[],
+        abortSignal: controller.signal,
+        authConfig: buildAuthConfig(config.data),
+        approvalGate: approvalGateRef.current,
+        commandCancelHandle: cancelHandleRef.current,
+        onStepFinish,
+        callbacks,
+      };
+
       try {
-        const streamResult = await runOffensiveSecurityAgent({
-          system: buildOperatorSystemPrompt(session, operatorState),
-          prompt,
-          model: model.id,
-          session,
-          messages: nextMessages,
-          stopWhen: [stepCountIs(10000)],
-          target: session.targets[0],
-          activeTools: [...ALL_TOOL_NAMES],
-          abortSignal: controller.signal,
-          authConfig: buildAuthConfig(config.data),
-          approvalGate: approvalGateRef.current,
-          commandCancelHandle: cancelHandleRef.current,
-          onStepFinish: (event) => {
-            const inputTokens = event.usage?.inputTokens ?? 0;
-            const outputTokens = event.usage?.outputTokens ?? 0;
-            if (inputTokens <= 0 && outputTokens <= 0) return;
+        let agentResult;
 
-            const nextUsage = {
-              inputTokens: tokenUsageRef.current.inputTokens + inputTokens,
-              outputTokens: tokenUsageRef.current.outputTokens + outputTokens,
-              totalTokens:
-                tokenUsageRef.current.totalTokens + inputTokens + outputTokens,
-            };
-            tokenUsageRef.current = nextUsage;
-
-            addTokenUsage(inputTokens, outputTokens);
-            try {
-              writeExecutionMetrics({
-                sessionRootPath: session.rootPath,
-                tokenUsage: nextUsage,
-              });
-            } catch {
-              // Best effort: token metrics should not interrupt operator runs.
-            }
-          },
-          callbacks: {
-            onTextDelta: (d) => {
-              setThinking(false);
-              appendText(d.text);
+        if (session) {
+          agentResult = await runOffensiveSecurityAgent({
+            ...commonInput,
+            system: buildOperatorSystemPrompt(session, operatorState),
+            session,
+          });
+        } else {
+          // First call — let the agent factory create the session
+          const requireApproval = initialConfig?.requireApproval ?? true;
+          const sessionConfig: SessionConfig = {
+            sessionType: "web-app",
+            mode: "operator",
+            operatorSettings: {
+              initialMode: "auto",
+              requireApproval,
+              enableSuggestions: true,
             },
-            onToolCall: (d) => {
-              setThinking(false);
-              commandCancelledRef.current = false;
-              addToolCall(
-                d.toolCallId,
-                d.toolName,
-                d.input as Record<string, unknown> | undefined,
-              );
+          };
+          agentResult = await runOffensiveSecurityAgent({
+            ...commonInput,
+            buildSystem: (s: SessionInfo) =>
+              buildOperatorSystemPrompt(s, operatorState),
+            sessionConfig,
+            onNameGenerated: (name: string) => {
+              pendingNameRef.current = name;
+              setSession((prev) => (prev ? { ...prev, name } : prev));
             },
-            onToolResult: (d) => {
-              flushCommandOutput();
-              if (cmdFlushTimerRef.current) {
-                clearInterval(cmdFlushTimerRef.current);
-                cmdFlushTimerRef.current = null;
-              }
-              setThinking(true);
-              updateToolResult(d.toolCallId, d.toolName, d.output);
-            },
-            onCommandOutput,
-            onError: (e) => {
-              console.error("Agent error:", e);
-              setError(e instanceof Error ? e.message : "Unknown error");
-            },
-            subagentCallbacks: {
-              onSubagentSpawn: ({ subagentId }) => {
-                appendLogToActiveTool(`▸ ${subagentId} started`);
-              },
-              onSubagentComplete: ({ subagentId, status }) => {
-                const icon = status === "completed" ? "✓" : "✗";
-                appendLogToActiveTool(`${icon} ${subagentId} ${status}`);
-              },
-              onTextDelta: (d) => {
-                if (!d.subagentId) return;
-                onCommandOutput(d.text);
-              },
-              onToolCall: (d) => {
-                if (!d.subagentId) return;
-                const args =
-                  ((d as Record<string, unknown>).input as Record<
-                    string,
-                    unknown
-                  >) ?? {};
-                const summary = getToolSummary(d.toolName, args);
-                appendLogToActiveTool(summary);
-              },
-              onToolResult: (d) => {
-                if (!d.subagentId) return;
-                const args =
-                  ((d as Record<string, unknown>).args as Record<
-                    string,
-                    unknown
-                  >) ?? {};
-                const summary = getToolSummary(d.toolName, args);
-                appendLogToActiveTool(`✓ ${summary}`);
-              },
-              onError: (e) => {
-                const msg = e instanceof Error ? e.message : "subagent error";
-                appendLogToActiveTool(`✗ ${msg}`);
-              },
-            },
-          },
-        });
+          });
+          // Apply any AI-generated name that arrived while the stream was running
+          const created = agentResult.session;
+          if (pendingNameRef.current) {
+            created.name = pendingNameRef.current;
+            pendingNameRef.current = null;
+          }
+          setSession(created);
+        }
 
         // Persist full conversation for next turn
         try {
-          const response = await streamResult.response;
+          const response = await agentResult.streamResult.response;
           if (gen === generationRef.current && response.messages) {
             conversationRef.current = [
               ...nextMessages,
@@ -683,30 +703,24 @@ export default function OperatorDashboard({
       if (status === "running") return;
 
       const trimmed = value.trim();
-      History.push(trimmed).then(() =>
-        setCommandHistory([...History.getEntries()]),
-      );
       setInputValue("");
       runAgent(trimmed);
     },
     [status, runAgent],
   );
 
-  // Auto-send initial message once the session finishes loading
+  // Auto-send initial message once loading completes.
+  // For new sessions, `session` is null until the first runAgent call creates
+  // it via the agent factory, so we intentionally don't gate on `session`.
   const initialMessageSentRef = useRef(false);
   const runAgentRef = useRef(runAgent);
   runAgentRef.current = runAgent;
   useEffect(() => {
-    if (
-      !loading &&
-      session &&
-      initialMessage &&
-      !initialMessageSentRef.current
-    ) {
+    if (!loading && initialMessage && !initialMessageSentRef.current) {
       initialMessageSentRef.current = true;
       runAgentRef.current(initialMessage);
     }
-  }, [loading, session, initialMessage]);
+  }, [loading, initialMessage]);
 
   const showModelPicker = useCallback(() => {
     setDialogSize("large");
@@ -923,7 +937,7 @@ export default function OperatorDashboard({
     );
   }
 
-  if (!session) {
+  if (!session && error) {
     return (
       <box
         flexDirection="column"
@@ -934,7 +948,7 @@ export default function OperatorDashboard({
         gap={1}
       >
         <text fg={colors.error}>Failed to load session</text>
-        {error && <text fg={colors.textMuted}>{error}</text>}
+        <text fg={colors.textMuted}>{error}</text>
         <text fg={colors.textMuted}>Press ESC to go back</text>
       </box>
     );
@@ -959,11 +973,13 @@ export default function OperatorDashboard({
         <box flexDirection="row" gap={2}>
           <text fg={colors.primary}>Operator</text>
           <text fg={colors.textMuted}>•</text>
-          <text fg={colors.text}>{session.name}</text>
-          {session.targets[0] && (
+          <text fg={colors.text}>{session?.name ?? "New Session"}</text>
+          {(session?.targets[0] || initialConfig?.target) && (
             <>
               <text fg={colors.textMuted}>•</text>
-              <text fg={colors.textMuted}>{session.targets[0]}</text>
+              <text fg={colors.textMuted}>
+                {session?.targets[0] || initialConfig?.target}
+              </text>
             </>
           )}
         </box>
@@ -1021,7 +1037,6 @@ export default function OperatorDashboard({
         autocompleteOptions={autocompleteOptions}
         enableCommands={true}
         onCommandExecute={handleCommandExecute}
-        commandHistory={commandHistory}
       />
     </box>
   );

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -48,11 +48,19 @@ import {
 } from "../../../core/session/execution-metrics";
 import { ModelPicker } from "../model-picker";
 import { stepCountIs, type ModelMessage } from "ai";
-import { isTerminalCopyShortcut, shouldHandleOperatorCtrlC } from "./keyboard";
+import {
+  type DashboardStatus,
+  filterOperatorAutocomplete,
+  resolveSubmit,
+  routeCommand,
+  resolveKeyboardShortcut,
+  resolveAbortAction,
+  buildOperatorSystemPrompt,
+  resolveInputFocused,
+  accumulateTokenUsage,
+} from "./logic";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-
-type DashboardStatus = "idle" | "running" | "waiting" | "done";
 
 /**
  * Operator Dashboard - interactive chat interface with the offensive security agent
@@ -94,11 +102,8 @@ export default function OperatorDashboard({
   } = useDialog();
 
   const autocompleteOptions = useMemo(() => {
-    const allowedCommands = new Set(["/create-skill", "/models"]);
     const skillSlugs = new Set(skills.map((s) => `/${slugify(s.name)}`));
-    return allAutocompleteOptions.filter(
-      (opt) => allowedCommands.has(opt.value) || skillSlugs.has(opt.value),
-    );
+    return filterOperatorAutocomplete(allAutocompleteOptions, skillSlugs);
   }, [allAutocompleteOptions, skills]);
 
   // Session state
@@ -488,19 +493,18 @@ export default function OperatorDashboard({
       const onStepFinish = (event: {
         usage?: { inputTokens?: number; outputTokens?: number };
       }) => {
-        const inputTokens = event.usage?.inputTokens ?? 0;
-        const outputTokens = event.usage?.outputTokens ?? 0;
-        if (inputTokens <= 0 && outputTokens <= 0) return;
-
-        const nextUsage = {
-          inputTokens: tokenUsageRef.current.inputTokens + inputTokens,
-          outputTokens: tokenUsageRef.current.outputTokens + outputTokens,
-          totalTokens:
-            tokenUsageRef.current.totalTokens + inputTokens + outputTokens,
-        };
+        const nextUsage = accumulateTokenUsage(
+          tokenUsageRef.current,
+          event.usage?.inputTokens ?? 0,
+          event.usage?.outputTokens ?? 0,
+        );
+        if (!nextUsage) return;
         tokenUsageRef.current = nextUsage;
 
-        addTokenUsage(inputTokens, outputTokens);
+        addTokenUsage(
+          event.usage?.inputTokens ?? 0,
+          event.usage?.outputTokens ?? 0,
+        );
         if (session) {
           try {
             writeExecutionMetrics({
@@ -689,22 +693,19 @@ export default function OperatorDashboard({
 
   const handleSubmit = useCallback(
     (value: string) => {
-      if (!value.trim()) return;
-
-      // If there's a pending approval and the user types, deny and redirect
       const pending = approvalGateRef.current.getPendingApprovals();
-      if (pending.length > 0) {
+      const result = resolveSubmit(value, status, pending.length > 0);
+
+      if (result.denyPending) {
         for (const p of pending) {
           approvalGateRef.current.deny(p.id);
         }
       }
 
-      // Block submission only when the agent is actively running (not waiting)
-      if (status === "running") return;
+      if (result.action !== "run" || !result.prompt) return;
 
-      const trimmed = value.trim();
       setInputValue("");
-      runAgent(trimmed);
+      runAgent(result.prompt);
     },
     [status, runAgent],
   );
@@ -760,28 +761,23 @@ export default function OperatorDashboard({
 
   const handleCommandExecute = useCallback(
     async (command: string) => {
-      const commandLower = command.trim().replace(/^\/+/, "").toLowerCase();
+      const action = routeCommand(command, resolveSkillContent);
 
-      // /models — show model picker dialog inline
-      if (commandLower === "models" || commandLower === "model") {
-        showModelPicker();
-        return;
+      switch (action.type) {
+        case "show-models":
+          showModelPicker();
+          return;
+        case "run-skill":
+          if (action.autopilot) {
+            approvalGateRef.current.updateConfig({ requireApproval: false });
+            setOperatorState((prev) => ({ ...prev, requireApproval: false }));
+          }
+          handleSubmit(action.content);
+          return;
+        case "execute-command":
+          await executeCommand(action.command);
+          return;
       }
-
-      // Detect and strip --autopilot flag before resolving
-      const autopilot = command.includes("--autopilot");
-      const cleanedCommand = command.replace(/\s*--autopilot\s*/g, "").trim();
-
-      const skillContent = resolveSkillContent(cleanedCommand);
-      if (skillContent) {
-        if (autopilot) {
-          approvalGateRef.current.updateConfig({ requireApproval: false });
-          setOperatorState((prev) => ({ ...prev, requireApproval: false }));
-        }
-        handleSubmit(skillContent);
-        return;
-      }
-      await executeCommand(command);
     },
     [resolveSkillContent, handleSubmit, executeCommand, showModelPicker],
   );
@@ -789,9 +785,11 @@ export default function OperatorDashboard({
   const handleAbort = useCallback(() => {
     if (!abortControllerRef.current) return;
 
-    // Stage 1: If a command is running and hasn't been cancelled yet,
-    // cancel just the command and let the agent continue.
-    if (!commandCancelledRef.current && cancelHandleRef.current.cancel()) {
+    const action = resolveAbortAction(commandCancelledRef.current, () =>
+      cancelHandleRef.current.cancel(),
+    );
+
+    if (action.type === "cancel-command") {
       commandCancelledRef.current = true;
       setMessages((prev) => [
         ...prev,
@@ -805,7 +803,7 @@ export default function OperatorDashboard({
       return;
     }
 
-    // Stage 2: No command running, or second Ctrl+C — kill the agent.
+    // Kill the agent
     generationRef.current++;
     abortControllerRef.current.abort();
     abortControllerRef.current = null;
@@ -859,66 +857,44 @@ export default function OperatorDashboard({
 
   // Keyboard shortcuts
   useKeyboard((key) => {
-    // Skip local shortcuts when dialogs are open (e.g. shortcuts popup)
-    if (stack.length > 0 || externalDialogOpen) return;
+    const dialogOpen = stack.length > 0 || externalDialogOpen;
+    const action = resolveKeyboardShortcut(
+      key,
+      status,
+      inputValue,
+      pendingApprovals.length > 0,
+      dialogOpen,
+    );
 
-    // Let terminal-native copy shortcuts pass through so selected output text
-    // in operator mode can still be copied.
-    if (isTerminalCopyShortcut(key)) {
-      return;
-    }
-
-    if (shouldHandleOperatorCtrlC(key, status, inputValue)) {
-      key.preventDefault?.();
-      if (status === "running" || status === "waiting") {
+    switch (action.type) {
+      case "skip":
+        return;
+      case "ctrl-c-abort":
+        key.preventDefault?.();
         handleAbort();
-      } else if (inputValue.trim()) {
+        return;
+      case "ctrl-c-clear":
+        key.preventDefault?.();
         setInputValue("");
-      }
-      return;
-    }
-
-    if (key.name === "escape" && status !== "running" && status !== "waiting") {
-      route.navigate({ type: "base", path: "home" });
-      return;
-    }
-
-    // Ctrl+V - toggle verbose mode
-    if (key.ctrl && key.name === "v") {
-      setVerboseMode((v) => !v);
-      return;
-    }
-
-    // Ctrl+L - toggle expanded logs
-    if (key.ctrl && key.name === "l") {
-      setExpandedLogs((e) => !e);
-      return;
-    }
-
-    // Shift+Tab - toggle command approval on/off
-    if (key.name === "tab" && key.shift) {
-      toggleApproval();
-      return;
-    }
-
-    // Y/y to approve pending
-    if (
-      status === "waiting" &&
-      pendingApprovals.length > 0 &&
-      (key.name === "y" || key.raw === "Y")
-    ) {
-      handleApprove();
-      return;
-    }
-
-    // A/a to auto-approve (disable approval)
-    if (
-      status === "waiting" &&
-      pendingApprovals.length > 0 &&
-      (key.name === "a" || key.raw === "A")
-    ) {
-      handleAutoApprove();
-      return;
+        return;
+      case "escape":
+        route.navigate({ type: "base", path: "home" });
+        return;
+      case "toggle-verbose":
+        setVerboseMode((v) => !v);
+        return;
+      case "toggle-expanded-logs":
+        setExpandedLogs((e) => !e);
+        return;
+      case "toggle-approval":
+        toggleApproval();
+        return;
+      case "approve":
+        handleApprove();
+        return;
+      case "auto-approve":
+        handleAutoApprove();
+        return;
     }
   });
 
@@ -1024,7 +1000,7 @@ export default function OperatorDashboard({
               ? "Type to redirect agent, or Y/A to approve..."
               : "Enter directive or / for commands & skills..."
         }
-        focused={status !== "running"}
+        focused={resolveInputFocused(status, stack.length, externalDialogOpen)}
         status={status === "waiting" ? "running" : status}
         mode="operator"
         operatorMode={operatorState.mode}
@@ -1040,38 +1016,6 @@ export default function OperatorDashboard({
       />
     </box>
   );
-}
-
-/**
- * Build a system prompt that includes operator context
- */
-function buildOperatorSystemPrompt(
-  session: SessionInfo,
-  operatorState: OperatorSessionState,
-): string {
-  const target = session.targets[0] || "unknown";
-
-  return `You are an offensive security agent operating in interactive operator mode.
-
-Target: ${target}
-Stage: ${operatorState.currentStage}
-Command approval: ${operatorState.requireApproval ? "enabled — the operator will approve each tool call" : "disabled — tool calls execute automatically"}
-
-You are tasked with performing security testing on the target system. The human operator
-will guide your actions through directives. Follow their instructions carefully.
-
-Guidelines:
-- Be thorough and methodical in your testing approach
-- Document all findings clearly
-- Respect scope constraints
-- Report any interesting observations, even if not directly exploitable
-- When you discover credentials, endpoints, or vulnerabilities, note them clearly
-
-Session paths:
-- Findings: ${session.findingsPath}
-- POCs: ${session.pocsPath}
-- Logs: ${session.logsPath}
-- Scratchpad: ${session.scratchpadPath}`;
 }
 
 // Re-export types for backward compatibility

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -62,7 +62,7 @@ export default function OperatorDashboard({
 }: {
   sessionId?: string;
   initialMessage?: string;
-  initialConfig?: { requireApproval?: boolean };
+  initialConfig?: { requireApproval?: boolean; target?: string };
 }) {
   const { colors } = useTheme();
   const route = useRoute();
@@ -194,6 +194,7 @@ export default function OperatorDashboard({
           s = await sessions.get(sessionId);
         } else {
           const requireApproval = initialConfig?.requireApproval ?? true;
+          const target = initialConfig?.target;
           const sessionConfig: SessionConfig = {
             sessionType: "web-app",
             mode: "operator",
@@ -204,7 +205,7 @@ export default function OperatorDashboard({
             },
           };
           s = await sessions.create({
-            targets: [],
+            targets: target ? [target] : [],
             config: sessionConfig,
             model: model.id,
             authConfig: buildAuthConfig(config.data),

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -15,7 +15,7 @@ import {
   type SessionConfig,
 } from "../../../core/session";
 import { runOffensiveSecurityAgent } from "../../../core/api/offesecAgent";
-import { generateRandomName } from "../../../util/name";
+import { generateRandomName, generateSessionName } from "../../../util/name";
 import { buildAuthConfig } from "../../../core/ai/utils";
 import { ALL_TOOL_NAMES } from "../../../core/agents/offSecAgent";
 import {
@@ -122,6 +122,8 @@ export default function OperatorDashboard({
   const textRef = useRef("");
   // AI SDK conversation history for multi-turn continuity
   const conversationRef = useRef<ModelMessage[]>([]);
+  // Track whether we've already kicked off AI session name generation
+  const nameGenTriggeredRef = useRef(false);
   // Input state
   const [inputValue, setInputValue] = useState("");
   const [commandHistory, setCommandHistory] = useState<string[]>(
@@ -240,6 +242,7 @@ export default function OperatorDashboard({
                 Array.isArray(savedState.messages) &&
                 savedState.messages.length > 0
               ) {
+                nameGenTriggeredRef.current = true;
                 const modelMsgs = savedState.messages;
                 conversationRef.current = modelMsgs;
 
@@ -625,6 +628,24 @@ export default function OperatorDashboard({
           }
         } catch {
           // Stream may have been aborted; conversation stays as-is
+        }
+
+        // Fire-and-forget AI session name generation on first successful exchange
+        if (!nameGenTriggeredRef.current && session) {
+          nameGenTriggeredRef.current = true;
+          generateSessionName({
+            targets: session.targets,
+            userMessage: prompt,
+            model: model.id,
+            authConfig: buildAuthConfig(config.data),
+          }).then((name) => {
+            if (name) {
+              sessions.update(session.id, (s) => {
+                s.name = name;
+              });
+              setSession((prev) => (prev ? { ...prev, name } : prev));
+            }
+          });
         }
       } catch (e) {
         if (gen !== generationRef.current) return;

--- a/src/tui/components/operator-dashboard/logic.test.ts
+++ b/src/tui/components/operator-dashboard/logic.test.ts
@@ -1,0 +1,549 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  filterOperatorAutocomplete,
+  resolveSubmit,
+  routeCommand,
+  resolveKeyboardShortcut,
+  resolveAbortAction,
+  buildOperatorSystemPrompt,
+  resolveInputFocused,
+  accumulateTokenUsage,
+  type DashboardStatus,
+} from "./logic";
+import type { AutocompleteOption } from "../shared/prompt-input";
+import type { SessionInfo } from "../../../core/session";
+import type { OperatorSessionState } from "../../../core/operator";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const allOptions: AutocompleteOption[] = [
+  { value: "/scan", label: "/scan", description: "Run a scan" },
+  { value: "/pentest", label: "/pentest", description: "Run a pentest" },
+  { value: "/help", label: "/help", description: "Show help" },
+  {
+    value: "/create-skill",
+    label: "/create-skill",
+    description: "Create skill",
+  },
+  { value: "/models", label: "/models", description: "Switch model" },
+  { value: "/sql-injection", label: "/sql-injection", description: "Skill" },
+  { value: "/xss-test", label: "/xss-test", description: "Skill" },
+];
+
+const skillSlugs = new Set(["/sql-injection", "/xss-test"]);
+
+// ---------------------------------------------------------------------------
+// filterOperatorAutocomplete
+// ---------------------------------------------------------------------------
+
+describe("filterOperatorAutocomplete", () => {
+  it("includes allowed commands (/create-skill, /models)", () => {
+    const result = filterOperatorAutocomplete(allOptions, new Set());
+    const values = result.map((o) => o.value);
+    expect(values).toContain("/create-skill");
+    expect(values).toContain("/models");
+  });
+
+  it("includes skill slugs", () => {
+    const result = filterOperatorAutocomplete(allOptions, skillSlugs);
+    const values = result.map((o) => o.value);
+    expect(values).toContain("/sql-injection");
+    expect(values).toContain("/xss-test");
+  });
+
+  it("excludes commands that are neither allowed nor skills", () => {
+    const result = filterOperatorAutocomplete(allOptions, skillSlugs);
+    const values = result.map((o) => o.value);
+    expect(values).not.toContain("/scan");
+    expect(values).not.toContain("/pentest");
+    expect(values).not.toContain("/help");
+  });
+
+  it("returns only allowed commands when no skills exist", () => {
+    const result = filterOperatorAutocomplete(allOptions, new Set());
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns empty for empty input", () => {
+    expect(filterOperatorAutocomplete([], new Set())).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSubmit
+// ---------------------------------------------------------------------------
+
+describe("resolveSubmit", () => {
+  it("returns 'run' with trimmed prompt for valid input when idle", () => {
+    const result = resolveSubmit("  hello world  ", "idle", false);
+    expect(result).toEqual({
+      action: "run",
+      prompt: "hello world",
+      denyPending: false,
+    });
+  });
+
+  it("returns 'empty' for whitespace-only input", () => {
+    const result = resolveSubmit("   ", "idle", false);
+    expect(result).toEqual({ action: "empty", denyPending: false });
+  });
+
+  it("returns 'blocked' when status is running", () => {
+    const result = resolveSubmit("hello", "running", false);
+    expect(result.action).toBe("blocked");
+  });
+
+  it("allows submit when status is waiting", () => {
+    const result = resolveSubmit("redirect", "waiting", true);
+    expect(result.action).toBe("run");
+    expect(result.prompt).toBe("redirect");
+  });
+
+  it("sets denyPending when there are pending approvals", () => {
+    const result = resolveSubmit("redirect", "waiting", true);
+    expect(result.denyPending).toBe(true);
+  });
+
+  it("does not set denyPending when no pending approvals", () => {
+    const result = resolveSubmit("hello", "idle", false);
+    expect(result.denyPending).toBe(false);
+  });
+
+  it("sets denyPending even when blocked", () => {
+    const result = resolveSubmit("hello", "running", true);
+    expect(result.denyPending).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// routeCommand
+// ---------------------------------------------------------------------------
+
+describe("routeCommand", () => {
+  const noSkill = () => null;
+
+  it("routes /models to show-models", () => {
+    expect(routeCommand("/models", noSkill)).toEqual({ type: "show-models" });
+  });
+
+  it("routes /model (singular) to show-models", () => {
+    expect(routeCommand("/model", noSkill)).toEqual({ type: "show-models" });
+  });
+
+  it("routes /MODELS (case-insensitive) to show-models", () => {
+    expect(routeCommand("/MODELS", noSkill)).toEqual({ type: "show-models" });
+  });
+
+  it("routes a skill command to run-skill", () => {
+    const resolveSkill = (cmd: string) =>
+      cmd === "/sql-injection" ? "Perform SQL injection testing" : null;
+    const result = routeCommand("/sql-injection", resolveSkill);
+    expect(result).toEqual({
+      type: "run-skill",
+      content: "Perform SQL injection testing",
+      autopilot: false,
+    });
+  });
+
+  it("detects --autopilot flag on skill commands", () => {
+    const resolveSkill = (cmd: string) =>
+      cmd === "/sql-injection" ? "SQL injection" : null;
+    const result = routeCommand("/sql-injection --autopilot", resolveSkill);
+    expect(result).toEqual({
+      type: "run-skill",
+      content: "SQL injection",
+      autopilot: true,
+    });
+  });
+
+  it("strips --autopilot before resolving skill", () => {
+    const resolveSkill = vi.fn().mockReturnValue("content");
+    routeCommand("/my-skill --autopilot", resolveSkill);
+    expect(resolveSkill).toHaveBeenCalledWith("/my-skill");
+  });
+
+  it("falls back to execute-command for unknown commands", () => {
+    const result = routeCommand("/unknown-cmd", noSkill);
+    expect(result).toEqual({
+      type: "execute-command",
+      command: "/unknown-cmd",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveKeyboardShortcut
+// ---------------------------------------------------------------------------
+
+describe("resolveKeyboardShortcut", () => {
+  const idle: DashboardStatus = "idle";
+  const running: DashboardStatus = "running";
+  const waiting: DashboardStatus = "waiting";
+
+  it("returns skip when dialog is open", () => {
+    expect(
+      resolveKeyboardShortcut(
+        { name: "c", ctrl: true },
+        running,
+        "",
+        true,
+        true,
+      ),
+    ).toEqual({ type: "skip" });
+  });
+
+  it("passes through Cmd+C (terminal copy)", () => {
+    expect(
+      resolveKeyboardShortcut(
+        { name: "c", meta: true },
+        running,
+        "text",
+        false,
+        false,
+      ),
+    ).toEqual({ type: "skip" });
+  });
+
+  it("passes through Super+C (terminal copy)", () => {
+    expect(
+      resolveKeyboardShortcut(
+        { name: "c", super: true },
+        running,
+        "text",
+        false,
+        false,
+      ),
+    ).toEqual({ type: "skip" });
+  });
+
+  describe("Ctrl+C", () => {
+    it("returns ctrl-c-abort when running", () => {
+      expect(
+        resolveKeyboardShortcut(
+          { name: "c", ctrl: true },
+          running,
+          "",
+          false,
+          false,
+        ),
+      ).toEqual({ type: "ctrl-c-abort" });
+    });
+
+    it("returns ctrl-c-abort when waiting", () => {
+      expect(
+        resolveKeyboardShortcut(
+          { name: "c", ctrl: true },
+          waiting,
+          "",
+          false,
+          false,
+        ),
+      ).toEqual({ type: "ctrl-c-abort" });
+    });
+
+    it("returns ctrl-c-clear when idle with input", () => {
+      expect(
+        resolveKeyboardShortcut(
+          { name: "c", ctrl: true },
+          idle,
+          "text",
+          false,
+          false,
+        ),
+      ).toEqual({ type: "ctrl-c-clear" });
+    });
+
+    it("returns skip when idle with empty input", () => {
+      expect(
+        resolveKeyboardShortcut(
+          { name: "c", ctrl: true },
+          idle,
+          "",
+          false,
+          false,
+        ),
+      ).toEqual({ type: "skip" });
+    });
+
+    it("returns skip when idle with whitespace-only input", () => {
+      expect(
+        resolveKeyboardShortcut(
+          { name: "c", ctrl: true },
+          idle,
+          "   ",
+          false,
+          false,
+        ),
+      ).toEqual({ type: "skip" });
+    });
+  });
+
+  describe("Escape", () => {
+    it("returns escape when idle", () => {
+      expect(
+        resolveKeyboardShortcut({ name: "escape" }, idle, "", false, false),
+      ).toEqual({ type: "escape" });
+    });
+
+    it("returns skip when running", () => {
+      expect(
+        resolveKeyboardShortcut({ name: "escape" }, running, "", false, false),
+      ).toEqual({ type: "skip" });
+    });
+
+    it("returns skip when waiting", () => {
+      expect(
+        resolveKeyboardShortcut({ name: "escape" }, waiting, "", false, false),
+      ).toEqual({ type: "skip" });
+    });
+  });
+
+  it("Ctrl+V returns toggle-verbose", () => {
+    expect(
+      resolveKeyboardShortcut(
+        { name: "v", ctrl: true },
+        idle,
+        "",
+        false,
+        false,
+      ),
+    ).toEqual({ type: "toggle-verbose" });
+  });
+
+  it("Ctrl+L returns toggle-expanded-logs", () => {
+    expect(
+      resolveKeyboardShortcut(
+        { name: "l", ctrl: true },
+        idle,
+        "",
+        false,
+        false,
+      ),
+    ).toEqual({ type: "toggle-expanded-logs" });
+  });
+
+  it("Shift+Tab returns toggle-approval", () => {
+    expect(
+      resolveKeyboardShortcut(
+        { name: "tab", shift: true },
+        idle,
+        "",
+        false,
+        false,
+      ),
+    ).toEqual({ type: "toggle-approval" });
+  });
+
+  describe("Approval shortcuts", () => {
+    it("Y approves when waiting with pending approvals", () => {
+      expect(
+        resolveKeyboardShortcut({ name: "y" }, waiting, "", true, false),
+      ).toEqual({ type: "approve" });
+    });
+
+    it("Y (raw) approves when waiting with pending approvals", () => {
+      expect(
+        resolveKeyboardShortcut(
+          { name: "Y", raw: "Y" },
+          waiting,
+          "",
+          true,
+          false,
+        ),
+      ).toEqual({ type: "approve" });
+    });
+
+    it("Y does nothing when not waiting", () => {
+      expect(
+        resolveKeyboardShortcut({ name: "y" }, idle, "", true, false),
+      ).toEqual({ type: "skip" });
+    });
+
+    it("Y does nothing when no pending approvals", () => {
+      expect(
+        resolveKeyboardShortcut({ name: "y" }, waiting, "", false, false),
+      ).toEqual({ type: "skip" });
+    });
+
+    it("A auto-approves when waiting with pending approvals", () => {
+      expect(
+        resolveKeyboardShortcut({ name: "a" }, waiting, "", true, false),
+      ).toEqual({ type: "auto-approve" });
+    });
+
+    it("A (raw) auto-approves when waiting with pending approvals", () => {
+      expect(
+        resolveKeyboardShortcut(
+          { name: "A", raw: "A" },
+          waiting,
+          "",
+          true,
+          false,
+        ),
+      ).toEqual({ type: "auto-approve" });
+    });
+
+    it("A does nothing when not waiting", () => {
+      expect(
+        resolveKeyboardShortcut({ name: "a" }, idle, "", true, false),
+      ).toEqual({ type: "skip" });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAbortAction
+// ---------------------------------------------------------------------------
+
+describe("resolveAbortAction", () => {
+  it("returns cancel-command when command not yet cancelled and cancel succeeds", () => {
+    const result = resolveAbortAction(false, () => true);
+    expect(result).toEqual({ type: "cancel-command" });
+  });
+
+  it("returns kill-agent when command already cancelled", () => {
+    const result = resolveAbortAction(true, () => true);
+    expect(result).toEqual({ type: "kill-agent" });
+  });
+
+  it("returns kill-agent when cancel returns false (no command running)", () => {
+    const result = resolveAbortAction(false, () => false);
+    expect(result).toEqual({ type: "kill-agent" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildOperatorSystemPrompt
+// ---------------------------------------------------------------------------
+
+describe("buildOperatorSystemPrompt", () => {
+  const session = {
+    targets: ["https://example.com"],
+    findingsPath: "/tmp/findings",
+    pocsPath: "/tmp/pocs",
+    logsPath: "/tmp/logs",
+    scratchpadPath: "/tmp/scratchpad",
+  } as unknown as SessionInfo;
+
+  const state: OperatorSessionState = {
+    mode: "auto",
+    requireApproval: true,
+    currentStage: "reconnaissance",
+    stageHistory: [],
+    approvedActions: [],
+  };
+
+  it("includes the target", () => {
+    const prompt = buildOperatorSystemPrompt(session, state);
+    expect(prompt).toContain("Target: https://example.com");
+  });
+
+  it("includes the stage", () => {
+    const prompt = buildOperatorSystemPrompt(session, state);
+    expect(prompt).toContain("Stage: reconnaissance");
+  });
+
+  it("shows approval enabled when requireApproval is true", () => {
+    const prompt = buildOperatorSystemPrompt(session, state);
+    expect(prompt).toContain("Command approval: enabled");
+  });
+
+  it("shows approval disabled when requireApproval is false", () => {
+    const prompt = buildOperatorSystemPrompt(session, {
+      ...state,
+      requireApproval: false,
+    });
+    expect(prompt).toContain("Command approval: disabled");
+  });
+
+  it("includes session paths", () => {
+    const prompt = buildOperatorSystemPrompt(session, state);
+    expect(prompt).toContain("Findings: /tmp/findings");
+    expect(prompt).toContain("POCs: /tmp/pocs");
+    expect(prompt).toContain("Logs: /tmp/logs");
+    expect(prompt).toContain("Scratchpad: /tmp/scratchpad");
+  });
+
+  it("falls back to 'unknown' when no targets", () => {
+    const noTargets = { ...session, targets: [] } as unknown as SessionInfo;
+    const prompt = buildOperatorSystemPrompt(noTargets, state);
+    expect(prompt).toContain("Target: unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveInputFocused
+// ---------------------------------------------------------------------------
+
+describe("resolveInputFocused", () => {
+  it("returns true when idle and no dialogs", () => {
+    expect(resolveInputFocused("idle", 0, false)).toBe(true);
+  });
+
+  it("returns false when running", () => {
+    expect(resolveInputFocused("running", 0, false)).toBe(false);
+  });
+
+  it("returns false when dialog stack is non-empty", () => {
+    expect(resolveInputFocused("idle", 1, false)).toBe(false);
+  });
+
+  it("returns false when external dialog is open", () => {
+    expect(resolveInputFocused("idle", 0, true)).toBe(false);
+  });
+
+  it("returns true when waiting (input is active for redirects)", () => {
+    expect(resolveInputFocused("waiting", 0, false)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// accumulateTokenUsage
+// ---------------------------------------------------------------------------
+
+describe("accumulateTokenUsage", () => {
+  const base = { inputTokens: 100, outputTokens: 50, totalTokens: 150 };
+
+  it("accumulates input and output tokens", () => {
+    const result = accumulateTokenUsage(base, 20, 10);
+    expect(result).toEqual({
+      inputTokens: 120,
+      outputTokens: 60,
+      totalTokens: 180,
+    });
+  });
+
+  it("returns null when both step values are zero", () => {
+    expect(accumulateTokenUsage(base, 0, 0)).toBeNull();
+  });
+
+  it("returns null when both step values are negative", () => {
+    expect(accumulateTokenUsage(base, -1, -1)).toBeNull();
+  });
+
+  it("accumulates when only input tokens are provided", () => {
+    const result = accumulateTokenUsage(base, 10, 0);
+    expect(result).not.toBeNull();
+    expect(result!.inputTokens).toBe(110);
+    expect(result!.outputTokens).toBe(50);
+  });
+
+  it("accumulates when only output tokens are provided", () => {
+    const result = accumulateTokenUsage(base, 0, 5);
+    expect(result).not.toBeNull();
+    expect(result!.outputTokens).toBe(55);
+    expect(result!.inputTokens).toBe(100);
+  });
+
+  it("handles zero base", () => {
+    const zero = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    const result = accumulateTokenUsage(zero, 10, 5);
+    expect(result).toEqual({
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+    });
+  });
+});

--- a/src/tui/components/operator-dashboard/logic.test.ts
+++ b/src/tui/components/operator-dashboard/logic.test.ts
@@ -427,13 +427,14 @@ describe("buildOperatorSystemPrompt", () => {
     scratchpadPath: "/tmp/scratchpad",
   } as unknown as SessionInfo;
 
-  const state: OperatorSessionState = {
+  const state = {
     mode: "auto",
     requireApproval: true,
-    currentStage: "reconnaissance",
-    stageHistory: [],
-    approvedActions: [],
-  };
+    currentStage: "recon",
+    pendingApprovals: [],
+    actionHistory: [],
+    stageProgress: {},
+  } as unknown as OperatorSessionState;
 
   it("includes the target", () => {
     const prompt = buildOperatorSystemPrompt(session, state);
@@ -442,7 +443,7 @@ describe("buildOperatorSystemPrompt", () => {
 
   it("includes the stage", () => {
     const prompt = buildOperatorSystemPrompt(session, state);
-    expect(prompt).toContain("Stage: reconnaissance");
+    expect(prompt).toContain("Stage: recon");
   });
 
   it("shows approval enabled when requireApproval is true", () => {

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -1,0 +1,234 @@
+import type { AutocompleteOption } from "../shared/prompt-input";
+import type { OperatorSessionState } from "../../../core/operator";
+import type { SessionInfo } from "../../../core/session";
+
+// ---------------------------------------------------------------------------
+// Autocomplete option filtering for operator mode
+// ---------------------------------------------------------------------------
+
+export function filterOperatorAutocomplete(
+  allOptions: AutocompleteOption[],
+  skillSlugs: Set<string>,
+): AutocompleteOption[] {
+  const allowedCommands = new Set(["/create-skill", "/models"]);
+  return allOptions.filter(
+    (opt) => allowedCommands.has(opt.value) || skillSlugs.has(opt.value),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Submit gating
+// ---------------------------------------------------------------------------
+
+export type DashboardStatus = "idle" | "running" | "waiting" | "done";
+
+export interface SubmitResult {
+  action: "run" | "blocked" | "empty";
+  prompt?: string;
+  denyPending: boolean;
+}
+
+export function resolveSubmit(
+  value: string,
+  status: DashboardStatus,
+  hasPendingApprovals: boolean,
+): SubmitResult {
+  const trimmed = value.trim();
+  if (!trimmed) return { action: "empty", denyPending: false };
+  if (status === "running")
+    return { action: "blocked", denyPending: hasPendingApprovals };
+  return { action: "run", prompt: trimmed, denyPending: hasPendingApprovals };
+}
+
+// ---------------------------------------------------------------------------
+// Command routing
+// ---------------------------------------------------------------------------
+
+export type CommandAction =
+  | { type: "show-models" }
+  | { type: "run-skill"; content: string; autopilot: boolean }
+  | { type: "execute-command"; command: string };
+
+export function routeCommand(
+  command: string,
+  resolveSkill: (cmd: string) => string | null,
+): CommandAction {
+  const commandLower = command.trim().replace(/^\/+/, "").toLowerCase();
+
+  if (commandLower === "models" || commandLower === "model") {
+    return { type: "show-models" };
+  }
+
+  const autopilot = command.includes("--autopilot");
+  const cleanedCommand = command.replace(/\s*--autopilot\s*/g, "").trim();
+  const skillContent = resolveSkill(cleanedCommand);
+
+  if (skillContent) {
+    return { type: "run-skill", content: skillContent, autopilot };
+  }
+
+  return { type: "execute-command", command };
+}
+
+// ---------------------------------------------------------------------------
+// Keyboard shortcut routing
+// ---------------------------------------------------------------------------
+
+interface KeyInfo {
+  name: string;
+  ctrl?: boolean;
+  shift?: boolean;
+  meta?: boolean;
+  super?: boolean;
+  raw?: string;
+}
+
+export type KeyboardAction =
+  | { type: "skip" }
+  | { type: "ctrl-c-abort" }
+  | { type: "ctrl-c-clear" }
+  | { type: "escape" }
+  | { type: "toggle-verbose" }
+  | { type: "toggle-expanded-logs" }
+  | { type: "toggle-approval" }
+  | { type: "approve" }
+  | { type: "auto-approve" };
+
+export function resolveKeyboardShortcut(
+  key: KeyInfo,
+  status: DashboardStatus,
+  inputValue: string,
+  hasPendingApprovals: boolean,
+  dialogOpen: boolean,
+): KeyboardAction {
+  if (dialogOpen) return { type: "skip" };
+
+  // Terminal-native copy (Cmd+C / Super+C) passes through
+  if ((key.meta || key.super) && key.name === "c") return { type: "skip" };
+
+  // Ctrl+C
+  if (key.ctrl && key.name === "c") {
+    if (status === "running" || status === "waiting")
+      return { type: "ctrl-c-abort" };
+    if (inputValue.trim()) return { type: "ctrl-c-clear" };
+    return { type: "skip" };
+  }
+
+  // Escape
+  if (key.name === "escape" && status !== "running" && status !== "waiting") {
+    return { type: "escape" };
+  }
+
+  // Ctrl+V — toggle verbose
+  if (key.ctrl && key.name === "v") return { type: "toggle-verbose" };
+
+  // Ctrl+L — toggle expanded logs
+  if (key.ctrl && key.name === "l") return { type: "toggle-expanded-logs" };
+
+  // Shift+Tab — toggle approval
+  if (key.name === "tab" && key.shift) return { type: "toggle-approval" };
+
+  // Y to approve
+  if (
+    status === "waiting" &&
+    hasPendingApprovals &&
+    (key.name === "y" || key.raw === "Y")
+  ) {
+    return { type: "approve" };
+  }
+
+  // A to auto-approve
+  if (
+    status === "waiting" &&
+    hasPendingApprovals &&
+    (key.name === "a" || key.raw === "A")
+  ) {
+    return { type: "auto-approve" };
+  }
+
+  return { type: "skip" };
+}
+
+// ---------------------------------------------------------------------------
+// Two-stage abort logic
+// ---------------------------------------------------------------------------
+
+export type AbortAction = { type: "cancel-command" } | { type: "kill-agent" };
+
+export function resolveAbortAction(
+  commandCancelled: boolean,
+  cancelCommand: () => boolean,
+): AbortAction {
+  if (!commandCancelled && cancelCommand()) {
+    return { type: "cancel-command" };
+  }
+  return { type: "kill-agent" };
+}
+
+// ---------------------------------------------------------------------------
+// System prompt builder
+// ---------------------------------------------------------------------------
+
+export function buildOperatorSystemPrompt(
+  session: SessionInfo,
+  operatorState: OperatorSessionState,
+): string {
+  const target = session.targets[0] || "unknown";
+
+  return `You are an offensive security agent operating in interactive operator mode.
+
+Target: ${target}
+Stage: ${operatorState.currentStage}
+Command approval: ${operatorState.requireApproval ? "enabled — the operator will approve each tool call" : "disabled — tool calls execute automatically"}
+
+You are tasked with performing security testing on the target system. The human operator
+will guide your actions through directives. Follow their instructions carefully.
+
+Guidelines:
+- Be thorough and methodical in your testing approach
+- Document all findings clearly
+- Respect scope constraints
+- Report any interesting observations, even if not directly exploitable
+- When you discover credentials, endpoints, or vulnerabilities, note them clearly
+
+Session paths:
+- Findings: ${session.findingsPath}
+- POCs: ${session.pocsPath}
+- Logs: ${session.logsPath}
+- Scratchpad: ${session.scratchpadPath}`;
+}
+
+// ---------------------------------------------------------------------------
+// Input focus resolution
+// ---------------------------------------------------------------------------
+
+export function resolveInputFocused(
+  status: DashboardStatus,
+  dialogStackLength: number,
+  externalDialogOpen: boolean,
+): boolean {
+  return status !== "running" && dialogStackLength === 0 && !externalDialogOpen;
+}
+
+// ---------------------------------------------------------------------------
+// Token usage accumulation
+// ---------------------------------------------------------------------------
+
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+export function accumulateTokenUsage(
+  current: TokenUsage,
+  stepInputTokens: number,
+  stepOutputTokens: number,
+): TokenUsage | null {
+  if (stepInputTokens <= 0 && stepOutputTokens <= 0) return null;
+  return {
+    inputTokens: current.inputTokens + stepInputTokens,
+    outputTokens: current.outputTokens + stepOutputTokens,
+    totalTokens: current.totalTokens + stepInputTokens + stepOutputTokens,
+  };
+}

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -81,7 +81,15 @@ function mapSubagentToAgentState(sa: UISubagent): AgentState {
 // Pentest — main component
 // ---------------------------------------------------------------------------
 
-export default function Pentest({ sessionId }: { sessionId: string }) {
+export default function Pentest({
+  sessionId,
+  targets,
+  sessionConfig,
+}: {
+  sessionId?: string;
+  targets?: string[];
+  sessionConfig?: import("../../../core/session").SessionConfig;
+}) {
   const { colors } = useTheme();
   const route = useRoute();
   const config = useConfig();
@@ -148,12 +156,25 @@ export default function Pentest({ sessionId }: { sessionId: string }) {
   useEffect(() => {
     async function load() {
       try {
-        const s = await sessions.get(sessionId);
-        if (!s) {
-          setError(`Session not found: ${sessionId}`);
-          setPhase("error");
-          return;
+        let s: SessionInfo;
+
+        if (sessionId) {
+          const loaded = await sessions.get(sessionId);
+          if (!loaded) {
+            setError(`Session not found: ${sessionId}`);
+            setPhase("error");
+            return;
+          }
+          s = loaded;
+        } else {
+          s = await sessions.create({
+            targets: targets ?? [],
+            config: sessionConfig,
+            model: model.id,
+            authConfig: buildAuthConfig(config.data),
+          });
         }
+
         setSession(s);
 
         // Always attempt to load saved state — a new session will have none

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -7,6 +7,7 @@ import { REPORT_FILENAME_MD } from "../../../core/report";
 import { openSessionReport } from "../../utils/open-report";
 
 import { sessions, type SessionInfo } from "../../../core/session";
+import { generateSessionName } from "../../../util/name";
 import {
   loadSessionState,
   type UISubagent,
@@ -199,8 +200,22 @@ export default function Pentest({ sessionId }: { sessionId: string }) {
             startPentest(s);
           }
         } else {
-          // Brand-new session — start immediately
+          // Brand-new session — start immediately and generate a descriptive name
           startPentest(s);
+          if (s.targets.length > 0) {
+            generateSessionName({
+              targets: s.targets,
+              model: model.id,
+              authConfig: buildAuthConfig(config.data),
+            }).then((name) => {
+              if (name) {
+                sessions.update(s.id, (sess) => {
+                  sess.name = name;
+                });
+                setSession((prev) => (prev ? { ...prev, name } : prev));
+              }
+            });
+          }
         }
       } catch (e) {
         setError(e instanceof Error ? e.message : "Failed to load session");

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -7,7 +7,6 @@ import { REPORT_FILENAME_MD } from "../../../core/report";
 import { openSessionReport } from "../../utils/open-report";
 
 import { sessions, type SessionInfo } from "../../../core/session";
-import { generateSessionName } from "../../../util/name";
 import {
   loadSessionState,
   type UISubagent,
@@ -200,22 +199,8 @@ export default function Pentest({ sessionId }: { sessionId: string }) {
             startPentest(s);
           }
         } else {
-          // Brand-new session — start immediately and generate a descriptive name
+          // Brand-new session — start immediately
           startPentest(s);
-          if (s.targets.length > 0) {
-            generateSessionName({
-              targets: s.targets,
-              model: model.id,
-              authConfig: buildAuthConfig(config.data),
-            }).then((name) => {
-              if (name) {
-                sessions.update(s.id, (sess) => {
-                  sess.name = name;
-                });
-                setSession((prev) => (prev ? { ...prev, name } : prev));
-              }
-            });
-          }
         }
       } catch (e) {
         setError(e instanceof Error ? e.message : "Failed to load session");

--- a/src/tui/components/shared/prompt-input-logic.test.ts
+++ b/src/tui/components/shared/prompt-input-logic.test.ts
@@ -1,0 +1,424 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterSuggestions,
+  resolveSubmitValue,
+  computeUpArrow,
+  computeDownArrow,
+  computeTab,
+  shouldResetHistory,
+  type NavState,
+} from "./prompt-input-logic";
+import type { AutocompleteOption } from "./prompt-input";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const options: AutocompleteOption[] = [
+  { value: "/scan", label: "/scan", description: "Run a scan" },
+  { value: "/pentest", label: "/pentest", description: "Run a pentest" },
+  { value: "/help", label: "/help", description: "Show help" },
+  { value: "/session", label: "/session", description: "Session info" },
+  { value: "/settings", label: "/settings", description: "Open settings" },
+];
+
+const history = ["first cmd", "second cmd", "third cmd"];
+
+// ---------------------------------------------------------------------------
+// filterSuggestions
+// ---------------------------------------------------------------------------
+
+describe("filterSuggestions", () => {
+  it("returns empty for empty input", () => {
+    expect(filterSuggestions("", options, 10)).toEqual([]);
+  });
+
+  it("returns empty for input without leading /", () => {
+    expect(filterSuggestions("scan", options, 10)).toEqual([]);
+  });
+
+  it("returns all options matching /", () => {
+    const result = filterSuggestions("/", options, 10);
+    expect(result).toHaveLength(5);
+  });
+
+  it("filters by value substring", () => {
+    const result = filterSuggestions("/sc", options, 10);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.value).toBe("/scan");
+  });
+
+  it("filters by label substring", () => {
+    const result = filterSuggestions("/pen", options, 10);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.value).toBe("/pentest");
+  });
+
+  it("is case-insensitive", () => {
+    const result = filterSuggestions("/HELP", options, 10);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.value).toBe("/help");
+  });
+
+  it("respects maxSuggestions", () => {
+    const result = filterSuggestions("/s", options, 2);
+    expect(result).toHaveLength(2);
+  });
+
+  it("matches multiple options with shared substring", () => {
+    const result = filterSuggestions("/se", options, 10);
+    expect(result.map((s) => s.value)).toEqual(["/session", "/settings"]);
+  });
+
+  it("returns empty for no matches", () => {
+    expect(filterSuggestions("/zzz", options, 10)).toEqual([]);
+  });
+
+  it("returns empty for empty options array", () => {
+    expect(filterSuggestions("/scan", [], 10)).toEqual([]);
+  });
+
+  it("trims whitespace from input", () => {
+    const result = filterSuggestions("  /scan  ", options, 10);
+    expect(result).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSubmitValue
+// ---------------------------------------------------------------------------
+
+describe("resolveSubmitValue", () => {
+  it("returns selected suggestion value when valid index", () => {
+    expect(resolveSubmitValue("typed text", options, 1)).toBe("/pentest");
+  });
+
+  it("returns trimmed raw text when no suggestions", () => {
+    expect(resolveSubmitValue("  hello  ", [], -1)).toBe("hello");
+  });
+
+  it("returns trimmed raw text when selectedIndex is -1", () => {
+    expect(resolveSubmitValue("  hello  ", options, -1)).toBe("hello");
+  });
+
+  it("returns trimmed raw text when selectedIndex is out of bounds", () => {
+    expect(resolveSubmitValue("hello", options, 999)).toBe("hello");
+  });
+
+  it("returns empty string for whitespace-only raw text with no selection", () => {
+    expect(resolveSubmitValue("   ", [], -1)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeUpArrow
+// ---------------------------------------------------------------------------
+
+describe("computeUpArrow", () => {
+  describe("when in autocomplete", () => {
+    it("exits autocomplete when at top of suggestion list (index 0)", () => {
+      const state: NavState = { historyIndex: -1, selectedSuggestionIndex: 0 };
+      const result = computeUpArrow(state, history, 3);
+      expect(result).not.toBeNull();
+      expect(result!.nextState.selectedSuggestionIndex).toBe(-1);
+      expect(result!.textToSet).toBeNull();
+    });
+
+    it("moves up within suggestion list", () => {
+      const state: NavState = { historyIndex: -1, selectedSuggestionIndex: 2 };
+      const result = computeUpArrow(state, history, 3);
+      expect(result).not.toBeNull();
+      expect(result!.nextState.selectedSuggestionIndex).toBe(1);
+      expect(result!.textToSet).toBeNull();
+    });
+  });
+
+  describe("when not in autocomplete", () => {
+    it("returns null when history is empty", () => {
+      const state: NavState = {
+        historyIndex: -1,
+        selectedSuggestionIndex: -1,
+      };
+      expect(computeUpArrow(state, [], 0)).toBeNull();
+    });
+
+    it("navigates to most recent history entry from current input", () => {
+      const state: NavState = {
+        historyIndex: -1,
+        selectedSuggestionIndex: -1,
+      };
+      const result = computeUpArrow(state, history, 0);
+      expect(result).not.toBeNull();
+      expect(result!.nextState.historyIndex).toBe(0);
+      expect(result!.textToSet).toBe("third cmd");
+      expect(result!.saveCurrentInput).toBe(true);
+    });
+
+    it("navigates up through history entries", () => {
+      const state: NavState = {
+        historyIndex: 0,
+        selectedSuggestionIndex: -1,
+      };
+      const result = computeUpArrow(state, history, 0);
+      expect(result).not.toBeNull();
+      expect(result!.nextState.historyIndex).toBe(1);
+      expect(result!.textToSet).toBe("second cmd");
+      expect(result!.saveCurrentInput).toBe(false);
+    });
+
+    it("clamps at the oldest history entry", () => {
+      const state: NavState = {
+        historyIndex: 2,
+        selectedSuggestionIndex: -1,
+      };
+      const result = computeUpArrow(state, history, 0);
+      expect(result).not.toBeNull();
+      expect(result!.nextState.historyIndex).toBe(2);
+      expect(result!.textToSet).toBe("first cmd");
+    });
+
+    it("marks saveCurrentInput only when entering history from -1", () => {
+      const from0: NavState = {
+        historyIndex: 0,
+        selectedSuggestionIndex: -1,
+      };
+      expect(computeUpArrow(from0, history, 0)!.saveCurrentInput).toBe(false);
+
+      const fromNeg: NavState = {
+        historyIndex: -1,
+        selectedSuggestionIndex: -1,
+      };
+      expect(computeUpArrow(fromNeg, history, 0)!.saveCurrentInput).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeDownArrow
+// ---------------------------------------------------------------------------
+
+describe("computeDownArrow", () => {
+  describe("when in autocomplete with multiple suggestions", () => {
+    it("moves down within suggestion list", () => {
+      const state: NavState = { historyIndex: -1, selectedSuggestionIndex: 0 };
+      const result = computeDownArrow(state, history, 3, "");
+      expect(result).not.toBeNull();
+      expect(result!.nextState.selectedSuggestionIndex).toBe(1);
+      expect(result!.textToSet).toBeNull();
+    });
+
+    it("clamps at the last suggestion", () => {
+      const state: NavState = { historyIndex: -1, selectedSuggestionIndex: 2 };
+      const result = computeDownArrow(state, history, 3, "");
+      expect(result).not.toBeNull();
+      expect(result!.nextState.selectedSuggestionIndex).toBe(2);
+    });
+  });
+
+  describe("when in autocomplete with single suggestion", () => {
+    it("exits autocomplete and falls through to history", () => {
+      const state: NavState = { historyIndex: -1, selectedSuggestionIndex: 0 };
+      const result = computeDownArrow(state, history, 1, "saved");
+      expect(result).not.toBeNull();
+      expect(result!.nextState.selectedSuggestionIndex).toBe(-1);
+    });
+
+    it("exits autocomplete to history navigation when browsing history", () => {
+      const state: NavState = { historyIndex: 1, selectedSuggestionIndex: 0 };
+      const result = computeDownArrow(state, history, 1, "saved");
+      expect(result).not.toBeNull();
+      expect(result!.nextState.selectedSuggestionIndex).toBe(-1);
+      expect(result!.nextState.historyIndex).toBe(0);
+      expect(result!.textToSet).toBe("third cmd");
+    });
+  });
+
+  describe("when not in autocomplete, no history", () => {
+    it("overflows to autocomplete when multiple suggestions", () => {
+      const state: NavState = {
+        historyIndex: -1,
+        selectedSuggestionIndex: -1,
+      };
+      const result = computeDownArrow(state, [], 3, "");
+      expect(result).not.toBeNull();
+      expect(result!.nextState.selectedSuggestionIndex).toBe(0);
+    });
+
+    it("returns null when single or no suggestions", () => {
+      const state: NavState = {
+        historyIndex: -1,
+        selectedSuggestionIndex: -1,
+      };
+      expect(computeDownArrow(state, [], 1, "")).toBeNull();
+      expect(computeDownArrow(state, [], 0, "")).toBeNull();
+    });
+  });
+
+  describe("when not in autocomplete, with history", () => {
+    it("navigates down through history entries", () => {
+      const state: NavState = {
+        historyIndex: 2,
+        selectedSuggestionIndex: -1,
+      };
+      const result = computeDownArrow(state, history, 0, "saved");
+      expect(result).not.toBeNull();
+      expect(result!.nextState.historyIndex).toBe(1);
+      expect(result!.textToSet).toBe("second cmd");
+    });
+
+    it("restores saved input when reaching bottom of history", () => {
+      const state: NavState = {
+        historyIndex: 0,
+        selectedSuggestionIndex: -1,
+      };
+      const result = computeDownArrow(state, history, 0, "my saved input");
+      expect(result).not.toBeNull();
+      expect(result!.nextState.historyIndex).toBe(-1);
+      expect(result!.textToSet).toBe("my saved input");
+    });
+
+    it("already at current input, overflows into autocomplete when multiple suggestions", () => {
+      const state: NavState = {
+        historyIndex: -1,
+        selectedSuggestionIndex: -1,
+      };
+      const result = computeDownArrow(state, history, 3, "saved");
+      expect(result).not.toBeNull();
+      expect(result!.nextState.historyIndex).toBe(-1);
+      expect(result!.nextState.selectedSuggestionIndex).toBe(0);
+      expect(result!.textToSet).toBe("saved");
+    });
+
+    it("already at current input, does not overflow with single suggestion", () => {
+      const state: NavState = {
+        historyIndex: -1,
+        selectedSuggestionIndex: -1,
+      };
+      const result = computeDownArrow(state, history, 1, "saved");
+      expect(result).not.toBeNull();
+      expect(result!.nextState.selectedSuggestionIndex).toBe(-1);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeTab
+// ---------------------------------------------------------------------------
+
+describe("computeTab", () => {
+  it("returns null when no suggestions", () => {
+    expect(computeTab([], 0)).toBeNull();
+  });
+
+  it("accepts the highlighted suggestion", () => {
+    const result = computeTab(options, 2);
+    expect(result).not.toBeNull();
+    expect(result!.acceptedValue).toBe("/help");
+    expect(result!.selectedSuggestionIndex).toBe(-1);
+  });
+
+  it("selects first suggestion when none is highlighted", () => {
+    const result = computeTab(options, -1);
+    expect(result).not.toBeNull();
+    expect(result!.acceptedValue).toBeNull();
+    expect(result!.selectedSuggestionIndex).toBe(0);
+  });
+
+  it("selects first suggestion when index is out of bounds", () => {
+    const result = computeTab(options, 999);
+    expect(result).not.toBeNull();
+    expect(result!.acceptedValue).toBeNull();
+    expect(result!.selectedSuggestionIndex).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldResetHistory
+// ---------------------------------------------------------------------------
+
+describe("shouldResetHistory", () => {
+  it("returns true when browsing history and not navigating programmatically", () => {
+    expect(shouldResetHistory(2, false)).toBe(true);
+  });
+
+  it("returns false when not browsing history (index -1)", () => {
+    expect(shouldResetHistory(-1, false)).toBe(false);
+  });
+
+  it("returns false when navigating programmatically", () => {
+    expect(shouldResetHistory(2, true)).toBe(false);
+  });
+
+  it("returns false when both at -1 and navigating", () => {
+    expect(shouldResetHistory(-1, true)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration-style scenarios: full navigation sequences
+// ---------------------------------------------------------------------------
+
+describe("navigation sequences", () => {
+  it("up through entire history and back down restores saved input", () => {
+    let state: NavState = { historyIndex: -1, selectedSuggestionIndex: -1 };
+    const savedInput = "my draft";
+
+    // Go up through all 3 history entries
+    const up1 = computeUpArrow(state, history, 0)!;
+    expect(up1.textToSet).toBe("third cmd");
+    expect(up1.saveCurrentInput).toBe(true);
+    state = up1.nextState;
+
+    const up2 = computeUpArrow(state, history, 0)!;
+    expect(up2.textToSet).toBe("second cmd");
+    state = up2.nextState;
+
+    const up3 = computeUpArrow(state, history, 0)!;
+    expect(up3.textToSet).toBe("first cmd");
+    state = up3.nextState;
+
+    // Clamp at top
+    const up4 = computeUpArrow(state, history, 0)!;
+    expect(up4.textToSet).toBe("first cmd");
+    expect(up4.nextState.historyIndex).toBe(2);
+    state = up4.nextState;
+
+    // Go all the way back down
+    const down1 = computeDownArrow(state, history, 0, savedInput)!;
+    expect(down1.textToSet).toBe("second cmd");
+    state = down1.nextState;
+
+    const down2 = computeDownArrow(state, history, 0, savedInput)!;
+    expect(down2.textToSet).toBe("third cmd");
+    state = down2.nextState;
+
+    const down3 = computeDownArrow(state, history, 0, savedInput)!;
+    expect(down3.textToSet).toBe(savedInput);
+    expect(down3.nextState.historyIndex).toBe(-1);
+  });
+
+  it("history bottom → autocomplete overflow → up exits autocomplete", () => {
+    let state: NavState = { historyIndex: -1, selectedSuggestionIndex: -1 };
+
+    // Down at bottom with multiple suggestions → overflow to autocomplete
+    const down1 = computeDownArrow(state, history, 3, "saved")!;
+    expect(down1.nextState.selectedSuggestionIndex).toBe(0);
+    state = down1.nextState;
+
+    // Up exits autocomplete
+    const up1 = computeUpArrow(state, history, 3)!;
+    expect(up1.nextState.selectedSuggestionIndex).toBe(-1);
+    expect(up1.textToSet).toBeNull();
+  });
+
+  it("single suggestion does not trap down arrow navigation", () => {
+    // Start in autocomplete with 1 suggestion + at history index 1
+    const state: NavState = { historyIndex: 1, selectedSuggestionIndex: 0 };
+
+    const result = computeDownArrow(state, history, 1, "saved")!;
+    // Should exit autocomplete and navigate history down
+    expect(result.nextState.selectedSuggestionIndex).toBe(-1);
+    expect(result.nextState.historyIndex).toBe(0);
+    expect(result.textToSet).toBe("third cmd");
+  });
+});

--- a/src/tui/components/shared/prompt-input-logic.ts
+++ b/src/tui/components/shared/prompt-input-logic.ts
@@ -1,0 +1,227 @@
+import type { AutocompleteOption } from "./prompt-input";
+
+// ---------------------------------------------------------------------------
+// Autocomplete filtering
+// ---------------------------------------------------------------------------
+
+export function filterSuggestions(
+  inputValue: string,
+  options: AutocompleteOption[],
+  maxSuggestions: number,
+): AutocompleteOption[] {
+  if (!options.length || !inputValue) return [];
+  const input = inputValue.toLowerCase().trim();
+  if (!input.startsWith("/")) return [];
+
+  return options
+    .filter(
+      (opt) =>
+        opt.value.toLowerCase().includes(input) ||
+        opt.label.toLowerCase().includes(input),
+    )
+    .slice(0, maxSuggestions);
+}
+
+// ---------------------------------------------------------------------------
+// Submit value resolution
+// ---------------------------------------------------------------------------
+
+export function resolveSubmitValue(
+  rawText: string,
+  suggestions: AutocompleteOption[],
+  selectedIndex: number,
+): string {
+  if (suggestions.length > 0 && selectedIndex >= 0) {
+    const selected = suggestions[selectedIndex];
+    if (selected) return selected.value;
+  }
+  return rawText.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Keyboard navigation state helpers
+//
+// Each function returns the next state (or null when the key should be
+// ignored).  The caller is responsible for applying side-effects such as
+// calling setText / setInputValue.
+// ---------------------------------------------------------------------------
+
+export interface NavState {
+  historyIndex: number;
+  selectedSuggestionIndex: number;
+}
+
+export interface UpArrowResult {
+  nextState: NavState;
+  /** History entry to display, or null when staying in autocomplete */
+  textToSet: string | null;
+  /** Whether the current input should be saved before navigating */
+  saveCurrentInput: boolean;
+}
+
+export function computeUpArrow(
+  currentState: NavState,
+  history: string[],
+  suggestionsCount: number,
+): UpArrowResult | null {
+  const inAutocomplete = currentState.selectedSuggestionIndex >= 0;
+
+  if (inAutocomplete) {
+    if (currentState.selectedSuggestionIndex <= 0) {
+      return {
+        nextState: {
+          historyIndex: currentState.historyIndex,
+          selectedSuggestionIndex: -1,
+        },
+        textToSet: null,
+        saveCurrentInput: false,
+      };
+    }
+    return {
+      nextState: {
+        historyIndex: currentState.historyIndex,
+        selectedSuggestionIndex: currentState.selectedSuggestionIndex - 1,
+      },
+      textToSet: null,
+      saveCurrentInput: false,
+    };
+  }
+
+  if (history.length === 0) return null;
+
+  const saveInput = currentState.historyIndex === -1;
+  const nextIdx = Math.min(currentState.historyIndex + 1, history.length - 1);
+  const entry = history[history.length - 1 - nextIdx];
+
+  return {
+    nextState: {
+      historyIndex: nextIdx,
+      selectedSuggestionIndex: currentState.selectedSuggestionIndex,
+    },
+    textToSet: entry ?? null,
+    saveCurrentInput: saveInput,
+  };
+}
+
+export interface DownArrowResult {
+  nextState: NavState;
+  textToSet: string | null;
+}
+
+export function computeDownArrow(
+  currentState: NavState,
+  history: string[],
+  suggestionsCount: number,
+  savedInput: string,
+): DownArrowResult | null {
+  const inAutocomplete = currentState.selectedSuggestionIndex >= 0;
+
+  if (inAutocomplete) {
+    if (suggestionsCount <= 1) {
+      // Single suggestion — exit autocomplete, fall through to history
+      return computeDownArrowFromHistory(
+        { ...currentState, selectedSuggestionIndex: -1 },
+        history,
+        suggestionsCount,
+        savedInput,
+      );
+    }
+    const nextIdx =
+      currentState.selectedSuggestionIndex >= suggestionsCount - 1
+        ? suggestionsCount - 1
+        : currentState.selectedSuggestionIndex + 1;
+    return {
+      nextState: {
+        historyIndex: currentState.historyIndex,
+        selectedSuggestionIndex: nextIdx,
+      },
+      textToSet: null,
+    };
+  }
+
+  return computeDownArrowFromHistory(
+    currentState,
+    history,
+    suggestionsCount,
+    savedInput,
+  );
+}
+
+function computeDownArrowFromHistory(
+  currentState: NavState,
+  history: string[],
+  suggestionsCount: number,
+  savedInput: string,
+): DownArrowResult | null {
+  if (history.length === 0) {
+    if (suggestionsCount > 1) {
+      return {
+        nextState: {
+          historyIndex: currentState.historyIndex,
+          selectedSuggestionIndex: 0,
+        },
+        textToSet: null,
+      };
+    }
+    return null;
+  }
+
+  if (currentState.historyIndex <= 0) {
+    const overflowToAutocomplete =
+      currentState.historyIndex === -1 && suggestionsCount > 1;
+    return {
+      nextState: {
+        historyIndex: -1,
+        selectedSuggestionIndex: overflowToAutocomplete
+          ? 0
+          : currentState.selectedSuggestionIndex,
+      },
+      textToSet: savedInput,
+    };
+  }
+
+  const nextIdx = currentState.historyIndex - 1;
+  const entry = history[history.length - 1 - nextIdx];
+  return {
+    nextState: {
+      historyIndex: nextIdx,
+      selectedSuggestionIndex: currentState.selectedSuggestionIndex,
+    },
+    textToSet: entry ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tab handling
+// ---------------------------------------------------------------------------
+
+export interface TabResult {
+  selectedSuggestionIndex: number;
+  acceptedValue: string | null;
+}
+
+export function computeTab(
+  suggestions: AutocompleteOption[],
+  selectedIndex: number,
+): TabResult | null {
+  if (suggestions.length === 0) return null;
+
+  if (selectedIndex >= 0 && selectedIndex < suggestions.length) {
+    const selected = suggestions[selectedIndex];
+    if (selected) {
+      return { selectedSuggestionIndex: -1, acceptedValue: selected.value };
+    }
+  }
+  return { selectedSuggestionIndex: 0, acceptedValue: null };
+}
+
+// ---------------------------------------------------------------------------
+// Content change — should we reset history browsing?
+// ---------------------------------------------------------------------------
+
+export function shouldResetHistory(
+  historyIndex: number,
+  isNavigatingHistory: boolean,
+): boolean {
+  return historyIndex !== -1 && !isNavigatingHistory;
+}

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -258,10 +258,17 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       // --- Down arrow ---------------------------------------------------
       if (key.name === "down") {
         if (inAutocomplete) {
-          setSelectedSuggestionIndex((prev) =>
-            prev >= suggestions.length - 1 ? suggestions.length - 1 : prev + 1,
-          );
-          return;
+          if (suggestions.length <= 1) {
+            // Single suggestion — exit autocomplete, fall through to history
+            setSelectedSuggestionIndex(-1);
+          } else {
+            setSelectedSuggestionIndex((prev) =>
+              prev >= suggestions.length - 1
+                ? suggestions.length - 1
+                : prev + 1,
+            );
+            return;
+          }
         }
 
         if (history.length === 0) {

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -11,6 +11,14 @@ import type { TextareaRenderable, RGBA } from "@opentui/core";
 import { useTheme } from "../../theme";
 import { useInput } from "../../context/input";
 import { useFocus } from "../../context/focus";
+import {
+  filterSuggestions,
+  resolveSubmitValue,
+  computeUpArrow,
+  computeDownArrow,
+  computeTab,
+  shouldResetHistory,
+} from "./prompt-input-logic";
 export interface AutocompleteOption {
   value: string;
   label: string;
@@ -121,21 +129,13 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
     const onSubmitRef = useRef(onSubmit);
     onSubmitRef.current = onSubmit;
 
-    // Filter suggestions using inputValue from context
-    const suggestions = useMemo(() => {
-      if (!enableAutocomplete || !autocompleteOptions || !inputValue) return [];
-      const input = inputValue.toLowerCase().trim();
-
-      if (!(input[0] === "/")) return [];
-
-      return autocompleteOptions
-        .filter(
-          (opt) =>
-            opt.value.toLowerCase().includes(input) ||
-            opt.label.toLowerCase().includes(input),
-        )
-        .slice(0, maxSuggestions);
-    }, [enableAutocomplete, autocompleteOptions, inputValue, maxSuggestions]);
+    const suggestions = useMemo(
+      () =>
+        enableAutocomplete
+          ? filterSuggestions(inputValue, autocompleteOptions, maxSuggestions)
+          : [],
+      [enableAutocomplete, autocompleteOptions, inputValue, maxSuggestions],
+    );
 
     // Keep refs in sync
     useEffect(() => {
@@ -204,111 +204,75 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       // --- Tab: accept the highlighted autocomplete suggestion -----------
       if (suggestions.length > 0 && key.name === "tab") {
         key.preventDefault?.();
-        const idx = selectedIndexRef.current;
-        if (idx >= 0 && idx < suggestions.length) {
-          const selected = suggestions[idx];
-          if (selected) {
-            textareaRef.current?.setText(selected.value);
-            setInputValue(selected.value);
-            setSelectedSuggestionIndex(-1);
+        const tabResult = computeTab(suggestions, selectedIndexRef.current);
+        if (tabResult) {
+          setSelectedSuggestionIndex(tabResult.selectedSuggestionIndex);
+          if (tabResult.acceptedValue !== null) {
+            textareaRef.current?.setText(tabResult.acceptedValue);
+            setInputValue(tabResult.acceptedValue);
             textareaRef.current?.gotoLineEnd();
           }
-        } else {
-          setSelectedSuggestionIndex(0);
         }
         return;
       }
 
-      const inAutocomplete = selectedIndexRef.current >= 0;
       const history = historyRef.current;
+      const currentState = {
+        historyIndex,
+        selectedSuggestionIndex: selectedIndexRef.current,
+      };
 
       // --- Up arrow -----------------------------------------------------
       if (key.name === "up") {
-        if (inAutocomplete) {
-          // At top of suggestion list → exit back to normal input
-          if (selectedIndexRef.current <= 0) {
-            setSelectedSuggestionIndex(-1);
-          } else {
-            setSelectedSuggestionIndex((prev) => prev - 1);
-          }
-          return;
-        }
+        const result = computeUpArrow(
+          currentState,
+          history,
+          suggestions.length,
+        );
+        if (!result) return;
 
-        if (history.length === 0) return;
-        setHistoryIndex((prev) => {
-          if (prev === -1) {
-            savedInputRef.current = textareaRef.current?.plainText ?? "";
-          }
-          const next = Math.min(prev + 1, history.length - 1);
-          const entry = history[history.length - 1 - next];
-          if (entry !== undefined) {
-            isNavigatingHistoryRef.current = true;
-            textareaRef.current?.setText(entry);
-            setInputValue(entry);
-            setTimeout(() => {
-              isNavigatingHistoryRef.current = false;
-              textareaRef.current?.gotoLineEnd();
-            }, 0);
-          }
-          return next;
-        });
+        if (result.saveCurrentInput) {
+          savedInputRef.current = textareaRef.current?.plainText ?? "";
+        }
+        setSelectedSuggestionIndex(result.nextState.selectedSuggestionIndex);
+        if (result.textToSet !== null) {
+          isNavigatingHistoryRef.current = true;
+          textareaRef.current?.setText(result.textToSet);
+          setInputValue(result.textToSet);
+          setHistoryIndex(result.nextState.historyIndex);
+          setTimeout(() => {
+            isNavigatingHistoryRef.current = false;
+            textareaRef.current?.gotoLineEnd();
+          }, 0);
+        } else {
+          setHistoryIndex(result.nextState.historyIndex);
+        }
         return;
       }
 
       // --- Down arrow ---------------------------------------------------
       if (key.name === "down") {
-        if (inAutocomplete) {
-          if (suggestions.length <= 1) {
-            // Single suggestion — exit autocomplete, fall through to history
-            setSelectedSuggestionIndex(-1);
-          } else {
-            setSelectedSuggestionIndex((prev) =>
-              prev >= suggestions.length - 1
-                ? suggestions.length - 1
-                : prev + 1,
-            );
-            return;
-          }
+        const result = computeDownArrow(
+          currentState,
+          history,
+          suggestions.length,
+          savedInputRef.current,
+        );
+        if (!result) return;
+
+        setSelectedSuggestionIndex(result.nextState.selectedSuggestionIndex);
+        if (result.textToSet !== null) {
+          isNavigatingHistoryRef.current = true;
+          textareaRef.current?.setText(result.textToSet);
+          setInputValue(result.textToSet);
+          setHistoryIndex(result.nextState.historyIndex);
+          setTimeout(() => {
+            isNavigatingHistoryRef.current = false;
+            textareaRef.current?.gotoLineEnd();
+          }, 0);
+        } else {
+          setHistoryIndex(result.nextState.historyIndex);
         }
-
-        if (history.length === 0) {
-          // No history — overflow into autocomplete (only when multiple suggestions)
-          if (suggestions.length > 1) {
-            setSelectedSuggestionIndex(0);
-          }
-          return;
-        }
-
-        setHistoryIndex((prev) => {
-          if (prev <= 0) {
-            const saved = savedInputRef.current;
-            isNavigatingHistoryRef.current = true;
-            textareaRef.current?.setText(saved);
-            setInputValue(saved);
-            setTimeout(() => {
-              isNavigatingHistoryRef.current = false;
-              textareaRef.current?.gotoLineEnd();
-            }, 0);
-
-            // Already at current input — overflow into autocomplete (only when multiple suggestions)
-            if (prev === -1 && suggestions.length > 1) {
-              setSelectedSuggestionIndex(0);
-            }
-            return -1;
-          }
-          const next = prev - 1;
-          const entry = history[history.length - 1 - next];
-          if (entry !== undefined) {
-            isNavigatingHistoryRef.current = true;
-            textareaRef.current?.setText(entry);
-            setInputValue(entry);
-            setTimeout(() => {
-              isNavigatingHistoryRef.current = false;
-              textareaRef.current?.gotoLineEnd();
-            }, 0);
-          }
-          return next;
-        });
         return;
       }
     });
@@ -319,17 +283,13 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       const currentSuggestions = suggestionsRef.current;
       const currentSelectedIndex = selectedIndexRef.current;
 
-      let valueToSubmit: string;
+      const valueToSubmit = resolveSubmitValue(
+        textareaRef.current?.plainText ?? "",
+        currentSuggestions,
+        currentSelectedIndex,
+      );
       if (currentSuggestions.length > 0 && currentSelectedIndex >= 0) {
-        const selected = currentSuggestions[currentSelectedIndex];
-        if (selected) {
-          valueToSubmit = selected.value;
-          setSelectedSuggestionIndex(-1);
-        } else {
-          valueToSubmit = (textareaRef.current?.plainText ?? "").trim();
-        }
-      } else {
-        valueToSubmit = (textareaRef.current?.plainText ?? "").trim();
+        setSelectedSuggestionIndex(-1);
       }
 
       if (!valueToSubmit) return;
@@ -351,7 +311,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
     const handleContentChange = () => {
       const text = textareaRef.current?.plainText ?? "";
       setInputValue(text);
-      if (historyIndex !== -1 && !isNavigatingHistoryRef.current) {
+      if (shouldResetHistory(historyIndex, isNavigatingHistoryRef.current)) {
         setHistoryIndex(-1);
       }
     };

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -182,49 +182,59 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       return () => registerPromptRef(null);
     }, [registerPromptRef]);
 
-    // Handle keyboard navigation for suggestions and command history
+    // Handle keyboard navigation for suggestions and command history.
+    //
+    // Priority: up/down navigate command history. When the user reaches
+    // the bottom of history (current input) and presses down again with
+    // autocomplete suggestions visible, navigation overflows into the
+    // suggestion list. Pressing up past the top of the list exits back
+    // to history. Tab always accepts the highlighted suggestion.
     useKeyboard((key) => {
       if (!focused) return;
 
-      // When autocomplete suggestions are visible, up/down navigates them
-      if (suggestions.length > 0) {
-        if (key.name === "up") {
-          setSelectedSuggestionIndex((prev) =>
-            prev <= 0 ? suggestions.length - 1 : prev - 1,
-          );
-          return;
-        }
-        if (key.name === "down") {
-          setSelectedSuggestionIndex((prev) =>
-            prev >= suggestions.length - 1 ? 0 : prev + 1,
-          );
-          return;
-        }
-        if (key.name === "tab") {
-          key.preventDefault?.();
-          const currentSelectedIndex = selectedIndexRef.current;
-          if (
-            currentSelectedIndex >= 0 &&
-            currentSelectedIndex < suggestions.length
-          ) {
-            const selected = suggestions[currentSelectedIndex];
-            if (selected) {
-              textareaRef.current?.setText(selected.value);
-              setInputValue(selected.value);
-              setSelectedSuggestionIndex(-1);
-              textareaRef.current?.gotoLineEnd();
-            }
+      // --- Ctrl+C: clear input ------------------------------------------
+      if (key.ctrl && key.name === "c") {
+        textareaRef.current?.setText("");
+        setInputValue("");
+        setHistoryIndex(-1);
+        setSelectedSuggestionIndex(-1);
+        return;
+      }
+
+      // --- Tab: accept the highlighted autocomplete suggestion -----------
+      if (suggestions.length > 0 && key.name === "tab") {
+        key.preventDefault?.();
+        const idx = selectedIndexRef.current;
+        if (idx >= 0 && idx < suggestions.length) {
+          const selected = suggestions[idx];
+          if (selected) {
+            textareaRef.current?.setText(selected.value);
+            setInputValue(selected.value);
+            setSelectedSuggestionIndex(-1);
+            textareaRef.current?.gotoLineEnd();
           }
-          return;
+        } else {
+          setSelectedSuggestionIndex(0);
         }
         return;
       }
 
-      // No autocomplete visible — up/down navigates command history
+      const inAutocomplete = selectedIndexRef.current >= 0;
       const history = historyRef.current;
-      if (history.length === 0) return;
 
+      // --- Up arrow -----------------------------------------------------
       if (key.name === "up") {
+        if (inAutocomplete) {
+          // At top of suggestion list → exit back to normal input
+          if (selectedIndexRef.current <= 0) {
+            setSelectedSuggestionIndex(-1);
+          } else {
+            setSelectedSuggestionIndex((prev) => prev - 1);
+          }
+          return;
+        }
+
+        if (history.length === 0) return;
         setHistoryIndex((prev) => {
           if (prev === -1) {
             savedInputRef.current = textareaRef.current?.plainText ?? "";
@@ -235,22 +245,48 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
             isNavigatingHistoryRef.current = true;
             textareaRef.current?.setText(entry);
             setInputValue(entry);
-            isNavigatingHistoryRef.current = false;
-            setTimeout(() => textareaRef.current?.gotoLineEnd(), 0);
+            setTimeout(() => {
+              isNavigatingHistoryRef.current = false;
+              textareaRef.current?.gotoLineEnd();
+            }, 0);
           }
           return next;
         });
         return;
       }
+
+      // --- Down arrow ---------------------------------------------------
       if (key.name === "down") {
+        if (inAutocomplete) {
+          setSelectedSuggestionIndex((prev) =>
+            prev >= suggestions.length - 1 ? suggestions.length - 1 : prev + 1,
+          );
+          return;
+        }
+
+        if (history.length === 0) {
+          // No history — overflow into autocomplete (only when multiple suggestions)
+          if (suggestions.length > 1) {
+            setSelectedSuggestionIndex(0);
+          }
+          return;
+        }
+
         setHistoryIndex((prev) => {
           if (prev <= 0) {
             const saved = savedInputRef.current;
             isNavigatingHistoryRef.current = true;
             textareaRef.current?.setText(saved);
             setInputValue(saved);
-            isNavigatingHistoryRef.current = false;
-            setTimeout(() => textareaRef.current?.gotoLineEnd(), 0);
+            setTimeout(() => {
+              isNavigatingHistoryRef.current = false;
+              textareaRef.current?.gotoLineEnd();
+            }, 0);
+
+            // Already at current input — overflow into autocomplete (only when multiple suggestions)
+            if (prev === -1 && suggestions.length > 1) {
+              setSelectedSuggestionIndex(0);
+            }
             return -1;
           }
           const next = prev - 1;
@@ -259,8 +295,10 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
             isNavigatingHistoryRef.current = true;
             textareaRef.current?.setText(entry);
             setInputValue(entry);
-            isNavigatingHistoryRef.current = false;
-            setTimeout(() => textareaRef.current?.gotoLineEnd(), 0);
+            setTimeout(() => {
+              isNavigatingHistoryRef.current = false;
+              textareaRef.current?.gotoLineEnd();
+            }, 0);
           }
           return next;
         });

--- a/src/tui/context/route.tsx
+++ b/src/tui/context/route.tsx
@@ -5,6 +5,7 @@ import {
   type ReactNode,
   useMemo,
 } from "react";
+import type { SessionConfig } from "../../core/session";
 
 export type RoutePath =
   | "home"
@@ -51,7 +52,10 @@ export type Route =
     }
   | {
       type: "pentest";
-      sessionId: string;
+      sessionId?: string;
+      /** When sessionId is omitted, create a new session from these fields */
+      targets?: string[];
+      sessionConfig?: SessionConfig;
       /** If true, open an auto-mode session in operator mode */
       openAsOperator?: boolean;
     }
@@ -61,6 +65,7 @@ export type Route =
       initialMessage?: string;
       initialConfig?: {
         requireApproval?: boolean;
+        target?: string;
       };
     };
 

--- a/src/tui/hooks/use-sessions-list.ts
+++ b/src/tui/hooks/use-sessions-list.ts
@@ -99,7 +99,7 @@ export function useSessionsList() {
   // Filter by search term
   const filtered = searchTerm
     ? allSessions.filter((s) =>
-        s.name.toLowerCase().includes(searchTerm.toLowerCase()),
+        (s.name ?? "").toLowerCase().includes(searchTerm.toLowerCase()),
       )
     : allSessions;
 

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -345,7 +345,13 @@ function CommandDisplay({
     if (route.data.openAsOperator) {
       return <OperatorDashboard sessionId={route.data.sessionId} />;
     }
-    return <Pentest sessionId={route.data.sessionId} />;
+    return (
+      <Pentest
+        sessionId={route.data.sessionId}
+        targets={route.data.targets}
+        sessionConfig={route.data.sessionConfig}
+      />
+    );
   }
 
   return null;

--- a/src/tui/utils/command-flags.ts
+++ b/src/tui/utils/command-flags.ts
@@ -10,7 +10,6 @@ import {
   type SessionConfig,
   type SessionInfo,
 } from "../../core/session";
-import { generateRandomName } from "../../util/name";
 import type { OperatorMode } from "../../core/operator";
 import { createToolsetState } from "../../core/toolset";
 
@@ -326,7 +325,7 @@ export async function createOperatorSessionFromFlags(
   const targets = flags.target ? [flags.target] : [];
   const session = await sessions.create({
     targets,
-    name: flags.name || generateRandomName(),
+    name: flags.name || undefined,
     config: sessionConfig,
   });
 
@@ -377,7 +376,7 @@ export async function createSwarmSessionFromFlags(
 
   const session = await sessions.create({
     targets: [flags.target!],
-    name: flags.name || generateRandomName(),
+    name: flags.name || undefined,
     config: sessionConfig,
   });
 

--- a/src/tui/utils/command-flags.ts
+++ b/src/tui/utils/command-flags.ts
@@ -5,11 +5,7 @@
  * Supports: --flag value, --flag=value, --boolean-flag
  */
 
-import {
-  sessions,
-  type SessionConfig,
-  type SessionInfo,
-} from "../../core/session";
+import type { SessionConfig } from "../../core/session";
 import type { OperatorMode } from "../../core/operator";
 import { createToolsetState } from "../../core/toolset";
 
@@ -275,12 +271,18 @@ export function hasEnoughFlagsToSkipWizard(flags: WebCommandFlags): boolean {
   return true;
 }
 
+export interface SessionCreateParams {
+  targets: string[];
+  name?: string;
+  config: SessionConfig;
+}
+
 /**
- * Create an operator session from CLI flags
+ * Build operator session config from CLI flags (no session creation).
  */
-export async function createOperatorSessionFromFlags(
+export function buildOperatorSessionConfig(
   flags: WebCommandFlags,
-): Promise<SessionInfo> {
+): SessionCreateParams {
   const sessionConfig: SessionConfig = {
     sessionType: "web-app",
     mode: "operator",
@@ -289,11 +291,9 @@ export async function createOperatorSessionFromFlags(
       requireApproval: flags.requireApproval ?? true,
       enableSuggestions: true,
     },
-    // Initialize toolset with full web-pentest tools
     toolsetState: createToolsetState("web-pentest"),
   };
 
-  // Auth config
   if (flags.authInstructions || flags.authUser) {
     sessionConfig.authenticationInstructions = flags.authInstructions;
     if (flags.authUser) {
@@ -305,7 +305,6 @@ export async function createOperatorSessionFromFlags(
     }
   }
 
-  // Scope constraints
   if (flags.hosts?.length || flags.ports?.length || flags.strict) {
     sessionConfig.scopeConstraints = {
       allowedHosts: flags.hosts,
@@ -314,7 +313,6 @@ export async function createOperatorSessionFromFlags(
     };
   }
 
-  // Headers config
   if (flags.headersMode && flags.headersMode !== "default") {
     sessionConfig.offensiveHeaders = {
       mode: flags.headersMode,
@@ -322,30 +320,25 @@ export async function createOperatorSessionFromFlags(
     };
   }
 
-  const targets = flags.target ? [flags.target] : [];
-  const session = await sessions.create({
-    targets,
+  return {
+    targets: flags.target ? [flags.target] : [],
     name: flags.name || undefined,
     config: sessionConfig,
-  });
-
-  return session;
+  };
 }
 
 /**
- * Create a swarm session from CLI flags
+ * Build swarm session config from CLI flags (no session creation).
  */
-export async function createSwarmSessionFromFlags(
+export function buildSwarmSessionConfig(
   flags: WebCommandFlags,
-): Promise<SessionInfo> {
+): SessionCreateParams {
   const sessionConfig: SessionConfig = {
     sessionType: "web-app",
     mode: "auto",
-    // Initialize toolset with full web-pentest tools
     toolsetState: createToolsetState("web-pentest"),
   };
 
-  // Auth config
   if (flags.authInstructions || flags.authUser) {
     sessionConfig.authenticationInstructions = flags.authInstructions;
     if (flags.authUser) {
@@ -357,7 +350,6 @@ export async function createSwarmSessionFromFlags(
     }
   }
 
-  // Scope constraints
   if (flags.hosts?.length || flags.ports?.length || flags.strict) {
     sessionConfig.scopeConstraints = {
       allowedHosts: flags.hosts,
@@ -366,7 +358,6 @@ export async function createSwarmSessionFromFlags(
     };
   }
 
-  // Headers config
   if (flags.headersMode && flags.headersMode !== "default") {
     sessionConfig.offensiveHeaders = {
       mode: flags.headersMode,
@@ -374,11 +365,9 @@ export async function createSwarmSessionFromFlags(
     };
   }
 
-  const session = await sessions.create({
+  return {
     targets: [flags.target!],
     name: flags.name || undefined,
     config: sessionConfig,
-  });
-
-  return session;
+  };
 }

--- a/src/util/name.ts
+++ b/src/util/name.ts
@@ -1,3 +1,7 @@
+import { z } from "zod";
+import { generateObjectResponse, type AIModel } from "../core/ai/ai";
+import type { AIAuthConfig } from "../core/ai/utils";
+
 // Random name generator (GitHub-style)
 const adjectives = [
   "swift",
@@ -70,4 +74,66 @@ export function generateRandomName(): string {
   const adj = adjectives[Math.floor(Math.random() * adjectives.length)]!;
   const noun = nouns[Math.floor(Math.random() * nouns.length)]!;
   return `${adj}-${noun}`;
+}
+
+const sessionNameSchema = z.object({
+  name: z
+    .string()
+    .describe(
+      "A short, descriptive session name (2-4 words, lowercase, hyphenated)",
+    ),
+});
+
+/**
+ * AI-generate a descriptive session name based on targets and/or user message.
+ * Returns null on failure — callers should keep the placeholder name.
+ */
+export async function generateSessionName(opts: {
+  targets: string[];
+  userMessage?: string;
+  model: AIModel;
+  authConfig?: AIAuthConfig;
+}): Promise<string | null> {
+  const { targets, userMessage, model, authConfig } = opts;
+
+  const contextParts: string[] = [];
+  if (targets.length > 0) {
+    contextParts.push(`Target(s): ${targets.join(", ")}`);
+  }
+  if (userMessage) {
+    contextParts.push(`User objective: ${userMessage}`);
+  }
+  if (contextParts.length === 0) return null;
+
+  const prompt = [
+    "Generate a short, descriptive name for a penetration testing session.",
+    "The name should be 2-4 lowercase words separated by hyphens.",
+    "It should capture the key aspect of the target or task — e.g. 'acme-api-pentest', 'login-auth-bypass', 'ecommerce-checkout-test'.",
+    "",
+    ...contextParts,
+  ].join("\n");
+
+  try {
+    const result = await generateObjectResponse({
+      model,
+      schema: sessionNameSchema,
+      prompt,
+      maxTokens: 50,
+      temperature: 0.7,
+      authConfig,
+    });
+
+    if (!result?.name) return null;
+
+    const name = result.name
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 50);
+
+    return name || null;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary

- **AI-generated session names**: Uses the target URL and/or user prompt to generate descriptive session names via AI. Falls back to random `adjective-noun` names when AI is unavailable or fails. Name generation is fire-and-forget — never blocks session creation.
- **Decouple session creation from TUI**: The operator dashboard no longer calls `sessions.create` directly. Instead, the first `runAgent` call uses `OffensiveSecurityAgent.create()` which owns the full session lifecycle. `buildSystem` callback lets the dashboard provide the system prompt after the session is created.
- **`runOffensiveSecurityAgent` returns `{ streamResult, session }`** so callers can access sessions auto-created by the factory.
- **Fix operator mode name gen**: Pass user prompt as `userMessage` context so operator sessions (which often have no targets) can still generate names. `onNameGenerated` callback + `pendingNameRef` handle the race between async name gen and stream completion.
- **Fix skills auto-launch**: The initial message auto-send no longer gates on `session` existing (since session is now created lazily on first agent call).
- **Remove operator history pollution**: Only the home page tracks command history — operator mode messages are no longer pushed to the global history.
- **Fix prompt-input history navigation**: Race condition in `isNavigatingHistoryRef` guard that limited up-arrow to only the last entry. Defer guard reset via `setTimeout`.
- **Rework autocomplete vs history**: Up/down always navigates history. When at the bottom with multiple suggestions, down overflows into autocomplete selection. Up past the top of suggestions exits back. Tab accepts the highlighted suggestion. Single-suggestion case skips autocomplete and goes straight to history.
- **Ctrl+C clears input** in the home page prompt.

## Test plan

- [ ] Operator mode: first message creates session and AI-generates a name from the prompt
- [ ] Operator mode: header updates from "New Session" → random name → AI name
- [ ] Skills from home page auto-launch operator with the skill content as first message
- [ ] Pentest mode still creates sessions with AI names from target URL
- [ ] Up/down arrow navigates full command history on home page (not just last entry)
- [ ] Down arrow overflows into autocomplete when multiple suggestions visible
- [ ] Single autocomplete suggestion: down arrow goes to history, Tab accepts
- [ ] Ctrl+C clears the home page input
- [ ] Operator messages don't pollute home page command history
- [ ] `bun run test` — all tests pass
- [ ] `bun run tsc` — no type errors
- [ ] `bun run lint` — no lint errors