### PR TITLE
fix: searchbar input conflicts with navigation shortcuts

### DIFF
--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -28,6 +28,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
     groupedSessions,
     visualOrderSessions,
     loading,
+    searchTerm,
     setSearchTerm,
     deleteSession: hookDeleteSession,
   } = useSessionsList();
@@ -99,11 +100,11 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
       return;
     }
 
-    // O - Open session in operator mode
     if (
       (key.name === "o" || key.name === "O") &&
       !key.ctrl &&
       !key.meta &&
+      !searchTerm &&
       visualOrderSessions.length > 0
     ) {
       const currentSelection = visualOrderSessions[selectedIndex];
@@ -143,8 +144,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
       return;
     }
 
-    // R - Open report
-    if (key.name === "r" && visualOrderSessions.length > 0) {
+    if (key.name === "r" && !searchTerm && visualOrderSessions.length > 0) {
       const currentSelection = visualOrderSessions[selectedIndex];
       if (!currentSelection) return;
       openReport(currentSelection.id);


### PR DESCRIPTION
Fixes #157

## Problem

Pressing single-letter shortcuts (o, r) while typing in the sessions search input fires navigation actions instead of inserting characters.

- Pressing `o` while searching triggers "Open in Operator mode"
- Pressing `r` while searching triggers "Open Report"

## Fix

Track search input value in local state. When the input has text, single-letter shortcuts are suppressed. Arrow keys, Enter, and Escape continue to work normally while searching.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI keyboard-handling change scoped to the sessions dialog; low risk beyond potentially altering shortcut availability when a search term is present.
> 
> **Overview**
> Prevents single-letter navigation shortcuts in the sessions dialog from firing while the search input contains text.
> 
> `SessionsDisplay` now reads `searchTerm` from `useSessionsList` and gates the `O` (open in operator mode) and `R` (open report) keyboard handlers on `!searchTerm`, keeping arrow navigation, Enter, Escape, and Ctrl+D behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 593afb3a797f21c97a488983719b0ab6162e05b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->