### PR TITLE
feat: add retry logic and improved error handling for Pensar Gateway

### DIFF
--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -14,6 +14,33 @@ import { signGatewayRequest } from "./pensarSigning";
 const DEBUG =
   process.env.PENSAR_DEBUG === "1" || process.env.PENSAR_DEBUG === "true";
 
+const MAX_RETRIES = 3;
+const INITIAL_RETRY_DELAY_MS = 1000;
+const MAX_RETRY_DELAY_MS = 10000;
+
+const RETRYABLE_STATUS_CODES = new Set([
+  408, // Request Timeout
+  409, // Conflict (often connection closed unexpectedly)
+  429, // Too Many Requests
+  500, // Internal Server Error
+  502, // Bad Gateway
+  503, // Service Unavailable
+  504, // Gateway Timeout
+]);
+
+const RETRYABLE_ERROR_PATTERNS = [
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "EPIPE",
+  "ENETUNREACH",
+  "EAI_AGAIN",
+  "socket hang up",
+  "connection closed",
+  "network error",
+  "fetch failed",
+];
+
 function log(...args: unknown[]) {
   if (DEBUG) console.error("[pensar:debug]", ...args);
 }
@@ -24,6 +51,33 @@ function logInfo(...args: unknown[]) {
 
 function logError(...args: unknown[]) {
   console.error("[pensar:error]", ...args);
+}
+
+function isRetryableError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    const name = error.name.toLowerCase();
+    return RETRYABLE_ERROR_PATTERNS.some(
+      (pattern) =>
+        message.includes(pattern.toLowerCase()) ||
+        name.includes(pattern.toLowerCase()),
+    );
+  }
+  return false;
+}
+
+function isRetryableStatusCode(status: number): boolean {
+  return RETRYABLE_STATUS_CODES.has(status);
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getRetryDelay(attempt: number): number {
+  const delay = INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt);
+  const jitter = Math.random() * 0.3 * delay;
+  return Math.min(delay + jitter, MAX_RETRY_DELAY_MS);
 }
 
 export interface PensarModelConfig {
@@ -213,63 +267,131 @@ export function createPensarModel(
         modelId: bedrockModelId,
         body,
       });
-      const headers = await buildHeaders();
 
-      if (config.signingKey) {
-        const sig = signGatewayRequest(
-          config.signingKey,
-          bedrockModelId,
-          serializedBody,
-        );
-        headers["X-Pensar-Signature"] = sig.signature;
-        headers["X-Pensar-Timestamp"] = sig.timestamp;
-        headers["X-Pensar-Nonce"] = sig.nonce;
-      }
+      let response: Response | null = null;
+      let lastError: Error | null = null;
 
-      log(`  headers: ${Object.keys(headers).join(", ")}`);
+      for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+        const headers = await buildHeaders();
 
-      let response: Response;
-      try {
-        response = await fetch(url, {
-          method: "POST",
-          headers,
-          signal: options.abortSignal,
-          body: serializedBody,
-        });
-      } catch (err) {
-        logError(`  SSE fetch failed (${Date.now() - startTime}ms):`, err);
-        throw new Error(
-          `Pensar Gateway request failed: ${err instanceof Error ? err.message : String(err)}`,
-          { cause: err },
-        );
-      }
-
-      const contentType = response.headers.get("content-type") ?? "unknown";
-      const transferEncoding =
-        response.headers.get("transfer-encoding") ?? "none";
-      logInfo(
-        `  response: ${response.status} (${Date.now() - startTime}ms) content-type=${contentType} transfer-encoding=${transferEncoding}`,
-      );
-
-      if (!response.ok) {
-        const errorBody = await response.text();
-        let errorMessage: string;
-        try {
-          const parsed = JSON.parse(errorBody);
-          errorMessage = parsed.error || parsed.message || errorBody;
-        } catch {
-          errorMessage = errorBody;
+        if (config.signingKey) {
+          const sig = signGatewayRequest(
+            config.signingKey,
+            bedrockModelId,
+            serializedBody,
+          );
+          headers["X-Pensar-Signature"] = sig.signature;
+          headers["X-Pensar-Timestamp"] = sig.timestamp;
+          headers["X-Pensar-Nonce"] = sig.nonce;
         }
-        logError(`  SSE FAILED ${response.status}: ${errorMessage}`);
 
-        if (response.status === 402) {
+        if (attempt > 0) {
+          logInfo(`  retry attempt ${attempt}/${MAX_RETRIES}...`);
+        }
+        log(`  headers: ${Object.keys(headers).join(", ")}`);
+
+        try {
+          response = await fetch(url, {
+            method: "POST",
+            headers,
+            signal: options.abortSignal,
+            body: serializedBody,
+          });
+
+          const contentType = response.headers.get("content-type") ?? "unknown";
+          const transferEncoding =
+            response.headers.get("transfer-encoding") ?? "none";
+          logInfo(
+            `  response: ${response.status} (${Date.now() - startTime}ms) content-type=${contentType} transfer-encoding=${transferEncoding}`,
+          );
+
+          if (response.ok) {
+            break;
+          }
+
+          const errorBody = await response.text();
+          let errorMessage: string;
+          try {
+            const parsed = JSON.parse(errorBody);
+            errorMessage = parsed.error || parsed.message || errorBody;
+          } catch {
+            errorMessage = errorBody;
+          }
+
+          if (response.status === 402) {
+            throw new Error(
+              `Insufficient Pensar credits: ${errorMessage}. ` +
+                `Top up at https://console.pensar.dev`,
+            );
+          }
+
+          if (response.status === 401 || response.status === 403) {
+            throw new Error(
+              `Pensar authentication error (${response.status}): ${errorMessage}`,
+            );
+          }
+
+          lastError = new Error(
+            `Pensar streaming error (${response.status}): ${errorMessage}`,
+          );
+
+          if (
+            isRetryableStatusCode(response.status) &&
+            attempt < MAX_RETRIES
+          ) {
+            const delay = getRetryDelay(attempt);
+            logInfo(
+              `  retryable error ${response.status}, waiting ${Math.round(delay)}ms before retry...`,
+            );
+            await sleep(delay);
+            continue;
+          }
+
+          logError(`  SSE FAILED ${response.status}: ${errorMessage}`);
+          throw lastError;
+        } catch (err) {
+          if (
+            err instanceof Error &&
+            (err.message.includes("Insufficient Pensar credits") ||
+              err.message.includes("authentication error"))
+          ) {
+            throw err;
+          }
+
+          lastError =
+            err instanceof Error
+              ? err
+              : new Error(`Pensar Gateway request failed: ${String(err)}`, {
+                  cause: err,
+                });
+
+          if (options.abortSignal?.aborted) {
+            logError(`  request aborted by user`);
+            throw lastError;
+          }
+
+          if (isRetryableError(err) && attempt < MAX_RETRIES) {
+            const delay = getRetryDelay(attempt);
+            logInfo(
+              `  connection error: ${lastError.message}, waiting ${Math.round(delay)}ms before retry...`,
+            );
+            await sleep(delay);
+            continue;
+          }
+
+          logError(`  SSE fetch failed (${Date.now() - startTime}ms):`, err);
           throw new Error(
-            `Insufficient Pensar credits: ${errorMessage}. ` +
-              `Top up at https://console.pensar.dev`,
+            `Pensar Gateway request failed after ${attempt + 1} attempt(s): ${lastError.message}. ` +
+              `This may be a temporary network issue. Please try again.`,
+            { cause: err },
           );
         }
-        throw new Error(
-          `Pensar streaming error (${response.status}): ${errorMessage}`,
+      }
+
+      if (!response || !response.ok) {
+        throw (
+          lastError ??
+          new Error("Pensar Gateway request failed after all retries")
         );
       }
 
@@ -458,8 +580,27 @@ export function createPensarModel(
             });
             controller.close();
           } catch (err) {
+            const errorMessage =
+              err instanceof Error ? err.message : String(err);
             logError(`  stream error:`, err);
-            controller.error(err);
+
+            if (
+              errorMessage.toLowerCase().includes("connection") ||
+              errorMessage.toLowerCase().includes("network") ||
+              errorMessage.toLowerCase().includes("aborted") ||
+              errorMessage.toLowerCase().includes("socket") ||
+              errorMessage.includes("ECONNRESET") ||
+              errorMessage.includes("EPIPE")
+            ) {
+              controller.error(
+                new Error(
+                  `Connection interrupted during inference streaming: ${errorMessage}. ` +
+                    `This is typically a temporary network issue. Please try again.`,
+                ),
+              );
+            } else {
+              controller.error(err);
+            }
           }
         },
       });

--- a/src/core/ai/providers/pensarSSE.ts
+++ b/src/core/ai/providers/pensarSSE.ts
@@ -11,6 +11,27 @@ export interface SSEEvent {
   data: string;
 }
 
+function isConnectionError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    const name = error.name.toLowerCase();
+    const patterns = [
+      "network",
+      "connection",
+      "abort",
+      "socket",
+      "econnreset",
+      "epipe",
+      "etimedout",
+      "enetunreach",
+    ];
+    return patterns.some(
+      (pattern) => message.includes(pattern) || name.includes(pattern),
+    );
+  }
+  return false;
+}
+
 export async function* parseSSE(
   stream: ReadableStream<Uint8Array>,
 ): AsyncGenerator<SSEEvent> {
@@ -22,11 +43,34 @@ export async function* parseSSE(
   let totalBytes = 0;
   let chunkCount = 0;
   let eventCount = 0;
+  let receivedMessageStop = false;
 
   try {
     while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
+      let done: boolean;
+      let value: Uint8Array | undefined;
+
+      try {
+        const readResult = await reader.read();
+        done = readResult.done;
+        value = readResult.value;
+      } catch (readError) {
+        console.error(
+          `[parseSSE] read error after ${chunkCount} chunks, ${totalBytes} bytes, ${eventCount} events:`,
+          readError,
+        );
+
+        if (isConnectionError(readError)) {
+          throw new Error(
+            `Connection closed unexpectedly during streaming (received ${eventCount} events, ${totalBytes} bytes). ` +
+              `This may be a temporary network issue.`,
+            { cause: readError },
+          );
+        }
+        throw readError;
+      }
+
+      if (done || !value) {
         console.error(
           `[parseSSE] stream done: ${chunkCount} chunks, ${totalBytes} bytes, ${eventCount} events yielded, remaining buffer=${buffer.length} chars`,
         );
@@ -57,7 +101,21 @@ export async function* parseSSE(
         if (line === "") {
           if (currentData.length > 0) {
             eventCount++;
-            yield { event: currentEvent, data: currentData.join("\n") };
+            const eventToYield = {
+              event: currentEvent,
+              data: currentData.join("\n"),
+            };
+
+            try {
+              const parsed = JSON.parse(eventToYield.data);
+              if (parsed.type === "message_stop") {
+                receivedMessageStop = true;
+              }
+            } catch {
+              // Ignore parse errors, just pass through
+            }
+
+            yield eventToYield;
           }
           currentEvent = "message";
           currentData = [];
@@ -78,6 +136,10 @@ export async function* parseSSE(
     if (eventCount === 0) {
       console.error(
         `[parseSSE] WARNING: stream ended with 0 events! totalBytes=${totalBytes}, chunks=${chunkCount}`,
+      );
+    } else if (!receivedMessageStop && eventCount > 0) {
+      console.error(
+        `[parseSSE] WARNING: stream ended without message_stop event (${eventCount} events received)`,
       );
     }
   } finally {


### PR DESCRIPTION
## Summary

- **Retry logic with exponential backoff** (up to 3 retries) for transient HTTP errors (408, 429, 500, 502, 503, 504) and connection errors (ECONNRESET, ETIMEDOUT, socket hang up, etc.) in the Pensar Gateway provider
- **Improved SSE parser resilience** — catches connection errors during stream reading, tracks `message_stop` receipt for diagnostics, and provides clearer error messages for connection interruptions
- **Inlined auth modules** — removed the `core/auth/` barrel and its separate modules (device-flow, token, signing, connection, workspaces, types), moving token refresh into `core/api/tokenRefresh`, signing into `providers/pensarSigning`, and auth UI logic directly into the TUI `auth-flow.tsx` component. Also removed the CLI `pensar auth` subcommand (`cli/auth.ts`) and the `web_search`/`get_page` agent tools (moved server-side)

This complements the infrastructure-level fix (CloudFront timeout increase) with defense-in-depth client-side error handling.

## Test plan

- [ ] Verify `bun run tsc` and `bun run test` pass
- [ ] Manual test: start a pentest against a target and confirm streaming works end-to-end
- [ ] Manual test: simulate network interruption during streaming and confirm retry + user-friendly error message
- [ ] Verify TUI auth flow still works (connect/disconnect to Pensar Console)
- [ ] Confirm `pensar auth --target <url>` CLI help is updated correctly


Made with [Cursor](https://cursor.com)