### PR TITLE
fix: use async writeFile to prevent event loop blocking

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -24,7 +24,8 @@ import type { ApprovalGate } from "../../operator";
 import { ApprovalDeniedError } from "../../operator";
 import { create as createSession, type SessionInfo } from "../../session";
 import { join } from "path";
-import { writeFileSync, mkdirSync, existsSync } from "fs";
+import { mkdirSync, existsSync } from "fs";
+import { writeFile } from "fs/promises";
 
 /**
  * General-purpose offensive security agent harness.
@@ -244,15 +245,15 @@ export class OffensiveSecurityAgent<TResult = void> {
       stopWhen,
       toolChoice: "auto",
       onStepFinish: (event) => {
-        try {
-          const allMessages = [
-            ...initialMessagesRef.current,
-            ...event.response.messages,
-          ];
-          writeFileSync(messagesPath, JSON.stringify(allMessages, null, 2));
-        } catch {
-          // Best-effort persistence — don't break the agent loop
-        }
+        const allMessages = [
+          ...initialMessagesRef.current,
+          ...event.response.messages,
+        ];
+        writeFile(messagesPath, JSON.stringify(allMessages, null, 2)).catch(
+          () => {
+            // Best-effort persistence — don't break the agent loop
+          }
+        );
         input.onStepFinish?.(event);
       },
       onSummarized: () => {


### PR DESCRIPTION
## Summary
- Replace `writeFileSync` + `JSON.stringify` with async `writeFile` in `OffensiveSecurityAgent.onStepFinish` to prevent blocking the Node.js event loop
- As conversations grow (100K+ tokens), synchronous serialization + disk I/O blocks for seconds per step, starving the Express health check and causing ECS to kill tasks

## Test plan
- [ ] Run a whitebox pentest scan and verify conversation messages are still persisted to disk
- [ ] Confirm no regression in agent behavior when write fails (error is caught and swallowed)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: swaps synchronous message persistence to async best-effort writes; main potential issue is altered timing/ordering of `messages.json` updates under rapid step completion.
> 
> **Overview**
> Prevents the offensive security agent’s `onStepFinish` from blocking the Node.js event loop by replacing `writeFileSync` with async `fs/promises.writeFile` when persisting `messages.json`.
> 
> The persistence logic remains best-effort (errors are swallowed), but writes are now scheduled asynchronously via a `.catch()` handler instead of a synchronous `try/catch`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f812c6fa91a1ef0dc1bc2ecbf1fb9a866c7fb699. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->