### PR TITLE
fix: support new user workspace onboarding in device auth flow

### DIFF
--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -178,13 +178,18 @@ async function handleWorkspaces(
   apiUrl: string,
   accessToken: string,
 ): Promise<void> {
-  let workspaces = await fetchWorkspaces(apiUrl, accessToken);
+  const wsResult = await fetchWorkspaces(apiUrl, accessToken);
+  let workspaces = wsResult.workspaces;
+
+  // Use dynamic consoleUrl from server if provided
+  const consoleUrl = wsResult.consoleUrl ?? getPensarConsoleUrl();
 
   if (workspaces.length === 0) {
-    const consoleUrl = getPensarConsoleUrl();
     console.log("\nNo workspaces found. Opening browser to create one...");
-    console.log(`If the browser didn't open, visit: ${consoleUrl}/credits\n`);
-    openUrl(`${consoleUrl}/credits`);
+    console.log(
+      `If the browser didn't open, visit: ${consoleUrl}/create-workspace?redirect=/credits\n`,
+    );
+    openUrl(`${consoleUrl}/create-workspace?redirect=/credits`);
     console.log("Waiting for workspace creation...");
     workspaces = await pollForWorkspaceCreation(apiUrl, accessToken);
   }

--- a/src/core/api/constants.ts
+++ b/src/core/api/constants.ts
@@ -3,7 +3,7 @@ export const PENSAR_GATEWAY_BASE_URL = "https://gateway.pensar.dev";
 export const PENSAR_CONSOLE_BASE_URL = "https://console.pensar.dev";
 
 export function getPensarApiUrl(): string {
-  return PENSAR_API_BASE_URL;
+  return process.env.PENSAR_API_URL || PENSAR_API_BASE_URL;
 }
 
 export function getPensarGatewayUrl(): string {

--- a/src/core/auth/index.ts
+++ b/src/core/auth/index.ts
@@ -3,6 +3,7 @@ export type {
   LegacyDeviceCodeResponse,
   LegacyTokenResponse,
   WorkspaceInfo,
+  FetchWorkspacesResponse,
   SelectWorkspaceResponse,
   DeviceFlowInfo,
   ValidToken,

--- a/src/core/auth/types.ts
+++ b/src/core/auth/types.ts
@@ -52,6 +52,11 @@ export interface WorkspaceInfo {
   hasPaymentMethod: boolean;
 }
 
+export interface FetchWorkspacesResponse {
+  workspaces: WorkspaceInfo[];
+  consoleUrl?: string;
+}
+
 export interface SelectWorkspaceResponse {
   confirmed: boolean;
   workspace: { id: string; name: string; slug: string };

--- a/src/core/auth/workspaces.ts
+++ b/src/core/auth/workspaces.ts
@@ -1,4 +1,8 @@
-import type { WorkspaceInfo, SelectWorkspaceResponse } from "./types";
+import type {
+  WorkspaceInfo,
+  FetchWorkspacesResponse,
+  SelectWorkspaceResponse,
+} from "./types";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -6,11 +10,12 @@ function sleep(ms: number): Promise<void> {
 
 /**
  * Fetch the list of workspaces visible to the authenticated user.
+ * Also returns the optional consoleUrl if provided by the server.
  */
 export async function fetchWorkspaces(
   apiUrl: string,
   accessToken: string,
-): Promise<WorkspaceInfo[]> {
+): Promise<FetchWorkspacesResponse> {
   const response = await fetch(`${apiUrl}/api/cli/workspaces`, {
     headers: { Authorization: `Bearer ${accessToken}` },
   });
@@ -19,8 +24,14 @@ export async function fetchWorkspaces(
     throw new Error(`Failed to fetch workspaces (${response.status})`);
   }
 
-  const data = (await response.json()) as { workspaces: WorkspaceInfo[] };
-  return data.workspaces;
+  const data = (await response.json()) as {
+    workspaces: WorkspaceInfo[];
+    consoleUrl?: string;
+  };
+  return {
+    workspaces: data.workspaces,
+    consoleUrl: data.consoleUrl,
+  };
 }
 
 /**

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -89,7 +89,9 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
     }
   };
 
-  // ── Step 1: Start device-authorization flow ─────────────────────────
+  const consoleUrlRef = useRef<string>(getPensarConsoleUrl());
+
+  // ── Step 1: Fetch WorkOS client config and start device flow ──────
 
   const startFlow = async () => {
     setStep("requesting");
@@ -102,6 +104,22 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
     const apiUrl = getPensarApiUrl();
 
     try {
+      // Optionally fetch CLI config to get dynamic consoleUrl
+      try {
+        const configResponse = await fetch(`${apiUrl}/api/cli/config`);
+        if (configResponse.ok) {
+          const cliConfig = (await configResponse.json()) as {
+            workosClientId: string;
+            consoleUrl?: string;
+          };
+          if (cliConfig.consoleUrl) {
+            consoleUrlRef.current = cliConfig.consoleUrl;
+          }
+        }
+      } catch {
+        // Config fetch is optional, continue with default consoleUrl
+      }
+
       const info = await startDeviceFlow(apiUrl);
       if (ac.signal.aborted) return;
 
@@ -220,12 +238,19 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
     ac: AbortController,
   ) => {
     try {
-      const ws = await fetchWorkspaces(apiUrl, accessToken);
+      const wsResult = await fetchWorkspaces(apiUrl, accessToken);
       if (ac.signal.aborted) return;
 
+      // Update consoleUrl if returned by the server
+      if (wsResult.consoleUrl) {
+        consoleUrlRef.current = wsResult.consoleUrl;
+      }
+
+      const ws = wsResult.workspaces;
+
       if (ws.length === 0) {
-        const consoleUrl = getPensarConsoleUrl();
-        openUrl(`${consoleUrl}/credits`);
+        const consoleUrl = consoleUrlRef.current;
+        openUrl(`${consoleUrl}/create-workspace?redirect=/credits`);
         setStep("creating-workspace");
         handleWorkspaceCreationPoll(apiUrl, accessToken, ac);
         return;
@@ -331,10 +356,10 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
   const effectiveBillingUrl =
     billingUrl ||
     (selectedWorkspace?.slug
-      ? `${getPensarConsoleUrl()}/${selectedWorkspace.slug}/settings/billing`
+      ? `${consoleUrlRef.current}/${selectedWorkspace.slug}/settings/billing`
       : connectedWorkspace?.slug
-        ? `${getPensarConsoleUrl()}/${connectedWorkspace.slug}/settings/billing`
-        : `${getPensarConsoleUrl()}/credits`);
+        ? `${consoleUrlRef.current}/${connectedWorkspace.slug}/settings/billing`
+        : `${consoleUrlRef.current}/credits`);
 
   const openBillingPage = () => {
     openUrl(effectiveBillingUrl);
@@ -529,7 +554,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
             </box>
             <box marginTop={1}>
               <text fg={colors.text}>
-                Create a workspace and add credits in your browser.
+                Create a workspace in your browser to get started.
               </text>
             </box>
             <box marginTop={1}>
@@ -540,7 +565,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
             <box marginTop={1}>
               <text fg={colors.textMuted}>
                 If the browser didn't open, visit:{"\n"}
-                {getPensarConsoleUrl()}/credits
+                {consoleUrlRef.current}/create-workspace
               </text>
             </box>
             <box marginTop={1}>


### PR DESCRIPTION
## Summary

- Make `PENSAR_API_URL` configurable via env var (symmetric with existing `PENSAR_CONSOLE_URL`)
- Accept dynamic `consoleUrl` from `/api/cli/config` and `/api/cli/workspaces` backend responses, stored in a ref for the duration of the auth flow
- Redirect new users (zero workspaces) to `/create-workspace?redirect=/credits` instead of `/credits` for proper onboarding

## Test plan

- [ ] Verify existing auth flow works unchanged when backend doesn't return `consoleUrl`
- [ ] Verify new user flow opens `/create-workspace?redirect=/credits` and polls until workspace is created
- [ ] Verify `PENSAR_API_URL` env var override works for local/staging testing

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the device-auth workspace onboarding path and changes the `fetchWorkspaces` return type, which could affect both CLI and TUI flows if backend responses or callers diverge.
> 
> **Overview**
> Fixes new-user onboarding in both CLI and TUI auth flows by sending users with **zero workspaces** to `consoleUrl/create-workspace?redirect=/credits` (instead of `/credits`) and then polling until a workspace appears.
> 
> Adds support for **dynamic Console URLs** returned by the backend (`/api/cli/config` and `/api/cli/workspaces`) and extends `fetchWorkspaces` to return `{ workspaces, consoleUrl? }`, updating callers and exported types accordingly. Also makes the API base URL overrideable via `PENSAR_API_URL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2449c10dd830c17c6c956d96507830bf7ab57e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->