### PR TITLE
Fix Shift+Tab tooltip text in operator mode

### DIFF
--- a/src/tui/components/chat/message-list.tsx
+++ b/src/tui/components/chat/message-list.tsx
@@ -131,7 +131,7 @@ export function MessageList({
             </box>
             <box flexDirection="row">
               <text fg={colors.primary}>Shift+Tab</text>
-              <text fg={colors.textMuted}> - Cycle approval on/off</text>
+              <text fg={colors.textMuted}> - Switch between Plan or Default mode</text>
             </box>
           </box>
         </box>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updated the Shift+Tab tooltip in the operator mode startup screen to accurately reflect its actual behavior.

## Changes

- Changed tooltip text from "Cycle approval on/off" to "Switch between Plan or Default mode"
- Updated in `src/tui/components/chat/message-list.tsx` line 134

## Testing

✅ Manually tested in the TUI - tooltip displays correctly in operator mode startup screen

## Screenshots

The updated tooltip now shows:
```
Tips:
/ - Create or use skills
Shift+Tab - Switch between Plan or Default mode
```

Fixes the issue where the tooltip incorrectly suggested that Shift+Tab cycles approval on/off, when it actually switches between Plan and Default modes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3183d79-8c3c-4caa-a1bf-595cd01bb544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3183d79-8c3c-4caa-a1bf-595cd01bb544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

