### PR TITLE
feat: add --sandbox flag to override agent working directory in operator mode

### DIFF
--- a/fern/docs/commands/operator.mdx
+++ b/fern/docs/commands/operator.mdx
@@ -82,6 +82,7 @@ Toggle approval with `Option+Shift+Tab` (or `Alt+Shift+Tab` on Linux/Windows).
 | `--strict`            | Enable strict scope mode                          |
 | `--headers <mode>`    | Headers mode: none, default, or custom            |
 | `--header <Name:Val>` | Custom header (repeatable)                        |
+| `--sandbox`           | Use isolated session directory as working directory instead of current directory |
 
 ## Keyboard Shortcuts
 

--- a/scripts/test-sandbox-playwright.ts
+++ b/scripts/test-sandbox-playwright.ts
@@ -280,6 +280,7 @@ async function main() {
         scratchpadPath: join(testDir, "scratchpad"),
         findingsPath: join(testDir, "findings"),
       } as ToolContext["session"],
+      agentCwd: testDir,
       target: "https://example.com",
       sandbox,
     };

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -19,7 +19,11 @@ import {
 } from "./tools";
 import { createResponseTool, RESPONSE_TOOL_NAME } from "./tools/response";
 import { PersistentShell } from "./tools/persistentShell";
-import { BASE_SYSTEM_PROMPT, buildSessionWorkspaceSection } from "./prompt";
+import {
+  BASE_SYSTEM_PROMPT,
+  buildBaseSystemPrompt,
+  buildSessionWorkspaceSection,
+} from "./prompt";
 import type { ApprovalGate } from "../../operator";
 import { ApprovalDeniedError } from "../../operator";
 import { create as createSession, type SessionInfo } from "../../session";
@@ -260,8 +264,10 @@ export class OffensiveSecurityAgent<TResult = void> {
     this.streamResult = streamResponse({
       prompt: input.prompt,
       system:
-        (input.system ?? BASE_SYSTEM_PROMPT) +
-        buildSessionWorkspaceSection(input.session),
+        (input.system ??
+          buildBaseSystemPrompt({
+            sandboxMode: agentCwd === input.session.rootPath,
+          })) + buildSessionWorkspaceSection(input.session, agentCwd),
       model: input.model,
       messages: input.messages,
       tools,

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -20,7 +20,6 @@ import {
 import { createResponseTool, RESPONSE_TOOL_NAME } from "./tools/response";
 import { PersistentShell } from "./tools/persistentShell";
 import {
-  BASE_SYSTEM_PROMPT,
   buildBaseSystemPrompt,
   buildSessionWorkspaceSection,
 } from "./prompt";
@@ -120,8 +119,7 @@ export class OffensiveSecurityAgent<TResult = void> {
     this.abortSignal = input.abortSignal;
 
     // -- Resolve agent working directory ----------------------------------------
-    const agentCwd =
-      input.session.config?.agentCwd ?? input.session.rootPath;
+    const agentCwd = input.session.config?.agentCwd ?? input.session.rootPath;
 
     // -- Persistent shell (local mode only) -----------------------------------
     // Shell survives command cancellation; only disposed in consume() after the

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -19,10 +19,7 @@ import {
 } from "./tools";
 import { createResponseTool, RESPONSE_TOOL_NAME } from "./tools/response";
 import { PersistentShell } from "./tools/persistentShell";
-import {
-  buildBaseSystemPrompt,
-  buildSessionWorkspaceSection,
-} from "./prompt";
+import { buildBaseSystemPrompt, buildSessionWorkspaceSection } from "./prompt";
 import type { ApprovalGate } from "../../operator";
 import { ApprovalDeniedError } from "../../operator";
 import { create as createSession, type SessionInfo } from "../../session";

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -115,12 +115,16 @@ export class OffensiveSecurityAgent<TResult = void> {
     this.subagentId = input.subagentId;
     this.abortSignal = input.abortSignal;
 
+    // -- Resolve agent working directory ----------------------------------------
+    const agentCwd =
+      input.session.config?.agentCwd ?? input.session.rootPath;
+
     // -- Persistent shell (local mode only) -----------------------------------
     // Shell survives command cancellation; only disposed in consume() after the
     // stream ends, or when the agent is fully killed.
     if (!input.sandbox) {
       this.persistentShell = new PersistentShell({
-        cwd: input.session.rootPath,
+        cwd: agentCwd,
       });
       if (input.commandCancelHandle) {
         const shell = this.persistentShell;
@@ -137,6 +141,7 @@ export class OffensiveSecurityAgent<TResult = void> {
 
     const builtinTools = createAllTools({
       session: input.session,
+      agentCwd,
       target: input.target,
       abortSignal: input.abortSignal,
       model: input.model,

--- a/src/core/agents/offSecAgent/prompt.ts
+++ b/src/core/agents/offSecAgent/prompt.ts
@@ -6,8 +6,14 @@ interface SessionPaths {
   logsPath: string;
 }
 
-export function buildSessionWorkspaceSection(session: SessionPaths): string {
-  return `
+export function buildSessionWorkspaceSection(
+  session: SessionPaths,
+  agentCwd: string,
+): string {
+  const sandboxMode = agentCwd === session.rootPath;
+
+  if (sandboxMode) {
+    return `
 
 # Session Workspace
 
@@ -21,9 +27,41 @@ The session directory (${session.rootPath}) contains these subdirectories:
 - **evidence/** — screenshots and evidence (written by browser tools)
 
 Tools like \`document_finding\`, \`create_poc\`, and browser evidence capture write to the correct subdirectories automatically.`;
+  }
+
+  return `
+
+# Working Directory
+
+Your shell starts in the user's project directory: ${agentCwd}
+Use relative paths to reference project files.
+
+Session artifacts are stored separately at ${session.rootPath}:
+- **findings/** — written by \`document_finding\`
+- **pocs/** — written by \`create_poc\`
+- **scratchpad/** — your scratch space
+- **logs/** — execution logs
+- **evidence/** — screenshots and evidence
+
+Tools like \`document_finding\`, \`create_poc\`, and browser evidence capture write to the session directory automatically.`;
 }
 
-export const BASE_SYSTEM_PROMPT = `You are an expert offensive security engineer. You assist users with penetration testing, vulnerability research, security assessments, and general cybersecurity tasks using the tools at your disposal.
+/** Options for building the base system prompt. */
+export interface BaseSystemPromptOptions {
+  /** When true, include the "Stay in the session folder" instruction. Defaults to true. */
+  sandboxMode?: boolean;
+}
+
+export function buildBaseSystemPrompt(
+  options?: BaseSystemPromptOptions,
+): string {
+  const sandboxMode = options?.sandboxMode ?? true;
+
+  const stayInSessionParagraph = sandboxMode
+    ? `\n\n**Stay in the session folder.** Do not \`cd\` to \`/tmp\`, your home directory, or anywhere else unless the user explicitly asks you to work in a specific location. Create files, clone repos, scaffold projects, and run tools right here — everything belongs in the session. Use relative paths (e.g. \`scratchpad/notes.txt\`, \`test-app/\`) rather than absolute paths to external directories.`
+    : "";
+
+  return `You are an expert offensive security engineer. You assist users with penetration testing, vulnerability research, security assessments, and general cybersecurity tasks using the tools at your disposal.
 
 You work interactively with the user. Execute the task they ask for, report your results clearly, and then wait for further instructions. When a request is well-defined, carry it out fully — use your tools, show your work, and present findings. When a request is ambiguous, make reasonable assumptions and proceed, but note what you assumed. The user can steer you between turns.
 
@@ -92,9 +130,7 @@ You can perform the full lifecycle of a penetration test and support a wide rang
 
 # Command Execution
 
-The shell is **persistent** and **already starts in your session directory**. Your working directory, environment variables, shell variables, and background processes all survive across \`execute_command\` calls.
-
-**Stay in the session folder.** Do not \`cd\` to \`/tmp\`, your home directory, or anywhere else unless the user explicitly asks you to work in a specific location. Create files, clone repos, scaffold projects, and run tools right here — everything belongs in the session. Use relative paths (e.g. \`scratchpad/notes.txt\`, \`test-app/\`) rather than absolute paths to external directories.
+The shell is **persistent** and **already starts in your session directory**. Your working directory, environment variables, shell variables, and background processes all survive across \`execute_command\` calls.${stayInSessionParagraph}
 
 For long-running processes (servers, listeners, watchers), background them with \`&\` so the command returns immediately:
 - \`python server.py > scratchpad/server.log 2>&1 &\`
@@ -106,3 +142,10 @@ For long-running processes (servers, listeners, watchers), background them with 
 2. **Stay in scope.** Only test targets and systems explicitly provided by the user or discovered within the authorized scope. Respect any scope constraints in the session config.
 3. **Handle failures gracefully.** If a tool call fails or a technique doesn't work, try alternative approaches. If your first PoC approach fails after 3 attempts, pivot to a different technique.
 4. **Summarize results.** After completing a task, give the user a clear summary of what you found, what you tried, and what the next steps could be.`;
+}
+
+/**
+ * Default base system prompt (sandbox mode — includes "Stay in session folder").
+ * Use {@link buildBaseSystemPrompt} when you need to control sandbox vs CWD mode.
+ */
+export const BASE_SYSTEM_PROMPT = buildBaseSystemPrompt();

--- a/src/core/agents/offSecAgent/tools/createFile.ts
+++ b/src/core/agents/offSecAgent/tools/createFile.ts
@@ -48,7 +48,7 @@ Parent directories are created automatically if they don't exist.`,
       );
       const resolved = isAbsolute(filePath)
         ? filePath
-        : resolve(ctx.session.rootPath, filePath);
+        : resolve(ctx.agentCwd, filePath);
       console.error(`[create_file] resolved: ${resolved}`);
       if (ctx.sandbox) {
         return executeSandboxCreate(ctx, resolved, content, overwrite);

--- a/src/core/agents/offSecAgent/tools/grep.ts
+++ b/src/core/agents/offSecAgent/tools/grep.ts
@@ -66,7 +66,7 @@ search with flags or a more specific directory if results are truncated.`,
       }
 
       const dir = directory || ".";
-      const cwd = ctx.session.rootPath;
+      const cwd = ctx.agentCwd;
       const userFlags = flags ? flags.trim().split(/\s+/) : [];
 
       // Add -r by default when the user hasn't specified it and we're targeting a directory

--- a/src/core/agents/offSecAgent/tools/listFiles.ts
+++ b/src/core/agents/offSecAgent/tools/listFiles.ts
@@ -93,8 +93,8 @@ Each directory entry is suffixed with "/" for easy identification.`,
       const dir = directory
         ? isAbsolute(directory)
           ? directory
-          : resolve(ctx.session.rootPath, directory)
-        : ctx.session.rootPath;
+          : resolve(ctx.agentCwd, directory)
+        : ctx.agentCwd;
 
       try {
         const info = await stat(dir);

--- a/src/core/agents/offSecAgent/tools/readFile.ts
+++ b/src/core/agents/offSecAgent/tools/readFile.ts
@@ -43,9 +43,7 @@ the end. If only endLine is given, reads from the beginning to that line.
 Output lines are prefixed with their line number for easy reference.`,
     inputSchema: readFileInputSchema,
     execute: async ({ path, startLine, endLine }): Promise<ReadFileResult> => {
-      const resolved = isAbsolute(path)
-        ? path
-        : resolve(ctx.agentCwd, path);
+      const resolved = isAbsolute(path) ? path : resolve(ctx.agentCwd, path);
       try {
         const raw = await fsReadFile(resolved, "utf-8");
         const allLines = raw.split("\n");

--- a/src/core/agents/offSecAgent/tools/readFile.ts
+++ b/src/core/agents/offSecAgent/tools/readFile.ts
@@ -45,7 +45,7 @@ Output lines are prefixed with their line number for easy reference.`,
     execute: async ({ path, startLine, endLine }): Promise<ReadFileResult> => {
       const resolved = isAbsolute(path)
         ? path
-        : resolve(ctx.session.rootPath, path);
+        : resolve(ctx.agentCwd, path);
       try {
         const raw = await fsReadFile(resolved, "utf-8");
         const allLines = raw.split("\n");

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -21,6 +21,9 @@ export type ToolContext = {
   /** Session providing paths for findings, POCs, logs, scratchpad, etc. */
   session: SessionInfo;
 
+  /** The agent's operational working directory. Defaults to session.rootPath. */
+  agentCwd: string;
+
   /** The target URL / host — needed by browser tools for context */
   target?: string;
 

--- a/src/core/agents/offSecAgent/tools/updateFile.ts
+++ b/src/core/agents/offSecAgent/tools/updateFile.ts
@@ -58,7 +58,7 @@ operation fails with an error — double-check whitespace and indentation.`,
     }): Promise<UpdateFileResult> => {
       const resolved = isAbsolute(filePath)
         ? filePath
-        : resolve(ctx.session.rootPath, filePath);
+        : resolve(ctx.agentCwd, filePath);
       if (ctx.sandbox) {
         return executeSandboxUpdate(
           ctx,

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -151,11 +151,13 @@ const SessionConfigObject = z.object({
   /** Whether to enumerate subdomains during attack surface discovery (default: false) */
   enumerateSubdomains: z.boolean().optional(),
   /** Local codebase path for whitebox analysis (source code access) */
-  cwd: z.string().optional(),
+  codebasePath: z.string().optional(),
   /** Email inboxes available to the agent for monitoring/reading email */
   emailIntegration: EmailIntegrationConfigObject.optional(),
   /** Enable exfiltration mode — allows internal pivoting and flag extraction through confirmed vulnerabilities */
   exfilMode: z.boolean().optional(),
+  /** Agent working directory — resolved to process.cwd() by default, undefined in sandbox mode */
+  agentCwd: z.string().optional(),
 });
 
 export type SessionConfig = z.infer<typeof SessionConfigObject>;

--- a/src/tests/agentWorkingDirectory.test.ts
+++ b/src/tests/agentWorkingDirectory.test.ts
@@ -15,7 +15,11 @@ import {
 
 describe("parseWebFlags", () => {
   it("parses --sandbox as a boolean flag", () => {
-    const flags = parseWebFlags(["--target", "https://example.com", "--sandbox"]);
+    const flags = parseWebFlags([
+      "--target",
+      "https://example.com",
+      "--sandbox",
+    ]);
     expect(flags.sandbox).toBe(true);
   });
 
@@ -26,9 +30,11 @@ describe("parseWebFlags", () => {
 
   it("parses --sandbox alongside other flags", () => {
     const flags = parseWebFlags([
-      "--target", "https://example.com",
+      "--target",
+      "https://example.com",
       "--sandbox",
-      "--mode", "auto",
+      "--mode",
+      "auto",
       "--no-approval",
     ]);
     expect(flags.sandbox).toBe(true);
@@ -89,7 +95,9 @@ describe("buildSessionWorkspaceSection", () => {
       mockSession.rootPath,
     );
     expect(result).toContain("Session Workspace");
-    expect(result).toContain("Your shell is already set to the session directory");
+    expect(result).toContain(
+      "Your shell is already set to the session directory",
+    );
     expect(result).toContain(mockSession.rootPath);
     expect(result).not.toContain("Working Directory");
   });

--- a/src/tests/agentWorkingDirectory.test.ts
+++ b/src/tests/agentWorkingDirectory.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseWebFlags,
+  buildOperatorSessionConfig,
+} from "../tui/utils/command-flags";
+import {
+  buildSessionWorkspaceSection,
+  buildBaseSystemPrompt,
+  BASE_SYSTEM_PROMPT,
+} from "../core/agents/offSecAgent/prompt";
+
+// =============================================================================
+// Flag Parsing
+// =============================================================================
+
+describe("parseWebFlags", () => {
+  it("parses --sandbox as a boolean flag", () => {
+    const flags = parseWebFlags(["--target", "https://example.com", "--sandbox"]);
+    expect(flags.sandbox).toBe(true);
+  });
+
+  it("does not set sandbox when flag is absent", () => {
+    const flags = parseWebFlags(["--target", "https://example.com"]);
+    expect(flags.sandbox).toBeUndefined();
+  });
+
+  it("parses --sandbox alongside other flags", () => {
+    const flags = parseWebFlags([
+      "--target", "https://example.com",
+      "--sandbox",
+      "--mode", "auto",
+      "--no-approval",
+    ]);
+    expect(flags.sandbox).toBe(true);
+    expect(flags.target).toBe("https://example.com");
+    expect(flags.mode).toBe("auto");
+    expect(flags.requireApproval).toBe(false);
+  });
+});
+
+// =============================================================================
+// Session Config
+// =============================================================================
+
+describe("buildOperatorSessionConfig", () => {
+  it("sets agentCwd to process.cwd() by default", () => {
+    const result = buildOperatorSessionConfig({
+      target: "https://example.com",
+    });
+    expect(result.config.agentCwd).toBe(process.cwd());
+  });
+
+  it("sets agentCwd to undefined when sandbox is true", () => {
+    const result = buildOperatorSessionConfig({
+      target: "https://example.com",
+      sandbox: true,
+    });
+    expect(result.config.agentCwd).toBeUndefined();
+  });
+
+  it("sets operator mode and target correctly alongside sandbox", () => {
+    const result = buildOperatorSessionConfig({
+      target: "https://example.com",
+      sandbox: true,
+      mode: "auto",
+    });
+    expect(result.config.mode).toBe("operator");
+    expect(result.config.agentCwd).toBeUndefined();
+    expect(result.targets).toEqual(["https://example.com"]);
+  });
+});
+
+// =============================================================================
+// Prompt Generation
+// =============================================================================
+
+const mockSession = {
+  rootPath: "/home/user/.pensar/sessions/abc123",
+  findingsPath: "/home/user/.pensar/sessions/abc123/findings",
+  pocsPath: "/home/user/.pensar/sessions/abc123/pocs",
+  scratchpadPath: "/home/user/.pensar/sessions/abc123/scratchpad",
+  logsPath: "/home/user/.pensar/sessions/abc123/logs",
+};
+
+describe("buildSessionWorkspaceSection", () => {
+  it("renders sandbox-mode prompt when agentCwd equals rootPath", () => {
+    const result = buildSessionWorkspaceSection(
+      mockSession,
+      mockSession.rootPath,
+    );
+    expect(result).toContain("Session Workspace");
+    expect(result).toContain("Your shell is already set to the session directory");
+    expect(result).toContain(mockSession.rootPath);
+    expect(result).not.toContain("Working Directory");
+  });
+
+  it("renders CWD-mode prompt when agentCwd differs from rootPath", () => {
+    const projectDir = "/home/user/Projects/my-app";
+    const result = buildSessionWorkspaceSection(mockSession, projectDir);
+    expect(result).toContain("Working Directory");
+    expect(result).toContain(projectDir);
+    expect(result).toContain("Session artifacts are stored separately");
+    expect(result).toContain(mockSession.rootPath);
+    expect(result).not.toContain("Session Workspace");
+  });
+
+  it("includes session artifact paths in CWD mode", () => {
+    const projectDir = "/home/user/Projects/my-app";
+    const result = buildSessionWorkspaceSection(mockSession, projectDir);
+    expect(result).toContain("findings/");
+    expect(result).toContain("pocs/");
+    expect(result).toContain("scratchpad/");
+    expect(result).toContain("logs/");
+  });
+});
+
+describe("buildBaseSystemPrompt", () => {
+  it("includes 'Stay in the session folder' in sandbox mode", () => {
+    const prompt = buildBaseSystemPrompt({ sandboxMode: true });
+    expect(prompt).toContain("Stay in the session folder");
+  });
+
+  it("excludes 'Stay in the session folder' in CWD mode", () => {
+    const prompt = buildBaseSystemPrompt({ sandboxMode: false });
+    expect(prompt).not.toContain("Stay in the session folder");
+  });
+
+  it("defaults to sandbox mode when no options provided", () => {
+    const prompt = buildBaseSystemPrompt();
+    expect(prompt).toContain("Stay in the session folder");
+  });
+
+  it("BASE_SYSTEM_PROMPT const equals default buildBaseSystemPrompt()", () => {
+    expect(BASE_SYSTEM_PROMPT).toBe(buildBaseSystemPrompt());
+  });
+
+  it("always includes core identity regardless of mode", () => {
+    const cwdPrompt = buildBaseSystemPrompt({ sandboxMode: false });
+    const sandboxPrompt = buildBaseSystemPrompt({ sandboxMode: true });
+    const corePhrase = "expert offensive security engineer";
+    expect(cwdPrompt).toContain(corePhrase);
+    expect(sandboxPrompt).toContain(corePhrase);
+  });
+});

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -183,6 +183,7 @@ export const commands: CommandConfig[] = [
         description: "Custom header (repeatable)",
       },
       { name: "--model", valueHint: "<model>", description: "AI model to use" },
+      { name: "--sandbox", description: "Use isolated session directory as working directory" },
     ],
     handler: async (args, ctx) => {
       const flags = parseWebFlags(args);

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -183,7 +183,10 @@ export const commands: CommandConfig[] = [
         description: "Custom header (repeatable)",
       },
       { name: "--model", valueHint: "<model>", description: "AI model to use" },
-      { name: "--sandbox", description: "Use isolated session directory as working directory" },
+      {
+        name: "--sandbox",
+        description: "Use isolated session directory as working directory",
+      },
     ],
     handler: async (args, ctx) => {
       const flags = parseWebFlags(args);

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -3,7 +3,6 @@ import type { Route, WebCommandOptions } from "./context/route";
 import {
   parseWebFlags,
   hasEnoughFlagsToSkipWizard,
-  buildOperatorSessionConfig,
   buildSwarmSessionConfig,
 } from "./utils/command-flags";
 import { getAllThemeNames } from "./theme";
@@ -187,13 +186,13 @@ export const commands: CommandConfig[] = [
     ],
     handler: async (args, ctx) => {
       const flags = parseWebFlags(args);
-      const params = buildOperatorSessionConfig(flags);
       ctx.navigate({
         type: "operator",
         nonce: Date.now(),
         initialConfig: {
           requireApproval: flags.requireApproval ?? true,
           target: flags.target,
+          sandbox: flags.sandbox,
         },
       });
     },

--- a/src/tui/components/commands/operator-wizard.tsx
+++ b/src/tui/components/commands/operator-wizard.tsx
@@ -13,6 +13,7 @@ type WizardStep = "config" | "creating";
 interface WizardState {
   target: string;
   requireApproval: boolean;
+  sandbox: boolean;
 }
 
 interface HITLWizardProps {
@@ -48,9 +49,10 @@ export default function HITLWizard(props: HITLWizardProps) {
   const [state, setState] = useState<WizardState>(() => ({
     target: initialTarget || "",
     requireApproval: initialRequireApproval ?? true,
+    sandbox: false,
   }));
 
-  const [focusedField, setFocusedField] = useState(0); // 0=approval, 1=model, 2=submit
+  const [focusedField, setFocusedField] = useState(0); // 0=approval, 1=model, 2=sandbox, 3=submit
   const [error, setError] = useState<string | null>(null);
 
   // Model picker state
@@ -116,6 +118,7 @@ export default function HITLWizard(props: HITLWizardProps) {
       initialConfig: {
         requireApproval: state.requireApproval,
         target: state.target.trim() || undefined,
+        sandbox: state.sandbox || undefined,
       },
     });
   }
@@ -123,8 +126,9 @@ export default function HITLWizard(props: HITLWizardProps) {
   // Config step fields:
   // 0: Require approval toggle
   // 1: Model selection
-  // 2: Submit button
-  const maxField = 2;
+  // 2: Sandbox toggle
+  // 3: Submit button
+  const maxField = 3;
 
   useKeyboard((key) => {
     if (key.name === "escape") {
@@ -176,6 +180,15 @@ export default function HITLWizard(props: HITLWizardProps) {
           if (newModel) setModel(newModel);
           return;
         }
+
+        // Sandbox toggle (field 2)
+        if (focusedField === 2) {
+          setState((prev) => ({
+            ...prev,
+            sandbox: !prev.sandbox,
+          }));
+          return;
+        }
       }
 
       if (key.name === "return") {
@@ -188,8 +201,17 @@ export default function HITLWizard(props: HITLWizardProps) {
           return;
         }
 
-        // Submit button (field 2)
+        // Sandbox toggle (field 2)
         if (focusedField === 2) {
+          setState((prev) => ({
+            ...prev,
+            sandbox: !prev.sandbox,
+          }));
+          return;
+        }
+
+        // Submit button (field 3)
+        if (focusedField === 3) {
           createSessionAndNavigate();
         }
         return;
@@ -255,19 +277,38 @@ export default function HITLWizard(props: HITLWizardProps) {
         {focusedField === 1 && <text fg={colors.textMuted}>(←/→)</text>}
       </box>
 
-      {/* Submit Button - Field 2 */}
-      <box flexDirection="row" gap={1} marginTop={1}>
+      {/* Sandbox Toggle - Field 2 */}
+      <box flexDirection="row" gap={1}>
         <text fg={focusedField === 2 ? colors.primary : colors.textMuted}>
           {focusedField === 2 ? "▸" : " "}
         </text>
-        <text fg={focusedField === 2 ? colors.primary : colors.textMuted}>
-          {focusedField === 2 ? "[" : " "}
-        </text>
         <text fg={focusedField === 2 ? colors.text : colors.textMuted}>
+          Sandbox mode:
+        </text>
+        <text fg={state.sandbox ? colors.warning : colors.primary}>
+          {state.sandbox ? "Enabled" : "Disabled"}
+        </text>
+        <text fg={colors.textMuted}>
+          {state.sandbox
+            ? "- agent operates in an isolated session directory"
+            : "- agent operates in your current directory"}
+        </text>
+        {focusedField === 2 && <text fg={colors.textMuted}>(Enter/←/→)</text>}
+      </box>
+
+      {/* Submit Button - Field 3 */}
+      <box flexDirection="row" gap={1} marginTop={1}>
+        <text fg={focusedField === 3 ? colors.primary : colors.textMuted}>
+          {focusedField === 3 ? "▸" : " "}
+        </text>
+        <text fg={focusedField === 3 ? colors.primary : colors.textMuted}>
+          {focusedField === 3 ? "[" : " "}
+        </text>
+        <text fg={focusedField === 3 ? colors.text : colors.textMuted}>
           Start Session
         </text>
-        <text fg={focusedField === 2 ? colors.primary : colors.textMuted}>
-          {focusedField === 2 ? "]" : " "}
+        <text fg={focusedField === 3 ? colors.primary : colors.textMuted}>
+          {focusedField === 3 ? "]" : " "}
         </text>
       </box>
 

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -272,7 +272,7 @@ export default function WebWizard({
 
       // Source code access (whitebox mode)
       if (state.sourceCodeAccess && state.cwd.trim()) {
-        sessionConfig.cwd = state.cwd.trim();
+        sessionConfig.codebasePath = state.cwd.trim();
       }
 
       // Headers config

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -86,6 +86,7 @@ export default function OperatorDashboard({
     requireApproval?: boolean;
     target?: string;
     operatorMode?: OperatorMode;
+    sandbox?: boolean;
   };
 }) {
   const { colors } = useTheme();
@@ -896,6 +897,7 @@ export default function OperatorDashboard({
               requireApproval,
               enableSuggestions: true,
             },
+            agentCwd: initialConfig?.sandbox ? undefined : process.cwd(),
           };
           agentResult = await runOffensiveSecurityAgent({
             ...commonInput,

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -883,7 +883,11 @@ export default function OperatorDashboard({
               initialConfig?.target,
               operatorState,
               agentMode,
-              { requireApproval, skillsCatalog },
+              {
+                requireApproval,
+                sandboxMode: !!initialConfig?.sandbox,
+                skillsCatalog,
+              },
             ),
             session,
           });
@@ -905,7 +909,11 @@ export default function OperatorDashboard({
               initialConfig?.target,
               operatorState,
               agentMode,
-              { requireApproval, skillsCatalog },
+              {
+                requireApproval,
+                sandboxMode: !!initialConfig?.sandbox,
+                skillsCatalog,
+              },
             ),
             sessionConfig,
             onNameGenerated: (name: string) => {

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -1,6 +1,6 @@
 import type { AutocompleteOption } from "../shared/prompt-input";
 import type { OperatorSessionState } from "../../../core/operator";
-import { BASE_SYSTEM_PROMPT } from "../../../core/agents/offSecAgent/prompt";
+import { buildBaseSystemPrompt } from "../../../core/agents/offSecAgent/prompt";
 
 // ---------------------------------------------------------------------------
 // Autocomplete option filtering for operator mode
@@ -186,6 +186,7 @@ export function buildOperatorSystemPrompt(
   agentMode?: "default" | "plan",
   opts?: {
     requireApproval?: boolean;
+    sandboxMode?: boolean;
     skillsCatalog?: string;
     activeSkillInstructions?: Array<{ name: string; instructions: string }>;
   },
@@ -199,7 +200,7 @@ export function buildOperatorSystemPrompt(
   const approvalEnabled =
     opts?.requireApproval ?? operatorState.requireApproval;
 
-  let prompt = `${BASE_SYSTEM_PROMPT}
+  let prompt = `${buildBaseSystemPrompt({ sandboxMode: opts?.sandboxMode })}
 
 # Operator Mode
 

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -805,7 +805,7 @@ export default function Pentest({
       try {
         await runPentestAgent({
           target: s.targets[0]!,
-          ...(s.config?.cwd ? { cwd: s.config.cwd } : {}),
+          ...(s.config?.codebasePath ? { cwd: s.config.codebasePath } : {}),
           session: s,
           model: model.id,
           abortSignal: controller.signal,

--- a/src/tui/context/route.tsx
+++ b/src/tui/context/route.tsx
@@ -67,6 +67,7 @@ export type Route =
         requireApproval?: boolean;
         target?: string;
         operatorMode?: import("../../core/operator").OperatorMode;
+        sandbox?: boolean;
       };
       /** Opaque value used to force a fresh remount (e.g. Date.now()) */
       nonce?: number;

--- a/src/tui/utils/command-flags.ts
+++ b/src/tui/utils/command-flags.ts
@@ -139,6 +139,9 @@ export interface WebCommandFlags {
 
   // Model option
   model?: string;
+
+  // Sandbox option
+  sandbox?: boolean;
 }
 
 /**
@@ -164,6 +167,7 @@ const webFlagSchema: FlagSchema = {
   model: { type: "string" },
   // Legacy --auto flag maps to --swarm
   auto: { type: "boolean" },
+  sandbox: { type: "boolean" },
 };
 
 /**
@@ -239,6 +243,9 @@ export function parseWebFlags(args: string[]): WebCommandFlags {
 
   // Model option
   if (raw.model) flags.model = String(raw.model);
+
+  // Sandbox option
+  if (raw.sandbox) flags.sandbox = true;
 
   return flags;
 }
@@ -319,6 +326,8 @@ export function buildOperatorSessionConfig(
       headers: flags.headersMode === "custom" ? flags.customHeaders : undefined,
     };
   }
+
+  sessionConfig.agentCwd = flags.sandbox ? undefined : process.cwd();
 
   return {
     targets: flags.target ? [flags.target] : [],


### PR DESCRIPTION
In operator mode, the agent now defaults to `process.cwd()` instead of the session directory. This means the agent operates where the user launched the CLI — matching how every other CLI tool behaves. Session artifacts (findings, POCs, scratchpad) still go to the session directory automatically.

A `--sandbox` flag (also available as a toggle in the operator wizard) reverts to the old behavior for cases where the user wants an isolated workspace.

Also renames `SessionConfig.cwd` to `codebasePath` to disambiguate the whitebox analysis path from the new operational working directory.

Closes #286


https://github.com/user-attachments/assets/b6aaf8a4-e003-45f2-9a82-385412a8e461


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the operator agent’s effective working directory and updates filesystem tools to resolve relative paths from `agentCwd`, which can affect where files are read/written and which codebase is searched. Also renames `SessionConfig.cwd` to `codebasePath`, requiring downstream consumers to be in sync.
> 
> **Overview**
> Operator sessions now default to running in the user’s current directory via a new `SessionConfig.agentCwd`, while keeping session artifacts (findings/PoCs/logs/etc.) in the session folder; `--sandbox` (CLI + operator wizard toggle) restores the prior “work inside the session directory” behavior.
> 
> The offsec agent, prompt generation, and core filesystem/search tools (`read_file`, `list_files`, `grep`, `create_file`, `update_file`) are updated to use `agentCwd` for relative-path resolution and messaging, including a new `buildBaseSystemPrompt({ sandboxMode })` and revised workspace instructions.
> 
> Separately, the session config field `cwd` is renamed to `codebasePath` for whitebox analysis, with corresponding TUI wiring updates and added tests covering flag parsing, session config defaults, and prompt variants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 933e03b01506a4e454959a7c0975ccf05294b9a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->