### PR TITLE
fix: prevent scroll reset in agent swarm view on streaming updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Want to run from the cloud or integrate it with your CI/CD? See <a href="https:/
 <!-- <p align="center">
   <img src="screenshot.png" alt="Pensar Apex Screenshot" width="800">
 </p> -->
+
 ## What is Apex?
 
 Apex is an autonomous penetration testing agent that runs directly in your terminal.
@@ -54,16 +55,17 @@ Start with `/pentest` to get coverage, then reopen the session in `/operator` to
 ## Use Cases
 
 ### Developers
+
 - Run `/pentest` before merging a PR — catch vulnerabilities as naturally as running tests
 - Get actionable findings with severity scores, evidence, and suggested fixes — no security background needed
 - Integrate into CI/CD via headless CLI commands or Pensar Console
 
 ### Security Engineers
+
 - Deploy agent-driven swarm testing across large attack surfaces
 - Use `/operator` mode for manual investigation, exploit chaining, and validation
 - Automate repetitive testing workflows with persistent memory that accumulates across engagements
 - Scale across teams and projects through Pensar Console
-
 
 ## Installation
 
@@ -91,7 +93,6 @@ npm install -g @pensar/apex
 ```powershell
 irm https://www.pensarai.com/apex.ps1 | iex
 ```
-
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensar/apex",
-  "version": "0.0.113",
+  "version": "0.0.114",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
   "main": "build/cli.js",

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -1431,11 +1431,16 @@ function AgentCardGrid({
 }: AgentCardGridProps) {
   const { colors } = useTheme();
   const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const agentsRef = useRef(agents);
+  agentsRef.current = agents;
 
+  const prevFocusedIndexRef = useRef(focusedIndex);
   useEffect(() => {
-    const agent = agents[focusedIndex];
+    if (prevFocusedIndexRef.current === focusedIndex) return;
+    prevFocusedIndexRef.current = focusedIndex;
+    const agent = agentsRef.current[focusedIndex];
     if (agent) scrollToChild(scrollRef.current, agent.id);
-  }, [focusedIndex, agents]);
+  }, [focusedIndex]);
 
   const rows = useMemo(() => {
     const result: AgentState[][] = [];

--- a/src/tui/components/shared/message-utils.ts
+++ b/src/tui/components/shared/message-utils.ts
@@ -4,23 +4,17 @@
  * Utilities for working with display messages in the TUI.
  */
 
-import { createHash } from "crypto";
 import type { DisplayMessage } from "../agent-display";
 import { isToolMessage } from "./type-guards";
-
-/**
- * Generate a short content hash for stable message keys.
- * Uses first 8 characters of SHA-256 hash.
- */
-function hashContent(content: string): string {
-  return createHash("sha256").update(content).digest("hex").slice(0, 8);
-}
 
 /**
  * Generate a stable unique key for a message.
  *
  * Uses toolCallId for tool messages (most stable),
- * otherwise uses a combination of role, timestamp, and content hash.
+ * otherwise uses role + timestamp. Content hash is intentionally
+ * omitted so that streaming updates (which mutate content in-place)
+ * don't change the key and cause React to remount the element,
+ * which would reset the parent scrollbox's scroll position.
  *
  * @param item - The display message
  * @param contextId - Optional context ID to prevent collisions across nested displays
@@ -35,13 +29,9 @@ export function getStableMessageKey(
     return `${contextId}-tool-${item.toolCallId}`;
   }
 
-  // Other messages use role + timestamp + content hash
-  const content =
-    typeof item.content === "string"
-      ? item.content
-      : JSON.stringify(item.content);
-  const contentHash = hashContent(content);
-  return `${contextId}-${item.role}-${item.createdAt.getTime()}-${contentHash}`;
+  // Use role + timestamp only — content is intentionally excluded so that
+  // streaming text deltas don't produce a new key on every frame.
+  return `${contextId}-${item.role}-${item.createdAt.getTime()}`;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes the `/pentest` agent swarm view where the scroll area resets to the top whenever a new message arrives or agent state changes during streaming.

**Root cause 1 — `AgentCardGrid` `useEffect` triggers on every state update:**
The `useEffect` that calls `scrollToChild` had `agents` in its dependency array. Since every streaming text delta or tool call updates the `pentestAgents` state, the `agents` array reference changed on every frame, causing the effect to fire and scroll to `agents[focusedIndex]`. When `focusedIndex` was 0 (the default), this scrolled the grid back to the first agent card at the top.

**Fix:** Use a ref (`agentsRef`) to access the current agents list without adding it as a dependency. Track the previous `focusedIndex` in a ref and only call `scrollToChild` when `focusedIndex` actually changes (i.e., user navigation).

**Root cause 2 — Unstable React keys during streaming:**
`getStableMessageKey` included a content hash for assistant messages. During streaming, content changes on every text delta, producing a new key each frame. This caused React to unmount the old element and mount a new one instead of updating in-place, which could disrupt the scrollbox's internal scroll state.

**Fix:** Remove the content hash from the key. Assistant message keys now use `role + createdAt` timestamp only, which remains stable throughout streaming since `createdAt` is set once when the message is first created.

### How did you verify your code works?

- `bun run tsc` — type check passes
- `bun run lint` — lint passes
- `bun run test` — all 454 tests pass (15 skipped, 7 test files skipped)
- `bun run format:check` — changed files pass formatting (pre-existing README.md format issue unrelated)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db82f636-ad8b-4d47-9463-c7037cbd4010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db82f636-ad8b-4d47-9463-c7037cbd4010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

