### PR TITLE
refactor: pentest wizard as dialog overlay

### DIFF
--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -17,6 +17,7 @@ export interface AppCommandContext {
   openSessionsDialog?: () => void;
   openThemeDialog?: () => void;
   openAuthDialog?: () => void;
+  openPentestDialog?: (flags?: Record<string, any>) => void;
 }
 
 /**
@@ -115,12 +116,8 @@ export const commands: CommandConfig[] = [
         });
         return;
       }
-      // Navigate to WebWizard (swarm wizard) for target input
-      ctx.navigate({
-        type: "base",
-        path: "web",
-        options: { auto: true, ...flags },
-      });
+      // Open WebWizard dialog for target input
+      ctx.openPentestDialog?.({ auto: true, ...flags });
     },
   },
   {

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -1,5 +1,5 @@
 import type { CommandDefinition } from "./command-router";
-import type { Route } from "./context/route";
+import type { Route, WebCommandOptions } from "./context/route";
 import {
   parseWebFlags,
   hasEnoughFlagsToSkipWizard,
@@ -17,7 +17,7 @@ export interface AppCommandContext {
   openSessionsDialog?: () => void;
   openThemeDialog?: () => void;
   openAuthDialog?: () => void;
-  openPentestDialog?: (flags?: Record<string, any>) => void;
+  openPentestDialog?: (flags?: WebCommandOptions) => void;
 }
 
 /**

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { useKeyboard } from "@opentui/react";
 import Input from "../input";
-import { useRoute } from "../../context/route";
 import { useConfig } from "../../context/config";
 import { useAgent } from "../../context/agent";
 import type { SessionConfig } from "../../../core/session";
@@ -9,6 +8,7 @@ import { SpinnerDots } from "../sprites";
 import { type ModelInfo } from "../../../core/ai";
 import { getAvailableModels } from "../../../core/providers/utils";
 import { useTheme } from "../../theme";
+import { Dialog } from "../../context/dialog";
 
 // Wizard step types
 type WizardStep = "target" | "configure" | "creating";
@@ -38,6 +38,10 @@ interface WizardState {
 
 // Props for the WebWizard
 interface WebWizardProps {
+  /** Called when the wizard is dismissed (ESC) */
+  onClose: () => void;
+  /** Called when the wizard completes and a pentest session should start */
+  onStartPentest: (targets: string[], sessionConfig: SessionConfig) => void;
   /** Pre-filled target URL from --target flag */
   initialTarget?: string;
   /** Enable auto mode from --auto flag */
@@ -67,6 +71,8 @@ interface WebWizardProps {
 }
 
 export default function WebWizard({
+  onClose,
+  onStartPentest,
   initialTarget,
   autoMode = false,
   initialName,
@@ -82,7 +88,6 @@ export default function WebWizard({
   initialModel,
 }: WebWizardProps) {
   const { colors } = useTheme();
-  const route = useRoute();
   const config = useConfig();
   const { model, setModel, isModelUserSelected } = useAgent();
 
@@ -280,11 +285,7 @@ export default function WebWizard({
         };
       }
 
-      route.navigate({
-        type: "pentest",
-        targets: [state.target],
-        sessionConfig,
-      });
+      onStartPentest([state.target], sessionConfig);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create session");
       setCurrentStep(initialTarget ? "configure" : "target");
@@ -293,6 +294,8 @@ export default function WebWizard({
 
   // Keyboard handling
   useKeyboard((key) => {
+    key.preventDefault();
+
     // ESC - Go back or close
     if (key.name === "escape") {
       if (currentStep === "creating") {
@@ -300,9 +303,9 @@ export default function WebWizard({
         return;
       }
       if (currentStep === "configure") {
-        // If we have an initial target, go home instead of back to target step
+        // If we have an initial target, close dialog instead of back to target step
         if (initialTarget) {
-          route.navigate({ type: "base", path: "home" });
+          onClose();
         } else {
           setCurrentStep("target");
           setFocusedSection(0);
@@ -310,7 +313,7 @@ export default function WebWizard({
         }
         return;
       }
-      route.navigate({ type: "base", path: "home" });
+      onClose();
       return;
     }
 
@@ -573,25 +576,28 @@ export default function WebWizard({
   // Render creating state
   if (currentStep === "creating") {
     return (
-      <box
-        flexDirection="column"
-        width="100%"
-        height="100%"
-        alignItems="center"
-        justifyContent="center"
-        flexGrow={1}
-        gap={2}
-      >
-        <SpinnerDots label="Creating session..." fg={colors.primary} />
-        <text fg={colors.textMuted}>Target: {state.target}</text>
-        <text fg={colors.textMuted}>Mode: {modeLabel}</text>
-      </box>
+      <Dialog size="large" onClose={onClose}>
+        <box
+          flexDirection="column"
+          width="100%"
+          height="100%"
+          alignItems="center"
+          justifyContent="center"
+          flexGrow={1}
+          gap={2}
+        >
+          <SpinnerDots label="Creating session..." fg={colors.primary} />
+          <text fg={colors.textMuted}>Target: {state.target}</text>
+          <text fg={colors.textMuted}>Mode: {modeLabel}</text>
+        </box>
+      </Dialog>
     );
   }
 
   // Render target step
   if (currentStep === "target") {
     return (
+      <Dialog size="large" onClose={onClose}>
       <box width="100%" flexDirection="column" gap={2} paddingLeft={4}>
         <text fg={colors.text}>Configure Web App Pentest</text>
         <text fg={colors.textMuted}>{modeDescription}</text>
@@ -659,11 +665,13 @@ export default function WebWizard({
           </text>
         </box>
       </box>
+      </Dialog>
     );
   }
 
   // Render configure step
   return (
+    <Dialog size="large" onClose={onClose}>
     <box width="100%" flexDirection="column" gap={2} paddingLeft={4}>
       <box flexDirection="column">
         <text fg={colors.text}>Configure Web App Pentest - {modeLabel}</text>
@@ -1022,5 +1030,6 @@ export default function WebWizard({
         </text>
       </box>
     </box>
+    </Dialog>
   );
 }

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -294,10 +294,9 @@ export default function WebWizard({
 
   // Keyboard handling
   useKeyboard((key) => {
-    key.preventDefault();
-
     // ESC - Go back or close
     if (key.name === "escape") {
+      key.preventDefault();
       if (currentStep === "creating") {
         // Can't cancel while creating
         return;
@@ -325,6 +324,7 @@ export default function WebWizard({
       const maxTargetField = state.sourceCodeAccess ? 2 : 1; // 0=target, 1=toggle, 2=cwd (if enabled)
       // Tab navigation
       if (key.name === "tab") {
+        key.preventDefault();
         if (key.shift) {
           setTargetFocusedField((prev) => Math.max(0, prev - 1));
         } else {
@@ -341,6 +341,7 @@ export default function WebWizard({
         targetFocusedField === 1 &&
         (key.name === "up" || key.name === "down")
       ) {
+        key.preventDefault();
         setState((prev) => ({
           ...prev,
           sourceCodeAccess: !prev.sourceCodeAccess,
@@ -349,6 +350,7 @@ export default function WebWizard({
       }
       // Enter to start if target is filled
       if (key.name === "return" && state.target.trim()) {
+        key.preventDefault();
         createSessionAndNavigate();
         return;
       }
@@ -359,6 +361,7 @@ export default function WebWizard({
     if (currentStep === "configure") {
       // Enter to create session
       if (key.name === "return") {
+        key.preventDefault();
         // Check if we should add an item instead of starting
         if (focusedSection === 1 && focusedField === 0 && hostInput.trim()) {
           setState((prev) => ({
@@ -409,6 +412,7 @@ export default function WebWizard({
 
       // Tab navigation between sections and fields
       if (key.name === "tab") {
+        key.preventDefault();
         if (key.shift) {
           if (focusedField > 0) {
             setFocusedField(focusedField - 1);
@@ -430,6 +434,7 @@ export default function WebWizard({
 
       // Arrow keys for toggles
       if (key.name === "up" || key.name === "down") {
+        key.preventDefault();
         if (focusedSection === 1 && focusedField === 2) {
           setState((prev) => ({
             ...prev,
@@ -491,6 +496,7 @@ export default function WebWizard({
       if (focusedSection === 3) {
         // Backspace - remove last char from search
         if (key.name === "backspace") {
+          key.preventDefault();
           setModelSearchQuery((prev) => prev.slice(0, -1));
           return;
         }
@@ -501,6 +507,7 @@ export default function WebWizard({
         }
         // Left/Right - toggle provider expansion
         if (key.name === "left" || key.name === "right") {
+          key.preventDefault();
           // Find which provider the current model belongs to
           const currentProvider = model.provider;
           if (key.name === "left") {
@@ -516,6 +523,7 @@ export default function WebWizard({
         }
         // Tab in model section - toggle next provider expansion
         if (key.name === "tab" && !key.shift) {
+          key.preventDefault();
           const availableProviders = providerOrder.filter(
             (p) => groupedModels[p]?.length > 0,
           );
@@ -541,6 +549,7 @@ export default function WebWizard({
           key.sequence.length === 1 &&
           /[a-zA-Z0-9\-_.]/.test(key.sequence)
         ) {
+          key.preventDefault();
           setModelSearchQuery((prev) => prev + key.sequence);
           // Auto-expand all providers when searching
           if (!modelSearchQuery) {
@@ -598,7 +607,7 @@ export default function WebWizard({
   if (currentStep === "target") {
     return (
       <Dialog size="large" onClose={onClose}>
-      <box width="100%" flexDirection="column" gap={2} paddingLeft={4}>
+      <box width="100%" flexDirection="column" gap={2} paddingLeft={4} paddingBottom={1}>
         <text fg={colors.text}>Configure Web App Pentest</text>
         <text fg={colors.textMuted}>{modeDescription}</text>
         <text fg={colors.textMuted}>
@@ -672,7 +681,7 @@ export default function WebWizard({
   // Render configure step
   return (
     <Dialog size="large" onClose={onClose}>
-    <box width="100%" flexDirection="column" gap={2} paddingLeft={4}>
+    <box width="100%" flexDirection="column" gap={2} paddingLeft={4} paddingBottom={1}>
       <box flexDirection="column">
         <text fg={colors.text}>Configure Web App Pentest - {modeLabel}</text>
         <text fg={colors.textMuted}>Target: {state.target}</text>

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -607,49 +607,435 @@ export default function WebWizard({
   if (currentStep === "target") {
     return (
       <Dialog size="large" onClose={onClose}>
-      <box width="100%" flexDirection="column" gap={2} paddingLeft={4} paddingBottom={1}>
-        <text fg={colors.text}>Configure Web App Pentest</text>
-        <text fg={colors.textMuted}>{modeDescription}</text>
-        <text fg={colors.textMuted}>
-          Model: {model.name} [{isModelUserSelected ? "user" : "default"}]
-        </text>
+        <box
+          width="100%"
+          flexDirection="column"
+          gap={2}
+          paddingLeft={4}
+          paddingBottom={1}
+        >
+          <text fg={colors.text}>Configure Web App Pentest</text>
+          <text fg={colors.textMuted}>{modeDescription}</text>
+          <text fg={colors.textMuted}>
+            Model: {model.name} [{isModelUserSelected ? "user" : "default"}]
+          </text>
 
-        {error && <text fg={colors.error}>Error: {error}</text>}
+          {error && <text fg={colors.error}>Error: {error}</text>}
 
-        <Input
-          label="Target URL"
-          description="e.g., https://example.com"
-          placeholder="https://example.com"
-          value={state.target}
-          onInput={(v) => setState((prev) => ({ ...prev, target: v }))}
-          focused={targetFocusedField === 0}
-        />
+          <Input
+            label="Target URL"
+            description="e.g., https://example.com"
+            placeholder="https://example.com"
+            value={state.target}
+            onInput={(v) => setState((prev) => ({ ...prev, target: v }))}
+            focused={targetFocusedField === 0}
+          />
 
-        <box flexDirection="column" gap={1}>
-          <box flexDirection="row" gap={1}>
-            <text
-              fg={targetFocusedField === 1 ? colors.primary : colors.textMuted}
-            >
-              Source Code Access:
-            </text>
-            <text
-              fg={state.sourceCodeAccess ? colors.primary : colors.textMuted}
-            >
-              {state.sourceCodeAccess ? "● Enabled" : "○ Disabled"}
-            </text>
-            {targetFocusedField === 1 && (
-              <text fg={colors.textMuted}>(↑/↓ to toggle)</text>
+          <box flexDirection="column" gap={1}>
+            <box flexDirection="row" gap={1}>
+              <text
+                fg={
+                  targetFocusedField === 1 ? colors.primary : colors.textMuted
+                }
+              >
+                Source Code Access:
+              </text>
+              <text
+                fg={state.sourceCodeAccess ? colors.primary : colors.textMuted}
+              >
+                {state.sourceCodeAccess ? "● Enabled" : "○ Disabled"}
+              </text>
+              {targetFocusedField === 1 && (
+                <text fg={colors.textMuted}>(↑/↓ to toggle)</text>
+              )}
+            </box>
+            {state.sourceCodeAccess && (
+              <Input
+                label="Codebase Path"
+                description="Path to the source code directory"
+                placeholder={process.cwd()}
+                value={state.cwd}
+                onInput={(v) => setState((prev) => ({ ...prev, cwd: v }))}
+                focused={targetFocusedField === 2}
+              />
             )}
           </box>
-          {state.sourceCodeAccess && (
-            <Input
-              label="Codebase Path"
-              description="Path to the source code directory"
-              placeholder={process.cwd()}
-              value={state.cwd}
-              onInput={(v) => setState((prev) => ({ ...prev, cwd: v }))}
-              focused={targetFocusedField === 2}
-            />
+
+          <box flexDirection="column" gap={0} marginTop={1}>
+            <text>
+              <span fg={colors.primary}>█ </span>
+              <span fg={colors.textMuted}>Press </span>
+              <span fg={colors.text}>[Enter]</span>
+              <span fg={colors.textMuted}> to start immediately</span>
+            </text>
+            <text>
+              <span fg={colors.primary}>█ </span>
+              <span fg={colors.textMuted}>Press </span>
+              <span fg={colors.text}>[Tab]</span>
+              <span fg={colors.textMuted}> to configure options</span>
+            </text>
+            <text>
+              <span fg={colors.primary}>█ </span>
+              <span fg={colors.textMuted}>Press </span>
+              <span fg={colors.text}>[ESC]</span>
+              <span fg={colors.textMuted}> to cancel</span>
+            </text>
+          </box>
+        </box>
+      </Dialog>
+    );
+  }
+
+  // Render configure step
+  return (
+    <Dialog size="large" onClose={onClose}>
+      <box
+        width="100%"
+        flexDirection="column"
+        gap={2}
+        paddingLeft={4}
+        paddingBottom={1}
+      >
+        <box flexDirection="column">
+          <text fg={colors.text}>Configure Web App Pentest - {modeLabel}</text>
+          <text fg={colors.textMuted}>Target: {state.target}</text>
+          <text fg={colors.textMuted}>
+            All fields are optional - configure only what you need
+          </text>
+        </box>
+
+        {/* Auth Section */}
+        <box flexDirection="column" gap={1}>
+          <text>
+            <span fg={colors.primary}>█ </span>
+            <span fg={focusedSection === 0 ? colors.text : colors.textMuted}>
+              Authentication
+            </span>
+          </text>
+          {focusedSection === 0 && (
+            <box flexDirection="column" gap={1} paddingLeft={2}>
+              <Input
+                label="Login URL"
+                placeholder="https://example.com/login"
+                value={state.auth.loginUrl}
+                onInput={(v) =>
+                  setState((prev) => ({
+                    ...prev,
+                    auth: { ...prev.auth, loginUrl: v },
+                  }))
+                }
+                onPaste={(event) => {
+                  const cleaned = String(event.text).replace(/\r?\n/g, " ");
+                  setState((prev) => ({
+                    ...prev,
+                    auth: {
+                      ...prev.auth,
+                      loginUrl: prev.auth.loginUrl + cleaned,
+                    },
+                  }));
+                }}
+                focused={focusedField === 0}
+              />
+              <Input
+                label="Username"
+                placeholder="admin"
+                value={state.auth.username}
+                onInput={(v) =>
+                  setState((prev) => ({
+                    ...prev,
+                    auth: { ...prev.auth, username: v },
+                  }))
+                }
+                onPaste={(event) => {
+                  const cleaned = String(event.text).replace(/\r?\n/g, " ");
+                  setState((prev) => ({
+                    ...prev,
+                    auth: {
+                      ...prev.auth,
+                      username: prev.auth.username + cleaned,
+                    },
+                  }));
+                }}
+                focused={focusedField === 1}
+              />
+              <Input
+                label="Password"
+                placeholder="••••••••"
+                value={state.auth.password}
+                onInput={(v) =>
+                  setState((prev) => ({
+                    ...prev,
+                    auth: { ...prev.auth, password: v },
+                  }))
+                }
+                onPaste={(event) => {
+                  const cleaned = String(event.text).replace(/\r?\n/g, " ");
+                  setState((prev) => ({
+                    ...prev,
+                    auth: {
+                      ...prev.auth,
+                      password: prev.auth.password + cleaned,
+                    },
+                  }));
+                }}
+                focused={focusedField === 2}
+              />
+              <Input
+                label="Auth Instructions"
+                placeholder="Use OAuth flow, extract bearer token..."
+                value={state.auth.instructions}
+                onInput={(v) =>
+                  setState((prev) => ({
+                    ...prev,
+                    auth: { ...prev.auth, instructions: v },
+                  }))
+                }
+                onPaste={(event) => {
+                  const cleaned = String(event.text).replace(/\r?\n/g, " ");
+                  setState((prev) => ({
+                    ...prev,
+                    auth: {
+                      ...prev.auth,
+                      instructions: prev.auth.instructions + cleaned,
+                    },
+                  }));
+                }}
+                focused={focusedField === 3}
+              />
+            </box>
+          )}
+        </box>
+
+        {/* Scope Section */}
+        <box flexDirection="column" gap={1}>
+          <text>
+            <span fg={colors.primary}>█ </span>
+            <span fg={focusedSection === 1 ? colors.text : colors.textMuted}>
+              Scope Constraints
+            </span>
+          </text>
+          {focusedSection === 1 && (
+            <box flexDirection="column" gap={1} paddingLeft={2}>
+              <Input
+                label="Add Allowed Host"
+                description="Press Enter to add"
+                placeholder="example.com"
+                value={hostInput}
+                onInput={setHostInput}
+                focused={focusedField === 0}
+              />
+              {state.scope.allowedHosts.length > 0 && (
+                <box flexDirection="column" paddingLeft={2}>
+                  {state.scope.allowedHosts.map((h, i) => (
+                    <text key={i} fg={colors.textMuted}>
+                      • {h}
+                    </text>
+                  ))}
+                </box>
+              )}
+              <Input
+                label="Add Allowed Port"
+                description="Press Enter to add"
+                placeholder="443"
+                value={portInput}
+                onInput={setPortInput}
+                focused={focusedField === 1}
+              />
+              {state.scope.allowedPorts.length > 0 && (
+                <box flexDirection="column" paddingLeft={2}>
+                  {state.scope.allowedPorts.map((p, i) => (
+                    <text key={i} fg={colors.textMuted}>
+                      • {p}
+                    </text>
+                  ))}
+                </box>
+              )}
+              <box flexDirection="row" gap={1}>
+                <text fg={focusedField === 2 ? colors.text : colors.textMuted}>
+                  Strict Scope:
+                </text>
+                <text
+                  fg={
+                    state.scope.strictScope ? colors.primary : colors.textMuted
+                  }
+                >
+                  {state.scope.strictScope ? "● Enabled" : "○ Disabled"}
+                </text>
+                {focusedField === 2 && (
+                  <text fg={colors.textMuted}>(↑/↓ to toggle)</text>
+                )}
+              </box>
+              <box flexDirection="row" gap={1}>
+                <text
+                  fg={focusedField === 3 ? colors.primary : colors.textMuted}
+                >
+                  Enumerate Subdomains:
+                </text>
+                <text
+                  fg={
+                    state.scope.enumerateSubdomains
+                      ? colors.primary
+                      : colors.textMuted
+                  }
+                >
+                  {state.scope.enumerateSubdomains ? "● Enabled" : "○ Disabled"}
+                </text>
+                {focusedField === 3 && (
+                  <text fg={colors.textMuted}>(↑/↓ to toggle)</text>
+                )}
+              </box>
+            </box>
+          )}
+        </box>
+
+        {/* Headers Section */}
+        <box flexDirection="column" gap={1}>
+          <text>
+            <span fg={colors.primary}>█ </span>
+            <span fg={focusedSection === 2 ? colors.text : colors.textMuted}>
+              Request Headers
+            </span>
+          </text>
+          {focusedSection === 2 && (
+            <box flexDirection="column" gap={1} paddingLeft={2}>
+              <box flexDirection="column">
+                <text
+                  fg={
+                    state.headers.mode === "none"
+                      ? colors.primary
+                      : colors.textMuted
+                  }
+                >
+                  {state.headers.mode === "none" ? "●" : "○"} None
+                </text>
+                <text
+                  fg={
+                    state.headers.mode === "default"
+                      ? colors.primary
+                      : colors.textMuted
+                  }
+                >
+                  {state.headers.mode === "default" ? "●" : "○"} Default
+                  (User-Agent: pensar-apex)
+                </text>
+                <text
+                  fg={
+                    state.headers.mode === "custom"
+                      ? colors.primary
+                      : colors.textMuted
+                  }
+                >
+                  {state.headers.mode === "custom" ? "●" : "○"} Custom
+                </text>
+              </box>
+              {focusedField === 0 && (
+                <text fg={colors.textMuted}>Use ↑/↓ to select</text>
+              )}
+
+              {state.headers.mode === "custom" && (
+                <box flexDirection="column" gap={1}>
+                  <Input
+                    label="Header Name"
+                    placeholder="X-Custom-Header"
+                    value={headerNameInput}
+                    onInput={setHeaderNameInput}
+                    focused={focusedField === 1}
+                  />
+                  <Input
+                    label="Header Value"
+                    placeholder="value"
+                    value={headerValueInput}
+                    onInput={setHeaderValueInput}
+                    focused={focusedField === 2}
+                  />
+                  {Object.keys(state.headers.customHeaders).length > 0 && (
+                    <box flexDirection="column">
+                      {Object.entries(state.headers.customHeaders).map(
+                        ([k, v]) => (
+                          <text key={k} fg={colors.textMuted}>
+                            • {k}: {v}
+                          </text>
+                        ),
+                      )}
+                    </box>
+                  )}
+                </box>
+              )}
+            </box>
+          )}
+        </box>
+
+        {/* Model Section */}
+        <box flexDirection="column" gap={1}>
+          <text>
+            <span fg={colors.primary}>█ </span>
+            <span fg={focusedSection === 3 ? colors.text : colors.textMuted}>
+              AI Model
+            </span>
+            <span fg={colors.textMuted}> ({model.name})</span>
+            <span fg={colors.textMuted}>
+              {" "}
+              [{isModelUserSelected ? "user" : "default"}]
+            </span>
+          </text>
+          {focusedSection === 3 && (
+            <box flexDirection="column" gap={0} paddingLeft={2}>
+              {/* Search input */}
+              {modelSearchQuery && (
+                <text fg={colors.text}>Search: {modelSearchQuery}_</text>
+              )}
+              {!modelSearchQuery && (
+                <text fg={colors.textMuted}>Type to search models...</text>
+              )}
+
+              {/* Provider groups */}
+              {providerOrder.map((provider) => {
+                const models = groupedModels[provider];
+                if (!models || models.length === 0) return null;
+
+                const isExpanded = expandedProviders.has(provider);
+                const providerName = providerNames[provider] || provider;
+
+                return (
+                  <box key={provider} flexDirection="column" gap={0}>
+                    {/* Provider header */}
+                    <text fg={isExpanded ? colors.text : colors.textMuted}>
+                      {isExpanded ? "▾" : "▸"} {providerName} ({models.length})
+                    </text>
+
+                    {/* Models list (when expanded) */}
+                    {isExpanded && (
+                      <box flexDirection="column" gap={0} paddingLeft={2}>
+                        {models.map((m) => {
+                          const isSelected = m.id === model.id;
+                          const isDefault =
+                            m.id === "claude-haiku-4-5" ||
+                            m.id === "gpt-4o-mini";
+                          return (
+                            <text
+                              key={m.id}
+                              fg={
+                                isSelected ? colors.primary : colors.textMuted
+                              }
+                            >
+                              {isSelected ? "●" : "○"} {m.name}
+                              {isDefault && !isModelUserSelected && isSelected
+                                ? " [default]"
+                                : ""}
+                            </text>
+                          );
+                        })}
+                      </box>
+                    )}
+                  </box>
+                );
+              })}
+
+              {/* Help text */}
+              <text fg={colors.textMuted}>
+                ↑/↓ select • Type to search • ←/→ collapse/expand
+              </text>
+            </box>
           )}
         </box>
 
@@ -658,387 +1044,22 @@ export default function WebWizard({
             <span fg={colors.primary}>█ </span>
             <span fg={colors.textMuted}>Press </span>
             <span fg={colors.text}>[Enter]</span>
-            <span fg={colors.textMuted}> to start immediately</span>
+            <span fg={colors.textMuted}> to start pentest ({modeLabel})</span>
           </text>
           <text>
             <span fg={colors.primary}>█ </span>
             <span fg={colors.textMuted}>Press </span>
             <span fg={colors.text}>[Tab]</span>
-            <span fg={colors.textMuted}> to configure options</span>
+            <span fg={colors.textMuted}> to navigate fields</span>
           </text>
           <text>
             <span fg={colors.primary}>█ </span>
             <span fg={colors.textMuted}>Press </span>
             <span fg={colors.text}>[ESC]</span>
-            <span fg={colors.textMuted}> to cancel</span>
+            <span fg={colors.textMuted}> to go back</span>
           </text>
         </box>
       </box>
-      </Dialog>
-    );
-  }
-
-  // Render configure step
-  return (
-    <Dialog size="large" onClose={onClose}>
-    <box width="100%" flexDirection="column" gap={2} paddingLeft={4} paddingBottom={1}>
-      <box flexDirection="column">
-        <text fg={colors.text}>Configure Web App Pentest - {modeLabel}</text>
-        <text fg={colors.textMuted}>Target: {state.target}</text>
-        <text fg={colors.textMuted}>
-          All fields are optional - configure only what you need
-        </text>
-      </box>
-
-      {/* Auth Section */}
-      <box flexDirection="column" gap={1}>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={focusedSection === 0 ? colors.text : colors.textMuted}>
-            Authentication
-          </span>
-        </text>
-        {focusedSection === 0 && (
-          <box flexDirection="column" gap={1} paddingLeft={2}>
-            <Input
-              label="Login URL"
-              placeholder="https://example.com/login"
-              value={state.auth.loginUrl}
-              onInput={(v) =>
-                setState((prev) => ({
-                  ...prev,
-                  auth: { ...prev.auth, loginUrl: v },
-                }))
-              }
-              onPaste={(event) => {
-                const cleaned = String(event.text).replace(/\r?\n/g, " ");
-                setState((prev) => ({
-                  ...prev,
-                  auth: {
-                    ...prev.auth,
-                    loginUrl: prev.auth.loginUrl + cleaned,
-                  },
-                }));
-              }}
-              focused={focusedField === 0}
-            />
-            <Input
-              label="Username"
-              placeholder="admin"
-              value={state.auth.username}
-              onInput={(v) =>
-                setState((prev) => ({
-                  ...prev,
-                  auth: { ...prev.auth, username: v },
-                }))
-              }
-              onPaste={(event) => {
-                const cleaned = String(event.text).replace(/\r?\n/g, " ");
-                setState((prev) => ({
-                  ...prev,
-                  auth: {
-                    ...prev.auth,
-                    username: prev.auth.username + cleaned,
-                  },
-                }));
-              }}
-              focused={focusedField === 1}
-            />
-            <Input
-              label="Password"
-              placeholder="••••••••"
-              value={state.auth.password}
-              onInput={(v) =>
-                setState((prev) => ({
-                  ...prev,
-                  auth: { ...prev.auth, password: v },
-                }))
-              }
-              onPaste={(event) => {
-                const cleaned = String(event.text).replace(/\r?\n/g, " ");
-                setState((prev) => ({
-                  ...prev,
-                  auth: {
-                    ...prev.auth,
-                    password: prev.auth.password + cleaned,
-                  },
-                }));
-              }}
-              focused={focusedField === 2}
-            />
-            <Input
-              label="Auth Instructions"
-              placeholder="Use OAuth flow, extract bearer token..."
-              value={state.auth.instructions}
-              onInput={(v) =>
-                setState((prev) => ({
-                  ...prev,
-                  auth: { ...prev.auth, instructions: v },
-                }))
-              }
-              onPaste={(event) => {
-                const cleaned = String(event.text).replace(/\r?\n/g, " ");
-                setState((prev) => ({
-                  ...prev,
-                  auth: {
-                    ...prev.auth,
-                    instructions: prev.auth.instructions + cleaned,
-                  },
-                }));
-              }}
-              focused={focusedField === 3}
-            />
-          </box>
-        )}
-      </box>
-
-      {/* Scope Section */}
-      <box flexDirection="column" gap={1}>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={focusedSection === 1 ? colors.text : colors.textMuted}>
-            Scope Constraints
-          </span>
-        </text>
-        {focusedSection === 1 && (
-          <box flexDirection="column" gap={1} paddingLeft={2}>
-            <Input
-              label="Add Allowed Host"
-              description="Press Enter to add"
-              placeholder="example.com"
-              value={hostInput}
-              onInput={setHostInput}
-              focused={focusedField === 0}
-            />
-            {state.scope.allowedHosts.length > 0 && (
-              <box flexDirection="column" paddingLeft={2}>
-                {state.scope.allowedHosts.map((h, i) => (
-                  <text key={i} fg={colors.textMuted}>
-                    • {h}
-                  </text>
-                ))}
-              </box>
-            )}
-            <Input
-              label="Add Allowed Port"
-              description="Press Enter to add"
-              placeholder="443"
-              value={portInput}
-              onInput={setPortInput}
-              focused={focusedField === 1}
-            />
-            {state.scope.allowedPorts.length > 0 && (
-              <box flexDirection="column" paddingLeft={2}>
-                {state.scope.allowedPorts.map((p, i) => (
-                  <text key={i} fg={colors.textMuted}>
-                    • {p}
-                  </text>
-                ))}
-              </box>
-            )}
-            <box flexDirection="row" gap={1}>
-              <text fg={focusedField === 2 ? colors.text : colors.textMuted}>
-                Strict Scope:
-              </text>
-              <text
-                fg={state.scope.strictScope ? colors.primary : colors.textMuted}
-              >
-                {state.scope.strictScope ? "● Enabled" : "○ Disabled"}
-              </text>
-              {focusedField === 2 && (
-                <text fg={colors.textMuted}>(↑/↓ to toggle)</text>
-              )}
-            </box>
-            <box flexDirection="row" gap={1}>
-              <text fg={focusedField === 3 ? colors.primary : colors.textMuted}>
-                Enumerate Subdomains:
-              </text>
-              <text
-                fg={
-                  state.scope.enumerateSubdomains
-                    ? colors.primary
-                    : colors.textMuted
-                }
-              >
-                {state.scope.enumerateSubdomains ? "● Enabled" : "○ Disabled"}
-              </text>
-              {focusedField === 3 && (
-                <text fg={colors.textMuted}>(↑/↓ to toggle)</text>
-              )}
-            </box>
-          </box>
-        )}
-      </box>
-
-      {/* Headers Section */}
-      <box flexDirection="column" gap={1}>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={focusedSection === 2 ? colors.text : colors.textMuted}>
-            Request Headers
-          </span>
-        </text>
-        {focusedSection === 2 && (
-          <box flexDirection="column" gap={1} paddingLeft={2}>
-            <box flexDirection="column">
-              <text
-                fg={
-                  state.headers.mode === "none"
-                    ? colors.primary
-                    : colors.textMuted
-                }
-              >
-                {state.headers.mode === "none" ? "●" : "○"} None
-              </text>
-              <text
-                fg={
-                  state.headers.mode === "default"
-                    ? colors.primary
-                    : colors.textMuted
-                }
-              >
-                {state.headers.mode === "default" ? "●" : "○"} Default
-                (User-Agent: pensar-apex)
-              </text>
-              <text
-                fg={
-                  state.headers.mode === "custom"
-                    ? colors.primary
-                    : colors.textMuted
-                }
-              >
-                {state.headers.mode === "custom" ? "●" : "○"} Custom
-              </text>
-            </box>
-            {focusedField === 0 && (
-              <text fg={colors.textMuted}>Use ↑/↓ to select</text>
-            )}
-
-            {state.headers.mode === "custom" && (
-              <box flexDirection="column" gap={1}>
-                <Input
-                  label="Header Name"
-                  placeholder="X-Custom-Header"
-                  value={headerNameInput}
-                  onInput={setHeaderNameInput}
-                  focused={focusedField === 1}
-                />
-                <Input
-                  label="Header Value"
-                  placeholder="value"
-                  value={headerValueInput}
-                  onInput={setHeaderValueInput}
-                  focused={focusedField === 2}
-                />
-                {Object.keys(state.headers.customHeaders).length > 0 && (
-                  <box flexDirection="column">
-                    {Object.entries(state.headers.customHeaders).map(
-                      ([k, v]) => (
-                        <text key={k} fg={colors.textMuted}>
-                          • {k}: {v}
-                        </text>
-                      ),
-                    )}
-                  </box>
-                )}
-              </box>
-            )}
-          </box>
-        )}
-      </box>
-
-      {/* Model Section */}
-      <box flexDirection="column" gap={1}>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={focusedSection === 3 ? colors.text : colors.textMuted}>
-            AI Model
-          </span>
-          <span fg={colors.textMuted}> ({model.name})</span>
-          <span fg={colors.textMuted}>
-            {" "}
-            [{isModelUserSelected ? "user" : "default"}]
-          </span>
-        </text>
-        {focusedSection === 3 && (
-          <box flexDirection="column" gap={0} paddingLeft={2}>
-            {/* Search input */}
-            {modelSearchQuery && (
-              <text fg={colors.text}>Search: {modelSearchQuery}_</text>
-            )}
-            {!modelSearchQuery && (
-              <text fg={colors.textMuted}>Type to search models...</text>
-            )}
-
-            {/* Provider groups */}
-            {providerOrder.map((provider) => {
-              const models = groupedModels[provider];
-              if (!models || models.length === 0) return null;
-
-              const isExpanded = expandedProviders.has(provider);
-              const providerName = providerNames[provider] || provider;
-
-              return (
-                <box key={provider} flexDirection="column" gap={0}>
-                  {/* Provider header */}
-                  <text fg={isExpanded ? colors.text : colors.textMuted}>
-                    {isExpanded ? "▾" : "▸"} {providerName} ({models.length})
-                  </text>
-
-                  {/* Models list (when expanded) */}
-                  {isExpanded && (
-                    <box flexDirection="column" gap={0} paddingLeft={2}>
-                      {models.map((m) => {
-                        const isSelected = m.id === model.id;
-                        const isDefault =
-                          m.id === "claude-haiku-4-5" || m.id === "gpt-4o-mini";
-                        return (
-                          <text
-                            key={m.id}
-                            fg={isSelected ? colors.primary : colors.textMuted}
-                          >
-                            {isSelected ? "●" : "○"} {m.name}
-                            {isDefault && !isModelUserSelected && isSelected
-                              ? " [default]"
-                              : ""}
-                          </text>
-                        );
-                      })}
-                    </box>
-                  )}
-                </box>
-              );
-            })}
-
-            {/* Help text */}
-            <text fg={colors.textMuted}>
-              ↑/↓ select • Type to search • ←/→ collapse/expand
-            </text>
-          </box>
-        )}
-      </box>
-
-      <box flexDirection="column" gap={0} marginTop={1}>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={colors.textMuted}>Press </span>
-          <span fg={colors.text}>[Enter]</span>
-          <span fg={colors.textMuted}> to start pentest ({modeLabel})</span>
-        </text>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={colors.textMuted}>Press </span>
-          <span fg={colors.text}>[Tab]</span>
-          <span fg={colors.textMuted}> to navigate fields</span>
-        </text>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={colors.textMuted}>Press </span>
-          <span fg={colors.text}>[ESC]</span>
-          <span fg={colors.textMuted}> to go back</span>
-        </text>
-      </box>
-    </box>
     </Dialog>
   );
 }

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -48,6 +48,7 @@ interface CommandProviderProps {
   onOpenSessionsDialog?: () => void;
   onOpenThemeDialog?: () => void;
   onOpenAuthDialog?: () => void;
+  onOpenPentestDialog?: (flags?: Record<string, any>) => void;
 }
 
 export function CommandProvider({
@@ -55,6 +56,7 @@ export function CommandProvider({
   onOpenSessionsDialog,
   onOpenThemeDialog,
   onOpenAuthDialog,
+  onOpenPentestDialog,
 }: CommandProviderProps) {
   const route = useRoute();
   const [skills, setSkills] = useState<Skill[]>([]);
@@ -66,9 +68,10 @@ export function CommandProvider({
       openSessionsDialog: onOpenSessionsDialog,
       openThemeDialog: onOpenThemeDialog,
       openAuthDialog: onOpenAuthDialog,
+      openPentestDialog: onOpenPentestDialog,
     };
     return ctx;
-  }, [route, onOpenSessionsDialog, onOpenThemeDialog, onOpenAuthDialog]);
+  }, [route, onOpenSessionsDialog, onOpenThemeDialog, onOpenAuthDialog, onOpenPentestDialog]);
 
   const refreshSkills = useCallback(async () => {
     const loaded = await loadSkills();

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -14,7 +14,7 @@ import {
   type AppCommandContext,
 } from "../command-registry";
 import type { AutocompleteOption } from "../components/shared/prompt-input";
-import { useRoute } from "./route";
+import { useRoute, type WebCommandOptions } from "./route";
 import { loadSkills, slugify, type Skill } from "../../core/skills";
 
 interface CommandContextValue {
@@ -48,7 +48,7 @@ interface CommandProviderProps {
   onOpenSessionsDialog?: () => void;
   onOpenThemeDialog?: () => void;
   onOpenAuthDialog?: () => void;
-  onOpenPentestDialog?: (flags?: Record<string, any>) => void;
+  onOpenPentestDialog?: (flags?: WebCommandOptions) => void;
 }
 
 export function CommandProvider({
@@ -71,7 +71,13 @@ export function CommandProvider({
       openPentestDialog: onOpenPentestDialog,
     };
     return ctx;
-  }, [route, onOpenSessionsDialog, onOpenThemeDialog, onOpenAuthDialog, onOpenPentestDialog]);
+  }, [
+    route,
+    onOpenSessionsDialog,
+    onOpenThemeDialog,
+    onOpenAuthDialog,
+    onOpenPentestDialog,
+  ]);
 
   const refreshSkills = useCallback(async () => {
     const loaded = await loadSkills();

--- a/src/tui/context/route.tsx
+++ b/src/tui/context/route.tsx
@@ -12,7 +12,6 @@ export type RoutePath =
   | "help"
   | "pentest"
   | "thorough"
-  | "web"
   | "operator"
   | "chat"
   | "dns"

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -10,6 +10,7 @@ import HITLWizard from "./components/commands/operator-wizard";
 import WebWizard from "./components/commands/web-wizard";
 import ProviderManager from "./components/commands/provider-manager";
 import type { Config } from "../core/config/config";
+import type { SessionConfig } from "../core/session";
 import { config } from "../core/config";
 import { createCliRenderer } from "@opentui/core";
 import { ConfigProvider, useConfig } from "./context/config";
@@ -68,6 +69,8 @@ function App({ appConfig }: AppProps) {
   const [showShortcutsDialog, setShowShortcutsDialog] = useState(false);
   const [showThemeDialog, setShowThemeDialog] = useState(false);
   const [showAuthDialog, setShowAuthDialog] = useState(false);
+  const [showPentestDialog, setShowPentestDialog] = useState(false);
+  const [pendingPentestFlags, setPendingPentestFlags] = useState<Record<string, any> | undefined>(undefined);
 
   const navigableItems = ["command-input"];
 
@@ -83,6 +86,10 @@ function App({ appConfig }: AppProps) {
                     onOpenSessionsDialog={() => setShowSessionsDialog(true)}
                     onOpenThemeDialog={() => setShowThemeDialog(true)}
                     onOpenAuthDialog={() => setShowAuthDialog(true)}
+                    onOpenPentestDialog={(flags) => {
+                      setPendingPentestFlags(flags);
+                      setShowPentestDialog(true);
+                    }}
                   >
                     <KeybindingProvider
                       deps={{
@@ -106,6 +113,10 @@ function App({ appConfig }: AppProps) {
                         setShowThemeDialog={setShowThemeDialog}
                         showAuthDialog={showAuthDialog}
                         setShowAuthDialog={setShowAuthDialog}
+                        showPentestDialog={showPentestDialog}
+                        setShowPentestDialog={setShowPentestDialog}
+                        pendingPentestFlags={pendingPentestFlags}
+                        setPendingPentestFlags={setPendingPentestFlags}
                         cwd={cwd}
                         setCtrlCPressTime={setCtrlCPressTime}
                         showExitWarning={showExitWarning}
@@ -135,6 +146,10 @@ function AppContent({
   setShowThemeDialog,
   showAuthDialog,
   setShowAuthDialog,
+  showPentestDialog,
+  setShowPentestDialog,
+  pendingPentestFlags,
+  setPendingPentestFlags,
   cwd,
   setCtrlCPressTime,
   showExitWarning,
@@ -151,6 +166,10 @@ function AppContent({
   setShowThemeDialog: (show: boolean) => void;
   showAuthDialog: boolean;
   setShowAuthDialog: (show: boolean) => void;
+  showPentestDialog: boolean;
+  setShowPentestDialog: (show: boolean) => void;
+  pendingPentestFlags: Record<string, any> | undefined;
+  setPendingPentestFlags: (flags: Record<string, any> | undefined) => void;
   cwd: string;
   setCtrlCPressTime: (time: number | null) => void;
   showExitWarning: boolean;
@@ -197,13 +216,13 @@ function AppContent({
     }
   }, [config.data.responsibleUseAccepted, route.data]);
 
-  // Track external dialog state for theme/auth dialogs so operator input
+  // Track external dialog state for theme/auth/pentest dialogs so operator input
   // unfocuses while a dialog overlay is open
   useEffect(() => {
-    if (showThemeDialog || showAuthDialog) {
+    if (showThemeDialog || showAuthDialog || showPentestDialog) {
       setExternalDialogOpen(true);
     }
-  }, [showThemeDialog, showAuthDialog]);
+  }, [showThemeDialog, showAuthDialog, showPentestDialog]);
 
   // Auto-clear the exit warning after 1 second
   useEffect(() => {
@@ -249,6 +268,25 @@ function AppContent({
     refocusPrompt();
   };
 
+  const handleClosePentestDialog = () => {
+    setShowPentestDialog(false);
+    setPendingPentestFlags(undefined);
+    setTimeout(() => {
+      setExternalDialogOpen(false);
+    }, 0);
+    setInputKey((prev) => prev + 1);
+    refocusPrompt();
+  };
+
+  const handleStartPentest = (targets: string[], sessionConfig: SessionConfig) => {
+    setShowPentestDialog(false);
+    setPendingPentestFlags(undefined);
+    setTimeout(() => {
+      setExternalDialogOpen(false);
+    }, 0);
+    route.navigate({ type: "pentest", targets, sessionConfig });
+  };
+
   // Check if we're on the home route
   const isHomeRoute = route.data.type === "base" && route.data.path === "home";
 
@@ -284,6 +322,26 @@ function AppContent({
       {showThemeDialog && <ThemePicker onClose={handleCloseThemeDialog} />}
 
       {showAuthDialog && <AuthFlow onClose={handleCloseAuthDialog} />}
+
+      {showPentestDialog && (
+        <WebWizard
+          onClose={handleClosePentestDialog}
+          onStartPentest={handleStartPentest}
+          initialTarget={pendingPentestFlags?.target}
+          autoMode={pendingPentestFlags?.auto}
+          initialName={pendingPentestFlags?.name}
+          initialAuthUrl={pendingPentestFlags?.authUrl}
+          initialAuthUser={pendingPentestFlags?.authUser}
+          initialAuthPass={pendingPentestFlags?.authPass}
+          initialAuthInstructions={pendingPentestFlags?.authInstructions}
+          initialHosts={pendingPentestFlags?.hosts}
+          initialPorts={pendingPentestFlags?.ports}
+          initialStrict={pendingPentestFlags?.strict}
+          initialHeadersMode={pendingPentestFlags?.headersMode}
+          initialCustomHeaders={pendingPentestFlags?.customHeaders}
+          initialModel={pendingPentestFlags?.model}
+        />
+      )}
     </box>
   );
 }
@@ -345,23 +403,6 @@ function CommandDisplay({
               initialTarget={route.data.options?.target}
               initialName={route.data.options?.name}
               initialRequireApproval={route.data.options?.requireApproval}
-              initialModel={route.data.options?.model}
-            />
-          </RouteSwitch.Case>
-          <RouteSwitch.Case when="web">
-            <WebWizard
-              initialTarget={route.data.options?.target}
-              autoMode={route.data.options?.auto}
-              initialName={route.data.options?.name}
-              initialAuthUrl={route.data.options?.authUrl}
-              initialAuthUser={route.data.options?.authUser}
-              initialAuthPass={route.data.options?.authPass}
-              initialAuthInstructions={route.data.options?.authInstructions}
-              initialHosts={route.data.options?.hosts}
-              initialPorts={route.data.options?.ports}
-              initialStrict={route.data.options?.strict}
-              initialHeadersMode={route.data.options?.headersMode}
-              initialCustomHeaders={route.data.options?.customHeaders}
               initialModel={route.data.options?.model}
             />
           </RouteSwitch.Case>

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -15,7 +15,12 @@ import { config } from "../core/config";
 import { createCliRenderer } from "@opentui/core";
 import { ConfigProvider, useConfig } from "./context/config";
 import { createSwitch } from "./components/switch";
-import { type RoutePath, RouteProvider, useRoute } from "./context/route";
+import {
+  type RoutePath,
+  type WebCommandOptions,
+  RouteProvider,
+  useRoute,
+} from "./context/route";
 import { ResponsibleUseDisclosure } from "./components/responsible-use-disclosure";
 import { hasAnyProviderConfigured } from "../core/providers";
 import { SessionProvider } from "./context/session";
@@ -70,7 +75,9 @@ function App({ appConfig }: AppProps) {
   const [showThemeDialog, setShowThemeDialog] = useState(false);
   const [showAuthDialog, setShowAuthDialog] = useState(false);
   const [showPentestDialog, setShowPentestDialog] = useState(false);
-  const [pendingPentestFlags, setPendingPentestFlags] = useState<Record<string, any> | undefined>(undefined);
+  const [pendingPentestFlags, setPendingPentestFlags] = useState<
+    WebCommandOptions | undefined
+  >(undefined);
 
   const navigableItems = ["command-input"];
 
@@ -168,8 +175,8 @@ function AppContent({
   setShowAuthDialog: (show: boolean) => void;
   showPentestDialog: boolean;
   setShowPentestDialog: (show: boolean) => void;
-  pendingPentestFlags: Record<string, any> | undefined;
-  setPendingPentestFlags: (flags: Record<string, any> | undefined) => void;
+  pendingPentestFlags: WebCommandOptions | undefined;
+  setPendingPentestFlags: (flags: WebCommandOptions | undefined) => void;
   cwd: string;
   setCtrlCPressTime: (time: number | null) => void;
   showExitWarning: boolean;
@@ -278,7 +285,10 @@ function AppContent({
     refocusPrompt();
   };
 
-  const handleStartPentest = (targets: string[], sessionConfig: SessionConfig) => {
+  const handleStartPentest = (
+    targets: string[],
+    sessionConfig: SessionConfig,
+  ) => {
     setShowPentestDialog(false);
     setPendingPentestFlags(undefined);
     setTimeout(() => {

--- a/src/tui/keybindings/registry.ts
+++ b/src/tui/keybindings/registry.ts
@@ -82,13 +82,12 @@ export function createKeybindings(
         }
 
         const isHome = route.data.type === "base" && route.data.path === "home";
-        const isWeb = route.data.type === "base" && route.data.path === "web";
         const isOperator =
           route.data.type === "base" && route.data.path === "operator";
         const isSession =
           route.data.type === "pentest" || route.data.type === "operator";
 
-        if (!isHome && !isWeb && !isOperator && !isSession) {
+        if (!isHome && !isOperator && !isSession) {
           route.navigate({
             type: "base",
             path: "home",


### PR DESCRIPTION
## Summary

Continues the dialog-over-navigation pattern from #311. The pentest wizard now opens as a dialog overlay instead of navigating to a dedicated page. Users stay in context (home or operator view) while configuring, and can ESC to cancel without losing their place. Navigation only happens once the session actually starts.

## Screen Recording
https://github.com/user-attachments/assets/db98f230-392f-4e58-8759-d107f5c0f019

## Test plan
- [x] `/pentest` from home — dialog overlays home, ESC dismisses
- [x] `/pentest` from operator — dialog overlays operator, ESC returns to session
- [x] Text input works in all wizard fields
- [x] Completing wizard navigates to pentest grid
- [x] `/pentest --target ... --auth-user ...` still skips wizard entirely

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/navigation refactor that changes how the pentest wizard is launched and dismissed; risk is mainly around focus/keyboard handling and ensuring session start/cancel flows still behave correctly from all screens.
> 
> **Overview**
> Refactors the `/pentest` (web) flow so the WebWizard opens as a **dialog overlay** rather than navigating to a dedicated `base` route.
> 
> Adds a new `openPentestDialog` hook through `AppCommandContext`/`CommandProvider`, wires `index.tsx` to manage wizard open/close state and start navigation only on completion, and removes the `"web"` route case.
> 
> Updates `WebWizard` to be route-independent (`onClose`/`onStartPentest` callbacks), wrap its steps in `Dialog`, and tighten keyboard handling by calling `key.preventDefault()` for ESC/Tab/Enter/arrow interactions to avoid input conflicts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c47e0406050dec1a3d708000418323c8c35c668e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->