### PR TITLE
Show agent session CWD in footer + per-subagent output windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensar/apex",
-  "version": "0.0.85",
+  "version": "0.0.86",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
   "main": "build/index.js",

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -30,6 +30,11 @@ Returns an array of results with the text output from each agent.`,
       tasks: z
         .array(
           z.object({
+            name: z
+              .string()
+              .describe(
+                "Short human-readable label for this agent shown in the UI (e.g. 'parseurl module', 'auth middleware')",
+              ),
             codebasePath: z
               .string()
               .describe("Root directory for this agent to work in"),
@@ -88,6 +93,7 @@ Returns an array of results with the text output from each agent.`,
               item.codebasePath,
               item.objective,
               item.index + 1,
+              item.name,
             )
               .then((output) => {
                 results.push({
@@ -143,6 +149,7 @@ async function runSingleCodingAgent(
   codebasePath: string,
   objective: string,
   agentIndex: number,
+  name: string,
 ): Promise<string> {
   // Dynamic import to break circular dependency
   const { CodeAgent } = await import("../../specialized/codeAgent/agent");
@@ -151,6 +158,7 @@ async function runSingleCodingAgent(
 
   ctx.subagentCallbacks?.onSubagentSpawn?.({
     subagentId,
+    name,
     input: { codebasePath, objective },
     status: "pending",
   });

--- a/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
@@ -31,6 +31,12 @@ Pass every target you want tested — the swarm handles concurrency automaticall
       targets: z
         .array(
           z.object({
+            name: z
+              .string()
+              .optional()
+              .describe(
+                "Short human-readable label for this agent shown in the UI (e.g. 'SQLi /api/users', 'IDOR orders')",
+              ),
             target: z
               .string()
               .describe("Full target URL including endpoint to test"),

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -271,10 +271,13 @@ export type ConsumeCallbacks = {
 export type SubagentConsumeCallbacks = {
   onSubagentSpawn?: ({
     subagentId,
+    name,
     input,
     status,
   }: {
     subagentId: string;
+    /** Short human-readable label for this sub-agent (e.g. truncated objective). */
+    name?: string;
     input: unknown;
     status: "pending" | "completed" | "failed";
   }) => void;

--- a/src/core/api/offesecAgent.ts
+++ b/src/core/api/offesecAgent.ts
@@ -23,11 +23,15 @@ export interface RunAgentResult {
  * session that was auto-created by the factory.
  */
 export async function runOffensiveSecurityAgent(
-  input: OffensiveSecurityAgentInput | CreateAgentInput,
+  input: (OffensiveSecurityAgentInput | CreateAgentInput) & {
+    onSessionReady?: (session: SessionInfo) => void;
+  },
 ): Promise<RunAgentResult> {
   const agent = input.session
     ? new OffensiveSecurityAgent(input as OffensiveSecurityAgentInput)
     : await OffensiveSecurityAgent.create(input as CreateAgentInput);
+
+  input.onSessionReady?.(agent.session);
 
   await agent.consume({
     onTextDelta: (d) => input.callbacks?.onTextDelta?.(d),

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -265,6 +265,7 @@ export function readAgentManifest(session: SessionInfo): AgentManifestEntry[] {
 
 /** A normalized target for the pentest swarm */
 export interface SwarmTarget {
+  name?: string;
   target: string;
   objectives: string[];
 }

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -192,6 +192,7 @@ export async function runPentestSwarm(
 
       subagentCallbacks?.onSubagentSpawn?.({
         subagentId,
+        name: target.name,
         input: { target: target.target, objectives: target.objectives },
         status: "pending",
       });

--- a/src/tui/components/agent-display.tsx
+++ b/src/tui/components/agent-display.tsx
@@ -30,6 +30,15 @@ export type Subagent = {
 export type ToolStatus = "streaming" | "pending" | "completed" | "error";
 
 /**
+ * Per-subagent log entry for tools that spawn child agents.
+ */
+export type SubagentLogEntry = {
+  name?: string;
+  status: "pending" | "completed" | "failed";
+  logs: string[];
+};
+
+/**
  * Display message type - flexible type for UI display.
  *
  * For tool messages: toolCallId, toolName, args, and status are required.
@@ -48,6 +57,7 @@ export type DisplayMessage = {
   result?: unknown;
   status?: ToolStatus;
   logs?: string[];
+  subagentLogs?: Record<string, SubagentLogEntry>;
 };
 
 function getStableKey(

--- a/src/tui/components/footer.tsx
+++ b/src/tui/components/footer.tsx
@@ -24,9 +24,10 @@ export default function Footer({
   cwd = process.cwd(),
   showExitWarning = false,
 }: FooterProps) {
-  cwd = "~" + cwd.split(os.homedir()).pop() || "";
   const { colors } = useTheme();
-  const { model, isExecuting } = useAgent();
+  const { model, isExecuting, sessionCwd } = useAgent();
+  const effectiveCwd = sessionCwd || cwd;
+  const displayCwd = "~" + effectiveCwd.split(os.homedir()).pop() || "";
   const session = useSession();
   const route = useRoute();
   const { isInputEmpty } = useInput();
@@ -47,7 +48,7 @@ export default function Footer({
       flexShrink={0}
     >
       <box flexDirection="row" gap={1}>
-        <text fg={colors.textMuted}>{cwd}</text>
+        <text fg={colors.textMuted}>{displayCwd}</text>
         <box border={["right"]} borderColor={colors.primary} />
         <text fg={colors.textMuted}>
           <span fg={colors.text}>{model.name}</span>

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -534,6 +534,81 @@ export default function OperatorDashboard({
   }, []);
 
   // ---------------------------------------------------------------------------
+  // Per-subagent log management
+  // ---------------------------------------------------------------------------
+
+  const initSubagent = useCallback((subagentId: string, name?: string) => {
+    setMessages((prev) => {
+      const idx = prev.findLastIndex(
+        (m) =>
+          isToolMessage(m) &&
+          (m.status === "pending" || m.status === "streaming"),
+      );
+      if (idx === -1) return prev;
+      const msg = prev[idx];
+      const subagentLogs = {
+        ...(msg.subagentLogs ?? {}),
+        [subagentId]: { name, status: "pending" as const, logs: [] },
+      };
+      const updated = [...prev];
+      updated[idx] = { ...msg, subagentLogs };
+      return updated;
+    });
+  }, []);
+
+  const completeSubagent = useCallback(
+    (subagentId: string, status: "completed" | "failed") => {
+      setMessages((prev) => {
+        const idx = prev.findLastIndex(
+          (m) =>
+            isToolMessage(m) &&
+            (m.status === "pending" || m.status === "streaming"),
+        );
+        if (idx === -1) return prev;
+        const msg = prev[idx];
+        const entry = msg.subagentLogs?.[subagentId];
+        if (!entry) return prev;
+        const subagentLogs = {
+          ...(msg.subagentLogs ?? {}),
+          [subagentId]: { ...entry, status },
+        };
+        const updated = [...prev];
+        updated[idx] = { ...msg, subagentLogs };
+        return updated;
+      });
+    },
+    [],
+  );
+
+  const appendLogToSubagent = useCallback(
+    (subagentId: string, line: string) => {
+      setMessages((prev) => {
+        const idx = prev.findLastIndex(
+          (m) =>
+            isToolMessage(m) &&
+            (m.status === "pending" || m.status === "streaming"),
+        );
+        if (idx === -1) return prev;
+        const msg = prev[idx];
+        const entry = msg.subagentLogs?.[subagentId];
+        if (!entry) return prev;
+        let logs = [...entry.logs, line];
+        if (logs.length > MAX_LOG_LINES) {
+          logs = logs.slice(-MAX_LOG_LINES);
+        }
+        const subagentLogs = {
+          ...(msg.subagentLogs ?? {}),
+          [subagentId]: { ...entry, logs },
+        };
+        const updated = [...prev];
+        updated[idx] = { ...msg, subagentLogs };
+        return updated;
+      });
+    },
+    [],
+  );
+
+  // ---------------------------------------------------------------------------
   // Approval handlers
   // ---------------------------------------------------------------------------
 
@@ -656,16 +731,15 @@ export default function OperatorDashboard({
           setError(e instanceof Error ? e.message : "Unknown error");
         },
         subagentCallbacks: {
-          onSubagentSpawn: ({ subagentId }) => {
-            appendLogToActiveTool(`▸ ${subagentId} started`);
+          onSubagentSpawn: ({ subagentId, name }) => {
+            initSubagent(subagentId, name);
           },
           onSubagentComplete: ({ subagentId, status }) => {
-            const icon = status === "completed" ? "✓" : "✗";
-            appendLogToActiveTool(`${icon} ${subagentId} ${status}`);
+            completeSubagent(subagentId, status);
           },
-          onTextDelta: (d) => {
-            if (!d.subagentId) return;
-            onCommandOutput(d.text);
+          onTextDelta: (_d) => {
+            // Text deltas from sub-agents are omitted from per-subagent
+            // windows — tool call summaries provide a cleaner activity log.
           },
           onToolCall: (d) => {
             if (!d.subagentId) return;
@@ -675,7 +749,7 @@ export default function OperatorDashboard({
                 unknown
               >) ?? {};
             const summary = getToolSummary(d.toolName, args);
-            appendLogToActiveTool(summary);
+            appendLogToSubagent(d.subagentId, summary);
           },
           onToolResult: (d) => {
             if (!d.subagentId) return;
@@ -685,7 +759,7 @@ export default function OperatorDashboard({
                 unknown
               >) ?? {};
             const summary = getToolSummary(d.toolName, args);
-            appendLogToActiveTool(`✓ ${summary}`);
+            appendLogToSubagent(d.subagentId, `✓ ${summary}`);
           },
           onError: (e) => {
             const msg = e instanceof Error ? e.message : "subagent error";
@@ -807,6 +881,9 @@ export default function OperatorDashboard({
       flushCommandOutput,
       onCommandOutput,
       appendLogToActiveTool,
+      initSubagent,
+      completeSubagent,
+      appendLogToSubagent,
       setThinking,
       setIsExecuting,
     ],

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -92,6 +92,7 @@ export default function OperatorDashboard({
     tokenUsage,
     addTokenUsage,
     resetTokenUsage,
+    setSessionCwd,
   } = useAgent();
   const {
     autocompleteOptions: allAutocompleteOptions,
@@ -215,6 +216,7 @@ export default function OperatorDashboard({
         if (sessionId) {
           const s = await sessions.get(sessionId);
           setSession(s);
+          setSessionCwd(s.rootPath);
 
           const hasState = sessions.hasOperatorState(s);
           if (hasState) {
@@ -281,6 +283,10 @@ export default function OperatorDashboard({
     }
     loadSession();
   }, [sessionId]);
+
+  useEffect(() => {
+    return () => setSessionCwd(null);
+  }, [setSessionCwd]);
 
   useEffect(() => {
     if (!session) return;
@@ -746,6 +752,7 @@ export default function OperatorDashboard({
             pendingNameRef.current = null;
           }
           setSession(created);
+          setSessionCwd(created.rootPath);
         }
 
         // Persist full conversation for next turn

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -707,6 +707,9 @@ export default function OperatorDashboard({
         commandCancelHandle: cancelHandleRef.current,
         onStepFinish,
         callbacks,
+        onSessionReady: (s: { rootPath: string }) => {
+          setSessionCwd(s.rootPath);
+        },
       };
 
       try {

--- a/src/tui/components/shared/result-registry.ts
+++ b/src/tui/components/shared/result-registry.ts
@@ -450,7 +450,10 @@ export function getResultSummary(
           const obj = result as Record<string, unknown>;
           if (obj.success === false) {
             return {
-              text: String(obj.error || "Failed to list memories").slice(0, 120),
+              text: String(obj.error || "Failed to list memories").slice(
+                0,
+                120,
+              ),
               isError: true,
             };
           }
@@ -516,10 +519,7 @@ export function getResultSummary(
             return {
               text: title,
               isError: false,
-              fullText:
-                content.length > 0
-                  ? preview + suffix
-                  : undefined,
+              fullText: content.length > 0 ? preview + suffix : undefined,
             };
           }
           return { text: "Memory retrieved", isError: false };

--- a/src/tui/components/shared/tool-renderer.tsx
+++ b/src/tui/components/shared/tool-renderer.tsx
@@ -70,8 +70,7 @@ export const ToolRenderer = memo(function ToolRenderer({
       ? colors.warning
       : colors.info;
 
-  const hasSubagentLogs =
-    subagentLogs && Object.keys(subagentLogs).length > 0;
+  const hasSubagentLogs = subagentLogs && Object.keys(subagentLogs).length > 0;
 
   return (
     <box flexDirection="row" marginTop={0}>
@@ -212,11 +211,7 @@ const SubagentLogWindow = memo(function SubagentLogWindow({
         ? colors.error
         : colors.warning;
   const statusIcon =
-    entry.status === "completed"
-      ? "✓"
-      : entry.status === "failed"
-        ? "✗"
-        : "";
+    entry.status === "completed" ? "✓" : entry.status === "failed" ? "✗" : "";
   const displayLabel = entry.name ?? subagentId;
   const visibleLogs = expandedLogs
     ? entry.logs

--- a/src/tui/components/shared/tool-renderer.tsx
+++ b/src/tui/components/shared/tool-renderer.tsx
@@ -3,6 +3,7 @@
  *
  * Unified tool display component for both operator and chat views.
  * Handles pending spinner, completion status, expandable output.
+ * Renders per-subagent output windows when subagentLogs are present.
  */
 
 import { memo, useState } from "react";
@@ -11,7 +12,7 @@ import { AsciiSpinner } from "./ascii-spinner";
 import { getToolSummary } from "./tool-registry";
 import { getResultSummary, type ResultSummary } from "./result-registry";
 import { isToolMessage } from "./type-guards";
-import type { DisplayMessage } from "../agent-display";
+import type { DisplayMessage, SubagentLogEntry } from "../agent-display";
 
 const TOOLS_WITH_LOG_WINDOW = new Set([
   "execute_command",
@@ -24,6 +25,8 @@ const TOOLS_WITH_LOG_WINDOW = new Set([
   "update_file",
   "document_vulnerability",
 ]);
+
+const DEFAULT_SUBAGENT_LOG_LINES = 5;
 
 interface ToolRendererProps {
   message: DisplayMessage;
@@ -51,7 +54,7 @@ export const ToolRenderer = memo(function ToolRenderer({
   const isPending = message.status === "pending" || isStreaming;
   const isCompleted = message.status === "completed";
   const isError = message.status === "error";
-  const { toolName, args, result, logs } = message;
+  const { toolName, args, result, logs, subagentLogs } = message;
 
   // Get tool summary from registry
   const summary = getToolSummary(toolName, args);
@@ -66,6 +69,9 @@ export const ToolRenderer = memo(function ToolRenderer({
     : isPending
       ? colors.warning
       : colors.info;
+
+  const hasSubagentLogs =
+    subagentLogs && Object.keys(subagentLogs).length > 0;
 
   return (
     <box flexDirection="row" marginTop={0}>
@@ -87,8 +93,23 @@ export const ToolRenderer = memo(function ToolRenderer({
           )}
         </box>
 
-        {/* Streaming log window for tools with live output */}
+        {/* Per-subagent output windows */}
+        {isPending && hasSubagentLogs && (
+          <box flexDirection="column" marginLeft={0} marginTop={0}>
+            {Object.entries(subagentLogs!).map(([id, entry]) => (
+              <SubagentLogWindow
+                key={id}
+                subagentId={id}
+                entry={entry}
+                expandedLogs={expandedLogs}
+              />
+            ))}
+          </box>
+        )}
+
+        {/* Shared log window — only when no per-subagent logs */}
         {isPending &&
+          !hasSubagentLogs &&
           TOOLS_WITH_LOG_WINDOW.has(toolName) &&
           logs &&
           logs.length > 0 && (
@@ -106,6 +127,7 @@ export const ToolRenderer = memo(function ToolRenderer({
 
         {/* Streaming logs for other pending tools */}
         {isPending &&
+          !hasSubagentLogs &&
           !TOOLS_WITH_LOG_WINDOW.has(toolName) &&
           logs &&
           logs.length > 0 && (
@@ -164,6 +186,64 @@ export const ToolRenderer = memo(function ToolRenderer({
           </box>
         )}
       </box>
+    </box>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Per-subagent log window
+// ---------------------------------------------------------------------------
+
+const SubagentLogWindow = memo(function SubagentLogWindow({
+  subagentId,
+  entry,
+  expandedLogs,
+}: {
+  subagentId: string;
+  entry: SubagentLogEntry;
+  expandedLogs: boolean;
+}) {
+  const { colors } = useTheme();
+  const isAgentPending = entry.status === "pending";
+  const statusColor =
+    entry.status === "completed"
+      ? colors.success
+      : entry.status === "failed"
+        ? colors.error
+        : colors.warning;
+  const statusIcon =
+    entry.status === "completed"
+      ? "✓"
+      : entry.status === "failed"
+        ? "✗"
+        : "";
+  const displayLabel = entry.name ?? subagentId;
+  const visibleLogs = expandedLogs
+    ? entry.logs
+    : entry.logs.slice(-DEFAULT_SUBAGENT_LOG_LINES);
+
+  return (
+    <box flexDirection="column">
+      <box flexDirection="row">
+        <text fg={colors.textMuted}>{"  ┌ "}</text>
+        {isAgentPending ? (
+          <AsciiSpinner label={displayLabel} fg={colors.warning} />
+        ) : (
+          <text>
+            <span fg={statusColor}>{statusIcon}</span>
+            <span fg={colors.textMuted}>{` ${displayLabel}`}</span>
+          </text>
+        )}
+      </box>
+      {visibleLogs.length > 0 && (
+        <box marginLeft={0}>
+          <text fg={colors.textMuted}>
+            {"  │ "}
+            {visibleLogs.join("\n  │ ")}
+          </text>
+        </box>
+      )}
+      <text fg={colors.textMuted}>{"  └─"}</text>
     </box>
   );
 });

--- a/src/tui/components/shared/type-guards.ts
+++ b/src/tui/components/shared/type-guards.ts
@@ -5,7 +5,11 @@
  * Eliminates `(m as any).status` casts throughout the codebase which agents love to use.
  */
 
-import type { DisplayMessage, ToolStatus } from "../agent-display";
+import type {
+  DisplayMessage,
+  ToolStatus,
+  SubagentLogEntry,
+} from "../agent-display";
 
 /**
  * Tool message with required tool-specific fields.
@@ -21,6 +25,7 @@ export interface ToolDisplayMessage {
   result?: unknown;
   status: ToolStatus;
   logs?: string[];
+  subagentLogs?: Record<string, SubagentLogEntry>;
 }
 
 /**

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -58,6 +58,9 @@ interface AgentContextValue {
   setThinking: (thinking: boolean) => void;
   isExecuting: boolean;
   setIsExecuting: (isExecuting: boolean) => void;
+  /** The agent's working directory (session rootPath), shown in footer. */
+  sessionCwd: string | null;
+  setSessionCwd: (cwd: string | null) => void;
 }
 
 const AgentContext = createContext<AgentContextValue | null>(null);
@@ -86,6 +89,7 @@ export function AgentProvider({ children }: AgentProviderProps) {
   const [hasExecuted, setHasExecuted] = useState<boolean>(false);
   const [thinking, setThinking] = useState<boolean>(false);
   const [isExecuting, setIsExecuting] = useState<boolean>(false);
+  const [sessionCwd, setSessionCwd] = useState<string | null>(null);
 
   // Wrapper that marks model as user-selected and persists to config.
   // Pass `persist = false` for programmatic/initialization calls so the
@@ -190,6 +194,8 @@ export function AgentProvider({ children }: AgentProviderProps) {
       setThinking,
       isExecuting,
       setIsExecuting,
+      sessionCwd,
+      setSessionCwd,
     }),
     [
       model,
@@ -199,6 +205,7 @@ export function AgentProvider({ children }: AgentProviderProps) {
       hasExecuted,
       thinking,
       isExecuting,
+      sessionCwd,
       addTokenUsage,
       resetTokenUsage,
     ],


### PR DESCRIPTION
## Summary
- Adds `sessionCwd` to AgentContext so the footer displays the agent's session working directory instead of `process.cwd()`
- Adds `onSessionReady` callback to `runOffensiveSecurityAgent` that fires before streaming begins, so the footer updates immediately when the agent starts
- **Per-subagent output windows in operator mode**: instead of interleaving all sub-agent activity into a single shared log, each sub-agent now gets its own bordered output panel (`┌/│/└`) showing individual tool call summaries and status
- Adds `name` field to `spawn_coding_agent` task schema and `spawn_pentest_swarm` target schema so the AI provides human-readable display labels per sub-agent

## Test plan
- [ ] Start a new operator session — footer should show the session directory as soon as the agent begins running
- [ ] Resume an existing session — footer should show the session directory on load
- [ ] Navigate back to home — footer should revert to `process.cwd()`
- [ ] Run `spawn_coding_agent` with multiple tasks — each sub-agent should appear in its own bordered panel with the AI-provided name
- [ ] Verify `Ctrl+L` toggles between truncated (last 5 lines) and full logs per sub-agent
- [ ] Completed/failed sub-agents should show ✓/✗ status icons

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `runOffensiveSecurityAgent` API surface and subagent callback payloads while reworking operator-mode tool logging, which could affect consumers and UI behavior if any edge cases were missed.
> 
> **Overview**
> Updates operator mode to **track and display the agent session working directory** in the footer via new `AgentContext.sessionCwd`, using a new `onSessionReady` hook on `runOffensiveSecurityAgent` so the path is available before streaming begins.
> 
> Reworks spawned-agent activity display to **separate subagent output into per-subagent bordered panels** (`subagentLogs`) with pending/completed/failed status, and extends `spawn_coding_agent`/`spawn_pentest_swarm` inputs plus `SubagentConsumeCallbacks.onSubagentSpawn` to carry an optional human-readable `name` label for UI display.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5031ee56e493c127f0cd5f0edb877155990f22df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->