### PR TITLE
Add global onUsage() callback for token usage reporting

### DIFF
--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -24,6 +24,19 @@ import {
 
 export type AIModel = AnthropicMessagesModelId | OpenAIChatModelId | string; // For OpenRouter and Bedrock models
 
+/** Callback for reporting token usage from AI operations */
+type UsageCallback = (
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+) => void;
+let _usageCallback: UsageCallback | null = null;
+
+/** Register a callback to receive token usage reports from all AI operations */
+export function onUsage(cb: UsageCallback | null): void {
+  _usageCallback = cb;
+}
+
 export type AIModelProvider =
   | "anthropic"
   | "openai"
@@ -253,13 +266,23 @@ export function streamResponse(
     stopWhen,
     toolChoice,
     tools,
-    onStepFinish,
+    onStepFinish: userOnStepFinish,
     abortSignal,
     activeTools,
     silent,
     authConfig,
     onFinish,
   } = opts;
+
+  // Wrap onStepFinish to fire usage callback for every step
+  const onStepFinish: typeof userOnStepFinish = (step) => {
+    userOnStepFinish?.(step);
+    if (_usageCallback) {
+      const inp = step.usage?.inputTokens ?? 0;
+      const out = step.usage?.outputTokens ?? 0;
+      if (inp > 0 || out > 0) _usageCallback(model, inp, out);
+    }
+  };
   // Use a container object so the reference stays stable but the value can be updated
   const messagesContainer = { current: messages || [] };
   const providerModel = getProviderModel(model, authConfig);
@@ -468,6 +491,13 @@ export async function generateObjectResponse<T extends z.ZodType>(
   // Report token usage if callback provided
   if (onTokenUsage && usage) {
     onTokenUsage(usage.inputTokens ?? 0, usage.outputTokens ?? 0);
+  }
+
+  // Fire global usage callback
+  if (_usageCallback && usage) {
+    const inp = usage.inputTokens ?? 0;
+    const out = usage.outputTokens ?? 0;
+    if (inp > 0 || out > 0) _usageCallback(model, inp, out);
   }
 
   return output;


### PR DESCRIPTION
## Summary
- Adds generic `onUsage(cb)` hook to `ai.ts` that fires for all AI operations (`streamResponse`, `generateObjectResponse`, tool repair)
- Consumers register a callback receiving `(model, inputTokens, outputTokens)` — no billing/Console-specific concepts

## Test plan
- [ ] Apex typecheck passes
- [ ] `onUsage` export is available and generic
- [ ] Existing agent behavior unchanged (callback is additive)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive instrumentation that reports token usage without changing model requests or outputs; main behavioral change is wrapping `onStepFinish`, which could affect consumers relying on function identity or expecting no extra side effects.
> 
> **Overview**
> Adds a global `onUsage(cb)` hook in `ai.ts` to report `(model, inputTokens, outputTokens)` for AI calls.
> 
> `streamResponse` now wraps the user-provided `onStepFinish` to emit per-step usage (including tool-call repair steps), and `generateObjectResponse` emits usage after `generateText` completes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33bf4c7e1ee41093cfe0ebc456fb61e32cbce9f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->