### PR TITLE
fix: /sessions resume starts fresh instead of continuing

### DIFF
--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -86,9 +86,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
         setTimeout(() => setStatusMessage(""), 2000);
         return;
       }
-      const isOperator =
-        currentSelection.config?.mode === "operator" ||
-        currentSelection.hasOperatorState;
+      const isOperator = currentSelection.config?.mode === "operator";
       refocusPrompt();
       onClose();
       route.navigate({

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -211,22 +211,49 @@ export default function Pentest({
             setPentestAgents(agents);
           }
 
-          if (state.hasReport || state.isComplete) {
-            // Truly finished — show read-only completed view
+          if (state.hasReport) {
+            // Truly finished with report — show read-only completed view
             setPhase("completed");
             if (attackSurfaceAgents.some((sa) => sa.messages.length > 0)) {
               setShowOrchestratorPanel(true);
             }
-          } else {
-            // Session was interrupted — show saved state then restart
+          } else if (state.isComplete) {
+            // All pentest agents done but report was not generated
+            // (interrupted during reporting) — show reporting phase
             if (attackSurfaceAgents.some((sa) => sa.messages.length > 0)) {
               setShowOrchestratorPanel(true);
             }
-            startPentest(s);
+            setPhase("reporting");
+          } else {
+            // Session was interrupted — show saved state without restarting
+            if (attackSurfaceAgents.some((sa) => sa.messages.length > 0)) {
+              setShowOrchestratorPanel(true);
+            }
+            // Infer phase from saved subagents:
+            //   - no pentest agents     -> interrupted during discovery
+            //   - all pentest agents done but no report -> interrupted during reporting
+            //   - pentest agents present but not all done -> interrupted during pentesting
+            const allPentestDone =
+              pentestSubagents.length > 0 &&
+              pentestSubagents.every(
+                (sa) => sa.status === "completed" || sa.status === "failed",
+              );
+            setPhase(
+              allPentestDone
+                ? "reporting"
+                : pentestSubagents.length > 0
+                  ? "pentesting"
+                  : "discovery",
+            );
           }
-        } else {
-          // Brand-new session — start immediately
+        } else if (!sessionId) {
+          // Brand-new session (no sessionId prop) — start immediately
           startPentest(s);
+        } else {
+          // Existing session loaded from /sessions but interrupted before
+          // any agent writes completed. Show paused discovery view.
+          // Do NOT restart — user did not ask for a new run.
+          setPhase("discovery");
         }
       } catch (e) {
         setError(e instanceof Error ? e.message : "Failed to load session");
@@ -1061,6 +1088,7 @@ export default function Pentest({
           assets={assets}
           expanded={showOrchestratorPanel}
           onToggle={() => setShowOrchestratorPanel((p) => !p)}
+          isExecuting={isExecuting}
         />
 
         {/* Right: Agent card grid or waiting state */}
@@ -1075,7 +1103,7 @@ export default function Pentest({
               backgroundColor={colors.backgroundElement}
               padding={2}
             >
-              {phase === "discovery" ? (
+              {phase === "discovery" && isExecuting ? (
                 <box flexDirection="column" alignItems="center" gap={1}>
                   <SpinnerDots
                     label="Discovering attack surface..."
@@ -1085,7 +1113,7 @@ export default function Pentest({
                     Press [D] to view orchestrator logs
                   </text>
                 </box>
-              ) : phase === "reporting" ? (
+              ) : phase === "reporting" && isExecuting ? (
                 <SpinnerDots label="Generating report..." fg={colors.primary} />
               ) : (
                 <text fg={colors.textMuted}>No pentest agents spawned yet</text>
@@ -1164,6 +1192,7 @@ interface OrchestratorPanelProps {
   assets: DocumentedAssetRecord[];
   expanded: boolean;
   onToggle: () => void;
+  isExecuting: boolean;
 }
 
 function OrchestratorPanel({
@@ -1172,10 +1201,14 @@ function OrchestratorPanel({
   assets,
   expanded,
   onToggle,
+  isExecuting,
 }: OrchestratorPanelProps) {
   const { colors } = useTheme();
   const isRunning =
-    phase !== "loading" && phase !== "completed" && phase !== "error";
+    isExecuting &&
+    phase !== "loading" &&
+    phase !== "completed" &&
+    phase !== "error";
 
   // Group assets by type for display
   const assetSummary = useMemo(() => {


### PR DESCRIPTION
Fixes #289

## Problem

Resuming an interrupted session restarts the pentest agent from scratch instead of showing where the session left off.

## Fix

The changes:
1. Interrupted sessions now set phase to "pentesting" to show saved state instead of calling startPentest()
2. Added isExecuting prop to OrchestratorPanel
3. isRunning in OrchestratorPanel now requires isExecuting to be true, so the spinner only shows when the agent is actually running
4. Infer resumed phase from saved subagents: sessions interrupted during discovery now correctly restore to "discovery" phase rather than "pentesting", fixing a misleading phase label
5. Infer resumed phase from saved subagents: sessions interrupted during discovery correctly restore to "discovery" phase
6. Gate discovery and reporting spinners on isExecuting to prevent infinite spinner animation on resumed sessions where no agent runs


## Behaviour after fix

- Completed sessions: read-only view (unchanged)
- Interrupted sessions: shows saved agent cards and discovery logs without restarting
- New sessions: start immediately (unchanged)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pentest session restore/phase state machine and execution indicators; mistakes could mislabel phases or hide/show spinners incorrectly when resuming sessions.
> 
> **Overview**
> Fixes session resume so loading an interrupted run from `/sessions` *restores saved subagent state* instead of calling `startPentest()` and starting over.
> 
> `Pentest` now infers the initial UI `phase` from persisted subagent status (discovery vs pentesting vs reporting), treats `isComplete` without `hasReport` as reporting-incomplete, and gates orchestrator/discovery/reporting spinners via a new `isExecuting` prop so resumed-but-paused sessions don’t show infinite “running” indicators. Separately, session opening no longer infers operator mode from `hasOperatorState`, only from `config.mode`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc15fd2efedf076d7b04e858e5987778c5684892. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->