### PR TITLE
Operator session message subset

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -206,14 +206,17 @@ export class OffensiveSecurityAgent<TResult = void> {
     }
     const messagesPath = join(messagesDir, "messages.json");
 
-    const initialMessages: ModelMessage[] = input.messages
-      ? [...input.messages]
-      : [
-          {
-            role: "user" as const,
-            content: [{ type: "text", text: input.prompt }],
-          },
-        ];
+    // Mutable so that summarization can clear stale history.
+    const initialMessagesRef: { current: ModelMessage[] } = {
+      current: input.messages
+        ? [...input.messages]
+        : [
+            {
+              role: "user" as const,
+              content: [{ type: "text", text: input.prompt }],
+            },
+          ],
+    };
 
     // -- Stream ---------------------------------------------------------------
     this.streamResult = streamResponse({
@@ -229,12 +232,20 @@ export class OffensiveSecurityAgent<TResult = void> {
       toolChoice: "auto",
       onStepFinish: (event) => {
         try {
-          const allMessages = [...initialMessages, ...event.response.messages];
+          const allMessages = [
+            ...initialMessagesRef.current,
+            ...event.response.messages,
+          ];
           writeFileSync(messagesPath, JSON.stringify(allMessages, null, 2));
         } catch {
           // Best-effort persistence — don't break the agent loop
         }
         input.onStepFinish?.(event);
+      },
+      onSummarized: () => {
+        // Context was reset by summarization — discard the old history so
+        // subsequent onStepFinish writes only persist post-summary messages.
+        initialMessagesRef.current = [];
       },
       onFinish: input.onFinish,
       abortSignal: input.abortSignal,

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -1,6 +1,10 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { join } from "path";
+import { writeFileSync, mkdirSync, existsSync } from "fs";
 import type { ToolContext } from "./types";
+
+const MAX_INLINE_BODY = 5_000;
 
 export const httpRequestInputSchema = z.object({
   url: z.string().describe("The URL to request"),
@@ -41,6 +45,39 @@ export type HttpRequestResult = {
   error?: string;
   method?: string;
 };
+
+/**
+ * If `body` exceeds the inline limit, save the full text to a file under
+ * `{session.logsPath}/http-responses/` and return truncated text + file path.
+ */
+function maybeSaveBody(
+  body: string,
+  ctx: ToolContext,
+): { text: string; file?: string } {
+  if (body.length <= MAX_INLINE_BODY) return { text: body };
+
+  const outputDir = join(ctx.session.logsPath, "http-responses");
+  if (!existsSync(outputDir)) {
+    mkdirSync(outputDir, { recursive: true });
+  }
+
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `response-${ts}.txt`;
+  const filePath = join(outputDir, filename);
+
+  try {
+    writeFileSync(filePath, body);
+  } catch {
+    return {
+      text: `${body.substring(0, MAX_INLINE_BODY)}...\n\n(truncated — failed to save full response to file)`,
+    };
+  }
+
+  return {
+    text: `${body.substring(0, MAX_INLINE_BODY)}...\n\n(truncated — full response saved to ${filePath}). Use read_file or grep to analyze.`,
+    file: filePath,
+  };
+}
 
 function parseHeaders(raw: string | undefined): Record<string, string> {
   if (!raw) return {};
@@ -145,15 +182,14 @@ COMMON TESTING PATTERNS:
           responseBody = "(unable to read response body)";
         }
 
+        const { text: truncatedBody } = maybeSaveBody(responseBody, ctx);
+
         return {
           success: true,
           status: response.status,
           statusText: response.statusText,
           headers: responseHeaders,
-          body:
-            responseBody.length > 5000
-              ? `${responseBody.substring(0, 5000)}...\n\n(truncated) use execute_command with grep / tail to paginate the response`
-              : responseBody,
+          body: truncatedBody,
           url: response.url,
           redirected: response.redirected,
         };
@@ -258,15 +294,14 @@ async function executeSandboxHttpRequest(
     const statusText = statusMatch ? statusMatch[2] : "Unknown";
     const responseBody = lines.slice(bodyStartIndex).join("\n");
 
+    const { text: truncatedBody } = maybeSaveBody(responseBody, ctx);
+
     return {
       success: status >= 200 && status < 400,
       status,
       statusText,
       headers: responseHeaders,
-      body:
-        responseBody.length > 5000
-          ? `${responseBody.substring(0, 5000)}...\n\n(truncated) use execute_command with grep / tail to paginate the response`
-          : responseBody,
+      body: truncatedBody,
       url,
       redirected: false,
     };

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -257,6 +257,13 @@ export interface StreamResponseOpts {
   silent?: boolean;
   authConfig?: AIAuthConfig;
   onFinish?: StreamTextOnFinishCallback<ToolSet>;
+  /**
+   * Called when the context window overflows and the conversation is
+   * summarized. Callers should use this to discard stale message history
+   * so that subsequent persistence writes only include the summary +
+   * new messages (not the full pre-summarization history).
+   */
+  onSummarized?: (summary: string) => void;
 }
 
 export function streamResponse(

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -340,6 +340,10 @@ export async function summarizeConversation(
     originalLength > 100000
       ? `Context: The previous conversation contained very long content that was summarized.\n\nSummary: ${summary}\n\nOriginal task: Please respond based on this summary.`
       : `${opts.prompt}\n\nThe previous agent has summarized the conversation to pass to you to continue the task. Here is the summary: ${summary}`;
+
+  // Notify callers that context was reset so they can discard stale history.
+  opts.onSummarized?.(summary);
+
   // streamResponse always wraps with error handling, so if this call
   // also hits context length limits, it will recursively summarize again
   const resumed = streamResponse({

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -658,6 +658,52 @@ export function hasOperatorState(session: SessionInfo): boolean {
   return existsSync(statePath);
 }
 
+/**
+ * Maximum number of model messages to pass to the AI when resuming a session.
+ *
+ * Keeps enough context for the agent to continue effectively without hitting
+ * the model's context window and triggering an immediate summarization cycle.
+ * The value is conservative; tool-heavy conversations can produce many messages
+ * per logical "turn" (assistant → tool × N), so 200 messages ≈ 20–50 turns.
+ */
+const MAX_RESUME_MESSAGES = 200;
+
+/**
+ * Return the tail subset of model messages suitable for resuming an agent.
+ *
+ * The full message array may be very long after an extended session. Feeding
+ * it all back to the model on resume would immediately exceed the context
+ * window and force an expensive summarization pass. Instead we keep only the
+ * most recent messages, cutting at a clean "user" message boundary so that no
+ * tool-call / tool-result pairs are orphaned.
+ */
+export function getResumeMessages(
+  messages: ModelMessage[],
+  limit: number = MAX_RESUME_MESSAGES,
+): ModelMessage[] {
+  if (messages.length <= limit) return messages;
+
+  // Walk backward from `limit` positions before the end to find the nearest
+  // "user" message — that is a safe boundary because every tool-call /
+  // tool-result exchange that follows it will be complete.
+  let cutIndex = messages.length - limit;
+
+  // Search forward from the rough cut point for the next user message.
+  // This guarantees we don't start mid-turn (e.g. on an orphaned tool
+  // result whose assistant tool-call was trimmed).
+  while (cutIndex < messages.length) {
+    if (messages[cutIndex].role === "user") break;
+    cutIndex++;
+  }
+
+  // If we couldn't find a user message (unlikely), fall back to the raw cut.
+  if (cutIndex >= messages.length) {
+    cutIndex = messages.length - limit;
+  }
+
+  return messages.slice(cutIndex);
+}
+
 // ============================================================================
 // Runtime Operator Settings Update
 // ============================================================================
@@ -755,6 +801,7 @@ export const sessions = {
   removeMessage,
   loadOperatorState,
   hasOperatorState,
+  getResumeMessages,
   updateOperatorSettings,
   updateToolsetState,
   toggleTool,

--- a/src/core/session/persistence.test.ts
+++ b/src/core/session/persistence.test.ts
@@ -19,6 +19,7 @@ import {
   type AgentManifestEntry,
   type SessionInfo,
 } from "./persistence";
+import { getResumeMessages } from "./index";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -555,5 +556,101 @@ describe("convertModelMessagesToUI", () => {
   it("returns empty array for empty input", () => {
     const uiMsgs = convertModelMessagesToUI([]);
     expect(uiMsgs).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getResumeMessages
+// ---------------------------------------------------------------------------
+
+describe("getResumeMessages", () => {
+  it("returns all messages when under the limit", () => {
+    const msgs: ModelMessage[] = [
+      makeMsg("user", "hello"),
+      makeMsg("assistant", "hi"),
+      makeMsg("user", "scan"),
+      makeMsg("assistant", "scanning..."),
+    ];
+    expect(getResumeMessages(msgs, 10)).toEqual(msgs);
+  });
+
+  it("returns all messages when exactly at the limit", () => {
+    const msgs: ModelMessage[] = Array.from({ length: 5 }, (_, i) =>
+      makeMsg(i % 2 === 0 ? "user" : "assistant", `msg-${i}`),
+    );
+    expect(getResumeMessages(msgs, 5)).toEqual(msgs);
+  });
+
+  it("trims to the limit and cuts at a user message boundary", () => {
+    // 10 messages: u a u a u a u a u a
+    const msgs: ModelMessage[] = Array.from({ length: 10 }, (_, i) =>
+      makeMsg(i % 2 === 0 ? "user" : "assistant", `msg-${i}`),
+    );
+
+    const result = getResumeMessages(msgs, 5);
+    // Cut should start at index 5 (rough cut) or later at a user boundary.
+    // Index 5 is assistant, so it should advance to index 6 which is user.
+    expect(result.length).toBeLessThanOrEqual(5);
+    expect(result[0].role).toBe("user");
+  });
+
+  it("preserves tool-call / tool-result pairs by cutting at user boundary", () => {
+    const msgs: ModelMessage[] = [
+      makeMsg("user", "start"),
+      makeMsg("assistant", [
+        { type: "text", text: "I'll scan" },
+        {
+          type: "tool-call",
+          toolCallId: "tc-1",
+          toolName: "cmd",
+          args: { cmd: "ls" },
+        },
+      ]),
+      makeMsg("tool", [
+        {
+          type: "tool-result",
+          toolCallId: "tc-1",
+          toolName: "cmd",
+          result: "ok",
+        },
+      ]),
+      makeMsg("assistant", "done with first"),
+      makeMsg("user", "next step"),
+      makeMsg("assistant", "doing next"),
+    ];
+
+    // Limit 3 → rough cut at index 3 ("done with first"), then advance
+    // to index 4 ("next step" user msg) for a clean boundary.
+    const result = getResumeMessages(msgs, 3);
+    expect(result[0].role).toBe("user");
+    expect((result[0] as { content: string }).content).toBe("next step");
+    expect(result.length).toBe(2);
+  });
+
+  it("handles conversations with no user messages after cut point", () => {
+    // All assistant messages except the first
+    const msgs: ModelMessage[] = [
+      makeMsg("user", "go"),
+      ...Array.from({ length: 20 }, (_, i) =>
+        makeMsg("assistant", `step-${i}`),
+      ),
+    ];
+
+    // Limit 5 → rough cut at index 16, no user message after that → fallback
+    const result = getResumeMessages(msgs, 5);
+    expect(result.length).toBe(5);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(getResumeMessages([], 10)).toEqual([]);
+  });
+
+  it("works with default limit (does not throw)", () => {
+    const msgs: ModelMessage[] = [
+      makeMsg("user", "hello"),
+      makeMsg("assistant", "hi"),
+    ];
+    expect(() => getResumeMessages(msgs)).not.toThrow();
+    expect(getResumeMessages(msgs)).toEqual(msgs);
   });
 });

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -835,17 +835,36 @@ export default function OperatorDashboard({
           setSessionCwd(created.rootPath);
         }
 
-        // Persist full conversation for next turn
-        try {
-          const response = await agentResult.streamResult.response;
-          if (gen === generationRef.current && response.messages) {
-            conversationRef.current = [
-              ...nextMessages,
-              ...response.messages,
-            ] as ModelMessage[];
+        // Sync conversationRef from the agent's persisted state.
+        // messages.json is the single source of truth — after summarization
+        // the agent discards stale history, so reading back avoids
+        // re-accumulating old messages that would overflow the context.
+        if (gen === generationRef.current) {
+          try {
+            const rootPath = agentResult.session.rootPath;
+            const mp = join(rootPath, "messages.json");
+            if (existsSync(mp)) {
+              const raw = JSON.parse(readFileSync(mp, "utf-8"));
+              if (Array.isArray(raw) && raw.length > 0) {
+                conversationRef.current = sessions.getResumeMessages(
+                  raw as ModelMessage[],
+                );
+              }
+            }
+          } catch {
+            // Best effort — fall back to stream response
+            try {
+              const response = await agentResult.streamResult.response;
+              if (response.messages) {
+                conversationRef.current = [
+                  ...nextMessages,
+                  ...response.messages,
+                ] as ModelMessage[];
+              }
+            } catch {
+              // conversation stays as-is
+            }
           }
-        } catch {
-          // Stream may have been aborted; conversation stays as-is
         }
       } catch (e) {
         if (gen !== generationRef.current) return;

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -240,7 +240,10 @@ export default function OperatorDashboard({
                 savedState.messages.length > 0
               ) {
                 const modelMsgs = savedState.messages;
-                conversationRef.current = modelMsgs;
+
+                // Only pass a recent subset to the AI to avoid immediately
+                // blowing the context window and triggering summarization.
+                conversationRef.current = sessions.getResumeMessages(modelMsgs);
 
                 const uiMsgs = convertModelMessagesToUI(modelMsgs);
                 setMessages(
@@ -1037,14 +1040,17 @@ export default function OperatorDashboard({
 
     approvalGateRef.current.denyAll();
 
-    // Read back persisted messages so the next run has full context
+    // Read back persisted messages so the next run has full context.
+    // Only keep a recent subset to avoid blowing the context window.
     if (session) {
       try {
         const messagesPath = join(session.rootPath, "messages.json");
         if (existsSync(messagesPath)) {
           const raw = JSON.parse(readFileSync(messagesPath, "utf-8"));
           if (Array.isArray(raw) && raw.length > 0) {
-            conversationRef.current = raw as ModelMessage[];
+            conversationRef.current = sessions.getResumeMessages(
+              raw as ModelMessage[],
+            );
           }
         }
       } catch {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR addresses an issue where resuming long operator sessions immediately triggered AI summarization due to all messages being loaded into the AI's context.

The changes introduce a `getResumeMessages` function that, when resuming a session, loads the full message history for UI display but only a subset of the most recent messages (up to 200, trimmed at a user message boundary to preserve tool-call/result pairs) into the AI's `conversationRef.current`. This ensures the AI's context window is not immediately exceeded, preventing premature summarization while still providing the user with the complete conversation history.

### How did you verify your code works?

*   Added 7 unit tests for `getResumeMessages` covering various scenarios, including under-limit passthrough, exact-limit, boundary trimming, and tool-pair preservation.
*   All 379 tests passed (`bun run test`).
*   Type checks passed (`bun run tsc`).
*   Linting passed (`bun run lint`).
*   Formatting checks passed (`bun run format:check`).
*   No manual GUI testing was performed as this is a TUI application requiring an AI provider API key for the affected codepath; the logic is pure and fully covered by unit tests.

---
<p><a href="https://cursor.com/agents/bc-a3721238-b8e9-4440-962a-176c2e5581f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3721238-b8e9-4440-962a-176c2e5581f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->