### PR TITLE
Lazy-discover Lambda Function URL for SSE streaming

### DIFF
--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -35,6 +35,8 @@ export interface PensarModelConfig {
    * allowing transparent token refresh for WorkOS auth.
    */
   getToken?: () => Promise<{ token: string; type: "workos" | "legacy" } | null>;
+  /** Optional explicit stream URL. If not set, discovered via /bedrock/validate. */
+  streamUrl?: string;
 }
 
 /**
@@ -86,6 +88,38 @@ export function createPensarModel(
     }
 
     return headers;
+  }
+
+  // ── Stream URL discovery ─────────────────────────────────────────────
+  let cachedStreamUrl: string | null = null;
+
+  async function getStreamUrl(): Promise<string> {
+    if (cachedStreamUrl) return cachedStreamUrl;
+
+    // Try to discover Lambda Function URL from /bedrock/validate
+    try {
+      const headers = await buildHeaders();
+      const res = await fetch(`${config.baseUrl}/bedrock/validate`, {
+        headers,
+      });
+      if (res.ok) {
+        const data = (await res.json()) as {
+          endpoints?: { stream?: string };
+        };
+        if (data.endpoints?.stream) {
+          cachedStreamUrl = data.endpoints.stream;
+          log(`  Discovered stream URL: ${cachedStreamUrl}`);
+          return cachedStreamUrl;
+        }
+      }
+    } catch {
+      // Fall through to fallback
+    }
+
+    // Fallback: buffered SSE via API Gateway
+    cachedStreamUrl = `${config.baseUrl}/bedrock/stream`;
+    log(`  Using fallback stream URL: ${cachedStreamUrl}`);
+    return cachedStreamUrl;
   }
 
   const model: LanguageModelV2 = {
@@ -201,7 +235,7 @@ export function createPensarModel(
       response?: { headers?: Record<string, string> };
     }> {
       const body = convertToBedrockFormat(bedrockModelId, options);
-      const url = `${config.baseUrl}/bedrock/stream`;
+      const url = config.streamUrl ?? (await getStreamUrl());
 
       log(`doStream → SSE streaming for ${bedrockModelId}`);
       log(`  URL: ${url}`);

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -35,8 +35,6 @@ export interface PensarModelConfig {
    * allowing transparent token refresh for WorkOS auth.
    */
   getToken?: () => Promise<{ token: string; type: "workos" | "legacy" } | null>;
-  /** Optional explicit stream URL. If not set, discovered via /bedrock/validate. */
-  streamUrl?: string;
 }
 
 /**
@@ -236,7 +234,7 @@ export function createPensarModel(
       response?: { headers?: Record<string, string> };
     }> {
       const body = convertToBedrockFormat(bedrockModelId, options);
-      const url = config.streamUrl ?? (await getStreamUrl());
+      const url = await getStreamUrl();
 
       log(`doStream → SSE streaming for ${bedrockModelId}`);
       log(`  URL: ${url}`);

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -47,8 +47,9 @@ export interface PensarModelConfig {
  * Supports both legacy API key auth and WorkOS JWT auth.
  * When workspaceId is provided, sends X-Workspace-Id header for WorkOS auth.
  *
- * doStream() posts to /bedrock/stream and parses SSE events for real
- * token-by-token streaming. Falls back to wrapping doGenerate() on error.
+ * doStream() discovers the Lambda Function URL via /bedrock/validate for
+ * true SSE streaming. Falls back to /bedrock/invoke with stream: true
+ * (buffered SSE) in dev, or wraps doGenerate() on error.
  */
 export function createPensarModel(
   bedrockModelId: string,
@@ -116,8 +117,8 @@ export function createPensarModel(
       // Fall through to fallback
     }
 
-    // Fallback: buffered SSE via API Gateway
-    cachedStreamUrl = `${config.baseUrl}/bedrock/stream`;
+    // Fallback: buffered SSE via /bedrock/invoke with stream: true
+    cachedStreamUrl = `${config.baseUrl}/bedrock/invoke`;
     log(`  Using fallback stream URL: ${cachedStreamUrl}`);
     return cachedStreamUrl;
   }
@@ -251,6 +252,7 @@ export function createPensarModel(
           body: JSON.stringify({
             modelId: bedrockModelId,
             body,
+            stream: true,
           }),
         });
       } catch (err) {


### PR DESCRIPTION
## Summary
- Adds `streamUrl` config option to `PensarModelConfig` for explicit override
- On first `doStream()` call, queries `GET /bedrock/validate` for the Lambda Function URL (`endpoints.stream`) and caches it
- Falls back to buffered `POST /bedrock/stream` API Gateway route if Lambda URL unavailable

## Test plan
- [ ] Set `PENSAR_DEBUG=1`, run Apex — confirm "Discovered stream URL: https://...lambda-url..." in logs
- [ ] Verify SSE streaming works token-by-token via Lambda Function URL
- [ ] If validate returns no stream URL, confirm fallback to `/bedrock/stream`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request routing and payloads for streaming, which could impact runtime behavior if the validate response/stream URL is misconfigured or differs across environments.
> 
> **Overview**
> Updates the Pensar provider’s `doStream()` to **lazily discover and cache** the true SSE streaming endpoint by calling `/bedrock/validate` and using `endpoints.stream` when available.
> 
> If discovery fails, streaming requests fall back to posting to `/bedrock/invoke` with `stream: true` (and still fall back to wrapping `doGenerate()` on fetch/errors), changing the default streaming route away from the previous hardcoded `/bedrock/stream`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69b71f5b30a53609d58aad2f93d15401e2f568e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->