### PR TITLE
Vulnerability documentation token limit

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -3,7 +3,10 @@ import { z } from "zod";
 import { join } from "path";
 import { writeFileSync, appendFileSync } from "fs";
 import type { ToolContext } from "./types";
-import { scoreFindingWithCVSS } from "../../specialized/cvssScorer";
+import {
+  scoreFindingWithCVSS,
+  type CVSSScorerResult,
+} from "../../specialized/cvssScorer";
 import type { Finding } from "../types";
 
 export const documentVulnerabilityInputSchema = z.object({
@@ -27,6 +30,31 @@ export const documentVulnerabilityInputSchema = z.object({
 export type DocumentVulnerabilityInput = z.infer<
   typeof documentVulnerabilityInputSchema
 >;
+
+const EVIDENCE_FILE_THRESHOLD = 20_000;
+
+const FALLBACK_CVSS: CVSSScorerResult = {
+  score: 5.0,
+  severity: "MEDIUM",
+  vectorString:
+    "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N",
+  metrics: {
+    AV: "N",
+    AC: "L",
+    AT: "N",
+    PR: "N",
+    UI: "N",
+    VC: "L",
+    VI: "L",
+    VA: "N",
+    SC: "N",
+    SI: "N",
+    SA: "N",
+    E: "A",
+  },
+  scoreType: "CVSS-BT",
+  reasoning: "CVSS scoring unavailable — using conservative MEDIUM default.",
+};
 
 export function documentVulnerability(ctx: ToolContext) {
   const { session } = ctx;
@@ -53,22 +81,50 @@ FINDING STRUCTURE:
       try {
         const timestamp = new Date().toISOString();
 
-        // -- CVSS 4.0 scoring (determines severity) --------------------------
-        const cvssResult = await scoreFindingWithCVSS(
-          {
-            finding: {
-              title: input.title,
-              description: input.description,
-              impact: input.impact,
-              evidence: input.evidence,
-              endpoint: input.endpoint,
-              remediation: input.remediation,
+        // -- Persist large evidence to a sidecar file -----------------------
+        let evidenceForPrompt = input.evidence;
+        let evidenceFilePath: string | undefined;
+
+        if (input.evidence.length > EVIDENCE_FILE_THRESHOLD) {
+          const safeSlug = input.title
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/^-|-$/g, "")
+            .substring(0, 40);
+          const evidenceFilename = `${timestamp.split("T")[0]}-${safeSlug}-evidence.txt`;
+          evidenceFilePath = join(session.findingsPath, evidenceFilename);
+          writeFileSync(evidenceFilePath, input.evidence);
+          evidenceForPrompt =
+            input.evidence.substring(0, EVIDENCE_FILE_THRESHOLD) +
+            `\n... [truncated — full output saved to ${evidenceFilename}]`;
+        }
+
+        // -- CVSS 4.0 scoring (determines severity) ------------------------
+        let cvssResult: CVSSScorerResult;
+        let cvssWarning: string | undefined;
+
+        try {
+          cvssResult = await scoreFindingWithCVSS(
+            {
+              finding: {
+                title: input.title,
+                description: input.description,
+                impact: input.impact,
+                evidence: evidenceForPrompt,
+                endpoint: input.endpoint,
+                remediation: input.remediation,
+              },
+              agentMessages: [],
             },
-            agentMessages: [],
-          },
-          ctx.model!,
-          ctx.authConfig,
-        );
+            ctx.model!,
+            ctx.authConfig,
+          );
+        } catch (cvssError: unknown) {
+          const msg =
+            cvssError instanceof Error ? cvssError.message : String(cvssError);
+          cvssWarning = `CVSS scoring failed (${msg}), using fallback severity.`;
+          cvssResult = FALLBACK_CVSS;
+        }
 
         const severity =
           cvssResult.severity === "NONE" ? "LOW" : cvssResult.severity;
@@ -78,7 +134,7 @@ FINDING STRUCTURE:
           severity: severity as Finding["severity"],
         };
 
-        // -- Dedup check (when a shared registry is available) ----------------
+        // -- Dedup check (when a shared registry is available) --------------
         if (ctx.findingsRegistry) {
           const check = await ctx.findingsRegistry.register(finding);
           if (check.duplicate) {
@@ -98,6 +154,7 @@ FINDING STRUCTURE:
           timestamp,
           sessionId: session.id,
           target: session.targets[0],
+          ...(evidenceFilePath && { evidenceFile: evidenceFilePath }),
           cvss: {
             score: cvssResult.score,
             severity: cvssResult.severity,
@@ -122,10 +179,37 @@ FINDING STRUCTURE:
         const mdPath = join(session.findingsPath, mdFilename);
 
         try {
-          // Write structured JSON (consumed by resolveResult)
           writeFileSync(jsonPath, JSON.stringify(findingWithMeta, null, 2));
 
-          // Write human-readable markdown
+          const cvssSection = cvssWarning
+            ? `## CVSS 4.0 Assessment
+
+**Warning:** ${cvssWarning}
+
+**Score:** ${cvssResult.score} / 10.0 (${cvssResult.severity})  
+**Score Type:** ${cvssResult.scoreType}`
+            : `## CVSS 4.0 Assessment
+
+**Score:** ${cvssResult.score} / 10.0 (${cvssResult.severity})  
+**Vector:** \`${cvssResult.vectorString}\`  
+**Score Type:** ${cvssResult.scoreType}
+
+**Reasoning:** ${cvssResult.reasoning}`;
+
+          const evidenceSection = evidenceFilePath
+            ? `## Evidence
+
+\`\`\`
+${input.evidence.substring(0, 5_000)}
+\`\`\`
+
+> Full evidence output: \`${evidenceFilePath}\``
+            : `## Evidence
+
+\`\`\`
+${finding.evidence}
+\`\`\``;
+
           const markdown = `# ${finding.title}
 
 **Severity:** ${finding.severity}  
@@ -144,19 +228,9 @@ ${finding.description}
 
 ${finding.impact}
 
-## CVSS 4.0 Assessment
+${cvssSection}
 
-**Score:** ${cvssResult.score} / 10.0 (${cvssResult.severity})  
-**Vector:** \`${cvssResult.vectorString}\`  
-**Score Type:** ${cvssResult.scoreType}
-
-**Reasoning:** ${cvssResult.reasoning}
-
-## Evidence
-
-\`\`\`
-${finding.evidence}
-\`\`\`
+${evidenceSection}
 
 ## POC
 
@@ -192,11 +266,15 @@ ${finding.references ? `## References\n\n${finding.references}` : ""}
           throw writeError;
         }
 
+        const resultMessage = cvssWarning
+          ? `Finding documented: [${finding.severity}] ${finding.title} (${cvssWarning})`
+          : `Finding documented: [${finding.severity}] ${finding.title}`;
+
         return {
           success: true,
           finding: findingWithMeta,
           filepath: mdPath,
-          message: `Finding documented: [${finding.severity}] ${finding.title}`,
+          message: resultMessage,
         };
       } catch (error: unknown) {
         const errorMsg = error instanceof Error ? error.message : String(error);

--- a/src/core/agents/specialized/cvssScorer/index.ts
+++ b/src/core/agents/specialized/cvssScorer/index.ts
@@ -267,8 +267,21 @@ export async function scoreFindingWithCVSS(
 /**
  * Build the scoring prompt from finding data and context
  */
+const MAX_EVIDENCE_CHARS = 10_000;
+const MAX_DESCRIPTION_CHARS = 3_000;
+const MAX_IMPACT_CHARS = 2_000;
+
+function truncateField(value: string, limit: number): string {
+  if (value.length <= limit) return value;
+  return value.substring(0, limit) + "\n... [truncated]";
+}
+
 function buildScoringPrompt(input: CVSSScorerInput): string {
   const { finding, agentMessages } = input;
+
+  const description = truncateField(finding.description, MAX_DESCRIPTION_CHARS);
+  const impact = truncateField(finding.impact, MAX_IMPACT_CHARS);
+  const evidence = truncateField(finding.evidence, MAX_EVIDENCE_CHARS);
 
   let prompt = `# Vulnerability Finding to Score
 
@@ -279,14 +292,14 @@ function buildScoringPrompt(input: CVSSScorerInput): string {
 **Endpoint:** ${finding.endpoint}
 
 ### Description
-${finding.description}
+${description}
 
 ### Impact Assessment
-${finding.impact}
+${impact}
 
 ### Evidence (POC Output)
 \`\`\`
-${finding.evidence}
+${evidence}
 \`\`\`
 
 `;

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -139,8 +139,13 @@ function wrapStreamWithErrorHandler(
               const errorMessage =
                 error instanceof Error ? error.message : String(error);
 
+              // Check context length FIRST — these should never be retried
+              // as-is; the prompt must be reduced via summarization.
+              const isCtxError = checkIfContextLengthError(error);
+
               // Handle rate limit errors with exponential backoff retry
               if (
+                !isCtxError &&
                 checkIfRateLimitError(error) &&
                 rateLimitRetryCount < MAX_RATE_LIMIT_RETRIES
               ) {
@@ -177,9 +182,6 @@ function wrapStreamWithErrorHandler(
                 }
                 return;
               }
-
-              // Handle context length errors with summarization
-              const isCtxError = checkIfContextLengthError(error);
 
               if (isCtxError) {
                 let currentMessages: ModelMessage[] = messagesContainer.current;
@@ -463,6 +465,8 @@ export interface GenerateObjectOpts<T extends z.ZodType> {
   onTokenUsage?: (inputTokens: number, outputTokens: number) => void;
 }
 
+const MAX_OBJECT_RATE_LIMIT_RETRIES = 8;
+
 export async function generateObjectResponse<T extends z.ZodType>(
   opts: GenerateObjectOpts<T>,
 ) {
@@ -479,28 +483,62 @@ export async function generateObjectResponse<T extends z.ZodType>(
 
   const providerModel = getProviderModel(model, authConfig);
 
-  const { output, usage } = await generateText({
-    model: providerModel,
-    output: Output.object({
-      schema,
-    }),
-    prompt,
-    system,
-    maxOutputTokens: maxTokens,
-    temperature,
-  });
+  let lastError: unknown;
 
-  // Report token usage if callback provided
-  if (onTokenUsage && usage) {
-    onTokenUsage(usage.inputTokens ?? 0, usage.outputTokens ?? 0);
+  for (let attempt = 0; attempt <= MAX_OBJECT_RATE_LIMIT_RETRIES; attempt++) {
+    try {
+      const { output, usage } = await generateText({
+        model: providerModel,
+        output: Output.object({
+          schema,
+        }),
+        prompt,
+        system,
+        maxOutputTokens: maxTokens,
+        temperature,
+        maxRetries: 0,
+      });
+
+      if (onTokenUsage && usage) {
+        onTokenUsage(usage.inputTokens ?? 0, usage.outputTokens ?? 0);
+      }
+
+      if (_usageCallback && usage) {
+        const inp = usage.inputTokens ?? 0;
+        const out = usage.outputTokens ?? 0;
+        if (inp > 0 || out > 0) _usageCallback(model, inp, out);
+      }
+
+      return output;
+    } catch (error) {
+      lastError = error;
+
+      if (checkIfContextLengthError(error)) {
+        const msg = error instanceof Error ? error.message : String(error);
+        throw new ContextLengthError(
+          `Prompt exceeds model context window: ${msg}`,
+        );
+      }
+
+      if (
+        checkIfRateLimitError(error) &&
+        attempt < MAX_OBJECT_RATE_LIMIT_RETRIES
+      ) {
+        const delayMs = Math.min(1000 * 2 ** attempt, 60_000);
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        continue;
+      }
+
+      throw error;
+    }
   }
 
-  // Fire global usage callback
-  if (_usageCallback && usage) {
-    const inp = usage.inputTokens ?? 0;
-    const out = usage.outputTokens ?? 0;
-    if (inp > 0 || out > 0) _usageCallback(model, inp, out);
-  }
+  throw lastError;
+}
 
-  return output;
+export class ContextLengthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ContextLengthError";
+  }
 }

--- a/src/core/findings/registry.ts
+++ b/src/core/findings/registry.ts
@@ -165,14 +165,19 @@ Two findings are NOT duplicates if they describe genuinely different vulnerabili
 
 Be conservative: when in doubt, mark as NOT a duplicate. It is better to allow a borderline finding through than to suppress a genuinely new one.`;
 
+const MAX_SEMANTIC_DEDUP_FINDINGS = 25;
+
 function buildSemanticDedupPrompt(
   newFinding: Finding,
   existingFindings: readonly Finding[],
 ): string {
-  const existingList = existingFindings
+  const capped = existingFindings.slice(-MAX_SEMANTIC_DEDUP_FINDINGS);
+  const offset = existingFindings.length - capped.length;
+
+  const existingList = capped
     .map(
       (f, i) =>
-        `${i + 1}. [${f.severity}] "${f.title}" — endpoint: ${f.endpoint}\n   Description: ${f.description.substring(0, 200)}`,
+        `${offset + i + 1}. [${f.severity}] "${f.title}" — endpoint: ${f.endpoint}\n   Description: ${f.description.substring(0, 200)}`,
     )
     .join("\n\n");
 
@@ -182,7 +187,7 @@ Endpoint: ${newFinding.endpoint}
 Severity: ${newFinding.severity}
 Description: ${newFinding.description.substring(0, 300)}
 
-## Existing Findings
+## Existing Findings (${existingFindings.length} total${offset > 0 ? `, showing last ${capped.length}` : ""})
 ${existingList}
 
 Is the new finding a duplicate of any existing finding?`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR addresses issues where the `document vulnerability` process failed due to AI context length overflows and rate limiting.

The root causes were:
1.  **Unbounded prompt sizes:** Large evidence payloads and an ever-growing list of existing findings were exceeding AI model context windows.
2.  **Ineffective error handling:** "Too many tokens" errors were often misclassified, leading to endless retries instead of context summarization. `generateObjectResponse` lacked retry logic for rate limits and proper context length error handling.
3.  **Fragile documentation:** The entire documentation process would fail if CVSS scoring encountered AI errors.

The changes implement a multi-pronged fix:
*   **`src/core/ai/ai.ts`**: Implemented robust rate-limit retry with exponential backoff in `generateObjectResponse` and ensured `ContextLengthError` is correctly identified and thrown. Reordered error checking in `wrapStreamWithErrorHandler` to prioritize context length errors over rate limits, preventing endless retries.
*   **`src/core/agents/specialized/cvssScorer/index.ts`**: Truncated large fields (evidence, description, impact) in the CVSS scorer prompt to prevent context overflows.
*   **`src/core/findings/registry.ts`**: Capped the number of findings included in the semantic dedup prompt to the last 25 to control prompt size.
*   **`src/core/agents/offSecAgent/tools/documentFinding.ts`**: For evidence exceeding 20K characters, it is now saved to a separate file and referenced in the prompt. A fallback to `MEDIUM` severity is provided if AI-based CVSS scoring fails, preventing the entire documentation process from failing.

These changes ensure the system is more resilient to AI service limitations, gracefully handles large inputs, and continues processing even if specific AI scoring steps encounter errors.

### How did you verify your code works?

*   ✅ `bun run tsc` — no type errors
*   ✅ `bun run lint` — clean
*   ✅ `bun run format:check` — all files formatted
*   ✅ `bun run test` — 372 passed, 15 skipped (integration tests requiring API keys)

No manual testing was performed, as reproducing the specific rate-limit and context-length errors requires a live AI provider under load with large evidence payloads, which cannot be simulated without real API credentials and a running pentest session.

---
<p><a href="https://cursor.com/agents/bc-a60a1afe-97a4-4594-96de-b027b25ef543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a60a1afe-97a4-4594-96de-b027b25ef543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->