### PR TITLE
Fix cursor disappearing on alt-tab in operator mode

### DIFF
--- a/src/tui/components/terminal-focus-handler.tsx
+++ b/src/tui/components/terminal-focus-handler.tsx
@@ -1,0 +1,34 @@
+/**
+ * Terminal Focus Handler Component
+ *
+ * Sets up terminal focus event handling to ensure cursor visibility
+ * and input focus are maintained when alt-tabbing or switching applications.
+ */
+
+import { useEffect } from "react";
+import { useFocus } from "../context/focus";
+import { useRenderer } from "@opentui/react";
+import { setupTerminalFocusHandling } from "../terminal-focus";
+
+/**
+ * Component that sets up terminal focus handling.
+ * Must be rendered inside FocusProvider to access refocusPrompt.
+ */
+export function TerminalFocusHandler() {
+  const { refocusPrompt } = useFocus();
+  const renderer = useRenderer();
+
+  useEffect(() => {
+    // Set up terminal focus handling with a callback to re-focus the prompt
+    const cleanup = setupTerminalFocusHandling(renderer, {
+      onTerminalFocus: refocusPrompt,
+      debug: false, // Set to true for debugging
+    });
+
+    // Clean up on unmount
+    return cleanup;
+  }, [renderer, refocusPrompt]);
+
+  // This component doesn't render anything
+  return null;
+}

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -60,6 +60,7 @@ import {
 import { createClipboardManager } from "./clipboard";
 import { setupAutoCopy } from "./auto-copy";
 import { TerminalDimensionsProvider } from "./context/dimensions";
+import { TerminalFocusHandler } from "./components/terminal-focus-handler";
 
 interface AppProps {
   appConfig: Config;
@@ -87,6 +88,7 @@ function App({ appConfig }: AppProps) {
       <SessionProvider>
         <RouteProvider>
           <FocusProvider>
+            <TerminalFocusHandler />
             <InputProvider>
               <DialogProvider>
                 <AgentProvider>

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -61,6 +61,7 @@ import { createClipboardManager } from "./clipboard";
 import { setupAutoCopy } from "./auto-copy";
 import { TerminalDimensionsProvider } from "./context/dimensions";
 import { TerminalFocusHandler } from "./components/terminal-focus-handler";
+import { cleanupTerminalFocusMode } from "./terminal-focus";
 
 interface AppProps {
   appConfig: Config;
@@ -496,6 +497,7 @@ async function main() {
   setupAutoCopy(renderer, copyToClipboard);
 
   const cleanup = () => {
+    cleanupTerminalFocusMode();
     renderer.destroy();
     process.exit(0);
   };
@@ -503,6 +505,7 @@ async function main() {
   process.on("SIGTERM", cleanup);
 
   process.on("uncaughtException", (err) => {
+    cleanupTerminalFocusMode();
     renderer.destroy();
     console.error("Uncaught exception:", err);
     writeErrorLog(err, "UNCAUGHT");
@@ -510,6 +513,7 @@ async function main() {
   });
 
   process.on("unhandledRejection", (reason) => {
+    cleanupTerminalFocusMode();
     renderer.destroy();
     console.error("Unhandled rejection:", reason);
     writeErrorLog(reason, "UNHANDLED_REJECTION");

--- a/src/tui/keybindings/registry.ts
+++ b/src/tui/keybindings/registry.ts
@@ -3,6 +3,7 @@ import { useRoute } from "../context/route";
 import { useFocus } from "../context/focus";
 import { useInput } from "../context/input";
 import { useDialog } from "../context/dialog";
+import { cleanupTerminalFocusMode } from "../terminal-focus";
 
 export interface KeybindingEntry {
   combo: string;
@@ -57,6 +58,7 @@ export function createKeybindings(
         const lastPress = ctrlCPressTime;
 
         if (lastPress && now - lastPress < 1000) {
+          cleanupTerminalFocusMode();
           renderer.destroy();
           process.exit(0);
         } else {

--- a/src/tui/terminal-focus.ts
+++ b/src/tui/terminal-focus.ts
@@ -20,6 +20,12 @@ export interface TerminalFocusOptions {
 }
 
 /**
+ * Track whether bracketed focus mode is currently enabled.
+ * This is used to ensure we only disable it if we enabled it.
+ */
+let bracketedFocusModeEnabled = false;
+
+/**
  * Set up terminal focus event handling.
  * Returns a cleanup function that removes all listeners.
  */
@@ -39,13 +45,15 @@ export function setupTerminalFocusHandling(
   const enableBracketedFocus = () => {
     if (process.stdout.isTTY) {
       process.stdout.write("\x1b[?1004h");
+      bracketedFocusModeEnabled = true;
       log("Enabled bracketed focus mode");
     }
   };
 
   const disableBracketedFocus = () => {
-    if (process.stdout.isTTY) {
+    if (process.stdout.isTTY && bracketedFocusModeEnabled) {
       process.stdout.write("\x1b[?1004l");
+      bracketedFocusModeEnabled = false;
       log("Disabled bracketed focus mode");
     }
   };
@@ -151,4 +159,16 @@ export function setupTerminalFocusHandling(
   setupListeners();
 
   return cleanup;
+}
+
+/**
+ * Global cleanup function to disable bracketed focus mode.
+ * This MUST be called before process.exit() to prevent leaving the terminal
+ * in focus reporting mode, which causes garbage characters in the user's shell.
+ */
+export function cleanupTerminalFocusMode(): void {
+  if (process.stdout.isTTY && bracketedFocusModeEnabled) {
+    process.stdout.write("\x1b[?1004l");
+    bracketedFocusModeEnabled = false;
+  }
 }

--- a/src/tui/terminal-focus.ts
+++ b/src/tui/terminal-focus.ts
@@ -1,0 +1,154 @@
+/**
+ * Terminal Focus Management
+ *
+ * Handles terminal window focus/blur events to ensure the cursor remains visible
+ * and input stays focused when alt-tabbing or switching between applications.
+ *
+ * This is necessary because:
+ * 1. When you alt-tab away, the terminal may hide the cursor
+ * 2. When you return, the terminal needs to explicitly re-show the cursor
+ * 3. The input field needs to be re-focused to accept keyboard input
+ */
+
+import type { CliRenderer } from "@opentui/core";
+
+export interface TerminalFocusOptions {
+  /** Callback to re-focus the prompt input when terminal regains focus */
+  onTerminalFocus?: () => void;
+  /** Enable debug logging */
+  debug?: boolean;
+}
+
+/**
+ * Set up terminal focus event handling.
+ * Returns a cleanup function that removes all listeners.
+ */
+export function setupTerminalFocusHandling(
+  renderer: CliRenderer,
+  options: TerminalFocusOptions = {},
+): () => void {
+  const { onTerminalFocus, debug = false } = options;
+
+  const log = (...args: unknown[]) => {
+    if (debug) console.error("[TerminalFocus]", ...args);
+  };
+
+  // Enable bracketed focus mode
+  // This tells the terminal to send \x1b[I when focused and \x1b[O when unfocused
+  // See: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-FocusIn_FocusOut
+  const enableBracketedFocus = () => {
+    if (process.stdout.isTTY) {
+      process.stdout.write("\x1b[?1004h");
+      log("Enabled bracketed focus mode");
+    }
+  };
+
+  const disableBracketedFocus = () => {
+    if (process.stdout.isTTY) {
+      process.stdout.write("\x1b[?1004l");
+      log("Disabled bracketed focus mode");
+    }
+  };
+
+  // Show cursor explicitly using DECTCEM escape sequence
+  const showCursor = () => {
+    if (process.stdout.isTTY) {
+      process.stdout.write("\x1b[?25h");
+      log("Showed cursor");
+    }
+  };
+
+  // Handle terminal gaining focus
+  const handleFocusIn = () => {
+    log("Terminal gained focus");
+    showCursor();
+    renderer.requestRender();
+    
+    // Re-focus the input after a short delay to ensure the terminal is ready
+    if (onTerminalFocus) {
+      setTimeout(() => {
+        onTerminalFocus();
+        log("Re-focused prompt input");
+      }, 10);
+    }
+  };
+
+  // Handle terminal losing focus
+  const handleFocusOut = () => {
+    log("Terminal lost focus");
+    // We don't hide the cursor on focus out because it can cause issues
+    // The terminal emulator will handle cursor visibility on its own
+  };
+
+  // Handle SIGCONT (terminal resume after being suspended)
+  const handleSigCont = () => {
+    log("Received SIGCONT (terminal resumed)");
+    showCursor();
+    renderer.requestRender();
+    
+    if (onTerminalFocus) {
+      setTimeout(() => {
+        onTerminalFocus();
+        log("Re-focused prompt input after SIGCONT");
+      }, 10);
+    }
+  };
+
+  // Listen for bracketed focus events on stdin
+  let stdinListenerActive = false;
+  const handleStdinData = (data: Buffer) => {
+    const str = data.toString();
+    
+    // Focus in event: \x1b[I
+    if (str.includes("\x1b[I")) {
+      handleFocusIn();
+    }
+    
+    // Focus out event: \x1b[O
+    if (str.includes("\x1b[O")) {
+      handleFocusOut();
+    }
+  };
+
+  // Set up listeners
+  const setupListeners = () => {
+    // Enable bracketed focus mode
+    enableBracketedFocus();
+    
+    // Show cursor initially
+    showCursor();
+    
+    // Listen for SIGCONT (resume after suspend)
+    process.on("SIGCONT", handleSigCont);
+    
+    // Listen for bracketed focus events on stdin
+    // Note: We need to be careful not to interfere with OpenTUI's stdin handling
+    // We only listen for specific escape sequences
+    if (process.stdin.isTTY && !stdinListenerActive) {
+      process.stdin.on("data", handleStdinData);
+      stdinListenerActive = true;
+      log("Set up stdin listener for bracketed focus events");
+    }
+  };
+
+  // Clean up function
+  const cleanup = () => {
+    log("Cleaning up terminal focus handling");
+    
+    // Disable bracketed focus mode
+    disableBracketedFocus();
+    
+    // Remove listeners
+    process.off("SIGCONT", handleSigCont);
+    
+    if (stdinListenerActive) {
+      process.stdin.off("data", handleStdinData);
+      stdinListenerActive = false;
+    }
+  };
+
+  // Set up listeners
+  setupListeners();
+
+  return cleanup;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR fixes the cursor disappearing issue when alt-tabbing away from and back to the terminal while in operator mode.

**Issue:** When users entered operator mode, alt-tabbed to another application, and then returned to the terminal, the cursor would disappear and typing would no longer work.

**Root Cause:** The application was not handling terminal-level focus events. When the terminal window loses and regains focus (via alt-tab or other OS window switching), the terminal emulator may hide the cursor. The application needs to explicitly:
1. Detect when the terminal regains focus
2. Re-show the cursor using terminal escape sequences
3. Re-focus the input field to accept keyboard input

**Changes Made:**

1. **Added terminal focus event handling** (`src/tui/terminal-focus.ts`):
   - Enables bracketed focus mode (`\x1b[?1004h`) to receive focus-in (`\x1b[I`) and focus-out (`\x1b[O`) events from the terminal
   - Listens for `SIGCONT` signal to detect terminal resume after suspension
   - Explicitly shows cursor using DECTCEM escape sequence (`\x1b[?25h`) when terminal regains focus
   - Re-focuses the input field when terminal is brought back to foreground

2. **Created TerminalFocusHandler component** (`src/tui/components/terminal-focus-handler.tsx`):
   - React component that integrates terminal focus handling with the FocusProvider context
   - Automatically sets up and tears down event listeners
   - Calls `refocusPrompt()` when terminal regains focus

3. **Integrated into main TUI** (`src/tui/index.tsx`):
   - Rendered TerminalFocusHandler inside FocusProvider to access focus management utilities

**Why This Works:**

Modern terminal emulators support bracketed focus mode, which sends escape sequences when the terminal window gains or loses focus. By enabling this mode and listening for these sequences (plus SIGCONT for terminal resume), the application can detect focus changes and take appropriate action:
- Show the cursor explicitly
- Re-render the UI
- Re-focus the input field

This ensures that after alt-tabbing back, both the cursor is visible and keyboard input works correctly.

### How did you verify your code works?

1. **Unit Tests:** All existing tests pass (412 tests)
2. **Type Checking:** TypeScript compilation successful with no errors
3. **Linting:** ESLint passes with no issues
4. **Manual Testing:** 
   - Started the TUI using `bun run start`
   - Entered operator mode using `/operator`
   - Verified cursor was visible and blinking
   - Alt-tabbed to Chrome browser
   - Waited 2 seconds
   - Alt-tabbed back to terminal
   - ✅ Cursor remained visible
   - ✅ Successfully typed "test input after alt-tab"
   - ✅ Input functionality works correctly

See the [screen recording](/opt/cursor/artifacts/alt_tab_cursor_fix_working.mp4) showing the fix in action.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a61d67de-a237-4f3c-89c1-f9f8dbebffdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a61d67de-a237-4f3c-89c1-f9f8dbebffdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

