### PR TITLE
Update docs to include separate sections in the sidebar for TUI slash commands and CLI args

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -52,22 +52,56 @@ navigation:
             path: ./docs/intro.mdx
           - page: Getting Started
             path: ./docs/getting-started.mdx
-      - section: Commands
+      - section: TUI Slash Commands
         contents:
           - page: /pentest
             path: ./docs/commands/pentest.mdx
           - page: /operator
             path: ./docs/commands/operator.mdx
+          - page: /auth
+            path: ./docs/commands/auth.mdx
           - page: /models
             path: ./docs/commands/models.mdx
           - page: /providers
             path: ./docs/commands/providers.mdx
-          - page: /auth
-            path: ./docs/commands/auth.mdx
+          - page: /sessions
+            path: ./docs/commands/sessions.mdx
+          - page: /themes
+            path: ./docs/commands/themes.mdx
           - page: /credits
             path: ./docs/commands/credits.mdx
+          - page: /config
+            path: ./docs/commands/config.mdx
+          - page: /create-skill
+            path: ./docs/commands/create-skill.mdx
           - page: /help
             path: ./docs/commands/help.mdx
+      - section: CLI Commands
+        contents:
+          - page: pensar pentest
+            path: ./docs/cli/pentest.mdx
+          - page: pensar targeted-pentest
+            path: ./docs/cli/targeted-pentest.mdx
+          - page: pensar auth
+            path: ./docs/cli/auth.mdx
+          - page: pensar projects
+            path: ./docs/cli/projects.mdx
+          - page: pensar pentests
+            path: ./docs/cli/pentests.mdx
+          - page: pensar issues
+            path: ./docs/cli/issues.mdx
+          - page: pensar fixes
+            path: ./docs/cli/fixes.mdx
+          - page: pensar logs
+            path: ./docs/cli/logs.mdx
+          - page: pensar upgrade
+            path: ./docs/cli/upgrade.mdx
+          - page: pensar doctor
+            path: ./docs/cli/doctor.mdx
+          - page: pensar uninstall
+            path: ./docs/cli/uninstall.mdx
+          - page: pensar version
+            path: ./docs/cli/version.mdx
   - tab: console
     layout:
 

--- a/fern/docs/cli/auth.mdx
+++ b/fern/docs/cli/auth.mdx
@@ -1,0 +1,70 @@
+---
+title: "pensar auth"
+description: "Connect to Pensar Console from the command line"
+---
+
+## Overview
+
+The `pensar auth` command connects your CLI to [Pensar Console](https://console.pensar.dev) for managed inference. This is the headless equivalent of the TUI [`/auth`](/apex/commands/auth) command — it uses the same device authorization flow but runs entirely in the terminal without the TUI.
+
+## Usage
+
+```bash
+pensar auth [subcommand]
+```
+
+## Subcommands
+
+| Subcommand           | Description                                              |
+| -------------------- | -------------------------------------------------------- |
+| `pensar auth`        | Start the login flow (or show status if already connected) |
+| `pensar auth login`  | Start the login flow                                     |
+| `pensar auth logout` | Disconnect from Pensar Console                           |
+| `pensar auth status` | Show current connection status                           |
+
+## Login Flow
+
+```bash
+pensar auth login
+```
+
+1. Apex requests a device code from the Pensar authentication service
+2. A browser window opens to the verification URL
+3. Enter the user code displayed in your terminal to confirm
+4. Select a workspace (if your account has multiple)
+5. Apex stores the auth tokens locally
+
+If you're already connected, `pensar auth` will show your current status and offer to reconnect.
+
+## Checking Status
+
+```bash
+pensar auth status
+```
+
+Displays your auth type (WorkOS or API key) and current workspace. When using API key auth, the command resolves your workspace from the server if it isn't already stored locally.
+
+```
+✓ Connected to Pensar Console
+  Workspace: my-team (my-team)
+  Auth: WorkOS
+```
+
+## Logging Out
+
+```bash
+pensar auth logout
+```
+
+Clears stored authentication tokens from your local configuration. You can reconnect at any time by running `pensar auth login` again.
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="/auth" icon="shield-check" href="/apex/commands/auth">
+    Connect via the TUI with the same device flow
+  </Card>
+  <Card title="pensar projects" icon="folder" href="/apex/cli/projects">
+    List workspace projects (requires auth)
+  </Card>
+</CardGroup>

--- a/fern/docs/cli/doctor.mdx
+++ b/fern/docs/cli/doctor.mdx
@@ -1,0 +1,70 @@
+---
+title: "pensar doctor"
+description: "Check dependencies and install missing tools"
+---
+
+## Overview
+
+The `pensar doctor` command performs a health check on your Pensar Apex installation. It verifies that optional dependencies are installed and offers to install missing ones automatically.
+
+## Usage
+
+```bash
+pensar doctor
+```
+
+## What It Checks
+
+### System Tools
+
+- **nmap** — network scanner used for port scanning and service detection. If nmap is not found, `doctor` offers to install it via your system package manager (Homebrew, apt, dnf, or pacman).
+
+### AI Providers
+
+Checks which AI provider API keys are configured via environment variables:
+
+| Provider    | Environment Variable            |
+| ----------- | ------------------------------- |
+| Anthropic   | `ANTHROPIC_API_KEY`             |
+| OpenAI      | `OPENAI_API_KEY`                |
+| Google      | `GOOGLE_GENERATIVE_AI_API_KEY`  |
+| OpenRouter  | `OPENROUTER_API_KEY`            |
+| AWS Bedrock | `BEDROCK_API_KEY`               |
+| AWS IAM     | `AWS_ACCESS_KEY_ID`             |
+| vLLM        | `LOCAL_MODEL_URL`               |
+
+## Example Output
+
+```
+Pensar Doctor
+=============
+
+System Tools
+------------
+  ✓ nmap (Nmap 7.94)
+
+AI Providers
+------------
+  ✓ Anthropic
+  · OpenAI
+  · Google
+  · OpenRouter
+  · AWS Bedrock
+  · AWS IAM
+  · vLLM (local)
+```
+
+<Callout intent="info">
+  API keys configured via `/providers` in the TUI are stored in `~/.pensar/config.json` and are not detected by `pensar doctor`. The doctor command only checks environment variables.
+</Callout>
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="pensar upgrade" icon="arrow-up" href="/apex/cli/upgrade">
+    Update to the latest version
+  </Card>
+  <Card title="/providers" icon="plug" href="/apex/commands/providers">
+    Configure AI providers in the TUI
+  </Card>
+</CardGroup>

--- a/fern/docs/cli/fixes.mdx
+++ b/fern/docs/cli/fixes.mdx
@@ -1,0 +1,58 @@
+---
+title: "pensar fixes"
+description: "View security fixes and diffs via the Pensar Console API"
+---
+
+## Overview
+
+The `pensar fixes` command lets you view suggested security fixes for issues discovered during pentests. Fixes include code diffs that show exactly what changes are recommended.
+
+## Usage
+
+```bash
+pensar fixes <issueId>         # List fixes for an issue
+pensar fixes get <fixId>       # Get fix details (includes diff)
+```
+
+## Prerequisites
+
+You must be connected to Pensar Console via [`pensar auth login`](/apex/cli/auth) before using this command.
+
+## Subcommands
+
+### List Fixes
+
+```bash
+pensar fixes <issueId>
+```
+
+Lists all suggested fixes for a given issue. Returns a JSON array of fix objects.
+
+### Get Fix Details
+
+```bash
+pensar fixes get <fixId>
+```
+
+Returns detailed information about a specific fix, including the code diff.
+
+## Examples
+
+```bash
+# List fixes for an issue
+pensar fixes issue_ghi789
+
+# Get details and diff for a specific fix
+pensar fixes get fix_jkl012
+```
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="pensar issues" icon="bug" href="/apex/cli/issues">
+    List and manage the issues that fixes address
+  </Card>
+  <Card title="pensar logs" icon="scroll" href="/apex/cli/logs">
+    View agent execution logs for debugging
+  </Card>
+</CardGroup>

--- a/fern/docs/cli/issues.mdx
+++ b/fern/docs/cli/issues.mdx
@@ -1,0 +1,86 @@
+---
+title: "pensar issues"
+description: "List, view, and update security issues via the Pensar Console API"
+---
+
+## Overview
+
+The `pensar issues` command lets you manage security issues discovered by pentests. You can list issues with filters, view detailed information, and update issue statuses.
+
+## Usage
+
+```bash
+pensar issues <projectId> [filters]            # List issues for a project
+pensar issues get <issueId>                    # Get issue details
+pensar issues update <issueId> [options]       # Update an issue
+```
+
+## Prerequisites
+
+You must be connected to Pensar Console via [`pensar auth login`](/apex/cli/auth) before using this command.
+
+## Subcommands
+
+### List Issues
+
+```bash
+pensar issues <projectId> [filters]
+```
+
+Lists security issues for a project. Returns a JSON array.
+
+| Filter                | Description                                              |
+| --------------------- | -------------------------------------------------------- |
+| `--status <status>`   | Filter by: `open`, `closed`, `false-positive`, `in-review` |
+| `--severity <sev>`    | Filter by: `critical`, `high`, `medium`, `low`           |
+| `--scan <scanId>`     | Filter by scan (pentest) ID                              |
+| `--branch <branch>`   | Filter by branch                                         |
+
+### Get Issue Details
+
+```bash
+pensar issues get <issueId>
+```
+
+Returns detailed information about a specific issue, including vulnerability description, reproduction steps, and severity.
+
+### Update an Issue
+
+```bash
+pensar issues update <issueId> [options]
+```
+
+| Option                       | Description                         |
+| ---------------------------- | ----------------------------------- |
+| `--status <status>`          | New status                          |
+| `--closed-reason <reason>`   | Reason for closing                  |
+| `--closed-comments <text>`   | Additional comments when closing    |
+| `--false-positive`           | Flag the issue as a false positive  |
+| `--fp-reason <reason>`       | Reason for the false positive flag  |
+
+## Examples
+
+```bash
+# List all open critical issues
+pensar issues proj_abc123 --status open --severity critical
+
+# Get details for a specific issue
+pensar issues get issue_ghi789
+
+# Close an issue with a reason
+pensar issues update issue_ghi789 --status closed --closed-reason "Patched in v2.1"
+
+# Flag as false positive
+pensar issues update issue_ghi789 --false-positive --fp-reason "Test environment only"
+```
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="pensar fixes" icon="wrench" href="/apex/cli/fixes">
+    View suggested fixes for an issue
+  </Card>
+  <Card title="pensar logs" icon="scroll" href="/apex/cli/logs">
+    View agent execution logs for an issue
+  </Card>
+</CardGroup>

--- a/fern/docs/cli/logs.mdx
+++ b/fern/docs/cli/logs.mdx
@@ -1,0 +1,79 @@
+---
+title: "pensar logs"
+description: "View and search agent execution logs via the Pensar Console API"
+---
+
+## Overview
+
+The `pensar logs` command provides access to agent execution logs for a given issue. You can list logs with filters or search for specific content within the log entries.
+
+## Usage
+
+```bash
+pensar logs <issueId> [filters]                 # List agent logs
+pensar logs search <issueId> <query> [options]  # Search agent logs
+```
+
+## Prerequisites
+
+You must be connected to Pensar Console via [`pensar auth login`](/apex/cli/auth) before using this command.
+
+## Subcommands
+
+### List Logs
+
+```bash
+pensar logs <issueId> [filters]
+```
+
+Lists agent execution logs for an issue. Returns a JSON array.
+
+| Filter            | Description                                                            |
+| ----------------- | ---------------------------------------------------------------------- |
+| `--level <level>` | Filter by: `debug`, `info`, `warn`, `error`                           |
+| `--role <role>`   | Filter by: `assistant`, `user`, `system`, `tool-call`, `tool-result`   |
+| `--limit <n>`     | Max entries to return (default: 100, max: 500)                         |
+
+### Search Logs
+
+```bash
+pensar logs search <issueId> <query> [options]
+```
+
+Searches log entries for a given query string.
+
+| Option              | Description                                                          |
+| ------------------- | -------------------------------------------------------------------- |
+| `--level <level>`   | Filter by: `debug`, `info`, `warn`, `error`                         |
+| `--role <role>`     | Filter by: `assistant`, `user`, `system`, `tool-call`, `tool-result` |
+| `--context <n>`     | Number of context lines around matches (default: 3)                  |
+
+## Examples
+
+```bash
+# List all logs for an issue
+pensar logs issue_ghi789
+
+# List only error-level logs
+pensar logs issue_ghi789 --level error
+
+# List tool call logs with a limit
+pensar logs issue_ghi789 --role tool-call --limit 50
+
+# Search logs for a specific term
+pensar logs search issue_ghi789 "SQL injection"
+
+# Search with filters
+pensar logs search issue_ghi789 "timeout" --level warn --context 5
+```
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="pensar issues" icon="bug" href="/apex/cli/issues">
+    View the issues these logs relate to
+  </Card>
+  <Card title="pensar fixes" icon="wrench" href="/apex/cli/fixes">
+    View suggested fixes for issues
+  </Card>
+</CardGroup>

--- a/fern/docs/cli/pentest.mdx
+++ b/fern/docs/cli/pentest.mdx
@@ -1,0 +1,89 @@
+---
+title: "pensar pentest"
+description: "Run a full autonomous pentest orchestration from the command line"
+---
+
+## Overview
+
+The `pensar pentest` command runs a full autonomous penetration test from the command line without launching the TUI. This is ideal for CI/CD pipelines, scripting, and headless environments.
+
+## Usage
+
+```bash
+pensar pentest --target <url> [options]
+```
+
+## Options
+
+| Flag              | Description                                                  |
+| ----------------- | ------------------------------------------------------------ |
+| `--target <url>`  | **(required)** Target URL, domain, or IP address             |
+| `--cwd <path>`    | Source code path — enables whitebox attack surface analysis   |
+| `--mode <mode>`   | Pentest mode: `exfil` (pivoting & flag extraction)           |
+| `--model <model>` | AI model to use (defaults to your configured provider's default) |
+
+## Examples
+
+```bash
+# Basic blackbox pentest
+pensar pentest --target https://example.com
+
+# Whitebox pentest with source code access
+pensar pentest --target https://example.com --cwd ./my-app
+
+# Specify a model
+pensar pentest --target https://example.com --model claude-sonnet-4-5
+
+# Exfil mode for CTF-style flag extraction
+pensar pentest --target https://example.com --mode exfil
+```
+
+## How It Works
+
+1. Apex creates a session (named "Blackbox Pentest" or "Whitebox Pentest" depending on whether `--cwd` is provided)
+2. The AI agent swarm is deployed against the target
+3. Progress and tool calls are streamed to stdout in real time
+4. On completion, a summary is printed with the number of findings and paths to the findings file, POCs directory, and report
+
+## Output
+
+```
+============================================================
+PENTEST ORCHESTRATION
+============================================================
+Target:  https://example.com
+Model:   claude-sonnet-4-5
+
+→ execute_command
+✓ execute_command completed
+→ http_request
+✓ http_request completed
+...
+
+============================================================
+RESULTS
+============================================================
+Findings:  3
+Path:      /home/user/.pensar/sessions/.../findings.json
+POCs:      /home/user/.pensar/sessions/.../pocs/
+Report:    /home/user/.pensar/sessions/.../report.md
+```
+
+## Default Model
+
+When `--model` is not provided, Apex uses the default model for your highest-priority configured provider. See [`pensar models`](/apex/commands/models#default-model-per-provider) for the priority order.
+
+<Callout intent="warning">
+  **Authorization Required**: Only test systems you own or have explicit authorization to test.
+</Callout>
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="pensar targeted-pentest" icon="crosshairs" href="/apex/cli/targeted-pentest">
+    Run a focused pentest with specific objectives
+  </Card>
+  <Card title="/pentest" icon="play" href="/apex/commands/pentest">
+    Launch a pentest from the TUI with an interactive wizard
+  </Card>
+</CardGroup>

--- a/fern/docs/cli/pentests.mdx
+++ b/fern/docs/cli/pentests.mdx
@@ -1,0 +1,78 @@
+---
+title: "pensar pentests"
+description: "List, view, and dispatch pentests via the Pensar Console API"
+---
+
+## Overview
+
+The `pensar pentests` command lets you manage pentests (scans) for a project through the Pensar Console API. You can list existing pentests, view details, or dispatch new ones — all from the command line.
+
+## Usage
+
+```bash
+pensar pentests <projectId>                     # List pentests for a project
+pensar pentests get <pentestId>                  # Get pentest details
+pensar pentests dispatch <projectId> [options]   # Dispatch a new pentest
+```
+
+## Prerequisites
+
+You must be connected to Pensar Console via [`pensar auth login`](/apex/cli/auth) before using this command.
+
+## Subcommands
+
+### List Pentests
+
+```bash
+pensar pentests <projectId>
+```
+
+Lists all pentests for the given project. Returns a JSON array of pentest objects.
+
+### Get Pentest Details
+
+```bash
+pensar pentests get <pentestId>
+```
+
+Retrieves detailed information about a specific pentest, including status, findings count, and configuration.
+
+### Dispatch a New Pentest
+
+```bash
+pensar pentests dispatch <projectId> [options]
+```
+
+Dispatches a new pentest scan for the specified project.
+
+| Flag                | Description                                      |
+| ------------------- | ------------------------------------------------ |
+| `--branch <branch>` | Target branch to scan                            |
+| `--level <level>`   | Scan depth: `priority` (default) or `full`       |
+
+## Examples
+
+```bash
+# List all pentests for a project
+pensar pentests proj_abc123
+
+# Get details for a specific pentest
+pensar pentests get scan_def456
+
+# Dispatch a new priority scan
+pensar pentests dispatch proj_abc123
+
+# Dispatch a full scan on a specific branch
+pensar pentests dispatch proj_abc123 --branch main --level full
+```
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="pensar projects" icon="folder" href="/apex/cli/projects">
+    List workspace projects to find project IDs
+  </Card>
+  <Card title="pensar issues" icon="bug" href="/apex/cli/issues">
+    View security issues found by pentests
+  </Card>
+</CardGroup>

--- a/fern/docs/cli/projects.mdx
+++ b/fern/docs/cli/projects.mdx
@@ -1,0 +1,50 @@
+---
+title: "pensar projects"
+description: "List workspace projects from the Pensar Console API"
+---
+
+## Overview
+
+The `pensar projects` command lists all projects in your connected Pensar Console workspace. Projects are the top-level organizational unit in Console — each project maps to a codebase or application being tested.
+
+## Usage
+
+```bash
+pensar projects
+```
+
+## Prerequisites
+
+You must be connected to Pensar Console via [`pensar auth login`](/apex/cli/auth) before using this command.
+
+## Output
+
+Returns a JSON array of project objects:
+
+```json
+[
+  {
+    "id": "proj_abc123",
+    "name": "My Web App",
+    "slug": "my-web-app",
+    "createdAt": "2026-01-15T10:30:00Z"
+  }
+]
+```
+
+## Options
+
+| Flag         | Description             |
+| ------------ | ----------------------- |
+| `-h, --help` | Show help message       |
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="pensar pentests" icon="shield-check" href="/apex/cli/pentests">
+    List and manage pentests for a project
+  </Card>
+  <Card title="pensar issues" icon="bug" href="/apex/cli/issues">
+    List and manage security issues for a project
+  </Card>
+</CardGroup>

--- a/fern/docs/cli/targeted-pentest.mdx
+++ b/fern/docs/cli/targeted-pentest.mdx
@@ -1,0 +1,83 @@
+---
+title: "pensar targeted-pentest"
+description: "Run a targeted pentest with specific testing objectives"
+---
+
+## Overview
+
+The `pensar targeted-pentest` command runs a focused penetration test with one or more specific testing objectives. Unlike `pensar pentest` which performs broad autonomous testing, targeted pentests let you direct the AI agent toward particular vulnerability classes or areas of concern.
+
+## Usage
+
+```bash
+pensar targeted-pentest --target <url> --objective <text> [options]
+```
+
+## Options
+
+| Flag                   | Description                                                      |
+| ---------------------- | ---------------------------------------------------------------- |
+| `--target <url>`       | **(required)** Target URL, domain, or IP address                 |
+| `--objective <text>`   | **(required, repeatable)** A specific testing objective           |
+| `--model <model>`      | AI model to use (defaults to your configured provider's default) |
+
+## Examples
+
+```bash
+# Single objective
+pensar targeted-pentest --target https://api.example.com \
+  --objective "Test for SQL injection in the login endpoint"
+
+# Multiple objectives
+pensar targeted-pentest --target https://example.com \
+  --objective "Test for IDOR vulnerabilities in the /api/users endpoint" \
+  --objective "Check for authentication bypass on admin routes" \
+  --objective "Verify CORS configuration"
+
+# With a specific model
+pensar targeted-pentest --target https://example.com \
+  --objective "Test for XSS in search functionality" \
+  --model claude-opus-4-5
+```
+
+## Output
+
+```
+============================================================
+TARGETED PENTEST
+============================================================
+Target:  https://example.com
+Model:   claude-sonnet-4-5
+Objectives:
+  1. Test for SQL injection in the login endpoint
+  2. Check for authentication bypass on admin routes
+
+...
+
+============================================================
+RESULTS
+============================================================
+Findings:  2
+Path:      /home/user/.pensar/sessions/.../findings.json
+POCs:      /home/user/.pensar/sessions/.../pocs/
+```
+
+## When to Use
+
+Use `pensar targeted-pentest` when you:
+
+- Have specific vulnerability hypotheses to validate
+- Want to focus testing on particular endpoints or features
+- Need faster, more focused results than a full pentest
+- Are investigating a specific area flagged by code review or other tools
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="pensar pentest" icon="play" href="/apex/cli/pentest">
+    Run a broad autonomous pentest
+  </Card>
+  <Card title="/operator" icon="terminal" href="/apex/commands/operator">
+    Interactive testing with step-by-step control
+  </Card>
+</CardGroup>

--- a/fern/docs/cli/uninstall.mdx
+++ b/fern/docs/cli/uninstall.mdx
@@ -1,0 +1,92 @@
+---
+title: "pensar uninstall"
+description: "Fully remove Pensar Apex from your system"
+---
+
+## Overview
+
+The `pensar uninstall` command removes Pensar Apex from your system. It detects how Apex was installed (npm, Homebrew, or standalone binary) and performs the appropriate removal. Your sessions, memories, and skills are preserved by default.
+
+## Usage
+
+```bash
+pensar uninstall             # Interactive uninstall with confirmation
+pensar uninstall --force     # Skip confirmation prompt
+```
+
+## Options
+
+| Flag             | Description                    |
+| ---------------- | ------------------------------ |
+| `--force`, `-f`  | Skip the confirmation prompt   |
+| `-h`, `--help`   | Show help message              |
+
+## What Gets Removed
+
+### Binary/Package
+
+Depending on your installation method:
+
+| Method   | Removal Command                      |
+| -------- | ------------------------------------ |
+| npm      | `npm uninstall -g @pensar/apex`      |
+| Homebrew | `brew uninstall pensarai/tap/apex`   |
+| Binary   | Removes the binary file directly     |
+
+### Data Directory (`~/.pensar/`)
+
+Configuration files, auth tokens, and cached data are removed from `~/.pensar/`.
+
+## What Gets Preserved
+
+The following directories under `~/.pensar/` are **preserved** during uninstall:
+
+| Directory    | Contents                         |
+| ------------ | -------------------------------- |
+| `sessions/`  | Pentest and operator session data |
+| `memories/`  | Agent memory and context         |
+| `skills/`    | Custom operator skills           |
+
+To remove all data including preserved directories:
+
+```bash
+rm -rf ~/.pensar
+```
+
+## Example
+
+```
+Pensar Uninstall
+
+  Install method:  npm
+  Binary removal:  npm uninstall -g @pensar/apex
+  Data directory:  /home/user/.pensar
+
+  Preserved data:  sessions, memories, skills
+
+Proceed with uninstall? (y/N): y
+
+Cleaning data directory...
+  Removed config.json
+  Preserved sessions/
+  Preserved memories/
+  Preserved skills/
+
+Removing pensar...
+  Removed npm package @pensar/apex
+
+✓ Pensar has been uninstalled.
+  Preserved data remains at /home/user/.pensar/ (sessions, memories, skills)
+  To remove all data: rm -rf ~/.pensar
+```
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="pensar upgrade" icon="arrow-up" href="/apex/cli/upgrade">
+    Update instead of uninstalling
+  </Card>
+  <Card title="pensar doctor" icon="stethoscope" href="/apex/cli/doctor">
+    Diagnose issues before deciding to uninstall
+  </Card>
+</CardGroup>

--- a/fern/docs/cli/upgrade.mdx
+++ b/fern/docs/cli/upgrade.mdx
@@ -1,0 +1,44 @@
+---
+title: "pensar upgrade"
+description: "Update Pensar Apex to the latest version"
+---
+
+## Overview
+
+The `pensar upgrade` command checks for and installs the latest version of Pensar Apex. It detects your installation method (npm, Homebrew, or standalone binary) and performs the appropriate update.
+
+## Usage
+
+```bash
+pensar upgrade
+```
+
+**Alias**: `pensar update`
+
+## How It Works
+
+1. Displays your current installed version
+2. Checks the latest available version from the release server
+3. If an update is available, downloads and installs it using the appropriate method for your installation type
+4. Reports the result
+
+## Example
+
+```bash
+$ pensar upgrade
+Current version: v0.0.112
+Checking for updates...
+
+Updated to v0.0.113
+```
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="pensar doctor" icon="stethoscope" href="/apex/cli/doctor">
+    Check dependencies and system health
+  </Card>
+  <Card title="pensar version" icon="tag" href="/apex/cli/version">
+    Show your current version
+  </Card>
+</CardGroup>

--- a/fern/docs/cli/version.mdx
+++ b/fern/docs/cli/version.mdx
@@ -1,0 +1,34 @@
+---
+title: "pensar version"
+description: "Display the installed Pensar Apex version"
+---
+
+## Overview
+
+The `pensar version` command prints the currently installed version of Pensar Apex.
+
+## Usage
+
+```bash
+pensar version
+pensar --version
+pensar -v
+```
+
+## Example
+
+```bash
+$ pensar version
+v0.0.112
+```
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="pensar upgrade" icon="arrow-up" href="/apex/cli/upgrade">
+    Update to the latest version
+  </Card>
+  <Card title="pensar doctor" icon="stethoscope" href="/apex/cli/doctor">
+    Check system health and dependencies
+  </Card>
+</CardGroup>

--- a/fern/docs/commands/auth.mdx
+++ b/fern/docs/commands/auth.mdx
@@ -23,6 +23,8 @@ pensar auth status     # Show current connection status
 pensar auth logout     # Disconnect from Pensar Console
 ```
 
+`pensar auth status` displays your auth type (WorkOS or API key) and current workspace. When using API key auth, the command resolves your workspace from the server if it isn't already stored locally.
+
 ## How It Works
 
 Both the TUI `/auth` command and the CLI `pensar auth` command use a **device authorization flow** — similar to how you link a streaming device to your account. Apex displays a code, you verify it in your browser, and the CLI is automatically authenticated.

--- a/fern/docs/commands/config.mdx
+++ b/fern/docs/commands/config.mdx
@@ -1,0 +1,45 @@
+---
+title: "/config"
+description: "View and manage Apex configuration settings"
+---
+
+## Overview
+
+The `/config` command opens the configuration dialog where you can view and modify Apex settings. All configuration is stored locally in `~/.pensar/config.json`.
+
+## Usage
+
+```bash
+/config
+```
+
+## Configuration File
+
+Apex stores all configuration at `~/.pensar/config.json`. This includes:
+
+- **AI provider API keys** — configured via `/providers`
+- **Selected model** — configured via `/models`
+- **Theme settings** — configured via `/themes`
+- **Auth tokens** — configured via `/auth`
+- **Workspace info** — workspace ID and slug from Pensar Console
+
+<Callout intent="info">
+  Most configuration is managed through dedicated commands (`/providers`, `/models`, `/themes`, `/auth`). The `/config` dialog provides a unified view of your current settings.
+</Callout>
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="/providers" icon="plug" href="/apex/commands/providers">
+    Configure AI provider API keys
+  </Card>
+  <Card title="/models" icon="microchip" href="/apex/commands/models">
+    Select AI model
+  </Card>
+  <Card title="/themes" icon="palette" href="/apex/commands/themes">
+    Customize visual appearance
+  </Card>
+  <Card title="/auth" icon="shield-check" href="/apex/commands/auth">
+    Connect to Pensar Console
+  </Card>
+</CardGroup>

--- a/fern/docs/commands/create-skill.mdx
+++ b/fern/docs/commands/create-skill.mdx
@@ -1,0 +1,63 @@
+---
+title: "/create-skill"
+description: "Create a new reusable operator skill"
+---
+
+## Overview
+
+The `/create-skill` command opens a guided flow for creating a new operator skill. Skills are reusable instruction sets that teach the AI agent specialized testing techniques or workflows tailored to your environment.
+
+## Usage
+
+```bash
+/create-skill
+```
+
+## What Are Skills?
+
+Skills are YAML-based configuration files stored in `~/.pensar/skills/`. Each skill defines:
+
+- **Name** — a human-readable name for the skill
+- **Description** — what the skill does
+- **Instructions** — detailed instructions the AI agent follows when the skill is invoked
+
+Once created, skills appear as dynamic slash commands in the TUI. For example, a skill named "SQL Injection Test" becomes available as `/sql-injection-test`.
+
+## How It Works
+
+<Steps>
+  <Step title="Launch Skill Creator">
+    Run `/create-skill` to open the skill creation interface.
+  </Step>
+  <Step title="Define the Skill">
+    Provide a name, description, and detailed instructions for the AI agent.
+  </Step>
+  <Step title="Save">
+    The skill is saved to `~/.pensar/skills/` and immediately available as a slash command.
+  </Step>
+</Steps>
+
+## Using Skills
+
+After creating a skill, invoke it from the operator prompt:
+
+```bash
+/your-skill-name
+```
+
+The AI agent will follow the instructions defined in the skill, applying them to the current session context.
+
+<Callout intent="info">
+  Skills only work in operator sessions (`/operator`). They are not available in autonomous pentest mode (`/pentest`).
+</Callout>
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="/operator" icon="terminal" href="/apex/commands/operator">
+    Start an operator session to use skills
+  </Card>
+  <Card title="/help" icon="circle-question" href="/apex/commands/help">
+    View all available commands including dynamic skills
+  </Card>
+</CardGroup>

--- a/fern/docs/commands/help.mdx
+++ b/fern/docs/commands/help.mdx
@@ -134,6 +134,22 @@ For new users, here's the recommended order of commands:
 | `Y`                | Approve pending tool call             |
 | `A`                | Auto-approve all remaining tool calls |
 
+## Command Suggestions
+
+When typing a `/` command, Apex displays a windowed suggestions dropdown with up to 6 visible entries at a time. Commands are sorted by priority — `/pentest`, `/operator`, `/auth`, `/models`, `/sessions`, `/themes`, `/help` appear first, followed by the rest alphabetically. Scroll indicators (`↑`/`↓`) appear when more suggestions exist outside the visible window.
+
+## CLI API Commands
+
+In addition to the TUI commands above, Apex provides headless CLI commands for interacting with the Pensar Console REST API. These require an active Pensar Console connection (`pensar auth login`).
+
+| Command | Description |
+| --- | --- |
+| `pensar projects` | List workspace projects |
+| `pensar pentests <projectId>` | List, get, or dispatch pentests |
+| `pensar issues <projectId>` | List, get, or update security issues |
+| `pensar fixes <issueId>` | List or get security fixes |
+| `pensar logs <issueId>` | List or search agent execution logs |
+
 ## Tips
 
 <Callout intent="info">

--- a/fern/docs/commands/help.mdx
+++ b/fern/docs/commands/help.mdx
@@ -138,17 +138,9 @@ For new users, here's the recommended order of commands:
 
 When typing a `/` command, Apex displays a windowed suggestions dropdown with up to 6 visible entries at a time. Commands are sorted by priority — `/pentest`, `/operator`, `/auth`, `/models`, `/sessions`, `/themes`, `/help` appear first, followed by the rest alphabetically. Scroll indicators (`↑`/`↓`) appear when more suggestions exist outside the visible window.
 
-## CLI API Commands
+## CLI Commands
 
-In addition to the TUI commands above, Apex provides headless CLI commands for interacting with the Pensar Console REST API. These require an active Pensar Console connection (`pensar auth login`).
-
-| Command | Description |
-| --- | --- |
-| `pensar projects` | List workspace projects |
-| `pensar pentests <projectId>` | List, get, or dispatch pentests |
-| `pensar issues <projectId>` | List, get, or update security issues |
-| `pensar fixes <issueId>` | List or get security fixes |
-| `pensar logs <issueId>` | List or search agent execution logs |
+In addition to the TUI slash commands above, Apex provides headless CLI commands for pentesting, Console API access, and system management. See the [CLI Commands](/apex/cli/pentest) section in the sidebar for full documentation.
 
 ## Tips
 

--- a/fern/docs/commands/models.mdx
+++ b/fern/docs/commands/models.mdx
@@ -17,6 +17,8 @@ The `/models` command opens the model selection interface where you can view ava
 
 The models interface displays all available models from your configured providers, organized by provider name. You can navigate through the list and select your preferred model.
 
+When no model is explicitly selected, Apex automatically picks a default based on your configured provider, prioritized as: Pensar → Anthropic → OpenAI → Google → OpenRouter → Bedrock.
+
 <Callout intent="info">
   Only models from **configured providers** are shown. Use `/providers` to set
   up additional AI providers, or `/auth` to connect via Pensar Console.
@@ -117,6 +119,7 @@ When you open `/models`, you'll see:
     Managed inference through Pensar Console — no API key required.
 
     Available models:
+    - Claude Opus 4.6 (default for Pensar)
     - Claude Sonnet 4.5 / Opus 4.5
     - Claude Sonnet 4.0 / Opus 4.0
     - Claude Haiku 4.5
@@ -126,6 +129,20 @@ When you open `/models`, you'll see:
 
   </Accordion>
 </AccordionGroup>
+
+## Default Model Per Provider
+
+When you haven't explicitly selected a model, Apex automatically uses the flagship model for your highest-priority configured provider:
+
+| Provider    | Default Model                |
+| ----------- | ---------------------------- |
+| Pensar      | Claude Opus 4.6 (Pensar)    |
+| Anthropic   | Claude Opus 4.6              |
+| OpenAI      | GPT-5.2 Pro                  |
+| Google      | Gemini 3.1 Pro Preview       |
+| OpenRouter  | Claude Opus 4.6 (OpenRouter) |
+
+This also applies to the headless CLI commands (`pensar pentest`, `pensar targeted-pentest`) when the `--model` flag is not provided.
 
 ## Setting Up Providers
 

--- a/fern/docs/commands/providers.mdx
+++ b/fern/docs/commands/providers.mdx
@@ -55,7 +55,11 @@ Apex supports the following AI providers:
     Use `↑/↓` arrows to navigate and `[Enter]` to select a provider
   </Step>
   <Step title="Enter API Key">
-    Input your API key for the selected provider
+    Input your API key for the selected provider. Apex verifies your key against the provider's API before saving — if the key is invalid, you'll see an inline error and can try again.
+
+    <Callout intent="info">
+      Selecting **Pensar Console** from the provider list routes you to the `/auth` device-flow login instead of the API key input screen.
+    </Callout>
   </Step>
   <Step title="Select Model">
     After configuring, you'll be redirected to `/models` to select a model
@@ -223,10 +227,11 @@ You can also access providers from the models screen:
     **Issue**: Provider shows configured but models won't load
     
     **Solutions**:
-    1. Verify the API key is correct (no extra spaces)
-    2. Check that your account has credits/access
-    3. Ensure the key has appropriate permissions
-    4. Try regenerating the key
+    1. Apex verifies keys on entry — if you see a verification error, double-check the key
+    2. Verify the API key is correct (no extra spaces)
+    3. Check that your account has credits/access
+    4. Ensure the key has appropriate permissions
+    5. Try regenerating the key
   </Accordion>
 
   <Accordion title="Provider not showing" icon="eye-slash">

--- a/fern/docs/commands/sessions.mdx
+++ b/fern/docs/commands/sessions.mdx
@@ -1,0 +1,52 @@
+---
+title: "/sessions"
+description: "Browse and resume previous penetration testing sessions"
+---
+
+## Overview
+
+The `/sessions` command opens a dialog listing all your previous penetration testing sessions. You can review past results, resume sessions, or use them as reference for future tests.
+
+## Usage
+
+```bash
+/sessions
+```
+
+**Alias**: `/s`
+
+## What You'll See
+
+When you run `/sessions`, Apex displays a scrollable list of your saved sessions, including:
+
+- **Session name** — the auto-generated or custom name you gave the session
+- **Target(s)** — the URL(s) that were tested
+- **Date** — when the session was created
+- **Type** — whether it was a pentest swarm or operator session
+
+## Keyboard Navigation
+
+| Key       | Action                        |
+| --------- | ----------------------------- |
+| `↑/↓`     | Navigate through session list |
+| `[Enter]` | Open selected session         |
+| `[ESC]`   | Close the sessions dialog     |
+
+<Callout intent="info">
+  You can also open the sessions dialog at any time using the `Ctrl+S` keyboard shortcut.
+</Callout>
+
+## Session Storage
+
+Sessions are stored locally in `~/.pensar/sessions/`. Each session includes the full conversation history, findings, and any generated reports. Session data is preserved even when you run `pensar uninstall`.
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="/pentest" icon="play" href="/apex/commands/pentest">
+    Start a new autonomous pentest session
+  </Card>
+  <Card title="/operator" icon="terminal" href="/apex/commands/operator">
+    Start a new interactive operator session
+  </Card>
+</CardGroup>

--- a/fern/docs/commands/themes.mdx
+++ b/fern/docs/commands/themes.mdx
@@ -1,0 +1,63 @@
+---
+title: "/themes"
+description: "Manage application themes and color modes"
+---
+
+## Overview
+
+The `/themes` command lets you customize the visual appearance of Apex. You can browse available themes, switch between them, and toggle between dark and light modes.
+
+## Usage
+
+```bash
+/themes
+```
+
+**Alias**: `/theme`
+
+## Subcommands
+
+### Open Theme Picker
+
+```bash
+/themes
+```
+
+Opens an interactive theme picker where you can browse and select from all available themes.
+
+### Switch Directly to a Theme
+
+```bash
+/themes <name>
+```
+
+Switch directly to a named theme without opening the picker. The theme name is case-insensitive.
+
+### Toggle or Set Color Mode
+
+```bash
+/themes mode          # Toggle between dark and light
+/themes mode dark     # Switch to dark mode
+/themes mode light    # Switch to light mode
+/themes mode auto     # Use system preference
+```
+
+## Configuration
+
+Theme settings are stored in `~/.pensar/config.json` and persist across sessions. The following config values are managed:
+
+| Config Key  | Description                                     |
+| ----------- | ----------------------------------------------- |
+| `theme`     | Name of the active theme                        |
+| `themeMode` | Color mode: `dark`, `light`, or `auto`          |
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="/config" icon="gear" href="/apex/commands/config">
+    View all configuration options
+  </Card>
+  <Card title="/help" icon="circle-question" href="/apex/commands/help">
+    View all available commands
+  </Card>
+</CardGroup>

--- a/fern/docs/getting-started.mdx
+++ b/fern/docs/getting-started.mdx
@@ -120,6 +120,11 @@ pensar targeted-pentest --target <url>      # Run a targeted pentest
 pensar auth login                           # Connect to Pensar Console from the CLI
 pensar auth status                          # Show current auth connection status
 pensar auth logout                          # Disconnect from Pensar Console
+pensar projects                             # List workspace projects
+pensar pentests <projectId>                 # List/get/dispatch pentests
+pensar issues <projectId>                   # List/get/update security issues
+pensar fixes <issueId>                      # List/get security fixes
+pensar logs <issueId>                       # List/search agent execution logs
 pensar upgrade                              # Update to the latest version
 pensar doctor                               # Check & install optional dependencies
 pensar uninstall                            # Fully remove Pensar (interactive)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Restructures the Apex documentation sidebar to have separate, clearly organized sections for TUI slash commands and CLI commands — addressing the gap where our docs didn't cover the CLI.

**Changes:**

**Sidebar restructure (`fern/docs.yml`):**
- Renamed the "Commands" section to **"TUI Slash Commands"**
- Added a new **"CLI Commands"** section
- Organized commands logically within each section

**New TUI slash command pages:**
- `/sessions` — browse and resume previous sessions
- `/themes` — manage application themes and color modes
- `/config` — view and manage configuration settings
- `/create-skill` — create reusable operator skills

**New CLI command pages (12 pages):**
- `pensar pentest` — run full autonomous pentest from CLI
- `pensar targeted-pentest` — run focused pentest with specific objectives
- `pensar auth` — connect to Pensar Console (login/logout/status)
- `pensar projects` — list workspace projects
- `pensar pentests` — list, view, and dispatch pentests
- `pensar issues` — list, view, and update security issues
- `pensar fixes` — view security fixes and diffs
- `pensar logs` — view and search agent execution logs
- `pensar upgrade` — update to latest version
- `pensar doctor` — check dependencies and system health
- `pensar uninstall` — remove Pensar from system
- `pensar version` — display installed version

**Content updates (cherry-picked from `cursor/canary-branch-docs-updates-7458`):**
- Updated auth, help, models, providers, and getting-started pages with latest content
- Added default model per provider documentation
- Added command suggestions dropdown documentation
- Updated provider API key verification docs

### How did you verify your code works?

- All CI checks pass: `bun run lint`, `bun run tsc`, `bun run test`, `bun run format:check`
- All doc pages use valid Fern MDX syntax matching existing page conventions
- Sidebar structure in `docs.yml` references all new pages with correct paths
- Cross-references between TUI and CLI pages use consistent link formats
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ac043f4-a593-4b06-a5ca-87e078b8f3c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ac043f4-a593-4b06-a5ca-87e078b8f3c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

