### PR TITLE
Add doc links for Apex Inference and Continuous Pentesting billing categories

### DIFF
--- a/fern/docs/commands/auth.mdx
+++ b/fern/docs/commands/auth.mdx
@@ -75,7 +75,7 @@ Apex inference through the Pensar gateway uses a **pre-paid credits** model. Cre
 | Concept | Description |
 |---|---|
 | **Credits** | Pre-paid balance (in USD) shared across your workspace |
-| **Category** | Apex inference is billed under the "Apex Inference" category, separate from CI pentest usage |
+| **Category** | Apex inference is billed under the "[Apex Inference](https://docs.pensar.dev/apex)" category, separate from [CI pentest usage](/console/features/billing) |
 | **Per-identity tracking** | Each request is attributed to the authenticated user, visible in Console's Usage page |
 | **Pre-flight checks** | Requests are rejected with a `402` error if credits are insufficient |
 | **Auto-reload** | Optional automatic top-up when balance drops below a threshold |

--- a/fern/docs/commands/credits.mdx
+++ b/fern/docs/commands/credits.mdx
@@ -50,9 +50,18 @@ Credits are a **pre-paid balance** (denominated in USD) stored at the workspace 
 | **Tracking** | Per-user — your requests are attributed to your authenticated identity |
 | **Pre-flight check** | Requests are rejected if credits are insufficient |
 
-<Callout intent="info">
-  Credits are shared across all billing categories in your workspace (Apex Inference and Continuous Pentesting). Monitor usage per category from **Settings > Usage** in Console.
-</Callout>
+### Billing Categories
+
+Credits are shared across all billing categories in your workspace. Monitor usage per category from **Settings > Usage** in Console.
+
+<CardGroup cols={2}>
+  <Card title="Apex Inference" icon="bolt" href="https://docs.pensar.dev/apex">
+    Usage-based billing for Pensar gateway inference via the Apex CLI. Tokens consumed through the Pensar gateway are deducted from your credit balance.
+  </Card>
+  <Card title="Continuous Pentesting" icon="rotate" href="/console/features/billing">
+    Usage-based billing for pentests triggered via the CI/CD pipeline. When enabled, AI inference tokens consumed during CI pentests are deducted from your credit balance.
+  </Card>
+</CardGroup>
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Adds documentation links to the two billing categories referenced in the Apex docs:

- **Apex Inference** — now links to [docs.pensar.dev/apex](https://docs.pensar.dev/apex)
- **Continuous Pentesting** — now links to the [Console Billing & Usage](/console/features/billing) docs

Changes:

- `fern/docs/commands/credits.mdx`: Replaced the inline `<Callout>` that mentioned both categories with a new **Billing Categories** subsection containing linked `<Card>` components, each with the user-facing description.
- `fern/docs/commands/auth.mdx`: Linked "Apex Inference" and "CI pentest usage" in the Key Billing Concepts table row.

### How did you verify your code works?

- `bun run lint` — passes
- `bun run tsc` — passes
- `bun run test` — all 408 tests pass (7 skipped integration suites)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4920a7c9-7c7f-4340-8957-00244cd3acd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4920a7c9-7c7f-4340-8957-00244cd3acd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

