### PR TITLE
Operator input jump

### DIFF
--- a/src/tui/components/chat/input-area.tsx
+++ b/src/tui/components/chat/input-area.tsx
@@ -86,15 +86,22 @@ function NormalInputAreaInner({
   const { inputValue, setInputValue } = useInput();
   const promptRef = useRef<PromptInputRef>(null);
   const isExternalUpdate = useRef(false);
+  const prevValueRef = useRef(value);
 
-  // Sync external value prop to context when it changes
+  // Sync external value prop to context when the parent explicitly changes it.
+  // Only sync when the value prop itself changed between renders (not just a
+  // re-render with stale value), to avoid resetting user input during typing.
   useEffect(() => {
-    if (value !== inputValue) {
+    const prevValue = prevValueRef.current;
+    prevValueRef.current = value;
+
+    // Only sync if the parent's value prop actually changed from the previous render
+    if (value !== prevValue && value !== inputValue) {
       isExternalUpdate.current = true;
       setInputValue(value);
       promptRef.current?.setValue(value);
     }
-  }, [value]);
+  }, [value, inputValue, setInputValue]);
 
   // Sync context changes back to parent via onChange
   useEffect(() => {
@@ -105,7 +112,7 @@ function NormalInputAreaInner({
     if (inputValue !== value) {
       onChange(inputValue);
     }
-  }, [inputValue]);
+  }, [inputValue, value, onChange]);
 
   const handleSubmit = (val: string) => {
     if (val.trim()) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR fixes a bug where the cursor jumps to the beginning of the input field in `/operator` mode. The issue was caused by a `useEffect` in `input-area.tsx` that incorrectly reset the input value and cursor. It would trigger when the parent component re-rendered with a stale `value` prop, causing `setValue()` to be called unnecessarily.

The fix introduces a `prevValueRef` to track the previous `value` prop. The `useEffect` now only calls `setValue()` when the `value` prop has genuinely changed between renders, preventing the cursor from resetting during parent re-renders with the same (stale) value.

### How did you verify your code works?

-   TypeScript type check: passing
-   ESLint: passing
-   All unit tests: passing (386 passed, 15 skipped)

---
<p><a href="https://cursor.com/agents/bc-6d999644-50c1-43c1-8d14-cb5509a796c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d999644-50c1-43c1-8d14-cb5509a796c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->