### PR TITLE
feat: add GPT-5.4 family of models to OpenAI provider

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@pensar/apex",
@@ -7,7 +8,7 @@
         "@ai-sdk/amazon-bedrock": "^4.0.69",
         "@ai-sdk/anthropic": "^3.0.50",
         "@ai-sdk/google": "^3.0.37",
-        "@ai-sdk/openai": "^3.0.37",
+        "@ai-sdk/openai": "3.0.46",
         "@ai-sdk/openai-compatible": "^2.0.35",
         "@daytonaio/sdk": "^0.112.1",
         "@googleapis/gmail": "^16.1.1",
@@ -61,7 +62,7 @@
 
     "@ai-sdk/google": ["@ai-sdk/google@3.0.43", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-NGCgP5g8HBxrNdxvF8Dhww+UKfqAkZAmyYBvbu9YLoBkzAmGKDBGhVptN/oXPB5Vm0jggMdoLycZ8JReQM8Zqg=="],
 
-    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.37", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.16" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bcYjT3/58i/C0DN3AnrjiGsAb0kYivZLWWUtgTjsBurHSht/LTEy+w3dw5XQe3FmZwX7Z/mUQCiA3wB/5Kf7ow=="],
+    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.46", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8grBb4sAMU0MAC6uOOD/wP/+SyX/3MMS/Lf+ToGgeUzoF9oWU9dWBLkvgjXpn7Ro81bPDeycW2GCCT63V/Vnvg=="],
 
     "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.35", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-g3wA57IAQFb+3j4YuFndgkUdXyRETZVvbfAWM+UX7bZSxA3xjes0v3XKgIdKdekPtDGsh4ZX2byHD0gJIMPfiA=="],
 
@@ -1318,6 +1319,8 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.19", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg=="],
+
+    "@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.20", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-gpUIj9uDhIGbuo9afKEgQ074BWmhvK4THJAAeBjRnroTy2yQYo6rbtGD7pQDMZM8ouXPYmT/SCdkWVJ0KcpX8A=="],
 
     "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.19", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg=="],
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@ai-sdk/amazon-bedrock": "^4.0.69",
     "@ai-sdk/anthropic": "^3.0.50",
     "@ai-sdk/google": "^3.0.37",
-    "@ai-sdk/openai": "^3.0.37",
+    "@ai-sdk/openai": "3.0.46",
     "@ai-sdk/openai-compatible": "^2.0.35",
     "@daytonaio/sdk": "^0.112.1",
     "@googleapis/gmail": "^16.1.1",

--- a/src/core/ai/models/openai.ts
+++ b/src/core/ai/models/openai.ts
@@ -125,30 +125,6 @@ export const OPENAI_MODELS: ModelInfo[] = [
     contextLength: 128000,
   },
   {
-    id: "gpt-4-turbo",
-    name: "GPT-4-turbo",
-    provider: "openai",
-    contextLength: 128000,
-  },
-  {
-    id: "gpt-4-turbo-2024-04-09",
-    name: "GPT-4-turbo-2024-04-09",
-    provider: "openai",
-    contextLength: 128000,
-  },
-  {
-    id: "gpt-4",
-    name: "GPT-4",
-    provider: "openai",
-    contextLength: 8192,
-  },
-  {
-    id: "gpt-4-0613",
-    name: "GPT-4-0613",
-    provider: "openai",
-    contextLength: 8192,
-  },
-  {
     id: "gpt-3.5-turbo-0125",
     name: "GPT-3.5-turbo-0125",
     provider: "openai",
@@ -171,12 +147,6 @@ export const OPENAI_MODELS: ModelInfo[] = [
     name: "GPT-3.5-turbo-16k",
     provider: "openai",
     contextLength: 16385,
-  },
-  {
-    id: "chatgpt-4o-latest",
-    name: "ChatGPT-4o (Latest)",
-    provider: "openai",
-    contextLength: 128000,
   },
   {
     id: "gpt-5",
@@ -265,6 +235,36 @@ export const OPENAI_MODELS: ModelInfo[] = [
   {
     id: "gpt-5.2-pro-2025-12-11",
     name: "GPT-5.2-pro-2025-12-11",
+    provider: "openai",
+    contextLength: 200000,
+  },
+  {
+    id: "gpt-5.3-chat-latest",
+    name: "GPT-5.3-chat (Latest)",
+    provider: "openai",
+    contextLength: 200000,
+  },
+  {
+    id: "gpt-5.4",
+    name: "GPT-5.4",
+    provider: "openai",
+    contextLength: 200000,
+  },
+  {
+    id: "gpt-5.4-2026-03-05",
+    name: "GPT-5.4-2026-03-05",
+    provider: "openai",
+    contextLength: 200000,
+  },
+  {
+    id: "gpt-5.4-pro",
+    name: "GPT-5.4-pro",
+    provider: "openai",
+    contextLength: 200000,
+  },
+  {
+    id: "gpt-5.4-pro-2026-03-05",
+    name: "GPT-5.4-pro-2026-03-05",
     provider: "openai",
     contextLength: 200000,
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Adds the GPT-5.4 family of models to the OpenAI provider by upgrading `@ai-sdk/openai` from `3.0.37` to `3.0.46` and regenerating the model list.

**New models added:**
- `gpt-5.4` — GPT-5.4 base model
- `gpt-5.4-2026-03-05` — GPT-5.4 dated snapshot
- `gpt-5.4-pro` — GPT-5.4 Pro variant
- `gpt-5.4-pro-2026-03-05` — GPT-5.4 Pro dated snapshot
- `gpt-5.3-chat-latest` — GPT-5.3 Chat (Latest)

All new models have a 200k context length, consistent with other GPT-5.x models.

**Note:** The SDK update also removes some deprecated models that OpenAI has sunset from the typed model ID union (`gpt-4-turbo`, `gpt-4`, `gpt-4-0613`, `chatgpt-4o-latest`). These can still be used as custom string model IDs if needed since the type includes a `(string & {})` fallback.

**Changes:**
- `package.json` — bumped `@ai-sdk/openai` from `3.0.37` → `3.0.46`
- `bun.lock` — updated lockfile
- `src/core/ai/models/openai.ts` — regenerated via `bun run generate:models`

### How did you verify your code works?

- Ran `bun run generate:models` — confirmed GPT-5.4 models appear in the generated output (44 models total)
- `bun run tsc` — TypeScript type check passes
- `bun run lint` — ESLint passes with no new warnings
- `bun run format:check` — changed files pass Prettier formatting
- `bun run test` — all 454 tests pass (15 skipped, which are pre-existing skips for integration tests)
- `bun run build` — full build succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-200b7a59-48e1-4a9f-9f80-62b2b8029274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-200b7a59-48e1-4a9f-9f80-62b2b8029274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

