### PR TITLE
feat: add AttackSurfaceRegistry for document_asset dedup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@pensar/apex",
@@ -9,7 +8,7 @@
         "@ai-sdk/anthropic": "^3.0.50",
         "@ai-sdk/google": "^3.0.37",
         "@ai-sdk/openai": "^3.0.37",
-        "@ai-sdk/openai-compatible": "^2.0.33",
+        "@ai-sdk/openai-compatible": "^2.0.35",
         "@daytonaio/sdk": "^0.112.1",
         "@googleapis/gmail": "^16.1.1",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -64,7 +63,7 @@
 
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.37", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.16" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bcYjT3/58i/C0DN3AnrjiGsAb0kYivZLWWUtgTjsBurHSht/LTEy+w3dw5XQe3FmZwX7Z/mUQCiA3wB/5Kf7ow=="],
 
-    "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.33", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.17" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HwptqeUS4vtDyjSSjmKCQExjoQMwPVq0C4pHH18i7c+3CQ0QN81HLvz3BdpULo0n/UtdQwTNISRqx3G5miPZhw=="],
+    "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.35", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-g3wA57IAQFb+3j4YuFndgkUdXyRETZVvbfAWM+UX7bZSxA3xjes0v3XKgIdKdekPtDGsh4ZX2byHD0gJIMPfiA=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
@@ -1320,7 +1319,7 @@
 
     "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.19", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg=="],
 
-    "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.17", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oyCeFINTYK0B8ZGUBiQc05G5vytPlKSmTTtm19xfJuUgoi8zkvvRcoPQci4mSnyfpPn2XSFFDfsALG8uGcapfg=="],
+    "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.19", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensar/apex",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@ai-sdk/anthropic": "^3.0.50",
     "@ai-sdk/google": "^3.0.37",
     "@ai-sdk/openai": "^3.0.37",
-    "@ai-sdk/openai-compatible": "^2.0.33",
+    "@ai-sdk/openai-compatible": "^2.0.35",
     "@daytonaio/sdk": "^0.112.1",
     "@googleapis/gmail": "^16.1.1",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -137,6 +137,7 @@ export class OffensiveSecurityAgent<TResult = void> {
       subagentCallbacks,
       sandbox: input.sandbox,
       findingsRegistry: input.findingsRegistry,
+      attackSurfaceRegistry: input.attackSurfaceRegistry,
       credentialManager,
       persistentShell: this.persistentShell,
       onCommandOutput: input.callbacks?.onCommandOutput,

--- a/src/core/agents/offSecAgent/tools/documentAsset.ts
+++ b/src/core/agents/offSecAgent/tools/documentAsset.ts
@@ -121,6 +121,21 @@ Each asset creates a JSON file in the assets directory for tracking and analysis
         ),
     }),
     execute: async (asset) => {
+      // -- Dedup check (when a shared registry is available) ----------------
+      if (ctx.attackSurfaceRegistry) {
+        const check = await ctx.attackSurfaceRegistry.register(asset);
+        if (check.duplicate) {
+          const matchName = check.matchedAsset?.assetName ?? "unknown";
+          return {
+            success: false,
+            duplicate: true,
+            matchType: check.matchType,
+            matchedAsset: matchName,
+            message: `Duplicate asset (${check.matchType}): already documented as "${matchName}". Skipping.`,
+          };
+        }
+      }
+
       // Ensure assets directory exists
       if (!existsSync(assetsPath)) {
         mkdirSync(assetsPath, { recursive: true });
@@ -140,7 +155,14 @@ Each asset creates a JSON file in the assets directory for tracking and analysis
         target: ctx.session.targets[0],
       };
 
-      writeFileSync(filepath, JSON.stringify(assetRecord, null, 2));
+      try {
+        writeFileSync(filepath, JSON.stringify(assetRecord, null, 2));
+      } catch (writeError: unknown) {
+        if (ctx.attackSurfaceRegistry) {
+          await ctx.attackSurfaceRegistry.unregister(asset);
+        }
+        throw writeError;
+      }
 
       return {
         success: true,

--- a/src/core/agents/offSecAgent/tools/runAttackSurface.ts
+++ b/src/core/agents/offSecAgent/tools/runAttackSurface.ts
@@ -95,6 +95,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
             session: ctx.session,
             authConfig: ctx.authConfig,
             abortSignal: ctx.abortSignal,
+            attackSurfaceRegistry: ctx.attackSurfaceRegistry,
             callbacks: ctx.callbacks,
           });
 
@@ -166,6 +167,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
           session: ctx.session,
           authConfig: ctx.authConfig,
           abortSignal: ctx.abortSignal,
+          attackSurfaceRegistry: ctx.attackSurfaceRegistry,
           callbacks: ctx.callbacks,
         });
 

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -1,6 +1,7 @@
 import type { AIModel } from "../../../ai";
 import type { AIAuthConfig } from "../../../ai/utils";
 import type { CredentialManager } from "../../../credentials";
+import type { AttackSurfaceRegistry } from "../../../findings/attackSurfaceRegistry";
 import type { FindingsRegistry } from "../../../findings/registry";
 import type { SessionInfo } from "../../../session";
 
@@ -46,6 +47,12 @@ export type ToolContext = {
    * When present, `document_vulnerability` checks for duplicates before writing.
    */
   findingsRegistry?: FindingsRegistry;
+
+  /**
+   * Shared attack surface registry for cross-agent asset dedup.
+   * When present, `document_asset` checks for duplicates before writing.
+   */
+  attackSurfaceRegistry?: AttackSurfaceRegistry;
 
   /**
    * In-memory credential store. When present, tools can resolve

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -11,6 +11,7 @@ import type {
 import type { AIModel } from "../../ai";
 import type { AIAuthConfig } from "../../ai/utils";
 import type { CredentialManager } from "../../credentials";
+import type { AttackSurfaceRegistry } from "../../findings/attackSurfaceRegistry";
 import type { FindingsRegistry } from "../../findings/registry";
 import type { SessionInfo, SessionConfig } from "../../session";
 import type { ApprovalGate } from "../../operator";
@@ -124,6 +125,12 @@ export type OffensiveSecurityAgentInput<TResult = void> = {
   findingsRegistry?: FindingsRegistry;
 
   /**
+   * Shared attack surface registry for cross-agent asset dedup.
+   * When present, `document_asset` checks for duplicates before writing.
+   */
+  attackSurfaceRegistry?: AttackSurfaceRegistry;
+
+  /**
    * In-memory credential store. When present, tools resolve credential
    * IDs to secrets at execution time and prompt builders emit only
    * safe {@link CredentialReference} metadata — the agent never sees
@@ -226,6 +233,9 @@ export interface SpecializedAgentInput {
 
   /** Shared findings registry for cross-agent dedup */
   findingsRegistry?: FindingsRegistry;
+
+  /** Shared attack surface registry for cross-agent asset dedup */
+  attackSurfaceRegistry?: AttackSurfaceRegistry;
 
   /** In-memory credential store for secret-free agent prompts */
   credentialManager?: CredentialManager;

--- a/src/core/agents/specialized/attackSurface/blackboxAgent.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxAgent.ts
@@ -70,7 +70,7 @@ export interface AttackSurfaceResult {
  */
 export class BlackboxAttackSurfaceAgent extends OffensiveSecurityAgent<AttackSurfaceResult> {
   constructor(opts: AttackSurfaceAgentInput) {
-    const { model, session, authConfig, onStepFinish, abortSignal } = opts;
+    const { model, session, authConfig, onStepFinish, abortSignal, attackSurfaceRegistry } = opts;
     const target = opts.target ?? opts.cwd!;
 
     const resultsPath = join(session.rootPath, "attack-surface-results.json");
@@ -85,6 +85,7 @@ export class BlackboxAttackSurfaceAgent extends OffensiveSecurityAgent<AttackSur
       authConfig,
       onStepFinish,
       abortSignal,
+      attackSurfaceRegistry,
 
       activeTools: [
         // Core recon tools

--- a/src/core/agents/specialized/attackSurface/blackboxAgent.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxAgent.ts
@@ -70,7 +70,14 @@ export interface AttackSurfaceResult {
  */
 export class BlackboxAttackSurfaceAgent extends OffensiveSecurityAgent<AttackSurfaceResult> {
   constructor(opts: AttackSurfaceAgentInput) {
-    const { model, session, authConfig, onStepFinish, abortSignal, attackSurfaceRegistry } = opts;
+    const {
+      model,
+      session,
+      authConfig,
+      onStepFinish,
+      abortSignal,
+      attackSurfaceRegistry,
+    } = opts;
     const target = opts.target ?? opts.cwd!;
 
     const resultsPath = join(session.rootPath, "attack-surface-results.json");

--- a/src/core/agents/specialized/codeAgent/agent.ts
+++ b/src/core/agents/specialized/codeAgent/agent.ts
@@ -66,6 +66,7 @@ export class CodeAgent<TResult = void> extends OffensiveSecurityAgent<TResult> {
       stopWhen,
       responseSchema,
       system,
+      attackSurfaceRegistry,
     } = opts;
 
     const activeTools: string[] = [
@@ -88,6 +89,7 @@ export class CodeAgent<TResult = void> extends OffensiveSecurityAgent<TResult> {
       authConfig,
       onStepFinish,
       abortSignal,
+      attackSurfaceRegistry,
       callbacks,
       subagentCallbacks: callbacks?.subagentCallbacks,
       stopWhen: stopWhen ?? stepCountIs(10000),

--- a/src/core/agents/specialized/whiteboxAttackSurface/agent.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/agent.ts
@@ -58,6 +58,7 @@ export class WhiteboxAttackSurfaceAgent extends OffensiveSecurityAgent<WhiteboxA
       onStepFinish,
       abortSignal,
       callbacks,
+      attackSurfaceRegistry,
     } = opts;
 
     // Closure variable that the response tool writes to
@@ -84,6 +85,7 @@ This ends the agent run — make sure all data is included.`,
       authConfig,
       onStepFinish,
       abortSignal,
+      attackSurfaceRegistry,
       callbacks,
       subagentCallbacks: callbacks?.subagentCallbacks,
 

--- a/src/core/api/attackSurface.ts
+++ b/src/core/api/attackSurface.ts
@@ -78,6 +78,7 @@ async function runWhiteboxAttackSurface(
     session: input.session,
     authConfig: input.authConfig,
     abortSignal: input.abortSignal,
+    attackSurfaceRegistry: input.attackSurfaceRegistry,
     callbacks: input.callbacks,
   });
 

--- a/src/core/findings/attackSurfaceRegistry.ts
+++ b/src/core/findings/attackSurfaceRegistry.ts
@@ -1,6 +1,5 @@
 import { existsSync, readdirSync, readFileSync } from "fs";
 import { join } from "path";
-import type { DocumentedAssetRecord } from "../agents/specialized/attackSurface/schemas";
 
 // ---------------------------------------------------------------------------
 // Fingerprinting helpers

--- a/src/core/findings/attackSurfaceRegistry.ts
+++ b/src/core/findings/attackSurfaceRegistry.ts
@@ -1,0 +1,269 @@
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join } from "path";
+import type { DocumentedAssetRecord } from "../agents/specialized/attackSurface/schemas";
+
+// ---------------------------------------------------------------------------
+// Fingerprinting helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalise a URL for comparison: lowercase, strip trailing slash,
+ * strip query string, fragment, and protocol.
+ */
+export function normalizeAssetUrl(url: string): string {
+  let u = url.trim().toLowerCase();
+
+  const hashIdx = u.indexOf("#");
+  if (hashIdx !== -1) u = u.substring(0, hashIdx);
+
+  const qIdx = u.indexOf("?");
+  if (qIdx !== -1) u = u.substring(0, qIdx);
+
+  u = u.replace(/^https?:\/\//, "");
+  u = u.replace(/^www\./, "");
+
+  if (u.length > 1 && u.endsWith("/")) {
+    u = u.replace(/\/+$/, "");
+  }
+
+  return u;
+}
+
+/**
+ * Normalise an asset name for comparison: lowercase, collapse
+ * non-alphanumeric runs into a single dash, trim leading/trailing dashes.
+ */
+export function normalizeAssetName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/**
+ * Build fingerprint keys for an asset.
+ *
+ * - `urlKey`:  `<normalized_url>||<asset_type>` — precise per-URL dedup
+ *              (only set when the asset has a URL)
+ * - `nameKey`: `<normalized_name>||<asset_type>` — catches the same logical
+ *              asset rediscovered with different metadata
+ */
+export function generateAssetFingerprint(asset: AssetRecord): {
+  urlKey: string | null;
+  nameKey: string;
+} {
+  const normalizedName = normalizeAssetName(asset.assetName);
+  const assetType = asset.assetType.toLowerCase();
+  const url = asset.details?.url;
+
+  return {
+    urlKey: url ? `${normalizeAssetUrl(url)}||${assetType}` : null,
+    nameKey: `${normalizedName}||${assetType}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal asset shape the registry needs for dedup.
+ * Compatible with both `DocumentAssetInput` (tool input) and
+ * `DocumentedAssetRecord` (persisted record).
+ */
+export interface AssetRecord {
+  assetName: string;
+  assetType: string;
+  description: string;
+  details?: {
+    url?: string;
+    [key: string]: unknown;
+  };
+  riskLevel?: string;
+}
+
+export interface AssetDuplicateCheckResult {
+  duplicate: boolean;
+  matchedAsset?: AssetRecord;
+  matchType?: "exact-url" | "exact-name";
+}
+
+// ---------------------------------------------------------------------------
+// AttackSurfaceRegistry
+// ---------------------------------------------------------------------------
+
+/**
+ * Thread-safe, in-memory registry of known attack surface assets.
+ *
+ * Supports two dedup tiers:
+ *   1. **Exact URL** — same normalised URL + same asset type
+ *   2. **Exact name** — same normalised name + same asset type
+ *
+ * The registry is designed to be created once per session and shared
+ * across concurrent attack surface agents via `ToolContext`.
+ */
+export class AttackSurfaceRegistry {
+  private urlKeys = new Map<string, AssetRecord>();
+  private nameKeys = new Map<string, AssetRecord>();
+  private assets: AssetRecord[] = [];
+
+  private mutex: Promise<void> = Promise.resolve();
+
+  /** How many assets are tracked. */
+  get size(): number {
+    return this.assets.length;
+  }
+
+  /** Return a snapshot of all tracked assets. */
+  getAssets(): readonly AssetRecord[] {
+    return [...this.assets];
+  }
+
+  // -----------------------------------------------------------------------
+  // Factories
+  // -----------------------------------------------------------------------
+
+  /**
+   * Create a registry pre-loaded with assets from a directory.
+   * Reads every `.json` file, parses each as an asset record, and indexes it.
+   * Malformed files are silently skipped.
+   */
+  static fromDirectory(assetsPath: string): AttackSurfaceRegistry {
+    const registry = new AttackSurfaceRegistry();
+
+    if (!existsSync(assetsPath)) return registry;
+
+    const files = readdirSync(assetsPath).filter((f) => f.endsWith(".json"));
+
+    for (const file of files) {
+      try {
+        const raw = readFileSync(join(assetsPath, file), "utf-8");
+        const asset = JSON.parse(raw) as AssetRecord;
+        if (asset && typeof asset.assetName === "string" && typeof asset.assetType === "string") {
+          registry.indexAsset(asset);
+        }
+      } catch {
+        // skip malformed files
+      }
+    }
+
+    return registry;
+  }
+
+  /**
+   * Create a registry pre-loaded with an array of assets (e.g. from Console DB).
+   */
+  static fromAssets(assets: AssetRecord[]): AttackSurfaceRegistry {
+    const registry = new AttackSurfaceRegistry();
+    for (const a of assets) {
+      registry.indexAsset(a);
+    }
+    return registry;
+  }
+
+  // -----------------------------------------------------------------------
+  // Core API
+  // -----------------------------------------------------------------------
+
+  /**
+   * Check whether an asset is a duplicate of something already registered.
+   * Synchronous.
+   *
+   * Tier 1: exact URL + asset type
+   * Tier 2: exact name + asset type
+   */
+  isDuplicate(asset: AssetRecord): AssetDuplicateCheckResult {
+    const { urlKey, nameKey } = generateAssetFingerprint(asset);
+
+    if (urlKey) {
+      const urlMatch = this.urlKeys.get(urlKey);
+      if (urlMatch) {
+        return {
+          duplicate: true,
+          matchedAsset: urlMatch,
+          matchType: "exact-url",
+        };
+      }
+    }
+
+    const nameMatch = this.nameKeys.get(nameKey);
+    if (nameMatch) {
+      return {
+        duplicate: true,
+        matchedAsset: nameMatch,
+        matchType: "exact-name",
+      };
+    }
+
+    return { duplicate: false };
+  }
+
+  /**
+   * Register a new asset in the registry.
+   *
+   * Thread-safe via an async mutex. Returns the dedup check result.
+   * If the asset is a duplicate it is **not** added to the registry.
+   */
+  async register(asset: AssetRecord): Promise<AssetDuplicateCheckResult> {
+    return new Promise<AssetDuplicateCheckResult>((resolve) => {
+      this.mutex = this.mutex.then(() => {
+        const check = this.isDuplicate(asset);
+        if (check.duplicate) {
+          resolve(check);
+        } else {
+          this.indexAsset(asset);
+          resolve({ duplicate: false });
+        }
+      });
+    });
+  }
+
+  /**
+   * Remove a previously-registered asset from all indexes.
+   *
+   * Rollback counterpart to {@link register}: call it when an asset was
+   * accepted by the registry but the caller failed to persist it.
+   */
+  async unregister(asset: AssetRecord): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.mutex = this.mutex.then(() => {
+        this.removeAsset(asset);
+        resolve();
+      });
+    });
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal
+  // -----------------------------------------------------------------------
+
+  private removeAsset(asset: AssetRecord): void {
+    const { urlKey, nameKey } = generateAssetFingerprint(asset);
+
+    if (urlKey && this.urlKeys.get(urlKey) === asset) {
+      this.urlKeys.delete(urlKey);
+    }
+    if (this.nameKeys.get(nameKey) === asset) {
+      this.nameKeys.delete(nameKey);
+    }
+
+    const idx = this.assets.indexOf(asset);
+    if (idx !== -1) {
+      this.assets.splice(idx, 1);
+    }
+  }
+
+  private indexAsset(asset: AssetRecord): void {
+    const { urlKey, nameKey } = generateAssetFingerprint(asset);
+
+    if (urlKey && !this.urlKeys.has(urlKey)) {
+      this.urlKeys.set(urlKey, asset);
+    }
+    if (!this.nameKeys.has(nameKey)) {
+      this.nameKeys.set(nameKey, asset);
+    }
+
+    this.assets.push(asset);
+  }
+}

--- a/src/core/findings/attackSurfaceRegistry.ts
+++ b/src/core/findings/attackSurfaceRegistry.ts
@@ -140,7 +140,11 @@ export class AttackSurfaceRegistry {
       try {
         const raw = readFileSync(join(assetsPath, file), "utf-8");
         const asset = JSON.parse(raw) as AssetRecord;
-        if (asset && typeof asset.assetName === "string" && typeof asset.assetType === "string") {
+        if (
+          asset &&
+          typeof asset.assetName === "string" &&
+          typeof asset.assetType === "string"
+        ) {
           registry.indexAsset(asset);
         }
       } catch {

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -126,6 +126,7 @@ export interface WhiteboxAttackSurfaceWorkflowInput {
   authConfig?: AIAuthConfig;
   abortSignal?: AbortSignal;
   callbacks?: ConsumeCallbacks;
+  attackSurfaceRegistry?: import("../findings/attackSurfaceRegistry").AttackSurfaceRegistry;
   onStepFinish?: (event: {
     usage?: {
       inputTokens?: number;
@@ -157,6 +158,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     authConfig,
     abortSignal,
     callbacks,
+    attackSurfaceRegistry,
     onStepFinish,
   } = input;
 
@@ -172,6 +174,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     session,
     authConfig,
     abortSignal,
+    attackSurfaceRegistry,
     callbacks,
     onStepFinish: (event) => onStepFinish?.(event),
     responseSchema: AppsDiscoveryResultSchema,
@@ -240,6 +243,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
         session,
         authConfig,
         abortSignal,
+        attackSurfaceRegistry,
         callbacks,
         onStepFinish: (event) => onStepFinish?.(event),
         responseSchema: EndpointsDiscoveryResultSchema,


### PR DESCRIPTION
## Summary

- Adds a new `AttackSurfaceRegistry` class (mirroring `FindingsRegistry`) that provides idempotency for the `document_asset` tool with two-tier dedup: exact URL+type match and exact name+type match
- Thread-safe via async mutex, with factory methods (`fromDirectory`, `fromAssets`) and rollback support via `unregister()` on write failure
- Wires the registry through the full agent stack: `ToolContext`, `OffensiveSecurityAgentInput`, `SpecializedAgentInput`, and all attack surface agents (blackbox, whitebox, code agent), workflows, and the public API

## Test plan

- [ ] Verify `bun run test` passes (unit tests)
- [ ] Verify `bun run tsc` passes (type check)
- [ ] Confirm `document_asset` correctly deduplicates assets when the registry is present
- [ ] Confirm `document_asset` still works normally when no registry is provided (backward compatible)
- [ ] Confirm rollback (`unregister`) fires on write failure
- [ ] Verify `fromDirectory` correctly pre-loads existing asset JSON files
- [ ] Verify `fromAssets` correctly pre-populates from an external array


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple agent entry points and tool context plumbing; mistakes could cause missing asset documentation or inconsistent dedup behavior across concurrent attack-surface runs.
> 
> **Overview**
> Introduces a new `AttackSurfaceRegistry` (with URL/name normalization, two-tier duplicate detection, preload factories, and rollback support) to prevent the same attack-surface asset being recorded multiple times.
> 
> Wires the registry through the tool/agent input types and attack-surface execution paths (offsec agent, `run_attack_surface`, blackbox/whitebox/code agents, and whitebox workflow/API), and updates `document_asset` to short-circuit on duplicates and to `unregister()` on write failures.
> 
> Also bumps `@ai-sdk/openai-compatible` and increments the package version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 984e4b7d803d9f47bdca3fd3a13c44959e76a41a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->