### PR TITLE
Add AI model trust boundary and prompt injection language to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,6 +67,14 @@ Apex assumes the following trust boundaries:
 
 Issues that require a user to execute internal development scripts against malicious inputs outside their intended workflow, or that require modification of local configurations or files outside documented usage, may be classified as out of scope.
 
+### AI Model Trust Boundary
+
+Apex is an AI-agent system. Internal agent tools (e.g., file operations, command execution) receive their parameters from the AI model at inference time — not from external or untrusted input. The model operates as a delegate of the operator, within the operator's own system permissions.
+
+Model-generated tool parameters (file paths, command strings, etc.) are part of the model's inference output and are governed by the model's system prompt and alignment, not by input-validation controls designed for untrusted external data. The absence of path restrictions or input sanitization on agent tool parameters is a deliberate design choice consistent with the trust model of AI coding and security agents, not an implementation defect.
+
+Reports that characterize model-generated tool parameters as "unsanitized external input" do not align with the product's trust model and will generally be classified as informational.
+
 ### Operational Risk Assumptions
 
 APEX is an autonomous penetration testing tool designed to intentionally interact with potentially adversarial infrastructure.
@@ -77,10 +85,11 @@ Operators accept inherent risk when directing the tool at any target during auth
 - Exposure to intentionally malformed or hostile protocol responses
 - Deceptive application-layer behavior from test targets
 - Attempts by targets to fingerprint, throttle, or retaliate against scanning infrastructure
+- Prompt injection attempts by hostile targets designed to influence AI model behavior
 
-Compromise scenarios arising from expected interaction with hostile targets — during authorized and intended usage — are considered inherent operational risk of offensive security tooling, not product vulnerabilities.
+Compromise scenarios arising from expected interaction with hostile targets — during authorized and intended usage — are considered inherent operational risk of offensive security tooling, not product vulnerabilities. This includes scenarios where a hostile target attempts to influence the AI model's tool-calling behavior via prompt injection payloads embedded in application content.
 
-Reports must demonstrate a defect in Apex’s implementation that violates its documented threat model, rather than outcomes that stem from intentionally engaging adversarial systems.
+Reports must demonstrate a defect in Apex's implementation that violates its documented threat model, rather than outcomes that stem from intentionally engaging adversarial systems or from the AI model's inference behavior.
 
 ## Severity & Impact
 


### PR DESCRIPTION
## Summary

- Adds a new **AI Model Trust Boundary** subsection to the Threat Model, clarifying that agent tool parameters are model-generated (not untrusted external input) and that the absence of path restrictions is by design.
- Adds **prompt injection via hostile targets** as an explicit operational risk bullet point.
- Extends the operational risk paragraph to explicitly cover scenarios where hostile targets attempt to influence model tool-calling behavior.

These additions make it easier to classify future security reports that frame model-generated tool parameters as unsanitized external input or that depend on prompt injection chains for exploitation.

## Test plan

- [ ] Review that the new language is consistent with the existing threat model
- [ ] Confirm no unintended scope narrowing for legitimate vulnerability reports

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies the threat model and how certain reports are triaged; no runtime code or security controls are modified.
> 
> **Overview**
> Updates `SECURITY.md` to explicitly define an **AI model trust boundary**, stating that agent tool parameters are model-generated (not treated as untrusted external input) and that lack of path/parameter sanitization is an intentional design choice.
> 
> Expands *operational risk assumptions* to call out prompt-injection attempts by hostile targets and clarifies that outcomes driven by prompt injection/model inference generally do not constitute product vulnerabilities unless they reveal an implementation defect that violates the documented threat model.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3286da49f3a1e331a7e49c59f91d63304e4fc475. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->