### PR TITLE
fix: auto-focus input when entering operator mode

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -29,6 +29,7 @@ import { useRoute } from "../../context/route";
 import { useConfig } from "../../context/config";
 import { useCommand } from "../../context/command";
 import { useDialog } from "../../context/dialog";
+import { useFocus } from "../../context/focus";
 import { MessageList } from "../chat/message-list";
 import { InputArea } from "../chat/input-area";
 import { useTheme } from "../../theme";
@@ -107,6 +108,7 @@ export default function OperatorDashboard({
     clear: clearDialog,
     setSize: setDialogSize,
   } = useDialog();
+  const { refocusPrompt } = useFocus();
 
   const autocompleteOptions = useMemo(() => {
     const skillSlugs = new Set(skills.map((s) => `/${slugify(s.name)}`));
@@ -290,6 +292,13 @@ export default function OperatorDashboard({
   useEffect(() => {
     return () => setSessionCwd(null);
   }, [setSessionCwd]);
+
+  // Auto-focus the input when the operator dashboard finishes loading
+  useEffect(() => {
+    if (!loading) {
+      refocusPrompt();
+    }
+  }, [loading, refocusPrompt]);
 
   useEffect(() => {
     if (!session) return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

When entering `/operator` mode, the directive/message input box was not automatically focused — users had to click the input before they could start typing.

This adds a `useEffect` in `OperatorDashboard` that calls `refocusPrompt()` (from the existing `FocusProvider` context) once loading completes. `refocusPrompt` uses a `setTimeout(..., 1)` to set focus on the registered `PromptInput` textarea, which is the same pattern already used elsewhere in the codebase (e.g., when closing dialogs or returning from the sessions display).

The `focused` prop on the input was already resolving to `true` correctly — the issue was that the underlying `@opentui` textarea needed an explicit `.focus()` call to actually receive keyboard input on mount.

### How did you verify your code works?

- `bun run tsc` — passes with no errors
- `bun run lint` — passes with no errors
- `bun run test` — all 408 tests pass (15 skipped, 7 test files skipped as expected)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71b92449-7d21-401f-8460-889892c503fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71b92449-7d21-401f-8460-889892c503fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

