### PR TITLE
CLI: support node (with helpful bun dependency error for tui) and unify npm and binary entry points into single router

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,43 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Smoke test published package
+      # Simulate `npm install -g @pensar/apex` — all smoke tests below use this
+      - name: Install npm package globally
         run: |
           npm pack
           npm install -g ./pensar-apex-*.tgz
-          pensar --version
+
+      # CLI commands should work natively under Node without Bun
+      - name: "Smoke: npm package under Node"
+        run: |
+          set -euo pipefail
+          node $(which pensar) --version
+          node $(which pensar) --help
+          node $(which pensar) auth --help
+          node $(which pensar) pentests --help
+
+      # Bare `pensar` under Node with no Bun on PATH should show a helpful error
+      - name: "Smoke: npm TUI fallback when Bun unavailable"
+        run: |
+          set -euo pipefail
+          PATH=$(echo "$PATH" | tr ':' '\n' | grep -v bun | tr '\n' ':') \
+            node $(which pensar) 2>/tmp/pensar-tui.txt || true
+          grep -q "TUI mode requires Bun" /tmp/pensar-tui.txt
+
+      # Explicitly invoke under Bun — bypasses the #!/usr/bin/env node shebang
+      - name: "Smoke: npm package under Bun"
+        run: |
+          set -euo pipefail
+          bun $(which pensar) --version
+          bun $(which pensar) --help
+          bun $(which pensar) auth --help
+          bun $(which pensar) pentests --help
+
+      # Standalone binary — self-contained, no Node/Bun runtime needed
+      - name: "Smoke: compiled binary"
+        run: |
+          set -euo pipefail
+          bun run build:binary
+          ./pensar --version
+          ./pensar --help
+          ./pensar auth --help

--- a/README.md
+++ b/README.md
@@ -20,11 +20,9 @@ Want to run from the cloud or integrate it with your CI/CD? See <a href="https:/
   <img src="screenshot.png" alt="Pensar Apex Screenshot" width="800">
 </p> -->
 
-
 ## Use Cases
 
 Apex enables both developers and security professionals to run autonomous and assisted penetration testing directly from the terminal.
-
 
 ### Developers: Run a Pentest in Minutes
 
@@ -39,6 +37,7 @@ This allows teams to quickly identify security issues before they reach producti
 ```
 
 Examples:
+
 - Test a staging environment before deploying
 - Scan a newly launched domain or API
 - Run quick security checks during development
@@ -54,12 +53,12 @@ Security professionals can use Apex as an **agentic offensive security harness**
 
 The `/operator` mode allows engineers to work interactively with the Offensive Security Agent, guiding investigations and chaining tools dynamically.
 
-
 ```bash
 /operator
 ```
 
 Examples:
+
 - Deep investigation of suspicious endpoints
 - Manual exploitation of discovered vulnerabilities
 - Tool orchestration across recon and exploitation phases

--- a/bin/pensar.js
+++ b/bin/pensar.js
@@ -1,282 +1,37 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 
-/**
- * Pensar - AI-Powered Penetration Testing CLI
- *
- * This is the main entry point for the Pensar CLI tool.
- * It supports:
- * - Default (no args): Launches the OpenTUI-based terminal interface
- * - benchmark command: Runs the benchmark CLI
- */
-
-import { fileURLToPath } from "url";
 import { dirname, join } from "path";
-
-// Import package.json directly so Bun can embed it at compile time
-import packageJson from "../package.json";
-import { getCurrentVersion, upgrade } from "../src/core/installation/index.ts";
+import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const cliPath = join(__dirname, "..", "build", "cli.js");
 
-// Get command-line arguments (skip node/bun and script path)
-const args = process.argv.slice(2);
-const command = args[0];
-
-const version = packageJson.version;
-
-// Handle different commands
-if (command === "benchmark") {
-  // Run benchmark CLI
-  const benchmarkPath = join(__dirname, "..", "build", "benchmark.js");
-
-  // Remove "benchmark" from args and pass the rest to benchmark script
-  process.argv = [process.argv[0], benchmarkPath, ...args.slice(1)];
-
-  // Import and run benchmark
-  await import(benchmarkPath);
-} else if (command === "swarm") {
-  const swarmPath = join(__dirname, "..", "build", "swarm.js");
-  process.argv = [process.argv[0], swarmPath, ...args.slice(1)];
-  await import(swarmPath);
-} else if (command === "quicktest") {
-  // Run quicktest CLI
-  const quicktestPath = join(__dirname, "..", "build", "quicktest.js");
-
-  // Remove "quicktest" from args and pass the rest to quicktest script
-  process.argv = [process.argv[0], quicktestPath, ...args.slice(1)];
-
-  // Import and run quicktest
-  await import(quicktestPath);
-} else if (command === "pentest") {
-  // Run pentest CLI
-  const pentestPath = join(__dirname, "..", "build", "pentest.js");
-
-  // Remove "pentest" from args and pass the rest to pentest script
-  process.argv = [process.argv[0], pentestPath, ...args.slice(1)];
-
-  // Import and run pentest
-  await import(pentestPath);
-} else if (command === "auth") {
-  // Run auth CLI
-  const authPath = join(__dirname, "..", "build", "auth.js");
-
-  // Remove "auth" from args and pass the rest to auth script
-  process.argv = [process.argv[0], authPath, ...args.slice(1)];
-
-  // Import and run auth
-  await import(authPath);
-} else if (command === "uninstall") {
-  // Run uninstall CLI
-  const uninstallPath = join(__dirname, "..", "build", "uninstall.js");
-
-  process.argv = [process.argv[0], uninstallPath, ...args.slice(1)];
-
-  await import(uninstallPath);
-} else if (command === "projects") {
-  const p = join(__dirname, "..", "build", "projects.js");
-  process.argv = [process.argv[0], p, ...args.slice(1)];
-  await import(p);
-} else if (command === "pentests") {
-  const p = join(__dirname, "..", "build", "pentests.js");
-  process.argv = [process.argv[0], p, ...args.slice(1)];
-  await import(p);
-} else if (command === "issues") {
-  const p = join(__dirname, "..", "build", "issues.js");
-  process.argv = [process.argv[0], p, ...args.slice(1)];
-  await import(p);
-} else if (command === "fixes") {
-  const p = join(__dirname, "..", "build", "fixes.js");
-  process.argv = [process.argv[0], p, ...args.slice(1)];
-  await import(p);
-} else if (command === "logs") {
-  const p = join(__dirname, "..", "build", "logs.js");
-  process.argv = [process.argv[0], p, ...args.slice(1)];
-  await import(p);
-} else if (command === "upgrade" || command === "update") {
-  const currentVersion = getCurrentVersion();
-  console.log(`Current version: v${currentVersion}`);
-  console.log("Checking for updates...");
-
-  const result = await upgrade({ interactive: true });
-  console.log();
-  console.log(result.message);
-
-  process.exit(result.success ? 0 : 1);
-} else if (
-  command === "version" ||
-  command === "--version" ||
-  command === "-v"
-) {
-  // Show version
-  console.log(`v${version}`);
-} else if (command === "help" || command === "--help" || command === "-h") {
-  // Show help
-  console.log("Pensar - AI-Powered Penetration Testing CLI");
-  console.log();
-  console.log("Usage:");
-  console.log("  pensar              Launch the TUI (Terminal User Interface)");
-  console.log("  pensar uninstall    Uninstall Pensar (keeps sessions, memories, skills)");
-  console.log("  pensar upgrade      Update pensar to the latest version");
-  console.log("  pensar help         Show this help message");
-  console.log("  pensar version      Show version number");
-  console.log("  pensar benchmark    Run the benchmark CLI");
-  console.log("  pensar quicktest    Run a quick penetration test");
-  console.log("  pensar pentest      Run a comprehensive penetration test");
-  console.log(
-    "  pensar swarm        Run parallel pentests on multiple targets"
-  );
-  console.log(
-    "  pensar auth         Connect to Pensar Console for managed inference"
-  );
-  console.log(
-    "  pensar projects     List workspace projects"
-  );
-  console.log(
-    "  pensar pentests     List and manage pentests"
-  );
-  console.log(
-    "  pensar issues       List and manage security issues"
-  );
-  console.log(
-    "  pensar fixes        View security fixes"
-  );
-  console.log(
-    "  pensar logs         View agent execution logs"
-  );
-  console.log();
-  console.log("Options:");
-  console.log("  -h, --help         Show this help message");
-  console.log("  -v, --version      Show version number");
-  console.log();
-  console.log("Benchmark Usage:");
-  console.log("  pensar benchmark <repo-path> [options] [branch1 branch2 ...]");
-  console.log();
-  console.log("Benchmark Options:");
-  console.log("  --all-branches       Test all branches in the repository");
-  console.log("  --limit <number>     Limit the number of branches to test");
-  console.log("  --skip <number>      Skip the first N branches");
-  console.log(
-    "  --model <model>      Specify the AI model to use (default: claude-sonnet-4-5)"
-  );
-  console.log();
-  console.log("Quicktest Usage:");
-  console.log(
-    "  pensar quicktest --target <target> --objective <objective> [options]"
-  );
-  console.log();
-  console.log("Quicktest Options:");
-  console.log(
-    "  --target <target>        Target URL or IP address to test (required)"
-  );
-  console.log(
-    "  --objective <objective>  Objective or goal of the pentest (required)"
-  );
-  console.log(
-    "  --model <model>          AI model to use (default: claude-sonnet-4-5)"
-  );
-  console.log(
-    "  --headers <mode>         Header mode: none, default, custom (default: default)"
-  );
-  console.log(
-    "  --header <name:value>    Add custom header (requires --headers custom)"
-  );
-  console.log();
-  console.log("Pentest Usage:");
-  console.log("  pensar pentest --target <target> [options]");
-  console.log();
-  console.log("Pentest Options:");
-  console.log(
-    "  --target <target>        Target domain or organization (required)"
-  );
-  console.log(
-    "  --model <model>          AI model to use (default: claude-sonnet-4-5)"
-  );
-  console.log(
-    "  --headers <mode>         Header mode: none, default, custom (default: default)"
-  );
-  console.log(
-    "  --header <name:value>    Add custom header (requires --headers custom)"
-  );
-  console.log();
-  console.log("Swarm Usage:");
-  console.log("  pensar swarm <targets> [options]");
-  console.log();
-  console.log("Swarm Arguments:");
-  console.log("  <targets>                JSON string or path to JSON file");
-  console.log();
-  console.log("Swarm Options:");
-  console.log(
-    "  --model <model>          AI model to use (default: claude-sonnet-4-5)"
-  );
-  console.log(
-    "  --headers <mode>         Header mode: none, default, custom (default: default)"
-  );
-  console.log(
-    "  --header <name:value>    Add custom header (requires --headers custom)"
-  );
-  console.log();
-  console.log("Auth Usage:");
-  console.log(
-    "  pensar auth              Login to Pensar Console (or show status if connected)"
-  );
-  console.log("  pensar auth login        Login to Pensar Console");
-  console.log("  pensar auth logout       Disconnect from Pensar Console");
-  console.log("  pensar auth status       Show connection status");
-  console.log();
-  console.log("Uninstall Usage:");
-  console.log(
-    "  pensar uninstall             Fully uninstall Pensar"
-  );
-  console.log(
-    "  pensar uninstall --force     Skip confirmation prompt"
-  );
-  console.log();
-  console.log("Header Modes (for quicktest, pentest, swarm):");
-  console.log("  none                     No custom headers added to requests");
-  console.log(
-    "  default                  Add 'User-Agent: pensar-apex' to all offensive requests"
-  );
-  console.log(
-    "  custom                   Use custom headers defined with --header flag"
-  );
-  console.log();
-  console.log("Examples:");
-  console.log("  pensar");
-  console.log("  pensar benchmark /path/to/vulnerable-app");
-  console.log("  pensar benchmark /path/to/app main develop");
-  console.log("  pensar benchmark /path/to/app --all-branches --limit 3");
-  console.log(
-    "  pensar quicktest --target http://localhost:3000 --objective 'Find SQL injection'"
-  );
-  console.log(
-    "  pensar quicktest --target api.example.com --objective 'API testing' --headers custom --header 'User-Agent: pensar_client123'"
-  );
-  console.log("  pensar pentest --target example.com");
-  console.log(
-    "  pensar pentest --target example.com --headers custom --header 'User-Agent: pensar_client123'"
-  );
-  console.log("  pensar swarm targets.json");
-  console.log("  pensar swarm targets.json --headers none");
-  console.log("  pensar auth");
-  console.log("  pensar auth status");
-  console.log("  pensar auth logout");
-  console.log();
-  console.log("Console API:");
-  console.log("  pensar projects");
-  console.log("  pensar pentests <projectId>");
-  console.log("  pensar issues <projectId>");
-  console.log("  pensar issues get <issueId>");
-  console.log("  pensar fixes <issueId>");
-  console.log("  pensar logs <issueId>");
-} else if (args.length === 0) {
-  // No command specified, run the TUI
-  const appPath = join(__dirname, "..", "build", "index.js");
-  await import(appPath);
-} else {
-  // Unknown command
-  console.error(`Error: Unknown command '${command}'`);
-  console.error();
-  console.error("Run 'pensar --help' for usage information");
-  process.exit(1);
+// Under Node, try to re-exec under Bun if no subcommand given (TUI needs Bun)
+if (typeof globalThis.Bun === "undefined") {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    // No subcommand = TUI mode — try re-exec under Bun
+    const { execFileSync } = await import("child_process");
+    try {
+      execFileSync("bun", [__filename], { stdio: "inherit" });
+      process.exit(0);
+    } catch (err) {
+      if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+        console.error(
+          "TUI mode requires Bun. Install Bun (https://bun.sh) or use a standalone binary release for interactive mode.",
+        );
+        console.error("All other commands work with Node — run 'pensar --help'.");
+        process.exit(1);
+      }
+      if (err && typeof err === "object" && "status" in err) {
+        process.exit(err.status ?? 1);
+      }
+      process.exit(1);
+    }
+  }
+  process.env.PENSAR_NO_TUI = "1";
 }
+
+process.argv = [process.argv[0], cliPath, ...process.argv.slice(2)];
+await import(cliPath);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.111",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
-  "main": "build/index.js",
+  "main": "build/cli.js",
   "type": "module",
   "repository": {
     "type": "git",
@@ -15,12 +15,11 @@
   "files": [
     "build",
     "bin",
-    "src/core/installation",
     "pensar.svg",
     "LICENSE"
   ],
   "scripts": {
-    "build": "bun build src/tui/index.tsx --outdir build --target node --format esm --external sharp && bun build src/cli/auth.ts --outdir build --target node --format esm",
+    "build": "bun build src/cli.ts --outdir build --target node --format esm --splitting --external @opentui/core --external @opentui/react --external @opentui/react/* --external react --external react/jsx-runtime --external react/jsx-dev-runtime --external react-reconciler",
     "generate:ascii": "bun run scripts/generate-ascii-art.ts",
     "generate:models": "bun run scripts/generate-models.ts",
     "build:binary": "bun run generate:ascii && bun build src/cli.ts --compile --outfile pensar",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,69 +49,39 @@ function getAllArgs(flag: string, argv = args): string[] {
 // ---------------------------------------------------------------------------
 
 function showHelp() {
-  console.log("Pensar - AI-Powered Penetration Testing CLI");
-  console.log();
-  console.log("Usage:");
-  console.log("  pensar                             Launch the TUI");
-  console.log(
-    "  pensar pentest [options]            Run a full pentest orchestration",
-  );
-  console.log(
-    "  pensar targeted-pentest [options]   Run a targeted pentest on a single target",
-  );
-  console.log(
-    "  pensar auth                         Connect to Pensar Console",
-  );
-  console.log(
-    "  pensar uninstall                    Uninstall Pensar (keeps sessions, memories, skills)",
-  );
-  console.log(
-    "  pensar projects                     List workspace projects",
-  );
-  console.log(
-    "  pensar pentests                     List and manage pentests",
-  );
-  console.log(
-    "  pensar issues                       List and manage security issues",
-  );
-  console.log(
-    "  pensar fixes                        View security fixes",
-  );
-  console.log(
-    "  pensar logs                         View agent execution logs",
-  );
-  console.log(
-    "  pensar upgrade                      Update pensar to the latest version",
-  );
-  console.log(
-    "  pensar doctor                       Check dependencies and install missing tools",
-  );
-  console.log("  pensar help                         Show this help message");
-  console.log("  pensar version                      Show version number");
-  console.log();
-  console.log("pentest options:");
-  console.log("  --target <url>     (required) Target URL / domain / IP");
-  console.log(
-    "  --cwd <path>       Source code path — enables whitebox attack surface",
-  );
-  console.log(
-    "  --mode <mode>      Pentest mode: exfil (pivoting & flag extraction)",
-  );
-  console.log("  --model <model>    AI model (default: claude-sonnet-4-5)");
-  console.log();
-  console.log("targeted-pentest options:");
-  console.log("  --target <url>          (required) Target URL / domain / IP");
-  console.log(
-    "  --objective <text>      (required, repeatable) Testing objective",
-  );
-  console.log(
-    "  --model <model>         AI model (default: claude-sonnet-4-5)",
-  );
-  console.log();
-  console.log("Global options:");
-  console.log("  -h, --help         Show this help message");
-  console.log("  -v, --version      Show version number");
-  console.log();
+  console.log(`Pensar - AI-Powered Penetration Testing CLI
+
+Usage:
+  pensar                             Launch the TUI
+  pensar pentest [options]            Run a full pentest orchestration
+  pensar targeted-pentest [options]   Run a targeted pentest on a single target
+  pensar auth                         Connect to Pensar Console
+  pensar uninstall                    Uninstall Pensar (keeps sessions, memories, skills)
+  pensar projects                     List workspace projects
+  pensar pentests                     List and manage pentests
+  pensar issues                       List and manage security issues
+  pensar fixes                        View security fixes
+  pensar logs                         View agent execution logs
+  pensar upgrade                      Update pensar to the latest version
+  pensar doctor                       Check dependencies and install missing tools
+  pensar help                         Show this help message
+  pensar version                      Show version number
+
+pentest options:
+  --target <url>     (required) Target URL / domain / IP
+  --cwd <path>       Source code path — enables whitebox attack surface
+  --mode <mode>      Pentest mode: exfil (pivoting & flag extraction)
+  --model <model>    AI model (default: claude-sonnet-4-5)
+
+targeted-pentest options:
+  --target <url>          (required) Target URL / domain / IP
+  --objective <text>      (required, repeatable) Testing objective
+  --model <model>         AI model (default: claude-sonnet-4-5)
+
+Global options:
+  -h, --help         Show this help message
+  -v, --version      Show version number
+`);
 }
 
 // ---------------------------------------------------------------------------
@@ -142,14 +112,13 @@ async function runPentest() {
     console.warn(modeWarning);
   }
 
-  console.log("=".repeat(60));
-  console.log("PENTEST ORCHESTRATION");
-  console.log("=".repeat(60));
-  console.log(`Target:  ${target}`);
-  if (cwd) console.log(`Cwd:     ${cwd} (whitebox)`);
-  if (exfilMode) console.log(`Mode:    exfil`);
-  console.log(`Model:   ${model}`);
-  console.log();
+  const sep = "=".repeat(60);
+  console.log(`${sep}
+PENTEST ORCHESTRATION
+${sep}
+Target:  ${target}${cwd ? `\nCwd:     ${cwd} (whitebox)` : ""}${exfilMode ? "\nMode:    exfil" : ""}
+Model:   ${model}
+`);
 
   const session = await sessions.create({
     name: cwd ? "Whitebox Pentest" : "Blackbox Pentest",
@@ -175,14 +144,13 @@ async function runPentest() {
       },
     });
 
-  console.log();
-  console.log("=".repeat(60));
-  console.log("RESULTS");
-  console.log("=".repeat(60));
-  console.log(`Findings:  ${findings.length}`);
-  console.log(`Path:      ${findingsPath}`);
-  console.log(`POCs:      ${pocsPath}`);
-  if (reportPath) console.log(`Report:    ${reportPath}`);
+  console.log(`
+${sep}
+RESULTS
+${sep}
+Findings:  ${findings.length}
+Path:      ${findingsPath}
+POCs:      ${pocsPath}${reportPath ? `\nReport:    ${reportPath}` : ""}`);
 }
 
 async function runTargetedPentest() {
@@ -209,14 +177,18 @@ async function runTargetedPentest() {
     process.exit(1);
   }
 
-  console.log("=".repeat(60));
-  console.log("TARGETED PENTEST");
-  console.log("=".repeat(60));
-  console.log(`Target:  ${target}`);
-  console.log(`Model:   ${model}`);
-  console.log("Objectives:");
-  objectives.forEach((o, i) => console.log(`  ${i + 1}. ${o}`));
-  console.log();
+  const sep = "=".repeat(60);
+  const objectivesList = objectives
+    .map((o, i) => `  ${i + 1}. ${o}`)
+    .join("\n");
+  console.log(`${sep}
+TARGETED PENTEST
+${sep}
+Target:  ${target}
+Model:   ${model}
+Objectives:
+${objectivesList}
+`);
 
   const session = await sessions.create({
     name: "Targeted Pentest",
@@ -231,23 +203,21 @@ async function runTargetedPentest() {
     authConfig: buildAuthConfig(pensarConfig),
   });
 
-  console.log();
-  console.log("=".repeat(60));
-  console.log("RESULTS");
-  console.log("=".repeat(60));
-  console.log(`Findings:  ${findings.length}`);
-  console.log(`Path:      ${findingsPath}`);
-  console.log(`POCs:      ${pocsPath}`);
+  console.log(`
+${sep}
+RESULTS
+${sep}
+Findings:  ${findings.length}
+Path:      ${findingsPath}
+POCs:      ${pocsPath}`);
 }
 
 async function runUpgrade() {
   const currentVersion = getCurrentVersion();
-  console.log(`Current version: v${currentVersion}`);
-  console.log("Checking for updates...");
+  console.log(`Current version: v${currentVersion}\nChecking for updates...`);
 
   const result = await upgrade({ interactive: true });
-  console.log();
-  console.log(result.message);
+  console.log(`\n${result.message}`);
 
   process.exit(result.success ? 0 : 1);
 }
@@ -291,6 +261,13 @@ if (command === "version" || command === "--version" || command === "-v") {
   const { runDoctor } = await import("./core/doctor");
   await runDoctor();
 } else if (args.length === 0) {
+  if (process.env.PENSAR_NO_TUI === "1") {
+    console.error(
+      "TUI mode requires Bun. Install Bun (https://bun.sh) or use a standalone binary release for interactive mode.",
+    );
+    console.error("All other commands work with Node — run 'pensar --help'.");
+    process.exit(1);
+  }
   await import("./tui/index.tsx");
 } else {
   console.error(`Error: Unknown command '${command}'`);

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -34,14 +34,18 @@ import * as readline from "readline";
 
 function openUrl(url: string): void {
   try {
+    const { spawn } =
+      require("child_process") as typeof import("child_process");
     const platform = process.platform;
+    let cmd: ReturnType<typeof spawn>;
     if (platform === "darwin") {
-      Bun.spawn(["open", url]);
+      cmd = spawn("open", [url]);
     } else if (platform === "win32") {
-      Bun.spawn(["cmd", "/c", "start", url]);
+      cmd = spawn("cmd", ["/c", "start", url]);
     } else {
-      Bun.spawn(["xdg-open", url]);
+      cmd = spawn("xdg-open", [url]);
     }
+    cmd.on("error", () => {}); // fire-and-forget — user sees the URL as fallback
   } catch {
     // Browser open failed — user will see the fallback URL
   }
@@ -99,8 +103,9 @@ async function login(): Promise<void> {
     }
   }
 
-  console.log("\nPensar Console — Managed Inference");
-  console.log("Connect for usage-based AI inference. No API keys needed.\n");
+  console.log(
+    "\nPensar Console — Managed Inference\nConnect for usage-based AI inference. No API keys needed.\n",
+  );
 
   const apiUrl = getPensarApiUrl();
   const flowInfo = await startDeviceFlow(apiUrl);
@@ -110,12 +115,9 @@ async function login(): Promise<void> {
 
     openUrl(deviceInfo.verification_uri_complete);
 
-    console.log("A browser window should have opened.");
     console.log(
-      `If not, open this URL:\n  ${deviceInfo.verification_uri_complete}\n`,
+      `A browser window should have opened.\nIf not, open this URL:\n  ${deviceInfo.verification_uri_complete}\n\nYour code: ${deviceInfo.user_code}\n\nWaiting for browser authorization...`,
     );
-    console.log(`Your code: ${deviceInfo.user_code}\n`);
-    console.log("Waiting for browser authorization...");
 
     const tokens = await pollWorkOSToken({
       clientId,
@@ -136,12 +138,9 @@ async function login(): Promise<void> {
 
     openUrl(deviceInfo.verificationUriComplete);
 
-    console.log("A browser window should have opened.");
     console.log(
-      `If not, open this URL:\n  ${deviceInfo.verificationUriComplete}\n`,
+      `A browser window should have opened.\nIf not, open this URL:\n  ${deviceInfo.verificationUriComplete}\n\nYour code: ${deviceInfo.userCode}\n\nWaiting for browser authorization...`,
     );
-    console.log(`Your code: ${deviceInfo.userCode}\n`);
-    console.log("Waiting for browser authorization...");
 
     const data = await pollLegacyToken({
       apiUrl,
@@ -185,9 +184,8 @@ async function handleWorkspaces(
   const consoleUrl = wsResult.consoleUrl ?? getPensarConsoleUrl();
 
   if (workspaces.length === 0) {
-    console.log("\nNo workspaces found. Opening browser to create one...");
     console.log(
-      `If the browser didn't open, visit: ${consoleUrl}/create-workspace?redirect=/credits\n`,
+      `\nNo workspaces found. Opening browser to create one...\nIf the browser didn't open, visit: ${consoleUrl}/create-workspace?redirect=/credits\n`,
     );
     openUrl(`${consoleUrl}/create-workspace?redirect=/credits`);
     console.log("Waiting for workspace creation...");
@@ -209,9 +207,9 @@ async function handleWorkspaces(
     gatewaySigningKey: result.signingKey ?? null,
   });
 
-  console.log("\n✓ Connected to Pensar Console");
-  console.log(`  Workspace: ${workspace.name} (${workspace.slug})`);
-  console.log(`  Credits: $${result.billing.balance.toFixed(2)}`);
+  console.log(
+    `\n✓ Connected to Pensar Console\n  Workspace: ${workspace.name} (${workspace.slug})\n  Credits: $${result.billing.balance.toFixed(2)}`,
+  );
 
   if (!result.confirmed && result.billingUrl) {
     console.log(
@@ -245,13 +243,18 @@ async function status(): Promise<void> {
   const appConfig = await config.get();
 
   if (!isConnected(appConfig)) {
-    console.log("Not connected to Pensar Console.");
-    console.log("\nRun `pensar auth login` to connect.");
+    console.log(
+      "Not connected to Pensar Console.\n\nRun `pensar auth login` to connect.",
+    );
     return;
   }
 
   // If using an API key without stored workspace info, resolve it from the server
-  if (!appConfig.accessToken && appConfig.pensarAPIKey && !appConfig.workspaceSlug) {
+  if (
+    !appConfig.accessToken &&
+    appConfig.pensarAPIKey &&
+    !appConfig.workspaceSlug
+  ) {
     try {
       const apiUrl = getPensarApiUrl();
       const res = await fetch(`${apiUrl}/auth/validate`, {
@@ -275,29 +278,23 @@ async function status(): Promise<void> {
     }
   }
 
-  console.log("✓ Connected to Pensar Console");
+  const authMethod = appConfig.accessToken ? "WorkOS" : "API key";
   console.log(
-    `  Workspace: ${appConfig.workspaceSlug ?? "not set"}`,
+    `✓ Connected to Pensar Console\n  Workspace: ${appConfig.workspaceSlug ?? "not set"}\n  Auth: ${authMethod}`,
   );
-  if (appConfig.accessToken) {
-    console.log("  Auth: WorkOS");
-  } else {
-    console.log("  Auth: API key");
-  }
 }
 
 function showHelp(): void {
-  console.log("Pensar Auth — Connect to Pensar Console\n");
-  console.log("Usage:");
-  console.log(
-    "  pensar auth              Login to Pensar Console (or show status if connected)",
-  );
-  console.log("  pensar auth login        Login to Pensar Console");
-  console.log("  pensar auth logout       Disconnect from Pensar Console");
-  console.log("  pensar auth status       Show connection status");
-  console.log();
-  console.log("Options:");
-  console.log("  -h, --help               Show this help message");
+  console.log(`Pensar Auth — Connect to Pensar Console
+
+Usage:
+  pensar auth              Login to Pensar Console (or show status if connected)
+  pensar auth login        Login to Pensar Console
+  pensar auth logout       Disconnect from Pensar Console
+  pensar auth status       Show connection status
+
+Options:
+  -h, --help               Show this help message`);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/fixes.ts
+++ b/src/cli/fixes.ts
@@ -11,13 +11,14 @@
 import { listFixes, getFix } from "../core/api/issues";
 
 function showHelp(): void {
-  console.log("pensar fixes — View security fixes via the Pensar API\n");
-  console.log("Usage:");
-  console.log("  pensar fixes <issueId>         List fixes for an issue");
-  console.log("  pensar fixes get <fixId>       Get fix details (includes diff)");
-  console.log();
-  console.log("Options:");
-  console.log("  -h, --help                     Show this help message");
+  console.log(`pensar fixes — View security fixes via the Pensar API
+
+Usage:
+  pensar fixes <issueId>         List fixes for an issue
+  pensar fixes get <fixId>       Get fix details (includes diff)
+
+Options:
+  -h, --help                     Show this help message`);
 }
 
 async function main(): Promise<void> {

--- a/src/cli/issues.ts
+++ b/src/cli/issues.ts
@@ -9,11 +9,7 @@
  *   pensar issues update <issueId> [opts]         Update an issue
  */
 
-import {
-  listIssues,
-  getIssue,
-  updateIssue,
-} from "../core/api/issues";
+import { listIssues, getIssue, updateIssue } from "../core/api/issues";
 
 function getFlag(flag: string, argv: string[]): string | undefined {
   const idx = argv.indexOf(flag);
@@ -21,27 +17,28 @@ function getFlag(flag: string, argv: string[]): string | undefined {
 }
 
 function showHelp(): void {
-  console.log("pensar issues — Manage security issues via the Pensar API\n");
-  console.log("Usage:");
-  console.log("  pensar issues <projectId> [filters]            List issues for a project");
-  console.log("  pensar issues get <issueId>                    Get issue details");
-  console.log("  pensar issues update <issueId> [options]       Update an issue");
-  console.log();
-  console.log("List filters:");
-  console.log("  --status <status>     Filter: open, closed, false-positive, in-review");
-  console.log("  --severity <sev>      Filter: critical, high, medium, low");
-  console.log("  --scan <scanId>       Filter by scan ID");
-  console.log("  --branch <branch>     Filter by branch");
-  console.log();
-  console.log("Update options:");
-  console.log("  --status <status>         New status");
-  console.log("  --closed-reason <reason>  Reason for closing");
-  console.log("  --closed-comments <text>  Additional comments");
-  console.log("  --false-positive          Flag as false positive");
-  console.log("  --fp-reason <reason>      Reason for false positive flag");
-  console.log();
-  console.log("Options:");
-  console.log("  -h, --help                Show this help message");
+  console.log(`pensar issues — Manage security issues via the Pensar API
+
+Usage:
+  pensar issues <projectId> [filters]            List issues for a project
+  pensar issues get <issueId>                    Get issue details
+  pensar issues update <issueId> [options]       Update an issue
+
+List filters:
+  --status <status>     Filter: open, closed, false-positive, in-review
+  --severity <sev>      Filter: critical, high, medium, low
+  --scan <scanId>       Filter by scan ID
+  --branch <branch>     Filter by branch
+
+Update options:
+  --status <status>         New status
+  --closed-reason <reason>  Reason for closing
+  --closed-comments <text>  Additional comments
+  --false-positive          Flag as false positive
+  --fp-reason <reason>      Reason for false positive flag
+
+Options:
+  -h, --help                Show this help message`);
 }
 
 async function main(): Promise<void> {
@@ -67,7 +64,9 @@ async function main(): Promise<void> {
       const issueId = args[1];
       if (!issueId) {
         console.error("Error: issue ID is required");
-        console.error("Usage: pensar issues update <issueId> [--status <status>] ...");
+        console.error(
+          "Usage: pensar issues update <issueId> [--status <status>] ...",
+        );
         process.exit(1);
       }
       const status = getFlag("--status", args) as

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -16,23 +16,24 @@ function getFlag(flag: string, argv: string[]): string | undefined {
 }
 
 function showHelp(): void {
-  console.log("pensar logs — View agent execution logs via the Pensar API\n");
-  console.log("Usage:");
-  console.log("  pensar logs <issueId> [filters]                 List agent logs");
-  console.log("  pensar logs search <issueId> <query> [options]  Search agent logs");
-  console.log();
-  console.log("List filters:");
-  console.log("  --level <level>       Filter: debug, info, warn, error");
-  console.log("  --role <role>         Filter: assistant, user, system, tool-call, tool-result");
-  console.log("  --limit <n>           Max entries (default: 100, max: 500)");
-  console.log();
-  console.log("Search options:");
-  console.log("  --level <level>       Filter: debug, info, warn, error");
-  console.log("  --role <role>         Filter: assistant, user, system, tool-call, tool-result");
-  console.log("  --context <n>         Context lines around matches (default: 3)");
-  console.log();
-  console.log("Options:");
-  console.log("  -h, --help            Show this help message");
+  console.log(`pensar logs — View agent execution logs via the Pensar API
+
+Usage:
+  pensar logs <issueId> [filters]                 List agent logs
+  pensar logs search <issueId> <query> [options]  Search agent logs
+
+List filters:
+  --level <level>       Filter: debug, info, warn, error
+  --role <role>         Filter: assistant, user, system, tool-call, tool-result
+  --limit <n>           Max entries (default: 100, max: 500)
+
+Search options:
+  --level <level>       Filter: debug, info, warn, error
+  --role <role>         Filter: assistant, user, system, tool-call, tool-result
+  --context <n>         Context lines around matches (default: 3)
+
+Options:
+  -h, --help            Show this help message`);
 }
 
 async function main(): Promise<void> {
@@ -50,7 +51,9 @@ async function main(): Promise<void> {
       const query = args[2];
       if (!issueId || !query) {
         console.error("Error: issue ID and query are required");
-        console.error("Usage: pensar logs search <issueId> <query> [--level <level>] [--role <role>] [--context <n>]");
+        console.error(
+          "Usage: pensar logs search <issueId> <query> [--level <level>] [--role <role>] [--context <n>]",
+        );
         process.exit(1);
       }
       const level = getFlag("--level", args) as

--- a/src/cli/pentests.ts
+++ b/src/cli/pentests.ts
@@ -9,11 +9,7 @@
  *   pensar pentests dispatch <projectId> [opts]        Dispatch a new pentest
  */
 
-import {
-  listScans,
-  getScan,
-  dispatchPentest,
-} from "../core/api/issues";
+import { listScans, getScan, dispatchPentest } from "../core/api/issues";
 
 function getFlag(flag: string, argv: string[]): string | undefined {
   const idx = argv.indexOf(flag);
@@ -21,18 +17,19 @@ function getFlag(flag: string, argv: string[]): string | undefined {
 }
 
 function showHelp(): void {
-  console.log("pensar pentests — Manage pentests via the Pensar API\n");
-  console.log("Usage:");
-  console.log("  pensar pentests <projectId>                     List pentests for a project");
-  console.log("  pensar pentests get <pentestId>                  Get pentest details");
-  console.log("  pensar pentests dispatch <projectId> [options]   Dispatch a new pentest");
-  console.log();
-  console.log("dispatch options:");
-  console.log("  --branch <branch>     Target branch to scan");
-  console.log("  --level <level>       Scan depth: priority (default), full");
-  console.log();
-  console.log("Options:");
-  console.log("  -h, --help            Show this help message");
+  console.log(`pensar pentests — Manage pentests via the Pensar API
+
+Usage:
+  pensar pentests <projectId>                     List pentests for a project
+  pensar pentests get <pentestId>                  Get pentest details
+  pensar pentests dispatch <projectId> [options]   Dispatch a new pentest
+
+dispatch options:
+  --branch <branch>     Target branch to scan
+  --level <level>       Scan depth: priority (default), full
+
+Options:
+  -h, --help            Show this help message`);
 }
 
 async function main(): Promise<void> {
@@ -58,11 +55,16 @@ async function main(): Promise<void> {
       const projectId = args[1];
       if (!projectId) {
         console.error("Error: project ID is required");
-        console.error("Usage: pensar pentests dispatch <projectId> [--branch <branch>] [--level <priority|full>]");
+        console.error(
+          "Usage: pensar pentests dispatch <projectId> [--branch <branch>] [--level <priority|full>]",
+        );
         process.exit(1);
       }
       const branch = getFlag("--branch", args);
-      const scanLevel = getFlag("--level", args) as "priority" | "full" | undefined;
+      const scanLevel = getFlag("--level", args) as
+        | "priority"
+        | "full"
+        | undefined;
       const result = await dispatchPentest(projectId, { branch, scanLevel });
       console.log(JSON.stringify(result, null, 2));
     } else {

--- a/src/cli/projects.ts
+++ b/src/cli/projects.ts
@@ -11,12 +11,13 @@
 import { listProjects } from "../core/api/issues";
 
 function showHelp(): void {
-  console.log("pensar projects — List workspace projects\n");
-  console.log("Usage:");
-  console.log("  pensar projects              List all projects");
-  console.log();
-  console.log("Options:");
-  console.log("  -h, --help                   Show this help message");
+  console.log(`pensar projects — List workspace projects
+
+Usage:
+  pensar projects              List all projects
+
+Options:
+  -h, --help                   Show this help message`);
 }
 
 async function main(): Promise<void> {

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -45,7 +45,10 @@ function findBinaryPath(): string | null {
   // For compiled binaries, process.execPath IS the pensar binary itself.
   // This is more reliable than `which` when multiple installations coexist.
   const execName =
-    process.execPath.split("/").pop()?.replace(/\.exe$/, "") ?? "";
+    process.execPath
+      .split("/")
+      .pop()
+      ?.replace(/\.exe$/, "") ?? "";
   const isCompiledBinary =
     execName !== "bun" && execName !== "node" && execName !== "bun-debug";
   if (isCompiledBinary && require("fs").existsSync(process.execPath)) {
@@ -193,15 +196,14 @@ async function uninstall(force: boolean): Promise<void> {
   const method = detectInstallMethod();
   const pensarDir = getPensarDir();
 
-  console.log("Pensar Uninstall");
-  console.log();
+  console.log(`Pensar Uninstall
 
-  console.log(`  Install method:  ${method}`);
-  console.log(`  Binary removal:  ${getUninstallDescription(method)}`);
-  console.log(`  Data directory:  ${pensarDir}`);
-  console.log();
-  console.log("  Preserved data:  sessions, memories, skills");
-  console.log();
+  Install method:  ${method}
+  Binary removal:  ${getUninstallDescription(method)}
+  Data directory:  ${pensarDir}
+
+  Preserved data:  sessions, memories, skills
+`);
 
   if (!force) {
     const answer = await prompt("Proceed with uninstall? (y/N): ");
@@ -257,27 +259,22 @@ async function uninstall(force: boolean): Promise<void> {
   }
 
   if (method === "binary") {
-    console.log();
     console.log(
-      "  Note: You may want to remove the PATH export from your shell config",
-    );
-    console.log(
-      "  (~/.bashrc, ~/.zshrc, etc.) if it was added during install.",
+      "\n  Note: You may want to remove the PATH export from your shell config\n  (~/.bashrc, ~/.zshrc, etc.) if it was added during install.",
     );
   }
 }
 
 function showHelp(): void {
-  console.log("Pensar Uninstall — Remove Pensar from your system\n");
-  console.log("Usage:");
-  console.log(
-    "  pensar uninstall             Uninstall Pensar (keeps sessions, memories, skills)",
-  );
-  console.log("  pensar uninstall --force     Skip confirmation prompt");
-  console.log();
-  console.log("Options:");
-  console.log("  --force, -f          Skip confirmation prompt");
-  console.log("  -h, --help           Show this help message");
+  console.log(`Pensar Uninstall — Remove Pensar from your system
+
+Usage:
+  pensar uninstall             Uninstall Pensar (keeps sessions, memories, skills)
+  pensar uninstall --force     Skip confirmation prompt
+
+Options:
+  --force, -f          Skip confirmation prompt
+  -h, --help           Show this help message`);
 }
 
 async function main(): Promise<void> {

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -449,10 +449,14 @@ function wrapToolsWithApprovalGate(
           }
           throw err;
         }
-        console.error(`[approval-gate] ${name} (${toolCallId}): approved, executing`);
+        console.error(
+          `[approval-gate] ${name} (${toolCallId}): approved, executing`,
+        );
 
         const result = await originalExecute(args, options);
-        console.error(`[approval-gate] ${name} (${toolCallId}): execute finished`);
+        console.error(
+          `[approval-gate] ${name} (${toolCallId}): execute finished`,
+        );
         return result;
       },
     };

--- a/src/core/agents/offSecAgent/tools/createFile.ts
+++ b/src/core/agents/offSecAgent/tools/createFile.ts
@@ -80,7 +80,9 @@ async function executeLocalCreate(
     const dir = dirname(filePath);
     console.error(`[create_file:local] mkdir ${dir}`);
     await mkdir(dir, { recursive: true });
-    console.error(`[create_file:local] mkdir done, writing ${content.length} bytes`);
+    console.error(
+      `[create_file:local] mkdir done, writing ${content.length} bytes`,
+    );
     await writeFile(filePath, content, "utf-8");
     console.error(`[create_file:local] writeFile done`);
 

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -127,7 +127,12 @@ export function createPensarModel(
         raw: undefined,
       };
       let usage: LanguageModelV3Usage = {
-        inputTokens: { total: 0, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
+        inputTokens: {
+          total: 0,
+          noCache: undefined,
+          cacheRead: undefined,
+          cacheWrite: undefined,
+        },
         outputTokens: { total: 0, text: undefined, reasoning: undefined },
       };
 
@@ -289,7 +294,8 @@ export function createPensarModel(
         async start(controller) {
           let inputTokens = 0;
           let outputTokens = 0;
-          let finishReasonUnified: LanguageModelV3FinishReason["unified"] = "other";
+          let finishReasonUnified: LanguageModelV3FinishReason["unified"] =
+            "other";
           let finishReasonRaw: string | undefined;
           let startEmitted = false;
           // Track active content blocks for proper id mapping
@@ -299,14 +305,16 @@ export function createPensarModel(
           let activeToolInput = "";
 
           if (abortSignal) {
-            abortSignal.addEventListener("abort", () => {
-              logError(
-                `  abort signal fired during stream (reason=${abortSignal.reason}), activeToolId=${activeToolId}, activeToolName=${activeToolName}, inputLen=${activeToolInput.length}`,
-              );
-              logError(
-                `  abort stack: ${new Error("abort-trace").stack}`,
-              );
-            }, { once: true });
+            abortSignal.addEventListener(
+              "abort",
+              () => {
+                logError(
+                  `  abort signal fired during stream (reason=${abortSignal.reason}), activeToolId=${activeToolId}, activeToolName=${activeToolName}, inputLen=${activeToolInput.length}`,
+                );
+                logError(`  abort stack: ${new Error("abort-trace").stack}`);
+              },
+              { once: true },
+            );
           }
 
           let eventCount = 0;
@@ -316,7 +324,9 @@ export function createPensarModel(
               const now = Date.now();
               const gap = now - lastEventTime;
               if (gap > 5000) {
-                logInfo(`  SSE gap: ${gap}ms between events (event #${eventCount + 1})`);
+                logInfo(
+                  `  SSE gap: ${gap}ms between events (event #${eventCount + 1})`,
+                );
               }
               lastEventTime = now;
               eventCount++;
@@ -480,8 +490,17 @@ export function createPensarModel(
                 raw: finishReasonRaw,
               },
               usage: {
-                inputTokens: { total: inputTokens, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
-                outputTokens: { total: outputTokens, text: undefined, reasoning: undefined },
+                inputTokens: {
+                  total: inputTokens,
+                  noCache: undefined,
+                  cacheRead: undefined,
+                  cacheWrite: undefined,
+                },
+                outputTokens: {
+                  total: outputTokens,
+                  text: undefined,
+                  reasoning: undefined,
+                },
               },
             });
             controller.close();

--- a/src/core/ai/providers/pensarFormatters.ts
+++ b/src/core/ai/providers/pensarFormatters.ts
@@ -20,16 +20,26 @@ export function convertToBedrockFormat(
 }
 
 function getDefaultMaxOutputTokens(modelId: string): number {
-  if (modelId.includes("claude-opus-4-6") || modelId.includes("claude-sonnet-4-6")) {
+  if (
+    modelId.includes("claude-opus-4-6") ||
+    modelId.includes("claude-sonnet-4-6")
+  ) {
     return 128_000;
   }
-  if (modelId.includes("claude-sonnet-4-5") || modelId.includes("claude-opus-4-5") || modelId.includes("claude-haiku-4-5")) {
+  if (
+    modelId.includes("claude-sonnet-4-5") ||
+    modelId.includes("claude-opus-4-5") ||
+    modelId.includes("claude-haiku-4-5")
+  ) {
     return 64_000;
   }
   if (modelId.includes("claude-opus-4-1")) {
     return 32_000;
   }
-  if (modelId.includes("claude-sonnet-4-") || modelId.includes("claude-3-7-sonnet")) {
+  if (
+    modelId.includes("claude-sonnet-4-") ||
+    modelId.includes("claude-3-7-sonnet")
+  ) {
     return 64_000;
   }
   if (modelId.includes("claude-opus-4-")) {

--- a/src/core/installation/index.ts
+++ b/src/core/installation/index.ts
@@ -70,7 +70,11 @@ export function detectInstallMethod(): InstallMethod {
   // Compiled Bun binaries have process.execPath pointing to the binary itself
   // (e.g. ~/.local/bin/pensar), while interpreted scripts have it pointing to
   // the runtime (e.g. ~/.bun/bin/bun or /usr/local/bin/node).
-  const execName = execPath.split("/").pop()?.replace(/\.exe$/, "") ?? "";
+  const execName =
+    execPath
+      .split("/")
+      .pop()
+      ?.replace(/\.exe$/, "") ?? "";
   const isInterpreter =
     execName === "bun" || execName === "node" || execName === "bun-debug";
 

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -739,11 +739,7 @@ export function normalizeMessages(messages: ModelMessage[]): ModelMessage[] {
         ...prev,
         content: `${prev.content}\n\n${msg.content}`,
       };
-    } else if (
-      prev &&
-      prev.role === "user" &&
-      msg.role === "user"
-    ) {
+    } else if (prev && prev.role === "user" && msg.role === "user") {
       // One or both have structured content — replace with the latest
       result[result.length - 1] = msg;
     } else {
@@ -768,10 +764,7 @@ function fixToolOutputs(messages: ModelMessage[]): ModelMessage[] {
     let partChanged = false;
     const fixedContent = (msg.content as Array<Record<string, unknown>>).map(
       (part) => {
-        if (
-          part.type === "tool-result" &&
-          typeof part.output === "string"
-        ) {
+        if (part.type === "tool-result" && typeof part.output === "string") {
           partChanged = true;
           return { ...part, output: { type: "text", value: part.output } };
         }

--- a/src/core/session/persistence.test.ts
+++ b/src/core/session/persistence.test.ts
@@ -702,9 +702,7 @@ describe("normalizeMessages", () => {
     expect(result[0].role).toBe("user");
     expect(result[1].role).toBe("assistant");
     expect(result[2].role).toBe("user");
-    expect((result[2] as { content: string }).content).toBe(
-      "retry1\n\nretry2",
-    );
+    expect((result[2] as { content: string }).content).toBe("retry1\n\nretry2");
     expect(result[3].role).toBe("assistant");
   });
 
@@ -730,7 +728,12 @@ describe("normalizeMessages", () => {
         },
       ]),
       makeMsg("tool", [
-        { type: "tool-result", toolCallId: "tc-1", toolName: "cmd", result: "ok" },
+        {
+          type: "tool-result",
+          toolCallId: "tc-1",
+          toolName: "cmd",
+          result: "ok",
+        },
       ]),
       makeMsg("user", "next"),
     ];
@@ -783,9 +786,11 @@ describe("normalizeMessages", () => {
       ]),
     ];
     const result = normalizeMessages(msgs);
-    const parts = (result.find((m) => m.role === "tool") as {
-      content: Array<Record<string, unknown>>;
-    }).content;
+    const parts = (
+      result.find((m) => m.role === "tool") as {
+        content: Array<Record<string, unknown>>;
+      }
+    ).content;
     expect(parts[0].output).toEqual({ type: "json", value: { ok: true } });
   });
 });

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -40,7 +40,8 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
 
   const alreadyConnected = isConnected(appConfig.data);
   const hasWorkspace = !!appConfig.data.workspaceId;
-  const needsWorkspace = alreadyConnected && !hasWorkspace && !!appConfig.data.accessToken;
+  const needsWorkspace =
+    alreadyConnected && !hasWorkspace && !!appConfig.data.accessToken;
 
   const [step, setStep] = useState<AuthStep>(
     needsWorkspace ? "requesting" : alreadyConnected ? "success" : "start",

--- a/src/tui/components/responsible-use-disclosure.tsx
+++ b/src/tui/components/responsible-use-disclosure.tsx
@@ -18,8 +18,8 @@ export function ResponsibleUseDisclosure({
     <box flexDirection="column" gap={1}>
       <text fg={colors.warning}>IMPORTANT: Read Before Use</text>
       <text fg={colors.text}>
-        This penetration testing tool is designed for AUTHORIZED security testing
-        only.
+        This penetration testing tool is designed for AUTHORIZED security
+        testing only.
       </text>
       <box flexDirection="column" marginBottom={1}>
         <text fg={colors.error}>

--- a/src/tui/components/shared/prompt-input-logic.test.ts
+++ b/src/tui/components/shared/prompt-input-logic.test.ts
@@ -510,17 +510,17 @@ describe("computeVisibleWindow", () => {
 
   it("correctly identifies scroll indicators", () => {
     const suggestions = makeSuggestions(15);
-    
+
     // At the top
     const top = computeVisibleWindow(suggestions, 0, 5);
     expect(top.hasMore).toBe(false);
     expect(top.hasMoreBelow).toBe(true);
-    
+
     // In the middle
     const middle = computeVisibleWindow(suggestions, 7, 5);
     expect(middle.hasMore).toBe(true);
     expect(middle.hasMoreBelow).toBe(true);
-    
+
     // At the bottom
     const bottom = computeVisibleWindow(suggestions, 14, 5);
     expect(bottom.hasMore).toBe(true);

--- a/src/tui/components/shared/prompt-input-logic.ts
+++ b/src/tui/components/shared/prompt-input-logic.ts
@@ -281,7 +281,7 @@ export function computeVisibleWindow(
 
   // Compute window centered on selected index
   const safeSelectedIndex = Math.max(0, selectedIndex);
-  
+
   // Try to center the selected item in the window
   let start = Math.max(0, safeSelectedIndex - Math.floor(maxVisible / 2));
   let end = start + maxVisible;

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -370,7 +370,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
         {/* Scroll indicator for more suggestions above */}
         {windowedView.hasMore && (
           <box flexDirection="row" gap={1}>
-            <text fg={colors.textMuted}>  ↑</text>
+            <text fg={colors.textMuted}> ↑</text>
             <text fg={colors.textMuted}>
               {windowedView.start} more above...
             </text>
@@ -399,7 +399,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
         {/* Scroll indicator for more suggestions below */}
         {windowedView.hasMoreBelow && (
           <box flexDirection="row" gap={1}>
-            <text fg={colors.textMuted}>  ↓</text>
+            <text fg={colors.textMuted}> ↓</text>
             <text fg={colors.textMuted}>
               {suggestions.length - windowedView.end} more below...
             </text>

--- a/src/tui/terminal-focus.ts
+++ b/src/tui/terminal-focus.ts
@@ -71,7 +71,7 @@ export function setupTerminalFocusHandling(
     log("Terminal gained focus");
     showCursor();
     renderer.requestRender();
-    
+
     // Re-focus the input after a short delay to ensure the terminal is ready
     if (onTerminalFocus) {
       setTimeout(() => {
@@ -93,7 +93,7 @@ export function setupTerminalFocusHandling(
     log("Received SIGCONT (terminal resumed)");
     showCursor();
     renderer.requestRender();
-    
+
     if (onTerminalFocus) {
       setTimeout(() => {
         onTerminalFocus();
@@ -106,12 +106,12 @@ export function setupTerminalFocusHandling(
   let stdinListenerActive = false;
   const handleStdinData = (data: Buffer) => {
     const str = data.toString();
-    
+
     // Focus in event: \x1b[I
     if (str.includes("\x1b[I")) {
       handleFocusIn();
     }
-    
+
     // Focus out event: \x1b[O
     if (str.includes("\x1b[O")) {
       handleFocusOut();
@@ -122,13 +122,13 @@ export function setupTerminalFocusHandling(
   const setupListeners = () => {
     // Enable bracketed focus mode
     enableBracketedFocus();
-    
+
     // Show cursor initially
     showCursor();
-    
+
     // Listen for SIGCONT (resume after suspend)
     process.on("SIGCONT", handleSigCont);
-    
+
     // Listen for bracketed focus events on stdin
     // Note: We need to be careful not to interfere with OpenTUI's stdin handling
     // We only listen for specific escape sequences
@@ -142,13 +142,13 @@ export function setupTerminalFocusHandling(
   // Clean up function
   const cleanup = () => {
     log("Cleaning up terminal focus handling");
-    
+
     // Disable bracketed focus mode
     disableBracketedFocus();
-    
+
     // Remove listeners
     process.off("SIGCONT", handleSigCont);
-    
+
     if (stdinListenerActive) {
       process.stdin.off("data", handleStdinData);
       stdinListenerActive = false;


### PR DESCRIPTION
`bin/pensar.js` and `src/cli.ts` were two independent copies of the same CLI router — duplicated help text, duplicated command routing, duplicated upgrade logic. They'd already drifted out of sync: bin had dead commands (`benchmark`, `swarm`, `quicktest`) routing to build files that didn't exist, while cli.ts had `targeted-pentest` and `doctor` that bin didn't know about.

This eliminates the duplication by building `src/cli.ts` into `build/cli.js` and reducing `bin/pensar.js` to a thin wrapper (282 → 35 lines). `src/cli.ts` is now the single source of truth for all CLI routing and help text. Adding a new command means adding it in one place.

### Node + Bun runtime support

The npm package now works under both Node (>=18) and Bun (>=1.0). Previously the shebang was `#!/usr/bin/env bun` but the `engines` field claimed Node support — in reality, the package crashed immediately under Node due to Bun-specific syntax (JSON imports without `with { type: "json" }`, raw `.ts` imports).

The shebang is now `#!/usr/bin/env node` so it runs everywhere. Runtime behavior:

- **CLI commands** (`pensar --help`, `pensar auth`, `pensar issues`, etc.) — work natively under both Node and Bun. No Bun required.
- **TUI** (bare `pensar` with no args) — requires Bun because of `@opentui`'s `bun:` protocol dependencies. When running under Node, `bin/pensar.js` detects the runtime and automatically re-execs itself under Bun if available. If Bun isn't installed, it shows a clear error: *"TUI mode requires Bun. Install Bun (https://bun.sh) or use a standalone binary release."*
- **Compiled binary** — unaffected by all of this. It bundles everything including the Bun runtime.

`Bun.spawn` in `auth.ts` (used to open the browser during `pensar auth login`) was replaced with `child_process.spawn` so it works in both runtimes.

### Build changes

- Build uses `--splitting` so TUI-related chunks are code-split and never loaded under Node
- Externalized `react`, `react/jsx-runtime`, `react/jsx-dev-runtime`, and `react-reconciler` — fixes a duplicate React instance crash where the build bundled its own React while `@opentui/react` used `node_modules/react`
- Removed the separate `bun build src/tui/index.tsx` step — now handled via cli.ts's code splitting
- Removed `src/core/installation` from npm `files` — bundled into `build/cli.js` now (was also shipping the test file unnecessarily)
- Updated `main` field from `build/index.js` to `build/cli.js`
- Consolidated all `console.log`-per-line help text into template literals
- Build output: 55 files / 22MB → 43 files / 8.2MB

### CI

Smoke tests for all three distribution paths: npm package under Node (including TUI error message assertion with Bun stripped from PATH), npm package under Bun, and compiled binary.

### Test plan

tested manually and confirmed:
```
⏺ cd ~/Projects/apex-worktrees/apex-cli-router-unify
  rm -rf build/ && bun run build
  npm pack && npm install -g ./pensar-apex-0.0.104.tgz && rm pensar-apex-0.0.104.tgz

  # Node — CLI commands
  node $(which pensar) --version
  node $(which pensar) --help
  node $(which pensar) auth --help
  node $(which pensar) pentests --help

  # Node — TUI (should re-exec under Bun automatically)
  node $(which pensar)

  # Node — TUI without Bun (should show error)
  PATH=$(echo "$PATH" | tr ':' '\n' | grep -v bun | tr '\n' ':') node $(which pensar)

  # Bun — everything
  pensar --version
  pensar --help
  pensar auth --help
  pensar
```

Also added these checks to the github actions build step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the published package entrypoint, build output, and runtime behavior (Node vs Bun) for all CLI invocations, so a regression could break installs or TUI launch behavior across environments. Logic changes are mostly routing/packaging and CI smoke coverage reduces risk.
> 
> **Overview**
> **Unifies the CLI entrypoint and adds first-class Node support for the published npm package.** `bin/pensar.js` is reduced to a thin Node wrapper that forwards to `build/cli.js`, re-execing under Bun only for TUI mode (no args) and otherwise setting `PENSAR_NO_TUI` to prevent accidental TUI loads.
> 
> **Build/packaging is reoriented around `src/cli.ts` as the single router source of truth.** `package.json` now points `main` to `build/cli.js`, the `build` script compiles `src/cli.ts` with code-splitting and externals for OpenTUI/React, and npm published files are trimmed accordingly.
> 
> **CI now smoke-tests all distribution paths.** The workflow installs the packed npm tarball and validates CLI help/version under Node and Bun, asserts a helpful error when Bun is unavailable for TUI mode, and also exercises the compiled binary path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f1ec5abcbd181324f9153e3cf75bde22d18a4d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->