### PR TITLE
feat: in-app report viewer dialog and graceful editor error handling

### DIFF
--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -1,14 +1,16 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useKeyboard } from "@opentui/react";
 import { useRoute } from "../../context/route";
 import { useFocus } from "../../context/focus";
 import { sessions } from "../../../core/session";
-import { openSessionReport } from "../../utils/open-report";
+import { openSessionReport, readSessionReport } from "../../utils/open-report";
+import ReportViewerDialog from "../report-viewer-dialog";
 import { Dialog } from "../../context/dialog";
 import { ScrollBoxRenderable } from "@opentui/core";
 import { scrollToIndex } from "../../utils/scroll";
 import { useTheme } from "../../theme";
 import { useSessionsList } from "../../hooks/use-sessions-list";
+import { useToast } from "../../context/toast";
 
 interface SessionsDisplayProps {
   onClose: () => void;
@@ -18,7 +20,12 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
   const { colors } = useTheme();
   const { refocusPrompt } = useFocus();
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [statusMessage, setStatusMessage] = useState<string>("");
+  const { toast } = useToast();
+  const [showReportViewer, setShowReportViewer] = useState(false);
+  const [reportContent, setReportContent] = useState<string | null>(null);
+  const [reportSessionPath, setReportSessionPath] = useState<string | null>(
+    null,
+  );
 
   const route = useRoute();
 
@@ -32,14 +39,25 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
     deleteSession: hookDeleteSession,
   } = useSessionsList();
 
-  async function openReport(sessionId: string) {
+  const viewReport = useCallback(async (sessionId: string) => {
     const session = await sessions.get(sessionId);
-    const err = openSessionReport(session.rootPath);
-    if (err) {
-      setStatusMessage(err);
-      setTimeout(() => setStatusMessage(""), 2000);
+    const content = readSessionReport(session.rootPath);
+    if (!content) {
+      toast("Report not found", "error");
+      return;
     }
-  }
+    setReportContent(content);
+    setReportSessionPath(session.rootPath);
+    setShowReportViewer(true);
+  }, []);
+
+  const openReportExternal = useCallback(async () => {
+    if (!reportSessionPath) return;
+    const err = await openSessionReport(reportSessionPath);
+    if (err) {
+      toast(err, "error");
+    }
+  }, [reportSessionPath]);
 
   // Clamp selectedIndex when list changes
   useEffect(() => {
@@ -56,17 +74,18 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
   async function deleteSession(sessionId: string) {
     try {
       await hookDeleteSession(sessionId);
-      setStatusMessage("Session deleted");
-      setTimeout(() => setStatusMessage(""), 2000);
+      toast("Session deleted");
       // selectedIndex clamping handled by the useEffect above after re-render
     } catch (error) {
       console.error("Error deleting session:", error);
-      setStatusMessage("Error deleting session");
-      setTimeout(() => setStatusMessage(""), 2000);
+      toast("Error deleting session", "error");
     }
   }
 
   useKeyboard(async (key) => {
+    // Don't handle keys when report viewer is open
+    if (showReportViewer) return;
+
     // Escape - Close sessions display
     if (key.name === "escape") {
       refocusPrompt();
@@ -82,8 +101,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
       try {
         await sessions.get(currentSelection.id);
       } catch {
-        setStatusMessage("Session not found");
-        setTimeout(() => setStatusMessage(""), 2000);
+        toast("Session not found", "error");
         return;
       }
       const isOperator =
@@ -111,8 +129,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
       try {
         await sessions.get(currentSelection.id);
       } catch {
-        setStatusMessage("Session not found");
-        setTimeout(() => setStatusMessage(""), 2000);
+        toast("Session not found", "error");
         return;
       }
       refocusPrompt();
@@ -143,16 +160,15 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
       return;
     }
 
-    // R - Open report
+    // R - View report in dialog
     if (key.name === "r" && visualOrderSessions.length > 0) {
       const currentSelection = visualOrderSessions[selectedIndex];
       if (!currentSelection) return;
       if (!currentSelection.hasReport) {
-        setStatusMessage("No report available");
-        setTimeout(() => setStatusMessage(""), 2000);
+        toast("No report available", "warn");
         return;
       }
-      openReport(currentSelection.id);
+      viewReport(currentSelection.id);
       return;
     }
 
@@ -171,6 +187,17 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
   };
 
   if (loading) return null;
+
+  if (showReportViewer && reportContent && reportSessionPath) {
+    return (
+      <ReportViewerDialog
+        content={reportContent}
+        reportPath={reportSessionPath}
+        onClose={() => setShowReportViewer(false)}
+        onOpenExternal={openReportExternal}
+      />
+    );
+  }
 
   return (
     <Dialog size="large" onClose={handleClose}>
@@ -321,8 +348,6 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
             </text>
           </box>
         )}
-
-        {statusMessage && <text fg={colors.primary}>{statusMessage}</text>}
       </box>
     </Dialog>
   );

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -5,6 +5,7 @@ import { useFocus } from "../../context/focus";
 import { sessions } from "../../../core/session";
 import { openSessionReport, readSessionReport } from "../../utils/open-report";
 import ReportViewerDialog from "../report-viewer-dialog";
+import { REPORT_FILENAME_MD } from "../../../core/report";
 import { Dialog } from "../../context/dialog";
 import { ScrollBoxRenderable } from "@opentui/core";
 import { scrollToIndex } from "../../utils/scroll";
@@ -192,7 +193,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
     return (
       <ReportViewerDialog
         content={reportContent}
-        reportPath={reportSessionPath}
+        reportPath={`${reportSessionPath}/${REPORT_FILENAME_MD}`}
         onClose={() => setShowReportViewer(false)}
         onOpenExternal={openReportExternal}
       />

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -5,7 +5,8 @@ import { RGBA, ScrollBoxRenderable } from "@opentui/core";
 import { existsSync, readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { REPORT_FILENAME_MD } from "../../../core/report";
-import { openSessionReport } from "../../utils/open-report";
+import { openSessionReport, readSessionReport } from "../../utils/open-report";
+import ReportViewerDialog from "../report-viewer-dialog";
 
 import { sessions, type SessionInfo } from "../../../core/session";
 import {
@@ -27,6 +28,7 @@ import {
   extractStreamableContent,
 } from "../shared/message-utils";
 import { isToolMessage } from "../shared/type-guards";
+import { useToast } from "../../context/toast";
 import type { DocumentedAssetRecord } from "../../../core/agents/specialized/attackSurface/schemas";
 
 // ---------------------------------------------------------------------------
@@ -105,6 +107,7 @@ export default function Pentest({
   // Session
   const [session, setSession] = useState<SessionInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const { toast } = useToast();
   const [phase, setPhase] = useState<Phase>("loading");
 
   // Abort
@@ -131,6 +134,8 @@ export default function Pentest({
   const [focusedIndex, setFocusedIndex] = useState(0);
   const [showOrchestratorPanel, setShowOrchestratorPanel] = useState(false);
   const [startTime, setStartTime] = useState<Date | null>(null);
+  const [showReportViewer, setShowReportViewer] = useState(false);
+  const [reportContent, setReportContent] = useState<string | null>(null);
 
   // Derived
   const pentestAgentList = useMemo(
@@ -917,7 +922,7 @@ export default function Pentest({
   // -------------------------------------------------------------------------
 
   useKeyboard((key) => {
-    if (stack.length > 0 || externalDialogOpen) return;
+    if (stack.length > 0 || externalDialogOpen || showReportViewer) return;
 
     if (viewMode === "overview") {
       if (key.name === "d" || key.name === "D") {
@@ -961,15 +966,25 @@ export default function Pentest({
       }
 
       if (!showOrchestratorPanel && key.name === "return") {
-        // Report card slot (last item when completed)
         if (phase === "completed" && focusedIndex === pentestAgentList.length) {
-          openReport();
+          viewReportInDialog();
           return;
         }
-        // Agent card
         if (pentestAgentList[focusedIndex]) {
           setSelectedAgentId(pentestAgentList[focusedIndex]!.id);
           setViewMode("detail");
+          return;
+        }
+      }
+
+      if (
+        !showOrchestratorPanel &&
+        (key.name === "r" || key.name === "R") &&
+        !key.ctrl &&
+        !key.meta
+      ) {
+        if (phase === "completed" && focusedIndex === pentestAgentList.length) {
+          viewReportInDialog();
           return;
         }
       }
@@ -982,14 +997,23 @@ export default function Pentest({
     }
   });
 
-  // -------------------------------------------------------------------------
-  // Open report
-  // -------------------------------------------------------------------------
-
-  const openReport = useCallback(() => {
+  const viewReportInDialog = useCallback(() => {
     if (!session) return;
-    const err = openSessionReport(session.rootPath);
-    if (err) setError(err);
+    const content = readSessionReport(session.rootPath);
+    if (!content) {
+      toast("Report not found", "error");
+      return;
+    }
+    setReportContent(content);
+    setShowReportViewer(true);
+  }, [session]);
+
+  const openReportExternal = useCallback(async () => {
+    if (!session) return;
+    const err = await openSessionReport(session.rootPath);
+    if (err) {
+      toast(err, "error");
+    }
   }, [session]);
 
   // -------------------------------------------------------------------------
@@ -1141,13 +1165,23 @@ export default function Pentest({
               </text>
               {reportFocused && (
                 <text>
-                  <span fg={colors.primary}>[Enter]</span>
+                  <span fg={colors.primary}>[Enter/R]</span>
                   <span fg={colors.textMuted}> View Report</span>
                 </text>
               )}
             </box>
           );
         })()}
+
+      {/* Report viewer dialog */}
+      {showReportViewer && reportContent && (
+        <ReportViewerDialog
+          content={reportContent}
+          reportPath={`${session.rootPath}/${REPORT_FILENAME_MD}`}
+          onClose={() => setShowReportViewer(false)}
+          onOpenExternal={openReportExternal}
+        />
+      )}
 
       {/* Bottom: Metrics bar */}
       <MetricsBar

--- a/src/tui/components/report-viewer-dialog.tsx
+++ b/src/tui/components/report-viewer-dialog.tsx
@@ -1,0 +1,162 @@
+import { useRef, useMemo } from "react";
+import { useKeyboard } from "@opentui/react";
+import { useDimensions } from "../context/dimensions";
+import { ScrollBoxRenderable, SyntaxStyle } from "@opentui/core";
+import { useTheme } from "../theme";
+
+interface ReportViewerDialogProps {
+  content: string;
+  reportPath: string;
+  onClose: () => void;
+  onOpenExternal?: () => void;
+}
+
+export default function ReportViewerDialog({
+  content,
+  reportPath,
+  onClose,
+  onOpenExternal,
+}: ReportViewerDialogProps) {
+  const { colors } = useTheme();
+  const dimensions = useDimensions();
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+
+  const syntaxStyle = useMemo(
+    () =>
+      SyntaxStyle.fromStyles({
+        default: { fg: colors.text },
+        "markup.heading": { fg: colors.markdownHeading, bold: true },
+        "markup.strong": { fg: colors.markdownStrong, bold: true },
+        "markup.italic": { fg: colors.markdownEmph, italic: true },
+        "markup.raw": { fg: colors.markdownCode },
+        "markup.raw.block": { fg: colors.markdownCode },
+        "markup.link": { fg: colors.markdownLink },
+        "markup.link.url": { fg: colors.markdownLink, dim: true },
+        "markup.link.label": { fg: colors.markdownLink, underline: true },
+        "markup.strikethrough": { fg: colors.textMuted, dim: true },
+        "markup.list": { fg: colors.primary },
+        "markup.quote": { fg: colors.textMuted, italic: true },
+        "punctuation.special": { fg: colors.border },
+      }),
+    [colors],
+  );
+
+  const lineCount = useMemo(() => content.split("\n").length, [content]);
+
+  useKeyboard((evt) => {
+    if (evt.name === "escape") {
+      evt.preventDefault();
+      onClose();
+      return;
+    }
+    if (
+      (evt.name === "e" || evt.name === "E") &&
+      !evt.ctrl &&
+      !evt.meta &&
+      onOpenExternal
+    ) {
+      evt.preventDefault();
+      onOpenExternal();
+      return;
+    }
+  });
+
+  const panelWidth = Math.min(120, dimensions.width - 4);
+  const panelHeight = Math.min(dimensions.height - 4, dimensions.height);
+
+  return (
+    <box
+      width={dimensions.width}
+      height={dimensions.height}
+      alignItems="center"
+      justifyContent="center"
+      position="absolute"
+      left={0}
+      top={0}
+      backgroundColor={colors.backgroundOverlay}
+    >
+      <box
+        width={panelWidth}
+        height={panelHeight}
+        backgroundColor={colors.backgroundPanel}
+        borderColor={colors.primary}
+        borderStyle="single"
+        flexDirection="column"
+      >
+        {/* Header */}
+        <box
+          width="100%"
+          padding={1}
+          flexDirection="row"
+          justifyContent="space-between"
+        >
+          <text fg={colors.primary}>Pentest Report</text>
+          <text fg={colors.textMuted}>{reportPath}</text>
+        </box>
+
+        {/* Separator */}
+        <box width="100%" height={1}>
+          <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
+        </box>
+
+        {/* Report Content */}
+        <scrollbox
+          ref={scrollRef}
+          style={{
+            rootOptions: {
+              flexGrow: 1,
+              width: "100%",
+              overflow: "hidden",
+            },
+            contentOptions: {
+              paddingLeft: 2,
+              paddingRight: 2,
+              paddingTop: 1,
+              paddingBottom: 1,
+              flexDirection: "column",
+            },
+            scrollbarOptions: {
+              trackOptions: {
+                foregroundColor: colors.primary,
+                backgroundColor: colors.backgroundElement,
+              },
+            },
+          }}
+          stickyScroll={false}
+          focused={true}
+        >
+          <markdown
+            content={content}
+            syntaxStyle={syntaxStyle}
+            conceal={true}
+          />
+        </scrollbox>
+
+        {/* Separator */}
+        <box width="100%" height={1}>
+          <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
+        </box>
+
+        {/* Footer */}
+        <box
+          width="100%"
+          padding={1}
+          flexDirection="row"
+          justifyContent="space-between"
+        >
+          <text fg={colors.textMuted}>
+            <span fg={colors.primary}>[↑/↓]</span> Scroll{" "}
+            {onOpenExternal && (
+              <>
+                <span fg={colors.primary}>[E]</span>
+                {" Open in Editor "}
+              </>
+            )}
+            <span fg={colors.primary}>[Esc]</span> Close
+          </text>
+          <text fg={colors.textMuted}>{lineCount} lines</text>
+        </box>
+      </box>
+    </box>
+  );
+}

--- a/src/tui/components/report-viewer-dialog.tsx
+++ b/src/tui/components/report-viewer-dialog.tsx
@@ -62,7 +62,7 @@ export default function ReportViewerDialog({
   });
 
   const panelWidth = Math.min(120, dimensions.width - 4);
-  const panelHeight = Math.min(dimensions.height - 4, dimensions.height);
+  const panelHeight = dimensions.height - 4;
 
   return (
     <box

--- a/src/tui/components/toast.tsx
+++ b/src/tui/components/toast.tsx
@@ -66,7 +66,7 @@ export function ToastContainer() {
       flexDirection="column"
       gap={0}
       alignItems="flex-end"
-      maxWidth={Math.min(60, dims.width - 4)}
+      maxWidth={Math.min(80, dims.width - 4)}
       zIndex={9999}
     >
       {toasts.map((t) => (

--- a/src/tui/utils/open-report.ts
+++ b/src/tui/utils/open-report.ts
@@ -1,12 +1,17 @@
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { REPORT_FILENAME_MD } from "../../core/report";
 
+const NO_EDITOR_MSG =
+  "No app found for .md files — set a default markdown editor";
+
 /**
  * Open the pentest report for a session in the user's default viewer.
- * Returns an error message string, or "" on success.
+ * Returns a promise that resolves to an error message string, or "" on success.
  */
-export function openSessionReport(sessionRootPath: string): string {
+export async function openSessionReport(
+  sessionRootPath: string,
+): Promise<string> {
   const reportPath = join(sessionRootPath, REPORT_FILENAME_MD);
 
   if (!existsSync(reportPath)) {
@@ -15,15 +20,45 @@ export function openSessionReport(sessionRootPath: string): string {
 
   try {
     const platform = process.platform;
+    let proc: ReturnType<typeof Bun.spawn>;
+
     if (platform === "darwin") {
-      Bun.spawn(["open", reportPath]);
+      proc = Bun.spawn(["open", reportPath], {
+        stderr: "pipe",
+        stdout: "pipe",
+      });
     } else if (platform === "win32") {
-      Bun.spawn(["cmd", "/c", "start", reportPath]);
+      proc = Bun.spawn(["cmd", "/c", "start", "", reportPath], {
+        stderr: "pipe",
+        stdout: "pipe",
+      });
     } else {
-      Bun.spawn(["xdg-open", reportPath]);
+      proc = Bun.spawn(["xdg-open", reportPath], {
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+    }
+
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      return NO_EDITOR_MSG;
     }
     return "";
   } catch {
-    return "Error opening report";
+    return NO_EDITOR_MSG;
+  }
+}
+
+/**
+ * Read the raw markdown content of a session's pentest report.
+ * Returns the content string or null if the report doesn't exist.
+ */
+export function readSessionReport(sessionRootPath: string): string | null {
+  const reportPath = join(sessionRootPath, REPORT_FILENAME_MD);
+  if (!existsSync(reportPath)) return null;
+  try {
+    return readFileSync(reportPath, "utf-8");
+  } catch {
+    return null;
   }
 }


### PR DESCRIPTION
Fixes #396

## Summary

- Add in-app report viewer dialog using OpenTUI's native `<markdown>` component with conceal mode for rich rendering (styled headings, bold, code blocks, lists, etc.)
- `R` key opens report viewer from both sessions list and pentest completion view
- `E` key inside viewer opens report in external editor (TextEdit on macOS)
- Report viewer renders as standalone full-screen overlay (not clipped inside sessions dialog)
- Replace ad-hoc inline status messages with the existing toast notification system for consistency
- Widen toast max width (60→80) to prevent long messages from truncating
- Improve `openSessionReport` to async detect editor launch failures with a clear error message

## Changes

| File | Change |
|------|--------|
| `src/tui/components/report-viewer-dialog.tsx` | **New** — full-screen scrollable report dialog with `<markdown>` rendering, `SyntaxStyle` mapped from theme colors |
| `src/tui/components/pentest/pentest.tsx` | `Enter`/`R` opens in-app viewer, external editor moved behind `E` inside dialog; status messages → toasts |
| `src/tui/components/commands/sessions-display.tsx` | `R` opens in-app viewer (was external editor); report dialog renders standalone; status messages → toasts |
| `src/tui/utils/open-report.ts` | `openSessionReport` now async with exit code checking; added `readSessionReport` helper; shortened error message |
| `src/tui/components/toast.tsx` | Widen `maxWidth` from 60→80 to fit longer messages |

## Test plan

- [x] Open sessions list (`Ctrl+S`), press `R` on a session with a report → in-app viewer opens full-screen with styled markdown
- [x] Inside report viewer, press `E` → report opens in system editor
- [x] Inside report viewer, press `Esc` → returns to sessions list
- [x] Complete a pentest, focus report card, press `Enter` or `R` → in-app viewer opens
- [x] Trigger editor error (no .md handler) → toast appears with full message, not truncated
- [x] `O` in sessions list still opens operator mode (no conflict)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/UX change that adds a new full-screen overlay and updates keyboard handling plus makes `openSessionReport` async with process exit-code checking, which could affect report-opening behavior across platforms.
> 
> **Overview**
> Adds an in-app, full-screen `ReportViewerDialog` that renders session reports via OpenTUI `<markdown>` with theme-based syntax styling, plus keyboard controls (`Esc` to close, optional `E` to open externally).
> 
> Updates both the sessions list and pentest completion view so `R`/`Enter` open the in-app viewer, disables underlying keyboard handlers while the viewer is open, and replaces inline status messages with toast notifications (also widening toast max width).
> 
> Improves external report launching by making `openSessionReport` async, capturing spawn exit codes, returning a clearer “no editor” error, and adding `readSessionReport` for loading markdown into the viewer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61042df4948d840e6c84107e3528f30a298a44e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->