### PR TITLE
feat: add Claude Opus 4.6 to Pensar provider models

### DIFF
--- a/src/core/ai/models/pensar.ts
+++ b/src/core/ai/models/pensar.ts
@@ -2,6 +2,12 @@ import type { ModelInfo } from "../ai";
 
 export const PENSAR_MODELS: ModelInfo[] = [
   {
+    id: "pensar:anthropic.claude-opus-4-6-v1",
+    name: "Claude Opus 4.6 (Pensar)",
+    provider: "pensar",
+    contextLength: 200000,
+  },
+  {
     id: "pensar:anthropic.claude-sonnet-4-5-20250929-v1:0",
     name: "Claude Sonnet 4.5 (Pensar)",
     provider: "pensar",


### PR DESCRIPTION
## Summary
- Adds `pensar:anthropic.claude-opus-4-6-v1` (Claude Opus 4.6) to the Pensar provider model list, enabling it for use through the Pensar Gateway.

## Test plan
- [x] `bun run tsc` passes
- [x] `bun run test` — all 386 tests pass

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single new entry is added to the curated `PENSAR_MODELS` registry with no changes to routing, auth, or request/response handling.
> 
> **Overview**
> Adds `pensar:anthropic.claude-opus-4-6-v1` ("Claude Opus 4.6") to the `PENSAR_MODELS` list so it becomes selectable via `AVAILABLE_MODELS` through the Pensar provider.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b55adbab8dc147471ece2404184fe1ec464027e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->