### PR TITLE
Add API key verification for providers & route Pensar to console auth

### DIFF
--- a/src/core/providers/index.ts
+++ b/src/core/providers/index.ts
@@ -1,2 +1,3 @@
 export * from "./types";
 export * from "./utils";
+export * from "./verify";

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -68,6 +68,6 @@ export const AVAILABLE_PROVIDERS: Provider[] = [
     id: "pensar",
     name: "Pensar",
     description: "Managed inference via Pensar Console (usage-based billing)",
-    requiresAPIKey: true,
+    requiresAPIKey: false,
   },
 ];

--- a/src/core/providers/verify.ts
+++ b/src/core/providers/verify.ts
@@ -1,0 +1,177 @@
+import type { ProviderType } from "./types";
+
+export interface VerifyResult {
+  valid: boolean;
+  error?: string;
+}
+
+const VERIFY_TIMEOUT_MS = 15_000;
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function verifyAnthropic(apiKey: string): Promise<VerifyResult> {
+  try {
+    const res = await fetchWithTimeout("https://api.anthropic.com/v1/models", {
+      method: "GET",
+      headers: {
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+    });
+    if (res.ok) return { valid: true };
+    if (res.status === 401) return { valid: false, error: "Invalid API key" };
+    return {
+      valid: false,
+      error: `Anthropic returned HTTP ${res.status}`,
+    };
+  } catch (err) {
+    return {
+      valid: false,
+      error:
+        err instanceof DOMException && err.name === "AbortError"
+          ? "Request timed out"
+          : "Could not reach Anthropic API",
+    };
+  }
+}
+
+async function verifyOpenAI(apiKey: string): Promise<VerifyResult> {
+  try {
+    const res = await fetchWithTimeout("https://api.openai.com/v1/models", {
+      method: "GET",
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (res.ok) return { valid: true };
+    if (res.status === 401) return { valid: false, error: "Invalid API key" };
+    return {
+      valid: false,
+      error: `OpenAI returned HTTP ${res.status}`,
+    };
+  } catch (err) {
+    return {
+      valid: false,
+      error:
+        err instanceof DOMException && err.name === "AbortError"
+          ? "Request timed out"
+          : "Could not reach OpenAI API",
+    };
+  }
+}
+
+async function verifyGoogle(apiKey: string): Promise<VerifyResult> {
+  try {
+    const res = await fetchWithTimeout(
+      `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(apiKey)}`,
+      { method: "GET" },
+    );
+    if (res.ok) return { valid: true };
+    if (res.status === 400 || res.status === 403)
+      return { valid: false, error: "Invalid API key" };
+    return {
+      valid: false,
+      error: `Google returned HTTP ${res.status}`,
+    };
+  } catch (err) {
+    return {
+      valid: false,
+      error:
+        err instanceof DOMException && err.name === "AbortError"
+          ? "Request timed out"
+          : "Could not reach Google AI API",
+    };
+  }
+}
+
+async function verifyOpenRouter(apiKey: string): Promise<VerifyResult> {
+  try {
+    const res = await fetchWithTimeout(
+      "https://openrouter.ai/api/v1/auth/key",
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${apiKey}` },
+      },
+    );
+    if (res.ok) return { valid: true };
+    if (res.status === 401 || res.status === 403)
+      return { valid: false, error: "Invalid API key" };
+    return {
+      valid: false,
+      error: `OpenRouter returned HTTP ${res.status}`,
+    };
+  } catch (err) {
+    return {
+      valid: false,
+      error:
+        err instanceof DOMException && err.name === "AbortError"
+          ? "Request timed out"
+          : "Could not reach OpenRouter API",
+    };
+  }
+}
+
+async function verifyInception(apiKey: string): Promise<VerifyResult> {
+  try {
+    const res = await fetchWithTimeout(
+      "https://api.inceptionlabs.ai/v1/models",
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${apiKey}` },
+      },
+    );
+    if (res.ok) return { valid: true };
+    if (res.status === 401 || res.status === 403)
+      return { valid: false, error: "Invalid API key" };
+    return {
+      valid: false,
+      error: `Inception returned HTTP ${res.status}`,
+    };
+  } catch (err) {
+    return {
+      valid: false,
+      error:
+        err instanceof DOMException && err.name === "AbortError"
+          ? "Request timed out"
+          : "Could not reach Inception API",
+    };
+  }
+}
+
+/**
+ * Verify an API key by making a lightweight request to the provider's API.
+ * Providers without a simple verification endpoint (bedrock, local, pensar)
+ * are skipped and treated as valid.
+ */
+export async function verifyApiKey(
+  provider: ProviderType,
+  apiKey: string,
+): Promise<VerifyResult> {
+  switch (provider) {
+    case "anthropic":
+      return verifyAnthropic(apiKey);
+    case "openai":
+      return verifyOpenAI(apiKey);
+    case "google":
+      return verifyGoogle(apiKey);
+    case "openrouter":
+      return verifyOpenRouter(apiKey);
+    case "inception":
+      return verifyInception(apiKey);
+    case "bedrock":
+    case "local":
+    case "pensar":
+      return { valid: true };
+    default:
+      return { valid: true };
+  }
+}

--- a/src/tui/components/commands/api-key-input.tsx
+++ b/src/tui/components/commands/api-key-input.tsx
@@ -1,8 +1,10 @@
 import { useKeyboard } from "@opentui/react";
 import { useState } from "react";
 import Input from "../input";
-import { type ProviderType } from "../../../core/providers";
+import { type ProviderType, verifyApiKey } from "../../../core/providers";
 import { useTheme } from "../../theme";
+
+type VerifyState = "idle" | "verifying" | "error";
 
 interface APIKeyInputProps {
   provider: ProviderType;
@@ -19,14 +21,33 @@ export default function APIKeyInput({
 }: APIKeyInputProps) {
   const { colors } = useTheme();
   const [apiKey, setApiKey] = useState("");
+  const [verifyState, setVerifyState] = useState<VerifyState>("idle");
+  const [errorMessage, setErrorMessage] = useState("");
 
   useKeyboard((key) => {
-    // Escape - Cancel
     if (key.name === "escape") {
+      if (verifyState === "verifying") return;
       onCancel();
       return;
     }
   });
+
+  const handleSubmit = async () => {
+    const key = apiKey.trim();
+    if (!key || verifyState === "verifying") return;
+
+    setVerifyState("verifying");
+    setErrorMessage("");
+
+    const result = await verifyApiKey(provider, key);
+
+    if (result.valid) {
+      onSubmit(key);
+    } else {
+      setVerifyState("error");
+      setErrorMessage(result.error ?? "Invalid API key");
+    }
+  };
 
   const getProviderInstructions = (provider: ProviderType): string => {
     switch (provider) {
@@ -88,7 +109,7 @@ export default function APIKeyInput({
             label="API Key"
             description="Your API key will be stored locally in ~/.pensar/config.json"
             value={apiKey}
-            focused={true}
+            focused={verifyState !== "verifying"}
             onChange={(value) =>
               setApiKey(typeof value === "string" ? value : "")
             }
@@ -96,14 +117,22 @@ export default function APIKeyInput({
               const cleaned = String(event.text);
               setApiKey((prev) => `${prev}${cleaned}`);
             }}
-            onSubmit={() => {
-              const key = apiKey.trim();
-              if (key) {
-                onSubmit(key);
-              }
-            }}
+            onSubmit={handleSubmit}
           />
         </box>
+
+        {/* Verification status */}
+        {verifyState === "verifying" && (
+          <box marginBottom={1}>
+            <text fg={colors.textMuted}>Verifying API key...</text>
+          </box>
+        )}
+
+        {verifyState === "error" && (
+          <box marginBottom={1}>
+            <text fg={colors.error}>✗ {errorMessage}</text>
+          </box>
+        )}
 
         {/* Footer help text */}
         <box marginTop={1}>

--- a/src/tui/components/commands/api-key-input.tsx
+++ b/src/tui/components/commands/api-key-input.tsx
@@ -40,8 +40,6 @@ export default function APIKeyInput({
         return "Get your API key from openrouter.ai/keys";
       case "bedrock":
         return "Enter your AWS Access Key ID (configure region separately) or AWS Bedrock API Key";
-      case "pensar":
-        return "Get your API key from console.pensar.dev/connect (or run /auth)";
       default:
         return "Enter your API key";
     }

--- a/src/tui/components/commands/provider-manager.tsx
+++ b/src/tui/components/commands/provider-manager.tsx
@@ -29,7 +29,11 @@ export default function ProviderManager() {
 
   const handleProviderSelected = (providerId: ProviderType) => {
     setSelectedProvider(providerId);
-    setFlowState("inputting");
+    if (providerId === "pensar") {
+      setFlowState("auth");
+    } else {
+      setFlowState("inputting");
+    }
   };
 
   const handleAPIKeySubmit = async (apiKey: string) => {


### PR DESCRIPTION
## Summary
- **API key verification**: When a user enters an API key in `/providers`, a lightweight request is made to the provider's API to verify the key before saving. Covers Anthropic, OpenAI, Google, OpenRouter, and Inception. Bedrock/Local/Pensar are skipped (Bedrock uses AWS IAM, Local has no remote endpoint, Pensar has its own auth flow).
- **Pensar auth redirect**: Selecting Pensar in the provider list now routes to the console auth flow instead of showing an API key input. Pensar's `requiresAPIKey` is set to `false` and the Pensar-specific API key instructions are removed.
- TUI shows "Verifying API key..." during the check and displays an inline error (e.g. "✗ Invalid API key") if verification fails, letting the user retry without losing context.

## Test plan
- [ ] Enter a valid Anthropic/OpenAI/Google key → verify passes, saved to config, navigates to model selection
- [ ] Enter an invalid key → "✗ Invalid API key" shown, input remains editable
- [ ] Select Pensar in provider list → routed to console auth flow, no API key prompt
- [ ] Disconnect network → "Could not reach <provider> API" error shown
- [ ] `bun run tsc`, `bun run lint`, `bun run test` all pass


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds synchronous API-key verification via network calls during provider setup, which can introduce new latency/failure modes (timeouts, provider endpoint changes) in the TUI flow. Pensar onboarding behavior changes to bypass API-key entry and may affect users expecting the old configuration path.
> 
> **Overview**
> Adds provider API key verification before saving credentials: a new `verifyApiKey` helper makes lightweight, timeout-bounded requests to Anthropic/OpenAI/Google/OpenRouter/Inception and returns inline error messages on failure.
> 
> Updates the TUI `/providers` flow to run verification on submit (disabling input while verifying and showing status/errors) and routes `pensar` selection directly into the console auth flow instead of prompting for an API key. Pensar is also marked `requiresAPIKey: false` and its API-key instructions are removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e234f05350f0815ddcc52172f9d4b28147142592. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->