### PR TITLE
Fix spelling errors in responsible use disclosure screen

### DIFF
--- a/src/tui/components/responsible-use-disclosure.tsx
+++ b/src/tui/components/responsible-use-disclosure.tsx
@@ -18,7 +18,7 @@ export function ResponsibleUseDisclosure({
     <box flexDirection="column" gap={1}>
       <text fg={colors.warning}>IMPORTANT: Read Before Use</text>
       <text fg={colors.text}>
-        This penetration testing tool is designedfor AUTHORIZED security testing
+        This penetration testing tool is designed for AUTHORIZED security testing
         only.
       </text>
       <box flexDirection="column" marginBottom={1}>
@@ -41,7 +41,7 @@ export function ResponsibleUseDisclosure({
       </box>
       <box flexDirection="column">
         <text fg={colors.error}>
-          Unauthorized access to computer systems is illegaland may result in
+          Unauthorized access to computer systems is illegal and may result in
           criminal prosecution.
         </text>
       </box>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixed spelling errors in the Responsible Use Disclosure screen:
- Changed "illegaland" to "illegal and" 
- Also fixed "designedfor" to "designed for" (similar spacing issue on the same screen)

### Changes Made

- Updated `src/tui/components/responsible-use-disclosure.tsx` to correct spacing in two text strings

### Testing

- All unit tests pass (`bun run test`)
- No functional changes, only text corrections
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ba066c6-0439-42d0-9adf-32bdddc2d12b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ba066c6-0439-42d0-9adf-32bdddc2d12b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

