### PR TITLE
feat: assign CWE identifiers during CVSS scoring

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -54,6 +54,7 @@ const FALLBACK_CVSS: CVSSScorerResult = {
   },
   scoreType: "CVSS-BT",
   reasoning: "CVSS scoring unavailable — using conservative MEDIUM default.",
+  cwes: [],
 };
 
 export function documentVulnerability(ctx: ToolContext) {

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -20,6 +20,12 @@ export const documentVulnerabilityInputSchema = z.object({
     .describe("Relative path to the POC script (e.g., pocs/poc_sqli.sh)"),
   remediation: z.string().describe("Steps to fix the issue"),
   references: z.string().optional().describe("CVE, CWE, or related references"),
+  vulnerabilityClass: z
+    .string()
+    .optional()
+    .describe(
+      "The class of vulnerability (e.g., sqli, xss, command-injection, idor, ssrf, path-traversal, crypto, cve)",
+    ),
   toolCallDescription: z
     .string()
     .describe(
@@ -114,6 +120,7 @@ FINDING STRUCTURE:
                 evidence: evidenceForPrompt,
                 endpoint: input.endpoint,
                 remediation: input.remediation,
+                vulnerabilityClass: input.vulnerabilityClass,
               },
               agentMessages: [],
             },
@@ -157,6 +164,7 @@ FINDING STRUCTURE:
           sessionId: session.id,
           target: session.targets[0],
           ...(evidenceFilePath && { evidenceFile: evidenceFilePath }),
+          cwes: cvssResult.cwes,
           cvss: {
             score: cvssResult.score,
             severity: cvssResult.severity,
@@ -198,6 +206,12 @@ FINDING STRUCTURE:
 
 **Reasoning:** ${cvssResult.reasoning}`;
 
+          const cweSection = cvssResult.cwes?.length
+            ? `## CWE Classification
+
+${cvssResult.cwes.map((cwe) => `- **${cwe.id}** — ${cwe.reasoning}`).join("\n")}`
+            : "";
+
           const evidenceSection = evidenceFilePath
             ? `## Evidence
 
@@ -232,7 +246,7 @@ ${finding.impact}
 
 ${cvssSection}
 
-${evidenceSection}
+${cweSection ? `${cweSection}\n\n` : ""}${evidenceSection}
 
 ## POC
 
@@ -253,7 +267,10 @@ ${finding.references ? `## References\n\n${finding.references}` : ""}
 
           // Append to summary
           const summaryPath = join(session.rootPath, "findings-summary.md");
-          const summaryEntry = `- [${finding.severity}] (CVSS ${cvssResult.score}) ${finding.title} - \`findings/${mdFilename}\`\n`;
+          const cweTag = cvssResult.cwes?.length
+            ? ` (${cvssResult.cwes.map((c) => c.id).join(", ")})`
+            : "";
+          const summaryEntry = `- [${finding.severity}] (CVSS ${cvssResult.score})${cweTag} ${finding.title} - \`findings/${mdFilename}\`\n`;
 
           try {
             appendFileSync(summaryPath, summaryEntry);

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -82,7 +82,8 @@ FINDING STRUCTURE:
 - Impact: Business and technical consequences if exploited
 - Evidence: Commands run, responses received, proof of exploitation
 - Remediation: Specific, actionable steps to fix
-- References: CVE, CWE, OWASP, or security advisories`,
+- References: CVE, CWE, OWASP, or security advisories
+- Vulnerability Class: The class of vulnerability (e.g., sqli, xss, command-injection) — improves CWE accuracy`,
     inputSchema: documentVulnerabilityInputSchema,
     execute: async (input) => {
       try {

--- a/src/core/agents/offSecAgent/types.test.ts
+++ b/src/core/agents/offSecAgent/types.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { ApexFindingObject } from "./types";
+import { DocumentFindingSchema } from "../../session/types";
+import { PentestReportFindingSchema } from "../../report/schemas";
+
+const baseFinding = {
+  title: "SQL Injection in /api/products",
+  severity: "HIGH",
+  description: "The search parameter is vulnerable to SQL injection.",
+  impact: "An attacker can extract database contents.",
+  evidence: "sqlmap confirmed injection point.",
+  endpoint: "https://example.com/api/products",
+  pocPath: "pocs/poc_sqli.sh",
+  remediation: "Use parameterized queries.",
+};
+
+const cwes = [
+  { id: "CWE-89", reasoning: "SQL injection via unsanitized user input" },
+  { id: "CWE-564", reasoning: "Hibernate-specific variant" },
+];
+
+// ---------------------------------------------------------------------------
+// ApexFindingObject
+// ---------------------------------------------------------------------------
+
+describe("ApexFindingObject", () => {
+  it("accepts finding without cwes (backward compatible)", () => {
+    const result = ApexFindingObject.safeParse(baseFinding);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts finding with cwes", () => {
+    const result = ApexFindingObject.safeParse({ ...baseFinding, cwes });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.cwes).toEqual(cwes);
+    }
+  });
+
+  it("rejects finding with invalid CWE id format", () => {
+    const result = ApexFindingObject.safeParse({
+      ...baseFinding,
+      cwes: [{ id: "cwe89", reasoning: "bad format" }],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DocumentFindingSchema
+// ---------------------------------------------------------------------------
+
+describe("DocumentFindingSchema", () => {
+  it("accepts finding without cwes (backward compatible)", () => {
+    const result = DocumentFindingSchema.safeParse(baseFinding);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts finding with cwes", () => {
+    const result = DocumentFindingSchema.safeParse({ ...baseFinding, cwes });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.cwes).toEqual(cwes);
+    }
+  });
+
+  it("rejects finding with invalid CWE id format", () => {
+    const result = DocumentFindingSchema.safeParse({
+      ...baseFinding,
+      cwes: [{ id: "SQL Injection", reasoning: "not a CWE id" }],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PentestReportFindingSchema
+// ---------------------------------------------------------------------------
+
+describe("PentestReportFindingSchema", () => {
+  it("accepts finding without cwes (backward compatible)", () => {
+    const result = PentestReportFindingSchema.safeParse(baseFinding);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts finding with cwes", () => {
+    const result = PentestReportFindingSchema.safeParse({
+      ...baseFinding,
+      cwes,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.cwes).toEqual(cwes);
+    }
+  });
+
+  it("rejects finding with invalid CWE id format", () => {
+    const result = PentestReportFindingSchema.safeParse({
+      ...baseFinding,
+      cwes: [{ id: "CWE-", reasoning: "missing number" }],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -18,6 +18,7 @@ import type { ApprovalGate } from "../../operator";
 import type { ToolName } from "./tools";
 import type { UnifiedSandbox } from "./tools/sandbox";
 import { z } from "zod";
+import { CweEntrySchema } from "../../../lib/cwe/types";
 
 // Backward-compatible Finding schema (toolCallDescription is optional for parsing old findings)
 export const ApexFindingObject = z.object({
@@ -43,6 +44,7 @@ export const ApexFindingObject = z.object({
   remediation: z.string(),
   references: z.string().optional(),
   toolCallDescription: z.string().optional(), // Optional for backward compatibility
+  cwes: z.array(CweEntrySchema).optional(),
 });
 
 export type Finding = z.infer<typeof ApexFindingObject>;

--- a/src/core/agents/specialized/cvssScorer/index.ts
+++ b/src/core/agents/specialized/cvssScorer/index.ts
@@ -131,7 +131,6 @@ const CVSSMetricsOutputSchema = z.object({
     ),
   cwes: z
     .array(CweEntrySchema)
-    .min(1)
     .describe(
       "CWE classifications for this vulnerability, most specific first",
     ),

--- a/src/core/agents/specialized/cvssScorer/index.ts
+++ b/src/core/agents/specialized/cvssScorer/index.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import { generateObjectResponse, type AIModel } from "../../../ai";
 import { type AIAuthConfig } from "../../../ai/utils";
 import { calculateCVSS4Score, type CVSS4Metrics } from "../../../../lib/cvss";
+import { CweEntrySchema, type CweEntry } from "../../../../lib/cwe/types";
 
 // =============================================================================
 // Types
@@ -45,6 +46,8 @@ export interface CVSSScorerResult {
   scoreType: string;
   /** AI's reasoning for metric choices */
   reasoning: string;
+  /** CWE classifications assigned to this vulnerability */
+  cwes: CweEntry[];
 }
 
 // =============================================================================
@@ -125,6 +128,12 @@ const CVSSMetricsOutputSchema = z.object({
     .string()
     .describe(
       "Brief explanation (2-3 sentences) of the key factors that influenced the metric choices",
+    ),
+  cwes: z
+    .array(CweEntrySchema)
+    .min(1)
+    .describe(
+      "CWE classifications for this vulnerability, most specific first",
     ),
 });
 
@@ -220,7 +229,40 @@ const CVSS_SCORER_SYSTEM_PROMPT = `You are a CVSS 4.0 scoring specialist. Your t
 6. Assess impact on both the vulnerable system AND potential subsequent systems
 7. Since a POC exists and confirmed the vulnerability, E should typically be 'A'
 
-Always provide brief reasoning explaining your key decisions.`;
+Always provide brief reasoning explaining your key decisions.
+
+## CWE Assignment Guidelines
+
+In addition to CVSS metrics, assign one or more CWE identifiers to the finding. For each CWE, provide a brief reasoning explaining why it applies.
+
+### Common CWE Mappings
+
+| Vulnerability Class | Primary CWE | Related CWEs |
+|---------------------|------------|--------------|
+| SQL Injection | CWE-89 | CWE-564 (Hibernate), CWE-943 (NoSQL) |
+| Cross-Site Scripting (XSS) | CWE-79 | CWE-80 (Basic XSS), CWE-87 (Alt XSS) |
+| Command/OS Injection | CWE-78 | CWE-77 (Command Injection) |
+| Code Injection / RCE | CWE-94 | CWE-95 (Eval Injection), CWE-96 (Static Code Injection) |
+| IDOR / Access Control | CWE-639 | CWE-284 (Improper Access Control), CWE-862 (Missing AuthZ) |
+| SSRF | CWE-918 | — |
+| Path Traversal / LFI | CWE-22 | CWE-23 (Relative Path), CWE-36 (Absolute Path) |
+| XXE | CWE-611 | CWE-776 (Recursive Entity) |
+| SSTI | CWE-1336 | CWE-94 (Code Injection) |
+| CSRF | CWE-352 | — |
+| Deserialization | CWE-502 | — |
+| Open Redirect | CWE-601 | — |
+| Information Disclosure | CWE-200 | CWE-209 (Error Messages), CWE-532 (Log Files) |
+| Authentication Bypass | CWE-287 | CWE-306 (Missing Auth) |
+| Cryptographic Issues | CWE-327 | CWE-328 (Weak Hash), CWE-330 (Insufficient Randomness) |
+
+### CWE Assignment Rules
+
+1. Assign the **most specific applicable CWE(s)** — prefer CWE-89 (SQL Injection) over CWE-74 (generic Injection).
+2. Use the standard \`CWE-<number>\` format (e.g., CWE-89, not "CWE 89" or "89").
+3. Assign **1-3 CWEs** per finding. Multiple CWEs are appropriate when the vulnerability spans categories (e.g., an IDOR that also leaks PII: CWE-639 + CWE-200).
+4. Order CWEs by relevance — the primary weakness first.
+5. When the vulnerability class is provided, use it as a strong hint but verify against the evidence.
+6. For each CWE, provide a specific reasoning explaining why it applies to *this* finding — not a generic definition of the CWE.`;
 
 // =============================================================================
 // Main Function
@@ -263,6 +305,7 @@ export async function scoreFindingWithCVSS(
     metrics: cvssResult.metrics,
     scoreType: cvssResult.scoreType,
     reasoning: assessment.reasoning,
+    cwes: assessment.cwes,
   };
 }
 

--- a/src/core/findings/registry.test.ts
+++ b/src/core/findings/registry.test.ts
@@ -50,6 +50,13 @@ const sqlInjectionProducts = makeFinding({
     "The /api/products endpoint's search query parameter is vulnerable to SQL injection.",
   remediation: "Use parameterized queries.",
   references: "CWE-89, OWASP A03:2021",
+  cwes: [
+    {
+      id: "CWE-89",
+      reasoning:
+        "Classic SQL injection via unsanitized user input in the search query parameter.",
+    },
+  ],
 });
 
 const sqlInjectionProductsId = makeFinding({
@@ -109,6 +116,13 @@ const reflectedXss = makeFinding({
   endpoint: "https://target.com/search",
   description: "Reflected cross-site scripting in the search parameter.",
   remediation: "Sanitize user input and encode output.",
+  cwes: [
+    {
+      id: "CWE-79",
+      reasoning:
+        "Reflected XSS via unsanitized search parameter injected into the response.",
+    },
+  ],
 });
 
 const storedXss = makeFinding({
@@ -127,6 +141,13 @@ const sentryExposure = makeFinding({
   description: "Sentry error tracking public key is exposed in meta tags.",
   remediation: "Consider using CSP to restrict Sentry event submission.",
   references: "CWE-200",
+  cwes: [
+    {
+      id: "CWE-200",
+      reasoning:
+        "Sentry public key exposed in HTML meta tags constitutes information disclosure.",
+    },
+  ],
 });
 
 // ---------------------------------------------------------------------------

--- a/src/core/report/renderers/markdown.test.ts
+++ b/src/core/report/renderers/markdown.test.ts
@@ -202,4 +202,48 @@ describe("renderMarkdown", () => {
       "```\nPOST /login HTTP/1.1\nusername=admin'--&password=x\n\nHTTP/1.1 200 OK\n```",
     );
   });
+
+  it("renders CWE Classification section when cwes are present", () => {
+    const report = makeSampleReport({
+      findings: [
+        {
+          title: "SQL Injection in Login Form",
+          severity: "HIGH",
+          description: "The login endpoint is vulnerable to SQL injection.",
+          impact:
+            "An attacker could bypass authentication and access all user data.",
+          evidence: "POST /login HTTP/1.1\nusername=admin'--&password=x",
+          endpoint: "/login",
+          pocPath: "pocs/poc_sqli.sh",
+          remediation: "Use parameterized queries.",
+          cwes: [
+            {
+              id: "CWE-89",
+              reasoning: "SQL injection via unsanitized user input",
+            },
+            {
+              id: "CWE-564",
+              reasoning: "Hibernate-specific SQL injection variant",
+            },
+          ],
+        },
+      ],
+    });
+    const output = renderMarkdown(report);
+
+    expect(output).toContain("## CWE Classification");
+    expect(output).toContain(
+      "- **CWE-89** — SQL injection via unsanitized user input",
+    );
+    expect(output).toContain(
+      "- **CWE-564** — Hibernate-specific SQL injection variant",
+    );
+  });
+
+  it("omits CWE Classification section when cwes are absent", () => {
+    const report = makeSampleReport();
+    const output = renderMarkdown(report);
+
+    expect(output).not.toContain("## CWE Classification");
+  });
 });

--- a/src/core/report/renderers/markdown.ts
+++ b/src/core/report/renderers/markdown.ts
@@ -57,6 +57,14 @@ function renderFinding(
     finding.evidence,
     "```",
     "",
+    ...(finding.cwes?.length
+      ? [
+          "## CWE Classification",
+          "",
+          ...finding.cwes.map((cwe) => `- **${cwe.id}** — ${cwe.reasoning}`),
+          "",
+        ]
+      : []),
     "## POC",
     "",
     `Path: \`${finding.pocPath}\``,

--- a/src/core/report/schemas.ts
+++ b/src/core/report/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CweEntrySchema } from "../../lib/cwe/types";
 
 export const PentestReportFindingSchema = z.object({
   title: z.string(),
@@ -10,6 +11,7 @@ export const PentestReportFindingSchema = z.object({
   pocPath: z.string(),
   remediation: z.string(),
   references: z.string().optional(),
+  cwes: z.array(CweEntrySchema).optional(),
 });
 
 export const PentestReportSchema = z.object({

--- a/src/core/session/types.ts
+++ b/src/core/session/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CweEntrySchema } from "../../lib/cwe/types";
 
 /**
  * Supported vulnerability classes for testing
@@ -116,6 +117,7 @@ export const DocumentFindingSchema = z.object({
     .describe("Relative path to POC script (e.g., pocs/poc_sqli_login.sh)"),
   remediation: z.string().describe("Steps to fix the vulnerability"),
   references: z.string().optional().describe("CVE, CWE, or related references"),
+  cwes: z.array(CweEntrySchema).optional(),
 });
 
 export type DocumentFindingInput = z.infer<typeof DocumentFindingSchema>;

--- a/src/lib/cwe/types.test.ts
+++ b/src/lib/cwe/types.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { CweEntrySchema } from "./types";
+
+describe("CweEntrySchema", () => {
+  it("accepts valid CWE entry", () => {
+    const result = CweEntrySchema.safeParse({
+      id: "CWE-89",
+      reasoning: "SQL injection via unsanitized user input",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts CWE with large number", () => {
+    const result = CweEntrySchema.safeParse({
+      id: "CWE-1336",
+      reasoning: "Server-side template injection",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects lowercase cwe prefix", () => {
+    const result = CweEntrySchema.safeParse({
+      id: "cwe-89",
+      reasoning: "SQL injection",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing hyphen", () => {
+    const result = CweEntrySchema.safeParse({
+      id: "CWE89",
+      reasoning: "SQL injection",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects space instead of hyphen", () => {
+    const result = CweEntrySchema.safeParse({
+      id: "CWE 89",
+      reasoning: "SQL injection",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects bare number without prefix", () => {
+    const result = CweEntrySchema.safeParse({
+      id: "89",
+      reasoning: "SQL injection",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects descriptive name instead of ID", () => {
+    const result = CweEntrySchema.safeParse({
+      id: "SQL Injection",
+      reasoning: "SQL injection",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects CWE- without number", () => {
+    const result = CweEntrySchema.safeParse({
+      id: "CWE-",
+      reasoning: "Missing number",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects CWE- with non-numeric suffix", () => {
+    const result = CweEntrySchema.safeParse({
+      id: "CWE-abc",
+      reasoning: "Invalid",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing reasoning", () => {
+    const result = CweEntrySchema.safeParse({
+      id: "CWE-89",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing id", () => {
+    const result = CweEntrySchema.safeParse({
+      reasoning: "SQL injection",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/cwe/types.ts
+++ b/src/lib/cwe/types.ts
@@ -8,9 +8,9 @@ import { z } from "zod";
  */
 export const CweEntrySchema = z.object({
   id: z.string().regex(/^CWE-\d+$/, "Must be CWE-<number> format"),
-  reasoning: z.string().describe(
-    "Why this CWE applies to the observed vulnerability",
-  ),
+  reasoning: z
+    .string()
+    .describe("Why this CWE applies to the observed vulnerability"),
 });
 
 export type CweEntry = z.infer<typeof CweEntrySchema>;

--- a/src/lib/cwe/types.ts
+++ b/src/lib/cwe/types.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+/**
+ * Schema for a single CWE classification entry.
+ *
+ * Each entry pairs a CWE identifier (e.g., "CWE-89") with a reasoning
+ * string explaining why that CWE applies to the observed vulnerability.
+ */
+export const CweEntrySchema = z.object({
+  id: z.string().regex(/^CWE-\d+$/, "Must be CWE-<number> format"),
+  reasoning: z.string().describe(
+    "Why this CWE applies to the observed vulnerability",
+  ),
+});
+
+export type CweEntry = z.infer<typeof CweEntrySchema>;


### PR DESCRIPTION
Extends the CVSS Scorer to assign CWE (Common Weakness Enumeration) identifiers
alongside CVSS 4.0 metrics. Adds a shared `CweEntry` type (`CWE-<number>` + per-CWE
reasoning), wires it through the scorer output, finding schemas, and
`document_vulnerability` so CWEs appear in persisted JSON, markdown reports, and the
findings summary. Also adds an optional `vulnerabilityClass` hint so the offensive
agent can pass what it already knows (e.g. "sqli") to improve CWE accuracy.

Right now we only validate the format (`CWE-\d+`), not against the actual CWE catalog.
Depending on the accuracy we see, the next step would be adding the full CWE list
(with a script to refresh it every few months when MITRE publishes new entries) and
spinning up a separate cheaper model with the catalog in context for classification.

Closes #261

Sample outputted findings:

<img width="1032" height="1212" alt="Screenshot 2026-03-10 at 1 07 25 PM" src="https://github.com/user-attachments/assets/6d8a8ee7-025b-419b-a237-e917bea96f71" />

<img width="1028" height="1176" alt="Screenshot 2026-03-10 at 1 08 01 PM" src="https://github.com/user-attachments/assets/178c8bc1-ed7e-4878-acbb-2e4407a14bf2" />

Sections in generated pentest report:
<img width="716" height="471" alt="Screenshot 2026-03-10 at 1 10 31 PM" src="https://github.com/user-attachments/assets/18d74d9d-2b34-4d48-a491-ab1ef1b3a3b8" />

<img width="701" height="421" alt="Screenshot 2026-03-10 at 1 10 51 PM" src="https://github.com/user-attachments/assets/ec8f7832-4bc5-4fb5-a822-69f755470f36" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends multiple persisted schemas and report renderers to carry new `cwes` data from an LLM scorer, which can affect saved finding JSON/markdown formats and downstream consumers if they assume a fixed shape.
> 
> **Overview**
> Findings now capture **CWE classifications** alongside CVSS results: the CVSS scorer returns a list of `cwes` (validated as `CWE-<number>` with per-CWE reasoning) and accepts an optional `vulnerabilityClass` hint to improve classification.
> 
> `document_vulnerability` persists the `cwes` field into finding JSON, renders a new **CWE Classification** section in the per-finding markdown, and tags entries in `findings-summary.md` with CWE IDs.
> 
> Schemas for agent/session/report finding objects are updated to allow optional `cwes`, and tests are added/updated to ensure backward compatibility and correct rendering/validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdbbc614da98ad8fd61e542809b816760f11f9b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->