### PR TITLE
fix: case-insensitive author check in auto-assign workflow

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -24,8 +24,8 @@ jobs:
               'jorgeraad',
             ];
 
-            const author = context.payload.pull_request.user.login;
-            const eligible = team.filter((m) => m !== author);
+            const author = context.payload.pull_request.user.login.toLowerCase();
+            const eligible = team.filter((m) => m.toLowerCase() !== author);
             if (eligible.length === 0) return;
 
             const { data: recentPRs } = await github.rest.pulls.list({


### PR DESCRIPTION
## Summary
- The auto-assign workflow's author filter used strict `!==` equality, so if GitHub returned the login in a different case than the hardcoded team array (e.g. `Yuvanesh-UX` vs `yuvanesh-ux`), the PR author could be assigned as their own reviewer.
- Fixed by lowercasing both sides of the comparison before filtering.

## Test plan
- [x] Verify the workflow YAML is valid
- [ ] Next PR opened by yuva should not assign him as his own reviewer

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to the reviewer eligibility filter in a GitHub Actions workflow; it only affects auto-assignment behavior and does not touch application code or data.
> 
> **Overview**
> Updates `.github/workflows/auto-assign.yml` to **prevent self-assignment when GitHub login casing differs** by lowercasing the PR author login and comparing against lowercased team members when building the eligible reviewer list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42613f5b53d89f0c3ad2c4ad3b4cf730ff068a5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->