### PR TITLE
feat: add `pensar uninstall` command

### DIFF
--- a/bin/pensar.js
+++ b/bin/pensar.js
@@ -66,6 +66,13 @@ if (command === "benchmark") {
 
   // Import and run auth
   await import(authPath);
+} else if (command === "uninstall") {
+  // Run uninstall CLI
+  const uninstallPath = join(__dirname, "..", "build", "uninstall.js");
+
+  process.argv = [process.argv[0], uninstallPath, ...args.slice(1)];
+
+  await import(uninstallPath);
 } else if (command === "upgrade" || command === "update") {
   const currentVersion = getCurrentVersion();
   console.log(`Current version: v${currentVersion}`);
@@ -89,6 +96,7 @@ if (command === "benchmark") {
   console.log();
   console.log("Usage:");
   console.log("  pensar              Launch the TUI (Terminal User Interface)");
+  console.log("  pensar uninstall    Uninstall Pensar (keeps sessions, memories, skills)");
   console.log("  pensar upgrade      Update pensar to the latest version");
   console.log("  pensar help         Show this help message");
   console.log("  pensar version      Show version number");
@@ -180,6 +188,14 @@ if (command === "benchmark") {
   console.log("  pensar auth login        Login to Pensar Console");
   console.log("  pensar auth logout       Disconnect from Pensar Console");
   console.log("  pensar auth status       Show connection status");
+  console.log();
+  console.log("Uninstall Usage:");
+  console.log(
+    "  pensar uninstall             Fully uninstall Pensar"
+  );
+  console.log(
+    "  pensar uninstall --force     Skip confirmation prompt"
+  );
   console.log();
   console.log("Header Modes (for quicktest, pentest, swarm):");
   console.log("  none                     No custom headers added to requests");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,9 @@ function showHelp() {
     "  pensar auth                         Connect to Pensar Console",
   );
   console.log(
+    "  pensar uninstall                    Uninstall Pensar (keeps sessions, memories, skills)",
+  );
+  console.log(
     "  pensar upgrade                      Update pensar to the latest version",
   );
   console.log(
@@ -245,6 +248,9 @@ if (command === "version" || command === "--version" || command === "-v") {
 } else if (command === "auth") {
   process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
   await import("./cli/auth");
+} else if (command === "uninstall") {
+  process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
+  await import("./cli/uninstall");
 } else if (command === "doctor") {
   const { runDoctor } = await import("./core/doctor");
   await runDoctor();

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -1,0 +1,294 @@
+#!/usr/bin/env bun
+
+/**
+ * Pensar Uninstall CLI
+ *
+ * Fully removes the Pensar installation:
+ *   - Removes the pensar binary/package (npm, homebrew, or binary)
+ *   - Cleans ~/.pensar/ data directory, preserving sessions, memories, and skills
+ *
+ * Usage:
+ *   pensar uninstall              Uninstall Pensar (interactive confirmation)
+ *   pensar uninstall --force      Uninstall without confirmation prompt
+ */
+
+import os from "os";
+import path from "path";
+import fs from "fs/promises";
+import { spawnSync } from "child_process";
+import * as readline from "readline";
+import {
+  detectInstallMethod,
+  type InstallMethod,
+} from "../core/installation/index";
+
+const PRESERVED_DIRS = new Set(["sessions", "memories", "skills"]);
+
+function getPensarDir(): string {
+  return process.env.PENSAR_DATA_DIR ?? path.join(os.homedir(), ".pensar");
+}
+
+function prompt(question: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+function findBinaryPath(): string | null {
+  const result = spawnSync("which", ["pensar"], {
+    encoding: "utf-8",
+    timeout: 5000,
+  });
+  if (result.status === 0 && result.stdout) {
+    return result.stdout.trim();
+  }
+  const defaultPath = path.join(os.homedir(), ".local", "bin", "pensar");
+  try {
+    const stat = require("fs").statSync(defaultPath);
+    if (stat) return defaultPath;
+  } catch {
+    // not found
+  }
+  return null;
+}
+
+function getUninstallDescription(method: InstallMethod): string {
+  switch (method) {
+    case "npm":
+      return "npm uninstall -g @pensar/apex";
+    case "homebrew":
+      return "brew uninstall pensarai/tap/apex";
+    case "binary": {
+      const binPath = findBinaryPath();
+      return binPath ? `rm ${binPath}` : "remove pensar binary";
+    }
+  }
+}
+
+function removeBinary(method: InstallMethod): {
+  success: boolean;
+  message: string;
+} {
+  switch (method) {
+    case "npm": {
+      const result = spawnSync("npm", ["uninstall", "-g", "@pensar/apex"], {
+        encoding: "utf-8",
+        timeout: 60000,
+        stdio: "pipe",
+      });
+      return result.status === 0
+        ? { success: true, message: "Removed npm package @pensar/apex" }
+        : {
+            success: false,
+            message: `npm uninstall failed: ${result.stderr?.trim() || "unknown error"}`,
+          };
+    }
+    case "homebrew": {
+      const result = spawnSync("brew", ["uninstall", "pensarai/tap/apex"], {
+        encoding: "utf-8",
+        timeout: 60000,
+        stdio: "pipe",
+      });
+      return result.status === 0
+        ? {
+            success: true,
+            message: "Removed Homebrew package pensarai/tap/apex",
+          }
+        : {
+            success: false,
+            message: `brew uninstall failed: ${result.stderr?.trim() || "unknown error"}`,
+          };
+    }
+    case "binary": {
+      const binPath = findBinaryPath();
+      if (!binPath) {
+        return {
+          success: false,
+          message: "Could not locate pensar binary",
+        };
+      }
+      try {
+        require("fs").unlinkSync(binPath);
+        return { success: true, message: `Removed binary at ${binPath}` };
+      } catch (err) {
+        return {
+          success: false,
+          message: `Failed to remove ${binPath}: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    }
+  }
+}
+
+async function cleanDataDir(): Promise<{
+  removed: string[];
+  preserved: string[];
+  errors: string[];
+}> {
+  const pensarDir = getPensarDir();
+  const removed: string[] = [];
+  const preserved: string[] = [];
+  const errors: string[] = [];
+
+  const dirExists = await fs
+    .access(pensarDir)
+    .then(() => true)
+    .catch(() => false);
+
+  if (!dirExists) {
+    return { removed, preserved, errors };
+  }
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(pensarDir);
+  } catch {
+    errors.push(`Could not read ${pensarDir}`);
+    return { removed, preserved, errors };
+  }
+
+  for (const name of entries) {
+    if (PRESERVED_DIRS.has(name)) {
+      preserved.push(name);
+      continue;
+    }
+
+    const target = path.join(pensarDir, name);
+    try {
+      const stat = await fs.lstat(target);
+      if (stat.isDirectory()) {
+        await fs.rm(target, { recursive: true, force: true });
+      } else {
+        await fs.unlink(target);
+      }
+      removed.push(name);
+    } catch (err) {
+      errors.push(
+        `Failed to remove ${name}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return { removed, preserved, errors };
+}
+
+async function uninstall(force: boolean): Promise<void> {
+  const method = detectInstallMethod();
+  const pensarDir = getPensarDir();
+
+  console.log("Pensar Uninstall");
+  console.log();
+
+  console.log(`  Install method:  ${method}`);
+  console.log(`  Binary removal:  ${getUninstallDescription(method)}`);
+  console.log(`  Data directory:  ${pensarDir}`);
+  console.log();
+  console.log("  Preserved data:  sessions, memories, skills");
+  console.log();
+
+  if (!force) {
+    const answer = await prompt("Proceed with uninstall? (y/N): ");
+    if (answer.toLowerCase() !== "y") {
+      console.log("Aborted.");
+      return;
+    }
+    console.log();
+  }
+
+  // 1. Clean data directory
+  console.log("Cleaning data directory...");
+  const { removed, preserved, errors } = await cleanDataDir();
+
+  for (const name of removed) {
+    console.log(`  Removed ${name}`);
+  }
+  for (const name of preserved) {
+    console.log(`  Preserved ${name}/`);
+  }
+  for (const msg of errors) {
+    console.error(`  ${msg}`);
+  }
+
+  if (removed.length === 0 && errors.length === 0) {
+    console.log("  Nothing to clean.");
+  }
+
+  // 2. Remove binary/package
+  console.log();
+  console.log("Removing pensar...");
+  const result = removeBinary(method);
+
+  if (result.success) {
+    console.log(`  ${result.message}`);
+  } else {
+    console.error(`  ${result.message}`);
+  }
+
+  // 3. Summary
+  console.log();
+  if (result.success && errors.length === 0) {
+    console.log("✓ Pensar has been uninstalled.");
+  } else {
+    console.log("⚠ Uninstall completed with warnings (see above).");
+  }
+
+  if (preserved.length > 0) {
+    console.log(
+      `  Preserved data remains at ${pensarDir}/ (${preserved.join(", ")})`,
+    );
+    console.log("  To remove all data: rm -rf ~/.pensar");
+  }
+
+  if (method === "binary") {
+    console.log();
+    console.log(
+      "  Note: You may want to remove the PATH export from your shell config",
+    );
+    console.log(
+      "  (~/.bashrc, ~/.zshrc, etc.) if it was added during install.",
+    );
+  }
+}
+
+function showHelp(): void {
+  console.log("Pensar Uninstall — Remove Pensar from your system\n");
+  console.log("Usage:");
+  console.log(
+    "  pensar uninstall             Uninstall Pensar (keeps sessions, memories, skills)",
+  );
+  console.log("  pensar uninstall --force     Skip confirmation prompt");
+  console.log();
+  console.log("Options:");
+  console.log("  --force, -f          Skip confirmation prompt");
+  console.log("  -h, --help           Show this help message");
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const subcommand = args[0];
+
+  if (subcommand === "help" || subcommand === "--help" || subcommand === "-h") {
+    showHelp();
+    return;
+  }
+
+  const force = args.includes("--force") || args.includes("-f");
+
+  try {
+    await uninstall(force);
+  } catch (err) {
+    console.error(
+      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Adds a `pensar uninstall` command that fully removes Pensar from the system. This is useful for testing fresh installs.

The command:
- **Detects install method** (npm, homebrew, or binary) and runs the appropriate removal (e.g. `npm uninstall -g`, `brew uninstall`, or removes the binary at its installed path)
- **Cleans `~/.pensar/`** data directory — removes config, executions, benchmark reports, and other transient data
- **Preserves** `sessions/`, `memories/`, and `skills/` directories
- **Interactive confirmation** by default; `--force` / `-f` flag skips the prompt
- Wired into both `bin/pensar.js` (dev entry point) and `src/cli.ts` (compiled binary entry point)
- Help text added to both entry points

#### New files
- `src/cli/uninstall.ts` — Uninstall CLI implementation

#### Modified files
- `bin/pensar.js` — Route `uninstall` command, add help text
- `src/cli.ts` — Route `uninstall` command, add help text

### How did you verify your code works?

- Created a realistic `~/.pensar/` directory with config, sessions, memories, skills, executions, and benchmark-reports
- Ran `pensar uninstall --force` and verified only sessions, memories, and skills remained
- Ran uninstall again to verify idempotent "nothing to clean" behavior
- Verified `--help` flag output
- All CI checks pass: `bun run lint`, `bun run format:check`, `bun run tsc`, `bun run test` (412 passed, 15 skipped)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-998893d0-be9f-48dc-a0da-9f0b68fbada9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-998893d0-be9f-48dc-a0da-9f0b68fbada9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

