### PR TITLE
fix: eliminate event listener leaks across child processes and TUI resize

### DIFF
--- a/src/core/agents/offSecAgent/tools/createPoc.ts
+++ b/src/core/agents/offSecAgent/tools/createPoc.ts
@@ -289,6 +289,14 @@ function runScript(
     let killed = false;
     let resolved = false;
 
+    // Wire up abort signal — clean up in safeResolve to cover all exit paths
+    let abortCleanup: (() => void) | undefined;
+    if (abortSignal) {
+      const handler = () => killProcess();
+      abortSignal.addEventListener("abort", handler, { once: true });
+      abortCleanup = () => abortSignal.removeEventListener("abort", handler);
+    }
+
     const safeResolve = (result: {
       stdout: string;
       stderr: string;
@@ -296,6 +304,8 @@ function runScript(
     }) => {
       if (!resolved) {
         resolved = true;
+        clearTimeout(timeoutTimer);
+        abortCleanup?.();
         resolve(result);
       }
     };
@@ -339,21 +349,11 @@ function runScript(
     });
 
     child.on("close", (code) => {
-      clearTimeout(timeoutTimer);
       safeResolve({ stdout, stderr, exitCode: code ?? 1 });
     });
 
     child.on("error", (err) => {
-      clearTimeout(timeoutTimer);
       safeResolve({ stdout, stderr, exitCode: 1 });
     });
-
-    if (abortSignal) {
-      const handler = () => killProcess();
-      abortSignal.addEventListener("abort", handler, { once: true });
-      child.on("close", () =>
-        abortSignal.removeEventListener("abort", handler),
-      );
-    }
   });
 }

--- a/src/core/agents/offSecAgent/tools/grep.ts
+++ b/src/core/agents/offSecAgent/tools/grep.ts
@@ -86,6 +86,26 @@ search with flags or a more specific directory if results are truncated.`,
 
         let stdout = "";
         let stderr = "";
+        let resolved = false;
+
+        // Wire up abort signal — clean up in safeResolve to cover all exit paths
+        let abortCleanup: (() => void) | undefined;
+        if (ctx.abortSignal) {
+          const abortHandler = () => child.kill("SIGTERM");
+          ctx.abortSignal.addEventListener("abort", abortHandler, {
+            once: true,
+          });
+          abortCleanup = () =>
+            ctx.abortSignal!.removeEventListener("abort", abortHandler);
+        }
+
+        const safeResolve = (result: GrepResult) => {
+          if (resolved) return;
+          resolved = true;
+          clearTimeout(timeout);
+          abortCleanup?.();
+          resolve(result);
+        };
 
         const timeout = setTimeout(() => {
           child.kill("SIGTERM");
@@ -100,8 +120,6 @@ search with flags or a more specific directory if results are truncated.`,
         });
 
         child.on("close", (code) => {
-          clearTimeout(timeout);
-
           // grep exits 1 when no matches — that's not an error
           const noMatch = code === 1 && stderr === "";
           const matchCount = stdout ? stdout.trimEnd().split("\n").length : 0;
@@ -111,7 +129,7 @@ search with flags or a more specific directory if results are truncated.`,
             ? `${stdout.substring(0, 50_000)}\n\n(truncated — narrow your search)`
             : stdout || "(no matches)";
 
-          resolve({
+          safeResolve({
             success: code === 0 || noMatch,
             error: noMatch || code === 0 ? "" : stderr || `Exit code: ${code}`,
             output,
@@ -121,8 +139,7 @@ search with flags or a more specific directory if results are truncated.`,
         });
 
         child.on("error", (err) => {
-          clearTimeout(timeout);
-          resolve({
+          safeResolve({
             success: false,
             error: err.message,
             output: "",
@@ -130,17 +147,6 @@ search with flags or a more specific directory if results are truncated.`,
             command,
           });
         });
-
-        // Wire up abort signal
-        if (ctx.abortSignal) {
-          const abortHandler = () => child.kill("SIGTERM");
-          ctx.abortSignal.addEventListener("abort", abortHandler, {
-            once: true,
-          });
-          child.on("close", () => {
-            ctx.abortSignal!.removeEventListener("abort", abortHandler);
-          });
-        }
       });
     },
   });

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -699,9 +699,10 @@ export function createBrowserTools(
 ) {
   const session = new PlaywrightMcpSession(headless ?? defaultHeadless);
 
-  abortSignal?.addEventListener("abort", () => {
-    session.disconnect().catch(() => {});
-  });
+  if (abortSignal) {
+    const onAbort = () => session.disconnect().catch(() => {});
+    abortSignal.addEventListener("abort", onAbort, { once: true });
+  }
 
   // Ensure evidence directory exists
   if (!existsSync(evidenceDir)) {

--- a/src/tui/components/agent-display.tsx
+++ b/src/tui/components/agent-display.tsx
@@ -1,13 +1,13 @@
 import { SpinnerDots } from "./sprites";
 import { useState, memo } from "react";
 import type { Message } from "../../core/messages/types";
-import { useTerminalDimensions } from "@opentui/react";
 import {
   markdownToStyledText,
   getStableMessageKey,
   getArgsPreview,
 } from "./shared";
 import { useTheme } from "../theme";
+import { useDimensions } from "../context/dimensions";
 
 export type Subagent = {
   id: string;
@@ -215,7 +215,7 @@ const AgentMessage = memo(function AgentMessage({
   message: DisplayMessage;
 }) {
   const { colors } = useTheme();
-  const dimensions = useTerminalDimensions();
+  const dimensions = useDimensions();
   let content = "";
 
   if (typeof message.content === "string") {

--- a/src/tui/components/alert-dialog.tsx
+++ b/src/tui/components/alert-dialog.tsx
@@ -1,8 +1,5 @@
-import {
-  useKeyboard,
-  useTerminalDimensions,
-  useRenderer,
-} from "@opentui/react";
+import { useKeyboard, useRenderer } from "@opentui/react";
+import { useDimensions } from "../context/dimensions";
 import type { JSX } from "react";
 import { useTheme } from "../theme";
 
@@ -26,7 +23,7 @@ export default function AlertDialog({
   size = "medium",
 }: AlertDialogProps) {
   const { colors } = useTheme();
-  const dimensions = useTerminalDimensions();
+  const dimensions = useDimensions();
   const renderer = useRenderer();
 
   useKeyboard((key) => {

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { useTerminalDimensions } from "@opentui/react";
+import { useDimensions } from "../../context/dimensions";
 import { PetriAnimation } from "./petri-animation";
 import { useCommand } from "../../context/command";
 import { useInput } from "../../context/input";
@@ -30,7 +30,7 @@ interface HomeViewProps {
 
 export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
   const { colors } = useTheme();
-  const dimensions = useTerminalDimensions();
+  const dimensions = useDimensions();
   const config = useConfig();
   const route = useRoute();
 

--- a/src/tui/components/chat/petri-animation.tsx
+++ b/src/tui/components/chat/petri-animation.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useEffect, useRef, useMemo } from "react";
 import { RGBA } from "@opentui/core";
-import { useTerminalDimensions } from "@opentui/react";
+import { useDimensions } from "../../context/dimensions";
 import { WaveSimulation } from "./lib/wave-simulation";
 import { useTheme } from "../../theme";
 
@@ -88,7 +88,7 @@ export function PetriAnimation({
   height = 0.4,
   width = "100%",
 }: PetriAnimationProps) {
-  const dimensions = useTerminalDimensions();
+  const dimensions = useDimensions();
   const tick = useGlobalTick();
   const { colors } = useTheme();
   const simulationRef = useRef<WaveSimulation | null>(null);

--- a/src/tui/components/commands/help-dialog.tsx
+++ b/src/tui/components/commands/help-dialog.tsx
@@ -7,7 +7,8 @@
  */
 
 import { useState, useEffect, useRef, useMemo } from "react";
-import { useKeyboard, useTerminalDimensions } from "@opentui/react";
+import { useKeyboard } from "@opentui/react";
+import { useDimensions } from "../../context/dimensions";
 import { ScrollBoxRenderable } from "@opentui/core";
 import { scrollToIndex } from "../../utils/scroll";
 import { useCommand } from "../../context/command";
@@ -19,7 +20,7 @@ export default function HelpDialog() {
   const { colors } = useTheme();
   const { commands } = useCommand();
   const route = useRoute();
-  const dimensions = useTerminalDimensions();
+  const dimensions = useDimensions();
 
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [showDetail, setShowDetail] = useState(false);

--- a/src/tui/components/commands/theme-picker.tsx
+++ b/src/tui/components/commands/theme-picker.tsx
@@ -7,7 +7,8 @@
  */
 
 import { useState, useCallback, useRef } from "react";
-import { useKeyboard, useTerminalDimensions } from "@opentui/react";
+import { useKeyboard } from "@opentui/react";
+import { useDimensions } from "../../context/dimensions";
 import { useTheme } from "../../theme";
 import { config } from "../../../core/config";
 import { Dialog } from "../../context/dialog";
@@ -17,7 +18,7 @@ interface ThemePickerProps {
 }
 
 export default function ThemePicker({ onClose }: ThemePickerProps) {
-  const dimensions = useTerminalDimensions();
+  const dimensions = useDimensions();
   const {
     colors,
     theme,

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
-import { useKeyboard, useTerminalDimensions } from "@opentui/react";
+import { useKeyboard } from "@opentui/react";
+import { useDimensions } from "../../context/dimensions";
 import { RGBA, ScrollBoxRenderable } from "@opentui/core";
 import { existsSync, readdirSync, readFileSync } from "fs";
 import { join } from "path";
@@ -145,7 +146,7 @@ export default function Pentest({
   );
 
   // Responsive grid columns
-  const { width: termWidth } = useTerminalDimensions();
+  const { width: termWidth } = useDimensions();
   const gridAvailableWidth = showOrchestratorPanel
     ? Math.floor((termWidth - 4) / 2) - 2
     : termWidth - ORCHESTRATOR_PANEL_WIDTH - GRID_OUTER_PADDING;

--- a/src/tui/components/toast.tsx
+++ b/src/tui/components/toast.tsx
@@ -1,5 +1,5 @@
-import { useTerminalDimensions } from "@opentui/react";
 import type { RGBA } from "@opentui/core";
+import { useDimensions } from "../context/dimensions";
 import { useTheme } from "../theme";
 import { type ToastVariant, useToast } from "../context/toast";
 
@@ -54,7 +54,7 @@ function ToastItem({
 
 export function ToastContainer() {
   const { toasts, dismiss } = useToast();
-  const dims = useTerminalDimensions();
+  const dims = useDimensions();
 
   if (toasts.length === 0) return null;
 

--- a/src/tui/components/tools-panel/index.tsx
+++ b/src/tui/components/tools-panel/index.tsx
@@ -7,7 +7,8 @@
  */
 
 import { useState, useCallback, useEffect, useRef } from "react";
-import { useKeyboard, useTerminalDimensions } from "@opentui/react";
+import { useKeyboard } from "@opentui/react";
+import { useDimensions } from "../../context/dimensions";
 import { ScrollBoxRenderable } from "@opentui/core";
 import { scrollToIndex } from "../../utils/scroll";
 import {
@@ -35,7 +36,7 @@ export default function ToolsPanel({
   onToolsetChange,
 }: ToolsPanelProps) {
   const { colors } = useTheme();
-  const dimensions = useTerminalDimensions();
+  const dimensions = useDimensions();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [categoryFilter, setCategoryFilter] = useState<ToolCategory | null>(
     null,

--- a/src/tui/context/dialog.tsx
+++ b/src/tui/context/dialog.tsx
@@ -1,8 +1,5 @@
-import {
-  useKeyboard,
-  useRenderer,
-  useTerminalDimensions,
-} from "@opentui/react";
+import { useKeyboard, useRenderer } from "@opentui/react";
+import { useDimensions } from "./dimensions";
 import {
   createContext,
   useContext,
@@ -21,7 +18,7 @@ interface DialogProps {
 }
 
 export function Dialog({ size = "medium", onClose, children }: DialogProps) {
-  const dimensions = useTerminalDimensions();
+  const dimensions = useDimensions();
   const renderer = useRenderer();
   const { colors: themeColors } = useTheme();
 

--- a/src/tui/context/dimensions.tsx
+++ b/src/tui/context/dimensions.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, type ReactNode } from "react";
+import { useTerminalDimensions } from "@opentui/react";
+
+interface Dimensions {
+  width: number;
+  height: number;
+}
+
+const DimensionsContext = createContext<Dimensions | null>(null);
+
+export function TerminalDimensionsProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const dimensions = useTerminalDimensions();
+  return (
+    <DimensionsContext.Provider value={dimensions}>
+      {children}
+    </DimensionsContext.Provider>
+  );
+}
+
+export function useDimensions(): Dimensions {
+  const ctx = useContext(DimensionsContext);
+  if (!ctx)
+    throw new Error(
+      "useDimensions() must be used within <TerminalDimensionsProvider>",
+    );
+  return ctx;
+}

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -489,6 +489,11 @@ async function main() {
     consoleOptions: buildConsoleOptions(themeColors),
   });
 
+  // Many components (AgentDisplay, Pentest, DialogProvider, Toast, etc.)
+  // legitimately listen for resize events via useTerminalDimensions().
+  // During a pentest swarm this easily exceeds the default 10 listener limit.
+  renderer.setMaxListeners(50);
+
   const { copyToClipboard } = createClipboardManager(renderer);
   setupAutoCopy(renderer, copyToClipboard);
 

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -59,6 +59,7 @@ import {
 } from "./console-theme";
 import { createClipboardManager } from "./clipboard";
 import { setupAutoCopy } from "./auto-copy";
+import { TerminalDimensionsProvider } from "./context/dimensions";
 
 interface AppProps {
   appConfig: Config;
@@ -489,11 +490,6 @@ async function main() {
     consoleOptions: buildConsoleOptions(themeColors),
   });
 
-  // Many components (AgentDisplay, Pentest, DialogProvider, Toast, etc.)
-  // legitimately listen for resize events via useTerminalDimensions().
-  // During a pentest swarm this easily exceeds the default 10 listener limit.
-  renderer.setMaxListeners(50);
-
   const { copyToClipboard } = createClipboardManager(renderer);
   setupAutoCopy(renderer, copyToClipboard);
 
@@ -521,12 +517,14 @@ async function main() {
   createRoot(renderer).render(
     <ThemeProvider initialTheme={themeName} initialMode={mode}>
       <ConsoleThemeSync />
-      <ToastProvider>
-        <ErrorBoundary>
-          <App appConfig={appConfig} />
-        </ErrorBoundary>
-        <ToastContainer />
-      </ToastProvider>
+      <TerminalDimensionsProvider>
+        <ToastProvider>
+          <ErrorBoundary>
+            <App appConfig={appConfig} />
+          </ErrorBoundary>
+          <ToastContainer />
+        </ToastProvider>
+      </TerminalDimensionsProvider>
     </ThemeProvider>,
   );
 }


### PR DESCRIPTION
Fixes #328

## Summary

### Child process listener cleanup
- Centralizes abort signal and timeout cleanup into `safeResolve()` in `grep.ts` and `createPoc.ts` so listeners are removed on close, error, *and* timeout — not just close
- Removes the pattern of adding a second `close` listener per tool call just for abort cleanup, which caused listener accumulation ("Possible EventTarget memory leak detected. 11 close listeners added to [ChildProcess]")
- Adds `{ once: true }` to the abort listener in `playwrightMcp.ts` for consistency

### TUI resize listener consolidation
- Adds a `TerminalDimensionsProvider` React context that calls `useTerminalDimensions()` once and shares `{ width, height }` to all consumers
- Replaces 10 independent `useTerminalDimensions()` calls with `useDimensions()` from the shared context, reducing N resize listeners on the `CliRenderer` EventEmitter down to 1
- Removes the `setMaxListeners(50)` band-aid — no longer needed since only one component registers a resize listener

## Test plan
- [x] Run a pentest session (`web` auto mode) and confirm no "EventTarget memory leak" warnings for `[ChildProcess]` close listeners
- [x] Resume a pentest session and confirm no new leak warnings appear
- [x] Launch TUI, resize terminal — all views respond correctly
- [x] Run a pentest with multiple agents — no "EventTarget memory leak" warnings for resize listeners