### PR TITLE
Move Pensar to first position in provider selection order

### DIFF
--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -23,6 +23,12 @@ export interface ConfiguredProvider extends Provider {
 
 export const AVAILABLE_PROVIDERS: Provider[] = [
   {
+    id: "pensar",
+    name: "Pensar",
+    description: "Managed inference via Pensar Console (usage-based billing)",
+    requiresAPIKey: false,
+  },
+  {
     id: "anthropic",
     name: "Anthropic",
     description: "Claude Pro/Max or API key",
@@ -62,12 +68,6 @@ export const AVAILABLE_PROVIDERS: Provider[] = [
     id: "local",
     name: "Local LLM",
     description: "OpenAI-compatible local model (vLLM, LM Studio, Ollama)",
-    requiresAPIKey: false,
-  },
-  {
-    id: "pensar",
-    name: "Pensar",
-    description: "Managed inference via Pensar Console (usage-based billing)",
     requiresAPIKey: false,
   },
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorders `AVAILABLE_PROVIDERS` so **Pensar** appears first in the provider selection UI.

During first-launch onboarding, the "Get Started" screen already presents Pensar as the primary choice with an "Other provider" fallback. This change ensures Pensar also appears first in the non-onboarding provider list (e.g. when accessed via `/providers` command after a provider is already configured).

## Changes

- Moved the Pensar entry from last to first position in `AVAILABLE_PROVIDERS` array in `src/core/providers/types.ts`

## Testing

- All 451 unit tests pass (7 test files skipped as expected)
- TypeScript type-check clean
- ESLint clean
- Manually verified the first-launch flow:
  1. Disclosure screen → Enter to accept
  2. "Get Started" screen shows "Pensar" first (highlighted) and "Use other provider" second
  3. Selecting "Use other provider" shows remaining providers (Pensar excluded)
  4. Escape returns to the "Get Started" screen
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9a9a145-1564-4956-b127-75eeb54780ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9a9a145-1564-4956-b127-75eeb54780ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

