### PR TITLE
Clean Up Close Listener in PersistentShell.execute()

### DIFF
--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -123,6 +123,7 @@ export class PersistentShell {
         if (abortCleanup) abortCleanup();
         proc.stdout!.removeListener("data", onStdout);
         proc.stderr!.removeListener("data", onStderr);
+        proc.removeListener("close", onClose);
         resolve(result);
       };
 


### PR DESCRIPTION
## What does this PR do?

Fixes an `EventEmitter` memory leak in `PersistentShell` where close listeners accumulate on the `ChildProcess` across `execute()` calls.

Each `execute()` registers a `proc.once("close", onClose)` handler as a safety net in case the shell dies mid-command. When the command completes normally (exit marker received on stdout), `safeResolve` cleans up the data listeners on `stdout`/`stderr` but never removes the `onClose` listener. Since `once` only auto-removes when it actually fires—and the shell intentionally stays alive between commands—each call leaks one listener. After 11 commands on the same shell, Node emits `MaxListenersExceededWarning`.

The fix adds `proc.removeListener("close", onClose)` to `safeResolve`, which is the single resolution path for all cases (normal completion, timeout, abort, cancel), so the listener is always cleaned up regardless of how the command finishes.

## How did you verify your code works?

Traced the stack from the warning:
```
at once (node:events:200:36)
at <anonymous> (persistentShell.ts:211:12)
```

This points directly to the `proc.once("close", onClose)` call. Confirmed by reading the code that `safeResolve` removes `onStdout` and `onStderr` listeners but not `onClose`, and that no other code path removes it either. The `onClose` handler and `safeResolve` reference each other (mutual cleanup pattern), which is already established in the codebase—`onClose` calls `safeResolve`, and now `safeResolve` removes `onClose`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to listener cleanup in process execution; behavior should only reduce leaked listeners without altering command semantics.
> 
> **Overview**
> Prevents an `EventEmitter` listener leak in `PersistentShell.execute()` by ensuring the per-command `proc.once("close", onClose)` handler is always cleaned up when a command resolves.
> 
> `safeResolve()` now removes the `close` listener alongside `stdout`/`stderr` listeners, avoiding accumulated `close` handlers (and `MaxListenersExceededWarning`) across repeated `execute()` calls on the same long-lived shell.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8027e4e0b02c9cde0fbae4cf7ddbd244cbb5aba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->