### PR TITLE
feat: add 409 error handling for Pensar Gateway transient errors

### DIFF
--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -103,6 +103,28 @@ function checkIfRateLimitError(error: unknown): boolean {
   );
 }
 
+/**
+ * Checks if an error is a retryable gateway error (e.g., 409 from Pensar Gateway).
+ * 409 errors can occur when the Lambda function is killed or times out during
+ * inference, which is a transient condition that may succeed on retry.
+ */
+function checkIfRetryableGatewayError(error: unknown): boolean {
+  const errObj =
+    typeof error === "object" && error !== null
+      ? (error as Record<string, unknown>)
+      : {};
+
+  const errorMessage = (
+    typeof errObj.message === "string" ? errObj.message : ""
+  ).toLowerCase();
+
+  return (
+    errorMessage.includes("pensar streaming error (409)") ||
+    errorMessage.includes("gateway") ||
+    errorMessage.includes("(409)")
+  );
+}
+
 const MAX_RATE_LIMIT_RETRIES = 20;
 
 // Helper function to wrap a stream with error handling for async errors
@@ -143,18 +165,24 @@ function wrapStreamWithErrorHandler(
               // as-is; the prompt must be reduced via summarization.
               const isCtxError = checkIfContextLengthError(error);
 
-              // Handle rate limit errors with exponential backoff retry
+              // Handle rate limit errors and retryable gateway errors with exponential backoff retry
+              const isRetryableError =
+                checkIfRateLimitError(error) ||
+                checkIfRetryableGatewayError(error);
               if (
                 !isCtxError &&
-                checkIfRateLimitError(error) &&
+                isRetryableError &&
                 rateLimitRetryCount < MAX_RATE_LIMIT_RETRIES
               ) {
                 const nextRetryCount = rateLimitRetryCount + 1;
                 const delayMs = Math.min(1000 * nextRetryCount, 30000);
 
                 if (!silent) {
+                  const errorType = checkIfRateLimitError(error)
+                    ? "Rate limit"
+                    : "Transient gateway";
                   console.warn(
-                    `Rate limit error (attempt ${nextRetryCount}/${MAX_RATE_LIMIT_RETRIES}), waiting ${delayMs}ms: ${errorMessage}`,
+                    `${errorType} error (attempt ${nextRetryCount}/${MAX_RATE_LIMIT_RETRIES}), waiting ${delayMs}ms: ${errorMessage}`,
                   );
                 }
 
@@ -531,10 +559,9 @@ export async function generateObjectResponse<T extends z.ZodType>(
         );
       }
 
-      if (
-        checkIfRateLimitError(error) &&
-        attempt < MAX_OBJECT_RATE_LIMIT_RETRIES
-      ) {
+      const isRetryableError =
+        checkIfRateLimitError(error) || checkIfRetryableGatewayError(error);
+      if (isRetryableError && attempt < MAX_OBJECT_RATE_LIMIT_RETRIES) {
         const delayMs = Math.min(1000 * 2 ** attempt, 60_000);
         await new Promise((resolve) => setTimeout(resolve, delayMs));
         continue;

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -268,6 +268,12 @@ export function createPensarModel(
               `Top up at https://console.pensar.dev`,
           );
         }
+        if (response.status === 409) {
+          throw new Error(
+            `Pensar streaming error (409): Gateway conflict - ${errorMessage}. ` +
+              `This is usually a transient error and will be retried automatically.`,
+          );
+        }
         throw new Error(
           `Pensar streaming error (${response.status}): ${errorMessage}`,
         );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR addresses the issue where users are getting 409 "gateway exited errors" when using Pensar hosted inference. The issue is suspected to be related to Lambda functions being killed during inference requests.

**Changes made:**

1. **Added `checkIfRetryableGatewayError()` function** in `src/core/ai/ai.ts`:
   - Detects 409 errors from the Pensar Gateway
   - Checks for error messages containing "pensar streaming error (409)", "gateway", or "(409)"

2. **Updated error retry logic** in both `streamResponse` and `generateObjectResponse`:
   - 409 errors are now treated as retryable with exponential backoff
   - Uses the existing retry mechanism (up to 20 retries for streaming, 8 for object generation)
   - Improved logging to distinguish between "Rate limit" and "Transient gateway" errors

3. **Added specific 409 error message** in `src/core/ai/providers/pensar.ts`:
   - Provides a clearer error message: "Gateway conflict - ... This is usually a transient error and will be retried automatically."
   - Helps users understand that this is a temporary issue

**Why these changes work:**
- 409 (Conflict) errors from the Lambda/Gateway are transient in nature - the Lambda may have been killed or timed out
- By making these errors retryable, the client will automatically retry the request, which will likely succeed on a fresh Lambda instance
- The exponential backoff ensures we don't overwhelm the server with retries

**Note:** The root cause investigation on the console/server side may still be needed to understand why the Lambda is being killed. This PR focuses on making the Apex client more resilient to these transient errors.

### How did you verify your code works?

- All existing unit tests pass (`bun run test`)
- Lint checks pass (`bun run lint`)
- Type checks pass (`bun run tsc`)
- Code changes are minimal and focused on error handling, following the existing patterns in the codebase
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cad1cb7d-7133-449c-a898-7ede559dd4b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cad1cb7d-7133-449c-a898-7ede559dd4b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

