### PR TITLE
fix: preserve agent message history across pentest resume

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -353,9 +353,6 @@ export class OffensiveSecurityAgent<TResult = void> {
 
     this.persistentShell?.dispose();
 
-    // If the stream ended because the abort signal fired (AI SDK may silently
-    // end the async iterator rather than throwing), surface this as an error
-    // so callers don't treat an aborted run as a successful completion.
     if (this.abortSignal?.aborted) {
       throw new DOMException("Agent aborted by user", "AbortError");
     }

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -70,6 +70,9 @@ export class OffensiveSecurityAgent<TResult = void> {
   /** Persistent shell for local-mode command execution; disposed on consume() completion. */
   private readonly persistentShell?: PersistentShell;
 
+  /** Abort signal passed at construction — used by consume() to detect silent abort. */
+  private readonly abortSignal?: AbortSignal;
+
   /** The session this agent is operating within. */
   private readonly _session: SessionInfo;
 
@@ -106,6 +109,7 @@ export class OffensiveSecurityAgent<TResult = void> {
   constructor(input: OffensiveSecurityAgentInput<TResult>) {
     this._session = input.session;
     this.subagentId = input.subagentId;
+    this.abortSignal = input.abortSignal;
 
     // -- Persistent shell (local mode only) -----------------------------------
     // Shell survives command cancellation; only disposed in consume() after the
@@ -348,6 +352,13 @@ export class OffensiveSecurityAgent<TResult = void> {
     }
 
     this.persistentShell?.dispose();
+
+    // If the stream ended because the abort signal fired (AI SDK may silently
+    // end the async iterator rather than throwing), surface this as an error
+    // so callers don't treat an aborted run as a successful completion.
+    if (this.abortSignal?.aborted) {
+      throw new DOMException("Agent aborted by user", "AbortError");
+    }
 
     if (this.resolveResult) {
       return this.resolveResult(this.streamResult);

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -70,7 +70,6 @@ export class OffensiveSecurityAgent<TResult = void> {
   /** Persistent shell for local-mode command execution; disposed on consume() completion. */
   private readonly persistentShell?: PersistentShell;
 
-  /** Abort signal passed at construction — used by consume() to detect silent abort. */
   private readonly abortSignal?: AbortSignal;
 
   /** The session this agent is operating within. */

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -222,6 +222,9 @@ export interface SpecializedAgentInput {
   /** Optional per-provider API key overrides */
   authConfig?: AIAuthConfig;
 
+  /** Existing conversation history for resumption */
+  messages?: Array<ModelMessage>;
+
   /** Callback fired after each agent step */
   onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
 

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -222,9 +222,6 @@ export interface SpecializedAgentInput {
   /** Optional per-provider API key overrides */
   authConfig?: AIAuthConfig;
 
-  /** Existing conversation history for resumption after abort */
-  messages?: Array<ModelMessage>;
-
   /** Callback fired after each agent step */
   onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
 

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -222,6 +222,9 @@ export interface SpecializedAgentInput {
   /** Optional per-provider API key overrides */
   authConfig?: AIAuthConfig;
 
+  /** Existing conversation history for resumption after abort */
+  messages?: Array<ModelMessage>;
+
   /** Callback fired after each agent step */
   onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
 

--- a/src/core/agents/specialized/attackSurface/blackboxAgent.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxAgent.ts
@@ -8,6 +8,7 @@ import { loadAttackSurfaceResults } from "./types";
 import { OffensiveSecurityAgent } from "../../offSecAgent/offensiveSecurityAgent";
 import type { SpecializedAgentInput } from "../../offSecAgent/types";
 import type { SessionInfo } from "../../../session";
+import type { ModelMessage } from "ai";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -26,7 +27,10 @@ export type AttackSurfaceAgentInput = SpecializedAgentInput &
         /** Working directory for source-code based analysis */
         cwd: string;
       }
-  );
+  ) & {
+    /** Existing conversation history for resumption */
+    messages?: ModelMessage[];
+  };
 
 /** The typed result returned by `AttackSurfaceAgent.consume()`. */
 export interface AttackSurfaceResult {

--- a/src/core/agents/specialized/attackSurface/blackboxAgent.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxAgent.ts
@@ -7,7 +7,6 @@ import type { AttackSurfaceAnalysisResults, PentestTarget } from "./types";
 import { loadAttackSurfaceResults } from "./types";
 import { OffensiveSecurityAgent } from "../../offSecAgent/offensiveSecurityAgent";
 import type { SpecializedAgentInput } from "../../offSecAgent/types";
-import type { ModelMessage } from "ai";
 import type { SessionInfo } from "../../../session";
 
 // ---------------------------------------------------------------------------
@@ -15,10 +14,8 @@ import type { SessionInfo } from "../../../session";
 // ---------------------------------------------------------------------------
 
 /** At least one of `target` or `cwd` must be provided. */
-export type AttackSurfaceAgentInput = SpecializedAgentInput & {
-  /** Prior conversation history for resuming an interrupted run */
-  messages?: ModelMessage[];
-} & (
+export type AttackSurfaceAgentInput = SpecializedAgentInput &
+  (
     | {
         /** The target to analyze (domain, IP, URL, network range, or org name) */
         target: string;

--- a/src/core/agents/specialized/attackSurface/blackboxAgent.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxAgent.ts
@@ -7,6 +7,7 @@ import type { AttackSurfaceAnalysisResults, PentestTarget } from "./types";
 import { loadAttackSurfaceResults } from "./types";
 import { OffensiveSecurityAgent } from "../../offSecAgent/offensiveSecurityAgent";
 import type { SpecializedAgentInput } from "../../offSecAgent/types";
+import type { ModelMessage } from "ai";
 import type { SessionInfo } from "../../../session";
 
 // ---------------------------------------------------------------------------
@@ -14,8 +15,10 @@ import type { SessionInfo } from "../../../session";
 // ---------------------------------------------------------------------------
 
 /** At least one of `target` or `cwd` must be provided. */
-export type AttackSurfaceAgentInput = SpecializedAgentInput &
-  (
+export type AttackSurfaceAgentInput = SpecializedAgentInput & {
+  /** Prior conversation history for resuming an interrupted run */
+  messages?: ModelMessage[];
+} & (
     | {
         /** The target to analyze (domain, IP, URL, network range, or org name) */
         target: string;
@@ -93,6 +96,7 @@ export class BlackboxAttackSurfaceAgent extends OffensiveSecurityAgent<AttackSur
       onStepFinish,
       abortSignal,
       attackSurfaceRegistry,
+      messages: opts.messages,
 
       activeTools: [
         // Core recon tools

--- a/src/core/agents/specialized/attackSurface/blackboxAgent.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxAgent.ts
@@ -8,7 +8,6 @@ import { loadAttackSurfaceResults } from "./types";
 import { OffensiveSecurityAgent } from "../../offSecAgent/offensiveSecurityAgent";
 import type { SpecializedAgentInput } from "../../offSecAgent/types";
 import type { SessionInfo } from "../../../session";
-import type { ModelMessage } from "ai";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -27,10 +26,7 @@ export type AttackSurfaceAgentInput = SpecializedAgentInput &
         /** Working directory for source-code based analysis */
         cwd: string;
       }
-  ) & {
-    /** Existing conversation history for resumption */
-    messages?: ModelMessage[];
-  };
+  );
 
 /** The typed result returned by `AttackSurfaceAgent.consume()`. */
 export interface AttackSurfaceResult {

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -22,6 +22,9 @@ export interface PentestAgentInput extends SpecializedAgentInput {
 
   /** Shared findings registry for cross-agent dedup */
   findingsRegistry?: FindingsRegistry;
+
+  /** Existing conversation history for resumption after abort */
+  messages?: Array<import("ai").ModelMessage>;
 }
 
 /** The typed result returned by `PentestAgent.consume()`. */
@@ -100,6 +103,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       abortSignal,
       sandbox,
       findingsRegistry,
+      messages,
     } = opts;
 
     super({
@@ -113,6 +117,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       abortSignal,
       sandbox,
       findingsRegistry,
+      messages,
 
       activeTools: [
         "execute_command",

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 import type { Finding, SpecializedAgentInput } from "../../offSecAgent/types";
 import { OffensiveSecurityAgent } from "../../offSecAgent/offensiveSecurityAgent";
 import type { UnifiedSandbox } from "../../offSecAgent/tools/sandbox";
-import type { ModelMessage } from "ai";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -23,9 +22,6 @@ export interface PentestAgentInput extends SpecializedAgentInput {
 
   /** Shared findings registry for cross-agent dedup */
   findingsRegistry?: FindingsRegistry;
-
-  /** Existing conversation history for resumption */
-  messages?: ModelMessage[];
 }
 
 /** The typed result returned by `PentestAgent.consume()`. */

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { Finding, SpecializedAgentInput } from "../../offSecAgent/types";
 import { OffensiveSecurityAgent } from "../../offSecAgent/offensiveSecurityAgent";
 import type { UnifiedSandbox } from "../../offSecAgent/tools/sandbox";
+import type { ModelMessage } from "ai";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -22,6 +23,9 @@ export interface PentestAgentInput extends SpecializedAgentInput {
 
   /** Shared findings registry for cross-agent dedup */
   findingsRegistry?: FindingsRegistry;
+
+  /** Existing conversation history for resumption */
+  messages?: ModelMessage[];
 }
 
 /** The typed result returned by `PentestAgent.consume()`. */

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -22,9 +22,6 @@ export interface PentestAgentInput extends SpecializedAgentInput {
 
   /** Shared findings registry for cross-agent dedup */
   findingsRegistry?: FindingsRegistry;
-
-  /** Existing conversation history for resumption after abort */
-  messages?: Array<import("ai").ModelMessage>;
 }
 
 /** The typed result returned by `PentestAgent.consume()`. */

--- a/src/core/session/loader.ts
+++ b/src/core/session/loader.ts
@@ -199,9 +199,6 @@ export async function loadSessionState(
     }
   }
 
-  // Determine if session is complete — the report file is the single source
-  // of truth. With the abort guard in the workflow, the report is only written
-  // when the pentest completes successfully.
   const isComplete = hasReportFile;
 
   return {

--- a/src/core/session/loader.ts
+++ b/src/core/session/loader.ts
@@ -16,8 +16,6 @@ import { REPORT_FILENAME_MD } from "../report";
 
 // Re-export types that consumers import from this module
 export type {
-  MessageContentPart,
-  SavedMessage,
   SavedSubagentData,
   UIMessage,
   ResumeInfo,

--- a/src/core/session/loader.ts
+++ b/src/core/session/loader.ts
@@ -57,7 +57,7 @@ export interface LoadedSessionState {
 /**
  * Load attack surface results
  */
-function loadAttackSurfaceResults(
+export function loadAttackSurfaceResults(
   rootPath: string,
 ): AttackSurfaceResults | null {
   const resultsPath = join(rootPath, "attack-surface-results.json");
@@ -199,18 +199,10 @@ export async function loadSessionState(
     }
   }
 
-  // Determine if session is complete
-  const pentestSubagents = subagents.filter((s) => s.type === "pentest");
-  const allPentestDone =
-    pentestSubagents.length > 0 &&
-    pentestSubagents.every(
-      (s) => s.status === "completed" || s.status === "failed",
-    );
-
-  const isComplete =
-    hasReportFile ||
-    (attackSurfaceResults?.summary?.analysisComplete === true &&
-      allPentestDone);
+  // Determine if session is complete — the report file is the single source
+  // of truth. With the abort guard in the workflow, the report is only written
+  // when the pentest completes successfully.
+  const isComplete = hasReportFile;
 
   return {
     session,

--- a/src/core/session/persistence.test.ts
+++ b/src/core/session/persistence.test.ts
@@ -55,21 +55,21 @@ function makeMsg(role: string, content: unknown): ModelMessage {
   return { role, content } as ModelMessage;
 }
 
-function makeToolCallPart(toolName: string, args: Record<string, unknown>) {
+function makeToolCallPart(toolName: string, input: Record<string, unknown>) {
   return {
     type: "tool-call",
     toolCallId: `tc-${toolName}`,
     toolName,
-    args,
+    input,
   };
 }
 
-function makeToolResultPart(toolName: string, result: unknown) {
+function makeToolResultPart(toolName: string, output: unknown) {
   return {
     type: "tool-result",
     toolCallId: `tc-${toolName}`,
     toolName,
-    result,
+    output,
   };
 }
 
@@ -78,7 +78,7 @@ function makeToolResultPart(toolName: string, result: unknown) {
 // ---------------------------------------------------------------------------
 
 describe("saveSubagentData + loadSubagents roundtrip", () => {
-  it("roundtrips tool-call args→input and tool-result result→output", () => {
+  it("roundtrips tool-call and tool-result content parts", () => {
     const session = makeSession();
     saveSubagentData(session, {
       agentName: "pentest-agent-1",
@@ -514,7 +514,7 @@ describe("convertModelMessagesToUI", () => {
           type: "tool-call",
           toolCallId: "tc-1",
           toolName: "execute_command",
-          args: { cmd: "nmap localhost" },
+          input: { cmd: "nmap localhost" },
         },
       ]),
       makeMsg("tool", [
@@ -522,7 +522,7 @@ describe("convertModelMessagesToUI", () => {
           type: "tool-result",
           toolCallId: "tc-1",
           toolName: "execute_command",
-          result: "PORT 80/tcp open",
+          output: "PORT 80/tcp open",
         },
       ]),
       makeMsg("assistant", "Found port 80 open."),
@@ -530,25 +530,20 @@ describe("convertModelMessagesToUI", () => {
 
     const uiMsgs = convertModelMessagesToUI(modelMessages);
 
-    // Should have: user msg, assistant text, tool call, assistant text
     expect(uiMsgs.length).toBe(4);
 
-    // User message
     expect(uiMsgs[0].role).toBe("user");
     expect(uiMsgs[0].content).toBe("run a scan");
 
-    // Assistant text
     expect(uiMsgs[1].role).toBe("assistant");
     expect(uiMsgs[1].content).toBe("I'll run a command");
 
-    // Tool call with paired result
     expect(uiMsgs[2].role).toBe("tool");
     expect(uiMsgs[2].toolName).toBe("execute_command");
     expect(uiMsgs[2].args).toEqual({ cmd: "nmap localhost" });
     expect(uiMsgs[2].result).toBe("PORT 80/tcp open");
     expect(uiMsgs[2].status).toBe("completed");
 
-    // Final assistant text
     expect(uiMsgs[3].role).toBe("assistant");
     expect(uiMsgs[3].content).toBe("Found port 80 open.");
   });

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -17,7 +17,7 @@ import { join } from "path";
 import type { SessionInfo } from "./index";
 export type { SessionInfo };
 import type { AuthenticationInfo } from "./types";
-import type { ModelMessage, TextPart, ToolCallPart, ToolResultPart } from "ai";
+import type { ModelMessage } from "ai";
 
 // ---------------------------------------------------------------------------
 // Shared path constants — used by both writer and reader
@@ -29,8 +29,6 @@ const MANIFEST_FILE = "agent-manifest.json";
 // ---------------------------------------------------------------------------
 // Types (previously in loader.ts — canonical home is now here)
 // ---------------------------------------------------------------------------
-
-type ContentPart = TextPart | ToolCallPart | ToolResultPart;
 
 /**
  * Saved subagent data format
@@ -349,7 +347,7 @@ function convertMessagesToUI(
   const toolResults = new Map<string, unknown>();
   for (const msg of messages) {
     if (Array.isArray(msg.content)) {
-      for (const part of msg.content as ContentPart[]) {
+      for (const part of msg.content) {
         if (part.type === "tool-result" && part.toolCallId) {
           toolResults.set(part.toolCallId, part.output);
         }
@@ -368,7 +366,7 @@ function convertMessagesToUI(
         createdAt,
       });
     } else if (Array.isArray(msg.content)) {
-      for (const part of msg.content as ContentPart[]) {
+      for (const part of msg.content) {
         if (part.type === "text" && part.text) {
           uiMessages.push({
             role: "assistant",

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -17,12 +17,7 @@ import { join } from "path";
 import type { SessionInfo } from "./index";
 export type { SessionInfo };
 import type { AuthenticationInfo } from "./types";
-import type {
-  ModelMessage,
-  TextPart,
-  ToolCallPart,
-  ToolResultPart,
-} from "ai";
+import type { ModelMessage, TextPart, ToolCallPart, ToolResultPart } from "ai";
 
 // ---------------------------------------------------------------------------
 // Shared path constants — used by both writer and reader

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -64,7 +64,7 @@ export interface SavedSubagentData {
   findingsCount?: number;
   status?: string;
   error?: string;
-  messages: SavedMessage[];
+  messages: ModelMessage[];
 }
 
 /**
@@ -121,107 +121,27 @@ export interface SubagentSaveInput {
   messages: ModelMessage[];
 }
 
-/**
- * Map an AI SDK message to the SavedMessage format.
- *
- * The AI SDK uses `args` for tool call parameters and `result` for tool
- * results, while the saved format uses `input` and `output` respectively.
- */
-function mapToSavedMessage(msg: ModelMessage): SavedMessage {
-  const m = msg as { role: string; content: unknown };
-
-  if (typeof m.content === "string") {
-    return { role: m.role as SavedMessage["role"], content: m.content };
-  }
-
-  if (Array.isArray(m.content)) {
-    const mapped: MessageContentPart[] = m.content.map(
-      (part: Record<string, unknown>) => {
-        if (part.type === "tool-call") {
-          return {
-            type: "tool-call" as const,
-            toolCallId: part.toolCallId as string,
-            toolName: part.toolName as string,
-            input: (part.args ?? part.input) as Record<string, unknown>,
-          };
-        }
-        if (part.type === "tool-result") {
-          return {
-            type: "tool-result" as const,
-            toolCallId: part.toolCallId as string,
-            toolName: part.toolName as string,
-            output: (part.result ?? part.output) as unknown,
-          };
-        }
-        return {
-          type: "text" as const,
-          text: (part.text as string) ?? "",
-        };
-      },
-    );
-    return { role: m.role as SavedMessage["role"], content: mapped };
-  }
-
-  return { role: m.role as SavedMessage["role"], content: String(m.content) };
-}
-
-/**
- * The AI SDK schema uses `input` (not `args`) and `output` (not `result`),
- * which is exactly what mapToSavedMessage produces. So SavedMessages are
- * already valid ModelMessages — just cast them.
- */
-function savedToModelMessage(saved: SavedMessage): ModelMessage {
-  return saved as unknown as ModelMessage;
-}
-
-/**
- * Load raw ModelMessage[] for a given agent name from its most recent
- * subagent file. Returns an empty array if no file is found.
- */
 export function loadSubagentMessages(
   session: SessionInfo,
   agentName: string,
 ): ModelMessage[] {
-  const subagentsPath = join(session.rootPath, SUBAGENTS_DIR);
-  if (!existsSync(subagentsPath)) return [];
-
-  // Try stable filename first (new format)
-  const stablePath = join(subagentsPath, `${agentName}.json`);
-  if (existsSync(stablePath)) {
-    try {
-      const data = JSON.parse(
-        readFileSync(stablePath, "utf-8"),
-      ) as SavedSubagentData;
-      return data.messages.map(savedToModelMessage);
-    } catch {
-      return [];
-    }
-  }
-
-  // Fallback: scan for old timestamped files (agentName-TIMESTAMP.json)
-  const files = readdirSync(subagentsPath)
-    .filter((f) => f.startsWith(`${agentName}-`) && f.endsWith(".json"))
-    .sort()
-    .reverse();
-
-  if (files.length === 0) return [];
-
+  const filePath = join(
+    session.rootPath,
+    SUBAGENTS_DIR,
+    `${agentName}.json`,
+  );
+  if (!existsSync(filePath)) return [];
   try {
     const data = JSON.parse(
-      readFileSync(join(subagentsPath, files[0]), "utf-8"),
+      readFileSync(filePath, "utf-8"),
     ) as SavedSubagentData;
-    return data.messages.map(savedToModelMessage);
+    return data.messages;
   } catch {
     return [];
   }
 }
 
-/**
- * Save subagent data as a flat JSON file.
- *
- * Writes to `{session.rootPath}/{SUBAGENTS_DIR}/{name}.json`.
- * One file per agent, overwritten on each save. Timestamp is inside the JSON.
- */
+/** Writes to `{session.rootPath}/{SUBAGENTS_DIR}/{name}.json`. */
 export function saveSubagentData(
   session: SessionInfo,
   data: SubagentSaveInput,
@@ -231,7 +151,6 @@ export function saveSubagentData(
 
   let toolCallCount = 0;
   let stepCount = 0;
-  const savedMessages: SavedMessage[] = [];
 
   for (const msg of data.messages) {
     if (msg.role === "assistant") {
@@ -242,13 +161,11 @@ export function saveSubagentData(
         }
       }
     }
-    savedMessages.push(mapToSavedMessage(msg));
   }
 
-  const now = new Date();
   const savedData: SavedSubagentData = {
     agentName: data.agentName,
-    timestamp: now.toISOString(),
+    timestamp: new Date().toISOString(),
     target: data.target,
     objective: data.objective,
     vulnerabilityClass: data.vulnerabilityClass,
@@ -257,12 +174,11 @@ export function saveSubagentData(
     findingsCount: data.findingsCount ?? 0,
     status: data.status,
     error: data.error,
-    messages: savedMessages,
+    messages: data.messages,
   };
 
-  const filename = `${data.agentName}.json`;
   writeFileSync(
-    join(subagentsDir, filename),
+    join(subagentsDir, `${data.agentName}.json`),
     JSON.stringify(savedData, null, 2),
   );
 }
@@ -342,8 +258,6 @@ export function buildManifestEntries(
  * Rewrite the agent manifest with final statuses.
  * Uses index-based matching (not target-based) to correctly handle
  * duplicate targets.
- *
- * Completed entries (preserved from a previous run) are left untouched.
  */
 export function finalizeManifest(
   session: SessionInfo,
@@ -364,49 +278,33 @@ export function finalizeManifest(
 }
 
 /**
- * Return the set of pentest agent IDs that successfully completed.
- *
- * Only truly completed agents are skipped on resume. Failed/aborted agents
- * are retried so the user doesn't have to start a new session.
- *
- * Checks the manifest first, then does a belt-and-suspenders scan of subagent
- * files so we catch agents that finished but whose manifest entry was lost.
+ * Atomically update a single agent's status in the manifest.
+ * Safe under Node.js concurrency — readFileSync + writeFileSync
+ * runs synchronously without event loop interleaving.
  */
-export function getCompletedAgentIds(session: SessionInfo): Set<string> {
-  const ids = new Set<string>();
-
+export function updateManifestEntryStatus(
+  session: SessionInfo,
+  agentId: string,
+  status: "completed" | "failed",
+): void {
   const manifest = readAgentManifest(session);
-  for (const entry of manifest) {
-    if (!entry.id.startsWith("pentest-agent-")) continue;
-    if (entry.status === "completed") {
-      ids.add(entry.id);
-    }
-  }
+  const updated = manifest.map((e) =>
+    e.id === agentId
+      ? { ...e, status, completedAt: new Date().toISOString() }
+      : e,
+  );
+  writeAgentManifest(session, updated);
+}
 
-  // Belt-and-suspenders: scan subagent files for completed agents
-  // not reflected in the manifest
-  const subagentsPath = join(session.rootPath, SUBAGENTS_DIR);
-  if (existsSync(subagentsPath)) {
-    for (const file of readdirSync(subagentsPath).filter((f) =>
-      f.endsWith(".json"),
-    )) {
-      try {
-        const data = JSON.parse(
-          readFileSync(join(subagentsPath, file), "utf-8"),
-        ) as SavedSubagentData;
-        if (
-          data.agentName.startsWith("pentest-agent-") &&
-          data.status === "completed"
-        ) {
-          ids.add(data.agentName);
-        }
-      } catch {
-        // skip unparseable files
-      }
-    }
-  }
-
-  return ids;
+export function getCompletedAgentIds(session: SessionInfo): Set<string> {
+  const manifest = readAgentManifest(session);
+  return new Set(
+    manifest
+      .filter(
+        (e) => e.id.startsWith("pentest-agent-") && e.status === "completed",
+      )
+      .map((e) => e.id),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -431,7 +329,6 @@ function parseSubagentFilename(filename: string): {
     return { agentType: "attack-surface", name: "Attack Surface Discovery" };
   }
 
-  // Current convention: pentest-agent-{N}.json (also matches old timestamped format)
   const pentestMatch = filename.match(/^pentest-agent-(\d+)/);
   if (pentestMatch) {
     return {
@@ -461,24 +358,20 @@ function parseSubagentFilename(filename: string): {
 }
 
 /**
- * Convert saved messages to UI-compatible format.
- *
- * Two-pass algorithm:
- *  1. Collect tool results by toolCallId so we can pair them with calls.
- *  2. Emit UIMessage[] with tool-call messages enriched with their results.
+ * Two-pass: collect tool results by toolCallId, then emit UIMessage[]
+ * with tool-call messages enriched with their results.
  */
 function convertMessagesToUI(
-  messages: SavedMessage[],
+  messages: ModelMessage[],
   baseTime: Date,
 ): UIMessage[] {
   const uiMessages: UIMessage[] = [];
   let messageIndex = 0;
 
-  // First pass: collect tool results by toolCallId
   const toolResults = new Map<string, unknown>();
   for (const msg of messages) {
     if (Array.isArray(msg.content)) {
-      for (const part of msg.content) {
+      for (const part of msg.content as MessageContentPart[]) {
         if (part.type === "tool-result" && part.toolCallId) {
           toolResults.set(part.toolCallId, part.output);
         }
@@ -497,7 +390,7 @@ function convertMessagesToUI(
         createdAt,
       });
     } else if (Array.isArray(msg.content)) {
-      for (const part of msg.content) {
+      for (const part of msg.content as MessageContentPart[]) {
         if (part.type === "text" && part.text) {
           uiMessages.push({
             role: "assistant",
@@ -523,7 +416,6 @@ function convertMessagesToUI(
             status: "completed",
           });
         }
-        // tool-result parts are already collected in the first pass
       }
     }
   }
@@ -531,17 +423,10 @@ function convertMessagesToUI(
   return uiMessages;
 }
 
-/**
- * Convert raw AI SDK model messages to UI-compatible display format.
- *
- * Used when restoring operator state on resume: the persisted state stores
- * only model messages, and this function derives the display messages.
- */
 export function convertModelMessagesToUI(
   messages: ModelMessage[],
 ): UIMessage[] {
-  const saved = messages.map((m) => mapToSavedMessage(m));
-  return convertMessagesToUI(saved, new Date());
+  return convertMessagesToUI(messages, new Date());
 }
 
 /**
@@ -600,7 +485,8 @@ export function loadSubagents(rootPath: string): UISubagent[] {
             break;
         }
 
-        const entry: UISubagent = {
+        agentNameIndex.set(data.agentName, subagents.length);
+        subagents.push({
           id: data.agentName,
           name:
             data.agentName === "attack-surface-agent"
@@ -611,17 +497,7 @@ export function loadSubagents(rootPath: string): UISubagent[] {
           messages,
           createdAt: timestamp,
           status,
-        };
-
-        // Deduplicate: if we already have an entry for this agentName
-        // (old sessions with multiple timestamped files), keep the latest.
-        const prevIdx = agentNameIndex.get(data.agentName);
-        if (prevIdx !== undefined) {
-          subagents[prevIdx] = entry;
-        } else {
-          agentNameIndex.set(data.agentName, subagents.length);
-          subagents.push(entry);
-        }
+        });
       } catch (e) {
         console.error(`Failed to load subagent file ${file}:`, e);
       }

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  appendFileSync,
   existsSync,
   mkdirSync,
   writeFileSync,
@@ -25,6 +26,27 @@ import type { ModelMessage } from "ai";
 
 const SUBAGENTS_DIR = "subagents";
 const MANIFEST_FILE = "agent-manifest.json";
+const RESUME_LOG_FILE = "swarm-resume.log";
+
+// ---------------------------------------------------------------------------
+// Resume logging — lightweight append-only log for diagnosing resume issues
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a timestamped line to `{rootPath}/logs/swarm-resume.log`.
+ * Safe to call from anywhere — never throws.
+ */
+export function resumeLog(rootPath: string, message: string): void {
+  try {
+    const logsDir = join(rootPath, "logs");
+    if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true });
+    const logPath = join(logsDir, RESUME_LOG_FILE);
+    const ts = new Date().toISOString();
+    appendFileSync(logPath, `${ts} - ${message}\n`, "utf8");
+  } catch {
+    /* never throw from logging */
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Types (previously in loader.ts — canonical home is now here)
@@ -166,10 +188,61 @@ function mapToSavedMessage(msg: ModelMessage): SavedMessage {
 }
 
 /**
+ * The AI SDK schema uses `input` (not `args`) and `output` (not `result`),
+ * which is exactly what mapToSavedMessage produces. So SavedMessages are
+ * already valid ModelMessages — just cast them.
+ */
+function savedToModelMessage(saved: SavedMessage): ModelMessage {
+  return saved as unknown as ModelMessage;
+}
+
+/**
+ * Load raw ModelMessage[] for a given agent name from its most recent
+ * subagent file. Returns an empty array if no file is found.
+ */
+export function loadSubagentMessages(
+  session: SessionInfo,
+  agentName: string,
+): ModelMessage[] {
+  const subagentsPath = join(session.rootPath, SUBAGENTS_DIR);
+  if (!existsSync(subagentsPath)) return [];
+
+  // Try stable filename first (new format)
+  const stablePath = join(subagentsPath, `${agentName}.json`);
+  if (existsSync(stablePath)) {
+    try {
+      const data = JSON.parse(
+        readFileSync(stablePath, "utf-8"),
+      ) as SavedSubagentData;
+      return data.messages.map(savedToModelMessage);
+    } catch {
+      return [];
+    }
+  }
+
+  // Fallback: scan for old timestamped files (agentName-TIMESTAMP.json)
+  const files = readdirSync(subagentsPath)
+    .filter((f) => f.startsWith(`${agentName}-`) && f.endsWith(".json"))
+    .sort()
+    .reverse();
+
+  if (files.length === 0) return [];
+
+  try {
+    const data = JSON.parse(
+      readFileSync(join(subagentsPath, files[0]), "utf-8"),
+    ) as SavedSubagentData;
+    return data.messages.map(savedToModelMessage);
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Save subagent data as a flat JSON file.
  *
- * Writes to `{session.rootPath}/{SUBAGENTS_DIR}/{name}-{timestamp}.json`.
- * loadSubagents reads back from the same directory with the same convention.
+ * Writes to `{session.rootPath}/{SUBAGENTS_DIR}/{name}.json`.
+ * One file per agent, overwritten on each save. Timestamp is inside the JSON.
  */
 export function saveSubagentData(
   session: SessionInfo,
@@ -209,11 +282,15 @@ export function saveSubagentData(
     messages: savedMessages,
   };
 
-  const ts = now.toISOString().replace(/[:.]/g, "-");
-  const filename = `${data.agentName}-${ts}.json`;
+  const filename = `${data.agentName}.json`;
   writeFileSync(
     join(subagentsDir, filename),
     JSON.stringify(savedData, null, 2),
+  );
+
+  resumeLog(
+    session.rootPath,
+    `[saveSubagentData] ${data.agentName}: status=${data.status}, toolCalls=${toolCallCount}, steps=${stepCount}, findings=${data.findingsCount ?? 0}, error=${data.error ?? "none"}, file=${filename}`,
   );
 }
 
@@ -292,20 +369,124 @@ export function buildManifestEntries(
  * Rewrite the agent manifest with final statuses.
  * Uses index-based matching (not target-based) to correctly handle
  * duplicate targets.
+ *
+ * Completed entries (preserved from a previous run) are left untouched.
  */
 export function finalizeManifest(
   session: SessionInfo,
   entries: AgentManifestEntry[],
   results: (unknown | null)[],
 ): void {
-  const finalManifest = entries.map((entry, i) => ({
-    ...entry,
-    status: (results[i] != null ? "completed" : "failed") as
-      | "completed"
-      | "failed",
-    completedAt: new Date().toISOString(),
-  }));
+  const log = (msg: string) => resumeLog(session.rootPath, msg);
+  log(
+    `[finalizeManifest] Finalizing ${entries.length} entries, ${results.length} results`,
+  );
+
+  const finalManifest = entries.map((entry, i) => {
+    const hasResult = results[i] != null;
+    // Preserve already-completed entries (skipped agents on resume)
+    if (entry.status === "completed") {
+      log(
+        `[finalizeManifest] ${entry.id}: PRESERVED completed (result=${hasResult ? "present" : "null"})`,
+      );
+      return entry;
+    }
+    const newStatus = hasResult ? "completed" : "failed";
+    log(
+      `[finalizeManifest] ${entry.id}: ${entry.status} → ${newStatus} (result=${hasResult ? "present" : "null"})`,
+    );
+    return {
+      ...entry,
+      status: newStatus as "completed" | "failed",
+      completedAt: new Date().toISOString(),
+    };
+  });
   writeAgentManifest(session, finalManifest);
+}
+
+/**
+ * Return the set of pentest agent IDs that successfully completed.
+ *
+ * Only truly completed agents are skipped on resume. Failed/aborted agents
+ * are retried so the user doesn't have to start a new session.
+ *
+ * Checks the manifest first, then does a belt-and-suspenders scan of subagent
+ * files so we catch agents that finished but whose manifest entry was lost.
+ */
+export function getCompletedAgentIds(session: SessionInfo): Set<string> {
+  const ids = new Set<string>();
+  const log = (msg: string) => resumeLog(session.rootPath, msg);
+
+  log("[getCompletedAgentIds] START");
+
+  // Manifest is the primary source
+  const manifest = readAgentManifest(session);
+  log(
+    `[getCompletedAgentIds] Manifest has ${manifest.length} entries: ${manifest.map((e) => `${e.id}=${e.status}`).join(", ") || "(empty)"}`,
+  );
+  for (const entry of manifest) {
+    // Only track pentest-agent-* IDs — discovery agents (attack-surface-agent)
+    // should never count toward the "all done" check for the swarm phase.
+    if (!entry.id.startsWith("pentest-agent-")) {
+      log(
+        `[getCompletedAgentIds] Manifest → SKIP non-pentest entry ${entry.id} (${entry.status})`,
+      );
+      continue;
+    }
+    if (entry.status === "completed") {
+      ids.add(entry.id);
+      log(
+        `[getCompletedAgentIds] Manifest → skip ${entry.id} (completed, target=${entry.target})`,
+      );
+    } else if (entry.status === "failed") {
+      log(
+        `[getCompletedAgentIds] Manifest → RETRY ${entry.id} (failed, target=${entry.target})`,
+      );
+    }
+  }
+
+  // Belt-and-suspenders: scan subagent files for completed status
+  const subagentsPath = join(session.rootPath, SUBAGENTS_DIR);
+  if (existsSync(subagentsPath)) {
+    const files = readdirSync(subagentsPath).filter((f) =>
+      f.endsWith(".json"),
+    );
+    log(
+      `[getCompletedAgentIds] Found ${files.length} subagent files in ${SUBAGENTS_DIR}/`,
+    );
+    for (const file of files) {
+      try {
+        const data = JSON.parse(
+          readFileSync(join(subagentsPath, file), "utf-8"),
+        ) as SavedSubagentData;
+        log(
+          `[getCompletedAgentIds] File ${file}: agentName=${data.agentName}, status=${data.status}, toolCalls=${data.toolCallCount ?? "?"}, steps=${data.stepCount ?? "?"}, findings=${data.findingsCount ?? "?"}`,
+        );
+        // Only track pentest-agent-* IDs from file scan too
+        if (!data.agentName.startsWith("pentest-agent-")) {
+          continue;
+        }
+        if (data.status === "completed") {
+          const wasNew = !ids.has(data.agentName);
+          ids.add(data.agentName);
+          if (wasNew) {
+            log(
+              `[getCompletedAgentIds] File scan → skip ${data.agentName} (completed) [NEW — not in manifest]`,
+            );
+          }
+        }
+      } catch {
+        log(`[getCompletedAgentIds] Failed to parse file: ${file}`);
+      }
+    }
+  } else {
+    log(`[getCompletedAgentIds] No ${SUBAGENTS_DIR}/ directory found`);
+  }
+
+  log(
+    `[getCompletedAgentIds] RESULT: skipSet = {${[...ids].join(", ")}} (${ids.size} agents)`,
+  );
+  return ids;
 }
 
 // ---------------------------------------------------------------------------
@@ -330,8 +511,8 @@ function parseSubagentFilename(filename: string): {
     return { agentType: "attack-surface", name: "Attack Surface Discovery" };
   }
 
-  // Current convention: pentest-agent-{N}-{timestamp}.json
-  const pentestMatch = filename.match(/^pentest-agent-(\d+)-/);
+  // Current convention: pentest-agent-{N}.json (also matches old timestamped format)
+  const pentestMatch = filename.match(/^pentest-agent-(\d+)/);
   if (pentestMatch) {
     return {
       agentType: "pentest",
@@ -454,7 +635,10 @@ export function convertModelMessagesToUI(
  *  5. Creates paused stubs for unmatched "running" manifest entries
  */
 export function loadSubagents(rootPath: string): UISubagent[] {
+  const log = (msg: string) => resumeLog(rootPath, msg);
   const subagentsPath = join(rootPath, SUBAGENTS_DIR);
+
+  log("[loadSubagents] START");
 
   // --- Load files ---
   const subagents: UISubagent[] = [];
@@ -463,13 +647,9 @@ export function loadSubagents(rootPath: string): UISubagent[] {
 
   if (existsSync(subagentsPath)) {
     const files = readdirSync(subagentsPath).filter((f) => f.endsWith(".json"));
+    log(`[loadSubagents] Found ${files.length} subagent files`);
 
-    // Sort files by timestamp in filename
-    files.sort((a, b) => {
-      const timeA = a.match(/\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}/)?.[0] || "";
-      const timeB = b.match(/\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}/)?.[0] || "";
-      return timeA.localeCompare(timeB);
-    });
+    files.sort();
 
     for (const file of files) {
       // Skip orchestrator summary files — not real subagents
@@ -504,9 +684,12 @@ export function loadSubagents(rootPath: string): UISubagent[] {
             break;
         }
 
-        const idx = subagents.length;
-        subagents.push({
-          id: `loaded-${file.replace(".json", "")}`,
+        log(
+          `[loadSubagents] File ${file}: agentName=${data.agentName}, fileStatus=${data.status}, resolvedStatus=${status}, msgs=${messages.length}, toolCalls=${data.toolCallCount ?? 0}, steps=${data.stepCount ?? 0}`,
+        );
+
+        const entry: UISubagent = {
+          id: data.agentName,
           name:
             data.agentName === "attack-surface-agent"
               ? "Attack Surface Discovery"
@@ -516,14 +699,28 @@ export function loadSubagents(rootPath: string): UISubagent[] {
           messages,
           createdAt: timestamp,
           status,
-        });
+        };
 
-        // Index by agentName for manifest matching
-        agentNameIndex.set(data.agentName, idx);
+        // Deduplicate: if we already have an entry for this agentName
+        // (old sessions with multiple timestamped files), replace it
+        // in-place so the array has one entry per agent.
+        const prevIdx = agentNameIndex.get(data.agentName);
+        if (prevIdx !== undefined) {
+          log(
+            `[loadSubagents] Dedup agentName=${data.agentName} — replacing idx=${prevIdx} with newer file ${file}`,
+          );
+          subagents[prevIdx] = entry;
+        } else {
+          agentNameIndex.set(data.agentName, subagents.length);
+          subagents.push(entry);
+        }
       } catch (e) {
+        log(`[loadSubagents] ERROR loading file ${file}: ${e}`);
         console.error(`Failed to load subagent file ${file}:`, e);
       }
     }
+  } else {
+    log(`[loadSubagents] No ${SUBAGENTS_DIR}/ directory`);
   }
 
   // --- Merge with manifest ---
@@ -533,9 +730,17 @@ export function loadSubagents(rootPath: string): UISubagent[] {
       const manifest: AgentManifestEntry[] = JSON.parse(
         readFileSync(manifestPath, "utf-8"),
       );
+      log(
+        `[loadSubagents] Manifest has ${manifest.length} entries: ${manifest.map((e) => `${e.id}=${e.status}`).join(", ")}`,
+      );
 
       for (const entry of manifest) {
-        if (entry.status !== "running") continue;
+        if (entry.status !== "running") {
+          log(
+            `[loadSubagents] Manifest ${entry.id}: status=${entry.status}, skipping merge (not running)`,
+          );
+          continue;
+        }
 
         const resumeInfo: ResumeInfo = {
           target: entry.target,
@@ -548,7 +753,11 @@ export function loadSubagents(rootPath: string): UISubagent[] {
         const existingIndex = agentNameIndex.get(entry.id);
 
         if (existingIndex !== undefined) {
+          const fileStatus = subagents[existingIndex].status;
           // File exists but manifest says running → interrupted after partial save
+          log(
+            `[loadSubagents] Manifest ${entry.id}: running in manifest, file has status=${fileStatus}, msgs=${subagents[existingIndex].messages.length} → overriding to "paused"`,
+          );
           subagents[existingIndex] = {
             ...subagents[existingIndex],
             status: "paused",
@@ -556,6 +765,9 @@ export function loadSubagents(rootPath: string): UISubagent[] {
           };
         } else {
           // No file for this running entry — create a paused stub
+          log(
+            `[loadSubagents] Manifest ${entry.id}: running in manifest, NO file found → creating paused stub`,
+          );
           subagents.push({
             id: entry.id,
             name: entry.name,
@@ -569,9 +781,15 @@ export function loadSubagents(rootPath: string): UISubagent[] {
         }
       }
     } catch (e) {
+      log(`[loadSubagents] ERROR loading manifest: ${e}`);
       console.error("Failed to load agent manifest:", e);
     }
+  } else {
+    log("[loadSubagents] No manifest file found");
   }
 
+  log(
+    `[loadSubagents] RESULT: ${subagents.length} subagents: ${subagents.map((s) => `${s.id}(${s.status})`).join(", ")}`,
+  );
   return subagents;
 }

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -7,7 +7,6 @@
  */
 
 import {
-  appendFileSync,
   existsSync,
   mkdirSync,
   writeFileSync,
@@ -26,27 +25,6 @@ import type { ModelMessage } from "ai";
 
 const SUBAGENTS_DIR = "subagents";
 const MANIFEST_FILE = "agent-manifest.json";
-const RESUME_LOG_FILE = "swarm-resume.log";
-
-// ---------------------------------------------------------------------------
-// Resume logging — lightweight append-only log for diagnosing resume issues
-// ---------------------------------------------------------------------------
-
-/**
- * Append a timestamped line to `{rootPath}/logs/swarm-resume.log`.
- * Safe to call from anywhere — never throws.
- */
-export function resumeLog(rootPath: string, message: string): void {
-  try {
-    const logsDir = join(rootPath, "logs");
-    if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true });
-    const logPath = join(logsDir, RESUME_LOG_FILE);
-    const ts = new Date().toISOString();
-    appendFileSync(logPath, `${ts} - ${message}\n`, "utf8");
-  } catch {
-    /* never throw from logging */
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Types (previously in loader.ts — canonical home is now here)
@@ -287,11 +265,6 @@ export function saveSubagentData(
     join(subagentsDir, filename),
     JSON.stringify(savedData, null, 2),
   );
-
-  resumeLog(
-    session.rootPath,
-    `[saveSubagentData] ${data.agentName}: status=${data.status}, toolCalls=${toolCallCount}, steps=${stepCount}, findings=${data.findingsCount ?? 0}, error=${data.error ?? "none"}, file=${filename}`,
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -377,27 +350,13 @@ export function finalizeManifest(
   entries: AgentManifestEntry[],
   results: (unknown | null)[],
 ): void {
-  const log = (msg: string) => resumeLog(session.rootPath, msg);
-  log(
-    `[finalizeManifest] Finalizing ${entries.length} entries, ${results.length} results`,
-  );
-
   const finalManifest = entries.map((entry, i) => {
-    const hasResult = results[i] != null;
-    // Preserve already-completed entries (skipped agents on resume)
-    if (entry.status === "completed") {
-      log(
-        `[finalizeManifest] ${entry.id}: PRESERVED completed (result=${hasResult ? "present" : "null"})`,
-      );
-      return entry;
-    }
-    const newStatus = hasResult ? "completed" : "failed";
-    log(
-      `[finalizeManifest] ${entry.id}: ${entry.status} → ${newStatus} (result=${hasResult ? "present" : "null"})`,
-    );
+    if (entry.status === "completed") return entry;
     return {
       ...entry,
-      status: newStatus as "completed" | "failed",
+      status: (results[i] != null ? "completed" : "failed") as
+        | "completed"
+        | "failed",
       completedAt: new Date().toISOString(),
     };
   });
@@ -415,77 +374,38 @@ export function finalizeManifest(
  */
 export function getCompletedAgentIds(session: SessionInfo): Set<string> {
   const ids = new Set<string>();
-  const log = (msg: string) => resumeLog(session.rootPath, msg);
 
-  log("[getCompletedAgentIds] START");
-
-  // Manifest is the primary source
   const manifest = readAgentManifest(session);
-  log(
-    `[getCompletedAgentIds] Manifest has ${manifest.length} entries: ${manifest.map((e) => `${e.id}=${e.status}`).join(", ") || "(empty)"}`,
-  );
   for (const entry of manifest) {
-    // Only track pentest-agent-* IDs — discovery agents (attack-surface-agent)
-    // should never count toward the "all done" check for the swarm phase.
-    if (!entry.id.startsWith("pentest-agent-")) {
-      log(
-        `[getCompletedAgentIds] Manifest → SKIP non-pentest entry ${entry.id} (${entry.status})`,
-      );
-      continue;
-    }
+    if (!entry.id.startsWith("pentest-agent-")) continue;
     if (entry.status === "completed") {
       ids.add(entry.id);
-      log(
-        `[getCompletedAgentIds] Manifest → skip ${entry.id} (completed, target=${entry.target})`,
-      );
-    } else if (entry.status === "failed") {
-      log(
-        `[getCompletedAgentIds] Manifest → RETRY ${entry.id} (failed, target=${entry.target})`,
-      );
     }
   }
 
-  // Belt-and-suspenders: scan subagent files for completed status
+  // Belt-and-suspenders: scan subagent files for completed agents
+  // not reflected in the manifest
   const subagentsPath = join(session.rootPath, SUBAGENTS_DIR);
   if (existsSync(subagentsPath)) {
-    const files = readdirSync(subagentsPath).filter((f) =>
+    for (const file of readdirSync(subagentsPath).filter((f) =>
       f.endsWith(".json"),
-    );
-    log(
-      `[getCompletedAgentIds] Found ${files.length} subagent files in ${SUBAGENTS_DIR}/`,
-    );
-    for (const file of files) {
+    )) {
       try {
         const data = JSON.parse(
           readFileSync(join(subagentsPath, file), "utf-8"),
         ) as SavedSubagentData;
-        log(
-          `[getCompletedAgentIds] File ${file}: agentName=${data.agentName}, status=${data.status}, toolCalls=${data.toolCallCount ?? "?"}, steps=${data.stepCount ?? "?"}, findings=${data.findingsCount ?? "?"}`,
-        );
-        // Only track pentest-agent-* IDs from file scan too
-        if (!data.agentName.startsWith("pentest-agent-")) {
-          continue;
-        }
-        if (data.status === "completed") {
-          const wasNew = !ids.has(data.agentName);
+        if (
+          data.agentName.startsWith("pentest-agent-") &&
+          data.status === "completed"
+        ) {
           ids.add(data.agentName);
-          if (wasNew) {
-            log(
-              `[getCompletedAgentIds] File scan → skip ${data.agentName} (completed) [NEW — not in manifest]`,
-            );
-          }
         }
       } catch {
-        log(`[getCompletedAgentIds] Failed to parse file: ${file}`);
+        // skip unparseable files
       }
     }
-  } else {
-    log(`[getCompletedAgentIds] No ${SUBAGENTS_DIR}/ directory found`);
   }
 
-  log(
-    `[getCompletedAgentIds] RESULT: skipSet = {${[...ids].join(", ")}} (${ids.size} agents)`,
-  );
   return ids;
 }
 
@@ -635,10 +555,7 @@ export function convertModelMessagesToUI(
  *  5. Creates paused stubs for unmatched "running" manifest entries
  */
 export function loadSubagents(rootPath: string): UISubagent[] {
-  const log = (msg: string) => resumeLog(rootPath, msg);
   const subagentsPath = join(rootPath, SUBAGENTS_DIR);
-
-  log("[loadSubagents] START");
 
   // --- Load files ---
   const subagents: UISubagent[] = [];
@@ -647,7 +564,6 @@ export function loadSubagents(rootPath: string): UISubagent[] {
 
   if (existsSync(subagentsPath)) {
     const files = readdirSync(subagentsPath).filter((f) => f.endsWith(".json"));
-    log(`[loadSubagents] Found ${files.length} subagent files`);
 
     files.sort();
 
@@ -684,10 +600,6 @@ export function loadSubagents(rootPath: string): UISubagent[] {
             break;
         }
 
-        log(
-          `[loadSubagents] File ${file}: agentName=${data.agentName}, fileStatus=${data.status}, resolvedStatus=${status}, msgs=${messages.length}, toolCalls=${data.toolCallCount ?? 0}, steps=${data.stepCount ?? 0}`,
-        );
-
         const entry: UISubagent = {
           id: data.agentName,
           name:
@@ -702,25 +614,18 @@ export function loadSubagents(rootPath: string): UISubagent[] {
         };
 
         // Deduplicate: if we already have an entry for this agentName
-        // (old sessions with multiple timestamped files), replace it
-        // in-place so the array has one entry per agent.
+        // (old sessions with multiple timestamped files), keep the latest.
         const prevIdx = agentNameIndex.get(data.agentName);
         if (prevIdx !== undefined) {
-          log(
-            `[loadSubagents] Dedup agentName=${data.agentName} — replacing idx=${prevIdx} with newer file ${file}`,
-          );
           subagents[prevIdx] = entry;
         } else {
           agentNameIndex.set(data.agentName, subagents.length);
           subagents.push(entry);
         }
       } catch (e) {
-        log(`[loadSubagents] ERROR loading file ${file}: ${e}`);
         console.error(`Failed to load subagent file ${file}:`, e);
       }
     }
-  } else {
-    log(`[loadSubagents] No ${SUBAGENTS_DIR}/ directory`);
   }
 
   // --- Merge with manifest ---
@@ -730,17 +635,8 @@ export function loadSubagents(rootPath: string): UISubagent[] {
       const manifest: AgentManifestEntry[] = JSON.parse(
         readFileSync(manifestPath, "utf-8"),
       );
-      log(
-        `[loadSubagents] Manifest has ${manifest.length} entries: ${manifest.map((e) => `${e.id}=${e.status}`).join(", ")}`,
-      );
-
       for (const entry of manifest) {
-        if (entry.status !== "running") {
-          log(
-            `[loadSubagents] Manifest ${entry.id}: status=${entry.status}, skipping merge (not running)`,
-          );
-          continue;
-        }
+        if (entry.status !== "running") continue;
 
         const resumeInfo: ResumeInfo = {
           target: entry.target,
@@ -753,21 +649,12 @@ export function loadSubagents(rootPath: string): UISubagent[] {
         const existingIndex = agentNameIndex.get(entry.id);
 
         if (existingIndex !== undefined) {
-          const fileStatus = subagents[existingIndex].status;
-          // File exists but manifest says running → interrupted after partial save
-          log(
-            `[loadSubagents] Manifest ${entry.id}: running in manifest, file has status=${fileStatus}, msgs=${subagents[existingIndex].messages.length} → overriding to "paused"`,
-          );
           subagents[existingIndex] = {
             ...subagents[existingIndex],
             status: "paused",
             resumeInfo,
           };
         } else {
-          // No file for this running entry — create a paused stub
-          log(
-            `[loadSubagents] Manifest ${entry.id}: running in manifest, NO file found → creating paused stub`,
-          );
           subagents.push({
             id: entry.id,
             name: entry.name,
@@ -781,15 +668,9 @@ export function loadSubagents(rootPath: string): UISubagent[] {
         }
       }
     } catch (e) {
-      log(`[loadSubagents] ERROR loading manifest: ${e}`);
       console.error("Failed to load agent manifest:", e);
     }
-  } else {
-    log("[loadSubagents] No manifest file found");
   }
 
-  log(
-    `[loadSubagents] RESULT: ${subagents.length} subagents: ${subagents.map((s) => `${s.id}(${s.status})`).join(", ")}`,
-  );
   return subagents;
 }

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -125,11 +125,7 @@ export function loadSubagentMessages(
   session: SessionInfo,
   agentName: string,
 ): ModelMessage[] {
-  const filePath = join(
-    session.rootPath,
-    SUBAGENTS_DIR,
-    `${agentName}.json`,
-  );
+  const filePath = join(session.rootPath, SUBAGENTS_DIR, `${agentName}.json`);
   if (!existsSync(filePath)) return [];
   try {
     const data = JSON.parse(

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -30,24 +30,14 @@ const MANIFEST_FILE = "agent-manifest.json";
 // Types (previously in loader.ts — canonical home is now here)
 // ---------------------------------------------------------------------------
 
-/**
- * Message content part from AI SDK format
- */
-export interface MessageContentPart {
+/** Shape of a content part when inspecting persisted ModelMessage arrays. */
+interface ContentPart {
   type: "text" | "tool-call" | "tool-result";
   text?: string;
   toolCallId?: string;
   toolName?: string;
   input?: Record<string, unknown>;
   output?: unknown;
-}
-
-/**
- * Raw message format from saved subagent files
- */
-export interface SavedMessage {
-  role: "assistant" | "tool" | "user";
-  content: MessageContentPart[] | string;
 }
 
 /**
@@ -367,7 +357,7 @@ function convertMessagesToUI(
   const toolResults = new Map<string, unknown>();
   for (const msg of messages) {
     if (Array.isArray(msg.content)) {
-      for (const part of msg.content as MessageContentPart[]) {
+      for (const part of msg.content as ContentPart[]) {
         if (part.type === "tool-result" && part.toolCallId) {
           toolResults.set(part.toolCallId, part.output);
         }
@@ -386,7 +376,7 @@ function convertMessagesToUI(
         createdAt,
       });
     } else if (Array.isArray(msg.content)) {
-      for (const part of msg.content as MessageContentPart[]) {
+      for (const part of msg.content as ContentPart[]) {
         if (part.type === "text" && part.text) {
           uiMessages.push({
             role: "assistant",

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -17,7 +17,12 @@ import { join } from "path";
 import type { SessionInfo } from "./index";
 export type { SessionInfo };
 import type { AuthenticationInfo } from "./types";
-import type { ModelMessage } from "ai";
+import type {
+  ModelMessage,
+  TextPart,
+  ToolCallPart,
+  ToolResultPart,
+} from "ai";
 
 // ---------------------------------------------------------------------------
 // Shared path constants — used by both writer and reader
@@ -30,15 +35,7 @@ const MANIFEST_FILE = "agent-manifest.json";
 // Types (previously in loader.ts — canonical home is now here)
 // ---------------------------------------------------------------------------
 
-/** Shape of a content part when inspecting persisted ModelMessage arrays. */
-interface ContentPart {
-  type: "text" | "tool-call" | "tool-result";
-  text?: string;
-  toolCallId?: string;
-  toolName?: string;
-  input?: Record<string, unknown>;
-  output?: unknown;
-}
+type ContentPart = TextPart | ToolCallPart | ToolResultPart;
 
 /**
  * Saved subagent data format
@@ -384,9 +381,10 @@ function convertMessagesToUI(
             createdAt,
           });
         } else if (part.type === "tool-call") {
+          const input = part.input as Record<string, unknown> | undefined;
           const toolDescription =
-            typeof part.input?.toolCallDescription === "string"
-              ? part.input.toolCallDescription
+            typeof input?.toolCallDescription === "string"
+              ? input.toolCallDescription
               : part.toolName || "tool";
           const result = part.toolCallId
             ? toolResults.get(part.toolCallId)
@@ -397,7 +395,7 @@ function convertMessagesToUI(
             createdAt,
             toolCallId: part.toolCallId,
             toolName: part.toolName,
-            args: part.input,
+            args: input,
             result: result,
             status: "completed",
           });

--- a/src/core/utils/concurrency.ts
+++ b/src/core/utils/concurrency.ts
@@ -7,6 +7,7 @@ export async function runWithBoundedConcurrency<T, R>(
   items: T[],
   concurrency: number,
   fn: (item: T, index: number) => Promise<R>,
+  abortSignal?: AbortSignal,
 ): Promise<(R | null)[]> {
   const results: (R | null)[] = new Array(items.length).fill(null);
   let nextIdx = 0;
@@ -21,12 +22,21 @@ export async function runWithBoundedConcurrency<T, R>(
     let active = 0;
 
     function next() {
-      if (completed === items.length) {
+      // Resolve when all launched tasks complete and either all items
+      // have been launched or the signal was aborted.
+      if (
+        completed >= nextIdx &&
+        (nextIdx === items.length || abortSignal?.aborted)
+      ) {
         resolve();
         return;
       }
 
-      while (active < concurrency && nextIdx < items.length) {
+      while (
+        active < concurrency &&
+        nextIdx < items.length &&
+        !abortSignal?.aborted
+      ) {
         const idx = nextIdx++;
         active++;
 

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -26,8 +26,12 @@ import type { SessionInfo } from "../session";
 import {
   saveSubagentData,
   writeAgentManifest,
+  readAgentManifest,
   buildManifestEntries,
   finalizeManifest,
+  getCompletedAgentIds,
+  loadSubagentMessages,
+  resumeLog,
   type SwarmTarget,
 } from "../session/persistence";
 import {
@@ -35,6 +39,7 @@ import {
   writeExecutionMetrics,
 } from "../session/execution-metrics";
 import { runWithBoundedConcurrency } from "../utils/concurrency";
+import { loadAttackSurfaceResults } from "../session/loader";
 import {
   runWhiteboxAttackSurfaceWorkflow,
   type WhiteboxAttackSurfaceWorkflowInput,
@@ -83,6 +88,8 @@ export interface PentestSwarmInput {
   subagentCallbacks?: SubagentConsumeCallbacks;
   onError?: (e: unknown) => void;
   concurrency?: number;
+  /** Agent IDs to skip (already completed/failed from a previous run). */
+  skipAgentIds?: Set<string>;
   onStepFinish?: (event: {
     usage?: {
       inputTokens?: number;
@@ -141,12 +148,43 @@ export async function runPentestSwarm(
     subagentCallbacks,
     onError,
     concurrency = DEFAULT_CONCURRENCY,
+    skipAgentIds,
     onStepFinish,
   } = input;
 
-  // Write agent manifest with all agents as "running" — if the process
-  // crashes mid-run, the loader will detect these as paused/interrupted.
-  const manifestEntries = buildManifestEntries(targets);
+  const log = (msg: string) => resumeLog(session.rootPath, msg);
+
+  log(
+    `[runPentestSwarm] START: ${targets.length} targets, concurrency=${concurrency}, skipSet={${skipAgentIds ? [...skipAgentIds].join(", ") : "none"}}`,
+  );
+
+  // Build manifest: on resume, preserve completed entries from the previous
+  // run so agent IDs stay stable. Failed/aborted agents get fresh "running"
+  // entries since they'll be retried.
+  const existingManifest = readAgentManifest(session);
+  log(
+    `[runPentestSwarm] Existing manifest: ${existingManifest.length} entries: ${existingManifest.map((e) => `${e.id}=${e.status}`).join(", ") || "(empty)"}`,
+  );
+  const freshEntries = buildManifestEntries(targets);
+  const manifestEntries = freshEntries.map((fresh) => {
+    const existing = existingManifest.find((e) => e.id === fresh.id);
+    if (existing && existing.status === "completed") {
+      log(
+        `[runPentestSwarm] Manifest merge: ${fresh.id} → PRESERVED completed (target=${existing.target})`,
+      );
+      return existing;
+    }
+    if (existing && existing.status === "failed") {
+      log(
+        `[runPentestSwarm] Manifest merge: ${fresh.id} → RESET to running (was failed, will retry, target=${fresh.target})`,
+      );
+    } else {
+      log(
+        `[runPentestSwarm] Manifest merge: ${fresh.id} → FRESH running (target=${fresh.target})`,
+      );
+    }
+    return fresh;
+  });
   writeAgentManifest(session, manifestEntries);
 
   const results = await runWithBoundedConcurrency(
@@ -154,6 +192,19 @@ export async function runPentestSwarm(
     concurrency,
     async (target, index) => {
       const subagentId = `pentest-agent-${index + 1}`;
+
+      // Skip agents that already completed or failed in a previous run
+      if (skipAgentIds?.has(subagentId)) {
+        log(
+          `[runPentestSwarm] SKIP ${subagentId} (in skipSet, target=${target.target})`,
+        );
+        return null;
+      }
+      // Load previous messages for resume (empty array for fresh runs)
+      const previousMessages = loadSubagentMessages(session, subagentId);
+      log(
+        `[runPentestSwarm] SPAWN ${subagentId} (target=${target.target}, resumeMessages=${previousMessages.length}, objectives=${target.objectives.join("; ")})`,
+      );
       let lastMessages: ModelMessage[] = [];
 
       const handleStepFinish = (e: {
@@ -207,6 +258,7 @@ export async function runPentestSwarm(
           abortSignal,
           findingsRegistry,
           onStepFinish: handleStepFinish,
+          messages: previousMessages.length > 0 ? previousMessages : undefined,
         });
 
         const result = await agent.consume({
@@ -214,13 +266,17 @@ export async function runPentestSwarm(
           subagentCallbacks: wrappedCallbacks,
         });
 
+        log(
+          `[runPentestSwarm] ${subagentId} COMPLETED: ${result.findings.length} findings, ${lastMessages.length} messages`,
+        );
+
         saveSubagentData(session, {
           agentName: subagentId,
           target: target.target,
           objective: target.objectives.join("; "),
           status: "completed",
           findingsCount: result.findings.length,
-          messages: lastMessages,
+          messages: [...previousMessages, ...lastMessages],
         });
 
         subagentCallbacks?.onSubagentComplete?.({
@@ -231,13 +287,21 @@ export async function runPentestSwarm(
 
         return result;
       } catch (error) {
+        const errMsg =
+          error instanceof Error ? error.message : String(error);
+        const isAbort =
+          error instanceof Error && error.name === "AbortError";
+        log(
+          `[runPentestSwarm] ${subagentId} FAILED: isAbort=${isAbort}, error=${errMsg}, ${lastMessages.length} messages`,
+        );
+
         saveSubagentData(session, {
           agentName: subagentId,
           target: target.target,
           objective: target.objectives.join("; "),
           status: "failed",
-          error: error instanceof Error ? error.message : String(error),
-          messages: lastMessages,
+          error: errMsg,
+          messages: [...previousMessages, ...lastMessages],
         });
 
         subagentCallbacks?.onSubagentComplete?.({
@@ -249,9 +313,15 @@ export async function runPentestSwarm(
         throw error;
       }
     },
+    abortSignal,
   );
 
   // Rewrite manifest with final statuses (index-based matching)
+  const completed = results.filter((r) => r != null).length;
+  const failed = results.filter((r) => r == null).length;
+  log(
+    `[runPentestSwarm] DONE: ${completed} completed, ${failed} null (failed/skipped) out of ${results.length}`,
+  );
   finalizeManifest(session, manifestEntries, results);
 
   return results;
@@ -299,7 +369,19 @@ export async function runPentestWorkflow(
 
     let swarmTargets: SwarmTarget[];
 
-    if (mode === "whitebox") {
+    // On resume, reuse existing attack surface results instead of re-running
+    // discovery from scratch.
+    const existingResults = loadAttackSurfaceResults(session.rootPath);
+    if (existingResults?.targets && existingResults.targets.length > 0) {
+      resumeLog(
+        session.rootPath,
+        `[runPentestWorkflow] Phase 1: reusing ${existingResults.targets.length} targets from existing attack-surface-results.json`,
+      );
+      swarmTargets = existingResults.targets.map((t) => ({
+        target: t.target,
+        objectives: [t.objective],
+      }));
+    } else if (mode === "whitebox") {
       swarmTargets = await runWhiteboxPhase({
         codebasePath: cwd!,
         baseTarget: target,
@@ -320,6 +402,12 @@ export async function runPentestWorkflow(
         callbacks,
         onStepFinish,
       });
+    }
+
+    // Abort guard: don't continue to the swarm if we were aborted during
+    // discovery.
+    if (abortSignal?.aborted) {
+      throw new DOMException("Pentest aborted by user", "AbortError");
     }
 
     if (swarmTargets.length === 0) {
@@ -355,17 +443,34 @@ export async function runPentestWorkflow(
       },
     );
 
-    await runPentestSwarm({
-      targets: swarmTargets,
-      model,
-      session,
-      authConfig,
-      abortSignal,
-      findingsRegistry,
-      subagentCallbacks: callbacks?.subagentCallbacks,
-      onError: (e) => callbacks?.onError?.(e),
-      onStepFinish,
-    });
+    // On resume, skip agents that already completed/failed — pass all
+    // targets so agent IDs stay stable (index-based).
+    const skipAgentIds = getCompletedAgentIds(session);
+
+    resumeLog(
+      session.rootPath,
+      `[runPentestWorkflow] Phase 2: ${swarmTargets.length} targets, ${skipAgentIds.size} completed/failed → ${skipAgentIds.size < swarmTargets.length ? "running swarm" : "ALL done, skipping swarm"}`,
+    );
+
+    if (skipAgentIds.size < swarmTargets.length) {
+      await runPentestSwarm({
+        targets: swarmTargets,
+        model,
+        session,
+        authConfig,
+        abortSignal,
+        findingsRegistry,
+        skipAgentIds,
+        subagentCallbacks: callbacks?.subagentCallbacks,
+        onError: (e) => callbacks?.onError?.(e),
+        onStepFinish,
+      });
+    }
+
+    // Abort guard: don't write the report if we were aborted during the swarm.
+    if (abortSignal?.aborted) {
+      throw new DOMException("Pentest aborted by user", "AbortError");
+    }
 
     // =========================================================================
     // Phase 3: Aggregate results

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -31,7 +31,6 @@ import {
   finalizeManifest,
   getCompletedAgentIds,
   loadSubagentMessages,
-  resumeLog,
   type SwarmTarget,
 } from "../session/persistence";
 import {
@@ -152,37 +151,12 @@ export async function runPentestSwarm(
     onStepFinish,
   } = input;
 
-  const log = (msg: string) => resumeLog(session.rootPath, msg);
-
-  log(
-    `[runPentestSwarm] START: ${targets.length} targets, concurrency=${concurrency}, skipSet={${skipAgentIds ? [...skipAgentIds].join(", ") : "none"}}`,
-  );
-
-  // Build manifest: on resume, preserve completed entries from the previous
-  // run so agent IDs stay stable. Failed/aborted agents get fresh "running"
-  // entries since they'll be retried.
+  // On resume, preserve completed manifest entries so agent IDs stay stable.
   const existingManifest = readAgentManifest(session);
-  log(
-    `[runPentestSwarm] Existing manifest: ${existingManifest.length} entries: ${existingManifest.map((e) => `${e.id}=${e.status}`).join(", ") || "(empty)"}`,
-  );
   const freshEntries = buildManifestEntries(targets);
   const manifestEntries = freshEntries.map((fresh) => {
     const existing = existingManifest.find((e) => e.id === fresh.id);
-    if (existing && existing.status === "completed") {
-      log(
-        `[runPentestSwarm] Manifest merge: ${fresh.id} → PRESERVED completed (target=${existing.target})`,
-      );
-      return existing;
-    }
-    if (existing && existing.status === "failed") {
-      log(
-        `[runPentestSwarm] Manifest merge: ${fresh.id} → RESET to running (was failed, will retry, target=${fresh.target})`,
-      );
-    } else {
-      log(
-        `[runPentestSwarm] Manifest merge: ${fresh.id} → FRESH running (target=${fresh.target})`,
-      );
-    }
+    if (existing && existing.status === "completed") return existing;
     return fresh;
   });
   writeAgentManifest(session, manifestEntries);
@@ -193,18 +167,9 @@ export async function runPentestSwarm(
     async (target, index) => {
       const subagentId = `pentest-agent-${index + 1}`;
 
-      // Skip agents that already completed or failed in a previous run
-      if (skipAgentIds?.has(subagentId)) {
-        log(
-          `[runPentestSwarm] SKIP ${subagentId} (in skipSet, target=${target.target})`,
-        );
-        return null;
-      }
-      // Load previous messages for resume (empty array for fresh runs)
+      if (skipAgentIds?.has(subagentId)) return null;
+
       const previousMessages = loadSubagentMessages(session, subagentId);
-      log(
-        `[runPentestSwarm] SPAWN ${subagentId} (target=${target.target}, resumeMessages=${previousMessages.length}, objectives=${target.objectives.join("; ")})`,
-      );
       let lastMessages: ModelMessage[] = [];
 
       const handleStepFinish = (e: {
@@ -266,10 +231,6 @@ export async function runPentestSwarm(
           subagentCallbacks: wrappedCallbacks,
         });
 
-        log(
-          `[runPentestSwarm] ${subagentId} COMPLETED: ${result.findings.length} findings, ${lastMessages.length} messages`,
-        );
-
         saveSubagentData(session, {
           agentName: subagentId,
           target: target.target,
@@ -287,20 +248,12 @@ export async function runPentestSwarm(
 
         return result;
       } catch (error) {
-        const errMsg =
-          error instanceof Error ? error.message : String(error);
-        const isAbort =
-          error instanceof Error && error.name === "AbortError";
-        log(
-          `[runPentestSwarm] ${subagentId} FAILED: isAbort=${isAbort}, error=${errMsg}, ${lastMessages.length} messages`,
-        );
-
         saveSubagentData(session, {
           agentName: subagentId,
           target: target.target,
           objective: target.objectives.join("; "),
           status: "failed",
-          error: errMsg,
+          error: error instanceof Error ? error.message : String(error),
           messages: [...previousMessages, ...lastMessages],
         });
 
@@ -316,12 +269,6 @@ export async function runPentestSwarm(
     abortSignal,
   );
 
-  // Rewrite manifest with final statuses (index-based matching)
-  const completed = results.filter((r) => r != null).length;
-  const failed = results.filter((r) => r == null).length;
-  log(
-    `[runPentestSwarm] DONE: ${completed} completed, ${failed} null (failed/skipped) out of ${results.length}`,
-  );
   finalizeManifest(session, manifestEntries, results);
 
   return results;
@@ -369,14 +316,8 @@ export async function runPentestWorkflow(
 
     let swarmTargets: SwarmTarget[];
 
-    // On resume, reuse existing attack surface results instead of re-running
-    // discovery from scratch.
     const existingResults = loadAttackSurfaceResults(session.rootPath);
     if (existingResults?.targets && existingResults.targets.length > 0) {
-      resumeLog(
-        session.rootPath,
-        `[runPentestWorkflow] Phase 1: reusing ${existingResults.targets.length} targets from existing attack-surface-results.json`,
-      );
       swarmTargets = existingResults.targets.map((t) => ({
         target: t.target,
         objectives: [t.objective],
@@ -404,8 +345,6 @@ export async function runPentestWorkflow(
       });
     }
 
-    // Abort guard: don't continue to the swarm if we were aborted during
-    // discovery.
     if (abortSignal?.aborted) {
       throw new DOMException("Pentest aborted by user", "AbortError");
     }
@@ -443,14 +382,7 @@ export async function runPentestWorkflow(
       },
     );
 
-    // On resume, skip agents that already completed/failed — pass all
-    // targets so agent IDs stay stable (index-based).
     const skipAgentIds = getCompletedAgentIds(session);
-
-    resumeLog(
-      session.rootPath,
-      `[runPentestWorkflow] Phase 2: ${swarmTargets.length} targets, ${skipAgentIds.size} completed/failed → ${skipAgentIds.size < swarmTargets.length ? "running swarm" : "ALL done, skipping swarm"}`,
-    );
 
     if (skipAgentIds.size < swarmTargets.length) {
       await runPentestSwarm({
@@ -467,7 +399,6 @@ export async function runPentestWorkflow(
       });
     }
 
-    // Abort guard: don't write the report if we were aborted during the swarm.
     if (abortSignal?.aborted) {
       throw new DOMException("Pentest aborted by user", "AbortError");
     }

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -29,6 +29,7 @@ import {
   readAgentManifest,
   buildManifestEntries,
   finalizeManifest,
+  updateManifestEntryStatus,
   getCompletedAgentIds,
   loadSubagentMessages,
   type SwarmTarget,
@@ -87,8 +88,6 @@ export interface PentestSwarmInput {
   subagentCallbacks?: SubagentConsumeCallbacks;
   onError?: (e: unknown) => void;
   concurrency?: number;
-  /** Agent IDs to skip (already completed/failed from a previous run). */
-  skipAgentIds?: Set<string>;
   onStepFinish?: (event: {
     usage?: {
       inputTokens?: number;
@@ -147,11 +146,12 @@ export async function runPentestSwarm(
     subagentCallbacks,
     onError,
     concurrency = DEFAULT_CONCURRENCY,
-    skipAgentIds,
     onStepFinish,
   } = input;
 
-  // On resume, preserve completed manifest entries so agent IDs stay stable.
+  const completedIds = getCompletedAgentIds(session);
+
+  // Preserve completed manifest entries on resume so agent IDs stay stable.
   const existingManifest = readAgentManifest(session);
   const freshEntries = buildManifestEntries(targets);
   const manifestEntries = freshEntries.map((fresh) => {
@@ -167,7 +167,7 @@ export async function runPentestSwarm(
     async (target, index) => {
       const subagentId = `pentest-agent-${index + 1}`;
 
-      if (skipAgentIds?.has(subagentId)) return null;
+      if (completedIds.has(subagentId)) return null;
 
       const previousMessages = loadSubagentMessages(session, subagentId);
       let lastMessages: ModelMessage[] = [];
@@ -239,6 +239,7 @@ export async function runPentestSwarm(
           findingsCount: result.findings.length,
           messages: [...previousMessages, ...lastMessages],
         });
+        updateManifestEntryStatus(session, subagentId, "completed");
 
         subagentCallbacks?.onSubagentComplete?.({
           subagentId,
@@ -256,6 +257,7 @@ export async function runPentestSwarm(
           error: error instanceof Error ? error.message : String(error),
           messages: [...previousMessages, ...lastMessages],
         });
+        updateManifestEntryStatus(session, subagentId, "failed");
 
         subagentCallbacks?.onSubagentComplete?.({
           subagentId,
@@ -316,12 +318,14 @@ export async function runPentestWorkflow(
 
     let swarmTargets: SwarmTarget[];
 
+    // Resume: reuse existing attack surface results if available (both modes).
     const existingResults = loadAttackSurfaceResults(session.rootPath);
     if (existingResults?.targets && existingResults.targets.length > 0) {
       swarmTargets = existingResults.targets.map((t) => ({
         target: t.target,
         objectives: [t.objective],
       }));
+    // First run: mode-specific discovery.
     } else if (mode === "whitebox") {
       swarmTargets = await runWhiteboxPhase({
         codebasePath: cwd!,
@@ -382,9 +386,9 @@ export async function runPentestWorkflow(
       },
     );
 
-    const skipAgentIds = getCompletedAgentIds(session);
+    const completedCount = getCompletedAgentIds(session).size;
 
-    if (skipAgentIds.size < swarmTargets.length) {
+    if (completedCount < swarmTargets.length) {
       await runPentestSwarm({
         targets: swarmTargets,
         model,
@@ -392,7 +396,6 @@ export async function runPentestWorkflow(
         authConfig,
         abortSignal,
         findingsRegistry,
-        skipAgentIds,
         subagentCallbacks: callbacks?.subagentCallbacks,
         onError: (e) => callbacks?.onError?.(e),
         onStepFinish,

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -325,7 +325,7 @@ export async function runPentestWorkflow(
         target: t.target,
         objectives: [t.objective],
       }));
-    // First run: mode-specific discovery.
+      // First run: mode-specific discovery.
     } else if (mode === "whitebox") {
       swarmTargets = await runWhiteboxPhase({
         codebasePath: cwd!,

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -88,7 +88,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
       }
       const isOperator =
         currentSelection.config?.mode === "operator" ||
-        currentSelection.hasOperatorState;
+        (!currentSelection.config?.mode && currentSelection.hasOperatorState);
       refocusPrompt();
       onClose();
       route.navigate({
@@ -147,6 +147,11 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
     if (key.name === "r" && visualOrderSessions.length > 0) {
       const currentSelection = visualOrderSessions[selectedIndex];
       if (!currentSelection) return;
+      if (!currentSelection.hasReport) {
+        setStatusMessage("No report available");
+        setTimeout(() => setStatusMessage(""), 2000);
+        return;
+      }
       openReport(currentSelection.id);
       return;
     }
@@ -243,6 +248,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
                     const mode = session.config?.mode || "auto";
                     const modeBadge =
                       mode === "operator" ? "[operator]" : "[auto]";
+                    const statusBadge = session.hasReport ? "✓" : "…";
                     const findingsText =
                       session.findingsCount > 0
                         ? `${session.findingsCount} finding${session.findingsCount > 1 ? "s" : ""}`
@@ -271,6 +277,15 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
                             fg={isSelected ? colors.text : colors.textMuted}
                           >
                             {session.name}
+                          </text>
+                          <text
+                            fg={
+                              session.hasReport
+                                ? colors.primary
+                                : colors.textMuted
+                            }
+                          >
+                            {statusBadge}
                           </text>
                           <text
                             fg={

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -12,7 +12,6 @@ import {
   type UISubagent,
 } from "../../../core/session/loader";
 import { runPentestAgent } from "../../../core/api/blackboxPentest";
-import { resumeLog } from "../../../core/session/persistence";
 import { buildAuthConfig } from "../../../core/ai/utils";
 import { useAgent } from "../../context/agent";
 import { useRoute } from "../../context/route";
@@ -188,18 +187,6 @@ export default function Pentest({
         const hasState =
           state.subagents.length > 0 || state.hasReport || state.isComplete;
 
-        const log = (msg: string) => resumeLog(s.rootPath, msg);
-        log(
-          `[TUI load] hasState=${hasState}, subagents=${state.subagents.length}, hasReport=${state.hasReport}, isComplete=${state.isComplete}, interruptedDuringDiscovery=${state.interruptedDuringDiscovery}`,
-        );
-        if (hasState) {
-          for (const sa of state.subagents) {
-            log(
-              `[TUI load] Subagent: id=${sa.id}, type=${sa.type}, status=${sa.status}, msgs=${sa.messages.length}, target=${sa.target}`,
-            );
-          }
-        }
-
         if (hasState) {
           // Load saved discovery messages into the panel
           const attackSurfaceAgents = state.subagents.filter(
@@ -219,18 +206,12 @@ export default function Pentest({
           if (pentestSubagents.length > 0) {
             const agents: Record<string, AgentState> = {};
             for (const sa of pentestSubagents) {
-              const mapped = mapSubagentToAgentState(sa);
-              log(
-                `[TUI load] Mapped ${sa.id}: UISubagent.status=${sa.status} → AgentState.status=${mapped.status}, msgs=${mapped.messages.length}`,
-              );
-              agents[sa.id] = mapped;
+              agents[sa.id] = mapSubagentToAgentState(sa);
             }
             setPentestAgents(agents);
           }
 
           if (state.hasReport || state.isComplete) {
-            // Truly finished — show read-only completed view
-            log("[TUI load] Session complete — showing read-only view");
             setPhase("completed");
             if (attackSurfaceAgents.some((sa) => sa.messages.length > 0)) {
               setShowOrchestratorPanel(true);
@@ -240,20 +221,12 @@ export default function Pentest({
             if (attackSurfaceAgents.some((sa) => sa.messages.length > 0)) {
               setShowOrchestratorPanel(true);
             }
-            // Set initial phase based on what was already completed:
-            // - If discovery completed, skip to pentesting phase
-            // - Otherwise start from discovery
             if (state.attackSurfaceResults?.summary?.analysisComplete) {
-              log("[TUI load] Session interrupted — discovery done, resuming at pentesting phase");
               setPhase("pentesting");
-            } else {
-              log("[TUI load] Session interrupted — restarting from discovery");
             }
             startPentest(s);
           }
         } else {
-          // Brand-new session — start immediately
-          log("[TUI load] Brand-new session — starting pentest");
           startPentest(s);
         }
       } catch (e) {
@@ -766,16 +739,11 @@ export default function Pentest({
 
   const startPentest = useCallback(
     async (s: SessionInfo) => {
-      // Only reset to "discovery" if not already set to a later phase
-      // (e.g. on resume when discovery was already completed)
       setPhase((prev) =>
         prev === "pentesting" || prev === "reporting" ? prev : "discovery",
       );
       setStartTime(new Date());
       setIsExecuting(true);
-      // Only show thinking animation if discovery hasn't already completed
-      // (on resume, attack-surface-results.json exists — no discovery stream
-      // events will arrive to clear the indicator).
       const discoveryDone = existsSync(
         join(s.rootPath, "attack-surface-results.json"),
       );

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -12,6 +12,7 @@ import {
   type UISubagent,
 } from "../../../core/session/loader";
 import { runPentestAgent } from "../../../core/api/blackboxPentest";
+import { resumeLog } from "../../../core/session/persistence";
 import { buildAuthConfig } from "../../../core/ai/utils";
 import { useAgent } from "../../context/agent";
 import { useRoute } from "../../context/route";
@@ -187,6 +188,18 @@ export default function Pentest({
         const hasState =
           state.subagents.length > 0 || state.hasReport || state.isComplete;
 
+        const log = (msg: string) => resumeLog(s.rootPath, msg);
+        log(
+          `[TUI load] hasState=${hasState}, subagents=${state.subagents.length}, hasReport=${state.hasReport}, isComplete=${state.isComplete}, interruptedDuringDiscovery=${state.interruptedDuringDiscovery}`,
+        );
+        if (hasState) {
+          for (const sa of state.subagents) {
+            log(
+              `[TUI load] Subagent: id=${sa.id}, type=${sa.type}, status=${sa.status}, msgs=${sa.messages.length}, target=${sa.target}`,
+            );
+          }
+        }
+
         if (hasState) {
           // Load saved discovery messages into the panel
           const attackSurfaceAgents = state.subagents.filter(
@@ -206,13 +219,18 @@ export default function Pentest({
           if (pentestSubagents.length > 0) {
             const agents: Record<string, AgentState> = {};
             for (const sa of pentestSubagents) {
-              agents[sa.id] = mapSubagentToAgentState(sa);
+              const mapped = mapSubagentToAgentState(sa);
+              log(
+                `[TUI load] Mapped ${sa.id}: UISubagent.status=${sa.status} → AgentState.status=${mapped.status}, msgs=${mapped.messages.length}`,
+              );
+              agents[sa.id] = mapped;
             }
             setPentestAgents(agents);
           }
 
           if (state.hasReport || state.isComplete) {
             // Truly finished — show read-only completed view
+            log("[TUI load] Session complete — showing read-only view");
             setPhase("completed");
             if (attackSurfaceAgents.some((sa) => sa.messages.length > 0)) {
               setShowOrchestratorPanel(true);
@@ -222,10 +240,20 @@ export default function Pentest({
             if (attackSurfaceAgents.some((sa) => sa.messages.length > 0)) {
               setShowOrchestratorPanel(true);
             }
+            // Set initial phase based on what was already completed:
+            // - If discovery completed, skip to pentesting phase
+            // - Otherwise start from discovery
+            if (state.attackSurfaceResults?.summary?.analysisComplete) {
+              log("[TUI load] Session interrupted — discovery done, resuming at pentesting phase");
+              setPhase("pentesting");
+            } else {
+              log("[TUI load] Session interrupted — restarting from discovery");
+            }
             startPentest(s);
           }
         } else {
           // Brand-new session — start immediately
+          log("[TUI load] Brand-new session — starting pentest");
           startPentest(s);
         }
       } catch (e) {
@@ -738,10 +766,20 @@ export default function Pentest({
 
   const startPentest = useCallback(
     async (s: SessionInfo) => {
-      setPhase("discovery");
+      // Only reset to "discovery" if not already set to a later phase
+      // (e.g. on resume when discovery was already completed)
+      setPhase((prev) =>
+        prev === "pentesting" || prev === "reporting" ? prev : "discovery",
+      );
       setStartTime(new Date());
       setIsExecuting(true);
-      setThinking(true);
+      // Only show thinking animation if discovery hasn't already completed
+      // (on resume, attack-surface-results.json exists — no discovery stream
+      // events will arrive to clear the indicator).
+      const discoveryDone = existsSync(
+        join(s.rootPath, "attack-surface-results.json"),
+      );
+      setThinking(!discoveryDone);
 
       const controller = new AbortController();
       setAbortController(controller);


### PR DESCRIPTION
Resuming a pentest session was broken in two ways: it would incorrectly open in operator mode, and sessions would appear as completed (because the completion heuristic counted previously-finished agents as done).

### Root causes & fixes

**Sessions falsely showing as completed on resume**
- `isComplete` used a heuristic that inferred completion when all pentest agents were done — on resume, already-completed agents got re-counted. Now `isComplete` only checks for the report file.

**Operator mode on resume**
- Resume always inferred operator mode from `hasOperatorState`. Now only does so when no explicit `config.mode` is set.

**Message history lost on resume**
- `response.messages` only contains messages from the current run. On save, this overwrote the full history. Now concatenates `previousMessages + lastMessages`, and `loadSubagentMessages()` reloads prior history before restarting an agent.

**Discovery & agents re-running unnecessarily**
- Skips attack surface discovery when `attack-surface-results.json` already exists.
- Skips agents the manifest already marks as completed (`getCompletedAgentIds`).

**Duplicate UI cards on resume**
- Subagent files changed from `{name}-{timestamp}.json` to `{name}.json` — stable filenames prevent duplicates and enable message reloading.

### Other changes

- `finalizeManifest` preserves already-completed entries; new `updateManifestEntryStatus()` for atomic per-agent updates during the swarm
- `runWithBoundedConcurrency` accepts an optional `abortSignal` — stops launching new items when aborted
- `OffensiveSecurityAgent` stores and checks `abortSignal`, throwing `AbortError` on completion if aborted
- `abortSignal` checked after discovery and after the swarm phase to surface silent aborts
- Dropped custom `SavedMessage`/`MessageContentPart` interfaces — messages saved and loaded as `ModelMessage[]` directly (AI SDK types), removing the no-op `mapToSavedMessage` conversion layer
- Session list shows status badge (✓ complete, … in-progress); `r` key guarded when no report exists


https://github.com/user-attachments/assets/5cd09e1c-c640-48f9-b05f-5eefdf9ffaa8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence/manifest semantics and resume orchestration for pentest sessions, which can affect whether agents rerun, how history is reconstructed, and when sessions are marked complete. Also alters cancellation behavior to stop launching new work and surface aborts consistently.
> 
> **Overview**
> Fixes pentest resume by **persisting and reusing prior subagent message history**, concatenating `previousMessages + lastMessages` on save and passing `messages` into specialized agents on restart.
> 
> Makes resume deterministic by switching subagent saves to **stable filenames** (`{agentName}.json`), adding helpers to load messages and update manifest entries incrementally, and preserving already-`completed` manifest entries so completed agents can be skipped.
> 
> Tightens workflow completion/cancellation: `isComplete` now keys off the presence of the final report file (not heuristics), attack-surface discovery is skipped when prior results exist, `runWithBoundedConcurrency` stops launching new tasks when aborted, and abort checks now throw `AbortError` after phases/agent completion.
> 
> Improves TUI resume UX: fixes operator-mode inference when `config.mode` is set, adds a report-availability guard and status indicator in the session list, and adjusts pentest phase/thinking state handling when resuming mid-run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 936759eee98fd2c72bd97a6f38f9f4bc2b06e7eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->