### PR TITLE
Fix pending shell tool call labels in the operator UI

### DIFF
--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -7,17 +7,18 @@ import type { ToolContext } from "./types";
 const MAX_INLINE = 50_000;
 
 export const executeCommandInputSchema = z.object({
+  // not actually sure if placing this above the other keys/zod values ensures that the model generates it first...
+  toolCallDescription: z
+    .string()
+    .describe(
+      "A concise, human-readable description of what this tool call is doing (e.g., 'Scanning for open ports on target')",
+    ),
   command: z.string().describe("The shell command to execute"),
   timeout: z
     .number()
     .optional()
     .describe(
       "Timeout in seconds. If omitted, the command runs until completion or abort.",
-    ),
-  toolCallDescription: z
-    .string()
-    .describe(
-      "A concise, human-readable description of what this tool call is doing (e.g., 'Scanning for open ports on target')",
     ),
 });
 

--- a/src/tui/components/chat/tool-message.tsx
+++ b/src/tui/components/chat/tool-message.tsx
@@ -11,7 +11,7 @@
 import { memo, useState } from "react";
 import { useTheme } from "../../theme";
 import { AsciiSpinner } from "../shared/ascii-spinner";
-import { getToolSummary } from "../shared/tool-registry";
+import { getToolDisplayLabel } from "../shared/tool-registry";
 import {
   getResultSummary,
   type ResultSummary,
@@ -61,8 +61,9 @@ export const ToolMessage = memo(function ToolMessage({
   const isError = message.status === "error";
   const { toolName, args, result, logs } = message;
 
-  // Get tool summary from registry
-  const summary = getToolSummary(toolName, args);
+  const summary = getToolDisplayLabel(toolName, args, {
+    preferDescription: isPending,
+  });
 
   // Get result summary for completed tools
   const resultDisplay: ResultSummary | null =

--- a/src/tui/components/shared/tool-registry.test.ts
+++ b/src/tui/components/shared/tool-registry.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { tryParsePartialJson } from "./message-utils";
+import { getToolDisplayLabel, getToolSummary } from "./tool-registry";
+
+describe("getToolDisplayLabel", () => {
+  it("reproduces the raw execute_command summary fallback for description-only args", () => {
+    const parsed = tryParsePartialJson(
+      '{"toolCallDescription":"Searching repository for secrets"}',
+    );
+
+    expect(parsed).toEqual({
+      toolCallDescription: "Searching repository for secrets",
+    });
+    expect(getToolSummary("execute_command", parsed!)).toBe("$ ");
+  });
+
+  it("prefers the human description for pending execute_command calls", () => {
+    const parsed = tryParsePartialJson(
+      '{"toolCallDescription":"Searching repository for secrets","command":"rg --fi',
+    );
+
+    expect(parsed).toEqual({
+      toolCallDescription: "Searching repository for secrets",
+      command: "rg --fi",
+    });
+    expect(
+      getToolDisplayLabel("execute_command", parsed!, {
+        preferDescription: true,
+      }),
+    ).toBe("Searching repository for secrets");
+  });
+
+  it("falls back to the command summary after execute_command completes", () => {
+    expect(
+      getToolDisplayLabel(
+        "execute_command",
+        {
+          toolCallDescription: "Searching repository for secrets",
+          command: "rg --files . | head",
+        },
+        { preferDescription: false },
+      ),
+    ).toBe("$ rg --files . | head");
+  });
+
+  it("leaves non-shell tool labels unchanged", () => {
+    expect(
+      getToolDisplayLabel(
+        "http_request",
+        {
+          toolCallDescription: "Fetching homepage",
+          method: "GET",
+          url: "https://example.com",
+        },
+        { preferDescription: true },
+      ),
+    ).toBe("GET https://example.com");
+  });
+});

--- a/src/tui/components/shared/tool-registry.ts
+++ b/src/tui/components/shared/tool-registry.ts
@@ -117,6 +117,27 @@ export function getToolSummary(
 }
 
 /**
+ * Get the label shown in the live tool header.
+ *
+ * Pending shell commands should prefer the model-provided human description
+ * over partial command text while the tool call is still streaming/executing.
+ */
+export function getToolDisplayLabel(
+  toolName: string,
+  args: Record<string, unknown>,
+  options: { preferDescription?: boolean } = {},
+): string {
+  if (options.preferDescription && toolName === "execute_command") {
+    const description = args.toolCallDescription;
+    if (typeof description === "string" && description.trim().length > 0) {
+      return description.trim();
+    }
+  }
+
+  return getToolSummary(toolName, args);
+}
+
+/**
  * Register a custom tool summary function.
  * Allows extensions to add their own tool displays.
  *

--- a/src/tui/components/shared/tool-renderer.tsx
+++ b/src/tui/components/shared/tool-renderer.tsx
@@ -9,7 +9,7 @@
 import { memo, useState } from "react";
 import { useTheme } from "../../theme";
 import { AsciiSpinner } from "./ascii-spinner";
-import { getToolSummary } from "./tool-registry";
+import { getToolDisplayLabel } from "./tool-registry";
 import { getResultSummary, type ResultSummary } from "./result-registry";
 import { isToolMessage } from "./type-guards";
 import type { DisplayMessage, SubagentLogEntry } from "../agent-display";
@@ -56,8 +56,9 @@ export const ToolRenderer = memo(function ToolRenderer({
   const isError = message.status === "error";
   const { toolName, args, result, logs, subagentLogs } = message;
 
-  // Get tool summary from registry
-  const summary = getToolSummary(toolName, args);
+  const summary = getToolDisplayLabel(toolName, args, {
+    preferDescription: isPending,
+  });
 
   // Get result summary for completed tools
   const resultDisplay: ResultSummary | null =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes #345.

The operator/chat tool-call renderer was using the partial `command` field to label pending `execute_command` calls, which meant open-ended shell calls could briefly show only `$ ` or a partially streamed command fragment. This change keeps the existing command summary for completed tool calls, but makes pending shell tool calls prefer `toolCallDescription` so the live label stays human-readable while the command args are still streaming.

### How did you verify your code works?

- Added a focused regression test covering description-only and partial-command `execute_command` args.
- Ran `bun run test src/tui/components/shared/tool-registry.test.ts`.
- Ran `bun run test`, `bun run lint`, `bun run tsc`, and `bun run build`.
- Manually verified in the TUI that asking "what version of bun is installed?" shows the pending shell tool call as "Checking the installed version of Bun" while the underlying `$ bun --version` command remains visible in the approval UI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4369727-a51f-4355-9c5b-b27ee8be5628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4369727-a51f-4355-9c5b-b27ee8be5628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

