### PR TITLE
feat: auto-copy on select with clipboard notification

### DIFF
--- a/src/tui/auto-copy.ts
+++ b/src/tui/auto-copy.ts
@@ -5,12 +5,9 @@ export function setupAutoCopy(
   renderer: CliRenderer,
   copyToClipboard: (text: string) => void,
 ) {
-  // Replace the copy button with a static "Select to copy" label
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (renderer.console as any).getCopyButtonLabel = () => "Select to copy";
 
-  // Console: auto-copy on select — when user finishes a mouse selection,
-  // immediately copy to clipboard and clear the selection.
   const originalHandleMouse = renderer.console.handleMouse.bind(
     renderer.console,
   );
@@ -26,8 +23,6 @@ export function setupAutoCopy(
     return result;
   };
 
-  // App-wide: auto-copy on select — when user finishes selecting text
-  // anywhere in the application, copy to clipboard and clear selection.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   renderer.on("selection", (selection: any) => {
     if (selection && !selection.isDragging) {

--- a/src/tui/auto-copy.ts
+++ b/src/tui/auto-copy.ts
@@ -28,6 +28,7 @@ export function setupAutoCopy(
 
   // App-wide: auto-copy on select — when user finishes selecting text
   // anywhere in the application, copy to clipboard and clear selection.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   renderer.on("selection", (selection: any) => {
     if (selection && !selection.isDragging) {
       const text = selection.getSelectedText();

--- a/src/tui/auto-copy.ts
+++ b/src/tui/auto-copy.ts
@@ -1,0 +1,40 @@
+import type { CliRenderer } from "@opentui/core";
+
+/** Wire up auto-copy-on-select for both the console pane and the main app. */
+export function setupAutoCopy(
+  renderer: CliRenderer,
+  copyToClipboard: (text: string) => void,
+) {
+  // Replace the copy button with a static "Select to copy" label
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (renderer.console as any).getCopyButtonLabel = () => "Select to copy";
+
+  // Console: auto-copy on select — when user finishes a mouse selection,
+  // immediately copy to clipboard and clear the selection.
+  const originalHandleMouse = renderer.console.handleMouse.bind(
+    renderer.console,
+  );
+  renderer.console.handleMouse = (event) => {
+    const result = originalHandleMouse(event);
+    if (event.type === "up") {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const c = renderer.console as any;
+      if (typeof c.hasSelection === "function" && c.hasSelection()) {
+        c.triggerCopy();
+      }
+    }
+    return result;
+  };
+
+  // App-wide: auto-copy on select — when user finishes selecting text
+  // anywhere in the application, copy to clipboard and clear selection.
+  renderer.on("selection", (selection: any) => {
+    if (selection && !selection.isDragging) {
+      const text = selection.getSelectedText();
+      if (text) {
+        copyToClipboard(text);
+      }
+      process.nextTick(() => renderer.clearSelection());
+    }
+  });
+}

--- a/src/tui/clipboard.ts
+++ b/src/tui/clipboard.ts
@@ -17,15 +17,13 @@ export function createClipboardManager(renderer: CliRenderer) {
       proc.stdin.write(text);
       proc.stdin.end();
     } catch {
-      // Clipboard command unavailable
+      // native clipboard command unavailable
     }
-    // Show "Copied to clipboard" notification for 2 seconds
     clipboardNotifExpiry = Date.now() + 2000;
     renderer.requestRender();
     setTimeout(() => renderer.requestRender(), 2010);
   };
 
-  // Draw the "Copied to clipboard" overlay in the top-right corner
   const notifLabel = "Copied to clipboard";
   const notifPadX = 1;
   const notifBoxWidth = 1 + notifPadX + notifLabel.length + notifPadX + 1;
@@ -54,14 +52,11 @@ export function createClipboardManager(renderer: CliRenderer) {
         c.text,
         c.backgroundElement,
       );
-      // NOTE: Do NOT call renderer.requestRender() here — post-process
-      // functions run during each render pass, so it would create an
-      // infinite render loop. The copyToClipboard function already triggers
-      // the initial render + a setTimeout for the cleanup render.
+      // Don't call renderer.requestRender() here — post-process functions
+      // run during each render pass, causing an infinite loop.
     }
   });
 
-  // Wire up console copy to system clipboard
   renderer.console.onCopySelection = copyToClipboard;
 
   return { copyToClipboard };

--- a/src/tui/clipboard.ts
+++ b/src/tui/clipboard.ts
@@ -1,0 +1,68 @@
+import type { CliRenderer } from "@opentui/core";
+import { overlayThemeRef } from "./console-theme";
+
+/** Set up clipboard copying (OSC52 + native) and the notification overlay. */
+export function createClipboardManager(renderer: CliRenderer) {
+  let clipboardNotifExpiry = 0;
+
+  const copyToClipboard = (text: string) => {
+    renderer.copyToClipboardOSC52(text);
+    try {
+      const proc = Bun.spawn(
+        process.platform === "darwin"
+          ? ["pbcopy"]
+          : ["xclip", "-selection", "clipboard"],
+        { stdin: "pipe" },
+      );
+      proc.stdin.write(text);
+      proc.stdin.end();
+    } catch {
+      // Clipboard command unavailable
+    }
+    // Show "Copied to clipboard" notification for 2 seconds
+    clipboardNotifExpiry = Date.now() + 2000;
+    renderer.requestRender();
+    setTimeout(() => renderer.requestRender(), 2010);
+  };
+
+  // Draw the "Copied to clipboard" overlay in the top-right corner
+  const notifLabel = "Copied to clipboard";
+  const notifPadX = 1;
+  const notifBoxWidth = 1 + notifPadX + notifLabel.length + notifPadX + 1;
+  const notifBoxHeight = 3;
+  const notifMargin = 1;
+  renderer.addPostProcessFn((buffer) => {
+    if (Date.now() < clipboardNotifExpiry && overlayThemeRef.current) {
+      const c = overlayThemeRef.current;
+      const x = buffer.width - notifBoxWidth - notifMargin;
+      const y = notifMargin;
+      buffer.fillRect(x, y, notifBoxWidth, notifBoxHeight, c.backgroundElement);
+      buffer.drawBox({
+        x,
+        y,
+        width: notifBoxWidth,
+        height: notifBoxHeight,
+        border: true,
+        borderColor: c.border,
+        backgroundColor: c.backgroundElement,
+        shouldFill: false,
+      });
+      buffer.drawText(
+        notifLabel,
+        x + 1 + notifPadX,
+        y + 1,
+        c.text,
+        c.backgroundElement,
+      );
+      // NOTE: Do NOT call renderer.requestRender() here — post-process
+      // functions run during each render pass, so it would create an
+      // infinite render loop. The copyToClipboard function already triggers
+      // the initial render + a setTimeout for the cleanup render.
+    }
+  });
+
+  // Wire up console copy to system clipboard
+  renderer.console.onCopySelection = copyToClipboard;
+
+  return { copyToClipboard };
+}

--- a/src/tui/console-theme.ts
+++ b/src/tui/console-theme.ts
@@ -41,6 +41,7 @@ export function ConsoleThemeSync() {
   useEffect(() => {
     overlayThemeRef.current = colors;
     // Keep console colors in sync with the active theme
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const c = renderer.console as any;
     c.backgroundColor = withAlpha(colors.backgroundPanel, 0.85);
     c._rgbaTitleBar = withAlpha(colors.backgroundElement, 0.9);

--- a/src/tui/console-theme.ts
+++ b/src/tui/console-theme.ts
@@ -40,7 +40,6 @@ export function ConsoleThemeSync() {
   const renderer = useRenderer();
   useEffect(() => {
     overlayThemeRef.current = colors;
-    // Keep console colors in sync with the active theme
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const c = renderer.console as any;
     c.backgroundColor = withAlpha(colors.backgroundPanel, 0.85);

--- a/src/tui/console-theme.ts
+++ b/src/tui/console-theme.ts
@@ -1,0 +1,59 @@
+import { useEffect } from "react";
+import { useRenderer } from "@opentui/react";
+import { RGBA } from "@opentui/core";
+import { useTheme, type ThemeColors } from "./theme";
+
+export const withAlpha = (rgba: RGBA, a: number) =>
+  RGBA.fromValues(rgba.r, rgba.g, rgba.b, a);
+
+/**
+ * Mutable ref for non-React code (post-process overlays) to read current
+ * theme colors. Updated by ConsoleThemeSync on every theme change.
+ */
+export const overlayThemeRef: { current: ThemeColors | null } = {
+  current: null,
+};
+
+/** Build the initial consoleOptions for createCliRenderer. */
+export function buildConsoleOptions(themeColors: ThemeColors) {
+  return {
+    backgroundColor: withAlpha(themeColors.backgroundPanel, 0.85),
+    titleBarColor: withAlpha(themeColors.backgroundElement, 0.9),
+    titleBarTextColor: themeColors.text,
+    colorDefault: themeColors.textMuted,
+    colorInfo: themeColors.info,
+    colorWarn: themeColors.warning,
+    colorError: themeColors.error,
+    colorDebug: themeColors.textMuted,
+    selectionColor: withAlpha(themeColors.primary, 0.35),
+    cursorColor: themeColors.primary,
+    copyButtonColor: themeColors.primary,
+  };
+}
+
+/**
+ * React component that syncs the active theme to the console pane and
+ * the overlay theme ref. Renders nothing — purely a side-effect component.
+ */
+export function ConsoleThemeSync() {
+  const { colors } = useTheme();
+  const renderer = useRenderer();
+  useEffect(() => {
+    overlayThemeRef.current = colors;
+    // Keep console colors in sync with the active theme
+    const c = renderer.console as any;
+    c.backgroundColor = withAlpha(colors.backgroundPanel, 0.85);
+    c._rgbaTitleBar = withAlpha(colors.backgroundElement, 0.9);
+    c._rgbaTitleBarText = colors.text;
+    c._rgbaDefault = colors.textMuted;
+    c._rgbaInfo = colors.info;
+    c._rgbaWarn = colors.warning;
+    c._rgbaError = colors.error;
+    c._rgbaDebug = colors.textMuted;
+    c._rgbaSelection = withAlpha(colors.primary, 0.35);
+    c._rgbaCursor = colors.primary;
+    c._rgbaCopyButton = colors.primary;
+    c.markNeedsRerender();
+  }, [colors]);
+  return null;
+}

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -1,4 +1,4 @@
-import { createRoot, useRenderer } from "@opentui/react";
+import { createRoot } from "@opentui/react";
 import { useState, useEffect } from "react";
 import Footer from "./components/footer";
 import { CommandProvider } from "./context/command";
@@ -11,7 +11,7 @@ import WebWizard from "./components/commands/web-wizard";
 import ProviderManager from "./components/commands/provider-manager";
 import type { Config } from "../core/config/config";
 import { config } from "../core/config";
-import { createCliRenderer, RGBA } from "@opentui/core";
+import { createCliRenderer } from "@opentui/core";
 import { ConfigProvider, useConfig } from "./context/config";
 import { createSwitch } from "./components/switch";
 import { type RoutePath, RouteProvider, useRoute } from "./context/route";
@@ -46,35 +46,13 @@ import {
 } from "./theme";
 import { registerBuiltinThemes } from "./theme/themes";
 import { detectTerminalMode } from "./theme/detect-mode";
-
-// Mutable theme colors for non-React overlay rendering (post-process functions).
-// Updated by OverlayThemeSync whenever the React theme context changes.
-let overlayThemeColors: import("./theme").ThemeColors | null = null;
-
-function OverlayThemeSync() {
-  const { colors } = useTheme();
-  const renderer = useRenderer();
-  useEffect(() => {
-    overlayThemeColors = colors;
-    // Keep console colors in sync with the active theme
-    const c = renderer.console as any;
-    const withAlpha = (rgba: import("@opentui/core").RGBA, a: number) =>
-      RGBA.fromValues(rgba.r, rgba.g, rgba.b, a);
-    c.backgroundColor = withAlpha(colors.backgroundPanel, 0.85);
-    c._rgbaTitleBar = withAlpha(colors.backgroundElement, 0.9);
-    c._rgbaTitleBarText = colors.text;
-    c._rgbaDefault = colors.textMuted;
-    c._rgbaInfo = colors.info;
-    c._rgbaWarn = colors.warning;
-    c._rgbaError = colors.error;
-    c._rgbaDebug = colors.textMuted;
-    c._rgbaSelection = withAlpha(colors.primary, 0.35);
-    c._rgbaCursor = colors.primary;
-    c._rgbaCopyButton = colors.primary;
-    c.markNeedsRerender();
-  }, [colors]);
-  return null;
-}
+import {
+  overlayThemeRef,
+  buildConsoleOptions,
+  ConsoleThemeSync,
+} from "./console-theme";
+import { createClipboardManager } from "./clipboard";
+import { setupAutoCopy } from "./auto-copy";
 
 interface AppProps {
   appConfig: Config;
@@ -407,114 +385,18 @@ async function main() {
     mode = await detectTerminalMode();
   }
 
-  // Resolve initial theme colors and seed the module-level ref for overlays
+  // Resolve initial theme colors and seed the ref for overlay rendering
   const themeColors = resolveThemeColors(getTheme(themeName), mode);
-  overlayThemeColors = themeColors;
-
-  // Semi-transparent variant of a color for console backgrounds
-  const withAlpha = (c: import("@opentui/core").RGBA, a: number) =>
-    RGBA.fromValues(c.r, c.g, c.b, a);
+  overlayThemeRef.current = themeColors;
 
   const renderer = await createCliRenderer({
     exitOnCtrlC: false,
-    consoleOptions: {
-      backgroundColor: withAlpha(themeColors.backgroundPanel, 0.85),
-      titleBarColor: withAlpha(themeColors.backgroundElement, 0.9),
-      titleBarTextColor: themeColors.text,
-      colorDefault: themeColors.textMuted,
-      colorInfo: themeColors.info,
-      colorWarn: themeColors.warning,
-      colorError: themeColors.error,
-      colorDebug: themeColors.textMuted,
-      selectionColor: withAlpha(themeColors.primary, 0.35),
-      cursorColor: themeColors.primary,
-      copyButtonColor: themeColors.primary,
-    },
+    consoleOptions: buildConsoleOptions(themeColors),
   });
 
-  // Copy text to the system clipboard using both OSC 52 and native commands
-  let clipboardNotifExpiry = 0;
-  const copyToClipboard = (text: string) => {
-    renderer.copyToClipboardOSC52(text);
-    try {
-      const proc = Bun.spawn(
-        process.platform === "darwin"
-          ? ["pbcopy"]
-          : ["xclip", "-selection", "clipboard"],
-        { stdin: "pipe" },
-      );
-      proc.stdin.write(text);
-      proc.stdin.end();
-    } catch {
-      // Clipboard command unavailable
-    }
-    // Show "Copied to clipboard" notification for 2 seconds
-    clipboardNotifExpiry = Date.now() + 2000;
-    renderer.requestRender();
-    setTimeout(() => renderer.requestRender(), 2010);
-  };
-
-  // Draw the "Copied to clipboard" overlay in the top-right corner
-  const notifLabel = "Copied to clipboard";
-  const notifPadX = 1; // horizontal padding between border and text
-  const notifBoxWidth = 1 + notifPadX + notifLabel.length + notifPadX + 1; // border + pad + text + pad + border
-  const notifBoxHeight = 3; // border + text + border
-  const notifMargin = 1; // equal margin from top and right edges
-  renderer.addPostProcessFn((buffer) => {
-    if (Date.now() < clipboardNotifExpiry && overlayThemeColors) {
-      const c = overlayThemeColors;
-      const x = buffer.width - notifBoxWidth - notifMargin;
-      const y = notifMargin;
-      buffer.fillRect(x, y, notifBoxWidth, notifBoxHeight, c.backgroundElement);
-      buffer.drawBox({
-        x,
-        y,
-        width: notifBoxWidth,
-        height: notifBoxHeight,
-        border: true,
-        borderColor: c.border,
-        backgroundColor: c.backgroundElement,
-        shouldFill: false,
-      });
-      buffer.drawText(notifLabel, x + 1 + notifPadX, y + 1, c.text, c.backgroundElement);
-    }
-  });
-
-  // Wire up console copy to system clipboard
-  renderer.console.onCopySelection = copyToClipboard;
-
-  // Replace the copy button with a static "Select to copy" label
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (renderer.console as any).getCopyButtonLabel = () => "Select to copy";
-
-  // Console: auto-copy on select — when user finishes a mouse selection,
-  // immediately copy to clipboard and clear the selection.
-  const originalHandleMouse = renderer.console.handleMouse.bind(
-    renderer.console,
-  );
-  renderer.console.handleMouse = (event) => {
-    const result = originalHandleMouse(event);
-    if (event.type === "up") {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const c = renderer.console as any;
-      if (typeof c.hasSelection === "function" && c.hasSelection()) {
-        c.triggerCopy();
-      }
-    }
-    return result;
-  };
-
-  // App-wide: auto-copy on select — when user finishes selecting text
-  // anywhere in the application, copy to clipboard and clear selection.
-  renderer.on("selection", (selection: any) => {
-    if (selection && !selection.isDragging) {
-      const text = selection.getSelectedText();
-      if (text) {
-        copyToClipboard(text);
-      }
-      process.nextTick(() => renderer.clearSelection());
-    }
-  });
+  // Clipboard: OSC52 + native copy, notification overlay, auto-copy on select
+  const { copyToClipboard } = createClipboardManager(renderer);
+  setupAutoCopy(renderer, copyToClipboard);
 
   // Graceful shutdown handler
   const cleanup = () => {
@@ -543,7 +425,7 @@ async function main() {
 
   createRoot(renderer).render(
     <ThemeProvider initialTheme={themeName} initialMode={mode}>
-      <OverlayThemeSync />
+      <ConsoleThemeSync />
       <ToastProvider>
         <ErrorBoundary>
           <App appConfig={appConfig} />

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -1,4 +1,4 @@
-import { createRoot } from "@opentui/react";
+import { createRoot, useRenderer } from "@opentui/react";
 import { useState, useEffect } from "react";
 import Footer from "./components/footer";
 import { CommandProvider } from "./context/command";
@@ -11,7 +11,7 @@ import WebWizard from "./components/commands/web-wizard";
 import ProviderManager from "./components/commands/provider-manager";
 import type { Config } from "../core/config/config";
 import { config } from "../core/config";
-import { createCliRenderer } from "@opentui/core";
+import { createCliRenderer, RGBA } from "@opentui/core";
 import { ConfigProvider, useConfig } from "./context/config";
 import { createSwitch } from "./components/switch";
 import { type RoutePath, RouteProvider, useRoute } from "./context/route";
@@ -37,9 +37,44 @@ import Pentest from "./components/pentest/pentest";
 import OperatorDashboard from "./components/operator-dashboard";
 import ThemePicker from "./components/commands/theme-picker";
 import CreateSkillWizard from "./components/commands/create-skill-wizard";
-import { ThemeProvider, useTheme, type ColorMode } from "./theme";
+import {
+  ThemeProvider,
+  useTheme,
+  resolveThemeColors,
+  getTheme,
+  type ColorMode,
+} from "./theme";
 import { registerBuiltinThemes } from "./theme/themes";
 import { detectTerminalMode } from "./theme/detect-mode";
+
+// Mutable theme colors for non-React overlay rendering (post-process functions).
+// Updated by OverlayThemeSync whenever the React theme context changes.
+let overlayThemeColors: import("./theme").ThemeColors | null = null;
+
+function OverlayThemeSync() {
+  const { colors } = useTheme();
+  const renderer = useRenderer();
+  useEffect(() => {
+    overlayThemeColors = colors;
+    // Keep console colors in sync with the active theme
+    const c = renderer.console as any;
+    const withAlpha = (rgba: import("@opentui/core").RGBA, a: number) =>
+      RGBA.fromValues(rgba.r, rgba.g, rgba.b, a);
+    c.backgroundColor = withAlpha(colors.backgroundPanel, 0.85);
+    c._rgbaTitleBar = withAlpha(colors.backgroundElement, 0.9);
+    c._rgbaTitleBarText = colors.text;
+    c._rgbaDefault = colors.textMuted;
+    c._rgbaInfo = colors.info;
+    c._rgbaWarn = colors.warning;
+    c._rgbaError = colors.error;
+    c._rgbaDebug = colors.textMuted;
+    c._rgbaSelection = withAlpha(colors.primary, 0.35);
+    c._rgbaCursor = colors.primary;
+    c._rgbaCopyButton = colors.primary;
+    c.markNeedsRerender();
+  }, [colors]);
+  return null;
+}
 
 interface AppProps {
   appConfig: Config;
@@ -372,7 +407,115 @@ async function main() {
     mode = await detectTerminalMode();
   }
 
-  const renderer = await createCliRenderer({ exitOnCtrlC: false });
+  // Resolve initial theme colors and seed the module-level ref for overlays
+  const themeColors = resolveThemeColors(getTheme(themeName), mode);
+  overlayThemeColors = themeColors;
+
+  // Semi-transparent variant of a color for console backgrounds
+  const withAlpha = (c: import("@opentui/core").RGBA, a: number) =>
+    RGBA.fromValues(c.r, c.g, c.b, a);
+
+  const renderer = await createCliRenderer({
+    exitOnCtrlC: false,
+    consoleOptions: {
+      backgroundColor: withAlpha(themeColors.backgroundPanel, 0.85),
+      titleBarColor: withAlpha(themeColors.backgroundElement, 0.9),
+      titleBarTextColor: themeColors.text,
+      colorDefault: themeColors.textMuted,
+      colorInfo: themeColors.info,
+      colorWarn: themeColors.warning,
+      colorError: themeColors.error,
+      colorDebug: themeColors.textMuted,
+      selectionColor: withAlpha(themeColors.primary, 0.35),
+      cursorColor: themeColors.primary,
+      copyButtonColor: themeColors.primary,
+    },
+  });
+
+  // Copy text to the system clipboard using both OSC 52 and native commands
+  let clipboardNotifExpiry = 0;
+  const copyToClipboard = (text: string) => {
+    renderer.copyToClipboardOSC52(text);
+    try {
+      const proc = Bun.spawn(
+        process.platform === "darwin"
+          ? ["pbcopy"]
+          : ["xclip", "-selection", "clipboard"],
+        { stdin: "pipe" },
+      );
+      proc.stdin.write(text);
+      proc.stdin.end();
+    } catch {
+      // Clipboard command unavailable
+    }
+    // Show "Copied to clipboard" notification for 2 seconds
+    clipboardNotifExpiry = Date.now() + 2000;
+    renderer.requestRender();
+    setTimeout(() => renderer.requestRender(), 2010);
+  };
+
+  // Draw the "Copied to clipboard" overlay in the top-right corner
+  const notifLabel = "Copied to clipboard";
+  const notifPadX = 1; // horizontal padding between border and text
+  const notifBoxWidth = 1 + notifPadX + notifLabel.length + notifPadX + 1; // border + pad + text + pad + border
+  const notifBoxHeight = 3; // border + text + border
+  const notifMargin = 1; // equal margin from top and right edges
+  renderer.addPostProcessFn((buffer) => {
+    if (Date.now() < clipboardNotifExpiry && overlayThemeColors) {
+      const c = overlayThemeColors;
+      const x = buffer.width - notifBoxWidth - notifMargin;
+      const y = notifMargin;
+      buffer.fillRect(x, y, notifBoxWidth, notifBoxHeight, c.backgroundElement);
+      buffer.drawBox({
+        x,
+        y,
+        width: notifBoxWidth,
+        height: notifBoxHeight,
+        border: true,
+        borderColor: c.border,
+        backgroundColor: c.backgroundElement,
+        shouldFill: false,
+      });
+      buffer.drawText(notifLabel, x + 1 + notifPadX, y + 1, c.text, c.backgroundElement);
+      renderer.requestRender();
+    }
+  });
+
+  // Wire up console copy to system clipboard
+  renderer.console.onCopySelection = copyToClipboard;
+
+  // Replace the copy button with a static "Select to copy" label
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (renderer.console as any).getCopyButtonLabel = () => "Select to copy";
+
+  // Console: auto-copy on select — when user finishes a mouse selection,
+  // immediately copy to clipboard and clear the selection.
+  const originalHandleMouse = renderer.console.handleMouse.bind(
+    renderer.console,
+  );
+  renderer.console.handleMouse = (event) => {
+    const result = originalHandleMouse(event);
+    if (event.type === "up") {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const c = renderer.console as any;
+      if (typeof c.hasSelection === "function" && c.hasSelection()) {
+        c.triggerCopy();
+      }
+    }
+    return result;
+  };
+
+  // App-wide: auto-copy on select — when user finishes selecting text
+  // anywhere in the application, copy to clipboard and clear selection.
+  renderer.on("selection", (selection: any) => {
+    if (selection && !selection.isDragging) {
+      const text = selection.getSelectedText();
+      if (text) {
+        copyToClipboard(text);
+      }
+      process.nextTick(() => renderer.clearSelection());
+    }
+  });
 
   // Graceful shutdown handler
   const cleanup = () => {
@@ -401,6 +544,7 @@ async function main() {
 
   createRoot(renderer).render(
     <ThemeProvider initialTheme={themeName} initialMode={mode}>
+      <OverlayThemeSync />
       <ToastProvider>
         <ErrorBoundary>
           <App appConfig={appConfig} />

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -477,7 +477,6 @@ async function main() {
         shouldFill: false,
       });
       buffer.drawText(notifLabel, x + 1 + notifPadX, y + 1, c.text, c.backgroundElement);
-      renderer.requestRender();
     }
   });
 

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -373,10 +373,8 @@ function CommandDisplay({
 async function main() {
   const appConfig = await config.get();
 
-  // Register built-in themes
   registerBuiltinThemes();
 
-  // Resolve theme and mode from config
   const themeName = appConfig.theme ?? "apex";
   let mode: ColorMode;
   if (appConfig.themeMode === "dark" || appConfig.themeMode === "light") {
@@ -385,7 +383,6 @@ async function main() {
     mode = await detectTerminalMode();
   }
 
-  // Resolve initial theme colors and seed the ref for overlay rendering
   const themeColors = resolveThemeColors(getTheme(themeName), mode);
   overlayThemeRef.current = themeColors;
 
@@ -394,21 +391,16 @@ async function main() {
     consoleOptions: buildConsoleOptions(themeColors),
   });
 
-  // Clipboard: OSC52 + native copy, notification overlay, auto-copy on select
   const { copyToClipboard } = createClipboardManager(renderer);
   setupAutoCopy(renderer, copyToClipboard);
 
-  // Graceful shutdown handler
   const cleanup = () => {
     renderer.destroy();
     process.exit(0);
   };
-
-  // Handle process signals for graceful shutdown
   process.on("SIGINT", cleanup);
   process.on("SIGTERM", cleanup);
 
-  // Handle uncaught errors - cleanup terminal before crash
   process.on("uncaughtException", (err) => {
     renderer.destroy();
     console.error("Uncaught exception:", err);


### PR DESCRIPTION
Selecting text anywhere in Apex now automatically copies it to the clipboard and clears the selection — no manual copy shortcut needed. Works in both the console pane (Ctrl+K) and the main app. A small "Copied to clipboard" overlay appears briefly in the top-right corner after each copy.

Also themes the console pane to match the active theme (background, title bar, log level colors, selection highlight), with live preview support in the theme picker.

Closes #306


https://github.com/user-attachments/assets/e4411871-b458-4d78-b622-ad909677ee07


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core TUI input/selection handling and clipboard integration (OSC52 + platform-specific commands), which may behave differently across terminals/OSes and could affect mouse interactions or render performance.
> 
> **Overview**
> Selecting text in the TUI now **auto-copies on mouse-up/selection** for both the console pane and the main app via new `setupAutoCopy`, and immediately clears the selection.
> 
> Adds a clipboard manager that copies via **OSC52 plus best-effort native clipboard** (`pbcopy`/`xclip`) and shows a short-lived, theme-colored “Copied to clipboard” overlay.
> 
> The console pane is now **theme-synced**: initial `consoleOptions` are derived from resolved theme colors at renderer creation, and `ConsoleThemeSync` updates console/overlay colors live on theme changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34989534cdd3f6f13a3919f2f7a182dcd279f3eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->