### PR TITLE
Fix: Route Pensar provider selection to console auth instead of API key input

### DIFF
--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -68,6 +68,6 @@ export const AVAILABLE_PROVIDERS: Provider[] = [
     id: "pensar",
     name: "Pensar",
     description: "Managed inference via Pensar Console (usage-based billing)",
-    requiresAPIKey: true,
+    requiresAPIKey: false,
   },
 ];

--- a/src/tui/components/commands/api-key-input.tsx
+++ b/src/tui/components/commands/api-key-input.tsx
@@ -40,8 +40,6 @@ export default function APIKeyInput({
         return "Get your API key from openrouter.ai/keys";
       case "bedrock":
         return "Enter your AWS Access Key ID (configure region separately) or AWS Bedrock API Key";
-      case "pensar":
-        return "Get your API key from console.pensar.dev/connect (or run /auth)";
       default:
         return "Enter your API key";
     }

--- a/src/tui/components/commands/provider-manager.tsx
+++ b/src/tui/components/commands/provider-manager.tsx
@@ -29,7 +29,11 @@ export default function ProviderManager() {
 
   const handleProviderSelected = (providerId: ProviderType) => {
     setSelectedProvider(providerId);
-    setFlowState("inputting");
+    if (providerId === "pensar") {
+      setFlowState("auth");
+    } else {
+      setFlowState("inputting");
+    }
   };
 
   const handleAPIKeySubmit = async (apiKey: string) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes the issue where selecting "Pensar" from the `/providers` command incorrectly showed an API key input screen. Pensar uses device-flow console authentication (via browser), not manual API key entry.

**Root cause:** In `provider-manager.tsx`, `handleProviderSelected` always set `flowState` to `"inputting"` regardless of provider, routing every provider (including Pensar) to the `APIKeyInput` component. The onboarding flow correctly handled Pensar (via `OnboardingChoice` → `"auth"`), but the non-onboarding provider list did not.

**Changes:**
- **`src/tui/components/commands/provider-manager.tsx`**: `handleProviderSelected` now checks if the selected provider is `"pensar"` and routes to the `"auth"` flow state (device-flow `AuthFlow` component) instead of `"inputting"` (API key input).
- **`src/core/providers/types.ts`**: Set `requiresAPIKey: false` for the Pensar provider since it uses device-flow authentication, not manual API key entry.
- **`src/tui/components/commands/api-key-input.tsx`**: Removed the unreachable `"pensar"` case from `getProviderInstructions` since Pensar will no longer reach the API key input screen.

### How did you verify your code works?

- All CI checks pass: lint, TypeScript type check, unit tests (442 passed, 15 skipped — skips are pre-existing integration tests requiring live services).
- Manual testing in the TUI: launched the app, opened `/providers`, selected "Pensar" from the provider list, and confirmed it shows the "Pensar Console — Managed Inference" auth flow screen instead of an API key input.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a0ca286-1c57-4d2d-8731-f42ba914dc49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a0ca286-1c57-4d2d-8731-f42ba914dc49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

