### PR TITLE
refactor: unify pensar gateway to streaming-only

### DIFF
--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -47,8 +47,8 @@ export interface PensarModelConfig {
  * When workspaceId is provided, sends X-Workspace-Id header for WorkOS auth.
  *
  * Both doGenerate() and doStream() use the same /gateway/invoke endpoint.
- * Streaming is true SSE via the Pensar Gateway. Falls back to wrapping
- * doGenerate() in a synthetic stream on network errors.
+ * doGenerate() delegates to doStream() and collects the full result.
+ * Streaming is true SSE via the Pensar Gateway.
  */
 export function createPensarModel(
   bedrockModelId: string,
@@ -217,8 +217,11 @@ export function createPensarModel(
           }),
         });
       } catch (err) {
-        logError(`  SSE fetch failed (${Date.now() - startTime}ms), falling back to doGenerate:`, err);
-        return doStreamFallback(model, options);
+        logError(`  SSE fetch failed (${Date.now() - startTime}ms):`, err);
+        throw new Error(
+          `Pensar Gateway request failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err },
+        );
       }
 
       const contentType = response.headers.get("content-type") ?? "unknown";
@@ -252,9 +255,9 @@ export function createPensarModel(
 
       if (!response.body) {
         logError(
-          `  SSE response has no body (${Date.now() - startTime}ms), falling back to doGenerate`,
+          `  SSE response has no body (${Date.now() - startTime}ms)`,
         );
-        return doStreamFallback(model, options);
+        throw new Error("Pensar Gateway returned an empty response body");
       }
 
       logInfo(`  SSE stream opened, reading events...`);
@@ -471,59 +474,3 @@ function mapStopReason(reason: string): LanguageModelV2FinishReason {
   }
 }
 
-/**
- * Non-streaming fallback: call doGenerate and wrap in a ReadableStream.
- * Used when streaming fails or is not available.
- */
-async function doStreamFallback(
-  model: LanguageModelV2,
-  options: LanguageModelV2CallOptions,
-): Promise<{
-  stream: ReadableStream<LanguageModelV2StreamPart>;
-  request?: { body?: unknown };
-  response?: { headers?: Record<string, string> };
-}> {
-  logInfo(`  doStreamFallback → using non-streaming doGenerate`);
-  const generateResult = await model.doGenerate(options);
-
-  const parts: LanguageModelV2StreamPart[] = [];
-
-  parts.push({ type: "stream-start", warnings: generateResult.warnings });
-
-  for (const item of generateResult.content) {
-    if (item.type === "text") {
-      const id = `text-${Date.now()}`;
-      parts.push({ type: "text-start", id });
-      parts.push({ type: "text-delta", id, delta: item.text });
-      parts.push({ type: "text-end", id });
-    } else if (item.type === "tool-call") {
-      const id = item.toolCallId;
-      parts.push({ type: "tool-input-start", id, toolName: item.toolName });
-      parts.push({ type: "tool-input-delta", id, delta: item.input });
-      parts.push({ type: "tool-input-end", id });
-      parts.push({
-        type: "tool-call",
-        toolCallId: id,
-        toolName: item.toolName,
-        input: item.input,
-      });
-    }
-  }
-
-  parts.push({
-    type: "finish",
-    finishReason: generateResult.finishReason,
-    usage: generateResult.usage,
-  });
-
-  const stream = new ReadableStream<LanguageModelV2StreamPart>({
-    start(controller) {
-      for (const part of parts) {
-        controller.enqueue(part);
-      }
-      controller.close();
-    },
-  });
-
-  return { stream, request: { body: generateResult.request?.body } };
-}

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -7,21 +7,22 @@ import type {
   LanguageModelV2StreamPart,
   LanguageModelV2Usage,
 } from "@ai-sdk/provider";
-import {
-  convertToBedrockFormat,
-  parseBedrockResponse,
-} from "./pensarFormatters";
+import { convertToBedrockFormat } from "./pensarFormatters";
 import { parseSSE } from "./pensarSSE";
 
 const DEBUG =
   process.env.PENSAR_DEBUG === "1" || process.env.PENSAR_DEBUG === "true";
 
 function log(...args: unknown[]) {
-  if (DEBUG) console.log("[pensar]", ...args);
+  if (DEBUG) console.error("[pensar:debug]", ...args);
+}
+
+function logInfo(...args: unknown[]) {
+  console.error("[pensar]", ...args);
 }
 
 function logError(...args: unknown[]) {
-  console.error("[pensar]", ...args);
+  console.error("[pensar:error]", ...args);
 }
 
 export interface PensarModelConfig {
@@ -39,21 +40,22 @@ export interface PensarModelConfig {
 
 /**
  * Creates a LanguageModelV2-compatible model that proxies requests through
- * the Pensar Console Bedrock proxy. This allows Apex CLI users to use
- * Pensar-managed inference with usage-based billing.
+ * the Pensar Gateway. This allows Apex CLI users to use Pensar-managed
+ * inference with usage-based billing.
  *
  * Supports both legacy API key auth and WorkOS JWT auth.
  * When workspaceId is provided, sends X-Workspace-Id header for WorkOS auth.
  *
- * doStream() discovers the Lambda Function URL via /bedrock/validate for
- * true SSE streaming. Falls back to /bedrock/invoke with stream: true
- * (buffered SSE) in dev, or wraps doGenerate() on error.
+ * Both doGenerate() and doStream() use the same /gateway/invoke endpoint.
+ * Streaming is true SSE via the Pensar Gateway. Falls back to wrapping
+ * doGenerate() in a synthetic stream on network errors.
  */
 export function createPensarModel(
   bedrockModelId: string,
   config: PensarModelConfig,
 ): LanguageModelV2 {
   const modelId = `pensar:${bedrockModelId}`;
+  logInfo(`createPensarModel: model=${bedrockModelId}, baseUrl=${config.baseUrl}`);
 
   /**
    * Build request headers, resolving the token via getToken() if available.
@@ -66,59 +68,30 @@ export function createPensarModel(
     if (config.getToken) {
       const result = await config.getToken();
       if (!result) {
+        logError("buildHeaders: getToken() returned null — auth failed");
         throw new Error(
           "Pensar authentication failed. Run /auth to reconnect.",
         );
       }
-      headers.Authorization = `Bearer ${result.token}`;
+      headers.Authorization = `Bearer ${result.token.slice(0, 12)}…`;
+      log(`  auth: ${result.type} token (${result.token.length} chars)`);
 
-      // WorkOS tokens need workspace ID header
       if (result.type === "workos" && config.workspaceId) {
         headers["X-Workspace-Id"] = config.workspaceId;
       }
+
+      // Restore the full token after logging the truncated version
+      headers.Authorization = `Bearer ${result.token}`;
     } else {
       headers.Authorization = `Bearer ${config.apiKey}`;
+      log(`  auth: apiKey (${config.apiKey.length} chars)`);
 
-      // If workspaceId is set and key doesn't look like a legacy key,
-      // include the workspace header
       if (config.workspaceId && !config.apiKey.startsWith("sk-")) {
         headers["X-Workspace-Id"] = config.workspaceId;
       }
     }
 
     return headers;
-  }
-
-  // ── Stream URL discovery ─────────────────────────────────────────────
-  let cachedStreamUrl: string | null = null;
-
-  async function getStreamUrl(): Promise<string> {
-    if (cachedStreamUrl) return cachedStreamUrl;
-
-    // Try to discover Lambda Function URL from /bedrock/validate
-    try {
-      const headers = await buildHeaders();
-      const res = await fetch(`${config.baseUrl}/bedrock/validate`, {
-        headers,
-      });
-      if (res.ok) {
-        const data = (await res.json()) as {
-          endpoints?: { stream?: string };
-        };
-        if (data.endpoints?.stream) {
-          cachedStreamUrl = data.endpoints.stream;
-          log(`  Discovered stream URL: ${cachedStreamUrl}`);
-          return cachedStreamUrl;
-        }
-      }
-    } catch {
-      // Fall through to fallback
-    }
-
-    // Fallback: buffered SSE via /bedrock/invoke with stream: true
-    cachedStreamUrl = `${config.baseUrl}/bedrock/invoke`;
-    log(`  Using fallback stream URL: ${cachedStreamUrl}`);
-    return cachedStreamUrl;
   }
 
   const model: LanguageModelV2 = {
@@ -136,94 +109,81 @@ export function createPensarModel(
       response?: { headers?: Record<string, string>; body?: unknown };
       warnings: Array<LanguageModelV2CallWarning>;
     }> {
-      const body = convertToBedrockFormat(bedrockModelId, options);
-      const url = `${config.baseUrl}/bedrock/invoke`;
-
-      log(`doGenerate → ${bedrockModelId}`);
-      log(`  URL: ${url}`);
-      log(
-        `  messages: ${(body.messages as unknown[])?.length ?? 0}, tools: ${(body.tools as unknown[])?.length ?? 0}`,
-      );
-
+      logInfo(`doGenerate → streaming and collecting for ${bedrockModelId}`);
       const startTime = Date.now();
-      const headers = await buildHeaders();
 
-      const response = await fetch(url, {
-        method: "POST",
-        headers,
-        signal: options.abortSignal,
-        body: JSON.stringify({
-          modelId: bedrockModelId,
-          body,
-          stream: false,
-        }),
-      });
-
-      log(`  response: ${response.status} (${Date.now() - startTime}ms)`);
-
-      if (!response.ok) {
-        const errorBody = await response.text();
-        let errorMessage: string;
-        try {
-          const parsed = JSON.parse(errorBody);
-          errorMessage = parsed.error || parsed.message || errorBody;
-        } catch {
-          errorMessage = errorBody;
-        }
-
-        logError(`  FAILED ${response.status}: ${errorMessage}`);
-
-        if (response.status === 402) {
-          throw new Error(
-            `Insufficient Pensar credits: ${errorMessage}. ` +
-              `Top up at https://console.pensar.dev`,
-          );
-        }
-
-        throw new Error(
-          `Pensar API error (${response.status}): ${errorMessage}`,
-        );
-      }
-
-      const result = (await response.json()) as {
-        response: Record<string, unknown>;
-        usage?: {
-          inputTokens: number;
-          outputTokens: number;
-          totalCost: number;
-        };
-      };
-
-      const usageFromProxy = result.usage ?? {
+      const { stream } = await model.doStream(options);
+      const content: LanguageModelV2Content[] = [];
+      let finishReason: LanguageModelV2FinishReason = "unknown";
+      let usage: LanguageModelV2Usage = {
         inputTokens: 0,
         outputTokens: 0,
+        totalTokens: 0,
       };
 
-      const parsed = parseBedrockResponse(bedrockModelId, result.response, {
-        inputTokens: usageFromProxy.inputTokens,
-        outputTokens: usageFromProxy.outputTokens,
-      });
+      const textParts: Record<string, string> = {};
+      const toolInputParts: Record<
+        string,
+        { toolName: string; input: string }
+      > = {};
 
-      log(
-        `  finish: ${parsed.finishReason}, content: ${parsed.content.length} parts`,
-      );
-      log(
-        `  usage: ${parsed.usage.inputTokens}in / ${parsed.usage.outputTokens}out`,
-      );
-      if (result.usage?.totalCost != null) {
-        log(`  cost: $${result.usage.totalCost.toFixed(6)}`);
+      const reader = stream.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          switch (value.type) {
+            case "text-start":
+              textParts[value.id] = "";
+              break;
+            case "text-delta":
+              textParts[value.id] =
+                (textParts[value.id] ?? "") + value.delta;
+              break;
+            case "text-end":
+              content.push({
+                type: "text",
+                text: textParts[value.id] ?? "",
+              });
+              break;
+            case "tool-input-start":
+              toolInputParts[value.id] = {
+                toolName: value.toolName,
+                input: "",
+              };
+              break;
+            case "tool-input-delta":
+              if (toolInputParts[value.id]) {
+                toolInputParts[value.id].input += value.delta;
+              }
+              break;
+            case "tool-call":
+              content.push({
+                type: "tool-call",
+                toolCallId: value.toolCallId,
+                toolName: value.toolName,
+                input: value.input,
+              });
+              break;
+            case "finish":
+              finishReason = value.finishReason;
+              usage = value.usage;
+              break;
+          }
+        }
+      } finally {
+        reader.releaseLock();
       }
 
+      logInfo(
+        `  doGenerate complete: ${finishReason}, ${content.length} parts, ${usage.inputTokens}in/${usage.outputTokens}out (${Date.now() - startTime}ms)`,
+      );
+
       return {
-        content: parsed.content,
-        finishReason: parsed.finishReason,
-        usage: parsed.usage,
-        request: {
-          body,
-        },
-        response: {
-          body: result,
-        },
+        content,
+        finishReason,
+        usage,
         warnings: [],
       };
     },
@@ -234,12 +194,16 @@ export function createPensarModel(
       response?: { headers?: Record<string, string> };
     }> {
       const body = convertToBedrockFormat(bedrockModelId, options);
-      const url = await getStreamUrl();
+      const url = `${config.baseUrl}/gateway/invoke`;
 
-      log(`doStream → SSE streaming for ${bedrockModelId}`);
-      log(`  URL: ${url}`);
+      logInfo(`doStream → ${bedrockModelId} (${url})`);
+      log(
+        `  messages: ${(body.messages as unknown[])?.length ?? 0}, tools: ${(body.tools as unknown[])?.length ?? 0}`,
+      );
 
+      const startTime = Date.now();
       const headers = await buildHeaders();
+      log(`  headers: ${Object.keys(headers).join(", ")}`);
 
       let response: Response;
       try {
@@ -250,14 +214,19 @@ export function createPensarModel(
           body: JSON.stringify({
             modelId: bedrockModelId,
             body,
-            stream: true,
           }),
         });
       } catch (err) {
-        // Network error — fall back to non-streaming
-        logError(`  SSE fetch failed, falling back to doGenerate:`, err);
+        logError(`  SSE fetch failed (${Date.now() - startTime}ms), falling back to doGenerate:`, err);
         return doStreamFallback(model, options);
       }
+
+      const contentType = response.headers.get("content-type") ?? "unknown";
+      const transferEncoding =
+        response.headers.get("transfer-encoding") ?? "none";
+      logInfo(
+        `  response: ${response.status} (${Date.now() - startTime}ms) content-type=${contentType} transfer-encoding=${transferEncoding}`,
+      );
 
       if (!response.ok) {
         const errorBody = await response.text();
@@ -282,9 +251,13 @@ export function createPensarModel(
       }
 
       if (!response.body) {
-        logError(`  SSE response has no body, falling back to doGenerate`);
+        logError(
+          `  SSE response has no body (${Date.now() - startTime}ms), falling back to doGenerate`,
+        );
         return doStreamFallback(model, options);
       }
+
+      logInfo(`  SSE stream opened, reading events...`);
 
       const sseStream = response.body;
 
@@ -300,18 +273,24 @@ export function createPensarModel(
           let activeToolName: string | null = null;
           let activeToolInput = "";
 
+          let eventCount = 0;
           try {
             for await (const sse of parseSSE(sseStream)) {
+              eventCount++;
               let parsed: Record<string, unknown>;
               try {
                 parsed = JSON.parse(sse.data);
               } catch {
+                log(`  SSE event #${eventCount}: unparseable data, skipping`);
                 continue;
               }
+
+              log(`  SSE event #${eventCount}: ${sse.event} (type=${parsed.type})`);
 
               if (sse.event === "error") {
                 const msg =
                   (parsed.error as string) ?? "Unknown streaming error";
+                logError(`  SSE error event: ${msg}`);
                 controller.error(new Error(msg));
                 return;
               }
@@ -441,8 +420,8 @@ export function createPensarModel(
               }
             }
 
-            log(
-              `  stream done: ${finishReason}, ${inputTokens}in/${outputTokens}out`,
+            logInfo(
+              `  stream complete: ${finishReason}, ${inputTokens}in/${outputTokens}out (${Date.now() - startTime}ms)`,
             );
 
             controller.enqueue({
@@ -456,6 +435,7 @@ export function createPensarModel(
             });
             controller.close();
           } catch (err) {
+            logError(`  stream error:`, err);
             controller.error(err);
           }
         },
@@ -503,6 +483,7 @@ async function doStreamFallback(
   request?: { body?: unknown };
   response?: { headers?: Record<string, string> };
 }> {
+  logInfo(`  doStreamFallback → using non-streaming doGenerate`);
   const generateResult = await model.doGenerate(options);
 
   const parts: LanguageModelV2StreamPart[] = [];

--- a/src/core/ai/providers/pensarSSE.ts
+++ b/src/core/ai/providers/pensarSSE.ts
@@ -19,25 +19,46 @@ export async function* parseSSE(
   let buffer = "";
   let currentEvent = "message";
   let currentData: string[] = [];
+  let totalBytes = 0;
+  let chunkCount = 0;
+  let eventCount = 0;
 
   try {
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        console.error(
+          `[parseSSE] stream done: ${chunkCount} chunks, ${totalBytes} bytes, ${eventCount} events yielded, remaining buffer=${buffer.length} chars`,
+        );
+        if (buffer.length > 0) {
+          console.error(
+            `[parseSSE] remaining buffer: ${buffer.slice(0, 500)}`,
+          );
+        }
+        break;
+      }
 
-      buffer += decoder.decode(value, { stream: true });
+      chunkCount++;
+      totalBytes += value.byteLength;
+      const decoded = decoder.decode(value, { stream: true });
+
+      if (chunkCount <= 3) {
+        console.error(
+          `[parseSSE] chunk #${chunkCount}: ${value.byteLength} bytes, preview: ${decoded.slice(0, 200)}`,
+        );
+      }
+
+      buffer += decoded;
 
       const lines = buffer.split("\n");
-      // Keep the last (potentially incomplete) line in the buffer
       buffer = lines.pop() ?? "";
 
       for (let line of lines) {
-        // Trim carriage return if present (handles both \r\n and \n line endings)
         line = line.replace(/\r$/, "");
 
         if (line === "") {
-          // Blank line = end of SSE message
           if (currentData.length > 0) {
+            eventCount++;
             yield { event: currentEvent, data: currentData.join("\n") };
           }
           currentEvent = "message";
@@ -47,13 +68,21 @@ export async function* parseSSE(
         } else if (line.startsWith("data:")) {
           currentData.push(line.slice(5).trim());
         }
-        // Ignore id:, retry:, and comment lines (: prefix)
       }
     }
 
-    // Flush remaining data if stream ended without trailing blank line
     if (currentData.length > 0) {
+      eventCount++;
+      console.error(
+        `[parseSSE] flushing final event: ${currentEvent}`,
+      );
       yield { event: currentEvent, data: currentData.join("\n") };
+    }
+
+    if (eventCount === 0) {
+      console.error(
+        `[parseSSE] WARNING: stream ended with 0 events! totalBytes=${totalBytes}, chunks=${chunkCount}`,
+      );
     }
   } finally {
     reader.releaseLock();

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -133,14 +133,22 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
     cancelledRef.current = false;
 
     const apiUrl = getPensarApiUrl(appConfig.data);
+    console.error(`[auth] apiUrl=${apiUrl}`);
 
     // Try new WorkOS flow first, fall back to legacy device auth
     try {
+      console.error(`[auth] fetching ${apiUrl}/api/cli/config`);
       const configResponse = await fetch(`${apiUrl}/api/cli/config`);
+      console.error(
+        `[auth] config response: ${configResponse.status} ${configResponse.statusText}`,
+      );
       if (configResponse.ok) {
         const cliConfig = (await configResponse.json()) as {
           workosClientId: string;
         };
+        console.error(
+          `[auth] got workosClientId=${cliConfig.workosClientId.slice(0, 12)}...`,
+        );
 
         // New WorkOS device authorization flow
         const response = await fetch(
@@ -152,8 +160,15 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
           },
         );
 
+        console.error(
+          `[auth] device authorize response: ${response.status}`,
+        );
+
         if (response.ok) {
           const data = (await response.json()) as WorkOSDeviceResponse;
+          console.error(
+            `[auth] device code obtained, polling interval=${data.interval}s, expires=${data.expires_in}s`,
+          );
           setAuthMode("workos");
           setDeviceInfo(data);
           openUrl(data.verification_uri_complete);
@@ -168,8 +183,8 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
           return;
         }
       }
-    } catch {
-      // New endpoint not available — fall through to legacy
+    } catch (e) {
+      console.error(`[auth] WorkOS flow failed, falling back to legacy:`, e);
     }
 
     // Legacy device auth flow (backward compat)
@@ -223,6 +238,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
       }
 
       try {
+        console.error(`[auth] polling WorkOS authenticate...`);
         const response = await fetch(
           "https://api.workos.com/user_management/authenticate",
           {
@@ -238,13 +254,16 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
 
         if (cancelledRef.current) return;
 
+        console.error(`[auth] poll response: ${response.status}`);
+
         if (response.status === 400) {
-          // Authorization pending — poll again
           pollingRef.current = setTimeout(poll, interval * 1000);
           return;
         }
 
         if (!response.ok) {
+          const body = await response.text();
+          console.error(`[auth] auth failed: ${response.status} ${body}`);
           throw new Error("Authentication failed");
         }
 
@@ -253,18 +272,21 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
           refresh_token: string;
         };
 
-        // Save tokens and sync React state
+        console.error(
+          `[auth] got tokens, access_token=${data.access_token.length} chars`,
+        );
+
         await config.update({
           accessToken: data.access_token,
           refreshToken: data.refresh_token,
         });
         await appConfig.reload();
 
-        // Fetch user's workspaces
+        console.error(`[auth] tokens saved, fetching workspaces...`);
         await fetchWorkspaces(apiUrl, data.access_token);
       } catch (err) {
         if (cancelledRef.current) return;
-        // Network error — retry
+        console.error(`[auth] poll error, retrying:`, err);
         pollingRef.current = setTimeout(poll, interval * 1000);
       }
     };
@@ -357,15 +379,28 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
 
   const fetchWorkspaces = async (apiUrl: string, accessToken: string) => {
     try {
-      const response = await fetch(`${apiUrl}/api/cli/workspaces`, {
+      const url = `${apiUrl}/api/cli/workspaces`;
+      console.error(
+        `[auth] fetchWorkspaces: ${url} (token=${accessToken.length} chars)`,
+      );
+      const response = await fetch(url, {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
 
+      console.error(
+        `[auth] workspaces response: ${response.status} ${response.statusText}`,
+      );
+
       if (!response.ok) {
-        throw new Error("Failed to fetch workspaces");
+        const body = await response.text();
+        console.error(`[auth] workspaces error body: ${body}`);
+        throw new Error(`Failed to fetch workspaces (${response.status})`);
       }
 
       const data = (await response.json()) as { workspaces: WorkspaceInfo[] };
+      console.error(
+        `[auth] got ${data.workspaces.length} workspace(s)`,
+      );
 
       if (data.workspaces.length === 0) {
         setError("No workspaces found. Create one at console.pensar.dev");
@@ -374,7 +409,6 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
       }
 
       if (data.workspaces.length === 1) {
-        // Auto-select single workspace
         await selectWorkspace(apiUrl, accessToken, data.workspaces[0]);
         return;
       }
@@ -383,6 +417,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
       setSelectedIndex(0);
       setStep("select-workspace");
     } catch (err) {
+      console.error(`[auth] fetchWorkspaces error:`, err);
       setError(
         err instanceof Error ? err.message : "Failed to fetch workspaces",
       );
@@ -401,6 +436,9 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
     setStep("checking-billing");
 
     try {
+      console.error(
+        `[auth] selectWorkspace: ${workspace.id} (${workspace.name})`,
+      );
       const response = await fetch(`${apiUrl}/api/cli/select-workspace`, {
         method: "POST",
         headers: {
@@ -410,7 +448,13 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
         body: JSON.stringify({ workspaceId: workspace.id }),
       });
 
+      console.error(
+        `[auth] select-workspace response: ${response.status}`,
+      );
+
       if (!response.ok) {
+        const body = await response.text();
+        console.error(`[auth] select-workspace error: ${body}`);
         throw new Error("Failed to select workspace");
       }
 

--- a/src/tui/components/commands/credits-flow.tsx
+++ b/src/tui/components/commands/credits-flow.tsx
@@ -73,7 +73,7 @@ export default function CreditsFlow({ onOpenAuthDialog }: CreditsFlowProps) {
       if (tokenResult.type === "workos" && appConfig.data.workspaceId) {
         headers["X-Workspace-Id"] = appConfig.data.workspaceId;
       }
-      const response = await fetch(`${apiUrl}/bedrock/validate`, {
+      const response = await fetch(`${apiUrl}/gateway/validate`, {
         method: "GET",
         headers,
       });


### PR DESCRIPTION
## Summary
- `doGenerate` now delegates to `doStream` internally — the gateway only supports streaming, so there's no need for a separate non-streaming request path
- Removes `parseBedrockResponse` import and `stream: true/false` toggle from request body
- Adds always-on `logInfo` logging for the full request/response lifecycle (model creation, doGenerate, doStream, SSE events, completion)
- Adds detailed SSE parser logging (chunk counts, byte counts, content previews) for debugging stream issues
- Adds auth flow logging (`[auth]` prefix) for debugging workspace/token issues during `/auth`
- Updates `credits-flow.tsx` to use `/gateway/validate` endpoint

## Test plan
- [x] Run apex and verify streaming responses work end-to-end
- [x] Verify `doGenerate` (used by tool repair, object generation) works by collecting stream
- [x] Verify `/auth` flow logs are visible and helpful for debugging
- [x] Verify `/credits` command hits `/gateway/validate`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Pensar AI provider to be streaming-only and removes non-streaming/fallback paths, which could impact any callers depending on the previous `/bedrock/invoke` behavior. Adds extensive stderr logging (including SSE chunk previews) that may be noisy and could risk leaking sensitive data if enabled in production.
> 
> **Overview**
> The Pensar `LanguageModelV2` provider is refactored to be *streaming-only*: both `doStream` and `doGenerate` now call the same `/gateway/invoke` SSE endpoint, with `doGenerate` collecting the streamed parts into a final `content`/`usage` result, and the old `/bedrock/*` non-streaming path, stream URL discovery, and `doStreamFallback` wrapper removed.
> 
> Adds significantly more diagnostic logging across the request lifecycle (model creation, auth header construction with truncated token logging, SSE event tracing) and enhances `parseSSE` with byte/chunk/event counters and initial chunk previews to debug streaming issues. The TUI updates include verbose `/auth` flow logging for WorkOS/legacy fallback and switching the credits balance check from `/bedrock/validate` to `/gateway/validate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 015946f4d1bbd794ae6354225184c28135efaef0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->