### PR TITLE
Fix model search view rendering bugs

### DIFF
--- a/src/tui/components/chat/config-view.tsx
+++ b/src/tui/components/chat/config-view.tsx
@@ -197,7 +197,8 @@ export function ConfigView({ config, onBack, onStart }: ConfigViewProps) {
           }
           paddingLeft={1}
           paddingRight={1}
-          maxHeight={8}
+          height={8}
+          overflow="hidden"
         >
           <ModelPicker
             config={config}

--- a/src/tui/components/commands/models-display.tsx
+++ b/src/tui/components/commands/models-display.tsx
@@ -74,6 +74,8 @@ export default function ModelsDisplay() {
         paddingLeft={2}
         paddingRight={2}
         marginTop={1}
+        flexGrow={1}
+        flexShrink={1}
         overflow="hidden"
       >
         <ModelPicker

--- a/src/tui/components/commands/models-display.tsx
+++ b/src/tui/components/commands/models-display.tsx
@@ -1,9 +1,18 @@
+import type { ReactNode } from "react";
 import { useKeyboard } from "@opentui/react";
 import { useAgent } from "../../context/agent";
 import { useRoute } from "../../context/route";
 import { useConfig } from "../../context/config";
 import { ModelPicker } from "../model-picker";
 import { useTheme } from "../../theme";
+
+function ClippedLine({ children }: { children: ReactNode }) {
+  return (
+    <box width="100%" overflow="hidden">
+      {children}
+    </box>
+  );
+}
 
 export default function ModelsDisplay() {
   const { colors } = useTheme();
@@ -41,25 +50,29 @@ export default function ModelsDisplay() {
       width="100%"
       height="100%"
       paddingLeft={4}
+      paddingRight={4}
       paddingTop={2}
       overflow="hidden"
     >
       {/* Header */}
-      <text>
-        <span fg={colors.primary}>█ </span>
-        <span fg={colors.text}>Select AI Model</span>
-        <span fg={colors.textMuted}> ({model.name})</span>
-        <span fg={colors.textMuted}>
-          {" "}
-          [{isModelUserSelected ? "user" : "default"}]
-        </span>
-      </text>
+      <ClippedLine>
+        <text>
+          <span fg={colors.primary}>█ </span>
+          <span fg={colors.text}>Select AI Model</span>
+          <span fg={colors.textMuted}> ({model.name})</span>
+          <span fg={colors.textMuted}>
+            {" "}
+            [{isModelUserSelected ? "user" : "default"}]
+          </span>
+        </text>
+      </ClippedLine>
 
       {/* Model Picker */}
       <box
         flexDirection="column"
         width="100%"
         paddingLeft={2}
+        paddingRight={2}
         marginTop={1}
         overflow="hidden"
       >
@@ -76,24 +89,30 @@ export default function ModelsDisplay() {
 
       {/* Footer */}
       <box flexDirection="column" marginTop={2}>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={colors.textMuted}>Press </span>
-          <span fg={colors.text}>[Enter]</span>
-          <span fg={colors.textMuted}> to confirm</span>
-        </text>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={colors.textMuted}>Press </span>
-          <span fg={colors.text}>[ESC]</span>
-          <span fg={colors.textMuted}> to go back</span>
-        </text>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={colors.textMuted}>Press </span>
-          <span fg={colors.text}>[Ctrl+P]</span>
-          <span fg={colors.textMuted}> to connect provider</span>
-        </text>
+        <ClippedLine>
+          <text>
+            <span fg={colors.primary}>█ </span>
+            <span fg={colors.textMuted}>Press </span>
+            <span fg={colors.text}>[Enter]</span>
+            <span fg={colors.textMuted}> to confirm</span>
+          </text>
+        </ClippedLine>
+        <ClippedLine>
+          <text>
+            <span fg={colors.primary}>█ </span>
+            <span fg={colors.textMuted}>Press </span>
+            <span fg={colors.text}>[ESC]</span>
+            <span fg={colors.textMuted}> to go back</span>
+          </text>
+        </ClippedLine>
+        <ClippedLine>
+          <text>
+            <span fg={colors.primary}>█ </span>
+            <span fg={colors.textMuted}>Press </span>
+            <span fg={colors.text}>[Ctrl+P]</span>
+            <span fg={colors.textMuted}> to connect provider</span>
+          </text>
+        </ClippedLine>
       </box>
     </box>
   );

--- a/src/tui/components/commands/models-display.tsx
+++ b/src/tui/components/commands/models-display.tsx
@@ -36,7 +36,14 @@ export default function ModelsDisplay() {
   });
 
   return (
-    <box flexDirection="column" width="100%" paddingLeft={4} paddingTop={2}>
+    <box
+      flexDirection="column"
+      width="100%"
+      height="100%"
+      paddingLeft={4}
+      paddingTop={2}
+      overflow="hidden"
+    >
       {/* Header */}
       <text>
         <span fg={colors.primary}>█ </span>
@@ -49,7 +56,13 @@ export default function ModelsDisplay() {
       </text>
 
       {/* Model Picker */}
-      <box flexDirection="column" paddingLeft={2} marginTop={1}>
+      <box
+        flexDirection="column"
+        width="100%"
+        paddingLeft={2}
+        marginTop={1}
+        overflow="hidden"
+      >
         <ModelPicker
           config={config.data}
           selectedModel={model}

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -136,7 +136,9 @@ export function ModelPicker({
       );
 
       if (preservedProviders.size > 0) {
-        return setsAreEqual(prev, preservedProviders) ? prev : preservedProviders;
+        return setsAreEqual(prev, preservedProviders)
+          ? prev
+          : preservedProviders;
       }
 
       const fallbackProvider = availableProviders.has(selectedModel.provider)
@@ -520,7 +522,9 @@ export function ModelPicker({
                     return (
                       <PickerRow>
                         <text
-                          fg={isModelFocused ? colors.primary : colors.textMuted}
+                          fg={
+                            isModelFocused ? colors.primary : colors.textMuted
+                          }
                         >
                           {`  Model: ${localModelName || "(press Enter to set)"}`}
                         </text>
@@ -576,8 +580,8 @@ export function ModelPicker({
                       : colors.textMuted
                 }
               >
-                {isProviderFocused ? "❯" : isExpanded ? "▾" : "▸"} {providerName}{" "}
-                ({models.length})
+                {isProviderFocused ? "❯" : isExpanded ? "▾" : "▸"}{" "}
+                {providerName} ({models.length})
               </text>
             </PickerRow>
 
@@ -603,9 +607,7 @@ export function ModelPicker({
                     m.id === "claude-haiku-4-5" || m.id === "gpt-4o-mini";
                   return (
                     <PickerRow key={m.id}>
-                      <text
-                        fg={isFocused ? colors.primary : colors.textMuted}
-                      >
+                      <text fg={isFocused ? colors.primary : colors.textMuted}>
                         {isSelected ? "●" : "○"} {m.name}
                         {isDefault && !isModelUserSelected && isSelected
                           ? " [default]"

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -492,7 +492,11 @@ export function ModelPicker({
               const isUrlEditing = editingLocalField === "url";
               if (isUrlEditing) {
                 elements.push(
-                  <PickerRow key="local-url" id="local-input-url" paddingLeft={2}>
+                  <PickerRow
+                    key="local-url"
+                    id="local-input-url"
+                    paddingLeft={2}
+                  >
                     <text fg={colors.primary}> URL: </text>
                     <input
                       focused={true}
@@ -515,10 +519,12 @@ export function ModelPicker({
                 );
               } else {
                 elements.push(
-                  <PickerRow key="local-url" id="local-input-url" paddingLeft={2}>
-                    <text
-                      fg={isUrlFocused ? colors.primary : colors.textMuted}
-                    >
+                  <PickerRow
+                    key="local-url"
+                    id="local-input-url"
+                    paddingLeft={2}
+                  >
+                    <text fg={isUrlFocused ? colors.primary : colors.textMuted}>
                       {`  URL: ${localUrl || "(press Enter to set)"}`}
                     </text>
                   </PickerRow>,
@@ -579,14 +585,8 @@ export function ModelPicker({
                   const isSelected = m.id === selectedModel.id;
                   const isMFocused = isModelFocused(m.id);
                   elements.push(
-                    <PickerRow
-                      key={m.id}
-                      id={`model-${m.id}`}
-                      paddingLeft={2}
-                    >
-                      <text
-                        fg={isMFocused ? colors.primary : colors.textMuted}
-                      >
+                    <PickerRow key={m.id} id={`model-${m.id}`} paddingLeft={2}>
+                      <text fg={isMFocused ? colors.primary : colors.textMuted}>
                         {isSelected ? "●" : "○"} {m.name}
                       </text>
                     </PickerRow>,
@@ -629,11 +629,7 @@ export function ModelPicker({
               const isDefault =
                 m.id === "claude-haiku-4-5" || m.id === "gpt-4o-mini";
               elements.push(
-                <PickerRow
-                  key={m.id}
-                  id={`model-${m.id}`}
-                  paddingLeft={2}
-                >
+                <PickerRow key={m.id} id={`model-${m.id}`} paddingLeft={2}>
                   <text fg={isMFocused ? colors.primary : colors.textMuted}>
                     {isSelected ? "●" : "○"} {m.name}
                     {isDefault && !isModelUserSelected && isSelected

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -3,13 +3,16 @@ import {
   useEffect,
   useMemo,
   useCallback,
+  useRef,
   type ReactNode,
 } from "react";
 import { useKeyboard } from "@opentui/react";
+import { ScrollBoxRenderable } from "@opentui/core";
 import type { ModelInfo } from "../../../core/ai";
 import { getAvailableModels } from "../../../core/providers/utils";
 import type { Config } from "../../../core/config/config";
 import { useTheme } from "../../theme";
+import { scrollToChild } from "../../utils/scroll";
 
 const providerNames: Record<string, string> = {
   anthropic: "Claude",
@@ -37,6 +40,7 @@ function setsAreEqual(a: Set<string>, b: Set<string>) {
 
 function PickerRow({
   children,
+  id,
   paddingLeft,
   paddingRight,
   backgroundColor,
@@ -44,6 +48,7 @@ function PickerRow({
   gap = 0,
 }: {
   children: ReactNode;
+  id?: string;
   paddingLeft?: number;
   paddingRight?: number;
   backgroundColor?: string;
@@ -52,6 +57,7 @@ function PickerRow({
 }) {
   return (
     <box
+      id={id}
       width="100%"
       overflow="hidden"
       flexDirection={flexDirection}
@@ -71,6 +77,12 @@ type NavigationItem =
   | { type: "local-input"; field: LocalInputField };
 
 type LocalInputField = "url" | "model";
+
+function getNavItemId(item: NavigationItem): string {
+  if (item.type === "provider") return `provider-${item.provider}`;
+  if (item.type === "model") return `model-${item.model.id}`;
+  return `local-input-${item.field}`;
+}
 
 export interface ModelPickerProps {
   config: Config | null;
@@ -92,6 +104,7 @@ export function ModelPicker({
   isModelUserSelected = false,
 }: ModelPickerProps) {
   const { colors } = useTheme();
+  const scrollBoxRef = useRef<ScrollBoxRenderable | null>(null);
   const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [expandedProviders, setExpandedProviders] = useState<Set<string>>(
@@ -223,6 +236,13 @@ export function ModelPicker({
       Math.min(prev, Math.max(0, navigationItems.length - 1)),
     );
   }, [navigationItems.length]);
+
+  // Scroll to keep focused item visible
+  useEffect(() => {
+    const item = navigationItems[focusedIndex];
+    if (!item) return;
+    scrollToChild(scrollBoxRef.current, getNavItemId(item));
+  }, [focusedIndex, navigationItems]);
 
   const commitLocalConfig = useCallback(
     (url: string, modelName: string) => {
@@ -377,8 +397,37 @@ export function ModelPicker({
     handleKeyboard(key);
   });
 
+  // Helper to check if a navigation item at focusedIndex matches a provider
+  const isProviderFocused = (provider: string) =>
+    navigationItems[focusedIndex]?.type === "provider" &&
+    (navigationItems[focusedIndex] as { type: "provider"; provider: string })
+      .provider === provider;
+
+  // Helper to check if a model is focused
+  const isModelFocused = (modelId: string) =>
+    navigationItems[focusedIndex]?.type === "model" &&
+    (navigationItems[focusedIndex] as { type: "model"; model: ModelInfo }).model
+      .id === modelId;
+
+  // Helper to check if a local input field is focused
+  const isLocalFieldFocused = (field: LocalInputField) =>
+    navigationItems[focusedIndex]?.type === "local-input" &&
+    (
+      navigationItems[focusedIndex] as {
+        type: "local-input";
+        field: LocalInputField;
+      }
+    ).field === field;
+
   return (
-    <box flexDirection="column" gap={0} width="100%" overflow="hidden">
+    <box
+      flexDirection="column"
+      gap={0}
+      width="100%"
+      flexGrow={1}
+      flexShrink={1}
+      overflow="hidden"
+    >
       {/* Search indicator */}
       {searchQuery ? (
         <PickerRow>
@@ -390,237 +439,215 @@ export function ModelPicker({
         </PickerRow>
       )}
 
-      {/* Provider groups */}
-      {providerOrder.map((provider) => {
-        const isExpanded = expandedProviders.has(provider);
-        const providerName = providerNames[provider] || provider;
-        const isProviderFocused =
-          navigationItems[focusedIndex]?.type === "provider" &&
-          (
-            navigationItems[focusedIndex] as {
-              type: "provider";
-              provider: string;
-            }
-          ).provider === provider;
+      {/* Scrollable provider/model list */}
+      <scrollbox
+        ref={scrollBoxRef}
+        style={{
+          rootOptions: {
+            flexGrow: 1,
+            flexShrink: 1,
+            width: "100%",
+            overflow: "hidden",
+          },
+          contentOptions: {
+            flexDirection: "column",
+          },
+          scrollbarOptions: {
+            visible: false,
+          },
+        }}
+        stickyScroll={false}
+      >
+        {providerOrder.flatMap((provider) => {
+          const isExpanded = expandedProviders.has(provider);
+          const providerName = providerNames[provider] || provider;
+          const isFocused = isProviderFocused(provider);
 
-        if (provider === "local") {
-          const localModels = groupedModels["local"];
-          const modelCount = localModels?.length ?? 0;
-          return (
-            <box
-              key="local"
-              flexDirection="column"
-              gap={0}
-              width="100%"
-              overflow="hidden"
-            >
-              <PickerRow>
+          if (provider === "local") {
+            const localModels = groupedModels["local"];
+            const modelCount = localModels?.length ?? 0;
+            const elements: ReactNode[] = [];
+
+            // Local provider header
+            elements.push(
+              <PickerRow key="local" id="provider-local">
                 <text
                   fg={
-                    isProviderFocused
+                    isFocused
                       ? colors.primary
                       : isExpanded
                         ? colors.text
                         : colors.textMuted
                   }
                 >
-                  {isProviderFocused ? "❯" : isExpanded ? "▾" : "▸"}{" "}
-                  {providerName}
+                  {isFocused ? "❯" : isExpanded ? "▾" : "▸"} {providerName}
                   {modelCount > 0 ? ` (${modelCount})` : ""}
                 </text>
-              </PickerRow>
+              </PickerRow>,
+            );
 
-              {isExpanded && (
-                <box
-                  flexDirection="column"
-                  gap={0}
-                  paddingLeft={2}
-                  width="100%"
-                  overflow="hidden"
-                >
-                  {/* URL input */}
-                  {(() => {
-                    const isUrlFocused =
-                      navigationItems[focusedIndex]?.type === "local-input" &&
-                      (
-                        navigationItems[focusedIndex] as {
-                          type: "local-input";
-                          field: LocalInputField;
-                        }
-                      ).field === "url";
-                    const isUrlEditing = editingLocalField === "url";
-                    if (isUrlEditing) {
-                      return (
-                        <PickerRow>
-                          <text fg={colors.primary}> URL: </text>
-                          <input
-                            focused={true}
-                            value={localUrl}
-                            backgroundColor="transparent"
-                            cursorColor={colors.textMuted}
-                            onInput={(v) =>
-                              setLocalUrl(typeof v === "string" ? v : "")
-                            }
-                            onPaste={(event) => {
-                              const cleaned = String(event.text).replace(
-                                /\r?\n/g,
-                                "",
-                              );
-                              setLocalUrl((prev) => `${prev}${cleaned}`);
-                            }}
-                            onSubmit={finishEditing}
-                          />
-                        </PickerRow>
-                      );
-                    }
-                    return (
-                      <PickerRow>
-                        <text
-                          fg={isUrlFocused ? colors.primary : colors.textMuted}
-                        >
-                          {`  URL: ${localUrl || "(press Enter to set)"}`}
-                        </text>
-                      </PickerRow>
-                    );
-                  })()}
+            if (isExpanded) {
+              // URL input
+              const isUrlFocused = isLocalFieldFocused("url");
+              const isUrlEditing = editingLocalField === "url";
+              if (isUrlEditing) {
+                elements.push(
+                  <PickerRow key="local-url" id="local-input-url" paddingLeft={2}>
+                    <text fg={colors.primary}> URL: </text>
+                    <input
+                      focused={true}
+                      value={localUrl}
+                      backgroundColor="transparent"
+                      cursorColor={colors.textMuted}
+                      onInput={(v) =>
+                        setLocalUrl(typeof v === "string" ? v : "")
+                      }
+                      onPaste={(event) => {
+                        const cleaned = String(event.text).replace(
+                          /\r?\n/g,
+                          "",
+                        );
+                        setLocalUrl((prev) => `${prev}${cleaned}`);
+                      }}
+                      onSubmit={finishEditing}
+                    />
+                  </PickerRow>,
+                );
+              } else {
+                elements.push(
+                  <PickerRow key="local-url" id="local-input-url" paddingLeft={2}>
+                    <text
+                      fg={isUrlFocused ? colors.primary : colors.textMuted}
+                    >
+                      {`  URL: ${localUrl || "(press Enter to set)"}`}
+                    </text>
+                  </PickerRow>,
+                );
+              }
 
-                  {/* Model name input */}
-                  {(() => {
-                    const isModelFocused =
-                      navigationItems[focusedIndex]?.type === "local-input" &&
-                      (
-                        navigationItems[focusedIndex] as {
-                          type: "local-input";
-                          field: LocalInputField;
-                        }
-                      ).field === "model";
-                    const isModelEditing = editingLocalField === "model";
-                    if (isModelEditing) {
-                      return (
-                        <PickerRow>
-                          <text fg={colors.primary}> Model: </text>
-                          <input
-                            focused={true}
-                            value={localModelName}
-                            backgroundColor="transparent"
-                            cursorColor={colors.textMuted}
-                            onInput={(v) =>
-                              setLocalModelName(typeof v === "string" ? v : "")
-                            }
-                            onPaste={(event) => {
-                              const cleaned = String(event.text).replace(
-                                /\r?\n/g,
-                                "",
-                              );
-                              setLocalModelName((prev) => `${prev}${cleaned}`);
-                            }}
-                            onSubmit={finishEditing}
-                          />
-                        </PickerRow>
-                      );
-                    }
-                    return (
-                      <PickerRow>
-                        <text
-                          fg={
-                            isModelFocused ? colors.primary : colors.textMuted
-                          }
-                        >
-                          {`  Model: ${localModelName || "(press Enter to set)"}`}
-                        </text>
-                      </PickerRow>
-                    );
-                  })()}
+              // Model name input
+              const isModelFieldFocused = isLocalFieldFocused("model");
+              const isModelEditing = editingLocalField === "model";
+              if (isModelEditing) {
+                elements.push(
+                  <PickerRow
+                    key="local-model"
+                    id="local-input-model"
+                    paddingLeft={2}
+                  >
+                    <text fg={colors.primary}> Model: </text>
+                    <input
+                      focused={true}
+                      value={localModelName}
+                      backgroundColor="transparent"
+                      cursorColor={colors.textMuted}
+                      onInput={(v) =>
+                        setLocalModelName(typeof v === "string" ? v : "")
+                      }
+                      onPaste={(event) => {
+                        const cleaned = String(event.text).replace(
+                          /\r?\n/g,
+                          "",
+                        );
+                        setLocalModelName((prev) => `${prev}${cleaned}`);
+                      }}
+                      onSubmit={finishEditing}
+                    />
+                  </PickerRow>,
+                );
+              } else {
+                elements.push(
+                  <PickerRow
+                    key="local-model"
+                    id="local-input-model"
+                    paddingLeft={2}
+                  >
+                    <text
+                      fg={
+                        isModelFieldFocused ? colors.primary : colors.textMuted
+                      }
+                    >
+                      {`  Model: ${localModelName || "(press Enter to set)"}`}
+                    </text>
+                  </PickerRow>,
+                );
+              }
 
-                  {/* Local models (after config is set) */}
-                  {localModels?.map((m) => {
-                    const isSelected = m.id === selectedModel.id;
-                    const isFocused =
-                      navigationItems[focusedIndex]?.type === "model" &&
-                      (
-                        navigationItems[focusedIndex] as {
-                          type: "model";
-                          model: ModelInfo;
-                        }
-                      ).model.id === m.id;
-                    return (
-                      <PickerRow key={m.id}>
-                        <text
-                          fg={isFocused ? colors.primary : colors.textMuted}
-                        >
-                          {isSelected ? "●" : "○"} {m.name}
-                        </text>
-                      </PickerRow>
-                    );
-                  })}
-                </box>
-              )}
-            </box>
-          );
-        }
+              // Local models
+              if (localModels) {
+                for (const m of localModels) {
+                  const isSelected = m.id === selectedModel.id;
+                  const isMFocused = isModelFocused(m.id);
+                  elements.push(
+                    <PickerRow
+                      key={m.id}
+                      id={`model-${m.id}`}
+                      paddingLeft={2}
+                    >
+                      <text
+                        fg={isMFocused ? colors.primary : colors.textMuted}
+                      >
+                        {isSelected ? "●" : "○"} {m.name}
+                      </text>
+                    </PickerRow>,
+                  );
+                }
+              }
+            }
 
-        const models = groupedModels[provider];
-        if (!models || models.length === 0) return null;
+            return elements;
+          }
 
-        return (
-          <box
-            key={provider}
-            flexDirection="column"
-            gap={0}
-            width="100%"
-            overflow="hidden"
-          >
-            <PickerRow>
+          const models = groupedModels[provider];
+          if (!models || models.length === 0) return [];
+
+          const elements: ReactNode[] = [];
+
+          // Provider header
+          elements.push(
+            <PickerRow key={provider} id={`provider-${provider}`}>
               <text
                 fg={
-                  isProviderFocused
+                  isFocused
                     ? colors.primary
                     : isExpanded
                       ? colors.text
                       : colors.textMuted
                 }
               >
-                {isProviderFocused ? "❯" : isExpanded ? "▾" : "▸"}{" "}
-                {providerName} ({models.length})
+                {isFocused ? "❯" : isExpanded ? "▾" : "▸"} {providerName} (
+                {models.length})
               </text>
-            </PickerRow>
+            </PickerRow>,
+          );
 
-            {isExpanded && (
-              <box
-                flexDirection="column"
-                gap={0}
-                paddingLeft={2}
-                width="100%"
-                overflow="hidden"
-              >
-                {models.map((m) => {
-                  const isSelected = m.id === selectedModel.id;
-                  const isFocused =
-                    navigationItems[focusedIndex]?.type === "model" &&
-                    (
-                      navigationItems[focusedIndex] as {
-                        type: "model";
-                        model: ModelInfo;
-                      }
-                    ).model.id === m.id;
-                  const isDefault =
-                    m.id === "claude-haiku-4-5" || m.id === "gpt-4o-mini";
-                  return (
-                    <PickerRow key={m.id}>
-                      <text fg={isFocused ? colors.primary : colors.textMuted}>
-                        {isSelected ? "●" : "○"} {m.name}
-                        {isDefault && !isModelUserSelected && isSelected
-                          ? " [default]"
-                          : ""}
-                      </text>
-                    </PickerRow>
-                  );
-                })}
-              </box>
-            )}
-          </box>
-        );
-      })}
+          // Model rows
+          if (isExpanded) {
+            for (const m of models) {
+              const isSelected = m.id === selectedModel.id;
+              const isMFocused = isModelFocused(m.id);
+              const isDefault =
+                m.id === "claude-haiku-4-5" || m.id === "gpt-4o-mini";
+              elements.push(
+                <PickerRow
+                  key={m.id}
+                  id={`model-${m.id}`}
+                  paddingLeft={2}
+                >
+                  <text fg={isMFocused ? colors.primary : colors.textMuted}>
+                    {isSelected ? "●" : "○"} {m.name}
+                    {isDefault && !isModelUserSelected && isSelected
+                      ? " [default]"
+                      : ""}
+                  </text>
+                </PickerRow>,
+              );
+            }
+          }
+
+          return elements;
+        })}
+      </scrollbox>
 
       {/* Help text */}
       <PickerRow>

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -122,7 +122,7 @@ export function ModelPicker({
   }, [config]);
 
   useEffect(() => {
-    const availableProviders = new Set(
+    const availableProviders = new Set<string>(
       availableModels.map((model) => model.provider),
     );
 

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -1,4 +1,10 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  type ReactNode,
+} from "react";
 import { useKeyboard } from "@opentui/react";
 import type { ModelInfo } from "../../../core/ai";
 import { getAvailableModels } from "../../../core/providers/utils";
@@ -24,6 +30,40 @@ const providerOrder = [
   "bedrock",
   "local",
 ];
+
+function setsAreEqual(a: Set<string>, b: Set<string>) {
+  return a.size === b.size && [...a].every((value) => b.has(value));
+}
+
+function PickerRow({
+  children,
+  paddingLeft,
+  paddingRight,
+  backgroundColor,
+  flexDirection = "row",
+  gap = 0,
+}: {
+  children: ReactNode;
+  paddingLeft?: number;
+  paddingRight?: number;
+  backgroundColor?: string;
+  flexDirection?: "row" | "column";
+  gap?: number;
+}) {
+  return (
+    <box
+      width="100%"
+      overflow="hidden"
+      flexDirection={flexDirection}
+      paddingLeft={paddingLeft}
+      paddingRight={paddingRight}
+      backgroundColor={backgroundColor}
+      gap={gap}
+    >
+      {children}
+    </box>
+  );
+}
 
 type NavigationItem =
   | { type: "provider"; provider: string }
@@ -73,19 +113,45 @@ export function ModelPicker({
 
   // Load models when config changes
   useEffect(() => {
-    if (config) {
-      const models = getAvailableModels(config);
-      setAvailableModels(models);
-      // Auto-expand provider of current model
-      if (models.length > 0) {
-        const currentModel =
-          models.find((m) => m.id === selectedModel.id) || models[0];
-        if (currentModel) {
-          setExpandedProviders(new Set([currentModel.provider]));
-        }
-      }
+    if (!config) {
+      setAvailableModels([]);
+      return;
     }
-  }, [config, selectedModel.id]);
+
+    setAvailableModels(getAvailableModels(config));
+  }, [config]);
+
+  useEffect(() => {
+    const availableProviders = new Set(
+      availableModels.map((model) => model.provider),
+    );
+
+    setExpandedProviders((prev) => {
+      if (availableProviders.size === 0) {
+        return prev.size === 0 ? prev : new Set();
+      }
+
+      const preservedProviders = new Set(
+        [...prev].filter((provider) => availableProviders.has(provider)),
+      );
+
+      if (preservedProviders.size > 0) {
+        return setsAreEqual(prev, preservedProviders) ? prev : preservedProviders;
+      }
+
+      const fallbackProvider = availableProviders.has(selectedModel.provider)
+        ? selectedModel.provider
+        : availableModels[0]?.provider;
+
+      if (!fallbackProvider) {
+        return prev.size === 0 ? prev : new Set();
+      }
+
+      return prev.size === 1 && prev.has(fallbackProvider)
+        ? prev
+        : new Set([fallbackProvider]);
+    });
+  }, [availableModels, selectedModel.provider]);
 
   // Group models by provider and filter by search
   const groupedModels = useMemo(() => {
@@ -310,12 +376,16 @@ export function ModelPicker({
   });
 
   return (
-    <box flexDirection="column" gap={0}>
+    <box flexDirection="column" gap={0} width="100%" overflow="hidden">
       {/* Search indicator */}
       {searchQuery ? (
-        <text fg={colors.text}>Search: {searchQuery}_</text>
+        <PickerRow>
+          <text fg={colors.text}>Search: {searchQuery}</text>
+        </PickerRow>
       ) : (
-        <text fg={colors.textMuted}>Type to search models...</text>
+        <PickerRow>
+          <text fg={colors.textMuted}>Type to search models...</text>
+        </PickerRow>
       )}
 
       {/* Provider groups */}
@@ -335,23 +405,37 @@ export function ModelPicker({
           const localModels = groupedModels["local"];
           const modelCount = localModels?.length ?? 0;
           return (
-            <box key="local" flexDirection="column" gap={0}>
-              <text
-                fg={
-                  isProviderFocused
-                    ? colors.primary
-                    : isExpanded
-                      ? colors.text
-                      : colors.textMuted
-                }
-              >
-                {isProviderFocused ? "❯" : isExpanded ? "▾" : "▸"}{" "}
-                {providerName}
-                {modelCount > 0 ? ` (${modelCount})` : ""}
-              </text>
+            <box
+              key="local"
+              flexDirection="column"
+              gap={0}
+              width="100%"
+              overflow="hidden"
+            >
+              <PickerRow>
+                <text
+                  fg={
+                    isProviderFocused
+                      ? colors.primary
+                      : isExpanded
+                        ? colors.text
+                        : colors.textMuted
+                  }
+                >
+                  {isProviderFocused ? "❯" : isExpanded ? "▾" : "▸"}{" "}
+                  {providerName}
+                  {modelCount > 0 ? ` (${modelCount})` : ""}
+                </text>
+              </PickerRow>
 
               {isExpanded && (
-                <box flexDirection="column" gap={0} paddingLeft={2}>
+                <box
+                  flexDirection="column"
+                  gap={0}
+                  paddingLeft={2}
+                  width="100%"
+                  overflow="hidden"
+                >
                   {/* URL input */}
                   {(() => {
                     const isUrlFocused =
@@ -365,7 +449,7 @@ export function ModelPicker({
                     const isUrlEditing = editingLocalField === "url";
                     if (isUrlEditing) {
                       return (
-                        <box flexDirection="row">
+                        <PickerRow>
                           <text fg={colors.primary}> URL: </text>
                           <input
                             focused={true}
@@ -384,15 +468,17 @@ export function ModelPicker({
                             }}
                             onSubmit={finishEditing}
                           />
-                        </box>
+                        </PickerRow>
                       );
                     }
                     return (
-                      <text
-                        fg={isUrlFocused ? colors.primary : colors.textMuted}
-                      >
-                        {`  URL: ${localUrl || "(press Enter to set)"}`}
-                      </text>
+                      <PickerRow>
+                        <text
+                          fg={isUrlFocused ? colors.primary : colors.textMuted}
+                        >
+                          {`  URL: ${localUrl || "(press Enter to set)"}`}
+                        </text>
+                      </PickerRow>
                     );
                   })()}
 
@@ -409,7 +495,7 @@ export function ModelPicker({
                     const isModelEditing = editingLocalField === "model";
                     if (isModelEditing) {
                       return (
-                        <box flexDirection="row">
+                        <PickerRow>
                           <text fg={colors.primary}> Model: </text>
                           <input
                             focused={true}
@@ -428,15 +514,17 @@ export function ModelPicker({
                             }}
                             onSubmit={finishEditing}
                           />
-                        </box>
+                        </PickerRow>
                       );
                     }
                     return (
-                      <text
-                        fg={isModelFocused ? colors.primary : colors.textMuted}
-                      >
-                        {`  Model: ${localModelName || "(press Enter to set)"}`}
-                      </text>
+                      <PickerRow>
+                        <text
+                          fg={isModelFocused ? colors.primary : colors.textMuted}
+                        >
+                          {`  Model: ${localModelName || "(press Enter to set)"}`}
+                        </text>
+                      </PickerRow>
                     );
                   })()}
 
@@ -452,12 +540,13 @@ export function ModelPicker({
                         }
                       ).model.id === m.id;
                     return (
-                      <text
-                        key={m.id}
-                        fg={isFocused ? colors.primary : colors.textMuted}
-                      >
-                        {isSelected ? "●" : "○"} {m.name}
-                      </text>
+                      <PickerRow key={m.id}>
+                        <text
+                          fg={isFocused ? colors.primary : colors.textMuted}
+                        >
+                          {isSelected ? "●" : "○"} {m.name}
+                        </text>
+                      </PickerRow>
                     );
                   })}
                 </box>
@@ -470,22 +559,36 @@ export function ModelPicker({
         if (!models || models.length === 0) return null;
 
         return (
-          <box key={provider} flexDirection="column" gap={0}>
-            <text
-              fg={
-                isProviderFocused
-                  ? colors.primary
-                  : isExpanded
-                    ? colors.text
-                    : colors.textMuted
-              }
-            >
-              {isProviderFocused ? "❯" : isExpanded ? "▾" : "▸"} {providerName}{" "}
-              ({models.length})
-            </text>
+          <box
+            key={provider}
+            flexDirection="column"
+            gap={0}
+            width="100%"
+            overflow="hidden"
+          >
+            <PickerRow>
+              <text
+                fg={
+                  isProviderFocused
+                    ? colors.primary
+                    : isExpanded
+                      ? colors.text
+                      : colors.textMuted
+                }
+              >
+                {isProviderFocused ? "❯" : isExpanded ? "▾" : "▸"} {providerName}{" "}
+                ({models.length})
+              </text>
+            </PickerRow>
 
             {isExpanded && (
-              <box flexDirection="column" gap={0} paddingLeft={2}>
+              <box
+                flexDirection="column"
+                gap={0}
+                paddingLeft={2}
+                width="100%"
+                overflow="hidden"
+              >
                 {models.map((m) => {
                   const isSelected = m.id === selectedModel.id;
                   const isFocused =
@@ -499,15 +602,16 @@ export function ModelPicker({
                   const isDefault =
                     m.id === "claude-haiku-4-5" || m.id === "gpt-4o-mini";
                   return (
-                    <text
-                      key={m.id}
-                      fg={isFocused ? colors.primary : colors.textMuted}
-                    >
-                      {isSelected ? "●" : "○"} {m.name}
-                      {isDefault && !isModelUserSelected && isSelected
-                        ? " [default]"
-                        : ""}
-                    </text>
+                    <PickerRow key={m.id}>
+                      <text
+                        fg={isFocused ? colors.primary : colors.textMuted}
+                      >
+                        {isSelected ? "●" : "○"} {m.name}
+                        {isDefault && !isModelUserSelected && isSelected
+                          ? " [default]"
+                          : ""}
+                      </text>
+                    </PickerRow>
                   );
                 })}
               </box>
@@ -517,11 +621,13 @@ export function ModelPicker({
       })}
 
       {/* Help text */}
-      <text fg={colors.textMuted}>
-        {editingLocalField
-          ? "Type or paste | Enter/Esc to confirm"
-          : "↑/↓ navigate | ←/→ collapse/expand | Type to search"}
-      </text>
+      <PickerRow>
+        <text fg={colors.textMuted}>
+          {editingLocalField
+            ? "Type or paste | Enter/Esc to confirm"
+            : "↑/↓ navigate | ←/→ collapse/expand | Type to search"}
+        </text>
+      </PickerRow>
     </box>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes the visual regressions in the `/models` view from issue #354.

Changes:
- remove the hardcoded trailing underscore from the active search label
- preserve expanded provider state while navigating filtered results so selection changes do not churn the tree
- render model picker rows inside full-width clipped containers to prevent stale text, concatenated labels, and right-edge bleed when the list shrinks or reflows
- clip the `/models` screen shell and embedded config-view picker so headers, footer help text, and model rows repaint cleanly
- apply the expected Prettier formatting to `ModelPicker.tsx` so the CI lint/format check passes

These changes work because the model search view now redraws each dynamic line inside a bounded row/viewport instead of leaving prior terminal content visible when provider sections collapse, expand, or filter results, and the final formatting update aligns the file with the repository's enforced Prettier rules.

### How did you verify your code works?

- `bun run format:check`
- `bun run lint`
- `bun run test`
- `bun run tsc`
- `bun run build`
- manually tested the `/models` TUI flow by searching (`opus`, `sonnet`), navigating with arrow keys, and collapsing/re-expanding providers; confirmed the search label no longer shows a trailing underscore, provider rows no longer corrupt/concatenate, help text stays clean, and no text bleeds on the right edge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad54b952-7a04-44e3-8654-f0cb6f0f42ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad54b952-7a04-44e3-8654-f0cb6f0f42ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

