### PR TITLE
feat: visually truncate large pasted text in input area

### DIFF
--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -9,8 +9,8 @@ import {
 import { useKeyboard } from "@opentui/react";
 import type {
   TextareaRenderable,
-  RGBA,
   KeyBinding as TextareaKeyBinding,
+  RGBA,
 } from "@opentui/core";
 import { useTheme } from "../../theme";
 import { useInput } from "../../context/input";
@@ -135,6 +135,14 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
     const onSubmitRef = useRef(onSubmit);
     onSubmitRef.current = onSubmit;
 
+    // Paste extmark tracking — virtual extmarks for atomic inline placeholders
+    const pasteCountRef = useRef(0);
+    const pasteTypeIdRef = useRef<number>(-1);
+    // Own map of extmark ID → { fullText, placeholder } for paste resolution
+    const pasteDataRef = useRef<
+      Map<number, { fullText: string; placeholder: string }>
+    >(new Map());
+
     const suggestions = useMemo(
       () =>
         enableAutocomplete
@@ -164,11 +172,17 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       reset: () => {
         setInputValue("");
         textareaRef.current?.setText("");
+        textareaRef.current?.extmarks.clear();
+        pasteCountRef.current = 0;
+        pasteDataRef.current.clear();
         setSelectedSuggestionIndex(-1);
       },
       setValue: (value: string) => {
         setInputValue(value);
         textareaRef.current?.setText(value);
+        textareaRef.current?.extmarks.clear();
+        pasteCountRef.current = 0;
+        pasteDataRef.current.clear();
       },
       getValue: () => inputValue,
       getTextareaRef: () => textareaRef.current,
@@ -201,6 +215,9 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       // --- Ctrl+C: clear input ------------------------------------------
       if (key.ctrl && key.name === "c") {
         textareaRef.current?.setText("");
+        textareaRef.current?.extmarks.clear();
+        pasteCountRef.current = 0;
+        pasteDataRef.current.clear();
         setInputValue("");
         setHistoryIndex(-1);
         setSelectedSuggestionIndex(-1);
@@ -286,14 +303,92 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       }
     });
 
+    // Paste handler: intercept large pastes, insert inline placeholder with virtual extmark
+    const handlePaste = (event: {
+      text: string;
+      preventDefault: () => void;
+    }) => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+
+      const text = event.text;
+      const lineCount = text.split("\n").length;
+
+      // Small pastes pass through normally
+      if (lineCount < 5 && text.length < 500) return;
+
+      event.preventDefault();
+
+      // Register extmark type on first use
+      if (pasteTypeIdRef.current === -1) {
+        pasteTypeIdRef.current =
+          textarea.extmarks.registerType("pasted-block");
+      }
+
+      pasteCountRef.current += 1;
+      const n = pasteCountRef.current;
+      const placeholder = `[Pasted text #${n} +${lineCount} lines]`;
+
+      const startOffset = textarea.cursorOffset;
+      textarea.insertText(placeholder);
+      const endOffset = startOffset + placeholder.length;
+
+      const extmarkId = textarea.extmarks.create({
+        start: startOffset,
+        end: endOffset,
+        virtual: true,
+        typeId: pasteTypeIdRef.current,
+      });
+      pasteDataRef.current.set(extmarkId, { fullText: text, placeholder });
+    };
+
+    // Resolve paste extmark placeholders back to their full text.
+    // Only expands if the placeholder text at the extmark range is unmodified.
+    const resolvePasteExtmarks = (plainText: string): string => {
+      const dataMap = pasteDataRef.current;
+      if (dataMap.size === 0) return plainText;
+
+      const textarea = textareaRef.current;
+      if (!textarea) return plainText;
+
+      const allExtmarks = textarea.extmarks.getAll();
+      const pasteExtmarks = allExtmarks.filter((ext) => dataMap.has(ext.id));
+
+      if (pasteExtmarks.length === 0) return plainText;
+
+      // Sort by start offset ascending, splice in full text
+      const sorted = [...pasteExtmarks].sort((a, b) => a.start - b.start);
+      let result = "";
+      let lastEnd = 0;
+      for (const ext of sorted) {
+        result += plainText.slice(lastEnd, ext.start);
+        const entry = dataMap.get(ext.id)!;
+        const currentText = plainText.slice(ext.start, ext.end);
+        // Only expand if placeholder is still intact
+        if (currentText === entry.placeholder) {
+          result += entry.fullText;
+        } else {
+          result += currentText;
+        }
+        lastEnd = ext.end;
+      }
+      result += plainText.slice(lastEnd);
+      return result;
+    };
+
     // Submit handler called by textarea's onSubmit.
     // Uses refs for all callbacks because textarea caches onSubmit at mount.
     const handleSubmit = async () => {
       const currentSuggestions = suggestionsRef.current;
       const currentSelectedIndex = selectedIndexRef.current;
 
-      const valueToSubmit = resolveSubmitValue(
+      // Resolve paste placeholders to full text before submit
+      const rawText = resolvePasteExtmarks(
         textareaRef.current?.plainText ?? "",
+      );
+
+      const valueToSubmit = resolveSubmitValue(
+        rawText,
         currentSuggestions,
         currentSelectedIndex,
       );
@@ -307,12 +402,18 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
         await onCommandExecuteRef.current?.(valueToSubmit);
         setInputValue("");
         textareaRef.current?.setText("");
+        textareaRef.current?.extmarks.clear();
+        pasteCountRef.current = 0;
+        pasteDataRef.current.clear();
         setSelectedSuggestionIndex(-1);
         setHistoryIndex(-1);
         return;
       }
 
       setHistoryIndex(-1);
+      textareaRef.current?.extmarks.clear();
+      pasteCountRef.current = 0;
+      pasteDataRef.current.clear();
       onSubmitRef.current?.(valueToSubmit);
     };
 
@@ -349,6 +450,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
             keyBindings={chatKeyBindings}
             onContentChange={handleContentChange}
             onSubmit={handleSubmit}
+            onPaste={handlePaste}
           />
         </box>
 

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -221,6 +221,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
         if (tabResult) {
           setSelectedSuggestionIndex(tabResult.selectedSuggestionIndex);
           if (tabResult.acceptedValue !== null) {
+            clearPaste();
             textareaRef.current?.setText(tabResult.acceptedValue);
             setInputValue(tabResult.acceptedValue);
             textareaRef.current?.gotoLineEnd();

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -23,6 +23,7 @@ import {
   computeTab,
   shouldResetHistory,
 } from "./prompt-input-logic";
+import { usePasteExtmarks } from "./use-paste-extmarks";
 export interface AutocompleteOption {
   value: string;
   label: string;
@@ -135,13 +136,8 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
     const onSubmitRef = useRef(onSubmit);
     onSubmitRef.current = onSubmit;
 
-    // Paste extmark tracking — virtual extmarks for atomic inline placeholders
-    const pasteCountRef = useRef(0);
-    const pasteTypeIdRef = useRef<number>(-1);
-    // Own map of extmark ID → { fullText, placeholder } for paste resolution
-    const pasteDataRef = useRef<
-      Map<number, { fullText: string; placeholder: string }>
-    >(new Map());
+    const { handlePaste, resolveText, clearPaste } =
+      usePasteExtmarks(textareaRef);
 
     const suggestions = useMemo(
       () =>
@@ -172,17 +168,13 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       reset: () => {
         setInputValue("");
         textareaRef.current?.setText("");
-        textareaRef.current?.extmarks.clear();
-        pasteCountRef.current = 0;
-        pasteDataRef.current.clear();
+        clearPaste();
         setSelectedSuggestionIndex(-1);
       },
       setValue: (value: string) => {
         setInputValue(value);
         textareaRef.current?.setText(value);
-        textareaRef.current?.extmarks.clear();
-        pasteCountRef.current = 0;
-        pasteDataRef.current.clear();
+        clearPaste();
       },
       getValue: () => inputValue,
       getTextareaRef: () => textareaRef.current,
@@ -215,9 +207,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       // --- Ctrl+C: clear input ------------------------------------------
       if (key.ctrl && key.name === "c") {
         textareaRef.current?.setText("");
-        textareaRef.current?.extmarks.clear();
-        pasteCountRef.current = 0;
-        pasteDataRef.current.clear();
+        clearPaste();
         setInputValue("");
         setHistoryIndex(-1);
         setSelectedSuggestionIndex(-1);
@@ -303,79 +293,6 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       }
     });
 
-    // Paste handler: intercept large pastes, insert inline placeholder with virtual extmark
-    const handlePaste = (event: {
-      text: string;
-      preventDefault: () => void;
-    }) => {
-      const textarea = textareaRef.current;
-      if (!textarea) return;
-
-      const text = event.text;
-      const lineCount = text.split("\n").length;
-
-      // Small pastes pass through normally
-      if (lineCount < 5 && text.length < 500) return;
-
-      event.preventDefault();
-
-      // Register extmark type on first use
-      if (pasteTypeIdRef.current === -1) {
-        pasteTypeIdRef.current =
-          textarea.extmarks.registerType("pasted-block");
-      }
-
-      pasteCountRef.current += 1;
-      const n = pasteCountRef.current;
-      const placeholder = `[Pasted text #${n} +${lineCount} lines]`;
-
-      const startOffset = textarea.cursorOffset;
-      textarea.insertText(placeholder);
-      const endOffset = startOffset + placeholder.length;
-
-      const extmarkId = textarea.extmarks.create({
-        start: startOffset,
-        end: endOffset,
-        virtual: true,
-        typeId: pasteTypeIdRef.current,
-      });
-      pasteDataRef.current.set(extmarkId, { fullText: text, placeholder });
-    };
-
-    // Resolve paste extmark placeholders back to their full text.
-    // Only expands if the placeholder text at the extmark range is unmodified.
-    const resolvePasteExtmarks = (plainText: string): string => {
-      const dataMap = pasteDataRef.current;
-      if (dataMap.size === 0) return plainText;
-
-      const textarea = textareaRef.current;
-      if (!textarea) return plainText;
-
-      const allExtmarks = textarea.extmarks.getAll();
-      const pasteExtmarks = allExtmarks.filter((ext) => dataMap.has(ext.id));
-
-      if (pasteExtmarks.length === 0) return plainText;
-
-      // Sort by start offset ascending, splice in full text
-      const sorted = [...pasteExtmarks].sort((a, b) => a.start - b.start);
-      let result = "";
-      let lastEnd = 0;
-      for (const ext of sorted) {
-        result += plainText.slice(lastEnd, ext.start);
-        const entry = dataMap.get(ext.id)!;
-        const currentText = plainText.slice(ext.start, ext.end);
-        // Only expand if placeholder is still intact
-        if (currentText === entry.placeholder) {
-          result += entry.fullText;
-        } else {
-          result += currentText;
-        }
-        lastEnd = ext.end;
-      }
-      result += plainText.slice(lastEnd);
-      return result;
-    };
-
     // Submit handler called by textarea's onSubmit.
     // Uses refs for all callbacks because textarea caches onSubmit at mount.
     const handleSubmit = async () => {
@@ -383,9 +300,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       const currentSelectedIndex = selectedIndexRef.current;
 
       // Resolve paste placeholders to full text before submit
-      const rawText = resolvePasteExtmarks(
-        textareaRef.current?.plainText ?? "",
-      );
+      const rawText = resolveText(textareaRef.current?.plainText ?? "");
 
       const valueToSubmit = resolveSubmitValue(
         rawText,
@@ -402,18 +317,14 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
         await onCommandExecuteRef.current?.(valueToSubmit);
         setInputValue("");
         textareaRef.current?.setText("");
-        textareaRef.current?.extmarks.clear();
-        pasteCountRef.current = 0;
-        pasteDataRef.current.clear();
+        clearPaste();
         setSelectedSuggestionIndex(-1);
         setHistoryIndex(-1);
         return;
       }
 
       setHistoryIndex(-1);
-      textareaRef.current?.extmarks.clear();
-      pasteCountRef.current = 0;
-      pasteDataRef.current.clear();
+      clearPaste();
       onSubmitRef.current?.(valueToSubmit);
     };
 

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -248,11 +248,14 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
         if (!result) return;
 
         if (result.saveCurrentInput) {
-          savedInputRef.current = textareaRef.current?.plainText ?? "";
+          savedInputRef.current = resolveText(
+            textareaRef.current?.plainText ?? "",
+          );
         }
         setSelectedSuggestionIndex(result.nextState.selectedSuggestionIndex);
         if (result.textToSet !== null) {
           isNavigatingHistoryRef.current = true;
+          clearPaste();
           textareaRef.current?.setText(result.textToSet);
           setInputValue(result.textToSet);
           setHistoryIndex(result.nextState.historyIndex);
@@ -279,6 +282,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
         setSelectedSuggestionIndex(result.nextState.selectedSuggestionIndex);
         if (result.textToSet !== null) {
           isNavigatingHistoryRef.current = true;
+          clearPaste();
           textareaRef.current?.setText(result.textToSet);
           setInputValue(result.textToSet);
           setHistoryIndex(result.nextState.historyIndex);

--- a/src/tui/components/shared/use-paste-extmarks.ts
+++ b/src/tui/components/shared/use-paste-extmarks.ts
@@ -1,0 +1,104 @@
+import { useRef } from "react";
+import type { TextareaRenderable } from "@opentui/core";
+
+interface PasteEntry {
+  fullText: string;
+  placeholder: string;
+}
+
+const LARGE_PASTE_MIN_LINES = 5;
+const LARGE_PASTE_MIN_CHARS = 500;
+
+/**
+ * Manages virtual extmarks for large pasted text.
+ *
+ * Large pastes are replaced with an atomic inline placeholder (e.g.
+ * `[Pasted text #1 +17 lines]`). On submit the placeholder is expanded
+ * back to the full text — unless the user has modified it.
+ */
+export function usePasteExtmarks(
+  textareaRef: React.RefObject<TextareaRenderable | null>,
+) {
+  const countRef = useRef(0);
+  const typeIdRef = useRef(-1);
+  const dataRef = useRef<Map<number, PasteEntry>>(new Map());
+
+  /** Reset all paste state and clear extmarks on the textarea. */
+  const clearPaste = () => {
+    textareaRef.current?.extmarks.clear();
+    countRef.current = 0;
+    dataRef.current.clear();
+  };
+
+  /**
+   * Paste handler — pass directly to `<textarea onPaste={handlePaste}>`.
+   * Intercepts large pastes (5+ lines or 500+ chars) and inserts a
+   * virtual extmark placeholder instead.
+   */
+  const handlePaste = (event: { text: string; preventDefault: () => void }) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    const text = event.text;
+    const lineCount = text.split("\n").length;
+
+    if (lineCount < LARGE_PASTE_MIN_LINES && text.length < LARGE_PASTE_MIN_CHARS) return;
+
+    event.preventDefault();
+
+    if (typeIdRef.current === -1) {
+      typeIdRef.current = textarea.extmarks.registerType("pasted-block");
+    }
+
+    countRef.current += 1;
+    const placeholder = `[Pasted text #${countRef.current} +${lineCount} lines]`;
+
+    const startOffset = textarea.cursorOffset;
+    textarea.insertText(placeholder);
+    const endOffset = startOffset + placeholder.length;
+
+    const extmarkId = textarea.extmarks.create({
+      start: startOffset,
+      end: endOffset,
+      virtual: true,
+      typeId: typeIdRef.current,
+    });
+    dataRef.current.set(extmarkId, { fullText: text, placeholder });
+  };
+
+  /**
+   * Expand paste placeholders in `plainText` back to the full pasted text.
+   * Only expands placeholders whose text is still intact — if the user
+   * modified the placeholder, the modified text is kept as-is.
+   */
+  const resolveText = (plainText: string): string => {
+    const dataMap = dataRef.current;
+    if (dataMap.size === 0) return plainText;
+
+    const textarea = textareaRef.current;
+    if (!textarea) return plainText;
+
+    const allExtmarks = textarea.extmarks.getAll();
+    const pasteExtmarks = allExtmarks.filter((ext) => dataMap.has(ext.id));
+    if (pasteExtmarks.length === 0) return plainText;
+
+    const sorted = [...pasteExtmarks].sort((a, b) => a.start - b.start);
+    let result = "";
+    let lastEnd = 0;
+    for (const ext of sorted) {
+      result += plainText.slice(lastEnd, ext.start);
+      const entry = dataMap.get(ext.id)!;
+      const currentText = plainText.slice(ext.start, ext.end);
+      if (currentText === entry.placeholder) {
+        result += entry.fullText;
+      } else {
+        result += currentText;
+      }
+      lastEnd = ext.end;
+    }
+    result += plainText.slice(lastEnd);
+    return result;
+  };
+
+  return { handlePaste, resolveText, clearPaste } as const;
+}

--- a/src/tui/components/shared/use-paste-extmarks.ts
+++ b/src/tui/components/shared/use-paste-extmarks.ts
@@ -42,7 +42,11 @@ export function usePasteExtmarks(
     const text = event.text;
     const lineCount = text.split("\n").length;
 
-    if (lineCount < LARGE_PASTE_MIN_LINES && text.length < LARGE_PASTE_MIN_CHARS) return;
+    if (
+      lineCount < LARGE_PASTE_MIN_LINES &&
+      text.length < LARGE_PASTE_MIN_CHARS
+    )
+      return;
 
     event.preventDefault();
 


### PR DESCRIPTION
Large pastes (5+ lines or 500+ chars) are replaced with an atomic inline placeholder like `[Pasted text #1 +17 lines]` using @opentui virtual extmarks. The placeholder deletes as a single unit on backspace. On submit, placeholders expand back to the full pasted text — unless the user has modified the placeholder, in which case the modified text is sent as-is.

Closes #303

https://github.com/user-attachments/assets/49b9f3af-390b-4697-8dc3-398d8740e689

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core input/paste/submit and history-navigation paths; incorrect extmark cleanup or placeholder resolution could lead to wrong text being submitted or confusing input state.
> 
> **Overview**
> Adds large-paste handling to `PromptInput` by replacing big pasted blocks (5+ lines or 500+ chars) with a virtual extmark placeholder like `[Pasted text #N +X lines]`, keeping the input visually small and making the placeholder behave atomically.
> 
> On submit (and when saving/restoring history), placeholders are expanded back to the original pasted content unless the placeholder was edited, and paste state is cleared whenever the input is programmatically changed (reset, Ctrl+C, tab-accept, history navigation, submit/command).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7187020a1dbb696f0f4880ee9daa9df21c3861b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->