### PR TITLE
TUI onboarding auth flow

### DIFF
--- a/src/tui/components/commands/provider-manager.tsx
+++ b/src/tui/components/commands/provider-manager.tsx
@@ -1,20 +1,28 @@
 import { useState } from "react";
+import { useKeyboard } from "@opentui/react";
 import { useRoute } from "../../context/route";
 import { useConfig } from "../../context/config";
 import { config } from "../../../core/config";
 import {
   type ProviderType,
   AVAILABLE_PROVIDERS,
+  hasAnyProviderConfigured,
 } from "../../../core/providers";
 import ProviderSelection from "./provider-selection";
 import APIKeyInput from "./api-key-input";
+import AuthFlow from "./auth-flow";
+import { useTheme } from "../../theme";
 
-type FlowState = "selecting" | "inputting";
+type FlowState = "choosing" | "selecting" | "inputting" | "auth";
 
 export default function ProviderManager() {
   const route = useRoute();
   const _config = useConfig();
-  const [flowState, setFlowState] = useState<FlowState>("selecting");
+
+  const isOnboarding = !hasAnyProviderConfigured(_config.data);
+  const [flowState, setFlowState] = useState<FlowState>(
+    isOnboarding ? "choosing" : "selecting",
+  );
   const [selectedProvider, setSelectedProvider] = useState<ProviderType | null>(
     null,
   );
@@ -27,7 +35,6 @@ export default function ProviderManager() {
   const handleAPIKeySubmit = async (apiKey: string) => {
     if (!selectedProvider) return;
 
-    // Update config based on provider
     const configUpdate: Record<string, string> = {};
     switch (selectedProvider) {
       case "anthropic":
@@ -47,13 +54,9 @@ export default function ProviderManager() {
         break;
     }
 
-    // Save to config
     await config.update(configUpdate);
-
-    // Reload config in context
     await _config.reload();
 
-    // Navigate to models to select a model
     route.navigate({
       type: "base",
       path: "models",
@@ -61,7 +64,11 @@ export default function ProviderManager() {
   };
 
   const handleAPIKeyCancel = () => {
-    setFlowState("selecting");
+    if (isOnboarding) {
+      setFlowState("choosing");
+    } else {
+      setFlowState("selecting");
+    }
     setSelectedProvider(null);
   };
 
@@ -72,16 +79,29 @@ export default function ProviderManager() {
     });
   };
 
+  const handleAuthClose = () => {
+    route.navigate({ type: "base", path: "home" });
+  };
+
+  const otherProviders = AVAILABLE_PROVIDERS.filter((p) => p.id !== "pensar");
+
   const selectedProviderInfo = AVAILABLE_PROVIDERS.find(
     (p) => p.id === selectedProvider,
   );
 
   return (
     <>
+      {flowState === "choosing" && (
+        <OnboardingChoice
+          onPensarSelected={() => setFlowState("auth")}
+          onOtherSelected={() => setFlowState("selecting")}
+        />
+      )}
       {flowState === "selecting" && (
         <ProviderSelection
+          providers={isOnboarding ? otherProviders : undefined}
           onProviderSelected={handleProviderSelected}
-          onClose={handleClose}
+          onClose={isOnboarding ? () => setFlowState("choosing") : handleClose}
         />
       )}
       {flowState === "inputting" &&
@@ -94,6 +114,122 @@ export default function ProviderManager() {
             onCancel={handleAPIKeyCancel}
           />
         )}
+      {flowState === "auth" && <AuthFlow onClose={handleAuthClose} />}
     </>
+  );
+}
+
+function OnboardingChoice({
+  onPensarSelected,
+  onOtherSelected,
+}: {
+  onPensarSelected: () => void;
+  onOtherSelected: () => void;
+}) {
+  const { colors } = useTheme();
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+
+  const choices = [
+    {
+      label: "Pensar",
+      description: "Managed inference — no API keys needed",
+      action: onPensarSelected,
+    },
+    {
+      label: "Use other provider",
+      description: "Connect with your own API key (Anthropic, OpenAI, etc.)",
+      action: onOtherSelected,
+    },
+  ];
+
+  useKeyboard((key) => {
+    if (key.name === "up") {
+      setHighlightedIndex((prev) =>
+        prev > 0 ? prev - 1 : choices.length - 1,
+      );
+      return;
+    }
+
+    if (key.name === "down") {
+      setHighlightedIndex((prev) =>
+        prev < choices.length - 1 ? prev + 1 : 0,
+      );
+      return;
+    }
+
+    if (key.name === "return") {
+      choices[highlightedIndex].action();
+      return;
+    }
+  });
+
+  return (
+    <box
+      position="absolute"
+      top={0}
+      left={0}
+      zIndex={1000}
+      width="100%"
+      height="100%"
+      justifyContent="center"
+      alignItems="center"
+      backgroundColor={"transparent"}
+    >
+      <box
+        width={70}
+        border={true}
+        borderColor={colors.primary}
+        backgroundColor={colors.backgroundPanel}
+        flexDirection="column"
+        padding={2}
+      >
+        {/* Header */}
+        <box flexDirection="row" marginBottom={2}>
+          <text fg={colors.primary}>Get Started</text>
+        </box>
+
+        <box marginBottom={2}>
+          <text fg={colors.textMuted}>
+            Choose how to connect an AI provider.
+          </text>
+        </box>
+
+        {/* Choices */}
+        <box flexDirection="column" gap={1}>
+          {choices.map((choice, index) => {
+            const isHighlighted = index === highlightedIndex;
+            return (
+              <box
+                key={choice.label}
+                flexDirection="column"
+                paddingLeft={1}
+                paddingRight={1}
+                backgroundColor={
+                  isHighlighted ? colors.backgroundSelected : undefined
+                }
+                onMouseDown={choice.action}
+              >
+                <text fg={isHighlighted ? colors.primary : colors.text}>
+                  {isHighlighted ? "▸ " : "  "}
+                  {choice.label}
+                </text>
+                <text fg={colors.textMuted}>
+                  {"    "}
+                  {choice.description}
+                </text>
+              </box>
+            );
+          })}
+        </box>
+
+        {/* Footer */}
+        <box marginTop={2}>
+          <text fg={colors.textMuted}>
+            <span fg={colors.primary}>[↑↓]</span> Navigate ·{" "}
+            <span fg={colors.primary}>[ENTER]</span> Select
+          </text>
+        </box>
+      </box>
+    </box>
   );
 }

--- a/src/tui/components/commands/provider-manager.tsx
+++ b/src/tui/components/commands/provider-manager.tsx
@@ -144,16 +144,12 @@ function OnboardingChoice({
 
   useKeyboard((key) => {
     if (key.name === "up") {
-      setHighlightedIndex((prev) =>
-        prev > 0 ? prev - 1 : choices.length - 1,
-      );
+      setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : choices.length - 1));
       return;
     }
 
     if (key.name === "down") {
-      setHighlightedIndex((prev) =>
-        prev < choices.length - 1 ? prev + 1 : 0,
-      );
+      setHighlightedIndex((prev) => (prev < choices.length - 1 ? prev + 1 : 0));
       return;
     }
 

--- a/src/tui/components/commands/provider-selection.tsx
+++ b/src/tui/components/commands/provider-selection.tsx
@@ -6,15 +6,18 @@ import {
   AVAILABLE_PROVIDERS,
   getConfiguredProviders,
   type ProviderType,
+  type Provider,
 } from "../../../core/providers";
 import { useTheme } from "../../theme";
 
 interface ProviderSelectionProps {
+  providers?: Provider[];
   onProviderSelected: (providerId: ProviderType) => void;
   onClose: () => void;
 }
 
 export default function ProviderSelection({
+  providers,
   onProviderSelected,
   onClose,
 }: ProviderSelectionProps) {
@@ -23,34 +26,31 @@ export default function ProviderSelection({
   const _config = useConfig();
   const [highlightedIndex, setHighlightedIndex] = useState(0);
 
+  const providerList = providers ?? AVAILABLE_PROVIDERS;
   const configuredProviders = getConfiguredProviders(_config.data);
 
   useKeyboard((key) => {
-    // Escape - Close provider selection
     if (key.name === "escape") {
       onClose();
       return;
     }
 
-    // Arrow Up - Previous provider
     if (key.name === "up") {
       setHighlightedIndex((prev) =>
-        prev > 0 ? prev - 1 : AVAILABLE_PROVIDERS.length - 1,
+        prev > 0 ? prev - 1 : providerList.length - 1,
       );
       return;
     }
 
-    // Arrow Down - Next provider
     if (key.name === "down") {
       setHighlightedIndex((prev) =>
-        prev < AVAILABLE_PROVIDERS.length - 1 ? prev + 1 : 0,
+        prev < providerList.length - 1 ? prev + 1 : 0,
       );
       return;
     }
 
-    // Enter - Select provider
     if (key.name === "return") {
-      const selected = AVAILABLE_PROVIDERS[highlightedIndex];
+      const selected = providerList[highlightedIndex];
       if (selected) {
         onProviderSelected(selected.id);
       }
@@ -118,7 +118,7 @@ export default function ProviderSelection({
             Popular providers
           </text>
 
-          {AVAILABLE_PROVIDERS.map((provider, index) => {
+          {providerList.map((provider, index) => {
             const isHighlighted = index === highlightedIndex;
             const configured = configuredProviders.find(
               (p) => p.id === provider.id,

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -376,7 +376,7 @@ function CommandDisplay({
     await config.update({ responsibleUseAccepted: true });
     route.navigate({
       type: "base",
-      path: "home",
+      path: "providers",
     });
   };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR updates the new user onboarding flow in the TUI to reflect the introduction of our own authentication.

Previously, the flow was responsible disclosure -> setup provider, with Pensar as one of many options.

The updated flow now:
1.  After responsible disclosure, presents a "Get Started" screen.
2.  The primary option is "Pensar", which, when selected, initiates an embedded authentication flow.
3.  A secondary option, "Use other provider", leads to the existing API key entry flow, but with Pensar excluded from the list of available providers.

This was achieved by:
*   Introducing new flow states (`"choosing"`, `"auth"`) and an `OnboardingChoice` component in `provider-manager.tsx`.
*   Modifying `provider-selection.tsx` to accept an optional `providers` prop, allowing the list to be filtered.
*   Adjusting `index.tsx` to navigate directly to the `providers` route after policy acceptance.

### How did you verify your code works?

*   `bun run tsc` passed with no type errors.
*   `bun run lint` passed with no lint errors.
*   `bun run test` passed (408 passed, 15 skipped, 0 failed).
*   Manual TUI testing confirmed the full onboarding flow:
    *   Disclosure acceptance leads to the "Get Started" screen with "Pensar" highlighted.
    *   Selecting "Pensar" opens the embedded authentication dialog.
    *   Selecting "Use other provider" displays the provider list without "Pensar".
    *   Pressing ESC from the provider list returns to the "Get Started" screen.
    *   Testing was performed with environment variables unset to simulate a clean first-run experience.

<div><a href="https://cursor.com/agents/bc-e41e8555-f2d2-4552-bf77-6263577d2d59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e41e8555-f2d2-4552-bf77-6263577d2d59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->