### PR TITLE
Operator mode new line

### DIFF
--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -35,7 +35,9 @@ interface KeyBinding {
   action: TextareaAction;
 }
 
-// Configure Enter to submit, Shift+Enter for newline
+// Enter (\r) submits; Shift+Enter (\n / linefeed) inserts a newline.
+// Terminals that support the Kitty keyboard protocol report shift
+// directly, so Shift+Return also maps to newline as a fallback.
 const keyBindings: KeyBinding[] = [
   { name: "Enter", action: "submit" },
   { name: "Enter", shift: true, action: "newline" },
@@ -351,7 +353,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
                 name: "return",
               },
               {
-                action: "submit",
+                action: "newline",
                 name: "linefeed",
               },
               {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR fixes an issue where Shift+Enter in `/operator` mode (and generally) would send the message instead of inserting a new line.

The problem stemmed from both `return` (Enter) and `linefeed` (Shift+Enter in raw terminal mode) being mapped to `"submit"`. This change remaps `linefeed` to `"newline"`, ensuring that Shift+Enter correctly adds a new line while Enter continues to submit the message. It also accounts for terminals supporting the Kitty keyboard protocol.

### How did you verify your code works?

The following checks were performed:
*   `bun run tsc` - no type errors
*   `bun run lint` - no lint issues
*   `bun run test` - all tests passed
*   `bun run format:check` - all files formatted

Manual GUI testing was not performed due to environment limitations, but the change is a targeted key-binding configuration that routes through well-tested `@opentui/core` textarea infrastructure.

---
<p><a href="https://cursor.com/agents/bc-f85be961-b863-489d-87bb-68d4a4d13f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f85be961-b863-489d-87bb-68d4a4d13f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->