### PR TITLE
Add disconnect hotkey to auth flow workspace selection

### DIFF
--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -427,6 +427,9 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
           ac,
         );
       }
+      if (key.raw === "d" || key.raw === "D") {
+        handleDisconnect();
+      }
     }
 
     if (step === "error") {
@@ -548,6 +551,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               <text fg={colors.textMuted}>
                 <span fg={colors.primary}>[↑/↓]</span> Navigate ·{" "}
                 <span fg={colors.primary}>[ENTER]</span> Select ·{" "}
+                <span fg={colors.error}>[D]</span> Disconnect ·{" "}
                 <span fg={colors.primary}>[ESC]</span> Cancel
               </text>
             </box>


### PR DESCRIPTION
## Summary
- Adds a `D` hotkey to the workspace selection screen in the auth flow, allowing users to disconnect their account directly without navigating away
- Displays the hotkey hint (`[D] Disconnect`) in the footer alongside existing navigation hints

## Test plan
- [ ] Open the auth flow while connected to a workspace
- [ ] Verify pressing `D` or `d` on the workspace selection screen triggers disconnect
- [ ] Verify the `[D] Disconnect` hint appears in the footer


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small TUI-only change that adds a new keybinding and hint text without altering auth/token or workspace selection logic.
> 
> **Overview**
> Adds a `D`/`d` hotkey on the auth flow’s `select-workspace` step to trigger `handleDisconnect()` directly from the workspace picker.
> 
> Updates the workspace selection footer to display the new **`[D] Disconnect`** hint alongside existing navigation controls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 514ad7a3e39cf9f021d07e899c165957070f90d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->