### PR TITLE
Read project knowledge base in pentest prompt

### DIFF
--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -323,6 +323,19 @@ The following vulnerabilities have already been documented. Do NOT re-test or re
 ${existing}`;
   }
 
+  let knowledgeBaseSection = "";
+  const knowledgePath = join(sessionRootPath, "scratchpad", "knowledge-base.md");
+  if (existsSync(knowledgePath)) {
+    try {
+      const knowledgeContent = readFileSync(knowledgePath, "utf-8").trim();
+      if (knowledgeContent) {
+        knowledgeBaseSection = `\n\n## Project Knowledge Base\nThe following is accumulated knowledge about this project from previous scans, user notes, and resolved issues. Use this context to avoid false positives and make better testing decisions.\n\n${knowledgeContent}`;
+      }
+    } catch {
+      /* ignore read errors */
+    }
+  }
+
   const outcomeSection = outcomeGuidance
     ? `\n## Outcome Guidance\n${outcomeGuidance}\n`
     : "";
@@ -357,6 +370,7 @@ Do NOT discover or enumerate other endpoints or services. Focus exclusively on t
 - **URL:** ${target}
 ${authSection}
 ${knownFindingsSection}
+${knowledgeBaseSection}
 
 ## Objectives
 ${objectiveList}

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -132,6 +132,9 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
         "email_list_messages",
         "email_search_messages",
         "email_get_message",
+        // Memory tools — for on-demand retrieval of project knowledge
+        "list_memories",
+        "get_memory",
       ],
 
       responseSchema: PentestResponseSchema,
@@ -324,15 +327,33 @@ ${existing}`;
   }
 
   let knowledgeBaseSection = "";
-  const knowledgePath = join(sessionRootPath, "scratchpad", "knowledge-base.md");
-  if (existsSync(knowledgePath)) {
+
+  // Check for a marker indicating memories were populated
+  const markerPath = join(sessionRootPath, "scratchpad", ".knowledge-populated");
+  if (existsSync(markerPath)) {
     try {
-      const knowledgeContent = readFileSync(knowledgePath, "utf-8").trim();
-      if (knowledgeContent) {
-        knowledgeBaseSection = `\n\n## Project Knowledge Base\nThe following is accumulated knowledge about this project from previous scans, user notes, and resolved issues. Use this context to avoid false positives and make better testing decisions.\n\n${knowledgeContent}`;
+      const count = parseInt(readFileSync(markerPath, "utf-8").trim(), 10) || 0;
+      if (count > 0) {
+        knowledgeBaseSection = `\n\n## Project Knowledge Available
+There are ${count} project knowledge entries in the memory system from previous scans, user notes, and resolved issues. Before beginning your testing plan, call \`list_memories\` with tag \`"project-knowledge"\` to check for relevant context. Pay special attention to false positive patterns and technology context that may affect your testing.`;
       }
     } catch {
-      /* ignore read errors */
+      /* ignore */
+    }
+  }
+
+  // Fallback: legacy knowledge-base.md (remove after migration complete)
+  if (!knowledgeBaseSection) {
+    const knowledgePath = join(sessionRootPath, "scratchpad", "knowledge-base.md");
+    if (existsSync(knowledgePath)) {
+      try {
+        const knowledgeContent = readFileSync(knowledgePath, "utf-8").trim();
+        if (knowledgeContent) {
+          knowledgeBaseSection = `\n\n## Project Knowledge Base\nThe following is accumulated knowledge about this project from previous scans, user notes, and resolved issues. Use this context to avoid false positives and make better testing decisions.\n\n${knowledgeContent}`;
+        }
+      } catch {
+        /* ignore read errors */
+      }
     }
   }
 

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -329,7 +329,11 @@ ${existing}`;
   let knowledgeBaseSection = "";
 
   // Check for a marker indicating memories were populated
-  const markerPath = join(sessionRootPath, "scratchpad", ".knowledge-populated");
+  const markerPath = join(
+    sessionRootPath,
+    "scratchpad",
+    ".knowledge-populated",
+  );
   if (existsSync(markerPath)) {
     try {
       const count = parseInt(readFileSync(markerPath, "utf-8").trim(), 10) || 0;
@@ -344,7 +348,11 @@ There are ${count} project knowledge entries in the memory system from previous 
 
   // Fallback: legacy knowledge-base.md (remove after migration complete)
   if (!knowledgeBaseSection) {
-    const knowledgePath = join(sessionRootPath, "scratchpad", "knowledge-base.md");
+    const knowledgePath = join(
+      sessionRootPath,
+      "scratchpad",
+      "knowledge-base.md",
+    );
     if (existsSync(knowledgePath)) {
       try {
         const knowledgeContent = readFileSync(knowledgePath, "utf-8").trim();

--- a/src/core/memory/index.ts
+++ b/src/core/memory/index.ts
@@ -84,6 +84,60 @@ export async function addMemory(input: {
 }
 
 /**
+ * Create or overwrite a memory with a pre-determined ID.
+ * Used for idempotent syncing from external sources (e.g., project knowledge).
+ */
+export async function addMemoryWithId(input: {
+  id: string;
+  title: string;
+  content: string;
+  category?: MemoryCategory;
+  tags?: string[];
+}): Promise<Memory> {
+  validateId(input.id);
+  const category: MemoryCategory = input.category ?? "general";
+  const now = new Date().toISOString();
+
+  // Preserve createdAt if this is an update
+  let createdAt = now;
+  try {
+    const existing = await Storage.read<Memory>(storageKey(category, input.id));
+    createdAt = existing.createdAt;
+  } catch {
+    // New memory — use current timestamp
+  }
+
+  const memory: Memory = {
+    id: input.id,
+    category,
+    title: input.title,
+    content: input.content,
+    tags: input.tags ?? [],
+    createdAt,
+    updatedAt: now,
+  };
+
+  await Storage.write(storageKey(category, input.id), memory);
+  return memory;
+}
+
+/**
+ * Delete a single memory by category + id.
+ * Returns true if deleted, false if not found.
+ */
+export async function deleteMemory(
+  category: MemoryCategory,
+  id: string,
+): Promise<boolean> {
+  validateId(id);
+  // Check existence first — Storage.remove silently succeeds on missing files
+  const existing = await getMemory(category, id);
+  if (!existing) return false;
+  await Storage.remove(storageKey(category, id));
+  return true;
+}
+
+/**
  * Retrieve a single memory by category + id.
  * Returns `null` when the entry does not exist.
  */

--- a/src/core/memory/memory.test.ts
+++ b/src/core/memory/memory.test.ts
@@ -4,7 +4,13 @@ import path from "path";
 import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 
-import { addMemory, getMemory, listMemories } from "./index";
+import {
+  addMemory,
+  addMemoryWithId,
+  deleteMemory,
+  getMemory,
+  listMemories,
+} from "./index";
 
 let tmpDir: string;
 
@@ -253,6 +259,104 @@ describe("memory system", () => {
       expect(list).toHaveLength(2);
       expect(list[0]!.title).toBe("Newer");
       expect(list[1]!.title).toBe("Older");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // addMemoryWithId
+  // -------------------------------------------------------------------------
+
+  describe("addMemoryWithId", () => {
+    it("creates a memory with a predetermined id", async () => {
+      const mem = await addMemoryWithId({
+        id: "pk-abc123",
+        title: "Known false positive",
+        content: "The /health endpoint always returns 200",
+        category: "app",
+        tags: ["project-knowledge", "false_positive_pattern"],
+      });
+
+      expect(mem.id).toBe("pk-abc123");
+      expect(mem.category).toBe("app");
+      expect(mem.title).toBe("Known false positive");
+      expect(mem.tags).toEqual(["project-knowledge", "false_positive_pattern"]);
+
+      // Verify it can be retrieved
+      const fetched = await getMemory("app", "pk-abc123");
+      expect(fetched).not.toBeNull();
+      expect(fetched!.content).toBe("The /health endpoint always returns 200");
+    });
+
+    it("overwrites an existing memory preserving createdAt", async () => {
+      const original = await addMemoryWithId({
+        id: "pk-overwrite",
+        title: "Original",
+        content: "v1",
+        category: "app",
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const updated = await addMemoryWithId({
+        id: "pk-overwrite",
+        title: "Updated",
+        content: "v2",
+        category: "app",
+      });
+
+      expect(updated.id).toBe("pk-overwrite");
+      expect(updated.title).toBe("Updated");
+      expect(updated.content).toBe("v2");
+      expect(updated.createdAt).toBe(original.createdAt);
+      expect(updated.updatedAt).not.toBe(original.updatedAt);
+    });
+
+    it("rejects ids with path traversal sequences", async () => {
+      await expect(
+        addMemoryWithId({ id: "../evil", title: "t", content: "c" }),
+      ).rejects.toThrow("Invalid memory id");
+    });
+
+    it("defaults category to general", async () => {
+      const mem = await addMemoryWithId({
+        id: "pk-default-cat",
+        title: "No category",
+        content: "data",
+      });
+      expect(mem.category).toBe("general");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // deleteMemory
+  // -------------------------------------------------------------------------
+
+  describe("deleteMemory", () => {
+    it("deletes an existing memory and returns true", async () => {
+      await addMemoryWithId({
+        id: "pk-to-delete",
+        title: "Doomed",
+        content: "will be removed",
+        category: "app",
+      });
+
+      const result = await deleteMemory("app", "pk-to-delete");
+      expect(result).toBe(true);
+
+      // Verify it's gone
+      const fetched = await getMemory("app", "pk-to-delete");
+      expect(fetched).toBeNull();
+    });
+
+    it("returns false for a non-existent memory", async () => {
+      const result = await deleteMemory("general", "does-not-exist");
+      expect(result).toBe(false);
+    });
+
+    it("rejects ids with path traversal sequences", async () => {
+      await expect(deleteMemory("general", "../../etc")).rejects.toThrow(
+        "Invalid memory id",
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- Read `scratchpad/knowledge-base.md` in `buildPrompt()` and inject as a "Project Knowledge Base" section into the pentest agent's prompt
- Companion to [pensarai/console#821](https://github.com/pensarai/console/pull/821) which writes the file

## How it works

### Where is the memory stored?

In a new PostgreSQL table called `project_knowledge` (defined in the console PR). Each row is a knowledge entry tied to a project — things like "Sanity CMS project IDs are public by design" or "this endpoint uses rate limiting intentionally".

### How does knowledge get into the database?

Three ways:
1. **Manually** — Users add entries via Project Settings > Knowledge Base
2. **From false positives** — Marking an issue as FP auto-creates a `false_positive_pattern` entry
3. **From scan completions** — Each pentest creates a `testing_history` summary entry

### How does it flow into Apex?

```
Console                              Apex (this PR)
───────                              ──────────────
populateKnowledgeBase()              buildPrompt()
  │                                    │
  ├─ Queries active entries            ├─ Reads knowledge-base.md
  │  from project_knowledge            │  from scratchpad/
  │                                    │
  ├─ Sorts by priority                 ├─ Injects as "Project
  │  (FPs first, then tech             │  Knowledge Base" section
  │   context, user notes...)          │  into agent prompt
  │                                    │
  └─ Writes markdown to:              └─ Agent now avoids known
     scratchpad/knowledge-base.md        FPs and uses context
```

The console PR writes the file during scan setup. This PR reads it in `buildPrompt()`. They're decoupled — the console PR can land first (the file write is harmless until this PR merges).

## Test plan
- [x] Run a pentest with knowledge entries in the project — verify the prompt contains the "Project Knowledge Base" section
- [x] Run a pentest with no knowledge entries — verify no section appears and behavior is unchanged
- [x] Verify false positive patterns in the knowledge base prevent the agent from re-flagging known FPs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to new write/delete paths in the persistent memory store and prompt behavior changes that may influence agent output; safeguards include ID validation and comprehensive unit tests.
> 
> **Overview**
> The pentest agent prompt now surfaces **project knowledge**: it detects a `.knowledge-populated` marker to tell the agent to query the memory system (via `list_memories` / `get_memory` with the `project-knowledge` tag) before planning tests, with a fallback to embedding the legacy `scratchpad/knowledge-base.md` contents when present.
> 
> The memory module adds `addMemoryWithId` for idempotent upserts (preserving `createdAt`) and `deleteMemory` for explicit removals, with new tests covering overwrite, deletion behavior, default category, and path-traversal id validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 291d0c8436cf90481ed43511db3d7db455737947. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->