### PR TITLE
Excessive timeout fix

### DIFF
--- a/src/core/agents/offSecAgent/tools/executeCommand.test.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeExecuteCommandTimeout } from "./executeCommand";
+
+describe("normalizeExecuteCommandTimeout", () => {
+  it("preserves valid second-based timeouts", () => {
+    expect(normalizeExecuteCommandTimeout(30)).toBe(30);
+    expect(normalizeExecuteCommandTimeout(120)).toBe(120);
+  });
+
+  it("converts obvious millisecond values to seconds", () => {
+    expect(normalizeExecuteCommandTimeout(30_000)).toBe(30);
+    expect(normalizeExecuteCommandTimeout(100_000)).toBe(100);
+    expect(normalizeExecuteCommandTimeout(120_000)).toBe(120);
+  });
+
+  it("drops invalid timeout values", () => {
+    expect(normalizeExecuteCommandTimeout()).toBeUndefined();
+    expect(normalizeExecuteCommandTimeout(0)).toBeUndefined();
+    expect(normalizeExecuteCommandTimeout(-5)).toBeUndefined();
+    expect(normalizeExecuteCommandTimeout(Number.NaN)).toBeUndefined();
+  });
+});

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -5,6 +5,7 @@ import { writeFileSync, mkdirSync, existsSync } from "fs";
 import type { ToolContext } from "./types";
 
 const MAX_INLINE = 50_000;
+const MS_TIMEOUT_THRESHOLD = 10_000;
 
 export const executeCommandInputSchema = z.object({
   // not actually sure if placing this above the other keys/zod values ensures that the model generates it first...
@@ -32,6 +33,27 @@ export type ExecuteCommandResult = {
   command: string;
   outputFile?: string;
 };
+
+/**
+ * Defensively normalize obviously-millisecond timeout values into seconds.
+ *
+ * The tool contract is seconds, but models sometimes emit JavaScript-style
+ * millisecond values like 30000 or 120000. Without normalization, those become
+ * multi-hour hangs instead of 30s / 120s command limits.
+ */
+export function normalizeExecuteCommandTimeout(
+  timeout?: number,
+): number | undefined {
+  if (timeout == null || !Number.isFinite(timeout) || timeout <= 0) {
+    return undefined;
+  }
+
+  if (timeout >= MS_TIMEOUT_THRESHOLD) {
+    return Math.max(1, Math.ceil(timeout / 1_000));
+  }
+
+  return timeout;
+}
 
 /**
  * If `raw` exceeds the inline limit, save the full text to a file under
@@ -100,6 +122,9 @@ SSL/TLS TESTING:
 OUTPUT HANDLING:
 - Use 2>&1 to capture stderr
 - Use timeout command for long-running scans
+- The tool's timeout parameter is in SECONDS, not milliseconds
+- Good timeout examples: 30, 60, 120
+- Do NOT pass millisecond values like 30000 or 120000
 
 IMPORTANT: Always analyze results and adjust your approach based on findings.`,
     inputSchema: executeCommandInputSchema,
@@ -118,8 +143,9 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
       if (ctx.sandbox) {
         try {
           const ssmOpts: { timeout?: number } = {};
-          if (timeout != null) {
-            ssmOpts.timeout = timeout;
+          const normalizedTimeout = normalizeExecuteCommandTimeout(timeout);
+          if (normalizedTimeout != null) {
+            ssmOpts.timeout = normalizedTimeout;
           }
           const result = await ctx.sandbox.execute(command, ssmOpts);
           const { text: stdout, file: outputFile } = maybeSaveFullOutput(
@@ -149,9 +175,10 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
       // Local mode: use the persistent shell
       if (ctx.persistentShell) {
         try {
+          const normalizedTimeout = normalizeExecuteCommandTimeout(timeout);
           const result = await ctx.persistentShell.execute(
             command,
-            timeout,
+            normalizedTimeout,
             ctx.onCommandOutput,
             ctx.abortSignal,
           );


### PR DESCRIPTION
#414 

### What does this PR do?

This pull request introduces defensive handling for the `timeout` parameter in the `executeCommand` tool to prevent accidental multi-hour hangs caused by millisecond-based timeout values. It adds a normalization function, updates the tool's documentation, and ensures that all usages of the timeout parameter are properly normalized. The changes are covered by new unit tests.

**Timeout normalization and safety improvements:**

* Added a `normalizeExecuteCommandTimeout` function to convert obvious millisecond timeout values (e.g., 30000, 120000) to seconds, returning `undefined` for invalid or non-positive values. This ensures the tool contract remains in seconds and prevents accidental long timeouts.

* Updated all usages of the `timeout` parameter in both sandboxed and local execution paths to use the new normalization function, ensuring consistent and safe timeout handling. [[1]](diffhunk://#diff-490aed4dfca62e2c3517bcc6528f39b9405ec7a3a5d3f4c3242c2a6dd5c82eceL121-R148) [[2]](diffhunk://#diff-490aed4dfca62e2c3517bcc6528f39b9405ec7a3a5d3f4c3242c2a6dd5c82eceR178-R181)

**Documentation and testing:**

* Enhanced the tool's usage documentation to clarify that timeout values should be in seconds, with explicit examples and warnings against millisecond values.

### How did you verify your code works?

* I couldn't. I tried to run a pentest on the same website again, but this time it was able to go through without any problems or timeouts. I was able to see the report.
* Nevertheless, ran `bun run test` and `tsc -noEmit` and those didn't pose any problems.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime behavior of `executeCommand` timeouts in both sandbox and local execution paths; incorrect normalization thresholds could shorten intended long-running commands or change timeout handling.
> 
> **Overview**
> Prevents accidental multi-hour `executeCommand` hangs by **normalizing the `timeout` input to seconds** when it looks like a millisecond value (and dropping invalid/non-positive values).
> 
> Applies the normalized timeout consistently in both sandbox and persistent-shell execution paths, and updates the tool description to explicitly warn against millisecond timeouts. Adds unit tests for `normalizeExecuteCommandTimeout` covering seconds passthrough, ms-to-seconds conversion, and invalid inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f6c7601db4d7e2a86771f430c6acca3f4734414. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->