### PR TITLE
fix: hardcode Pensar API URL

### DIFF
--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -26,7 +26,6 @@ export type AIAuthConfig = {
   openRouterAPIKey?: string;
   inceptionAPIKey?: string;
   pensarAPIKey?: string;
-  pensarApiUrl?: string;
   // WorkOS CLI auth
   accessToken?: string;
   refreshToken?: string;
@@ -55,7 +54,6 @@ export function buildAuthConfig(cfg: {
   openRouterAPIKey?: string | null;
   inceptionAPIKey?: string | null;
   pensarAPIKey?: string | null;
-  pensarApiUrl?: string | null;
   accessToken?: string | null;
   refreshToken?: string | null;
   workspaceId?: string | null;
@@ -69,7 +67,6 @@ export function buildAuthConfig(cfg: {
     openRouterAPIKey: cfg.openRouterAPIKey ?? undefined,
     inceptionAPIKey: cfg.inceptionAPIKey ?? undefined,
     pensarAPIKey: cfg.pensarAPIKey ?? undefined,
-    pensarApiUrl: cfg.pensarApiUrl ?? undefined,
     accessToken: cfg.accessToken ?? undefined,
     refreshToken: cfg.refreshToken ?? undefined,
     workspaceId: cfg.workspaceId ?? undefined,
@@ -177,7 +174,7 @@ export function getProviderModel(
         );
       }
 
-      const pensarApiUrl = authConfig?.pensarApiUrl || getPensarApiUrl();
+      const pensarApiUrl = getPensarApiUrl();
       const bedrockModelId = model.startsWith("pensar:")
         ? model.slice(7)
         : model;
@@ -207,7 +204,6 @@ export function getProviderModel(
             accessToken: freshConfig.accessToken,
             refreshToken: freshConfig.refreshToken,
             pensarAPIKey: freshConfig.pensarAPIKey,
-            pensarApiUrl: freshConfig.pensarApiUrl,
           });
         };
       }

--- a/src/core/api/constants.ts
+++ b/src/core/api/constants.ts
@@ -1,12 +1,8 @@
 export const PENSAR_API_BASE_URL = "https://api.console.pensar.dev";
 export const PENSAR_CONSOLE_BASE_URL = "https://console.pensar.dev";
 
-export function getPensarApiUrl(config?: {
-  pensarApiUrl?: string | null;
-}): string {
-  return (
-    config?.pensarApiUrl || process.env.PENSAR_API_URL || PENSAR_API_BASE_URL
-  );
+export function getPensarApiUrl(): string {
+  return PENSAR_API_BASE_URL;
 }
 
 export function getPensarConsoleUrl(): string {

--- a/src/core/api/constants.ts
+++ b/src/core/api/constants.ts
@@ -1,4 +1,4 @@
-export const PENSAR_API_BASE_URL = "https://api.console.pensar.dev";
+export const PENSAR_API_BASE_URL = "https://api.pensar.dev";
 export const PENSAR_CONSOLE_BASE_URL = "https://console.pensar.dev";
 
 export function getPensarApiUrl(): string {

--- a/src/core/api/tokenRefresh.ts
+++ b/src/core/api/tokenRefresh.ts
@@ -89,7 +89,6 @@ export async function ensureValidToken(cfg: {
   accessToken?: string | null;
   refreshToken?: string | null;
   pensarAPIKey?: string | null;
-  pensarApiUrl?: string | null;
 }): Promise<{ token: string; type: "workos" | "legacy" } | null> {
   // If we have a WorkOS access token, prefer it
   if (cfg.accessToken) {
@@ -100,7 +99,7 @@ export async function ensureValidToken(cfg: {
     // Try to refresh
     if (cfg.refreshToken) {
       // Fetch client ID from the CLI config endpoint
-      const clientId = await fetchWorkOSClientId(cfg);
+      const clientId = await fetchWorkOSClientId();
       if (clientId) {
         const newToken = await refreshAccessToken(clientId, cfg.refreshToken);
         if (newToken) {
@@ -126,14 +125,12 @@ export async function ensureValidToken(cfg: {
  */
 let cachedClientId: string | null = null;
 
-async function fetchWorkOSClientId(cfg: {
-  pensarApiUrl?: string | null;
-}): Promise<string | null> {
+async function fetchWorkOSClientId(): Promise<string | null> {
   if (cachedClientId) return cachedClientId;
 
   try {
     const { getPensarApiUrl } = await import("./constants");
-    const apiUrl = getPensarApiUrl(cfg);
+    const apiUrl = getPensarApiUrl();
     const response = await fetch(`${apiUrl}/api/cli/config`);
 
     if (!response.ok) return null;

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -16,7 +16,6 @@ export interface Config {
   inceptionAPIKey?: string | null;
   bedrockAPIKey?: string | null;
   pensarAPIKey?: string | null;
-  pensarApiUrl?: string | null;
   responsibleUseAccepted: boolean;
   // Remote execution providers
   daytonaAPIKey?: string | null;
@@ -89,7 +88,6 @@ export async function get(): Promise<Config> {
       process.env.INCEPTION_API_KEY ?? parsedConfig.inceptionAPIKey,
     bedrockAPIKey: process.env.BEDROCK_API_KEY ?? parsedConfig.bedrockAPIKey,
     pensarAPIKey: process.env.PENSAR_API_KEY ?? parsedConfig.pensarAPIKey,
-    pensarApiUrl: process.env.PENSAR_API_URL ?? parsedConfig.pensarApiUrl,
     daytonaAPIKey: process.env.DAYTONA_API_KEY ?? parsedConfig.daytonaAPIKey,
     daytonaOrgId: process.env.DAYTONA_ORG_ID ?? parsedConfig.daytonaOrgId,
     runloopAPIKey: process.env.RUNLOOP_API_KEY ?? parsedConfig.runloopAPIKey,

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -132,7 +132,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
     setError(null);
     cancelledRef.current = false;
 
-    const apiUrl = getPensarApiUrl(appConfig.data);
+    const apiUrl = getPensarApiUrl();
     console.error(`[auth] apiUrl=${apiUrl}`);
 
     // Try new WorkOS flow first, fall back to legacy device auth
@@ -539,7 +539,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
       }
       if (key.name === "return" && workspaces[selectedIndex]) {
         const currentConfig = appConfig.data;
-        const apiUrl = getPensarApiUrl(currentConfig);
+        const apiUrl = getPensarApiUrl();
         const accessToken = currentConfig.accessToken!;
         selectWorkspace(apiUrl, accessToken, workspaces[selectedIndex]);
       }

--- a/src/tui/components/commands/credits-flow.tsx
+++ b/src/tui/components/commands/credits-flow.tsx
@@ -54,7 +54,6 @@ export default function CreditsFlow({ onOpenAuthDialog }: CreditsFlowProps) {
       accessToken: appConfig.data.accessToken,
       refreshToken: appConfig.data.refreshToken,
       pensarAPIKey: appConfig.data.pensarAPIKey,
-      pensarApiUrl: appConfig.data.pensarApiUrl,
     });
     if (!tokenResult) {
       setStep("no-auth");
@@ -65,7 +64,7 @@ export default function CreditsFlow({ onOpenAuthDialog }: CreditsFlowProps) {
     setError(null);
 
     try {
-      const apiUrl = getPensarApiUrl(appConfig.data);
+      const apiUrl = getPensarApiUrl();
       const headers: Record<string, string> = {
         Authorization: `Bearer ${tokenResult.token}`,
       };


### PR DESCRIPTION
## Summary
- Remove `pensarApiUrl` config field and `PENSAR_API_URL` env var override
- `getPensarApiUrl()` now always returns the hardcoded prod URL (`https://api.console.pensar.dev`)
- Prevents stale/incorrect API URLs from persisting in user config and breaking `/auth`

## Test plan
- [x] `tsc --noEmit` passes
- [ ] `/auth` flow connects to correct endpoint
- [ ] `/credits` fetches balance from correct endpoint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an override knob and routes all Pensar CLI/auth/credits traffic to the single production API base URL; main risk is breaking any non-prod/custom endpoint workflows that relied on `PENSAR_API_URL` or persisted `pensarApiUrl`.
> 
> **Overview**
> Forces all Pensar API calls to use the hardcoded production base URL by changing `getPensarApiUrl()` to always return `https://api.console.pensar.dev` and removing support for `PENSAR_API_URL` and the persisted `pensarApiUrl` config field.
> 
> Updates the AI provider (`createPensarModel`), WorkOS token refresh (`ensureValidToken`/client-id fetch), and TUI flows (`/auth`, `/credits`) to stop reading/passing a configurable API URL and consistently target the fixed endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c072b2a338b2583a0c4d2f07dde7d51cc4fe04ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->