### PR TITLE
feat: in-session commands for operator mode

### DIFF
--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -188,6 +188,7 @@ export const commands: CommandConfig[] = [
       const params = buildOperatorSessionConfig(flags);
       ctx.navigate({
         type: "operator",
+        nonce: Date.now(),
         initialConfig: {
           requireApproval: flags.requireApproval ?? true,
           target: flags.target,
@@ -253,7 +254,7 @@ export const commands: CommandConfig[] = [
     description: "Start a new operator session",
     category: "Session",
     handler: async (args, ctx) => {
-      ctx.navigate({ type: "operator" });
+      ctx.navigate({ type: "operator", nonce: Date.now() });
     },
   },
   {

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -15,6 +15,8 @@ export interface AppCommandContext {
   route: Route;
   navigate: (route: Route) => void;
   openSessionsDialog?: () => void;
+  openThemeDialog?: () => void;
+  openAuthDialog?: () => void;
 }
 
 /**
@@ -247,6 +249,14 @@ export const commands: CommandConfig[] = [
     },
   },
   {
+    name: "new",
+    description: "Start a new operator session",
+    category: "Session",
+    handler: async (args, ctx) => {
+      ctx.navigate({ type: "operator" });
+    },
+  },
+  {
     name: "chat",
     aliases: ["c"],
     description: "Open the Chat TUI interface",
@@ -303,7 +313,7 @@ export const commands: CommandConfig[] = [
       }
 
       // /theme — open picker
-      ctx.navigate({ type: "base", path: "theme" });
+      ctx.openThemeDialog?.();
     },
   },
   {
@@ -337,10 +347,7 @@ export const commands: CommandConfig[] = [
     description: "Connect to Pensar Console for managed inference",
     category: "General",
     handler: async (args, ctx) => {
-      ctx.navigate({
-        type: "base",
-        path: "auth",
-      });
+      ctx.openAuthDialog?.();
     },
   },
 

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -15,6 +15,7 @@ import { useInput } from "../../context/input";
 import { useFocus } from "../../context/focus";
 import { useConfig } from "../../context/config";
 import { useRoute } from "../../context/route";
+import { useDialog } from "../../context/dialog";
 import { PromptInput } from "../shared/prompt-input";
 import { useTheme } from "../../theme";
 import { slugify } from "../../../core/skills";
@@ -37,6 +38,7 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
     useCommand();
   const { setInputValue } = useInput();
   const { promptRef } = useFocus();
+  const { externalDialogOpen, stack } = useDialog();
 
   const [hintMessage, setHintMessage] = useState<string | null>(null);
   const [commandHistory, setCommandHistory] = useState<string[]>(
@@ -178,7 +180,7 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
         {/* Input with built-in autocomplete */}
         <PromptInput
           ref={promptRef}
-          focused
+          focused={!externalDialogOpen && stack.length === 0}
           width={inputWidth - 4}
           minHeight={1}
           maxHeight={4}

--- a/src/tui/components/chat/input-area.tsx
+++ b/src/tui/components/chat/input-area.tsx
@@ -55,6 +55,8 @@ export interface InputAreaProps {
   commandHistory?: string[];
   /** Suppress Up/Down history navigation in PromptInput (e.g. queue takes priority) */
   disableHistoryNavigation?: boolean;
+  /** Whether autocomplete suggestions appear above or below the input */
+  autocompletePlacement?: "above" | "below";
 }
 
 /**
@@ -78,6 +80,7 @@ function NormalInputAreaInner({
   onCommandExecute,
   commandHistory = [],
   disableHistoryNavigation = false,
+  autocompletePlacement = "below",
 }: Omit<
   InputAreaProps,
   "pendingApproval" | "onApprove" | "onAutoApprove" | "lastDeclineNote"
@@ -140,6 +143,7 @@ function NormalInputAreaInner({
           onCommandExecute={onCommandExecute}
           commandHistory={commandHistory}
           disableHistoryNavigation={disableHistoryNavigation}
+          autocompletePlacement={autocompletePlacement}
         />
       </box>
 
@@ -208,6 +212,7 @@ export function InputArea(props: InputAreaProps) {
     onCommandExecute,
     commandHistory,
     disableHistoryNavigation,
+    autocompletePlacement,
     ...normalProps
   } = props;
 
@@ -239,6 +244,7 @@ export function InputArea(props: InputAreaProps) {
         onCommandExecute={onCommandExecute}
         commandHistory={commandHistory}
         disableHistoryNavigation={disableHistoryNavigation}
+        autocompletePlacement={autocompletePlacement}
         {...normalProps}
       />
     </InputProvider>

--- a/src/tui/components/chat/input-area.tsx
+++ b/src/tui/components/chat/input-area.tsx
@@ -85,7 +85,7 @@ function NormalInputAreaInner({
   InputAreaProps,
   "pendingApproval" | "onApprove" | "onAutoApprove" | "lastDeclineNote"
 >) {
-  const { colors } = useTheme();
+  const { colors, theme, mode: colorMode } = useTheme();
   const { inputValue, setInputValue } = useInput();
   const promptRef = useRef<PromptInputRef>(null);
   const isExternalUpdate = useRef(false);
@@ -129,6 +129,7 @@ function NormalInputAreaInner({
       <box flexDirection="row" gap={1} backgroundColor="transparent">
         <text fg={!focused ? colors.textMuted : colors.primary}>{">"}</text>
         <PromptInput
+          key={`${theme.name}-${colorMode}`}
           ref={promptRef}
           width="100%"
           minHeight={1}

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -7,6 +7,7 @@ import {
   getPensarConsoleUrl,
 } from "../../../core/api/constants";
 import { Dialog } from "../../context/dialog";
+import { useTheme } from "../../theme";
 
 interface AuthFlowProps {
   onClose: () => void;
@@ -63,6 +64,7 @@ interface SelectWorkspaceResponse {
 }
 
 export default function AuthFlow({ onClose }: AuthFlowProps) {
+  const { colors } = useTheme();
   const appConfig = useConfig();
 
   // Determine if already connected (WorkOS token or legacy API key)
@@ -537,11 +539,11 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
     >
       {/* Header */}
       <box marginBottom={1}>
-        <text fg="green">Pensar Console — Managed Inference</text>
+        <text fg={colors.primary}>Pensar Console — Managed Inference</text>
       </box>
 
       <box marginBottom={1}>
-        <text fg="gray">
+        <text fg={colors.textMuted}>
           Connect to Pensar Console for usage-based AI inference.{"\n"}
           No API keys needed — just a Pensar account with credits.
         </text>
@@ -551,15 +553,15 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
       {step === "start" && (
         <box flexDirection="column" gap={1}>
           <box>
-            <text fg="white">
-              Press <span fg="green">[ENTER]</span> to authorize via your
-              browser.
+            <text fg={colors.text}>
+              Press <span fg={colors.primary}>[ENTER]</span> to authorize via
+              your browser.
             </text>
           </box>
           <box marginTop={1}>
-            <text fg="gray">
-              <span fg="green">[ENTER]</span> Connect ·{" "}
-              <span fg="green">[ESC]</span> Cancel
+            <text fg={colors.textMuted}>
+              <span fg={colors.primary}>[ENTER]</span> Connect ·{" "}
+              <span fg={colors.primary}>[ESC]</span> Cancel
             </text>
           </box>
         </box>
@@ -568,7 +570,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
       {/* Step: Requesting */}
       {step === "requesting" && (
         <box>
-          <text fg="yellow">Starting authorization...</text>
+          <text fg={colors.warning}>Starting authorization...</text>
         </box>
       )}
 
@@ -576,26 +578,28 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
       {step === "polling" && (deviceInfo || legacyDeviceInfo) && (
         <box flexDirection="column" gap={1}>
           <box>
-            <text fg="yellow">Waiting for browser authorization...</text>
+            <text fg={colors.warning}>
+              Waiting for browser authorization...
+            </text>
           </box>
           <box marginTop={1}>
-            <text fg="white">
+            <text fg={colors.text}>
               Your code:{" "}
-              <span fg="green">
+              <span fg={colors.primary}>
                 {deviceInfo?.user_code || legacyDeviceInfo?.userCode}
               </span>
             </text>
           </box>
           <box marginTop={1}>
-            <text fg="gray">
+            <text fg={colors.textMuted}>
               If the browser didn't open, visit:{"\n"}
               {deviceInfo?.verification_uri_complete ||
                 legacyDeviceInfo?.verificationUriComplete}
             </text>
           </box>
           <box marginTop={1}>
-            <text fg="gray">
-              <span fg="green">[ESC]</span> Cancel
+            <text fg={colors.textMuted}>
+              <span fg={colors.primary}>[ESC]</span> Cancel
             </text>
           </box>
         </box>
@@ -605,15 +609,15 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
       {step === "select-workspace" && (
         <box flexDirection="column" gap={1}>
           <box>
-            <text fg="white">Select a workspace:</text>
+            <text fg={colors.text}>Select a workspace:</text>
           </box>
           <box flexDirection="column" marginTop={1}>
             {workspaces.map((ws, i) => (
               <box key={ws.id}>
-                <text fg={i === selectedIndex ? "green" : "gray"}>
+                <text fg={i === selectedIndex ? colors.primary : colors.textMuted}>
                   {i === selectedIndex ? "▸ " : "  "}
                   {ws.name}{" "}
-                  <span fg="gray">
+                  <span fg={colors.textMuted}>
                     ({ws.slug}) — ${ws.balance.toFixed(2)}
                   </span>
                 </text>
@@ -621,10 +625,10 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
             ))}
           </box>
           <box marginTop={1}>
-            <text fg="gray">
-              <span fg="green">[↑/↓]</span> Navigate ·{" "}
-              <span fg="green">[ENTER]</span> Select ·{" "}
-              <span fg="green">[ESC]</span> Cancel
+            <text fg={colors.textMuted}>
+              <span fg={colors.primary}>[↑/↓]</span> Navigate ·{" "}
+              <span fg={colors.primary}>[ENTER]</span> Select ·{" "}
+              <span fg={colors.primary}>[ESC]</span> Cancel
             </text>
           </box>
         </box>
@@ -633,7 +637,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
       {/* Step: Checking Billing */}
       {step === "checking-billing" && (
         <box>
-          <text fg="yellow">
+          <text fg={colors.warning}>
             Checking billing for {selectedWorkspace?.name}...
           </text>
         </box>
@@ -643,17 +647,17 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
       {step === "success" && (
         <box flexDirection="column" gap={1}>
           <box>
-            <text fg="green">Connected to Pensar Console</text>
+            <text fg={colors.success}>Connected to Pensar Console</text>
           </box>
           {(selectedWorkspace || connectedWorkspace) && (
             <box flexDirection="column">
-              <text fg="white">
+              <text fg={colors.text}>
                 Workspace: {selectedWorkspace?.name || connectedWorkspace?.name}
               </text>
               {balance !== null && (
-                <text fg="white">
+                <text fg={colors.text}>
                   Credits:{" "}
-                  <span fg={hasLowBalance ? "yellow" : "white"}>
+                  <span fg={hasLowBalance ? colors.warning : colors.text}>
                     ${balance.toFixed(2)}
                   </span>
                 </text>
@@ -662,7 +666,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
           )}
           {(hasLowBalance || billingUrl) && (
             <box marginTop={1}>
-              <text fg="yellow">
+              <text fg={colors.warning}>
                 {billingUrl
                   ? "Your workspace needs credits to use Apex CLI."
                   : "Your credit balance is very low. We recommend at least $30 to run"}
@@ -677,22 +681,22 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
             !connectedWorkspace &&
             appConfig.data.pensarAPIKey && (
               <box>
-                <text fg="gray">
+                <text fg={colors.textMuted}>
                   Already connected (legacy key saved in config)
                 </text>
               </box>
             )}
           <box marginTop={1}>
-            <text fg="gray">
+            <text fg={colors.textMuted}>
               Pensar models are now available in the model selector.
             </text>
           </box>
           <box marginTop={1}>
-            <text fg="gray">
-              <span fg="green">[ENTER]</span>{" "}
+            <text fg={colors.textMuted}>
+              <span fg={colors.primary}>[ENTER]</span>{" "}
               {hasLowBalance || billingUrl ? "Open billing" : "Done"} ·{" "}
-              <span fg="red">[D]</span> Disconnect ·{" "}
-              <span fg="green">[ESC]</span> Back
+              <span fg={colors.error}>[D]</span> Disconnect ·{" "}
+              <span fg={colors.primary}>[ESC]</span> Back
             </text>
           </box>
         </box>
@@ -702,12 +706,12 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
       {step === "error" && (
         <box flexDirection="column" gap={1}>
           <box>
-            <text fg="red">{error}</text>
+            <text fg={colors.error}>{error}</text>
           </box>
           <box marginTop={1}>
-            <text fg="gray">
-              <span fg="green">[ENTER]</span> Try again ·{" "}
-              <span fg="green">[ESC]</span> Cancel
+            <text fg={colors.textMuted}>
+              <span fg={colors.primary}>[ENTER]</span> Try again ·{" "}
+              <span fg={colors.primary}>[ESC]</span> Cancel
             </text>
           </box>
         </box>

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -1,12 +1,16 @@
 import { useState, useRef, useEffect } from "react";
 import { useKeyboard } from "@opentui/react";
 import { config } from "../../../core/config";
-import { useRoute } from "../../context/route";
 import { useConfig } from "../../context/config";
 import {
   getPensarApiUrl,
   getPensarConsoleUrl,
 } from "../../../core/api/constants";
+import { Dialog } from "../../context/dialog";
+
+interface AuthFlowProps {
+  onClose: () => void;
+}
 
 type AuthStep =
   | "start"
@@ -58,8 +62,7 @@ interface SelectWorkspaceResponse {
   billingUrl?: string;
 }
 
-export default function AuthFlow() {
-  const route = useRoute();
+export default function AuthFlow({ onClose }: AuthFlowProps) {
   const appConfig = useConfig();
 
   // Determine if already connected (WorkOS token or legacy API key)
@@ -90,7 +93,7 @@ export default function AuthFlow() {
     : null;
 
   const goHome = () => {
-    route.navigate({ type: "base", path: "home" });
+    onClose();
   };
 
   const cleanup = () => {
@@ -522,10 +525,10 @@ export default function AuthFlow() {
   // ── Render ────────────────────────────────────────────────────────
 
   return (
+    <Dialog size="large" onClose={goHome}>
     <box
       flexDirection="column"
       width="100%"
-      maxWidth={80}
       alignItems="flex-start"
       padding={1}
     >
@@ -707,5 +710,6 @@ export default function AuthFlow() {
         </box>
       )}
     </box>
+    </Dialog>
   );
 }

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -531,192 +531,195 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
 
   return (
     <Dialog size="large" onClose={goHome}>
-    <box
-      flexDirection="column"
-      width="100%"
-      alignItems="flex-start"
-      padding={1}
-    >
-      {/* Header */}
-      <box marginBottom={1}>
-        <text fg={colors.primary}>Pensar Console — Managed Inference</text>
-      </box>
-
-      <box marginBottom={1}>
-        <text fg={colors.textMuted}>
-          Connect to Pensar Console for usage-based AI inference.{"\n"}
-          No API keys needed — just a Pensar account with credits.
-        </text>
-      </box>
-
-      {/* Step: Start */}
-      {step === "start" && (
-        <box flexDirection="column" gap={1}>
-          <box>
-            <text fg={colors.text}>
-              Press <span fg={colors.primary}>[ENTER]</span> to authorize via
-              your browser.
-            </text>
-          </box>
-          <box marginTop={1}>
-            <text fg={colors.textMuted}>
-              <span fg={colors.primary}>[ENTER]</span> Connect ·{" "}
-              <span fg={colors.primary}>[ESC]</span> Cancel
-            </text>
-          </box>
+      <box
+        flexDirection="column"
+        width="100%"
+        alignItems="flex-start"
+        padding={1}
+      >
+        {/* Header */}
+        <box marginBottom={1}>
+          <text fg={colors.primary}>Pensar Console — Managed Inference</text>
         </box>
-      )}
 
-      {/* Step: Requesting */}
-      {step === "requesting" && (
-        <box>
-          <text fg={colors.warning}>Starting authorization...</text>
-        </box>
-      )}
-
-      {/* Step: Polling */}
-      {step === "polling" && (deviceInfo || legacyDeviceInfo) && (
-        <box flexDirection="column" gap={1}>
-          <box>
-            <text fg={colors.warning}>
-              Waiting for browser authorization...
-            </text>
-          </box>
-          <box marginTop={1}>
-            <text fg={colors.text}>
-              Your code:{" "}
-              <span fg={colors.primary}>
-                {deviceInfo?.user_code || legacyDeviceInfo?.userCode}
-              </span>
-            </text>
-          </box>
-          <box marginTop={1}>
-            <text fg={colors.textMuted}>
-              If the browser didn't open, visit:{"\n"}
-              {deviceInfo?.verification_uri_complete ||
-                legacyDeviceInfo?.verificationUriComplete}
-            </text>
-          </box>
-          <box marginTop={1}>
-            <text fg={colors.textMuted}>
-              <span fg={colors.primary}>[ESC]</span> Cancel
-            </text>
-          </box>
-        </box>
-      )}
-
-      {/* Step: Select Workspace */}
-      {step === "select-workspace" && (
-        <box flexDirection="column" gap={1}>
-          <box>
-            <text fg={colors.text}>Select a workspace:</text>
-          </box>
-          <box flexDirection="column" marginTop={1}>
-            {workspaces.map((ws, i) => (
-              <box key={ws.id}>
-                <text fg={i === selectedIndex ? colors.primary : colors.textMuted}>
-                  {i === selectedIndex ? "▸ " : "  "}
-                  {ws.name}{" "}
-                  <span fg={colors.textMuted}>
-                    ({ws.slug}) — ${ws.balance.toFixed(2)}
-                  </span>
-                </text>
-              </box>
-            ))}
-          </box>
-          <box marginTop={1}>
-            <text fg={colors.textMuted}>
-              <span fg={colors.primary}>[↑/↓]</span> Navigate ·{" "}
-              <span fg={colors.primary}>[ENTER]</span> Select ·{" "}
-              <span fg={colors.primary}>[ESC]</span> Cancel
-            </text>
-          </box>
-        </box>
-      )}
-
-      {/* Step: Checking Billing */}
-      {step === "checking-billing" && (
-        <box>
-          <text fg={colors.warning}>
-            Checking billing for {selectedWorkspace?.name}...
+        <box marginBottom={1}>
+          <text fg={colors.textMuted}>
+            Connect to Pensar Console for usage-based AI inference.{"\n"}
+            No API keys needed — just a Pensar account with credits.
           </text>
         </box>
-      )}
 
-      {/* Step: Success */}
-      {step === "success" && (
-        <box flexDirection="column" gap={1}>
-          <box>
-            <text fg={colors.success}>Connected to Pensar Console</text>
-          </box>
-          {(selectedWorkspace || connectedWorkspace) && (
-            <box flexDirection="column">
+        {/* Step: Start */}
+        {step === "start" && (
+          <box flexDirection="column" gap={1}>
+            <box>
               <text fg={colors.text}>
-                Workspace: {selectedWorkspace?.name || connectedWorkspace?.name}
+                Press <span fg={colors.primary}>[ENTER]</span> to authorize via
+                your browser.
               </text>
-              {balance !== null && (
-                <text fg={colors.text}>
-                  Credits:{" "}
-                  <span fg={hasLowBalance ? colors.warning : colors.text}>
-                    ${balance.toFixed(2)}
-                  </span>
-                </text>
-              )}
             </box>
-          )}
-          {(hasLowBalance || billingUrl) && (
             <box marginTop={1}>
-              <text fg={colors.warning}>
-                {billingUrl
-                  ? "Your workspace needs credits to use Apex CLI."
-                  : "Your credit balance is very low. We recommend at least $30 to run"}
-                {"\n"}
-                {billingUrl
-                  ? "Press ENTER to open billing and add credits."
-                  : "pentests without interruptions. Press ENTER to open billing."}
+              <text fg={colors.textMuted}>
+                <span fg={colors.primary}>[ENTER]</span> Connect ·{" "}
+                <span fg={colors.primary}>[ESC]</span> Cancel
               </text>
             </box>
-          )}
-          {!selectedWorkspace &&
-            !connectedWorkspace &&
-            appConfig.data.pensarAPIKey && (
-              <box>
-                <text fg={colors.textMuted}>
-                  Already connected (legacy key saved in config)
+          </box>
+        )}
+
+        {/* Step: Requesting */}
+        {step === "requesting" && (
+          <box>
+            <text fg={colors.warning}>Starting authorization...</text>
+          </box>
+        )}
+
+        {/* Step: Polling */}
+        {step === "polling" && (deviceInfo || legacyDeviceInfo) && (
+          <box flexDirection="column" gap={1}>
+            <box>
+              <text fg={colors.warning}>
+                Waiting for browser authorization...
+              </text>
+            </box>
+            <box marginTop={1}>
+              <text fg={colors.text}>
+                Your code:{" "}
+                <span fg={colors.primary}>
+                  {deviceInfo?.user_code || legacyDeviceInfo?.userCode}
+                </span>
+              </text>
+            </box>
+            <box marginTop={1}>
+              <text fg={colors.textMuted}>
+                If the browser didn't open, visit:{"\n"}
+                {deviceInfo?.verification_uri_complete ||
+                  legacyDeviceInfo?.verificationUriComplete}
+              </text>
+            </box>
+            <box marginTop={1}>
+              <text fg={colors.textMuted}>
+                <span fg={colors.primary}>[ESC]</span> Cancel
+              </text>
+            </box>
+          </box>
+        )}
+
+        {/* Step: Select Workspace */}
+        {step === "select-workspace" && (
+          <box flexDirection="column" gap={1}>
+            <box>
+              <text fg={colors.text}>Select a workspace:</text>
+            </box>
+            <box flexDirection="column" marginTop={1}>
+              {workspaces.map((ws, i) => (
+                <box key={ws.id}>
+                  <text
+                    fg={i === selectedIndex ? colors.primary : colors.textMuted}
+                  >
+                    {i === selectedIndex ? "▸ " : "  "}
+                    {ws.name}{" "}
+                    <span fg={colors.textMuted}>
+                      ({ws.slug}) — ${ws.balance.toFixed(2)}
+                    </span>
+                  </text>
+                </box>
+              ))}
+            </box>
+            <box marginTop={1}>
+              <text fg={colors.textMuted}>
+                <span fg={colors.primary}>[↑/↓]</span> Navigate ·{" "}
+                <span fg={colors.primary}>[ENTER]</span> Select ·{" "}
+                <span fg={colors.primary}>[ESC]</span> Cancel
+              </text>
+            </box>
+          </box>
+        )}
+
+        {/* Step: Checking Billing */}
+        {step === "checking-billing" && (
+          <box>
+            <text fg={colors.warning}>
+              Checking billing for {selectedWorkspace?.name}...
+            </text>
+          </box>
+        )}
+
+        {/* Step: Success */}
+        {step === "success" && (
+          <box flexDirection="column" gap={1}>
+            <box>
+              <text fg={colors.success}>Connected to Pensar Console</text>
+            </box>
+            {(selectedWorkspace || connectedWorkspace) && (
+              <box flexDirection="column">
+                <text fg={colors.text}>
+                  Workspace:{" "}
+                  {selectedWorkspace?.name || connectedWorkspace?.name}
+                </text>
+                {balance !== null && (
+                  <text fg={colors.text}>
+                    Credits:{" "}
+                    <span fg={hasLowBalance ? colors.warning : colors.text}>
+                      ${balance.toFixed(2)}
+                    </span>
+                  </text>
+                )}
+              </box>
+            )}
+            {(hasLowBalance || billingUrl) && (
+              <box marginTop={1}>
+                <text fg={colors.warning}>
+                  {billingUrl
+                    ? "Your workspace needs credits to use Apex CLI."
+                    : "Your credit balance is very low. We recommend at least $30 to run"}
+                  {"\n"}
+                  {billingUrl
+                    ? "Press ENTER to open billing and add credits."
+                    : "pentests without interruptions. Press ENTER to open billing."}
                 </text>
               </box>
             )}
-          <box marginTop={1}>
-            <text fg={colors.textMuted}>
-              Pensar models are now available in the model selector.
-            </text>
+            {!selectedWorkspace &&
+              !connectedWorkspace &&
+              appConfig.data.pensarAPIKey && (
+                <box>
+                  <text fg={colors.textMuted}>
+                    Already connected (legacy key saved in config)
+                  </text>
+                </box>
+              )}
+            <box marginTop={1}>
+              <text fg={colors.textMuted}>
+                Pensar models are now available in the model selector.
+              </text>
+            </box>
+            <box marginTop={1}>
+              <text fg={colors.textMuted}>
+                <span fg={colors.primary}>[ENTER]</span>{" "}
+                {hasLowBalance || billingUrl ? "Open billing" : "Done"} ·{" "}
+                <span fg={colors.error}>[D]</span> Disconnect ·{" "}
+                <span fg={colors.primary}>[ESC]</span> Back
+              </text>
+            </box>
           </box>
-          <box marginTop={1}>
-            <text fg={colors.textMuted}>
-              <span fg={colors.primary}>[ENTER]</span>{" "}
-              {hasLowBalance || billingUrl ? "Open billing" : "Done"} ·{" "}
-              <span fg={colors.error}>[D]</span> Disconnect ·{" "}
-              <span fg={colors.primary}>[ESC]</span> Back
-            </text>
-          </box>
-        </box>
-      )}
+        )}
 
-      {/* Step: Error */}
-      {step === "error" && (
-        <box flexDirection="column" gap={1}>
-          <box>
-            <text fg={colors.error}>{error}</text>
+        {/* Step: Error */}
+        {step === "error" && (
+          <box flexDirection="column" gap={1}>
+            <box>
+              <text fg={colors.error}>{error}</text>
+            </box>
+            <box marginTop={1}>
+              <text fg={colors.textMuted}>
+                <span fg={colors.primary}>[ENTER]</span> Try again ·{" "}
+                <span fg={colors.primary}>[ESC]</span> Cancel
+              </text>
+            </box>
           </box>
-          <box marginTop={1}>
-            <text fg={colors.textMuted}>
-              <span fg={colors.primary}>[ENTER]</span> Try again ·{" "}
-              <span fg={colors.primary}>[ESC]</span> Cancel
-            </text>
-          </box>
-        </box>
-      )}
-    </box>
+        )}
+      </box>
     </Dialog>
   );
 }

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -475,6 +475,9 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
   // ── Keyboard handler ──────────────────────────────────────────────
 
   useKeyboard((key) => {
+    // Modal dialog — consume all keystrokes to prevent leaking to components underneath
+    key.preventDefault();
+
     if (key.name === "escape") {
       cleanup();
       goHome();

--- a/src/tui/components/commands/credits-flow.tsx
+++ b/src/tui/components/commands/credits-flow.tsx
@@ -15,7 +15,11 @@ interface CreditsInfo {
   workspace: string;
 }
 
-export default function CreditsFlow() {
+interface CreditsFlowProps {
+  onOpenAuthDialog?: () => void;
+}
+
+export default function CreditsFlow({ onOpenAuthDialog }: CreditsFlowProps) {
   const route = useRoute();
   const appConfig = useConfig();
   const [step, setStep] = useState<CreditsStep>("loading");
@@ -106,7 +110,7 @@ export default function CreditsFlow() {
 
     if (step === "no-auth") {
       if (key.name === "return") {
-        route.navigate({ type: "base", path: "auth" });
+        onOpenAuthDialog?.();
       }
     }
 

--- a/src/tui/components/commands/theme-picker.tsx
+++ b/src/tui/components/commands/theme-picker.tsx
@@ -114,17 +114,9 @@ export default function ThemePicker({ onClose }: ThemePickerProps) {
 
   return (
     <Dialog size="large" onClose={handleClose}>
-      <box
-        width="100%"
-        flexDirection="column"
-        padding={1}
-      >
+      <box width="100%" flexDirection="column" padding={1}>
         {/* Header */}
-        <box
-          width="100%"
-          flexDirection="row"
-          justifyContent="space-between"
-        >
+        <box width="100%" flexDirection="row" justifyContent="space-between">
           <text fg={colors.primary}>Themes</text>
           <text fg={colors.textMuted}>mode: {mode}</text>
         </box>
@@ -135,10 +127,7 @@ export default function ThemePicker({ onClose }: ThemePickerProps) {
         </box>
 
         {/* Theme List */}
-        <box
-          flexDirection="column"
-          flexGrow={1}
-        >
+        <box flexDirection="column" flexGrow={1}>
           {visibleThemes.map((themeName) => {
             const actualIndex = availableThemes.indexOf(themeName);
             const isSelected = actualIndex === selectedIndex;

--- a/src/tui/components/commands/theme-picker.tsx
+++ b/src/tui/components/commands/theme-picker.tsx
@@ -51,6 +51,9 @@ export default function ThemePicker({ onClose }: ThemePickerProps) {
   }, [availableThemes, selectedIndex, onClose]);
 
   useKeyboard((evt) => {
+    // Modal dialog — consume all keystrokes to prevent leaking to components underneath
+    evt.preventDefault();
+
     if (evt.name === "escape") {
       handleClose();
       return;

--- a/src/tui/components/commands/theme-picker.tsx
+++ b/src/tui/components/commands/theme-picker.tsx
@@ -9,12 +9,15 @@
 import { useState, useCallback, useRef } from "react";
 import { useKeyboard, useTerminalDimensions } from "@opentui/react";
 import { useTheme } from "../../theme";
-import { useRoute } from "../../context/route";
 import { config } from "../../../core/config";
+import { Dialog } from "../../context/dialog";
 
-export default function ThemePicker() {
+interface ThemePickerProps {
+  onClose: () => void;
+}
+
+export default function ThemePicker({ onClose }: ThemePickerProps) {
   const dimensions = useTerminalDimensions();
-  const route = useRoute();
   const {
     colors,
     theme,
@@ -35,8 +38,8 @@ export default function ThemePicker() {
     // Revert to original theme
     setTheme(originalThemeRef.current);
     setMode(originalModeRef.current);
-    route.navigate({ type: "base", path: "home" });
-  }, [setTheme, setMode, route]);
+    onClose();
+  }, [setTheme, setMode, onClose]);
 
   const handleConfirm = useCallback(async () => {
     // Persist the current theme and mode
@@ -44,8 +47,8 @@ export default function ThemePicker() {
     if (currentThemeName) {
       await config.update({ theme: currentThemeName });
     }
-    route.navigate({ type: "base", path: "home" });
-  }, [availableThemes, selectedIndex, route]);
+    onClose();
+  }, [availableThemes, selectedIndex, onClose]);
 
   useKeyboard((evt) => {
     if (evt.name === "escape") {
@@ -107,29 +110,15 @@ export default function ThemePicker() {
   );
 
   return (
-    <box
-      width={dimensions.width}
-      height={dimensions.height}
-      alignItems="center"
-      justifyContent="center"
-      position="absolute"
-      left={0}
-      top={0}
-      backgroundColor={colors.background}
-    >
+    <Dialog size="large" onClose={handleClose}>
       <box
-        width={panelWidth}
-        height={panelHeight}
-        backgroundColor={colors.backgroundPanel}
-        borderColor={colors.border}
-        borderStyle="single"
+        width="100%"
         flexDirection="column"
+        padding={1}
       >
         {/* Header */}
         <box
           width="100%"
-          paddingLeft={1}
-          paddingRight={1}
           flexDirection="row"
           justifyContent="space-between"
         >
@@ -146,8 +135,6 @@ export default function ThemePicker() {
         <box
           flexDirection="column"
           flexGrow={1}
-          paddingLeft={1}
-          paddingRight={1}
         >
           {visibleThemes.map((themeName) => {
             const actualIndex = availableThemes.indexOf(themeName);
@@ -174,12 +161,12 @@ export default function ThemePicker() {
         </box>
 
         {/* Footer */}
-        <box width="100%" paddingLeft={1} paddingRight={1} flexDirection="row">
+        <box width="100%" flexDirection="row">
           <text fg={colors.textMuted}>
             [↑↓] browse [enter] select [m] toggle mode [esc] cancel
           </text>
         </box>
       </box>
-    </box>
+    </Dialog>
   );
 }

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -1335,6 +1335,7 @@ export default function OperatorDashboard({
         onAutoApprove={handleAutoApprove}
         enableAutocomplete={true}
         autocompleteOptions={autocompleteOptions}
+        autocompletePlacement="above"
         enableCommands={true}
         onCommandExecute={handleCommandExecute}
         disableHistoryNavigation={

--- a/src/tui/components/operator-dashboard/logic.test.ts
+++ b/src/tui/components/operator-dashboard/logic.test.ts
@@ -56,13 +56,12 @@ describe("filterOperatorAutocomplete", () => {
     const result = filterOperatorAutocomplete(allOptions, skillSlugs);
     const values = result.map((o) => o.value);
     expect(values).not.toContain("/scan");
-    expect(values).not.toContain("/pentest");
     expect(values).not.toContain("/help");
   });
 
   it("returns only allowed commands when no skills exist", () => {
     const result = filterOperatorAutocomplete(allOptions, new Set());
-    expect(result).toHaveLength(2);
+    expect(result).toHaveLength(3);
   });
 
   it("returns empty for empty input", () => {

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -10,7 +10,15 @@ export function filterOperatorAutocomplete(
   allOptions: AutocompleteOption[],
   skillSlugs: Set<string>,
 ): AutocompleteOption[] {
-  const allowedCommands = new Set(["/create-skill", "/models"]);
+  const allowedCommands = new Set([
+    "/create-skill",
+    "/models",
+    "/auth",
+    "/themes",
+    "/new",
+    "/operator",
+    "/pentest",
+  ]);
   return allOptions.filter(
     (opt) => allowedCommands.has(opt.value) || skillSlugs.has(opt.value),
   );

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -85,6 +85,9 @@ interface PromptInputProps {
 
   // Visual customization
   showPromptIndicator?: boolean;
+
+  // Whether autocomplete suggestions appear above or below the input
+  autocompletePlacement?: "above" | "below";
 }
 
 export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
@@ -109,6 +112,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       commandHistory = [],
       disableHistoryNavigation = false,
       showPromptIndicator = false,
+      autocompletePlacement = "below",
     },
     ref,
   ) {
@@ -325,8 +329,36 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       }
     };
 
+    const suggestionsBox = suggestions.length > 0 && (
+      <box
+        flexDirection="column"
+        {...(autocompletePlacement === "above"
+          ? { marginBottom: 1 }
+          : { marginTop: 1 })}
+      >
+        {suggestions.map((suggestion, index) => {
+          const isSelected = index === selectedSuggestionIndex;
+          return (
+            <box key={suggestion.value} flexDirection="row" gap={1}>
+              <text fg={isSelected ? colors.primary : colors.textMuted}>
+                {isSelected ? " ▸" : "  "}
+              </text>
+              <text fg={isSelected ? colors.text : colors.textMuted}>
+                {suggestion.label}
+              </text>
+              {suggestion.description && (
+                <text fg={colors.textMuted}> {suggestion.description}</text>
+              )}
+            </box>
+          );
+        })}
+      </box>
+    );
+
     return (
       <box flexDirection="column">
+        {autocompletePlacement === "above" && suggestionsBox}
+
         {/* Input row with optional prompt indicator */}
         <box flexDirection="row">
           {showPromptIndicator && (
@@ -352,27 +384,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
           />
         </box>
 
-        {/* Autocomplete suggestions */}
-        {suggestions.length > 0 && (
-          <box flexDirection="column" marginTop={1}>
-            {suggestions.map((suggestion, index) => {
-              const isSelected = index === selectedSuggestionIndex;
-              return (
-                <box key={suggestion.value} flexDirection="row" gap={1}>
-                  <text fg={isSelected ? colors.primary : colors.textMuted}>
-                    {isSelected ? " ▸" : "  "}
-                  </text>
-                  <text fg={isSelected ? colors.text : colors.textMuted}>
-                    {suggestion.label}
-                  </text>
-                  {suggestion.description && (
-                    <text fg={colors.textMuted}> {suggestion.description}</text>
-                  )}
-                </box>
-              );
-            })}
-          </box>
-        )}
+        {autocompletePlacement === "below" && suggestionsBox}
       </box>
     );
   },

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -46,11 +46,15 @@ export function useCommand(): CommandContextValue {
 interface CommandProviderProps {
   children: ReactNode;
   onOpenSessionsDialog?: () => void;
+  onOpenThemeDialog?: () => void;
+  onOpenAuthDialog?: () => void;
 }
 
 export function CommandProvider({
   children,
   onOpenSessionsDialog,
+  onOpenThemeDialog,
+  onOpenAuthDialog,
 }: CommandProviderProps) {
   const route = useRoute();
   const [skills, setSkills] = useState<Skill[]>([]);
@@ -60,9 +64,11 @@ export function CommandProvider({
       route: route.data,
       navigate: route.navigate,
       openSessionsDialog: onOpenSessionsDialog,
+      openThemeDialog: onOpenThemeDialog,
+      openAuthDialog: onOpenAuthDialog,
     };
     return ctx;
-  }, [route, onOpenSessionsDialog]);
+  }, [route, onOpenSessionsDialog, onOpenThemeDialog, onOpenAuthDialog]);
 
   const refreshSkills = useCallback(async () => {
     const loaded = await loadSkills();

--- a/src/tui/context/route.tsx
+++ b/src/tui/context/route.tsx
@@ -67,6 +67,8 @@ export type Route =
         requireApproval?: boolean;
         target?: string;
       };
+      /** Opaque value used to force a fresh remount (e.g. Date.now()) */
+      nonce?: number;
     };
 
 type RouteContext = {

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -372,7 +372,7 @@ function CommandDisplay({
             <ModelsDisplay />
           </RouteSwitch.Case>
           <RouteSwitch.Case when="credits">
-            <CreditsFlow />
+            <CreditsFlow onOpenAuthDialog={() => setShowAuthDialog(true)} />
           </RouteSwitch.Case>
           <RouteSwitch.Case when="create-skill">
             <CreateSkillWizard />

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -262,7 +262,11 @@ function AppContent({
       overflow="hidden"
       backgroundColor={colors.background}
     >
-      <CommandDisplay focusIndex={focusIndex} inputKey={inputKey} />
+      <CommandDisplay
+        focusIndex={focusIndex}
+        inputKey={inputKey}
+        onOpenAuthDialog={() => setShowAuthDialog(true)}
+      />
 
       <Footer cwd={cwd} showExitWarning={showExitWarning} />
 
@@ -289,9 +293,11 @@ const RouteSwitch = createSwitch<RoutePath>();
 function CommandDisplay({
   focusIndex,
   inputKey,
+  onOpenAuthDialog,
 }: {
   focusIndex: number;
   inputKey: number;
+  onOpenAuthDialog: () => void;
 }) {
   const route = useRoute();
   const config = useConfig();
@@ -372,7 +378,7 @@ function CommandDisplay({
             <ModelsDisplay />
           </RouteSwitch.Case>
           <RouteSwitch.Case when="credits">
-            <CreditsFlow onOpenAuthDialog={() => setShowAuthDialog(true)} />
+            <CreditsFlow onOpenAuthDialog={onOpenAuthDialog} />
           </RouteSwitch.Case>
           <RouteSwitch.Case when="create-skill">
             <CreateSkillWizard />

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -197,6 +197,14 @@ function AppContent({
     }
   }, [config.data.responsibleUseAccepted, route.data]);
 
+  // Track external dialog state for theme/auth dialogs so operator input
+  // unfocuses while a dialog overlay is open
+  useEffect(() => {
+    if (showThemeDialog || showAuthDialog) {
+      setExternalDialogOpen(true);
+    }
+  }, [showThemeDialog, showAuthDialog]);
+
   // Auto-clear the exit warning after 1 second
   useEffect(() => {
     if (showExitWarning) {
@@ -225,12 +233,18 @@ function AppContent({
 
   const handleCloseThemeDialog = () => {
     setShowThemeDialog(false);
+    setTimeout(() => {
+      setExternalDialogOpen(false);
+    }, 0);
     setInputKey((prev) => prev + 1);
     refocusPrompt();
   };
 
   const handleCloseAuthDialog = () => {
     setShowAuthDialog(false);
+    setTimeout(() => {
+      setExternalDialogOpen(false);
+    }, 0);
     setInputKey((prev) => prev + 1);
     refocusPrompt();
   };
@@ -376,6 +390,7 @@ function CommandDisplay({
   if (route.data.type === "operator") {
     return (
       <OperatorDashboard
+        key={route.data.sessionId ?? route.data.nonce ?? "new"}
         sessionId={route.data.sessionId}
         initialMessage={route.data.initialMessage}
         initialConfig={route.data.initialConfig}

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -66,6 +66,8 @@ function App({ appConfig }: AppProps) {
   const [inputKey, setInputKey] = useState(0);
   const [showSessionsDialog, setShowSessionsDialog] = useState(false);
   const [showShortcutsDialog, setShowShortcutsDialog] = useState(false);
+  const [showThemeDialog, setShowThemeDialog] = useState(false);
+  const [showAuthDialog, setShowAuthDialog] = useState(false);
 
   const navigableItems = ["command-input"];
 
@@ -79,6 +81,8 @@ function App({ appConfig }: AppProps) {
                 <AgentProvider>
                   <CommandProvider
                     onOpenSessionsDialog={() => setShowSessionsDialog(true)}
+                    onOpenThemeDialog={() => setShowThemeDialog(true)}
+                    onOpenAuthDialog={() => setShowAuthDialog(true)}
                   >
                     <KeybindingProvider
                       deps={{
@@ -98,6 +102,10 @@ function App({ appConfig }: AppProps) {
                         setShowSessionsDialog={setShowSessionsDialog}
                         showShortcutsDialog={showShortcutsDialog}
                         setShowShortcutsDialog={setShowShortcutsDialog}
+                        showThemeDialog={showThemeDialog}
+                        setShowThemeDialog={setShowThemeDialog}
+                        showAuthDialog={showAuthDialog}
+                        setShowAuthDialog={setShowAuthDialog}
                         cwd={cwd}
                         setCtrlCPressTime={setCtrlCPressTime}
                         showExitWarning={showExitWarning}
@@ -123,6 +131,10 @@ function AppContent({
   setShowSessionsDialog,
   showShortcutsDialog,
   setShowShortcutsDialog,
+  showThemeDialog,
+  setShowThemeDialog,
+  showAuthDialog,
+  setShowAuthDialog,
   cwd,
   setCtrlCPressTime,
   showExitWarning,
@@ -135,6 +147,10 @@ function AppContent({
   setShowSessionsDialog: (show: boolean) => void;
   showShortcutsDialog: boolean;
   setShowShortcutsDialog: (show: boolean) => void;
+  showThemeDialog: boolean;
+  setShowThemeDialog: (show: boolean) => void;
+  showAuthDialog: boolean;
+  setShowAuthDialog: (show: boolean) => void;
   cwd: string;
   setCtrlCPressTime: (time: number | null) => void;
   showExitWarning: boolean;
@@ -207,6 +223,18 @@ function AppContent({
     refocusPrompt();
   };
 
+  const handleCloseThemeDialog = () => {
+    setShowThemeDialog(false);
+    setInputKey((prev) => prev + 1);
+    refocusPrompt();
+  };
+
+  const handleCloseAuthDialog = () => {
+    setShowAuthDialog(false);
+    setInputKey((prev) => prev + 1);
+    refocusPrompt();
+  };
+
   // Check if we're on the home route
   const isHomeRoute = route.data.type === "base" && route.data.path === "home";
 
@@ -233,6 +261,14 @@ function AppContent({
           open={showShortcutsDialog}
           onClose={handleCloseShortcutsDialog}
         />
+      )}
+
+      {showThemeDialog && (
+        <ThemePicker onClose={handleCloseThemeDialog} />
+      )}
+
+      {showAuthDialog && (
+        <AuthFlow onClose={handleCloseAuthDialog} />
       )}
     </box>
   );
@@ -319,17 +355,11 @@ function CommandDisplay({
           <RouteSwitch.Case when="providers">
             <ProviderManager />
           </RouteSwitch.Case>
-          <RouteSwitch.Case when="theme">
-            <ThemePicker />
-          </RouteSwitch.Case>
           <RouteSwitch.Case when="help">
             <HelpDialog />
           </RouteSwitch.Case>
           <RouteSwitch.Case when="models">
             <ModelsDisplay />
-          </RouteSwitch.Case>
-          <RouteSwitch.Case when="auth">
-            <AuthFlow />
           </RouteSwitch.Case>
           <RouteSwitch.Case when="credits">
             <CreditsFlow />

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -277,13 +277,9 @@ function AppContent({
         />
       )}
 
-      {showThemeDialog && (
-        <ThemePicker onClose={handleCloseThemeDialog} />
-      )}
+      {showThemeDialog && <ThemePicker onClose={handleCloseThemeDialog} />}
 
-      {showAuthDialog && (
-        <AuthFlow onClose={handleCloseAuthDialog} />
-      )}
+      {showAuthDialog && <AuthFlow onClose={handleCloseAuthDialog} />}
     </box>
   );
 }

--- a/src/tui/theme/themes/apex.ts
+++ b/src/tui/theme/themes/apex.ts
@@ -52,7 +52,7 @@ export const apex: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromInts(40, 40, 60, 255),

--- a/src/tui/theme/themes/ayu.ts
+++ b/src/tui/theme/themes/ayu.ts
@@ -51,7 +51,7 @@ export const ayu: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#1a1f29"),

--- a/src/tui/theme/themes/catppuccin.ts
+++ b/src/tui/theme/themes/catppuccin.ts
@@ -51,7 +51,7 @@ export const catppuccin: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#45475a"), // surface1 (mocha)

--- a/src/tui/theme/themes/dracula.ts
+++ b/src/tui/theme/themes/dracula.ts
@@ -52,7 +52,7 @@ export const dracula: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#44475a"), // selection

--- a/src/tui/theme/themes/everforest.ts
+++ b/src/tui/theme/themes/everforest.ts
@@ -51,7 +51,7 @@ export const everforest: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#3d484d"), // bg2

--- a/src/tui/theme/themes/flexoki.ts
+++ b/src/tui/theme/themes/flexoki.ts
@@ -52,7 +52,7 @@ export const flexoki: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#343331"), // ui-2

--- a/src/tui/theme/themes/github.ts
+++ b/src/tui/theme/themes/github.ts
@@ -51,7 +51,7 @@ export const github: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#1f2937"),

--- a/src/tui/theme/themes/gruvbox.ts
+++ b/src/tui/theme/themes/gruvbox.ts
@@ -51,7 +51,7 @@ export const gruvbox: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#504945"), // bg2 (dark2)

--- a/src/tui/theme/themes/kanagawa.ts
+++ b/src/tui/theme/themes/kanagawa.ts
@@ -51,7 +51,7 @@ export const kanagawa: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#2d4f67"), // waveBlue2 (wave)

--- a/src/tui/theme/themes/material.ts
+++ b/src/tui/theme/themes/material.ts
@@ -52,7 +52,7 @@ export const material: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#364850"),

--- a/src/tui/theme/themes/monokai.ts
+++ b/src/tui/theme/themes/monokai.ts
@@ -52,7 +52,7 @@ export const monokai: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#4a474c"),

--- a/src/tui/theme/themes/nightfox.ts
+++ b/src/tui/theme/themes/nightfox.ts
@@ -51,7 +51,7 @@ export const nightfox: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#2b3b51"), // sel0

--- a/src/tui/theme/themes/nord.ts
+++ b/src/tui/theme/themes/nord.ts
@@ -52,7 +52,7 @@ export const nord: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#434c5e"), // nord2

--- a/src/tui/theme/themes/onedark.ts
+++ b/src/tui/theme/themes/onedark.ts
@@ -52,7 +52,7 @@ export const oneDark: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#3e4451"),

--- a/src/tui/theme/themes/rose-pine.ts
+++ b/src/tui/theme/themes/rose-pine.ts
@@ -51,7 +51,7 @@ export const rosePine: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#2a283e"),

--- a/src/tui/theme/themes/solarized.ts
+++ b/src/tui/theme/themes/solarized.ts
@@ -51,7 +51,7 @@ export const solarized: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#0a4a5c"),

--- a/src/tui/theme/themes/tokyonight.ts
+++ b/src/tui/theme/themes/tokyonight.ts
@@ -51,7 +51,7 @@ export const tokyonight: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#283457"),

--- a/src/tui/theme/themes/vesper.ts
+++ b/src/tui/theme/themes/vesper.ts
@@ -53,7 +53,7 @@ export const vesper: ThemeDefinition = {
     },
     backgroundOverlay: {
       dark: RGBA.fromInts(0, 0, 0, 200),
-      light: RGBA.fromInts(255, 255, 255, 200),
+      light: RGBA.fromInts(0, 0, 0, 180),
     },
     backgroundSelected: {
       dark: RGBA.fromHex("#232323"),


### PR DESCRIPTION
Adds `/auth`, `/themes`, `/new`, `/operator`, and `/pentest` as usable commands during active operator sessions. Previously only `/models`, `/create-skill`, and skills worked — everything else navigated away from the session.

- Refactored ThemePicker and AuthFlow to the Dialog overlay pattern (same as `/sessions`), so they work from both home and operator mode
- Registered `/new` command to start a fresh operator session
- Autocomplete dropdown renders above the input in operator mode since the input sits at the bottom
- `/new` and `/operator` pass a nonce to force OperatorDashboard remount, so a fresh session actually starts
- Theme/auth dialogs set `externalDialogOpen` to unfocus the underlying prompt and prevent keyboard event leaks (`evt.preventDefault()` on all keystrokes)
- Dialog overlay background in light mode changed from white scrim to dark scrim across all 18 themes
- PromptInput remounts on theme/mode change so the textarea picks up the new `textColor` immediately
- Auth flow converted from hardcoded color strings to semantic theme tokens (`colors.primary`, `colors.text`, etc.)
- Home screen prompt unfocuses when a dialog is open, hiding the cursor behind the overlay

Closes #273


https://github.com/user-attachments/assets/32ed2f06-0b2e-4466-8999-762379e5fcdd


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/routing changes that affect session navigation, focus/keyboard handling, and dialog overlays; regressions could break in-session command execution or input focus but do not change core auth/token logic.
> 
> **Overview**
> Enables running more slash commands *while staying in an active operator session*, including `/auth`, `/themes`, `/new`, `/operator`, and `/pentest`, and introduces a `nonce` on the operator route to force `OperatorDashboard` remounts for truly fresh sessions.
> 
> Refactors `ThemePicker` and `AuthFlow` to use the `Dialog` overlay pattern (with `preventDefault()` to avoid key leakage), wires new open-dialog callbacks through `CommandProvider`, and updates home/operator input focus behavior when dialogs are open.
> 
> Improves operator UX by allowing autocomplete suggestions to render *above* the input, forcing `PromptInput` to remount on theme/mode changes, and adjusting light-mode overlay scrims across all themes (dark scrim instead of white).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db99718f2ee00a0c9b618b7bf423058677543f9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->