### PR TITLE
Fix Tab key to show options in /pentest dialog

### DIFF
--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -222,6 +222,7 @@ export default function WebWizard({
 
   // Error state
   const [error, setError] = useState<string | null>(null);
+  const [targetError, setTargetError] = useState<string | null>(null);
 
   // Create session and navigate to session route
   async function createSessionAndNavigate() {
@@ -326,7 +327,10 @@ export default function WebWizard({
       if (key.name === "tab" && !key.shift) {
         key.preventDefault();
         if (state.target.trim()) {
+          setTargetError(null);
           setCurrentStep("configure");
+        } else {
+          setTargetError("Target URL is required");
         }
         return;
       }
@@ -640,9 +644,13 @@ export default function WebWizard({
             description="e.g., https://example.com"
             placeholder="https://example.com"
             value={state.target}
-            onInput={(v) => setState((prev) => ({ ...prev, target: v }))}
+            onInput={(v) => {
+              setTargetError(null);
+              setState((prev) => ({ ...prev, target: v }));
+            }}
             focused={targetFocusedField === 0}
           />
+          {targetError && <text fg={colors.error}>{targetError}</text>}
 
           <box flexDirection="column" gap={1}>
             <box flexDirection="row" gap={1}>

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -648,6 +648,14 @@ export default function WebWizard({
               setTargetError(null);
               setState((prev) => ({ ...prev, target: v }));
             }}
+            onSubmit={() => {
+              if (state.target.trim()) {
+                setTargetError(null);
+                setCurrentStep("configure");
+              } else {
+                setTargetError("Target URL is required");
+              }
+            }}
             focused={targetFocusedField === 0}
           />
           {targetError && <text fg={colors.error}>{targetError}</text>}

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -336,32 +336,29 @@ export default function WebWizard({
         setTargetFocusedField((prev) => Math.max(0, prev - 1));
         return;
       }
-      // Down arrow - toggle source code access or navigate to next field
+      // Down arrow - navigate to next field
       if (key.name === "down") {
         key.preventDefault();
-        if (targetFocusedField === 1) {
-          // Toggle source code access when on that field
-          setState((prev) => ({
-            ...prev,
-            sourceCodeAccess: !prev.sourceCodeAccess,
-          }));
-        } else if (targetFocusedField < maxTargetField) {
+        if (targetFocusedField < maxTargetField) {
           setTargetFocusedField((prev) => prev + 1);
         }
         return;
       }
-      // Up arrow - toggle source code access or navigate to previous field
+      // Up arrow - navigate to previous field
       if (key.name === "up") {
         key.preventDefault();
-        if (targetFocusedField === 1) {
-          // Toggle source code access when on that field
-          setState((prev) => ({
-            ...prev,
-            sourceCodeAccess: !prev.sourceCodeAccess,
-          }));
-        } else if (targetFocusedField > 0) {
+        if (targetFocusedField > 0) {
           setTargetFocusedField((prev) => prev - 1);
         }
+        return;
+      }
+      // Space - toggle source code access when on that field
+      if (key.sequence === " " && targetFocusedField === 1) {
+        key.preventDefault();
+        setState((prev) => ({
+          ...prev,
+          sourceCodeAccess: !prev.sourceCodeAccess,
+        }));
         return;
       }
       // Enter to start if target is filled
@@ -662,7 +659,7 @@ export default function WebWizard({
                 {state.sourceCodeAccess ? "● Enabled" : "○ Disabled"}
               </text>
               {targetFocusedField === 1 && (
-                <text fg={colors.textMuted}>(↑/↓ to toggle)</text>
+                <text fg={colors.textMuted}>(Space to toggle)</text>
               )}
             </box>
             {state.sourceCodeAccess && (

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -319,33 +319,49 @@ export default function WebWizard({
     // Don't allow navigation while creating
     if (currentStep === "creating") return;
 
-    // Target step: Enter to start, Tab to navigate/configure
+    // Target step: Enter to start, Tab to configure options
     if (currentStep === "target") {
       const maxTargetField = state.sourceCodeAccess ? 2 : 1; // 0=target, 1=toggle, 2=cwd (if enabled)
-      // Tab navigation
-      if (key.name === "tab") {
+      // Tab - go directly to configure step when target is filled
+      if (key.name === "tab" && !key.shift) {
         key.preventDefault();
-        if (key.shift) {
-          setTargetFocusedField((prev) => Math.max(0, prev - 1));
-        } else {
-          if (targetFocusedField === maxTargetField && state.target.trim()) {
-            setCurrentStep("configure");
-          } else {
-            setTargetFocusedField((prev) => Math.min(maxTargetField, prev + 1));
-          }
+        if (state.target.trim()) {
+          setCurrentStep("configure");
         }
         return;
       }
-      // Up/Down to toggle source code access when focused
-      if (
-        targetFocusedField === 1 &&
-        (key.name === "up" || key.name === "down")
-      ) {
+      // Shift+Tab - navigate backwards through fields
+      if (key.name === "tab" && key.shift) {
         key.preventDefault();
-        setState((prev) => ({
-          ...prev,
-          sourceCodeAccess: !prev.sourceCodeAccess,
-        }));
+        setTargetFocusedField((prev) => Math.max(0, prev - 1));
+        return;
+      }
+      // Down arrow - toggle source code access or navigate to next field
+      if (key.name === "down") {
+        key.preventDefault();
+        if (targetFocusedField === 1) {
+          // Toggle source code access when on that field
+          setState((prev) => ({
+            ...prev,
+            sourceCodeAccess: !prev.sourceCodeAccess,
+          }));
+        } else if (targetFocusedField < maxTargetField) {
+          setTargetFocusedField((prev) => prev + 1);
+        }
+        return;
+      }
+      // Up arrow - toggle source code access or navigate to previous field
+      if (key.name === "up") {
+        key.preventDefault();
+        if (targetFocusedField === 1) {
+          // Toggle source code access when on that field
+          setState((prev) => ({
+            ...prev,
+            sourceCodeAccess: !prev.sourceCodeAccess,
+          }));
+        } else if (targetFocusedField > 0) {
+          setTargetFocusedField((prev) => prev - 1);
+        }
         return;
       }
       // Enter to start if target is filled

--- a/src/tui/components/input.tsx
+++ b/src/tui/components/input.tsx
@@ -1,17 +1,23 @@
 import { forwardRef } from "react";
 import type { InputProps } from "@opentui/react";
-import type { InputRenderable } from "@opentui/core";
+import type { InputRenderable, KeyBinding } from "@opentui/core";
 import { useTheme } from "../theme";
 
 interface InputComponentProps extends InputProps {
   label: string;
   description?: string;
+  onTab?: () => void;
 }
+
+const inputKeyBindings: KeyBinding[] = [
+  { name: "tab", action: "submit" },
+  { name: "tab", shift: true, action: "submit" },
+];
 
 const Input = forwardRef<InputRenderable, InputComponentProps>(
   function Input(opts, ref) {
     const { colors } = useTheme();
-    const { label, focused = true, description, ...inputProps } = opts;
+    const { label, focused = true, description, onTab, ...inputProps } = opts;
 
     return (
       <box
@@ -33,6 +39,7 @@ const Input = forwardRef<InputRenderable, InputComponentProps>(
           cursorColor={colors.textMuted}
           textColor={colors.text}
           focusedTextColor={colors.text}
+          keyBindings={inputKeyBindings}
           {...inputProps}
         />
       </box>

--- a/src/tui/components/input.tsx
+++ b/src/tui/components/input.tsx
@@ -1,23 +1,17 @@
 import { forwardRef } from "react";
 import type { InputProps } from "@opentui/react";
-import type { InputRenderable, KeyBinding } from "@opentui/core";
+import type { InputRenderable } from "@opentui/core";
 import { useTheme } from "../theme";
 
 interface InputComponentProps extends InputProps {
   label: string;
   description?: string;
-  onTab?: () => void;
 }
-
-const inputKeyBindings: KeyBinding[] = [
-  { name: "tab", action: "submit" },
-  { name: "tab", shift: true, action: "submit" },
-];
 
 const Input = forwardRef<InputRenderable, InputComponentProps>(
   function Input(opts, ref) {
     const { colors } = useTheme();
-    const { label, focused = true, description, onTab, ...inputProps } = opts;
+    const { label, focused = true, description, ...inputProps } = opts;
 
     return (
       <box
@@ -39,7 +33,6 @@ const Input = forwardRef<InputRenderable, InputComponentProps>(
           cursorColor={colors.textMuted}
           textColor={colors.text}
           focusedTextColor={colors.text}
-          keyBindings={inputKeyBindings}
           {...inputProps}
         />
       </box>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes the Tab key functionality in the `/pentest` dialog. Previously, pressing Tab would cycle through all fields in the target step (target URL input → source code access toggle → optionally cwd field) before reaching the configure step with auth/scope/header options.

The UI text says "Press [Tab] to configure options" but the behavior didn't match - users had to Tab multiple times through fields before seeing the options.

**Changes made:**
- Modified the Tab key handler in the target step to go directly to the configure step when the target URL is filled
- **Added validation error message** - Shows "Target URL is required" in red when Tab is pressed without entering a URL
- Arrow keys (up/down) navigate between fields in the target step
- Space key toggles the source code access option (field 1) - this fixes a bug where the cwd field was unreachable
- Shift+Tab navigates backwards through fields
- The behavior now matches the UI hint text

**Bug Fix:** Fixed an issue where the cwd (codebase path) field was unreachable via keyboard navigation. When focused on the source code access toggle (field 1), both up and down arrows were consumed by toggle actions, creating a navigation trap. Now arrow keys navigate between fields, and Space toggles the source code access option.

**Why this works:**
The fix changes the Tab key behavior from field-cycling to step-progression. When a user has entered a target URL and presses Tab, they now immediately see the configure options (Authentication, Scope Constraints, Request Headers, AI Model) as expected. If no URL is entered, a clear error message is displayed. Field navigation within the target step is still possible using arrow keys for users who want to access the source code access option and cwd field.

### How did you verify your code works?

1. Ran all lint, type checks, and unit tests - all pass
2. Manually tested the TUI:
   - Started the app with `bun run start`
   - Typed `/pentest` to open the dialog
   - **Tab without URL** → "Target URL is required" error appears ✅
   - Entered `https://example.com` as target URL  
   - Pressed Tab → Configure options appeared immediately ✅
   - Arrow down to source code access toggle
   - Press Space to enable → cwd field appears
   - Arrow down to cwd field → Successfully focused
   - **Verified:** Full keyboard navigation and validation works
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51add4c3-a815-4282-928d-492c5f006bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51add4c3-a815-4282-928d-492c5f006bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

