### PR TITLE
docs: add /auth and /credits command documentation

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -62,6 +62,10 @@ navigation:
             path: ./docs/commands/models.mdx
           - page: /providers
             path: ./docs/commands/providers.mdx
+          - page: /auth
+            path: ./docs/commands/auth.mdx
+          - page: /credits
+            path: ./docs/commands/credits.mdx
           - page: /help
             path: ./docs/commands/help.mdx
   - tab: console

--- a/fern/docs/commands/auth.mdx
+++ b/fern/docs/commands/auth.mdx
@@ -1,0 +1,160 @@
+---
+title: "/auth"
+description: "Connect Apex to Pensar Console for managed inference and billing"
+---
+
+## Overview
+
+The `/auth` command connects your Apex CLI to [Pensar Console](https://console.pensar.dev) for **managed inference**. Once connected, Apex uses Pensar-hosted AI models — no API key configuration required. Inference costs are tracked and deducted from your workspace's credit balance.
+
+## Usage
+
+```bash
+/auth
+```
+
+## How It Works
+
+The `/auth` command uses a **device authorization flow** — similar to how you link a streaming device to your account. Apex displays a code, you verify it in your browser, and the CLI is automatically authenticated.
+
+<Steps>
+  <Step title="Start Auth Flow">
+    Run `/auth` in Apex and press Enter to begin. Apex requests a device code from the Pensar authentication service.
+  </Step>
+  <Step title="Verify in Browser">
+    A browser window opens automatically to the verification URL. If it doesn't open, copy the URL displayed in the terminal and open it manually. Enter the **user code** shown in Apex to confirm the connection.
+
+    <!-- TODO: screenshot of the polling step with user code -->
+  </Step>
+  <Step title="Select Workspace">
+    If your account belongs to multiple workspaces, Apex presents a list showing each workspace name and current credit balance. Use the arrow keys to select a workspace and press Enter.
+
+    <!-- TODO: screenshot of workspace selection -->
+  </Step>
+  <Step title="Billing Check">
+    Apex verifies that the selected workspace has billing configured and sufficient credits. If billing isn't set up or the balance is low, you'll see a prompt with a link to the Console billing page.
+  </Step>
+  <Step title="Connected">
+    On success, Apex displays your connected workspace and credit balance. You can now use Pensar-hosted models for pentesting without configuring any API keys.
+
+    <!-- TODO: screenshot of success state -->
+  </Step>
+</Steps>
+
+## Pensar Console
+
+[Pensar Console](https://console.pensar.dev) is the web platform where you manage workspaces, projects, billing, and more. When you authenticate Apex with `/auth`, you're linking it to a Console workspace.
+
+If you don't have an account yet, the verification URL will guide you through sign-up and workspace creation.
+
+### What You Can Do in Console
+
+<CardGroup cols={2}>
+  <Card title="Manage Billing" icon="credit-card">
+    Purchase credits, configure auto-reload, add payment methods, and view invoices from **Settings > Billing**.
+  </Card>
+  <Card title="Monitor Usage" icon="chart-line">
+    Track Apex inference spend per user and per API key from **Settings > Usage**.
+  </Card>
+  <Card title="Manage Workspaces" icon="users">
+    Create workspaces, invite team members, and control access roles.
+  </Card>
+  <Card title="Run Pentests" icon="shield-check">
+    Launch whitebox and blackbox pentests from the Console UI with full reporting.
+  </Card>
+</CardGroup>
+
+For full billing documentation, see the [Console Billing & Usage](/console/features/billing) guide.
+
+## Billing
+
+Apex inference through the Pensar gateway uses a **pre-paid credits** model. Credits are purchased in your Console workspace and deducted per inference request.
+
+### Key Billing Concepts
+
+| Concept | Description |
+|---|---|
+| **Credits** | Pre-paid balance (in USD) shared across your workspace |
+| **Category** | Apex inference is billed under the "Apex Inference" category, separate from CI pentest usage |
+| **Per-identity tracking** | Each request is attributed to the authenticated user, visible in Console's Usage page |
+| **Pre-flight checks** | Requests are rejected with a `402` error if credits are insufficient |
+| **Auto-reload** | Optional automatic top-up when balance drops below a threshold |
+
+### Setting Up Billing
+
+If Apex reports that billing isn't configured or your balance is low during `/auth`:
+
+<Steps>
+  <Step title="Open Billing Page">
+    Press the key shown in Apex to open the billing page in your browser, or navigate to **Settings > Billing** in Console manually.
+  </Step>
+  <Step title="Add Payment Method">
+    Add a credit or debit card via the inline form on the Billing page.
+  </Step>
+  <Step title="Purchase Credits">
+    Buy credits via a one-time purchase ($10 / $30 / $50 / $100 or custom) or set up a monthly subscription.
+  </Step>
+  <Step title="Enable Apex Inference">
+    On the **Settings > Usage** page, ensure the "Apex Inference" toggle is enabled. This is turned on automatically when you add your first payment method.
+  </Step>
+</Steps>
+
+For detailed billing documentation including auto-reload, invoices, and usage tracking, see [Console Billing & Usage](/console/features/billing).
+
+## Disconnecting
+
+When connected, press `[D]` on the `/auth` screen to disconnect. This clears the stored authentication tokens from your local Apex configuration. You can reconnect at any time by running `/auth` again.
+
+## Configuration
+
+Authentication state is stored in your local Apex configuration at `~/.pensar/`. The following values are managed by the `/auth` flow:
+
+| Config Key | Description |
+|---|---|
+| `accessToken` | Short-lived access token for API requests |
+| `refreshToken` | Long-lived token used to refresh the access token |
+| `workspaceId` | Selected workspace ID |
+| `workspaceSlug` | Selected workspace slug |
+
+Tokens are automatically refreshed when they expire. You do not need to re-run `/auth` unless you want to switch workspaces or have explicitly disconnected.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Browser doesn't open automatically">
+    Copy the verification URL displayed in the terminal and open it in your browser manually. The URL and user code remain valid for several minutes.
+  </Accordion>
+
+  <Accordion title="'Billing not ready' after connecting">
+    Navigate to **Settings > Billing** in Console and add a payment method. Then purchase credits and ensure the Apex Inference category is enabled on the Usage page. See [Console Billing & Usage](/console/features/billing) for step-by-step instructions.
+  </Accordion>
+
+  <Accordion title="'Insufficient credits' errors during pentesting">
+    Your workspace balance is too low. Purchase additional credits from **Settings > Billing** in Console, or enable auto-reload to prevent future interruptions. See [Console Billing & Usage](/console/features/billing#auto-reload).
+  </Accordion>
+
+  <Accordion title="Want to switch workspaces">
+    Press `[D]` to disconnect, then run `/auth` again. You'll be prompted to select a workspace during the new auth flow.
+  </Accordion>
+
+  <Accordion title="Auth flow times out">
+    Device codes expire after a few minutes. Run `/auth` again to restart the flow with a fresh code.
+  </Accordion>
+</AccordionGroup>
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="/credits" icon="credit-card" href="/apex/commands/credits">
+    Check your credit balance or open the purchase page.
+  </Card>
+  <Card title="/providers" icon="plug" href="/apex/commands/providers">
+    Configure API keys for direct provider access (alternative to managed inference).
+  </Card>
+  <Card title="/models" icon="microchip" href="/apex/commands/models">
+    Select which AI model to use for testing.
+  </Card>
+  <Card title="/pentest" icon="play" href="/apex/commands/pentest">
+    Launch a penetration test after connecting.
+  </Card>
+</CardGroup>

--- a/fern/docs/commands/credits.mdx
+++ b/fern/docs/commands/credits.mdx
@@ -1,0 +1,85 @@
+---
+title: "/credits"
+description: "Check your credit balance and purchase credits for Pensar managed inference"
+---
+
+## Overview
+
+The `/credits` command displays your current workspace credit balance and provides a quick way to open the Console billing page to purchase more credits.
+
+## Usage
+
+```bash
+/credits
+```
+
+Alias: `/buy`
+
+## Prerequisites
+
+You must be connected to Pensar Console via the [`/auth`](/apex/commands/auth) command before using `/credits`. If you're not authenticated, Apex will prompt you to connect first.
+
+## What You'll See
+
+When you run `/credits`, Apex:
+
+1. Validates your authentication token
+2. Fetches your current workspace credit balance from the Pensar gateway
+3. Displays the balance along with your connected workspace name
+
+<!-- TODO: screenshot of the credits display -->
+
+## Purchasing Credits
+
+From the `/credits` screen, press the indicated key to open the Console credits page in your browser. This takes you directly to the purchase flow where you can:
+
+- **Buy credits instantly** — choose from $10, $30, $50, $100, or enter a custom amount
+- **Start a monthly subscription** — receive credits automatically each billing cycle
+- **Configure auto-reload** — automatically top up when your balance drops below a threshold
+
+For full details on credit purchases, auto-reload, and billing management, see the [Console Billing & Usage](/console/features/billing) documentation.
+
+## How Credits Work
+
+Credits are a **pre-paid balance** (denominated in USD) stored at the workspace level in Pensar Console. When Apex uses Pensar managed inference, each AI request deducts from this balance based on the model used and tokens consumed.
+
+| Detail | Value |
+|---|---|
+| **Billing category** | Apex Inference |
+| **Pricing** | Base model cost + 15% Pensar markup |
+| **Tracking** | Per-user — your requests are attributed to your authenticated identity |
+| **Pre-flight check** | Requests are rejected if credits are insufficient |
+
+<Callout intent="info">
+  Credits are shared across all billing categories in your workspace (Apex Inference and Continuous Pentesting). Monitor usage per category from **Settings > Usage** in Console.
+</Callout>
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="'Not authenticated' error">
+    Run [`/auth`](/apex/commands/auth) first to connect Apex to your Console workspace.
+  </Accordion>
+
+  <Accordion title="Balance shows $0.00">
+    Open the Console billing page to purchase credits. You can also enable auto-reload to prevent your balance from reaching zero. See [Console Billing & Usage](/console/features/billing).
+  </Accordion>
+
+  <Accordion title="Browser doesn't open">
+    Copy the URL displayed in the terminal and open it manually in your browser.
+  </Accordion>
+</AccordionGroup>
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="/auth" icon="shield-check" href="/apex/commands/auth">
+    Connect to Pensar Console for managed inference.
+  </Card>
+  <Card title="/providers" icon="plug" href="/apex/commands/providers">
+    Configure direct API key access as an alternative to managed inference.
+  </Card>
+  <Card title="/pentest" icon="play" href="/apex/commands/pentest">
+    Launch a penetration test.
+  </Card>
+</CardGroup>

--- a/fern/docs/commands/help.mdx
+++ b/fern/docs/commands/help.mdx
@@ -53,10 +53,10 @@ When you run `/help`, you'll see a dialog showing:
   <Card title="/providers" icon="plug">
     Manage AI providers and configure API keys
   </Card>
-  <Card title="/auth" icon="shield-check">
+  <Card title="/auth" icon="shield-check" href="/apex/commands/auth">
     Connect to Pensar Console for managed inference
   </Card>
-  <Card title="/credits" icon="credit-card">
+  <Card title="/credits" icon="credit-card" href="/apex/commands/credits">
     Buy credits or check your balance
   </Card>
   <Card title="/themes" icon="palette">
@@ -144,5 +144,11 @@ For new users, here's the recommended order of commands:
   </Card>
   <Card title="/providers" icon="plug" href="/apex/commands/providers">
     Configure AI providers
+  </Card>
+  <Card title="/auth" icon="shield-check" href="/apex/commands/auth">
+    Connect to Pensar Console
+  </Card>
+  <Card title="/credits" icon="credit-card" href="/apex/commands/credits">
+    Check balance or buy credits
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Add comprehensive `/auth` command docs covering the device authorization flow, Pensar Console connection, workspace selection, billing checks, disconnecting, troubleshooting, and cross-links to Console billing docs
- Add `/credits` command docs covering balance display, credit purchasing, how credits work, and troubleshooting
- Update `/help` docs with `href` links to the new `/auth` and `/credits` pages and add both to the Related Commands section
- Add `/auth` and `/credits` to the fern `docs.yml` navigation under Commands

## Test plan
- [ ] Verify fern docs build locally with `fern generate --docs --preview`
- [ ] Confirm `/auth` and `/credits` appear in the Commands sidebar navigation
- [ ] Check all cross-links between Apex and Console docs resolve correctly


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is broken or incorrect cross-links in the docs/navigation.
> 
> **Overview**
> Adds new documentation pages for Apex commands `/auth` and `/credits`, including the device auth flow, workspace selection, billing/credits behavior, and troubleshooting, with cross-links into Console billing docs.
> 
> Updates Fern navigation (`fern/docs.yml`) to include the new command pages under **Commands**, and updates `docs/commands/help.mdx` to link `/auth` and `/credits` cards to their new pages and include them in the *Related Commands* section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8db396ac18ba7b831411ec24dabea761b3191c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->