### PR TITLE
feat: use gateway.pensar.dev for inference (bypasses CloudFront timeout)

### DIFF
--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -7,7 +7,7 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { getModelInfo } from "./models";
 import { createPensarModel } from "./providers/pensar";
-import { getPensarApiUrl } from "../api/constants";
+import { getPensarGatewayUrl } from "../api/constants";
 import { ensureValidToken } from "../auth";
 import { config } from "../config";
 import {
@@ -32,6 +32,8 @@ export type AIAuthConfig = {
   workspaceId?: string;
   // Gateway request signing
   gatewaySigningKey?: string;
+  // Gateway URL for inference (bypasses CloudFront timeout)
+  gatewayUrl?: string;
   bedrock?: {
     apiKey?: string;
     accessKeyId?: string;
@@ -60,6 +62,7 @@ export function buildAuthConfig(cfg: {
   refreshToken?: string | null;
   workspaceId?: string | null;
   gatewaySigningKey?: string | null;
+  gatewayUrl?: string | null;
   bedrockAPIKey?: string | null;
   localModelUrl?: string | null;
 }): AIAuthConfig {
@@ -74,6 +77,7 @@ export function buildAuthConfig(cfg: {
     refreshToken: cfg.refreshToken ?? undefined,
     workspaceId: cfg.workspaceId ?? undefined,
     gatewaySigningKey: cfg.gatewaySigningKey ?? undefined,
+    gatewayUrl: cfg.gatewayUrl ?? undefined,
     bedrock: cfg.bedrockAPIKey ? { apiKey: cfg.bedrockAPIKey } : undefined,
     local: cfg.localModelUrl ? { baseURL: cfg.localModelUrl } : undefined,
   };
@@ -178,7 +182,7 @@ export function getProviderModel(
         );
       }
 
-      const pensarApiUrl = getPensarApiUrl();
+      const gatewayUrl = authConfig?.gatewayUrl || getPensarGatewayUrl();
       const bedrockModelId = model.startsWith("pensar:")
         ? model.slice(7)
         : model;
@@ -187,14 +191,14 @@ export function getProviderModel(
         process.env.PENSAR_DEBUG === "true"
       ) {
         console.log(
-          `[pensar] getProviderModel: ${model} → bedrock:${bedrockModelId} via ${pensarApiUrl}`,
+          `[pensar] getProviderModel: ${model} → bedrock:${bedrockModelId} via ${gatewayUrl}`,
         );
       }
 
       // Build config with token refresh support for WorkOS auth
       const modelConfig: Parameters<typeof createPensarModel>[1] = {
         apiKey: pensarApiKey || authConfig?.accessToken || "",
-        baseUrl: pensarApiUrl,
+        baseUrl: gatewayUrl,
         workspaceId: authConfig?.workspaceId,
         signingKey: authConfig?.gatewaySigningKey,
       };

--- a/src/core/api/constants.ts
+++ b/src/core/api/constants.ts
@@ -1,8 +1,13 @@
 export const PENSAR_API_BASE_URL = "https://api.pensar.dev";
+export const PENSAR_GATEWAY_BASE_URL = "https://gateway.pensar.dev";
 export const PENSAR_CONSOLE_BASE_URL = "https://console.pensar.dev";
 
 export function getPensarApiUrl(): string {
   return PENSAR_API_BASE_URL;
+}
+
+export function getPensarGatewayUrl(): string {
+  return process.env.PENSAR_GATEWAY_URL || PENSAR_GATEWAY_BASE_URL;
 }
 
 export function getPensarConsoleUrl(): string {

--- a/src/core/auth/types.ts
+++ b/src/core/auth/types.ts
@@ -37,6 +37,7 @@ export interface LegacyTokenResponse {
   workspace?: { id: string; name: string; slug: string };
   credits?: { balance: number };
   signingKey?: string;
+  gatewayUrl?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -57,6 +58,7 @@ export interface SelectWorkspaceResponse {
   billing: { balance: number; hasPaymentMethod: boolean; ready: boolean };
   billingUrl?: string;
   signingKey?: string;
+  gatewayUrl?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -36,6 +36,8 @@ export interface Config {
   workspaceSlug?: string | null;
   // Gateway request signing key (server-issued)
   gatewaySigningKey?: string | null;
+  // Gateway URL for inference (server-issued, bypasses CloudFront timeout)
+  gatewayUrl?: string | null;
 }
 
 export async function init() {

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -183,6 +183,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
       await config.update({
         pensarAPIKey: data.apiKey!,
         gatewaySigningKey: data.signingKey ?? null,
+        gatewayUrl: data.gatewayUrl ?? null,
       });
 
       if (data.workspace) {
@@ -293,6 +294,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
         workspaceId: workspace.id,
         workspaceSlug: workspace.slug,
         gatewaySigningKey: data.signingKey ?? null,
+        gatewayUrl: data.gatewayUrl ?? null,
       });
       appConfig.reload();
 

--- a/src/tui/components/commands/credits-flow.tsx
+++ b/src/tui/components/commands/credits-flow.tsx
@@ -86,10 +86,14 @@ export default function CreditsFlow({ onOpenAuthDialog }: CreditsFlowProps) {
         workspace: { name: string };
         credits: { balance: number };
         signingKey?: string;
+        gatewayUrl?: string;
       };
 
-      if (result.signingKey) {
-        await config.update({ gatewaySigningKey: result.signingKey });
+      if (result.signingKey || result.gatewayUrl) {
+        await config.update({
+          gatewaySigningKey: result.signingKey ?? undefined,
+          gatewayUrl: result.gatewayUrl ?? undefined,
+        });
       }
 
       setCredits({


### PR DESCRIPTION
Updates the Apex client to use the Cloudflare Worker gateway URL for inference, which bypasses CloudFront's 120-second timeout limitation.

Changes:
- Add PENSAR_GATEWAY_BASE_URL constant (gateway.pensar.dev)
- Add gatewayUrl to Config interface for server-provided gateway URL
- Add gatewayUrl to AIAuthConfig for runtime configuration
- Update getProviderModel to use gatewayUrl instead of api.pensar.dev
- Store gatewayUrl from /gateway/validate response during auth flow
- Update LegacyTokenResponse and SelectWorkspaceResponse types

The client will:
1. Use server-provided gatewayUrl if available (from /gateway/validate)
2. Fall back to PENSAR_GATEWAY_URL env var if set
3. Fall back to gateway.pensar.dev as the default

This change works with the console repo PR that adds the Cloudflare Worker proxy at gateway.pensar.dev.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Pensar inference base URL selection and persists a server-provided `gatewayUrl`, which can affect all managed-inference requests and is sensitive to misconfiguration/outages of the new gateway.
> 
> **Overview**
> Switches Pensar managed inference to use a **gateway base URL** (defaulting to `https://gateway.pensar.dev` or `PENSAR_GATEWAY_URL`) instead of `api.pensar.dev`, and allows a **server-provided** `gatewayUrl` to override it per user/workspace.
> 
> Propagates `gatewayUrl` through config/auth surfaces (`Config`, `AIAuthConfig`, auth API response types) and persists it during auth, workspace selection, and credits validation so subsequent inference calls use the updated endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21192178dd4d1cffda09e9310adc7f10a87a18a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->