### PR TITLE
feat: add pentestObjectives field to document_asset tool

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentAsset.ts
+++ b/src/core/agents/offSecAgent/tools/documentAsset.ts
@@ -115,6 +115,12 @@ Each asset creates a JSON file in the assets directory for tracking and analysis
         .string()
         .optional()
         .describe("Additional notes or observations about the asset"),
+      pentestObjectives: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Specific pentest objectives for this asset — what a pentest agent should test (e.g., 'Test for IDOR in /api/orders/{id}')",
+        ),
       toolCallDescription: z
         .string()
         .describe(

--- a/src/core/agents/offSecAgent/tools/documentAsset.ts
+++ b/src/core/agents/offSecAgent/tools/documentAsset.ts
@@ -117,7 +117,6 @@ Each asset creates a JSON file in the assets directory for tracking and analysis
         .describe("Additional notes or observations about the asset"),
       pentestObjectives: z
         .array(z.string())
-        .optional()
         .describe(
           "Specific pentest objectives for this asset — what a pentest agent should test (e.g., 'Test for IDOR in /api/orders/{id}')",
         ),

--- a/src/core/agents/specialized/attackSurface/prompts.ts
+++ b/src/core/agents/specialized/attackSurface/prompts.ts
@@ -263,10 +263,13 @@ For each asset, include:
 - Technology stack (only what you have evidence for)
 - Authentication requirements
 - Risk level (LOW / MEDIUM / HIGH / CRITICAL)
+- \`pentestObjectives\` — specific pentest objectives (see 5b below)
 
-## 5b. Identify pentest objectives
+## 5b. Include pentest objectives with every asset
 
-For each asset, determine what a pentest agent should test. Map asset types to specific vulnerability classes:
+**Every \`document_asset\` call MUST include a \`pentestObjectives\` array.** These objectives are passed directly to pentest agents downstream — they define exactly what each agent will test. An asset without objectives will not be pentested.
+
+Map asset types to specific vulnerability classes:
 
 | Asset Type | Test For |
 |---|---|
@@ -281,8 +284,8 @@ For each asset, determine what a pentest agent should test. Map asset types to s
 | Encrypted session tokens | Cipher mode attacks, padding oracle, session forgery |
 
 Write objectives that are **specific**, not vague:
-- Good: "Test for IDOR in /api/orders/{id} — verify whether user A can access user B's orders by manipulating the order ID"
-- Bad: "Test for vulnerabilities"
+- Good: \`pentestObjectives: ["Test for IDOR in /api/orders/{id} — verify whether user A can access user B's orders by manipulating the order ID"]\`
+- Bad: \`pentestObjectives: ["Test for vulnerabilities"]\`
 
 ## 5c. Include authentication info with every target
 

--- a/src/core/agents/specialized/attackSurface/schemas.ts
+++ b/src/core/agents/specialized/attackSurface/schemas.ts
@@ -108,6 +108,12 @@ export const DocumentAssetSchema = z.object({
     .string()
     .optional()
     .describe("Additional notes or observations about the asset"),
+  pentestObjectives: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Specific pentest objectives for this asset (e.g., 'Test for IDOR in /api/orders/{id}')",
+    ),
 });
 
 /**

--- a/src/core/agents/specialized/attackSurface/schemas.ts
+++ b/src/core/agents/specialized/attackSurface/schemas.ts
@@ -110,7 +110,6 @@ export const DocumentAssetSchema = z.object({
     .describe("Additional notes or observations about the asset"),
   pentestObjectives: z
     .array(z.string())
-    .optional()
     .describe(
       "Specific pentest objectives for this asset (e.g., 'Test for IDOR in /api/orders/{id}')",
     ),


### PR DESCRIPTION
## Summary

- Adds `pentestObjectives: string[]` (optional) to `DocumentAssetSchema` and the `document_asset` tool input schema
- Updates Phase 5 prompt to require `pentestObjectives` on every `document_asset` call, using the existing vulnerability class mapping table as guidance
- Objectives flow directly from `document_asset` -> asset JSON files -> Console adapter -> `endpoints.objectives` DB column -> pentest agent prompt

**Problem:** The `document_asset` tool had no field for pentest objectives. Objectives were only generated in the final report `targets[]`, but `transformReportTargetsToEndpoints()` was dead code — never called by the adapter. This meant endpoints in the DB always had empty `objectives`, causing the pentest agent to fail or have no testing direction.

**Companion PR:** Console adapter change to map `asset.pentestObjectives` -> `endpoint.objectives`.

## Test plan

- [ ] Run blackbox attack surface scan and verify `pentestObjectives` appear in asset JSON files
- [ ] Verify objectives are populated on endpoints in the DB after recon completes
- [ ] Run a pentest after recon and verify the agent receives non-empty objectives

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Makes `pentestObjectives` a required field on `document_asset` inputs and the shared `DocumentAssetSchema`, which can break existing callers/adapters until they populate it. Prompt changes also alter downstream pentest behavior by gating testing on objectives being present.
> 
> **Overview**
> Adds a new required `pentestObjectives: string[]` field to the `document_asset` tool input and the exported `DocumentAssetSchema`, so documented asset JSON now carries explicit pentest objectives.
> 
> Updates the attack-surface Phase 5 prompt to **require** `pentestObjectives` on every `document_asset` call and provides guidance/examples for writing specific objectives that are passed downstream to pentest agents.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f9e9901aac58277cf2ef2441b681ba0f94826c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->