### PR TITLE
Fixed the problem where even with credits it showed needs credits

### DIFF
--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -211,9 +211,12 @@ async function handleWorkspaces(
     `\n✓ Connected to Pensar Console\n  Workspace: ${workspace.name} (${workspace.slug})\n  Credits: $${result.billing.balance.toFixed(2)}`,
   );
 
-  if (!result.confirmed && result.billingUrl) {
+  const needsBillingSetup =
+    !result.billing.ready && result.billing.balance <= 0 && !!result.billingUrl;
+
+  if (needsBillingSetup && result.billingUrl) {
     console.log(
-      `\n⚠ Your workspace needs credits. Add them at:\n  ${result.billingUrl}`,
+      `\n⚠ Your workspace billing setup is not ready yet. Finish setup at:\n  ${result.billingUrl}`,
     );
   } else if (result.billing.balance < 1) {
     const billingUrl = `${getPensarConsoleUrl()}/${workspace.slug}/settings/billing`;

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -54,6 +54,11 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [billingUrl, setBillingUrl] = useState<string | null>(null);
   const [balance, setBalance] = useState<number | null>(null);
+  const [billingStatus, setBillingStatus] = useState<{
+    confirmed: boolean;
+    ready: boolean;
+    hasPaymentMethod: boolean;
+  } | null>(null);
 
   const abortRef = useRef<AbortController | null>(null);
 
@@ -225,6 +230,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
           : null,
       );
       setBalance(data.credits?.balance ?? null);
+      setBillingStatus(null);
       setStep("success");
     } catch (err) {
       if (ac.signal.aborted) return;
@@ -327,6 +333,11 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
       appConfig.reload();
 
       setBalance(data.billing.balance);
+      setBillingStatus({
+        confirmed: data.confirmed,
+        ready: data.billing.ready,
+        hasPaymentMethod: data.billing.hasPaymentMethod,
+      });
 
       if (!data.confirmed && data.billingUrl) {
         setBillingUrl(data.billingUrl);
@@ -359,10 +370,14 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
     setSelectedWorkspace(null);
     setBalance(null);
     setBillingUrl(null);
+    setBillingStatus(null);
     setStep("start");
   };
 
   const hasLowBalance = balance !== null && balance < 1;
+  const needsBillingSetup =
+    billingStatus !== null && !billingStatus.ready && (balance ?? 0) <= 0;
+  const showBillingWarning = hasLowBalance || needsBillingSetup;
 
   const effectiveBillingUrl =
     billingUrl ||
@@ -441,7 +456,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
 
     if (step === "success") {
       if (key.name === "return") {
-        if (hasLowBalance || billingUrl) {
+        if (showBillingWarning) {
           openBillingPage();
         } else {
           goHome();
@@ -622,15 +637,15 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
                 )}
               </box>
             )}
-            {(hasLowBalance || billingUrl) && (
+            {showBillingWarning && (
               <box marginTop={1}>
                 <text fg={colors.warning}>
-                  {billingUrl
-                    ? "Your workspace needs credits to use Apex CLI."
+                  {needsBillingSetup
+                    ? "Your workspace billing setup is not ready yet."
                     : "Your credit balance is very low. We recommend at least $30 to run"}
                   {"\n"}
-                  {billingUrl
-                    ? "Press ENTER to open billing and add credits."
+                  {needsBillingSetup
+                    ? "Press ENTER to open billing and finish setup."
                     : "pentests without interruptions. Press ENTER to open billing."}
                 </text>
               </box>
@@ -652,7 +667,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
             <box marginTop={1}>
               <text fg={colors.textMuted}>
                 <span fg={colors.primary}>[ENTER]</span>{" "}
-                {hasLowBalance || billingUrl ? "Open billing" : "Done"} ·{" "}
+                {showBillingWarning ? "Open billing" : "Done"} ·{" "}
                 <span fg={colors.error}>[D]</span> Disconnect ·{" "}
                 <span fg={colors.primary}>[ESC]</span> Back
               </text>


### PR DESCRIPTION
#419 

- Updated billing status checks in `auth.ts` to provide clearer messaging for users regarding workspace billing setup.
- Introduced a new state for billing status in `auth-flow.tsx` to manage billing readiness and payment method availability.
- Improved user feedback in the TUI for low balance and incomplete billing setup scenarios, ensuring users are directed to the appropriate actions.

### What does this PR do?

This pull request enhances the workspace authentication and billing flow by introducing a more robust check for billing setup readiness, improving user feedback and warnings when a workspace requires billing setup or has a low balance. The changes ensure users are clearly informed about the billing status and what actions are needed.

**Billing flow improvements:**

* Added a new `billingStatus` state in `AuthFlow` to track billing readiness, confirmation, and payment method status, enabling more precise billing checks.
* Implemented a `needsBillingSetup` check that combines billing readiness and balance, improving detection of workspaces that require billing setup. [[1]](diffhunk://#diff-ad51430ca88dc77cde7617593833d7ecfd678499bfcaeca6c34748ca5d21ba8bL214-R219) [[2]](diffhunk://#diff-5915057898fa8458541be809a400c60f87d65f4b20493427904ffd10c9657a08R373-R380)
* Updated logic and UI to show a distinct warning and action prompt when billing setup is not ready, differentiating it from low balance warnings. [[1]](diffhunk://#diff-5915057898fa8458541be809a400c60f87d65f4b20493427904ffd10c9657a08L625-R648) [[2]](diffhunk://#diff-5915057898fa8458541be809a400c60f87d65f4b20493427904ffd10c9657a08L655-R670) [[3]](diffhunk://#diff-5915057898fa8458541be809a400c60f87d65f4b20493427904ffd10c9657a08L444-R459)

**State management enhancements:**

* Ensured that `billingStatus` is reset appropriately when workspace selection changes or authentication completes, preventing stale state issues. [[1]](diffhunk://#diff-5915057898fa8458541be809a400c60f87d65f4b20493427904ffd10c9657a08R233) [[2]](diffhunk://#diff-5915057898fa8458541be809a400c60f87d65f4b20493427904ffd10c9657a08R373-R380) [[3]](diffhunk://#diff-5915057898fa8458541be809a400c60f87d65f4b20493427904ffd10c9657a08R336-R340)

### How did you verify your code works?

* Ran the project locally, and the problem seemed to be fixed. `bun run test` and `tsc -noEmit` didn't cause any problems either.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adjusts billing-state checks and user-facing messaging during auth without changing authentication, token storage, or billing mutations.
> 
> **Overview**
> Refines post-auth billing warnings so workspaces with existing credits are no longer incorrectly flagged as “needs credits”.
> 
> The CLI and TUI now compute a `needsBillingSetup` condition based on `billing.ready` and zero/negative balance, show a distinct “billing setup not ready” message with the server-provided `billingUrl`, and otherwise fall back to the existing low-balance warning and “Open billing” enter-key behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3886e30aeb6eeae31cfe06e0452b3ef0d3ca2df0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->