### PR TITLE
docs: add Homebrew tap migration troubleshooting

### DIFF
--- a/HOMEBREW_INVESTIGATION.md
+++ b/HOMEBREW_INVESTIGATION.md
@@ -1,0 +1,196 @@
+# Homebrew Installation Error Investigation
+
+## Issue Summary
+Users are experiencing errors when trying to install Pensar Apex via Homebrew using the commands in the README.
+
+### Actual Error (From Screenshot)
+```
+Error: Formulae found in multiple taps:
+  * pensarai/apex/apex
+  * pensarai/tap/apex
+```
+
+### Root Cause Confirmed ✅
+The user has **BOTH** taps registered:
+- **Old tap**: `pensarai/apex` (deprecated)
+- **New tap**: `pensarai/tap` (current)
+
+When running `brew install apex`, Homebrew finds the formula in both taps and cannot determine which one to use, resulting in an ambiguous formula error.
+
+## Investigation Findings
+
+### 1. Homebrew Tap & Formula Status ✅
+- **Tap Repository**: `pensarai/homebrew-tap` exists and is **public**
+- **Formula File**: `Formula/apex.rb` exists and is accessible
+- **Latest Version**: v0.0.101 (successfully deployed on 2026-03-17)
+- **Workflow Status**: The `homebrew` job in the release workflow completed successfully
+
+### 2. Formula Analysis
+
+The current formula structure:
+```ruby
+class Apex < Formula
+  desc "AI-powered penetration testing CLI tool with terminal UI"
+  homepage "https://github.com/pensarai/apex"
+  version "0.0.101"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/pensarai/apex/releases/download/v0.0.101/pensar-darwin-arm64.tar.gz"
+      sha256 "2237deb47faaa5afa640440846a7437bfec5a107a17712e28e8c17bd56de346f"
+    end
+    on_intel do
+      url "https://github.com/pensarai/apex/releases/download/v0.0.101/pensar-darwin-x64.tar.gz"
+      sha256 "96d23b62936c0c12d7aba4a57f58a20b4e56fab03256ae202c0d4ba08df28d83"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/pensarai/apex/releases/download/v0.0.101/pensar-linux-x64.tar.gz"
+      sha256 "e2f5d95a3adf1ee198dd2768f8345237314bcf67499f28b3d3a61bc32057c937"
+    end
+  end
+
+  def install
+    bin.install "pensar"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/pensar --version")
+  end
+end
+```
+
+### 3. Potential Issues Identified
+
+#### Issue #1: Missing Linux ARM64 Support 🔴
+The formula only supports:
+- macOS ARM (Apple Silicon)
+- macOS Intel
+- Linux x64 (Intel/AMD)
+
+**Missing**: Linux ARM64 (e.g., Raspberry Pi, AWS Graviton)
+
+If users try to install on an unsupported platform, they'll get an error like:
+```
+Error: apex: no bottle available!
+```
+
+#### Issue #2: License Mismatch ⚠️
+- **Formula license**: `MIT`
+- **Repository LICENSE file**: Likely `Apache-2.0` (based on README badge)
+- **package.json license**: `MIT`
+
+This inconsistency should be resolved.
+
+#### Issue #3: Possible Name Collision ⚠️
+While there's no `apex` formula in Homebrew core, there could be conflicts with:
+- Local casks or formulae with the same name
+- User-installed packages named `apex` from other sources
+
+#### Issue #4: Binary Test Failure 🔴
+The formula includes a test:
+```ruby
+test do
+  assert_match version.to_s, shell_output("#{bin}/pensar --version")
+end
+```
+
+If the binary doesn't properly respond to `--version`, installation will fail during the test phase.
+
+#### Issue #5: Tap Not Added First 🔴
+If users run `brew install apex` without first running `brew tap pensarai/tap`, they'll get:
+```
+Error: No available formula with the name "apex"
+```
+
+### 4. Common Homebrew Installation Errors
+
+Based on research, users might encounter:
+
+1. **No available formula**: Tap not added first
+2. **No bottle available**: Unsupported platform (likely **Linux ARM64**)
+3. **Checksum mismatch**: Corrupted download or incorrect SHA256
+4. **Test failure**: Binary doesn't respond correctly to `--version`
+5. **Permission errors**: Installation directory not writable
+
+### 5. Release Workflow Analysis
+
+The release workflow (`.github/workflows/release.yml`):
+- ✅ Builds binaries for: darwin-arm64, darwin-x64, linux-x64, windows-x64
+- ✅ Creates GitHub release with assets
+- ✅ Calculates SHA256 checksums
+- ✅ Updates Homebrew formula
+- ✅ Commits and pushes to tap repository
+
+**Missing**: Linux ARM64 build
+
+## Root Cause: Tap Migration Conflict
+
+### The Problem
+The Homebrew tap was migrated from `pensarai/apex` to `pensarai/tap`, but users who had the old tap installed still have it registered. This creates a conflict when both taps are present.
+
+### Why This Happened
+1. The old tap repository was `pensarai/apex`
+2. At some point, the tap was migrated to `pensarai/homebrew-tap` (which users access as `pensarai/tap`)
+3. Users who tapped the old repository before the migration never removed it
+4. The release workflow now updates `pensarai/tap`, but doesn't clean up the old `pensarai/apex` tap
+5. Homebrew sees two formulas with the same name in different taps and errors out
+
+### Impact
+Any user who:
+- Installed Pensar via Homebrew before the tap migration
+- Still has `pensarai/apex` registered
+- Tries to install or upgrade
+
+Will encounter this error.
+
+## Solution
+
+### Immediate Fix for Affected Users
+Users encountering this error should run:
+
+```bash
+# Remove the old deprecated tap
+brew untap pensarai/apex
+
+# Ensure the current tap is registered
+brew tap pensarai/tap
+
+# Now install apex
+brew install apex
+```
+
+### Recommended Actions
+
+#### Immediate (This PR):
+1. ✅ **Add troubleshooting section to README** with tap migration instructions
+2. **Document the correct installation process** clearly
+3. **Add a note about the old tap** for users who might have it installed
+
+#### Short-term:
+1. **Consider deprecating the old tap repository** (if it still exists)
+   - Add a README to `pensarai/apex` (if accessible) directing users to the new tap
+   - Archive or delete the old tap repository if possible
+2. **Fix license inconsistency**: Ensure license field is correct (MIT vs Apache-2.0)
+
+#### Long-term:
+1. **Add Linux ARM64 support**: Extend release workflow to build for linux-arm64
+2. **Improve installation validation**: Add post-install smoke tests
+3. **Add caveat to formula**: Consider adding a caveat that checks for and warns about the old tap
+
+## Why This Wasn't Caught Earlier
+
+1. **New installations work fine**: Users installing Pensar for the first time only see `pensarai/tap` and have no issues
+2. **Old tap still functional**: The old tap (if it exists) may still be receiving updates, masking the problem
+3. **Homebrew doesn't auto-cleanup**: When a tap is migrated, Homebrew doesn't automatically remove the old tap from users' systems
+
+## Prevention for Future
+
+To prevent similar issues in future tap migrations:
+
+1. **Document tap name in AGENTS.md**: Clearly state the canonical tap name
+2. **Add deprecation notices**: If migrating taps, add caveats to old formulas directing users to remove the old tap
+3. **Automated cleanup**: Consider adding a post-install script that checks for and warns about conflicting taps

--- a/HOMEBREW_TAP_MIGRATION.md
+++ b/HOMEBREW_TAP_MIGRATION.md
@@ -1,0 +1,97 @@
+# Homebrew Tap Migration Guide
+
+## Background
+
+Pensar Apex's Homebrew tap was migrated from `pensarai/apex` to `pensarai/tap`. This follows Homebrew's naming convention where tap repositories are named `homebrew-{name}` and accessed as `{org}/{name}`.
+
+## If You're Experiencing Installation Errors
+
+### The Error
+If you see this error when running `brew install apex`:
+
+```
+Error: Formulae found in multiple taps:
+  * pensarai/apex/apex
+  * pensarai/tap/apex
+```
+
+### The Cause
+You have both the old (deprecated) tap and the new tap registered on your system. Homebrew doesn't know which one to use.
+
+### The Solution
+
+Run these commands to remove the old tap and use the new one:
+
+```bash
+# 1. Remove the old deprecated tap
+brew untap pensarai/apex
+
+# 2. Ensure the current tap is registered
+brew tap pensarai/tap
+
+# 3. Install or upgrade apex
+brew install apex
+# or
+brew upgrade apex
+```
+
+## Fresh Installation
+
+If you're installing Pensar Apex for the first time, simply run:
+
+```bash
+brew tap pensarai/tap
+brew install apex
+```
+
+## Verification
+
+To verify you're using the correct tap:
+
+```bash
+# List all tapped repositories
+brew tap
+
+# You should see "pensarai/tap" in the list
+# You should NOT see "pensarai/apex" in the list
+```
+
+To verify your installation:
+
+```bash
+# Check the installed version
+pensar --version
+
+# Check which tap the formula came from
+brew info apex
+```
+
+## Additional Notes
+
+- The formula is named `apex`, but it installs the `pensar` binary
+- Only the tap name changed; the formula name (`apex`) remained the same
+- The old tap (`pensarai/apex`) is deprecated and should not be used
+
+## Supported Platforms
+
+Homebrew installation is supported on:
+- macOS (Apple Silicon and Intel)
+- Linux (x64/AMD64)
+
+For other platforms, consider:
+- **npm**: `npm install -g @pensar/apex`
+- **Quick install script**: `curl -fsSL https://pensarai.com/install.sh | bash`
+
+## Need Help?
+
+If you continue to experience issues after following this guide:
+
+1. Check the [troubleshooting section](./README.md#troubleshooting-homebrew-installation) in the README
+2. Open an issue on [GitHub](https://github.com/pensarai/apex/issues)
+3. Include the output of:
+   ```bash
+   brew tap
+   brew --version
+   brew config
+   uname -a
+   ```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,28 @@ irm https://www.pensarai.com/apex.ps1 | iex
 npm install -g @pensar/apex
 ```
 
+### Troubleshooting Homebrew Installation
+
+If you encounter an error like:
+```
+Error: Formulae found in multiple taps:
+  * pensarai/apex/apex
+  * pensarai/tap/apex
+```
+
+This means you have both the old and new Homebrew taps installed. To fix this:
+
+```bash
+# Remove the old deprecated tap
+brew untap pensarai/apex
+
+# Ensure the current tap is registered
+brew tap pensarai/tap
+
+# Now install or upgrade apex
+brew install apex
+```
+
 ## Usage
 
 Run Apex:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR addresses issue #367 where users encounter a "Formulae found in multiple taps" error when trying to install Pensar Apex via Homebrew.

**The Issue:**
Users who installed Pensar before the Homebrew tap was migrated from `pensarai/apex` to `pensarai/tap` have both taps registered on their system. When they try to install or upgrade, Homebrew sees the `apex` formula in both taps and doesn't know which one to use, resulting in an error:

```
Error: Formulae found in multiple taps:
  * pensarai/apex/apex
  * pensarai/tap/apex
```

**Changes Made:**

1. **Added troubleshooting section to README.md**
   - Provides immediate solution for users encountering the tap conflict error
   - Includes step-by-step instructions to remove the old tap and use the new one

2. **Created HOMEBREW_INVESTIGATION.md**
   - Comprehensive technical investigation of the issue
   - Documents the root cause (tap migration from `pensarai/apex` → `pensarai/tap`)
   - Identifies other potential issues (missing Linux ARM64 support, license inconsistency)
   - Provides recommendations for short-term and long-term improvements

3. **Created HOMEBREW_TAP_MIGRATION.md**
   - User-friendly migration guide for affected users
   - Clear instructions for fixing the error
   - Verification steps to ensure correct setup
   - Additional context about the tap migration

**Why This Works:**

The solution is straightforward: users need to remove the old deprecated tap (`pensarai/apex`) and ensure they're using the current tap (`pensarai/tap`). Once only one tap contains the `apex` formula, Homebrew can install it without ambiguity.

The documentation provides:
- Immediate troubleshooting steps in the README (most visible location)
- Technical details for maintainers in the investigation document
- Comprehensive migration guide that can be linked/shared with affected users

### How did you verify your code works?

1. **Analyzed the actual error screenshot** from issue #367 to identify the root cause
2. **Verified Homebrew tap infrastructure:**
   - Confirmed `pensarai/homebrew-tap` repository is public and accessible
   - Verified the `apex.rb` formula exists and has the correct structure
   - Checked release workflow logs to confirm Homebrew job completes successfully
3. **Confirmed the solution** matches the fix provided by @joshkotrous in issue #367
4. **Validated documentation accuracy:**
   - Verified tap naming conventions (Homebrew repos are `homebrew-{name}`, accessed as `{org}/{name}`)
   - Confirmed CLI supports `--version` flag (required by formula test)
   - Checked supported platforms against release workflow build matrix

The changes are documentation-only and provide accurate troubleshooting steps based on the confirmed root cause. No code changes were necessary as the Homebrew tap infrastructure is working correctly—this is purely a migration/user education issue.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c095e472-5394-4003-b94e-8c6dda9ac343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c095e472-5394-4003-b94e-8c6dda9ac343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

