### PR TITLE
feat: support API key auth mode for web search

### DIFF
--- a/src/core/agents/offSecAgent/tools/webSearch.ts
+++ b/src/core/agents/offSecAgent/tools/webSearch.ts
@@ -55,6 +55,22 @@ COMMON SEARCH PATTERNS:
     execute: async ({ query }): Promise<WebSearchResponse> => {
       try {
         const cfg = await config.get();
+        const apiUrl = getPensarApiUrl();
+        const body = JSON.stringify({ query });
+
+        // API key mode: authenticate directly without token exchange or signing
+        if (cfg.pensarAPIKey && !cfg.accessToken) {
+          const response = await fetch(`${apiUrl}/agents/web_search`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "x-api-key": cfg.pensarAPIKey,
+            },
+            body,
+          });
+
+          return handleSearchResponse(response);
+        }
 
         const tokenResult = await ensureValidToken({
           accessToken: cfg.accessToken,
@@ -89,8 +105,6 @@ COMMON SEARCH PATTERNS:
           };
         }
 
-        const apiUrl = getPensarApiUrl();
-        const body = JSON.stringify({ query });
         const { signature, timestamp, nonce } = signGatewayRequest(
           cfg.gatewaySigningKey,
           "web_search",
@@ -110,50 +124,7 @@ COMMON SEARCH PATTERNS:
           body,
         });
 
-        if (!response.ok) {
-          if (response.status === 401) {
-            return {
-              success: false,
-              results: [],
-              error:
-                "Authentication failed. Please sign in again to your Pensar account.",
-            };
-          }
-
-          if (response.status === 429) {
-            return {
-              success: false,
-              results: [],
-              error:
-                "Rate limit exceeded. Please wait a moment before searching again.",
-            };
-          }
-
-          const errorText = await response.text().catch(() => "Unknown error");
-          return {
-            success: false,
-            results: [],
-            error: `Web search failed: ${response.status} ${response.statusText}. ${errorText}`,
-          };
-        }
-
-        const data = (await response.json()) as {
-          results?: WebSearchResult[];
-          error?: string;
-        };
-
-        if (data.error) {
-          return {
-            success: false,
-            results: [],
-            error: data.error,
-          };
-        }
-
-        return {
-          success: true,
-          results: data.results || [],
-        };
+        return handleSearchResponse(response);
       } catch (error: unknown) {
         const errorMsg = error instanceof Error ? error.message : String(error);
         return {
@@ -164,4 +135,53 @@ COMMON SEARCH PATTERNS:
       }
     },
   });
+}
+
+async function handleSearchResponse(
+  response: Response,
+): Promise<WebSearchResponse> {
+  if (!response.ok) {
+    if (response.status === 401) {
+      return {
+        success: false,
+        results: [],
+        error:
+          "Authentication failed. Please sign in again to your Pensar account.",
+      };
+    }
+
+    if (response.status === 429) {
+      return {
+        success: false,
+        results: [],
+        error:
+          "Rate limit exceeded. Please wait a moment before searching again.",
+      };
+    }
+
+    const errorText = await response.text().catch(() => "Unknown error");
+    return {
+      success: false,
+      results: [],
+      error: `Web search failed: ${response.status} ${response.statusText}. ${errorText}`,
+    };
+  }
+
+  const data = (await response.json()) as {
+    results?: WebSearchResult[];
+    error?: string;
+  };
+
+  if (data.error) {
+    return {
+      success: false,
+      results: [],
+      error: data.error,
+    };
+  }
+
+  return {
+    success: true,
+    results: data.results || [],
+  };
 }


### PR DESCRIPTION
When a Pensar API key is available without WorkOS credentials, authenticate directly via x-api-key header without requiring workspace ID or gateway signing. This simplifies integration for environments using API key auth.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an alternate authentication path for the web-search call; risk is moderate because it changes request auth headers/flow and could affect access control and error handling if misconfigured.
> 
> **Overview**
> `webSearch` now supports an **API key-only auth mode**: when `pensarAPIKey` is present and no `accessToken` is available, it calls `/agents/web_search` using the `x-api-key` header and skips token exchange, workspace headers, and gateway request signing.
> 
> Response parsing and error handling for both API-key and token+signed modes is consolidated into a shared `handleSearchResponse` helper (including 401/429 handling and JSON `error` propagation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea4da58abd5eb0c77b54fdf8f91adcef4b33fce9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->