### PR TITLE
Add CLI commands for Pensar REST API (projects, pentests, issues, fixes, logs)

### DIFF
--- a/bin/pensar.js
+++ b/bin/pensar.js
@@ -73,6 +73,26 @@ if (command === "benchmark") {
   process.argv = [process.argv[0], uninstallPath, ...args.slice(1)];
 
   await import(uninstallPath);
+} else if (command === "projects") {
+  const p = join(__dirname, "..", "build", "projects.js");
+  process.argv = [process.argv[0], p, ...args.slice(1)];
+  await import(p);
+} else if (command === "pentests") {
+  const p = join(__dirname, "..", "build", "pentests.js");
+  process.argv = [process.argv[0], p, ...args.slice(1)];
+  await import(p);
+} else if (command === "issues") {
+  const p = join(__dirname, "..", "build", "issues.js");
+  process.argv = [process.argv[0], p, ...args.slice(1)];
+  await import(p);
+} else if (command === "fixes") {
+  const p = join(__dirname, "..", "build", "fixes.js");
+  process.argv = [process.argv[0], p, ...args.slice(1)];
+  await import(p);
+} else if (command === "logs") {
+  const p = join(__dirname, "..", "build", "logs.js");
+  process.argv = [process.argv[0], p, ...args.slice(1)];
+  await import(p);
 } else if (command === "upgrade" || command === "update") {
   const currentVersion = getCurrentVersion();
   console.log(`Current version: v${currentVersion}`);
@@ -108,6 +128,21 @@ if (command === "benchmark") {
   );
   console.log(
     "  pensar auth         Connect to Pensar Console for managed inference"
+  );
+  console.log(
+    "  pensar projects     List workspace projects"
+  );
+  console.log(
+    "  pensar pentests     List and manage pentests"
+  );
+  console.log(
+    "  pensar issues       List and manage security issues"
+  );
+  console.log(
+    "  pensar fixes        View security fixes"
+  );
+  console.log(
+    "  pensar logs         View agent execution logs"
   );
   console.log();
   console.log("Options:");
@@ -226,6 +261,14 @@ if (command === "benchmark") {
   console.log("  pensar auth");
   console.log("  pensar auth status");
   console.log("  pensar auth logout");
+  console.log();
+  console.log("Console API:");
+  console.log("  pensar projects");
+  console.log("  pensar pentests <projectId>");
+  console.log("  pensar issues <projectId>");
+  console.log("  pensar issues get <issueId>");
+  console.log("  pensar fixes <issueId>");
+  console.log("  pensar logs <issueId>");
 } else if (args.length === 0) {
   // No command specified, run the TUI
   const appPath = join(__dirname, "..", "build", "index.js");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,6 +66,21 @@ function showHelp() {
     "  pensar uninstall                    Uninstall Pensar (keeps sessions, memories, skills)",
   );
   console.log(
+    "  pensar projects                     List workspace projects",
+  );
+  console.log(
+    "  pensar pentests                     List and manage pentests",
+  );
+  console.log(
+    "  pensar issues                       List and manage security issues",
+  );
+  console.log(
+    "  pensar fixes                        View security fixes",
+  );
+  console.log(
+    "  pensar logs                         View agent execution logs",
+  );
+  console.log(
     "  pensar upgrade                      Update pensar to the latest version",
   );
   console.log(
@@ -251,6 +266,21 @@ if (command === "version" || command === "--version" || command === "-v") {
 } else if (command === "uninstall") {
   process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
   await import("./cli/uninstall");
+} else if (command === "projects") {
+  process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
+  await import("./cli/projects");
+} else if (command === "pentests") {
+  process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
+  await import("./cli/pentests");
+} else if (command === "issues") {
+  process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
+  await import("./cli/issues");
+} else if (command === "fixes") {
+  process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
+  await import("./cli/fixes");
+} else if (command === "logs") {
+  process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
+  await import("./cli/logs");
 } else if (command === "doctor") {
   const { runDoctor } = await import("./core/doctor");
   await runDoctor();

--- a/src/cli/fixes.ts
+++ b/src/cli/fixes.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env bun
+
+/**
+ * pensar fixes — View security fixes via the Pensar API
+ *
+ * Usage:
+ *   pensar fixes <issueId>          List fixes for an issue
+ *   pensar fixes get <fixId>        Get fix details (includes diff)
+ */
+
+import { listFixes, getFix } from "../core/api/issues";
+
+function showHelp(): void {
+  console.log("pensar fixes — View security fixes via the Pensar API\n");
+  console.log("Usage:");
+  console.log("  pensar fixes <issueId>         List fixes for an issue");
+  console.log("  pensar fixes get <fixId>       Get fix details (includes diff)");
+  console.log();
+  console.log("Options:");
+  console.log("  -h, --help                     Show this help message");
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+    showHelp();
+    return;
+  }
+
+  try {
+    if (sub === "get") {
+      const fixId = args[1];
+      if (!fixId) {
+        console.error("Error: fix ID is required");
+        console.error("Usage: pensar fixes get <fixId>");
+        process.exit(1);
+      }
+      const fix = await getFix(fixId);
+      console.log(JSON.stringify(fix, null, 2));
+    } else {
+      const fixes = await listFixes(sub);
+      console.log(JSON.stringify(fixes, null, 2));
+    }
+  } catch (err) {
+    console.error(
+      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/cli/issues.ts
+++ b/src/cli/issues.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env bun
+
+/**
+ * pensar issues — Manage security issues via the Pensar API
+ *
+ * Usage:
+ *   pensar issues <projectId> [filters]          List issues for a project
+ *   pensar issues get <issueId>                   Get issue details
+ *   pensar issues update <issueId> [opts]         Update an issue
+ */
+
+import {
+  listIssues,
+  getIssue,
+  updateIssue,
+} from "../core/api/issues";
+
+function getFlag(flag: string, argv: string[]): string | undefined {
+  const idx = argv.indexOf(flag);
+  return idx !== -1 && idx + 1 < argv.length ? argv[idx + 1] : undefined;
+}
+
+function showHelp(): void {
+  console.log("pensar issues — Manage security issues via the Pensar API\n");
+  console.log("Usage:");
+  console.log("  pensar issues <projectId> [filters]            List issues for a project");
+  console.log("  pensar issues get <issueId>                    Get issue details");
+  console.log("  pensar issues update <issueId> [options]       Update an issue");
+  console.log();
+  console.log("List filters:");
+  console.log("  --status <status>     Filter: open, closed, false-positive, in-review");
+  console.log("  --severity <sev>      Filter: critical, high, medium, low");
+  console.log("  --scan <scanId>       Filter by scan ID");
+  console.log("  --branch <branch>     Filter by branch");
+  console.log();
+  console.log("Update options:");
+  console.log("  --status <status>         New status");
+  console.log("  --closed-reason <reason>  Reason for closing");
+  console.log("  --closed-comments <text>  Additional comments");
+  console.log("  --false-positive          Flag as false positive");
+  console.log("  --fp-reason <reason>      Reason for false positive flag");
+  console.log();
+  console.log("Options:");
+  console.log("  -h, --help                Show this help message");
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+    showHelp();
+    return;
+  }
+
+  try {
+    if (sub === "get") {
+      const issueId = args[1];
+      if (!issueId) {
+        console.error("Error: issue ID is required");
+        console.error("Usage: pensar issues get <issueId>");
+        process.exit(1);
+      }
+      const issue = await getIssue(issueId);
+      console.log(JSON.stringify(issue, null, 2));
+    } else if (sub === "update") {
+      const issueId = args[1];
+      if (!issueId) {
+        console.error("Error: issue ID is required");
+        console.error("Usage: pensar issues update <issueId> [--status <status>] ...");
+        process.exit(1);
+      }
+      const status = getFlag("--status", args) as
+        | "open"
+        | "closed"
+        | "false-positive"
+        | "in-review"
+        | undefined;
+      const closedReason = getFlag("--closed-reason", args);
+      const closedComments = getFlag("--closed-comments", args);
+      const userFlaggedFalsePositive = args.includes("--false-positive")
+        ? true
+        : undefined;
+      const userFlaggedFalsePositiveReason = getFlag("--fp-reason", args);
+
+      const result = await updateIssue(issueId, {
+        status,
+        closedReason,
+        closedComments,
+        userFlaggedFalsePositive,
+        userFlaggedFalsePositiveReason,
+      });
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      const projectId = sub;
+      const issues = await listIssues(projectId, {
+        scanId: getFlag("--scan", args),
+        status: getFlag("--status", args),
+        severity: getFlag("--severity", args),
+        branch: getFlag("--branch", args),
+      });
+      console.log(JSON.stringify(issues, null, 2));
+    }
+  } catch (err) {
+    console.error(
+      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env bun
+
+/**
+ * pensar logs — View agent execution logs via the Pensar API
+ *
+ * Usage:
+ *   pensar logs <issueId> [filters]                List agent logs for an issue
+ *   pensar logs search <issueId> <query> [opts]    Search agent logs
+ */
+
+import { listAgentLogs, searchAgentLogs } from "../core/api/issues";
+
+function getFlag(flag: string, argv: string[]): string | undefined {
+  const idx = argv.indexOf(flag);
+  return idx !== -1 && idx + 1 < argv.length ? argv[idx + 1] : undefined;
+}
+
+function showHelp(): void {
+  console.log("pensar logs — View agent execution logs via the Pensar API\n");
+  console.log("Usage:");
+  console.log("  pensar logs <issueId> [filters]                 List agent logs");
+  console.log("  pensar logs search <issueId> <query> [options]  Search agent logs");
+  console.log();
+  console.log("List filters:");
+  console.log("  --level <level>       Filter: debug, info, warn, error");
+  console.log("  --role <role>         Filter: assistant, user, system, tool-call, tool-result");
+  console.log("  --limit <n>           Max entries (default: 100, max: 500)");
+  console.log();
+  console.log("Search options:");
+  console.log("  --level <level>       Filter: debug, info, warn, error");
+  console.log("  --role <role>         Filter: assistant, user, system, tool-call, tool-result");
+  console.log("  --context <n>         Context lines around matches (default: 3)");
+  console.log();
+  console.log("Options:");
+  console.log("  -h, --help            Show this help message");
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+    showHelp();
+    return;
+  }
+
+  try {
+    if (sub === "search") {
+      const issueId = args[1];
+      const query = args[2];
+      if (!issueId || !query) {
+        console.error("Error: issue ID and query are required");
+        console.error("Usage: pensar logs search <issueId> <query> [--level <level>] [--role <role>] [--context <n>]");
+        process.exit(1);
+      }
+      const level = getFlag("--level", args) as
+        | "debug"
+        | "info"
+        | "warn"
+        | "error"
+        | undefined;
+      const role = getFlag("--role", args) as
+        | "assistant"
+        | "user"
+        | "system"
+        | "tool-call"
+        | "tool-result"
+        | undefined;
+      const contextStr = getFlag("--context", args);
+      const contextLines = contextStr ? parseInt(contextStr, 10) : undefined;
+
+      const result = await searchAgentLogs(issueId, query, {
+        level,
+        role,
+        contextLines,
+      });
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      const issueId = sub;
+      const level = getFlag("--level", args) as
+        | "debug"
+        | "info"
+        | "warn"
+        | "error"
+        | undefined;
+      const role = getFlag("--role", args) as
+        | "assistant"
+        | "user"
+        | "system"
+        | "tool-call"
+        | "tool-result"
+        | undefined;
+      const limitStr = getFlag("--limit", args);
+      const limit = limitStr ? parseInt(limitStr, 10) : undefined;
+
+      const result = await listAgentLogs(issueId, { level, role, limit });
+      console.log(JSON.stringify(result, null, 2));
+    }
+  } catch (err) {
+    console.error(
+      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/cli/pentests.ts
+++ b/src/cli/pentests.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env bun
+
+/**
+ * pensar pentests — Manage pentests (scans) via the Pensar API
+ *
+ * Usage:
+ *   pensar pentests <projectId>                       List pentests for a project
+ *   pensar pentests get <pentestId>                    Get pentest details
+ *   pensar pentests dispatch <projectId> [opts]        Dispatch a new pentest
+ */
+
+import {
+  listScans,
+  getScan,
+  dispatchPentest,
+} from "../core/api/issues";
+
+function getFlag(flag: string, argv: string[]): string | undefined {
+  const idx = argv.indexOf(flag);
+  return idx !== -1 && idx + 1 < argv.length ? argv[idx + 1] : undefined;
+}
+
+function showHelp(): void {
+  console.log("pensar pentests — Manage pentests via the Pensar API\n");
+  console.log("Usage:");
+  console.log("  pensar pentests <projectId>                     List pentests for a project");
+  console.log("  pensar pentests get <pentestId>                  Get pentest details");
+  console.log("  pensar pentests dispatch <projectId> [options]   Dispatch a new pentest");
+  console.log();
+  console.log("dispatch options:");
+  console.log("  --branch <branch>     Target branch to scan");
+  console.log("  --level <level>       Scan depth: priority (default), full");
+  console.log();
+  console.log("Options:");
+  console.log("  -h, --help            Show this help message");
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+    showHelp();
+    return;
+  }
+
+  try {
+    if (sub === "get") {
+      const pentestId = args[1];
+      if (!pentestId) {
+        console.error("Error: pentest ID is required");
+        console.error("Usage: pensar pentests get <pentestId>");
+        process.exit(1);
+      }
+      const scan = await getScan(pentestId);
+      console.log(JSON.stringify(scan, null, 2));
+    } else if (sub === "dispatch") {
+      const projectId = args[1];
+      if (!projectId) {
+        console.error("Error: project ID is required");
+        console.error("Usage: pensar pentests dispatch <projectId> [--branch <branch>] [--level <priority|full>]");
+        process.exit(1);
+      }
+      const branch = getFlag("--branch", args);
+      const scanLevel = getFlag("--level", args) as "priority" | "full" | undefined;
+      const result = await dispatchPentest(projectId, { branch, scanLevel });
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      const scans = await listScans(sub);
+      console.log(JSON.stringify(scans, null, 2));
+    }
+  } catch (err) {
+    console.error(
+      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/cli/projects.ts
+++ b/src/cli/projects.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env bun
+
+/**
+ * pensar projects — List workspace projects
+ *
+ * Usage:
+ *   pensar projects              List all projects
+ *   pensar projects --help       Show help
+ */
+
+import { listProjects } from "../core/api/issues";
+
+function showHelp(): void {
+  console.log("pensar projects — List workspace projects\n");
+  console.log("Usage:");
+  console.log("  pensar projects              List all projects");
+  console.log();
+  console.log("Options:");
+  console.log("  -h, --help                   Show this help message");
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    showHelp();
+    return;
+  }
+
+  try {
+    const projects = await listProjects();
+    console.log(JSON.stringify(projects, null, 2));
+  } catch (err) {
+    console.error(
+      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/core/api/issues.ts
+++ b/src/core/api/issues.ts
@@ -184,11 +184,11 @@ export async function listProjects(): Promise<ProjectSummary[]> {
 }
 
 export async function listScans(projectId: string): Promise<ScanSummary[]> {
-  return apiRequest<ScanSummary[]>("GET", `/projects/${projectId}/scans`);
+  return apiRequest<ScanSummary[]>("GET", `/projects/${projectId}/pentests`);
 }
 
 export async function getScan(scanId: string): Promise<ScanDetail> {
-  return apiRequest<ScanDetail>("GET", `/scans/${scanId}`);
+  return apiRequest<ScanDetail>("GET", `/pentests/${scanId}`);
 }
 
 export async function dispatchPentest(
@@ -197,7 +197,7 @@ export async function dispatchPentest(
 ): Promise<DispatchPentestResult> {
   return apiRequest<DispatchPentestResult>(
     "POST",
-    `/projects/${projectId}/scans`,
+    `/projects/${projectId}/pentests`,
     opts,
   );
 }

--- a/src/core/api/issues.ts
+++ b/src/core/api/issues.ts
@@ -1,0 +1,282 @@
+/**
+ * REST API client for the Pensar Issues API.
+ *
+ * Wraps the /{proxy+} endpoints exposed by the console's issues-api Lambda.
+ * Auth is handled via Bearer token (WorkOS JWT) or API key, with an
+ * X-Workspace-Id header for JWT auth.
+ */
+
+import { getPensarApiUrl } from "./constants";
+import { config } from "../config";
+import { ensureValidToken } from "../auth/token";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  source?: string;
+}
+
+export interface ScanSummary {
+  id: string;
+  label: string;
+  status: string;
+  scanType?: string;
+  branch?: string;
+  startedAt?: string;
+  completedAt?: string;
+}
+
+export interface ScanDetail extends ScanSummary {
+  projectId: string;
+  projectName: string;
+  errorMessage?: string;
+  issuesFound: number;
+  reportReady: boolean;
+}
+
+export interface IssueSummary {
+  id: string;
+  title: string;
+  severity: string;
+  status: string;
+  location: string;
+}
+
+export interface IssueDetail extends IssueSummary {
+  description?: string;
+  lineRange?: string;
+  cwe?: string;
+  branch?: string;
+  endpoint?: string;
+  poc?: string;
+  projectId: string;
+  projectName: string;
+  createdAt: string;
+}
+
+export interface UpdateIssueResult {
+  success: boolean;
+  issue: {
+    id: string;
+    name: string;
+    status: string;
+    severity: string;
+    userFlaggedFalsePositive: boolean;
+    closedAt: string | null;
+    closedReason: string | null;
+  };
+}
+
+export interface FixSummary {
+  id: string;
+  filePath: string;
+}
+
+export interface FixDetail extends FixSummary {
+  diff: string;
+  explanation: string;
+  issueId: string;
+}
+
+export interface DispatchPentestResult {
+  scanId: string;
+  label: string;
+  status: "queued";
+  message: string;
+}
+
+export interface AgentLogEntry {
+  id: string;
+  createdAt: string;
+  level: string;
+  role: string;
+  message: string;
+  metadata: Record<string, unknown> | null;
+  service: string | null;
+  subagent: string | null;
+}
+
+export interface ListAgentLogsResult {
+  issueId: string;
+  totalLogs: number;
+  returnedLogs: number;
+  logs: AgentLogEntry[];
+}
+
+export interface SearchAgentLogsResult {
+  issueId: string;
+  query: string;
+  totalMatches: number;
+  totalLogs?: number;
+  contextLines?: number;
+  matches: Array<{
+    matchIndex: number;
+    entries: Array<AgentLogEntry & { isMatch: boolean }>;
+  }>;
+}
+
+// ── HTTP helpers ─────────────────────────────────────────────────────
+
+async function getAuthHeaders(): Promise<Record<string, string>> {
+  const cfg = await config.get();
+
+  const validToken = await ensureValidToken({
+    accessToken: cfg.accessToken,
+    refreshToken: cfg.refreshToken,
+    pensarAPIKey: cfg.pensarAPIKey,
+  });
+
+  if (!validToken) {
+    throw new Error(
+      "Not authenticated. Run `pensar auth login` to connect to Pensar Console.",
+    );
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${validToken.token}`,
+  };
+
+  if (validToken.type === "workos" && cfg.workspaceId) {
+    headers["X-Workspace-Id"] = cfg.workspaceId;
+  }
+
+  return headers;
+}
+
+async function apiRequest<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const baseUrl = getPensarApiUrl();
+  const headers = await getAuthHeaders();
+  const url = `${baseUrl}${path}`;
+
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(url, init);
+
+  if (!response.ok) {
+    const text = await response.text();
+    let message: string;
+    try {
+      const err = JSON.parse(text) as { error?: string };
+      message = err.error ?? text;
+    } catch {
+      message = text;
+    }
+    throw new Error(`API error (${response.status}): ${message}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+// ── API functions ────────────────────────────────────────────────────
+
+export async function listProjects(): Promise<ProjectSummary[]> {
+  return apiRequest<ProjectSummary[]>("GET", "/projects");
+}
+
+export async function listScans(projectId: string): Promise<ScanSummary[]> {
+  return apiRequest<ScanSummary[]>("GET", `/projects/${projectId}/scans`);
+}
+
+export async function getScan(scanId: string): Promise<ScanDetail> {
+  return apiRequest<ScanDetail>("GET", `/scans/${scanId}`);
+}
+
+export async function dispatchPentest(
+  projectId: string,
+  opts?: { branch?: string; scanLevel?: "priority" | "full" },
+): Promise<DispatchPentestResult> {
+  return apiRequest<DispatchPentestResult>(
+    "POST",
+    `/projects/${projectId}/scans`,
+    opts,
+  );
+}
+
+export async function listIssues(
+  projectId: string,
+  filters?: {
+    scanId?: string;
+    status?: string;
+    severity?: string;
+    branch?: string;
+  },
+): Promise<IssueSummary[]> {
+  const params = new URLSearchParams();
+  if (filters?.scanId) params.set("scanId", filters.scanId);
+  if (filters?.status) params.set("status", filters.status);
+  if (filters?.severity) params.set("severity", filters.severity);
+  if (filters?.branch) params.set("branch", filters.branch);
+
+  const qs = params.toString();
+  const path = `/projects/${projectId}/issues${qs ? `?${qs}` : ""}`;
+  return apiRequest<IssueSummary[]>("GET", path);
+}
+
+export async function getIssue(issueId: string): Promise<IssueDetail> {
+  return apiRequest<IssueDetail>("GET", `/issues/${issueId}`);
+}
+
+export async function updateIssue(
+  issueId: string,
+  data: {
+    status?: "open" | "closed" | "false-positive" | "in-review";
+    userFlaggedFalsePositive?: boolean;
+    userFlaggedFalsePositiveReason?: string;
+    closedReason?: string;
+    closedComments?: string;
+  },
+): Promise<UpdateIssueResult> {
+  return apiRequest<UpdateIssueResult>("PATCH", `/issues/${issueId}`, data);
+}
+
+export async function listFixes(issueId: string): Promise<FixSummary[]> {
+  return apiRequest<FixSummary[]>("GET", `/issues/${issueId}/fixes`);
+}
+
+export async function getFix(fixId: string): Promise<FixDetail> {
+  return apiRequest<FixDetail>("GET", `/fixes/${fixId}`);
+}
+
+export async function listAgentLogs(
+  issueId: string,
+  opts?: {
+    level?: "debug" | "info" | "warn" | "error";
+    role?: "assistant" | "user" | "system" | "tool-call" | "tool-result";
+    limit?: number;
+  },
+): Promise<ListAgentLogsResult> {
+  const params = new URLSearchParams();
+  if (opts?.level) params.set("level", opts.level);
+  if (opts?.role) params.set("role", opts.role);
+  if (opts?.limit) params.set("limit", String(opts.limit));
+
+  const qs = params.toString();
+  const path = `/issues/${issueId}/logs${qs ? `?${qs}` : ""}`;
+  return apiRequest<ListAgentLogsResult>("GET", path);
+}
+
+export async function searchAgentLogs(
+  issueId: string,
+  query: string,
+  opts?: {
+    level?: "debug" | "info" | "warn" | "error";
+    role?: "assistant" | "user" | "system" | "tool-call" | "tool-result";
+    contextLines?: number;
+  },
+): Promise<SearchAgentLogsResult> {
+  return apiRequest<SearchAgentLogsResult>(
+    "POST",
+    `/issues/${issueId}/logs/search`,
+    { query, ...opts },
+  );
+}


### PR DESCRIPTION
## Summary

- Adds new CLI commands (`pensar projects`, `pensar pentests`, `pensar issues`, `pensar fixes`, `pensar logs`) backed by a new REST API client (`src/core/api/issues.ts`) for managing Pensar Console resources from the command line

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new networked CLI surfaces that authenticate and call Pensar Console REST endpoints; failures or auth/header mismatches could break workflows or expose confusing errors, but changes are additive and isolated to new commands/client.
> 
> **Overview**
> Adds new Console-backed CLI commands: `pensar projects`, `pensar pentests` (list/get/dispatch), `pensar issues` (list/get/update with filters), `pensar fixes` (list/get), and `pensar logs` (list/search), all outputting JSON.
> 
> Introduces a new REST client in `src/core/api/issues.ts` that centralizes auth header construction (WorkOS bearer token w/ optional `X-Workspace-Id`, or legacy API key) and implements the corresponding `/projects`, `/pentests`, `/issues`, `/fixes`, and `/logs` requests with consistent error handling.
> 
> Wires these commands into both entrypoints (`bin/pensar.js` and `src/cli.ts`) and updates help text/examples to advertise the new subcommands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6edf965affe00482fe8261a0e98711063326214c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->