### PR TITLE
feat: persist and restore auth cookies+headers into browser for pentest handoff

### DIFF
--- a/src/core/agents/offSecAgent/tools/browserTools.ts
+++ b/src/core/agents/offSecAgent/tools/browserTools.ts
@@ -20,7 +20,8 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { join } from "path";
-import { createBrowserTools } from "./playwrightMcp";
+import { existsSync, readFileSync } from "fs";
+import { createBrowserTools, type BrowserAuthData } from "./playwrightMcp";
 import { createSandboxBrowserTools } from "./sandboxPlaywright";
 import type { ToolContext } from "./types";
 
@@ -54,15 +55,18 @@ export type BrowserToolName = (typeof BROWSER_TOOL_NAMES)[number];
  * credential-aware wrapper that resolves secrets from IDs at execution time.
  */
 export function createBrowserToolset(ctx: ToolContext) {
-  // Sandbox mode: use direct Playwright execution inside the sandbox
+  const authData = loadAuthData(ctx.session.rootPath);
+
   const tools = ctx.sandbox
-    ? createSandboxBrowserTools(ctx)
+    ? createSandboxBrowserTools(ctx, authData)
     : createBrowserTools(
         ctx.target ?? "",
         join(ctx.session.rootPath, "evidence"),
         "operator",
         undefined,
         ctx.abortSignal,
+        undefined,
+        authData,
       );
 
   if (!ctx.credentialManager) {
@@ -173,4 +177,33 @@ export function createBrowserToolset(ctx: ToolContext) {
     ...tools,
     browser_fill: credentialAwareFill,
   };
+}
+
+/**
+ * Read persisted auth state from `<sessionRoot>/auth/auth-data.json`.
+ * Returns `undefined` when the file is absent or the session was not
+ * authenticated.
+ */
+function loadAuthData(sessionRootPath: string): BrowserAuthData | undefined {
+  const authDataPath = join(sessionRootPath, "auth", "auth-data.json");
+  if (!existsSync(authDataPath)) return undefined;
+
+  try {
+    const raw = JSON.parse(readFileSync(authDataPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    if (!raw.authenticated) return undefined;
+
+    return {
+      cookies: (raw.cookies as string) || undefined,
+      rawCookies: Array.isArray(raw.rawCookies)
+        ? (raw.rawCookies as BrowserAuthData["rawCookies"])
+        : undefined,
+      headers: raw.headers as Record<string, string> | undefined,
+      target: (raw.target as string) || undefined,
+    };
+  } catch {
+    return undefined;
+  }
 }

--- a/src/core/agents/offSecAgent/tools/completeAuthentication.ts
+++ b/src/core/agents/offSecAgent/tools/completeAuthentication.ts
@@ -55,6 +55,22 @@ This tool marks the end of the authentication flow.`,
         .describe(
           'Auth headers to include in future requests (e.g. {"Authorization": "Bearer <token>"})',
         ),
+      rawCookies: z
+        .array(
+          z.object({
+            name: z.string(),
+            value: z.string(),
+            domain: z.string(),
+            path: z.string().optional(),
+            httpOnly: z.boolean().optional(),
+            secure: z.boolean().optional(),
+          }),
+        )
+        .optional()
+        .describe(
+          "Full cookie objects from browser_get_cookies (includes domain, path, httpOnly, secure). " +
+            "Pass the cookies array from browser_get_cookies for full browser state restoration in downstream agents.",
+        ),
       strategy: z
         .string()
         .optional()
@@ -87,7 +103,9 @@ This tool marks the end of the authentication flow.`,
 
       if (
         result.success &&
-        (result.exportedCookies || result.exportedHeaders)
+        (result.exportedCookies ||
+          result.exportedHeaders ||
+          (result.rawCookies && result.rawCookies.length > 0))
       ) {
         try {
           const authDir = join(ctx.session.rootPath, AUTH_DIR);
@@ -101,6 +119,7 @@ This tool marks the end of the authentication flow.`,
             authenticated: true,
             strategy: result.strategy || "unknown",
             cookies: result.exportedCookies || "",
+            rawCookies: result.rawCookies || [],
             headers: result.exportedHeaders || {},
             summary: result.summary,
             target: ctx.target || "",

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -499,6 +499,22 @@ export class PlaywrightMcpSession {
   }
 }
 
+/**
+ * Extract the hostname from a URL or bare host string.
+ * Returns `undefined` when parsing fails.
+ */
+function deriveHostname(urlOrHost: string): string | undefined {
+  if (!urlOrHost) return undefined;
+  try {
+    const withScheme = urlOrHost.includes("://")
+      ? urlOrHost
+      : `https://${urlOrHost}`;
+    return new URL(withScheme).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
 // Mode-specific descriptions
 const PENTEST_DESCRIPTIONS = {
   navigate: `Navigate the browser to a URL.
@@ -629,6 +645,28 @@ Use this to check for:
 
 export type BrowserToolMode = "pentest" | "operator" | "auth";
 
+/**
+ * Auth state to inject into a browser session so the pentest agent
+ * inherits cookies and headers from a prior auth test.
+ */
+export interface BrowserAuthData {
+  /** Cookie header string (e.g. "name1=value1; name2=value2") */
+  cookies?: string;
+  /** Full cookie objects with domain info — preferred over cookie string */
+  rawCookies?: Array<{
+    name: string;
+    value: string;
+    domain: string;
+    path?: string;
+    httpOnly?: boolean;
+    secure?: boolean;
+  }>;
+  /** Extra HTTP headers (e.g. {"Authorization": "Bearer ..."}) */
+  headers?: Record<string, string>;
+  /** Target URL — used to derive domain when rawCookies are absent */
+  target?: string;
+}
+
 // Auth mode descriptions - focused on authentication flows
 const AUTH_DESCRIPTIONS = {
   navigate: `Navigate the browser to a login page or auth endpoint.
@@ -688,6 +726,9 @@ Use this to check for:
  * @param abortSignal - Optional abort signal for cleanup
  * @param headless - Override headless mode for this session (defaults to the
  *   value set by {@link setHeadlessMode}, which itself defaults to `true`)
+ * @param authData - Pre-existing auth state (cookies/headers) to inject into
+ *   the browser context on the first navigation. Used by the pentest agent
+ *   to inherit the authenticated session from a prior auth test.
  */
 export function createBrowserTools(
   targetUrl: string,
@@ -696,6 +737,7 @@ export function createBrowserTools(
   logger?: Logger,
   abortSignal?: AbortSignal,
   headless?: boolean,
+  authData?: BrowserAuthData,
 ) {
   const session = new PlaywrightMcpSession(headless ?? defaultHeadless);
 
@@ -715,6 +757,72 @@ export function createBrowserTools(
         ? AUTH_DESCRIPTIONS
         : OPERATOR_DESCRIPTIONS;
 
+  // -- Auth state injection ---------------------------------------------------
+  // When authData is provided (from a prior auth test), we inject cookies and
+  // headers into the browser context after the first navigation so the pentest
+  // agent inherits the authenticated session.
+  let authInjected = false;
+  const hasAuthData =
+    authData &&
+    (authData.cookies ||
+      (authData.rawCookies && authData.rawCookies.length > 0) ||
+      (authData.headers && Object.keys(authData.headers).length > 0));
+
+  async function injectAuthState(): Promise<void> {
+    if (authInjected || !authData) return;
+    authInjected = true;
+
+    try {
+      // Build the cookie array for addCookies
+      let cookiesToSet: Array<{
+        name: string;
+        value: string;
+        domain: string;
+        path: string;
+        httpOnly?: boolean;
+        secure?: boolean;
+      }> = [];
+
+      if (authData.rawCookies && authData.rawCookies.length > 0) {
+        cookiesToSet = authData.rawCookies.map((c) => ({
+          name: c.name,
+          value: c.value,
+          domain: c.domain,
+          path: c.path || "/",
+          httpOnly: c.httpOnly,
+          secure: c.secure,
+        }));
+      } else if (authData.cookies) {
+        const targetDomain = deriveHostname(authData.target || targetUrl);
+        if (targetDomain) {
+          cookiesToSet = authData.cookies
+            .split(";")
+            .filter(Boolean)
+            .map((c) => {
+              const eqIdx = c.indexOf("=");
+              const name = eqIdx >= 0 ? c.slice(0, eqIdx).trim() : c.trim();
+              const value = eqIdx >= 0 ? c.slice(eqIdx + 1) : "";
+              return { name, value, domain: targetDomain, path: "/" };
+            })
+            .filter((c) => c.name.length > 0);
+        }
+      }
+
+      if (cookiesToSet.length > 0) {
+        const code = `async (page) => { await page.context().addCookies(${JSON.stringify(cookiesToSet)}); return 'cookies_set'; }`;
+        await session.callTool("browser_run_code", { code }, abortSignal);
+      }
+
+      // Set extra HTTP headers on the page
+      if (authData.headers && Object.keys(authData.headers).length > 0) {
+        const code = `async (page) => { await page.setExtraHTTPHeaders(${JSON.stringify(authData.headers)}); return 'headers_set'; }`;
+        await session.callTool("browser_run_code", { code }, abortSignal);
+      }
+    } catch (err) {
+      console.error(`Failed to inject auth state into browser: ${err}`);
+    }
+  }
+
   const browser_navigate = tool({
     description: `${descriptions.navigate}\n\nTarget base URL: ${targetUrl}`,
     inputSchema: BrowserNavigateInput,
@@ -728,6 +836,19 @@ export function createBrowserTools(
           { url },
           abortSignal,
         );
+
+        // On first navigation with auth data: inject cookies/headers, then
+        // re-navigate so the page loads with the authenticated context.
+        if (!authInjected && hasAuthData) {
+          await injectAuthState();
+          const reloadResult = await session.callTool(
+            "browser_navigate",
+            { url },
+            abortSignal,
+          );
+          return { success: true, url, result: reloadResult };
+        }
+
         return {
           success: true,
           url,

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -31,6 +31,7 @@ import type {
   BrowserFillResult,
   BrowserEvaluateResult,
   BrowserConsoleResult,
+  BrowserAuthData,
 } from "./playwrightMcp";
 
 // ---------------------------------------------------------------------------
@@ -321,6 +322,21 @@ const fs = require('fs');
   }
 }
 
+/**
+ * Extract the hostname from a URL or bare host string.
+ */
+function deriveHostnameForSandbox(urlOrHost: string): string | undefined {
+  if (!urlOrHost) return undefined;
+  try {
+    const withScheme = urlOrHost.includes("://")
+      ? urlOrHost
+      : `https://${urlOrHost}`;
+    return new URL(withScheme).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Input schemas (mirrors playwrightMcp.ts – kept local for decoupling)
 // ---------------------------------------------------------------------------
@@ -415,8 +431,15 @@ const BrowserGetCookiesInput = z.object({
  *
  * The factory lazily installs Playwright and launches Chromium in the sandbox
  * on the first tool invocation.
+ *
+ * @param ctx - Tool context (session, sandbox, target, etc.)
+ * @param authData - Pre-existing auth state (cookies/headers) to inject into
+ *   the browser context on the first navigation.
  */
-export function createSandboxBrowserTools(ctx: ToolContext) {
+export function createSandboxBrowserTools(
+  ctx: ToolContext,
+  authData?: BrowserAuthData,
+) {
   const sandbox = ctx.sandbox!;
   const evidenceDir = join(ctx.session.rootPath, "evidence");
   const targetUrl = ctx.target ?? "";
@@ -434,6 +457,70 @@ export function createSandboxBrowserTools(ctx: ToolContext) {
     return setupPromise;
   }
 
+  // -- Auth state injection for sandbox mode --------------------------------
+  let authInjected = false;
+  const hasAuthData =
+    authData &&
+    (authData.cookies ||
+      (authData.rawCookies && authData.rawCookies.length > 0) ||
+      (authData.headers && Object.keys(authData.headers).length > 0));
+
+  function buildAuthInjectionScript(): string {
+    if (!authData) return "";
+
+    const parts: string[] = [];
+
+    let cookiesToSet: Array<{
+      name: string;
+      value: string;
+      domain: string;
+      path: string;
+      httpOnly?: boolean;
+      secure?: boolean;
+    }> = [];
+
+    if (authData.rawCookies && authData.rawCookies.length > 0) {
+      cookiesToSet = authData.rawCookies.map((c) => ({
+        name: c.name,
+        value: c.value,
+        domain: c.domain,
+        path: c.path || "/",
+        httpOnly: c.httpOnly,
+        secure: c.secure,
+      }));
+    } else if (authData.cookies) {
+      const targetDomain = deriveHostnameForSandbox(
+        authData.target || targetUrl,
+      );
+      if (targetDomain) {
+        cookiesToSet = authData.cookies
+          .split(";")
+          .filter(Boolean)
+          .map((c) => {
+            const eqIdx = c.indexOf("=");
+            const name = eqIdx >= 0 ? c.slice(0, eqIdx).trim() : c.trim();
+            const value = eqIdx >= 0 ? c.slice(eqIdx + 1) : "";
+            return { name, value, domain: targetDomain, path: "/" };
+          })
+          .filter((c) => c.name.length > 0);
+      }
+    }
+
+    if (cookiesToSet.length > 0) {
+      parts.push(
+        `await context.addCookies(${JSON.stringify(cookiesToSet)});`,
+      );
+    }
+
+    if (authData.headers && Object.keys(authData.headers).length > 0) {
+      parts.push(
+        `await page.setExtraHTTPHeaders(${JSON.stringify(authData.headers)});`,
+      );
+    }
+
+    return parts.join("\n    ");
+  }
+
   // ------- browser_navigate -------------------------------------------------
 
   const browser_navigate = tool({
@@ -447,6 +534,28 @@ Target base URL: ${targetUrl}`,
     execute: async ({ url }): Promise<BrowserNavigateResult> => {
       try {
         await setup();
+
+        const needsAuthInjection = !authInjected && hasAuthData;
+
+        if (needsAuthInjection) {
+          authInjected = true;
+          const authScript = buildAuthInjectionScript();
+          // Navigate, inject auth, then re-navigate with cookies/headers
+          const result = (await runPlaywrightScript(
+            sandbox,
+            `
+    await page.goto(${JSON.stringify(url)}, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    ${authScript}
+    await page.goto(${JSON.stringify(url)}, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    require('fs').writeFileSync('${SANDBOX_URL_FILE}', page.url());
+    const title = await page.title();
+    resolve({ success: true, url: page.url(), title });
+            `,
+            90,
+          )) as BrowserNavigateResult;
+          return result;
+        }
+
         const result = (await runPlaywrightScript(
           sandbox,
           `

--- a/src/core/agents/specialized/authenticationAgent/prompts.ts
+++ b/src/core/agents/specialized/authenticationAgent/prompts.ts
@@ -104,9 +104,9 @@ If both API and browser approaches fail, use \`delegate_to_auth_subagent\` for c
 - \`strategy\`: method used ("browser", "form_post", "json_post", "basic_auth", "bearer")
 - \`authBarrier\`: if a barrier was encountered (captcha, mfa, etc.)
 
-CRITICAL: You MUST include exportedCookies and exportedHeaders when authentication succeeds.
+CRITICAL: You MUST include exportedCookies, rawCookies, and exportedHeaders when authentication succeeds.
 These are the ONLY way downstream agents receive the session credentials.
-- After browser auth: get cookies from \`browser_get_cookies\` (use the cookieHeader field) and tokens from \`browser_evaluate\`
+- After browser auth: get cookies from \`browser_get_cookies\` — pass \`cookieHeader\` as \`exportedCookies\` AND pass the full \`cookies\` array as \`rawCookies\` (this preserves domain/path/httpOnly/secure attributes so downstream agents can fully restore the browser session). Also extract tokens from \`browser_evaluate\`.
 - After API auth: use the session cookie and any auth headers from the response
 
 **Then**, call the \`response\` tool with your final summary to end the run. This is required — complete_authentication persists the data, response terminates the agent.
@@ -626,7 +626,8 @@ CRITICAL: Always call browser_snapshot BEFORE browser_fill or browser_click to g
 9. **Verify Result**: \`browser_screenshot\` to capture final state
 10. **Extract Session Cookies**: \`browser_get_cookies\` to get httpOnly session cookies
     - This returns cookies including httpOnly ones that document.cookie can't access
-    - **Save the \`cookieHeader\` field** — you will need it for \`complete_authentication\`
+    - **Save the \`cookieHeader\` field** — you will need it as \`exportedCookies\` for \`complete_authentication\`
+    - **Save the \`cookies\` array** — you will need it as \`rawCookies\` for \`complete_authentication\` (preserves domain/path/httpOnly/secure for full browser state restoration)
 11. **Extract Bearer Tokens**: \`browser_evaluate\` with script to get tokens from storage:
    \`\`\`javascript
    (() => {
@@ -641,9 +642,10 @@ CRITICAL: Always call browser_snapshot BEFORE browser_fill or browser_click to g
    \`\`\`
 12. **Persist credentials**: Call \`complete_authentication\` and include:
     - \`exportedCookies\`: the \`cookieHeader\` string from step 10
+    - \`rawCookies\`: the full \`cookies\` array from step 10 (preserves domain/path/httpOnly/secure for browser restoration)
     - \`exportedHeaders\`: e.g. \`{"Authorization": "Bearer <token>"}\` if a JWT/access token was found in step 11
     - \`strategy\`: "browser"
-    - This persists the session credentials for downstream agents
+    - This persists the session credentials for downstream agents (including browser state)
 13. **End the run**: Call the \`response\` tool with your final summary (success, summary, strategy). This terminates the agent.
 
 ### Key Rules:

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -212,6 +212,7 @@ Authentication:
 - If the prompt includes an "Existing Authentication Session" section, USE those cookies/headers on every request. Do NOT attempt to re-authenticate.
 - For http_request: include the provided Cookie and Authorization headers in every call.
 - For execute_command (curl): include -H "Cookie: ..." and/or -H "Authorization: ..." flags.
+- For browser tools (browser_navigate, browser_click, etc.): cookies and headers from the auth session are automatically pre-loaded into the browser context. You do NOT need to set them manually — just navigate normally and the browser will send authenticated requests.
 - If a request returns 401/403, the session may have expired — note it in your findings but do not try to log in again.`;
 
 const PENTEST_SYSTEM_PROMPT_EXFIL = `You are an expert penetration tester performing a targeted security assessment with the goal of demonstrating full exploit impact.
@@ -243,6 +244,7 @@ Authentication:
 - If the prompt includes an "Existing Authentication Session" section, USE those cookies/headers on every request. Do NOT attempt to re-authenticate.
 - For http_request: include the provided Cookie and Authorization headers in every call.
 - For execute_command (curl): include -H "Cookie: ..." and/or -H "Authorization: ..." flags.
+- For browser tools (browser_navigate, browser_click, etc.): cookies and headers from the auth session are automatically pre-loaded into the browser context. You do NOT need to set them manually — just navigate normally and the browser will send authenticated requests.
 - If a request returns 401/403, the session may have expired — note it in your findings but do not try to log in again.`;
 
 function buildSystemPrompt(session: {
@@ -303,6 +305,7 @@ function buildPrompt(
         parts.push(
           `\nFor \`http_request\`, pass these as the \`headers\` parameter.`,
           `For \`execute_command\` (curl), add the appropriate \`-H\` or \`-b\` flags.`,
+          `For browser tools (\`browser_navigate\`, \`browser_click\`, etc.), the cookies and headers are **automatically loaded** into the browser context — no extra steps needed. The browser will send the auth cookies with every request.`,
         );
 
         authSection = parts.join("\n");

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -213,7 +213,7 @@ Authentication:
 - For http_request: include the provided Cookie and Authorization headers in every call.
 - For execute_command (curl): include -H "Cookie: ..." and/or -H "Authorization: ..." flags.
 - For browser tools (browser_navigate, browser_click, etc.): cookies and headers from the auth session are automatically pre-loaded into the browser context. You do NOT need to set them manually — just navigate normally and the browser will send authenticated requests.
-- If a request returns 401/403, the session may have expired — note it in your findings but do not try to log in again.`;
+- If a request returns 401/403, the session may have expired — attempt to re-authenticate using the same credentials/method before continuing. If re-authentication fails, note it in your findings and move on.`;
 
 const PENTEST_SYSTEM_PROMPT_EXFIL = `You are an expert penetration tester performing a targeted security assessment with the goal of demonstrating full exploit impact.
 
@@ -245,7 +245,7 @@ Authentication:
 - For http_request: include the provided Cookie and Authorization headers in every call.
 - For execute_command (curl): include -H "Cookie: ..." and/or -H "Authorization: ..." flags.
 - For browser tools (browser_navigate, browser_click, etc.): cookies and headers from the auth session are automatically pre-loaded into the browser context. You do NOT need to set them manually — just navigate normally and the browser will send authenticated requests.
-- If a request returns 401/403, the session may have expired — note it in your findings but do not try to log in again.`;
+- If a request returns 401/403, the session may have expired — attempt to re-authenticate using the same credentials/method before continuing. If re-authentication fails, note it in your findings and move on.`;
 
 function buildSystemPrompt(session: {
   config?: { exfilMode?: boolean };


### PR DESCRIPTION
## Summary

- Persists full cookie objects (`rawCookies` with domain/path/httpOnly/secure) alongside the existing cookie header string when `complete_authentication` is called
- On pentest agent startup, loads auth state from `<session>/auth/auth-data.json` and injects cookies + extra HTTP headers into the browser context on first navigation — both for direct Playwright mode and sandbox mode
- Updates auth agent prompts to instruct the agent to pass the full `cookies` array as `rawCookies` to `complete_authentication`, and updates pentest agent system prompts to inform the agent that browser cookies/headers are pre-loaded automatically

## Test plan

- [ ] Run an authenticated pentest end-to-end: verify the pentest browser session is pre-authenticated without the agent needing to log in again
- [ ] Verify `auth-data.json` contains a `rawCookies` array after an auth run
- [ ] Check that missing/invalid `auth-data.json` does not break a non-authenticated pentest run
- [ ] Run `bun run test` — all unit tests pass

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how authentication data is serialized and replayed into browser contexts; mistakes could cause failed logins or unintended cookie/header injection across targets/sessions.
> 
> **Overview**
> Enables authenticated-session handoff from the authentication run to downstream pentest browser tooling by persisting richer auth state and automatically restoring it.
> 
> `complete_authentication` now accepts and saves `rawCookies` (full cookie objects) alongside cookie header strings/extra headers in `<session>/auth/auth-data.json`. On tool initialization, `browserTools` loads this auth file and passes it into both MCP and sandbox Playwright implementations, which inject cookies/extra HTTP headers on first `browser_navigate` (then re-navigate) so subsequent browser actions run as the authenticated user.
> 
> Prompts for the auth agent and pentest agent are updated to require/describe passing `rawCookies` and to clarify that browser tools auto-load the saved auth state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bef24ec2bb57caf5c35b8bc0f5c1948fef3225f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->