### PR TITLE
feat: add HMAC request signing for gateway inference calls

### DIFF
--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -9,6 +9,7 @@ import type {
 } from "@ai-sdk/provider";
 import { convertToBedrockFormat } from "./pensarFormatters";
 import { parseSSE } from "./pensarSSE";
+import { signGatewayRequest } from "./pensarSigning";
 
 const DEBUG =
   process.env.PENSAR_DEBUG === "1" || process.env.PENSAR_DEBUG === "true";
@@ -30,6 +31,11 @@ export interface PensarModelConfig {
   baseUrl: string;
   /** Workspace ID for WorkOS-authenticated requests. */
   workspaceId?: string;
+  /**
+   * Server-issued HMAC signing key for request authentication.
+   * When present, every inference request is signed with this key.
+   */
+  signingKey?: string;
   /**
    * Optional callback to get a fresh token before each request.
    * If provided, this is called instead of using `apiKey` directly,
@@ -203,7 +209,23 @@ export function createPensarModel(
       );
 
       const startTime = Date.now();
+      const serializedBody = JSON.stringify({
+        modelId: bedrockModelId,
+        body,
+      });
       const headers = await buildHeaders();
+
+      if (config.signingKey) {
+        const sig = signGatewayRequest(
+          config.signingKey,
+          bedrockModelId,
+          serializedBody,
+        );
+        headers["X-Pensar-Signature"] = sig.signature;
+        headers["X-Pensar-Timestamp"] = sig.timestamp;
+        headers["X-Pensar-Nonce"] = sig.nonce;
+      }
+
       log(`  headers: ${Object.keys(headers).join(", ")}`);
 
       let response: Response;
@@ -212,10 +234,7 @@ export function createPensarModel(
           method: "POST",
           headers,
           signal: options.abortSignal,
-          body: JSON.stringify({
-            modelId: bedrockModelId,
-            body,
-          }),
+          body: serializedBody,
         });
       } catch (err) {
         logError(`  SSE fetch failed (${Date.now() - startTime}ms):`, err);

--- a/src/core/ai/providers/pensarSigning.ts
+++ b/src/core/ai/providers/pensarSigning.ts
@@ -1,0 +1,25 @@
+import { createHmac, createHash, randomUUID } from "crypto";
+
+/**
+ * Sign an inference request for the Pensar Gateway.
+ *
+ * The signature proves possession of the server-issued signing key
+ * and binds the request to a specific timestamp, nonce, model, and body —
+ * preventing replay attacks and request tampering.
+ *
+ * Payload format: "<timestamp>\n<nonce>\n<modelId>\n<SHA256(body)>"
+ */
+export function signGatewayRequest(
+  signingKey: string,
+  modelId: string,
+  body: string,
+): { signature: string; timestamp: string; nonce: string } {
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const nonce = randomUUID();
+  const bodyHash = createHash("sha256").update(body).digest("hex");
+  const payload = `${timestamp}\n${nonce}\n${modelId}\n${bodyHash}`;
+  const signature = createHmac("sha256", signingKey)
+    .update(payload)
+    .digest("base64");
+  return { signature, timestamp, nonce };
+}

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -30,6 +30,8 @@ export type AIAuthConfig = {
   accessToken?: string;
   refreshToken?: string;
   workspaceId?: string;
+  // Gateway request signing
+  gatewaySigningKey?: string;
   bedrock?: {
     apiKey?: string;
     accessKeyId?: string;
@@ -57,6 +59,7 @@ export function buildAuthConfig(cfg: {
   accessToken?: string | null;
   refreshToken?: string | null;
   workspaceId?: string | null;
+  gatewaySigningKey?: string | null;
   bedrockAPIKey?: string | null;
   localModelUrl?: string | null;
 }): AIAuthConfig {
@@ -70,6 +73,7 @@ export function buildAuthConfig(cfg: {
     accessToken: cfg.accessToken ?? undefined,
     refreshToken: cfg.refreshToken ?? undefined,
     workspaceId: cfg.workspaceId ?? undefined,
+    gatewaySigningKey: cfg.gatewaySigningKey ?? undefined,
     bedrock: cfg.bedrockAPIKey ? { apiKey: cfg.bedrockAPIKey } : undefined,
     local: cfg.localModelUrl ? { baseURL: cfg.localModelUrl } : undefined,
   };
@@ -192,6 +196,7 @@ export function getProviderModel(
         apiKey: pensarApiKey || authConfig?.accessToken || "",
         baseUrl: pensarApiUrl,
         workspaceId: authConfig?.workspaceId,
+        signingKey: authConfig?.gatewaySigningKey,
       };
 
       // If WorkOS tokens are available, use token refresh callback.

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -34,6 +34,8 @@ export interface Config {
   refreshToken?: string | null;
   workspaceId?: string | null;
   workspaceSlug?: string | null;
+  // Gateway request signing key (server-issued)
+  gatewaySigningKey?: string | null;
 }
 
 export async function init() {

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -46,6 +46,7 @@ interface LegacyTokenResponse {
   apiKey?: string;
   workspace?: { id: string; name: string; slug: string };
   credits?: { balance: number };
+  signingKey?: string;
 }
 
 interface WorkspaceInfo {
@@ -61,6 +62,7 @@ interface SelectWorkspaceResponse {
   workspace: { id: string; name: string; slug: string };
   billing: { balance: number; hasPaymentMethod: boolean; ready: boolean };
   billingUrl?: string;
+  signingKey?: string;
 }
 
 export default function AuthFlow({ onClose }: AuthFlowProps) {
@@ -327,8 +329,11 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
         if (cancelledRef.current) return;
 
         if (data.status === "complete" && data.apiKey) {
-          // Save legacy API key
-          await config.update({ pensarAPIKey: data.apiKey });
+          // Save legacy API key and signing key
+          await config.update({
+            pensarAPIKey: data.apiKey,
+            gatewaySigningKey: data.signingKey ?? null,
+          });
           if (data.workspace) {
             await config.update({
               workspaceId: data.workspace.id,
@@ -454,10 +459,11 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
 
       const data = (await response.json()) as SelectWorkspaceResponse;
 
-      // Save workspace to config
+      // Save workspace and signing key to config
       await config.update({
         workspaceId: workspace.id,
         workspaceSlug: workspace.slug,
+        gatewaySigningKey: data.signingKey ?? null,
       });
       appConfig.reload();
 
@@ -486,6 +492,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
       refreshToken: null,
       workspaceId: null,
       workspaceSlug: null,
+      gatewaySigningKey: null,
     });
     appConfig.reload();
     setAuthMode(null);

--- a/src/tui/components/commands/credits-flow.tsx
+++ b/src/tui/components/commands/credits-flow.tsx
@@ -7,6 +7,7 @@ import {
   getPensarConsoleUrl,
 } from "../../../core/api/constants";
 import { ensureValidToken } from "../../../core/api/tokenRefresh";
+import { config } from "../../../core/config";
 
 type CreditsStep = "loading" | "no-auth" | "display" | "browser-opened";
 
@@ -84,7 +85,12 @@ export default function CreditsFlow({ onOpenAuthDialog }: CreditsFlowProps) {
       const result = (await response.json()) as {
         workspace: { name: string };
         credits: { balance: number };
+        signingKey?: string;
       };
+
+      if (result.signingKey) {
+        await config.update({ gatewaySigningKey: result.signingKey });
+      }
 
       setCredits({
         balance: result.credits.balance,


### PR DESCRIPTION
## Summary

- Adds HMAC request signing to the Pensar Gateway provider, binding each inference request to a timestamp, nonce, model ID, and body hash to prevent replay attacks and request tampering.
- Introduces `pensarSigning.ts` with the `signGatewayRequest` helper using SHA-256 HMAC.
- Plumbs the server-issued `signingKey` through config, auth config, and the Pensar model — persisting it from `/auth` (legacy token + workspace selection) and `/credits` API responses, and clearing it on logout.

## Test plan

- [x] Verify signing headers (`X-Pensar-Signature`, `X-Pensar-Timestamp`, `X-Pensar-Nonce`) are attached to gateway requests when a signing key is present
- [x] Verify requests still work without a signing key (no headers added)
- [x] Verify signing key is persisted after auth flow (legacy token and workspace selection)
- [x] Verify signing key is refreshed from `/credits` endpoint
- [x] Verify signing key is cleared on logout
- [x] `bun run test` passes


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds request-authentication behavior to all Pensar gateway inference calls when a signing key is present; incorrect key handling or header generation could break inference requests across users.
> 
> **Overview**
> Adds optional HMAC request signing for Pensar Gateway `/gateway/invoke` inference calls by generating `X-Pensar-Signature`, `X-Pensar-Timestamp`, and `X-Pensar-Nonce` headers from a timestamp/nonce/modelId/body-hash payload.
> 
> Introduces `signGatewayRequest` (`pensarSigning.ts`) and threads a persisted `gatewaySigningKey` through config/auth config into the Pensar provider; the key is saved from auth (legacy device token + workspace selection) and refreshed from the credits/validate response, and cleared on disconnect.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92ff27c9865c46c93e396336f84ed8f26ac542d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->