### PR TITLE
Canary branch docs updates

### DIFF
--- a/fern/docs/commands/auth.mdx
+++ b/fern/docs/commands/auth.mdx
@@ -23,6 +23,8 @@ pensar auth status     # Show current connection status
 pensar auth logout     # Disconnect from Pensar Console
 ```
 
+`pensar auth status` displays your auth type (WorkOS or API key) and current workspace. When using API key auth, the command resolves your workspace from the server if it isn't already stored locally.
+
 ## How It Works
 
 Both the TUI `/auth` command and the CLI `pensar auth` command use a **device authorization flow** — similar to how you link a streaming device to your account. Apex displays a code, you verify it in your browser, and the CLI is automatically authenticated.

--- a/fern/docs/commands/help.mdx
+++ b/fern/docs/commands/help.mdx
@@ -134,6 +134,22 @@ For new users, here's the recommended order of commands:
 | `Y`                | Approve pending tool call             |
 | `A`                | Auto-approve all remaining tool calls |
 
+## Command Suggestions
+
+When typing a `/` command, Apex displays a windowed suggestions dropdown with up to 6 visible entries at a time. Commands are sorted by priority — `/pentest`, `/operator`, `/auth`, `/models`, `/sessions`, `/themes`, `/help` appear first, followed by the rest alphabetically. Scroll indicators (`↑`/`↓`) appear when more suggestions exist outside the visible window.
+
+## CLI API Commands
+
+In addition to the TUI commands above, Apex provides headless CLI commands for interacting with the Pensar Console REST API. These require an active Pensar Console connection (`pensar auth login`).
+
+| Command | Description |
+| --- | --- |
+| `pensar projects` | List workspace projects |
+| `pensar pentests <projectId>` | List, get, or dispatch pentests |
+| `pensar issues <projectId>` | List, get, or update security issues |
+| `pensar fixes <issueId>` | List or get security fixes |
+| `pensar logs <issueId>` | List or search agent execution logs |
+
 ## Tips
 
 <Callout intent="info">

--- a/fern/docs/commands/models.mdx
+++ b/fern/docs/commands/models.mdx
@@ -17,6 +17,8 @@ The `/models` command opens the model selection interface where you can view ava
 
 The models interface displays all available models from your configured providers, organized by provider name. You can navigate through the list and select your preferred model.
 
+When no model is explicitly selected, Apex automatically picks a default based on your configured provider, prioritized as: Pensar → Anthropic → OpenAI → Google → OpenRouter → Bedrock.
+
 <Callout intent="info">
   Only models from **configured providers** are shown. Use `/providers` to set
   up additional AI providers, or `/auth` to connect via Pensar Console.
@@ -117,6 +119,7 @@ When you open `/models`, you'll see:
     Managed inference through Pensar Console — no API key required.
 
     Available models:
+    - Claude Opus 4.6 (default for Pensar)
     - Claude Sonnet 4.5 / Opus 4.5
     - Claude Sonnet 4.0 / Opus 4.0
     - Claude Haiku 4.5
@@ -126,6 +129,20 @@ When you open `/models`, you'll see:
 
   </Accordion>
 </AccordionGroup>
+
+## Default Model Per Provider
+
+When you haven't explicitly selected a model, Apex automatically uses the flagship model for your highest-priority configured provider:
+
+| Provider    | Default Model                |
+| ----------- | ---------------------------- |
+| Pensar      | Claude Opus 4.6 (Pensar)    |
+| Anthropic   | Claude Opus 4.6              |
+| OpenAI      | GPT-5.2 Pro                  |
+| Google      | Gemini 3.1 Pro Preview       |
+| OpenRouter  | Claude Opus 4.6 (OpenRouter) |
+
+This also applies to the headless CLI commands (`pensar pentest`, `pensar targeted-pentest`) when the `--model` flag is not provided.
 
 ## Setting Up Providers
 

--- a/fern/docs/commands/providers.mdx
+++ b/fern/docs/commands/providers.mdx
@@ -55,7 +55,11 @@ Apex supports the following AI providers:
     Use `↑/↓` arrows to navigate and `[Enter]` to select a provider
   </Step>
   <Step title="Enter API Key">
-    Input your API key for the selected provider
+    Input your API key for the selected provider. Apex verifies your key against the provider's API before saving — if the key is invalid, you'll see an inline error and can try again.
+
+    <Callout intent="info">
+      Selecting **Pensar Console** from the provider list routes you to the `/auth` device-flow login instead of the API key input screen.
+    </Callout>
   </Step>
   <Step title="Select Model">
     After configuring, you'll be redirected to `/models` to select a model
@@ -223,10 +227,11 @@ You can also access providers from the models screen:
     **Issue**: Provider shows configured but models won't load
     
     **Solutions**:
-    1. Verify the API key is correct (no extra spaces)
-    2. Check that your account has credits/access
-    3. Ensure the key has appropriate permissions
-    4. Try regenerating the key
+    1. Apex verifies keys on entry — if you see a verification error, double-check the key
+    2. Verify the API key is correct (no extra spaces)
+    3. Check that your account has credits/access
+    4. Ensure the key has appropriate permissions
+    5. Try regenerating the key
   </Accordion>
 
   <Accordion title="Provider not showing" icon="eye-slash">

--- a/fern/docs/getting-started.mdx
+++ b/fern/docs/getting-started.mdx
@@ -120,6 +120,11 @@ pensar targeted-pentest --target <url>      # Run a targeted pentest
 pensar auth login                           # Connect to Pensar Console from the CLI
 pensar auth status                          # Show current auth connection status
 pensar auth logout                          # Disconnect from Pensar Console
+pensar projects                             # List workspace projects
+pensar pentests <projectId>                 # List/get/dispatch pentests
+pensar issues <projectId>                   # List/get/update security issues
+pensar fixes <issueId>                      # List/get security fixes
+pensar logs <issueId>                       # List/search agent execution logs
 pensar upgrade                              # Update to the latest version
 pensar doctor                               # Check & install optional dependencies
 pensar uninstall                            # Fully remove Pensar (interactive)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR updates the documentation in `fern/docs/` to reflect recent changes on the `canary` branch (versions 0.0.102–0.0.111). Key updates include:

*   **`getting-started.mdx`**: Added new CLI API commands (`projects`, `pentests`, `issues`, `fixes`, `logs`).
*   **`commands/models.mdx`**: Documented dynamic default model selection per provider, added a "Default Model Per Provider" table, and updated the Pensar models list.
*   **`commands/providers.mdx`**: Added API key verification documentation and noted Pensar's `/auth` device-flow routing.
*   **`commands/auth.mdx`**: Updated `pensar auth status` workspace resolution for API key authentication.
*   **`commands/help.mdx`**: Added sections for "Command Suggestions" and "CLI API Commands".

These changes ensure the documentation accurately reflects the latest CLI features and behaviors.

### How did you verify your code works?

All lint, type checks, and tests passed (451 passed, 15 skipped) after applying the documentation updates.

[Slack Thread](https://pensarhq.slack.com/archives/C0ALYALLXNH/p1773835693184859)

<div><a href="https://cursor.com/agents/bc-79ed3dea-8d1f-44a9-b1cb-635e041bc0e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79ed3dea-8d1f-44a9-b1cb-635e041bc0e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->