### PR TITLE
feat: persist POC execution output

### DIFF
--- a/src/core/agents/offSecAgent/tools/createPoc.ts
+++ b/src/core/agents/offSecAgent/tools/createPoc.ts
@@ -133,6 +133,15 @@ async function executeLocalPoc(
       } catch {
         // ignore cleanup errors
       }
+    } else {
+      writePocOutputSidecar(
+        pocsPath,
+        filename,
+        stdout,
+        stderr,
+        exitCode,
+        poc.description,
+      );
     }
 
     return {
@@ -215,6 +224,15 @@ async function executeSandboxPoc(
       } catch {
         // ignore
       }
+    } else {
+      writePocOutputSidecar(
+        localPocsPath,
+        filename,
+        result.stdout || "",
+        result.stderr || "",
+        result.exitCode,
+        poc.description,
+      );
     }
 
     return {
@@ -244,6 +262,36 @@ async function executeSandboxPoc(
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
+
+function writePocOutputSidecar(
+  pocsPath: string,
+  filename: string,
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  description: string,
+): void {
+  try {
+    const outputPath = join(pocsPath, `${filename}.output.json`);
+    writeFileSync(
+      outputPath,
+      JSON.stringify(
+        {
+          stdout,
+          stderr,
+          exitCode,
+          executedAt: new Date().toISOString(),
+          pocFile: filename,
+          description,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch {
+    // Non-critical: don't fail the POC on output write errors
+  }
+}
 
 function preparePoc(
   poc: CreatePocInput,

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { join } from "path";
-import { writeFileSync, appendFileSync } from "fs";
+import { writeFileSync, appendFileSync, readFileSync } from "fs";
 import type { ToolContext } from "./types";
 import {
   scoreFindingWithCVSS,
@@ -159,12 +159,34 @@ FINDING STRUCTURE:
           }
         }
 
+        // Read POC execution output if available
+        let pocOutput: {
+          stdout: string;
+          stderr: string;
+          exitCode: number;
+          executedAt: string;
+        } | null = null;
+
+        if (input.pocPath) {
+          try {
+            const pocBasename = input.pocPath.replace(/^pocs\//, "");
+            const outputPath = join(
+              session.pocsPath,
+              `${pocBasename}.output.json`,
+            );
+            pocOutput = JSON.parse(readFileSync(outputPath, "utf-8"));
+          } catch {
+            // Non-critical: file may not exist or be malformed
+          }
+        }
+
         const findingWithMeta = {
           ...finding,
           timestamp,
           sessionId: session.id,
           target: session.targets[0],
           ...(evidenceFilePath && { evidenceFile: evidenceFilePath }),
+          ...(pocOutput && { pocOutput }),
           cwes: cvssResult.cwes,
           cvss: {
             score: cvssResult.score,


### PR DESCRIPTION
## Summary
- Write `.output.json` sidecar files alongside POC scripts after successful execution
- Read and embed `pocOutput` in finding JSON during `documentFinding`
- Extract shared `writePocOutputSidecar()` helper

## Test plan
- [ ] Run a pentest, verify `.output.json` files appear in pocs/ directory
- [ ] Verify finding JSON includes `pocOutput` when POC executed successfully
- [ ] Verify backward compat: findings without POC output still work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds best-effort file I/O to persist PoC stdout/stderr and optionally include it in documented findings; failures are explicitly non-fatal and should not affect exploit execution paths beyond extra writes/reads.
> 
> **Overview**
> PoC creation/execution now **persists successful run output** by writing a `${pocFilename}.output.json` sidecar next to the generated script (both for local and sandbox execution), capturing `stdout`, `stderr`, `exitCode`, timestamp, and description.
> 
> Finding documentation now **optionally reads and embeds** this sidecar as `pocOutput` in the saved finding JSON when `pocPath` is provided; missing/malformed sidecars are ignored to keep backward compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b09a08f53ace09bfbd9e3d30de2762cd8bd63cc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->