### PR TITLE
fix: use JSX comment syntax in MDX docs

### DIFF
--- a/fern/docs/commands/auth.mdx
+++ b/fern/docs/commands/auth.mdx
@@ -24,12 +24,12 @@ The `/auth` command uses a **device authorization flow** — similar to how you 
   <Step title="Verify in Browser">
     A browser window opens automatically to the verification URL. If it doesn't open, copy the URL displayed in the terminal and open it manually. Enter the **user code** shown in Apex to confirm the connection.
 
-    <!-- TODO: screenshot of the polling step with user code -->
+    {/* TODO: screenshot of the polling step with user code */}
   </Step>
   <Step title="Select Workspace">
     If your account belongs to multiple workspaces, Apex presents a list showing each workspace name and current credit balance. Use the arrow keys to select a workspace and press Enter.
 
-    <!-- TODO: screenshot of workspace selection -->
+    {/* TODO: screenshot of workspace selection */}
   </Step>
   <Step title="Billing Check">
     Apex verifies that the selected workspace has billing configured and sufficient credits. If billing isn't set up or the balance is low, you'll see a prompt with a link to the Console billing page.
@@ -37,7 +37,7 @@ The `/auth` command uses a **device authorization flow** — similar to how you 
   <Step title="Connected">
     On success, Apex displays your connected workspace and credit balance. You can now use Pensar-hosted models for pentesting without configuring any API keys.
 
-    <!-- TODO: screenshot of success state -->
+    {/* TODO: screenshot of success state */}
   </Step>
 </Steps>
 

--- a/fern/docs/commands/credits.mdx
+++ b/fern/docs/commands/credits.mdx
@@ -27,7 +27,7 @@ When you run `/credits`, Apex:
 2. Fetches your current workspace credit balance from the Pensar gateway
 3. Displays the balance along with your connected workspace name
 
-<!-- TODO: screenshot of the credits display -->
+{/* TODO: screenshot of the credits display */}
 
 ## Purchasing Credits
 


### PR DESCRIPTION
## Summary
- Replace HTML comments (`<!-- -->`) with JSX comments (`{/* */}`) in the `/auth` and `/credits` MDX docs
- HTML comments are not valid MDX syntax and cause `fern generate --docs` to fail with: `Unexpected character '!' (U+0021) before name`

## Test plan
- [ ] Verify `fern generate --docs --preview` succeeds without parse errors


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that adjusts comment syntax to prevent MDX parsing failures during `fern generate --docs`. No runtime or business-logic impact.
> 
> **Overview**
> Fixes MDX build issues in the `/auth` and `/credits` docs by replacing invalid HTML comment blocks (`<!-- ... -->`) with MDX-compatible JSX comments (`{/* ... */}`). This prevents `fern generate --docs` from failing on the embedded TODO placeholders for future screenshots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e033ef60aae983401a057db7d6c11cba7f49e34e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->