### PR TITLE
fix: debounce conversation persistence to prevent event loop starvation

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -232,6 +232,24 @@ export class OffensiveSecurityAgent<TResult = void> {
           ],
     };
 
+    // Debounced persistence: avoid blocking the event loop with
+    // JSON.stringify on every step when many agents run concurrently.
+    const PERSIST_INTERVAL_MS = 15_000;
+    let persistTimer: ReturnType<typeof setTimeout> | null = null;
+    let latestMessages: ModelMessage[] | null = null;
+
+    const schedulePersist = () => {
+      if (persistTimer) return;
+      persistTimer = setTimeout(() => {
+        persistTimer = null;
+        if (latestMessages) {
+          const toWrite = latestMessages;
+          latestMessages = null;
+          writeFile(messagesPath, JSON.stringify(toWrite)).catch(() => {});
+        }
+      }, PERSIST_INTERVAL_MS);
+    };
+
     // -- Stream ---------------------------------------------------------------
     this.streamResult = streamResponse({
       prompt: input.prompt,
@@ -245,15 +263,11 @@ export class OffensiveSecurityAgent<TResult = void> {
       stopWhen,
       toolChoice: "auto",
       onStepFinish: (event) => {
-        const allMessages = [
+        latestMessages = [
           ...initialMessagesRef.current,
           ...event.response.messages,
         ];
-        writeFile(messagesPath, JSON.stringify(allMessages, null, 2)).catch(
-          () => {
-            // Best-effort persistence — don't break the agent loop
-          },
-        );
+        schedulePersist();
         input.onStepFinish?.(event);
       },
       onSummarized: () => {
@@ -261,7 +275,21 @@ export class OffensiveSecurityAgent<TResult = void> {
         // subsequent onStepFinish writes only persist post-summary messages.
         initialMessagesRef.current = [];
       },
-      onFinish: input.onFinish,
+      onFinish: async (event) => {
+        // Flush any pending persistence before finishing
+        if (persistTimer) {
+          clearTimeout(persistTimer);
+          persistTimer = null;
+        }
+        const finalMessages = latestMessages ?? [
+          ...initialMessagesRef.current,
+          ...event.response.messages,
+        ];
+        await writeFile(messagesPath, JSON.stringify(finalMessages)).catch(
+          () => {},
+        );
+        await input.onFinish?.(event);
+      },
       abortSignal: input.abortSignal,
       authConfig: input.authConfig,
       silent: true,


### PR DESCRIPTION
## Summary
- Debounce conversation persistence from every AI step to once per 15 seconds per agent — eliminates ~86 synchronous `JSON.stringify` calls per step round
- Remove pretty-printing (`, null, 2`) for ~2-3x faster serialization  
- Flush final state in `onFinish` so no conversation data is lost

## Context
With 86 concurrent domain pentest agents, even async `writeFile` wasn't enough — the `JSON.stringify` call is synchronous and with conversations at 40-64K tokens (3-10ms each), 86 agents doing this on every step blocks the event loop for 260-860ms per round. This starves the Express health check and causes ECS to kill tasks.

## Test plan
- [ ] Run a domain pentest with many concurrent endpoints and verify health check remains responsive
- [ ] Verify conversation messages.json is populated after agent finishes
- [ ] Verify resume from persisted messages still works (compact JSON vs pretty-printed)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the timing/format of agent conversation persistence (debounced writes and compact JSON), which could affect how much history is saved if a process terminates between flushes.
> 
> **Overview**
> **Debounces agent conversation persistence** by batching `messages.json` writes to at most once every 15s instead of on every `onStepFinish`, reducing synchronous `JSON.stringify` overhead when many agents run concurrently.
> 
> **Updates finish behavior** to flush any pending write in `onFinish` and switches persistence output to compact JSON (removing pretty-printing) for faster serialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4998b7ae40fdf891d089426ec8332a9b1e76b5af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->