### PR TITLE
Remove Claude Opus 4.1 from Pensar model options

### DIFF
--- a/src/core/ai/models/pensar.ts
+++ b/src/core/ai/models/pensar.ts
@@ -14,12 +14,6 @@ export const PENSAR_MODELS: ModelInfo[] = [
     contextLength: 200000,
   },
   {
-    id: "pensar:anthropic.claude-opus-4-1-20250805-v1:0",
-    name: "Claude Opus 4.1 (Pensar)",
-    provider: "pensar",
-    contextLength: 200000,
-  },
-  {
     id: "pensar:anthropic.claude-haiku-4-5-20251001-v1:0",
     name: "Claude Haiku 4.5 (Pensar)",
     provider: "pensar",

--- a/src/core/providers/utils.test.ts
+++ b/src/core/providers/utils.test.ts
@@ -17,9 +17,7 @@ describe("getDefaultModelForConfig", () => {
     const model = getDefaultModelForConfig(config);
     expect(model).not.toBeNull();
     expect(model!.provider).toBe("pensar");
-    expect(model!.id).toBe(
-      "pensar:anthropic.claude-opus-4-1-20250805-v1:0",
-    );
+    expect(model!.id).toBe("pensar:anthropic.claude-opus-4-6-v1");
   });
 
   it("returns a Pensar model when Pensar is configured via pensarAPIKey", () => {

--- a/src/core/providers/utils.ts
+++ b/src/core/providers/utils.ts
@@ -17,7 +17,7 @@ const PROVIDER_PREFERENCE_ORDER: ProviderType[] = [
 ];
 
 const PREFERRED_MODEL_BY_PROVIDER: Record<string, string> = {
-  pensar: "pensar:anthropic.claude-opus-4-1-20250805-v1:0",
+  pensar: "pensar:anthropic.claude-opus-4-6-v1",
   anthropic: "claude-opus-4-6",
   openai: "gpt-5.2-pro",
   google: "gemini-3.1-pro-preview",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Removes Claude Opus 4.1 from the Pensar provider model options. The model entry is deleted from `PENSAR_MODELS`, and the preferred default Pensar model is updated from Opus 4.1 to Opus 4.6.

Changes:
- Removed the `pensar:anthropic.claude-opus-4-1-20250805-v1:0` entry from `src/core/ai/models/pensar.ts`
- Updated `PREFERRED_MODEL_BY_PROVIDER.pensar` in `src/core/providers/utils.ts` to point to `pensar:anthropic.claude-opus-4-6-v1`
- Updated the corresponding test assertion in `src/core/providers/utils.test.ts`

### How did you verify your code works?

- All unit tests pass (`bun run test` — 451 passed, 15 skipped)
- Lint passes (`bun run lint`)
- Type check passes (`bun run tsc`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71c92ddd-42a7-4ea3-a5d3-61a8ab81e155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71c92ddd-42a7-4ea3-a5d3-61a8ab81e155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

