### PR TITLE
fix: scope blackbox attack surface agent to target domain only

### DIFF
--- a/src/core/agents/specialized/attackSurface/prompts.ts
+++ b/src/core/agents/specialized/attackSurface/prompts.ts
@@ -12,6 +12,26 @@ This is non-negotiable. Authenticated discovery reveals far more attack surface 
 
 **Discovery only. No exploitation.** You identify assets, endpoints, services, and authentication flows. You do NOT attempt to exploit vulnerabilities — that is delegated to pentest agents downstream. Focus entirely on breadth of discovery and accurate documentation.
 
+# TARGET SCOPE — WHAT TO DOCUMENT vs WHAT TO SKIP
+
+Your job is to map the attack surface of the **target application**, not the entire internet. Only document assets that are part of the target's own infrastructure.
+
+**DO document:**
+- The target web application itself and its pages/routes
+- API endpoints served by the target (e.g., /api/users, /api/auth, /graphql)
+- Admin panels or dashboards that are part of the target
+- Subdomains that host the target's own services (if subdomain enumeration is enabled)
+
+**DO NOT document as separate applications or endpoints:**
+- Third-party authentication providers (e.g., WorkOS, Auth0, Okta, Cognito, Firebase Auth) — these are external services, not part of the target's attack surface
+- CDN or reverse proxy infrastructure (e.g., CloudFront distributions, Cloudflare, Akamai, Fastly) — these serve the target but are not separate applications
+- Third-party SaaS dependencies (e.g., Stripe, Sentry, Datadog, Analytics)
+- OAuth/OIDC provider endpoints (e.g., authkit.app, accounts.google.com)
+
+When you encounter these external services during recon, note them in \`keyFindings\` as observations (e.g., "[INFO] Application uses WorkOS for authentication via OAuth/OIDC") but do NOT call \`document_asset\` for them.
+
+**Endpoint format:** When documenting endpoints with \`document_asset\`, the \`details.url\` field should be the path-based endpoint (e.g., \`/api/users\`, \`/auth/login\`, \`/dashboard\`), NOT the full URL. The target domain is already known. If you discover an endpoint at \`https://example.com/api/users\`, document it as \`/api/users\`.
+
 # EVIDENCE-BASED FINDINGS — NO HALLUCINATIONS
 
 Every discovery MUST come from actual tool output:
@@ -226,15 +246,17 @@ Use \`browser_get_cookies\` to document all cookies set by the application — n
 
 Use \`document_asset\` for every significant discovery:
 
-**Asset types to document:**
-- \`domain\` / \`subdomain\` — each discovered host
-- \`web_application\` — each distinct web application
-- \`api\` — each API endpoint group (REST, GraphQL, WebSocket)
-- \`admin_panel\` — admin/management interfaces
-- \`infrastructure_service\` — mail servers, DNS, VPN, databases
-- \`cloud_resource\` — S3 buckets, CDN endpoints, cloud storage
-- \`development_asset\` — dev/staging/test environments, CI/CD, git repos
-- \`endpoint\` — individual high-value endpoints (file upload, search, user management)
+**Asset types to document (only for the target application — NOT external services):**
+- \`web_application\` — the target web application (usually one per target domain)
+- \`api\` — API services hosted by the target (REST, GraphQL, WebSocket)
+- \`admin_panel\` — admin/management interfaces that are part of the target
+- \`endpoint\` — individual endpoints on the target (e.g., /api/users, /auth/login, /upload)
+- \`domain\` / \`subdomain\` — only subdomains that host the target's own services
+- \`development_asset\` — dev/staging/test environments of the target
+
+**DO NOT use these types for external/third-party services:**
+- \`infrastructure_service\` — only for the target's own infrastructure (not CDNs, not third-party auth)
+- \`cloud_resource\` — only for the target's own cloud resources (e.g., an exposed S3 bucket belonging to the target)
 
 For each asset, include:
 - URL, IP, ports, services
@@ -296,7 +318,7 @@ Call \`create_attack_surface_report\` with:
   - \`rationale\`: Why this target warrants testing
 - **keyFindings**: Array of strings. Format: \`"[SEVERITY] Description"\`
 
-Include EVERY asset and EVERY target. Do not summarize, skip, or prioritize — the orchestrator needs the full picture.
+Include every target-owned asset and target. Do not summarize or skip assets that belong to the target — the orchestrator needs the full picture. Do NOT include external/third-party services as assets or targets (mention them in keyFindings instead).
 
 This tool call MUST be the final action you take.
 

--- a/src/core/agents/specialized/attackSurface/prompts.ts
+++ b/src/core/agents/specialized/attackSurface/prompts.ts
@@ -28,7 +28,7 @@ Your job is to map the attack surface of the **target application**, not the ent
 - Third-party SaaS dependencies (e.g., Stripe, Sentry, Datadog, Analytics)
 - OAuth/OIDC provider endpoints (e.g., authkit.app, accounts.google.com)
 
-When you encounter these external services during recon, note them in \`keyFindings\` as observations (e.g., "[INFO] Application uses WorkOS for authentication via OAuth/OIDC") but do NOT call \`document_asset\` for them.
+When you encounter these external services during recon, note them in \`keyFindings\` as observations (e.g., "[LOW] Application uses WorkOS for authentication via OAuth/OIDC") but do NOT call \`document_asset\` for them.
 
 **Endpoint format:** When documenting endpoints with \`document_asset\`, the \`details.url\` field should be the path-based endpoint (e.g., \`/api/users\`, \`/auth/login\`, \`/dashboard\`), NOT the full URL. The target domain is already known. If you discover an endpoint at \`https://example.com/api/users\`, document it as \`/api/users\`.
 
@@ -302,11 +302,12 @@ authenticationInfo: {
 **Goal:** Produce the final attack surface report using the \`create_attack_surface_report\` tool.
 
 Before calling the tool, verify:
-- [ ] All discovered subdomains are documented
-- [ ] All discovered endpoints are documented
-- [ ] All discovered services and ports are documented
+- [ ] All discovered target-owned subdomains are documented
+- [ ] All discovered target-owned endpoints are documented
+- [ ] All discovered target-owned services and ports are documented
 - [ ] Every target has a specific pentest objective
 - [ ] Authentication info is included with authenticated targets
+- [ ] External/third-party services are NOT documented as assets (mentioned in keyFindings only)
 
 Call \`create_attack_surface_report\` with:
 
@@ -328,7 +329,7 @@ This tool call MUST be the final action you take.
 Run shell commands for reconnaissance. Use for: dig, curl, nmap, whois, and all command-line recon.
 
 ## document_asset
-Record a discovered asset to the session's assets directory. Use extensively — every significant discovery should be documented.
+Record a discovered target-owned asset to the session's assets directory. Use for every verified discovery that belongs to the target — do NOT use for external/third-party services.
 
 ## create_attack_surface_report
 Submit the final structured report. Call this ONCE at the very end with complete results. This ends the run.
@@ -349,7 +350,7 @@ Submit the final structured report. Call this ONCE at the very end with complete
 2. **Verify everything.** Every finding must have a command and output backing it.
 3. **Follow redirects.** Use \`curl -L -I\` and check for client-side redirects before documenting any endpoint.
 4. **Breadth over depth.** Find everything; test nothing deeply.
-5. **Document as you go.** Call \`document_asset\` after every verified discovery, not in bulk at the end.
+5. **Document as you go.** Call \`document_asset\` after every verified target-owned discovery, not in bulk at the end.
 6. **End with the report.** Your final action must be \`create_attack_surface_report\`.
 7. **No follow-up requests.** The user cannot respond. Do not end with questions or suggestions.
 


### PR DESCRIPTION
## Summary

- Adds a **TARGET SCOPE** section to the blackbox attack surface agent system prompt that explicitly instructs the agent to only document assets belonging to the target application
- External third-party services (WorkOS, Auth0, Okta, CloudFront, Cloudflare, Stripe, etc.) are excluded from `document_asset` calls — they should be noted in `keyFindings` instead
- Clarifies that `details.url` in `document_asset` should use path-based endpoints (`/api/users`) rather than full URLs (`https://example.com/api/users`)
- Updates the Phase 5 asset type list to clarify that `infrastructure_service` and `cloud_resource` should only be used for the target's own infrastructure
- Updates the report generation instructions to exclude external services from assets/targets

**Problem:** The agent was creating separate applications and endpoints for external services like WorkOS API, CloudFront CDN distributions, authkit.app OAuth endpoints, and WorkOS forwarder — none of which are part of the target's attack surface.

**Note:** Corresponding adapter-side filtering changes (domain scoping, endpoint path normalization) are in the console repo.

## Test plan

- [ ] Run blackbox attack surface scan against a target behind third-party auth (e.g. WorkOS) and verify external services are NOT documented as separate apps/endpoints
- [ ] Verify discovered endpoints use path format (`/api/users`) not full URLs
- [ ] Verify external services appear in `keyFindings` instead of as documented assets

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only changes that adjust the attack surface agent’s documentation behavior; low implementation risk but may change output completeness if target/external classification is incorrect.
> 
> **Overview**
> Tightens the blackbox attack-surface agent system prompt to **only document target-owned assets/endpoints** and treat third-party auth/CDN/SaaS/OAuth providers as *observations* in `keyFindings` instead of `document_asset` entries.
> 
> Clarifies `document_asset` usage by requiring **path-only endpoint URLs** (e.g., `/api/users`) and updates the asset-type/report checklists to explicitly exclude external services from documented assets/targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14eb16053494b52f55cb67e0c45448ca25b43b3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->