### PR TITLE
feat: add risk scoring and attack surface registry with token overflow fixes

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentAsset.ts
+++ b/src/core/agents/offSecAgent/tools/documentAsset.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import { writeFileSync, mkdirSync, existsSync } from "fs";
 import type { ToolContext } from "./types";
 import type { DocumentedAssetRecord } from "../../specialized/attackSurface/schemas";
+import { computeBlackboxRiskScore } from "../../specialized/attackSurface/blackboxRiskScoring";
 
 /**
  * Factory for the `document_asset` tool.
@@ -148,11 +149,19 @@ Each asset creates a JSON file in the assets directory for tracking and analysis
       const filename = `asset_${sanitizedName}_${timestamp}.json`;
       const filepath = join(assetsPath, filename);
 
+      const riskScore = computeBlackboxRiskScore(
+        asset.riskLevel,
+        asset.assetType,
+        asset.details,
+        asset.notes,
+      );
+
       const assetRecord: DocumentedAssetRecord = {
         ...asset,
         discoveredAt: new Date().toISOString(),
         sessionId: ctx.session.id,
         target: ctx.session.targets[0],
+        riskScore,
       };
 
       try {

--- a/src/core/agents/specialized/attackSurface/blackboxRiskScoring.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxRiskScoring.ts
@@ -63,13 +63,12 @@ export function computeBlackboxRiskScore(
   const score = Math.min(10, Math.max(0, rawSum));
 
   const baseScore = RISK_LEVEL_BASE_SCORE[riskLevel] ?? 0;
-  const explanation = buildExplanation(
-    riskLevel,
-    assetType,
-    baseScore,
-    score,
-    { exposure, dataSensitivity, functionCriticality, securityIndicators },
-  );
+  const explanation = buildExplanation(riskLevel, assetType, baseScore, score, {
+    exposure,
+    dataSensitivity,
+    functionCriticality,
+    securityIndicators,
+  });
 
   return {
     score,
@@ -87,10 +86,7 @@ export function computeBlackboxRiskScore(
 // Dimension helpers
 // ---------------------------------------------------------------------------
 
-function computeExposure(
-  riskLevel: RiskLevel,
-  details?: AssetDetails,
-): number {
+function computeExposure(riskLevel: RiskLevel, details?: AssetDetails): number {
   let base = EXPOSURE_BY_RISK[riskLevel] ?? 1;
 
   if (details?.authentication) {

--- a/src/core/agents/specialized/attackSurface/blackboxRiskScoring.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxRiskScoring.ts
@@ -1,0 +1,266 @@
+import type { RiskScore } from "../whiteboxAttackSurface/types";
+import type { RiskLevel, AssetType, AssetDetails } from "./schemas";
+
+/**
+ * Base score mapping from risk level to total score.
+ */
+const RISK_LEVEL_BASE_SCORE: Record<RiskLevel, number> = {
+  CRITICAL: 10,
+  HIGH: 8,
+  MEDIUM: 5,
+  LOW: 2,
+};
+
+/**
+ * Heuristic exposure scores by risk level.
+ *
+ * Blackbox assets are discovered from the outside, so exposure is
+ * generally higher than for whitebox endpoints. The agent's riskLevel
+ * already encodes how exposed/sensitive the asset is.
+ */
+const EXPOSURE_BY_RISK: Record<RiskLevel, number> = {
+  CRITICAL: 3,
+  HIGH: 3,
+  MEDIUM: 2,
+  LOW: 1,
+};
+
+/**
+ * Compute a heuristic {@link RiskScore} for a blackbox-discovered asset.
+ *
+ * Since there is no source code to read, we derive the four breakdown
+ * dimensions from the agent-assigned `riskLevel`, the `assetType`, and
+ * observable metadata (authentication, services, technology stack).
+ *
+ * The breakdown dimensions match the whitebox model:
+ *   - **exposure** (0-3): How reachable is the asset from the outside?
+ *   - **dataSensitivity** (0-3): How sensitive is the data it likely handles?
+ *   - **functionCriticality** (0-2): How critical is the business function?
+ *   - **securityIndicators** (0-2): Are there observable security concerns?
+ */
+export function computeBlackboxRiskScore(
+  riskLevel: RiskLevel,
+  assetType: AssetType,
+  details?: AssetDetails,
+  notes?: string,
+): RiskScore {
+  const exposure = computeExposure(riskLevel, details);
+  const dataSensitivity = computeDataSensitivity(riskLevel, assetType, details);
+  const functionCriticality = computeFunctionCriticality(
+    riskLevel,
+    assetType,
+    details,
+    notes,
+  );
+  const securityIndicators = computeSecurityIndicators(
+    riskLevel,
+    details,
+    notes,
+  );
+
+  const rawSum =
+    exposure + dataSensitivity + functionCriticality + securityIndicators;
+  const score = Math.min(10, Math.max(0, rawSum));
+
+  const baseScore = RISK_LEVEL_BASE_SCORE[riskLevel] ?? 0;
+  const explanation = buildExplanation(
+    riskLevel,
+    assetType,
+    baseScore,
+    score,
+    { exposure, dataSensitivity, functionCriticality, securityIndicators },
+  );
+
+  return {
+    score,
+    explanation,
+    breakdown: {
+      exposure,
+      dataSensitivity,
+      functionCriticality,
+      securityIndicators,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Dimension helpers
+// ---------------------------------------------------------------------------
+
+function computeExposure(
+  riskLevel: RiskLevel,
+  details?: AssetDetails,
+): number {
+  let base = EXPOSURE_BY_RISK[riskLevel] ?? 1;
+
+  if (details?.authentication) {
+    const authLower = details.authentication.toLowerCase();
+    if (
+      authLower.includes("none") ||
+      authLower.includes("no auth") ||
+      authLower.includes("public")
+    ) {
+      base = Math.max(base, 3);
+    } else if (
+      authLower.includes("admin") ||
+      authLower.includes("privileged")
+    ) {
+      base = Math.min(base, 1);
+    }
+  }
+
+  return Math.min(3, Math.max(0, base));
+}
+
+function computeDataSensitivity(
+  riskLevel: RiskLevel,
+  assetType: AssetType,
+  details?: AssetDetails,
+): number {
+  if (riskLevel === "CRITICAL") return 3;
+
+  let score = riskLevel === "HIGH" ? 2 : riskLevel === "MEDIUM" ? 1 : 0;
+
+  if (assetType === "admin_panel") score = Math.max(score, 2);
+
+  const techStr = (details?.technology ?? []).join(" ").toLowerCase();
+  if (
+    techStr.includes("database") ||
+    techStr.includes("postgres") ||
+    techStr.includes("mysql") ||
+    techStr.includes("mongo") ||
+    techStr.includes("redis")
+  ) {
+    score = Math.max(score, 2);
+  }
+
+  return Math.min(3, score);
+}
+
+function computeFunctionCriticality(
+  riskLevel: RiskLevel,
+  assetType: AssetType,
+  details?: AssetDetails,
+  notes?: string,
+): number {
+  if (assetType === "admin_panel") return 2;
+  if (riskLevel === "CRITICAL") return 2;
+
+  const searchText = [
+    ...(details?.services ?? []),
+    ...(details?.technology ?? []),
+    details?.authentication ?? "",
+    notes ?? "",
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  const criticalPatterns = [
+    "auth",
+    "login",
+    "payment",
+    "checkout",
+    "password",
+    "oauth",
+    "sso",
+    "saml",
+    "admin",
+    "transfer",
+    "billing",
+  ];
+  if (criticalPatterns.some((p) => searchText.includes(p))) return 2;
+
+  if (riskLevel === "HIGH") return 1;
+  if (assetType === "api" || assetType === "web_application") return 1;
+
+  return 0;
+}
+
+function computeSecurityIndicators(
+  riskLevel: RiskLevel,
+  details?: AssetDetails,
+  notes?: string,
+): number {
+  if (riskLevel === "CRITICAL") return 2;
+
+  const searchText = [
+    ...(details?.services ?? []),
+    ...(details?.technology ?? []),
+    notes ?? "",
+    String(details?.status ?? ""),
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  const criticalIndicators = [
+    "injection",
+    "sqli",
+    "xss",
+    "rce",
+    "traversal",
+    "deserialization",
+    "hardcoded",
+    "default credentials",
+    "vulnerable",
+    "cve-",
+    "exploit",
+  ];
+  if (criticalIndicators.some((p) => searchText.includes(p))) return 2;
+
+  const moderateIndicators = [
+    "outdated",
+    "deprecated",
+    "insecure",
+    "http:",
+    "self-signed",
+    "debug",
+    "verbose error",
+    "stack trace",
+    "cors",
+    "misconfigur",
+  ];
+  if (moderateIndicators.some((p) => searchText.includes(p))) return 1;
+
+  if (riskLevel === "HIGH") return 1;
+
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Explanation builder
+// ---------------------------------------------------------------------------
+
+function buildExplanation(
+  riskLevel: RiskLevel,
+  assetType: AssetType,
+  _baseScore: number,
+  totalScore: number,
+  breakdown: {
+    exposure: number;
+    dataSensitivity: number;
+    functionCriticality: number;
+    securityIndicators: number;
+  },
+): string {
+  const parts: string[] = [
+    `${riskLevel} risk ${assetType.replace(/_/g, " ")} (score ${totalScore}/10).`,
+  ];
+
+  if (breakdown.exposure >= 3) parts.push("Publicly exposed.");
+  else if (breakdown.exposure >= 2) parts.push("Externally accessible.");
+
+  if (breakdown.dataSensitivity >= 3)
+    parts.push("Likely handles sensitive data.");
+  else if (breakdown.dataSensitivity >= 2)
+    parts.push("May handle business-critical data.");
+
+  if (breakdown.functionCriticality >= 2) parts.push("Critical function.");
+  else if (breakdown.functionCriticality >= 1) parts.push("Core function.");
+
+  if (breakdown.securityIndicators >= 2)
+    parts.push("Security concerns observed.");
+  else if (breakdown.securityIndicators >= 1)
+    parts.push("Moderate security concerns.");
+
+  return parts.join(" ");
+}

--- a/src/core/agents/specialized/attackSurface/schemas.ts
+++ b/src/core/agents/specialized/attackSurface/schemas.ts
@@ -5,7 +5,10 @@ import {
 } from "../whiteboxAttackSurface/types";
 
 export { RiskScoreSchema, RiskScoreBreakdownSchema };
-export type { RiskScore, RiskScoreBreakdown } from "../whiteboxAttackSurface/types";
+export type {
+  RiskScore,
+  RiskScoreBreakdown,
+} from "../whiteboxAttackSurface/types";
 
 /**
  * Shared schemas for attack surface agent tools.

--- a/src/core/agents/specialized/attackSurface/schemas.ts
+++ b/src/core/agents/specialized/attackSurface/schemas.ts
@@ -1,4 +1,11 @@
 import { z } from "zod";
+import {
+  RiskScoreSchema,
+  RiskScoreBreakdownSchema,
+} from "../whiteboxAttackSurface/types";
+
+export { RiskScoreSchema, RiskScoreBreakdownSchema };
+export type { RiskScore, RiskScoreBreakdown } from "../whiteboxAttackSurface/types";
 
 /**
  * Shared schemas for attack surface agent tools.
@@ -157,6 +164,9 @@ export const DocumentedAssetRecordSchema = DocumentAssetSchema.extend({
   discoveredAt: z.string().describe("ISO timestamp when asset was discovered"),
   sessionId: z.string().describe("Session ID where asset was discovered"),
   target: z.string().describe("Target being analyzed when asset was found"),
+  riskScore: RiskScoreSchema.optional().describe(
+    "Computed risk score with breakdown (heuristic for blackbox, AI-scored for whitebox)",
+  ),
 });
 
 // Type exports

--- a/src/core/workflows/riskScoring.ts
+++ b/src/core/workflows/riskScoring.ts
@@ -126,8 +126,8 @@ export async function scoreEndpoints(
     endpoints,
     concurrency,
     async (ep) => {
-      const key = `${ep.file}:${ep.path}`;
-      const subagentId = `risk-score-${ep.appName}-${ep.path}`;
+      const key = `${ep.method}:${ep.file}:${ep.path}`;
+      const subagentId = `risk-score-${ep.appName}-${ep.method}-${ep.path}`;
 
       callbacks?.subagentCallbacks?.onSubagentSpawn?.({
         subagentId,

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -363,7 +363,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
   // =========================================================================
 
   function attachRiskScore(ep: Endpoint): Endpoint {
-    const key = `${ep.file}:${ep.path}`;
+    const key = `${ep.method}:${ep.file}:${ep.path}`;
     const score = riskScores.get(key);
     return score ? { ...ep, riskScore: score } : ep;
   }


### PR DESCRIPTION
## Summary

- **AttackSurfaceRegistry**: New cross-agent dedup registry for attack surface assets. Supports URL-based and name-based dedup with an async mutex for thread safety. Integrated into `document_asset` tool across all agent types (blackbox, whitebox, code agent).
- **Risk scoring**: Heuristic risk scoring for blackbox-discovered assets (`computeBlackboxRiskScore`) and AI-driven risk scoring for whitebox endpoints via parallel CodeAgent instances (new Phase 4 in whitebox workflow). Both produce a 0-10 score with four breakdown dimensions (exposure, dataSensitivity, functionCriticality, securityIndicators).
- **Token overflow prevention**: Large evidence is persisted to sidecar files and truncated before CVSS scoring. CVSS failures now fall back to a conservative MEDIUM default. Semantic dedup is capped at 25 findings. `generateObjectResponse` gains rate limit retry with exponential backoff and a dedicated `ContextLengthError` class.

## Test plan

- [ ] `bun run test` — all unit tests pass
- [ ] `bun run tsc` — no type errors
- [ ] `bun run lint` — clean
- [ ] Verify blackbox attack surface assets include `riskScore` in output JSON
- [ ] Verify whitebox workflow produces risk-scored endpoints in Phase 4
- [ ] Verify duplicate assets are rejected by `AttackSurfaceRegistry` across concurrent agents
- [ ] Verify large evidence findings write sidecar `.txt` files and CVSS scoring receives truncated input


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape of persisted asset JSON and adjusts how endpoint risk scores are matched/attached, which could affect downstream consumers and scoring completeness if key formats diverge.
> 
> **Overview**
> Blackbox `document_asset` records now include a computed `riskScore` (0–10 with breakdown + explanation) via new `computeBlackboxRiskScore`, and `DocumentedAssetRecordSchema` is extended to optionally persist this score.
> 
> Whitebox endpoint risk scoring now keys results by `method:file:path` (and updates subagent IDs + attachment logic) to avoid collisions when multiple HTTP methods share the same path/file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09d6954683b68153e5f8f29abc1d8a6977b3ff6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->