### PR TITLE
fix: clean up textarea keybinding configuration

### DIFF
--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -25,23 +25,22 @@ export interface AutocompleteOption {
   description?: string;
 }
 
-// Key binding type for textarea actions
-type TextareaAction = "submit" | "newline";
-interface KeyBinding {
-  name: string;
-  ctrl?: boolean;
-  shift?: boolean;
-  meta?: boolean;
-  action: TextareaAction;
-}
-
-// Enter (\r) submits; Shift+Enter (\n / linefeed) inserts a newline.
-// Terminals that support the Kitty keyboard protocol report shift
-// directly, so Shift+Return also maps to newline as a fallback.
-const keyBindings: KeyBinding[] = [
-  { name: "Enter", action: "submit" },
-  { name: "Enter", shift: true, action: "newline" },
-];
+/**
+ * Textarea keybindings for chat-style input.
+ *
+ * Terminal key semantics:
+ * - Enter sends \r (carriage return) → @opentui parses as "return"
+ * - Shift+Enter / Ctrl+J send \n (linefeed) → @opentui parses as "linefeed"
+ * - Kitty keyboard protocol reports Shift+Enter as shift+return explicitly
+ *
+ * We override @opentui's textarea defaults (return=newline, Cmd+return=submit)
+ * to make Enter submit and Shift+Enter / Ctrl+J insert newlines.
+ */
+const chatKeyBindings = [
+  { name: "return", action: "submit" },
+  { name: "linefeed", action: "newline" },
+  { name: "return", shift: true, action: "newline" },
+] as const;
 
 export interface PromptInputRef {
   focus: () => void;
@@ -346,27 +345,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
             backgroundColor={backgroundColor}
             focusedBackgroundColor={focusedBackgroundColor}
             cursorColor={cursorColor ?? colors.textMuted}
-            // keyBindings={keyBindings}
-            keyBindings={[
-              {
-                action: "submit",
-                name: "return",
-              },
-              {
-                action: "newline",
-                name: "linefeed",
-              },
-              {
-                action: "newline",
-                shift: true,
-                name: "return",
-              },
-              {
-                action: "newline",
-                shift: true,
-                name: "linefeed",
-              },
-            ]}
+            keyBindings={chatKeyBindings}
             onContentChange={handleContentChange}
             onSubmit={handleSubmit}
           />

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -7,7 +7,11 @@ import {
   useMemo,
 } from "react";
 import { useKeyboard } from "@opentui/react";
-import type { TextareaRenderable, RGBA } from "@opentui/core";
+import type {
+  TextareaRenderable,
+  RGBA,
+  KeyBinding as TextareaKeyBinding,
+} from "@opentui/core";
 import { useTheme } from "../../theme";
 import { useInput } from "../../context/input";
 import { useFocus } from "../../context/focus";
@@ -26,21 +30,18 @@ export interface AutocompleteOption {
 }
 
 /**
- * Textarea keybindings for chat-style input.
+ * Chat-style keybindings: Enter submits, Shift+Enter / Ctrl+J inserts newline.
+ * Overrides @opentui defaults (return=newline, Cmd+return=submit).
  *
- * Terminal key semantics:
- * - Enter sends \r (carriage return) → @opentui parses as "return"
- * - Shift+Enter / Ctrl+J send \n (linefeed) → @opentui parses as "linefeed"
- * - Kitty keyboard protocol reports Shift+Enter as shift+return explicitly
- *
- * We override @opentui's textarea defaults (return=newline, Cmd+return=submit)
- * to make Enter submit and Shift+Enter / Ctrl+J insert newlines.
+ * Both "return" (\r) and "linefeed" (\n) need shift variants because
+ * @opentui matches modifiers exactly (Kitty protocol reports shift explicitly).
  */
-const chatKeyBindings = [
+const chatKeyBindings: TextareaKeyBinding[] = [
   { name: "return", action: "submit" },
   { name: "linefeed", action: "newline" },
   { name: "return", shift: true, action: "newline" },
-] as const;
+  { name: "linefeed", shift: true, action: "newline" },
+];
 
 export interface PromptInputRef {
   focus: () => void;


### PR DESCRIPTION
Closes #302

Remove dead code and inline keybinding array in `prompt-input.tsx`. Replace with a typed, named `chatKeyBindings` const using `TextareaKeyBinding` from `@opentui/core`.

No behavioral change — the linefeed→newline fix from #304 is preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized refactor of keybinding configuration with no functional changes expected beyond type-safety and readability.
> 
> **Overview**
> Refactors `PromptInput` textarea keybinding configuration by removing unused local keybinding types and replacing the inline `keyBindings` prop with a named, typed `chatKeyBindings` constant using `KeyBinding` from `@opentui/core`.
> 
> This keeps the same chat-style behavior (Enter submits; linefeed/shift variants insert newline) while making the configuration clearer and type-checked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac9ac17e6c25d6d6086b51b326219dd90ee00785. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->