### PR TITLE
fix: swarm footer Thinking flicker

### DIFF
--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -807,7 +807,6 @@ export default function Pentest({
               onSubagentComplete: handleSubagentComplete,
               onTextDelta: (d) => {
                 if (!d.subagentId) return;
-                setThinking(false);
                 if (d.subagentId === "attack-surface-agent") {
                   appendPanelText(d.subagentId, d.text);
                 } else {
@@ -816,7 +815,6 @@ export default function Pentest({
               },
               onToolCallStreaming: (d) => {
                 if (!d.subagentId) return;
-                setThinking(false);
                 if (d.subagentId === "attack-surface-agent") {
                   addPanelStreamingToolCall(d.toolCallId, d.toolName);
                 } else {
@@ -841,7 +839,6 @@ export default function Pentest({
               },
               onToolCall: (d) => {
                 if (!d.subagentId) return;
-                setThinking(false);
                 if (d.subagentId === "attack-surface-agent") {
                   addPanelToolCall(
                     d.toolCallId,
@@ -859,7 +856,6 @@ export default function Pentest({
               },
               onToolResult: (d) => {
                 if (!d.subagentId) return;
-                setThinking(true);
                 if (d.subagentId === "attack-surface-agent") {
                   updatePanelToolResult(d.toolCallId, d.toolName, d.output);
                 } else {


### PR DESCRIPTION
## Summary
- Remove `setThinking()` calls from subagent callbacks in pentest swarm view
- Only the orchestrator's own events now control the footer "Thinking" state
- Concurrent subagent events were rapidly toggling the boolean, causing visible flicker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only state management change that stops subagent streaming events from toggling the global `thinking` flag; low risk aside from potentially changing when the footer indicates activity.
> 
> **Overview**
> Stops subagent stream/tool events in `src/tui/components/pentest/pentest.tsx` from calling `setThinking`, so the footer "Thinking" state is now driven only by the orchestrator callbacks.
> 
> This prevents rapid toggling when multiple subagents emit events concurrently, eliminating visible flicker during swarm runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d75cb931a9a38531661d1ec80af5e3b297abca7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->