### PR TITLE
fix: prevent TUI text garbling on small terminals (#400)

### DIFF
--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -20,6 +20,7 @@ export interface AppCommandContext {
   openProvidersDialog?: () => void;
   openConfigDialog?: () => void;
   openCreditsDialog?: () => void;
+  openHelpDialog?: () => void;
   openAuthDialog?: () => void;
   openPentestDialog?: (flags?: WebCommandOptions) => void;
 }
@@ -202,10 +203,7 @@ export const commands: CommandConfig[] = [
     description: "Show help dialog",
     category: "General",
     handler: async (args, ctx) => {
-      ctx.navigate({
-        type: "base",
-        path: "help",
-      });
+      ctx.openHelpDialog?.();
     },
   },
   {

--- a/src/tui/components/chat/config-view.tsx
+++ b/src/tui/components/chat/config-view.tsx
@@ -136,6 +136,7 @@ export function ConfigView({ config, onBack, onStart }: ConfigViewProps) {
       paddingLeft={4}
       paddingRight={4}
       gap={1}
+      overflow="hidden"
     >
       {/* Header */}
       <box flexDirection="row" justifyContent="space-between">

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -133,6 +133,21 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
   const inputPadding = height >= 20 ? 1 : 0;
   const inputWidth = Math.min(80, dimensions.width - 10);
 
+  // Estimate rows consumed above the input to size the autocomplete dropdown
+  const rowsAboveInput =
+    animationHeight +
+    titleMarginTop +
+    2 + // title + subtitle
+    (showCommands ? menuMarginTop + 5 : 0) +
+    inputMarginTop +
+    inputPadding + // top padding
+    1; // input row itself
+  const rowsBelowInput =
+    (showHelpText ? 2 : 0) + // help text + marginTop
+    inputPadding + // bottom padding
+    3; // footer bar approximate
+  const maxSuggestions = Math.max(2, height - rowsAboveInput - rowsBelowInput);
+
   return (
     <box
       flexDirection="column"
@@ -210,6 +225,7 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
           focusedBackgroundColor="transparent"
           enableAutocomplete={true}
           autocompleteOptions={autocompleteOptions}
+          maxVisibleSuggestions={maxSuggestions}
           enableCommands={true}
           onCommandExecute={handleCommandExecute}
           commandHistory={commandHistory}

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -128,6 +128,7 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
   const inputMarginTop = height >= 25 ? 2 : height >= 15 ? 1 : 0;
 
   // Content visibility: hide decorative elements first
+  const showCommands = height >= 22;
   const showHelpText = height >= 18;
   const inputPadding = height >= 20 ? 1 : 0;
   const inputWidth = Math.min(80, dimensions.width - 10);
@@ -162,25 +163,27 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
       </box>
 
       {/* Command Quick Reference */}
-      <box flexDirection="column" marginTop={menuMarginTop} flexShrink={0}>
-        {[
-          { cmd: "/pentest", desc: "autonomous pentest" },
-          { cmd: "/operator", desc: "interactive operator" },
-          { cmd: "/auth", desc: "login to Pensar" },
-          { cmd: "/models", desc: "select AI model" },
-          { cmd: "/providers", desc: "manage API keys" },
-        ].map(({ cmd, desc }) => (
-          <box key={cmd} flexDirection="row">
-            <box width={24} justifyContent="flex-end">
-              <text fg={colors.primary}>{cmd}</text>
+      {showCommands && (
+        <box flexDirection="column" marginTop={menuMarginTop} flexShrink={0}>
+          {[
+            { cmd: "/pentest", desc: "autonomous pentest" },
+            { cmd: "/operator", desc: "interactive operator" },
+            { cmd: "/auth", desc: "login to Pensar" },
+            { cmd: "/models", desc: "select AI model" },
+            { cmd: "/providers", desc: "manage API keys" },
+          ].map(({ cmd, desc }) => (
+            <box key={cmd} flexDirection="row">
+              <box width={24} justifyContent="flex-end">
+                <text fg={colors.primary}>{cmd}</text>
+              </box>
+              <box width={4} />
+              <box>
+                <text fg={colors.textMuted}>{desc}</text>
+              </box>
             </box>
-            <box width={4} />
-            <box>
-              <text fg={colors.textMuted}>{desc}</text>
-            </box>
-          </box>
-        ))}
-      </box>
+          ))}
+        </box>
+      )}
 
       {/* Centered Input Area */}
       <box

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -146,7 +146,11 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
     (showHelpText ? 2 : 0) + // help text + marginTop
     inputPadding + // bottom padding
     3; // footer bar approximate
-  const maxSuggestions = Math.max(2, height - rowsAboveInput - rowsBelowInput);
+  // Subtract 3 extra rows: 1 margin + 1 "↑ more above" + 1 "↓ more below" indicators
+  const maxSuggestions = Math.max(
+    2,
+    height - rowsAboveInput - rowsBelowInput - 3,
+  );
 
   return (
     <box

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -133,7 +133,13 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
   const inputWidth = Math.min(80, dimensions.width - 10);
 
   return (
-    <box flexDirection="column" width="100%" height="100%" alignItems="center" overflow="hidden">
+    <box
+      flexDirection="column"
+      width="100%"
+      height="100%"
+      alignItems="center"
+      overflow="hidden"
+    >
       {/* Petri Animation */}
       {animationHeight > 0 && (
         <box height={animationHeight} width="100%">
@@ -142,7 +148,12 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
       )}
 
       {/* Title - centered */}
-      <box flexDirection="column" alignItems="center" marginTop={titleMarginTop} flexShrink={0}>
+      <box
+        flexDirection="column"
+        alignItems="center"
+        marginTop={titleMarginTop}
+        flexShrink={0}
+      >
         <text fg={colors.text}>
           Apex{" "}
           <span fg={colors.textMuted}>({config.data.version || "local"})</span>

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -109,19 +109,40 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
     [skillsRegistry, route, executeCommand, pushHistory],
   );
 
-  // Calculate layout dimensions
-  const animationHeight = Math.max(6, Math.floor(dimensions.height * 0.2));
+  // Responsive layout calculations
+  const height = dimensions.height;
+
+  // Animation: scale down on small terminals, hide below 15 rows
+  const animationHeight =
+    height < 15
+      ? 0
+      : height < 20
+        ? 2
+        : height < 30
+          ? Math.max(3, Math.floor(height * 0.15))
+          : Math.max(6, Math.floor(height * 0.2));
+
+  // Margins: reduce spacing on small terminals
+  const titleMarginTop = height >= 20 ? 1 : 0;
+  const menuMarginTop = height >= 25 ? 2 : height >= 15 ? 1 : 0;
+  const inputMarginTop = height >= 25 ? 2 : height >= 15 ? 1 : 0;
+
+  // Content visibility: hide decorative elements first
+  const showHelpText = height >= 18;
+  const inputPadding = height >= 20 ? 1 : 0;
   const inputWidth = Math.min(80, dimensions.width - 10);
 
   return (
-    <box flexDirection="column" width="100%" height="100%" alignItems="center">
+    <box flexDirection="column" width="100%" height="100%" alignItems="center" overflow="hidden">
       {/* Petri Animation */}
-      <box height={animationHeight} width="100%">
-        <PetriAnimation height={animationHeight} />
-      </box>
+      {animationHeight > 0 && (
+        <box height={animationHeight} width="100%">
+          <PetriAnimation height={animationHeight} />
+        </box>
+      )}
 
       {/* Title - centered */}
-      <box flexDirection="column" alignItems="center" marginTop={1}>
+      <box flexDirection="column" alignItems="center" marginTop={titleMarginTop} flexShrink={0}>
         <text fg={colors.text}>
           Apex{" "}
           <span fg={colors.textMuted}>({config.data.version || "local"})</span>
@@ -130,7 +151,7 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
       </box>
 
       {/* Command Quick Reference */}
-      <box flexDirection="column" marginTop={2}>
+      <box flexDirection="column" marginTop={menuMarginTop} flexShrink={0}>
         {[
           { cmd: "/pentest", desc: "autonomous pentest" },
           { cmd: "/operator", desc: "interactive operator" },
@@ -154,16 +175,17 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
       <box
         flexDirection="column"
         width={inputWidth}
-        marginTop={2}
-        padding={1}
+        marginTop={inputMarginTop}
+        padding={inputPadding}
         border={["left", "right"]}
         borderColor={colors.primary}
+        flexShrink={0}
       >
         {/* Input with built-in autocomplete */}
         <PromptInput
           ref={promptRef}
           focused={!externalDialogOpen && stack.length === 0}
-          width={inputWidth - 4}
+          width={inputWidth - 2 - inputPadding * 2}
           minHeight={1}
           maxHeight={4}
           onSubmit={handleSubmit}
@@ -192,7 +214,7 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
           modelName={model.name}
           providerName={providerDisplayName(model.provider)}
           showMode={false}
-          maxWidth={inputWidth - 4}
+          maxWidth={inputWidth - 2 - inputPadding * 2}
           rightContent={
             <text fg={colors.textMuted}>
               <span fg={colors.text}>[/]</span> commands

--- a/src/tui/components/chat/index.tsx
+++ b/src/tui/components/chat/index.tsx
@@ -123,7 +123,7 @@ export function ChatApp({
   }, []);
 
   return (
-    <box flexDirection="column" width="100%" height="100%" flexGrow={1}>
+    <box flexDirection="column" width="100%" height="100%" flexGrow={1} overflow="hidden">
       {currentView === "home" && (
         <HomeView
           onNavigate={handleNavigate}

--- a/src/tui/components/chat/index.tsx
+++ b/src/tui/components/chat/index.tsx
@@ -123,7 +123,13 @@ export function ChatApp({
   }, []);
 
   return (
-    <box flexDirection="column" width="100%" height="100%" flexGrow={1} overflow="hidden">
+    <box
+      flexDirection="column"
+      width="100%"
+      height="100%"
+      flexGrow={1}
+      overflow="hidden"
+    >
       {currentView === "home" && (
         <HomeView
           onNavigate={handleNavigate}

--- a/src/tui/components/commands/help-dialog.tsx
+++ b/src/tui/components/commands/help-dialog.tsx
@@ -10,14 +10,16 @@ import { useKeyboard } from "@opentui/react";
 import { ScrollBoxRenderable } from "@opentui/core";
 import { scrollToIndex } from "../../utils/scroll";
 import { useCommand } from "../../context/command";
-import { useRoute } from "../../context/route";
 import { Dialog } from "../../context/dialog";
 import { useTheme } from "../../theme";
 
-export default function HelpDialog() {
+interface HelpDialogProps {
+  onClose: () => void;
+}
+
+export default function HelpDialog({ onClose }: HelpDialogProps) {
   const { colors } = useTheme();
   const { commands } = useCommand();
-  const route = useRoute();
 
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [showDetail, setShowDetail] = useState(false);
@@ -43,17 +45,13 @@ export default function HelpDialog() {
     );
   }, [selectedIndex, flatCommands]);
 
-  const handleClose = () => {
-    route.navigate({ type: "base", path: "home" });
-  };
-
   useKeyboard((evt) => {
     if (evt.name === "escape") {
       evt.preventDefault();
       if (showDetail) {
         setShowDetail(false);
       } else {
-        handleClose();
+        onClose();
       }
       return;
     }
@@ -99,7 +97,7 @@ export default function HelpDialog() {
       selectedCommand.options && selectedCommand.options.length > 0;
 
     return (
-      <Dialog size="large" onClose={handleClose}>
+      <Dialog size="large" onClose={onClose}>
         <box flexDirection="column" padding={2} gap={1} width="100%">
           {/* Header */}
           <box flexDirection="row" justifyContent="space-between" width="100%">
@@ -149,7 +147,7 @@ export default function HelpDialog() {
 
   // List view
   return (
-    <Dialog size="large" onClose={handleClose}>
+    <Dialog size="large" onClose={onClose}>
       <box flexDirection="column" padding={2} gap={1} width="100%">
         {/* Header */}
         <box flexDirection="row" justifyContent="space-between" width="100%">

--- a/src/tui/components/commands/help-dialog.tsx
+++ b/src/tui/components/commands/help-dialog.tsx
@@ -154,9 +154,10 @@ export default function HelpDialog() {
           borderColor={colors.primary}
           borderStyle="single"
           flexDirection="column"
+          overflow="hidden"
         >
           {/* Detail Header */}
-          <box width="100%" padding={1} flexDirection="row">
+          <box width="100%" padding={1} flexDirection="row" flexShrink={0}>
             <text fg={colors.primary}>/{selectedCommand.name}</text>
             <text
               fg={colors.textMuted}
@@ -164,12 +165,18 @@ export default function HelpDialog() {
           </box>
 
           {/* Separator */}
-          <box width="100%" height={1}>
+          <box width="100%" height={1} flexShrink={0}>
             <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
           </box>
 
           {/* Detail Content */}
-          <box width="100%" padding={2} flexDirection="column" flexGrow={1}>
+          <box
+            width="100%"
+            padding={2}
+            flexDirection="column"
+            flexGrow={1}
+            overflow="hidden"
+          >
             {/* Description */}
             <text fg={colors.text}>
               {selectedCommand.description || "No description available"}
@@ -205,12 +212,12 @@ export default function HelpDialog() {
           </box>
 
           {/* Separator */}
-          <box width="100%" height={1}>
+          <box width="100%" height={1} flexShrink={0}>
             <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
           </box>
 
           {/* Detail Footer */}
-          <box width="100%" padding={1} flexDirection="row">
+          <box width="100%" padding={1} flexDirection="row" flexShrink={0}>
             <text fg={colors.textMuted}>[enter/esc] back</text>
           </box>
         </box>
@@ -237,9 +244,10 @@ export default function HelpDialog() {
         borderColor={colors.border}
         borderStyle="single"
         flexDirection="column"
+        overflow="hidden"
       >
         {/* Header */}
-        <box width="100%" padding={1} flexDirection="row">
+        <box width="100%" padding={1} flexDirection="row" flexShrink={0}>
           <text fg={colors.primary}>
             {"Help - Available Commands".padEnd(panelWidth - 20)}
           </text>
@@ -247,12 +255,18 @@ export default function HelpDialog() {
         </box>
 
         {/* Separator */}
-        <box width="100%" height={1}>
+        <box width="100%" height={1} flexShrink={0}>
           <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
         </box>
 
         {/* Column Headers */}
-        <box width="100%" paddingLeft={2} paddingRight={2} flexDirection="row">
+        <box
+          width="100%"
+          paddingLeft={2}
+          paddingRight={2}
+          flexDirection="row"
+          flexShrink={0}
+        >
           <text fg={colors.textMuted}>
             {"Command".padEnd(18)}
             {"Category".padEnd(14)}
@@ -294,6 +308,7 @@ export default function HelpDialog() {
                 }
                 flexDirection="row"
                 paddingLeft={1}
+                overflow="hidden"
               >
                 <text fg={isSelected ? colors.primary : colors.text}>
                   {name}
@@ -309,12 +324,12 @@ export default function HelpDialog() {
         </scrollbox>
 
         {/* Separator */}
-        <box width="100%" height={1}>
+        <box width="100%" height={1} flexShrink={0}>
           <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
         </box>
 
         {/* Footer */}
-        <box width="100%" padding={1} flexDirection="row">
+        <box width="100%" padding={1} flexDirection="row" flexShrink={0}>
           <text fg={colors.textMuted}>
             [j/k] navigate [enter/v] details [esc] close
           </text>

--- a/src/tui/components/commands/help-dialog.tsx
+++ b/src/tui/components/commands/help-dialog.tsx
@@ -3,60 +3,37 @@
  *
  * Modal overlay for viewing available commands.
  * Shows commands in a scrollable list with detail view for options/flags.
- * Press Enter/v to view detailed description of selected command.
  */
 
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useKeyboard } from "@opentui/react";
-import { useDimensions } from "../../context/dimensions";
 import { ScrollBoxRenderable } from "@opentui/core";
 import { scrollToIndex } from "../../utils/scroll";
 import { useCommand } from "../../context/command";
 import { useRoute } from "../../context/route";
-import type { CommandConfig } from "../../command-registry";
+import { Dialog } from "../../context/dialog";
 import { useTheme } from "../../theme";
 
 export default function HelpDialog() {
   const { colors } = useTheme();
   const { commands } = useCommand();
   const route = useRoute();
-  const dimensions = useDimensions();
 
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [showDetail, setShowDetail] = useState(false);
   const scrollboxRef = useRef<ScrollBoxRenderable | null>(null);
 
-  const visibleCommands = useMemo(
+  const flatCommands = useMemo(
     () => commands.filter((cmd) => !cmd.hidden),
     [commands],
   );
 
-  // Group commands by category
-  const commandsByCategory = useMemo(() => {
-    const grouped: Record<string, CommandConfig[]> = {};
-    for (const cmd of visibleCommands) {
-      const category = cmd.category || "Other";
-      if (!grouped[category]) {
-        grouped[category] = [];
-      }
-      grouped[category].push(cmd);
-    }
-    return grouped;
-  }, [visibleCommands]);
-
-  // Flat list of commands for navigation
-  const flatCommands = useMemo(() => {
-    return visibleCommands;
-  }, [visibleCommands]);
-
-  // Ensure selected index is within bounds
   useEffect(() => {
     if (selectedIndex >= flatCommands.length) {
       setSelectedIndex(Math.max(0, flatCommands.length - 1));
     }
   }, [flatCommands.length, selectedIndex]);
 
-  // Scroll to keep selected item in view
   useEffect(() => {
     scrollToIndex(
       scrollboxRef.current,
@@ -67,15 +44,10 @@ export default function HelpDialog() {
   }, [selectedIndex, flatCommands]);
 
   const handleClose = () => {
-    route.navigate({
-      type: "base",
-      path: "home",
-    });
+    route.navigate({ type: "base", path: "home" });
   };
 
-  // Keyboard handling
   useKeyboard((evt) => {
-    // Handle escape key - either go back from detail view or close dialog
     if (evt.name === "escape") {
       evt.preventDefault();
       if (showDetail) {
@@ -86,7 +58,6 @@ export default function HelpDialog() {
       return;
     }
 
-    // Handle detail view
     if (showDetail) {
       if (evt.name === "return") {
         evt.preventDefault();
@@ -103,7 +74,6 @@ export default function HelpDialog() {
           prev > 0 ? prev - 1 : flatCommands.length - 1,
         );
         break;
-
       case "down":
       case "j":
         evt.preventDefault();
@@ -111,7 +81,6 @@ export default function HelpDialog() {
           prev < flatCommands.length - 1 ? prev + 1 : 0,
         );
         break;
-
       case "return":
       case "v":
         evt.preventDefault();
@@ -122,219 +91,112 @@ export default function HelpDialog() {
     }
   });
 
-  const panelWidth = Math.min(80, dimensions.width - 4);
-  const panelHeight = Math.min(30, dimensions.height - 4);
-
   const selectedCommand = flatCommands[selectedIndex];
 
   // Detail view
   if (showDetail && selectedCommand) {
     const hasOptions =
       selectedCommand.options && selectedCommand.options.length > 0;
-    const detailHeight = Math.min(
-      hasOptions ? 16 + (selectedCommand.options?.length || 0) * 2 : 12,
-      dimensions.height - 4,
-    );
 
     return (
-      <box
-        width={dimensions.width}
-        height={dimensions.height}
-        alignItems="center"
-        justifyContent="center"
-        position="absolute"
-        left={0}
-        top={0}
-        backgroundColor={colors.backgroundOverlay}
-      >
-        <box
-          width={panelWidth}
-          height={detailHeight}
-          backgroundColor={colors.backgroundPanel}
-          borderColor={colors.primary}
-          borderStyle="single"
-          flexDirection="column"
-          overflow="hidden"
-        >
-          {/* Detail Header */}
-          <box width="100%" padding={1} flexDirection="row" flexShrink={0}>
+      <Dialog size="large" onClose={handleClose}>
+        <box flexDirection="column" padding={2} gap={1} width="100%">
+          {/* Header */}
+          <box flexDirection="row" justifyContent="space-between" width="100%">
             <text fg={colors.primary}>/{selectedCommand.name}</text>
-            <text
-              fg={colors.textMuted}
-            >{`  (${selectedCommand.category || "General"})`}</text>
+            <text fg={colors.textMuted}>esc to close</text>
           </box>
 
-          {/* Separator */}
-          <box width="100%" height={1} flexShrink={0}>
-            <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
-          </box>
+          {/* Description */}
+          <text fg={colors.text}>
+            {selectedCommand.description || "No description available"}
+          </text>
 
-          {/* Detail Content */}
-          <box
-            width="100%"
-            padding={2}
-            flexDirection="column"
-            flexGrow={1}
-            overflow="hidden"
-          >
-            {/* Description */}
-            <text fg={colors.text}>
-              {selectedCommand.description || "No description available"}
-            </text>
+          {/* Aliases */}
+          {selectedCommand.aliases && selectedCommand.aliases.length > 0 && (
+            <box flexDirection="row">
+              <text fg={colors.textMuted}>Aliases: </text>
+              <text fg={colors.text}>
+                {selectedCommand.aliases.map((a) => `/${a}`).join(", ")}
+              </text>
+            </box>
+          )}
 
-            {/* Aliases */}
-            {selectedCommand.aliases && selectedCommand.aliases.length > 0 && (
-              <box flexDirection="row" marginTop={1}>
-                <text fg={colors.textMuted}>Aliases: </text>
-                <text fg={colors.text}>
-                  {selectedCommand.aliases.map((a) => `/${a}`).join(", ")}
-                </text>
-              </box>
-            )}
+          {/* Options */}
+          {hasOptions && (
+            <box flexDirection="column" gap={0} marginTop={1}>
+              <text fg={colors.textMuted}>Options:</text>
+              {selectedCommand.options?.map((opt, idx) => (
+                <box key={idx} flexDirection="row" paddingLeft={2} gap={1}>
+                  <text fg={colors.primary}>{opt.name}</text>
+                  {opt.valueHint && (
+                    <text fg={colors.textMuted}>{opt.valueHint}</text>
+                  )}
+                  <text fg={colors.text}>{opt.description}</text>
+                </box>
+              ))}
+            </box>
+          )}
 
-            {/* Options section */}
-            {hasOptions && (
-              <>
-                <box height={1} />
-                <text fg={colors.textMuted}>Options:</text>
-                <box height={1} />
-                {selectedCommand.options?.map((opt, idx) => (
-                  <box key={idx} flexDirection="row" paddingLeft={2}>
-                    <text fg={colors.primary}>{opt.name}</text>
-                    {opt.valueHint && (
-                      <text fg={colors.textMuted}>{` ${opt.valueHint}`}</text>
-                    )}
-                    <text fg={colors.text}>{`  ${opt.description}`}</text>
-                  </box>
-                ))}
-              </>
-            )}
-          </box>
-
-          {/* Separator */}
-          <box width="100%" height={1} flexShrink={0}>
-            <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
-          </box>
-
-          {/* Detail Footer */}
-          <box width="100%" padding={1} flexDirection="row" flexShrink={0}>
+          {/* Footer hint */}
+          <box marginTop={1}>
             <text fg={colors.textMuted}>[enter/esc] back</text>
           </box>
         </box>
-      </box>
+      </Dialog>
     );
   }
 
-  // Main list view
+  // List view
   return (
-    <box
-      width={dimensions.width}
-      height={dimensions.height}
-      alignItems="center"
-      justifyContent="center"
-      position="absolute"
-      left={0}
-      top={0}
-      backgroundColor={colors.backgroundOverlay}
-    >
-      <box
-        width={panelWidth}
-        height={panelHeight}
-        backgroundColor={colors.backgroundPanel}
-        borderColor={colors.border}
-        borderStyle="single"
-        flexDirection="column"
-        overflow="hidden"
-      >
+    <Dialog size="large" onClose={handleClose}>
+      <box flexDirection="column" padding={2} gap={1} width="100%">
         {/* Header */}
-        <box width="100%" padding={1} flexDirection="row" flexShrink={0}>
-          <text fg={colors.primary}>
-            {"Help - Available Commands".padEnd(panelWidth - 20)}
-          </text>
-          <text fg={colors.textMuted}>{`${flatCommands.length} commands`}</text>
+        <box flexDirection="row" justifyContent="space-between" width="100%">
+          <text fg={colors.text}>Commands</text>
+          <text fg={colors.textMuted}>esc to close</text>
         </box>
 
-        {/* Separator */}
-        <box width="100%" height={1} flexShrink={0}>
-          <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
-        </box>
-
-        {/* Column Headers */}
-        <box
-          width="100%"
-          paddingLeft={2}
-          paddingRight={2}
-          flexDirection="row"
-          flexShrink={0}
-        >
-          <text fg={colors.textMuted}>
-            {"Command".padEnd(18)}
-            {"Category".padEnd(14)}
-            {"Description"}
-          </text>
-        </box>
-
-        {/* Commands List - Scrollbox */}
+        {/* Commands list */}
         <scrollbox
           ref={scrollboxRef}
           style={{
             rootOptions: { flexGrow: 1, width: "100%" },
-            contentOptions: {
-              paddingLeft: 1,
-              paddingRight: 1,
-              flexDirection: "column",
-            },
+            contentOptions: { flexDirection: "column" },
           }}
           stickyScroll={false}
           focused={true}
         >
           {flatCommands.map((cmd, idx) => {
             const isSelected = idx === selectedIndex;
-            const hasOptions = cmd.options && cmd.options.length > 0;
-            const name = `/${cmd.name}`.padEnd(17).slice(0, 17);
-            const category = (cmd.category || "General")
-              .slice(0, 12)
-              .padEnd(14);
-            const desc = cmd.description || "";
-            const optionHint = hasOptions ? " [...]" : "";
-
             return (
               <box
                 key={cmd.name}
                 id={cmd.name}
                 width="100%"
+                flexDirection="row"
+                gap={2}
                 backgroundColor={
                   isSelected ? colors.backgroundSelected : undefined
                 }
-                flexDirection="row"
-                paddingLeft={1}
                 overflow="hidden"
               >
-                <text fg={isSelected ? colors.primary : colors.text}>
-                  {name}
+                <text fg={isSelected ? colors.primary : colors.text} width={18}>
+                  /{cmd.name}
                 </text>
-                <text fg={colors.textMuted}>{category}</text>
                 <text fg={isSelected ? colors.text : colors.textMuted}>
-                  {desc}
+                  {cmd.description || ""}
                 </text>
-                {hasOptions && <text fg={colors.primary}>{optionHint}</text>}
               </box>
             );
           })}
         </scrollbox>
 
-        {/* Separator */}
-        <box width="100%" height={1} flexShrink={0}>
-          <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
-        </box>
-
         {/* Footer */}
-        <box width="100%" padding={1} flexDirection="row" flexShrink={0}>
-          <text fg={colors.textMuted}>
-            [j/k] navigate [enter/v] details [esc] close
-          </text>
-        </box>
+        <text fg={colors.textMuted}>
+          [↑/↓] navigate [enter] details [esc] close
+        </text>
       </box>
-    </box>
+    </Dialog>
   );
 }

--- a/src/tui/components/commands/models-display.tsx
+++ b/src/tui/components/commands/models-display.tsx
@@ -90,7 +90,7 @@ export default function ModelsDisplay() {
       </box>
 
       {/* Footer */}
-      <box flexDirection="column" marginTop={2}>
+      <box flexDirection="column" marginTop={2} flexShrink={0}>
         <ClippedLine>
           <text>
             <span fg={colors.primary}>█ </span>

--- a/src/tui/components/footer.tsx
+++ b/src/tui/components/footer.tsx
@@ -4,6 +4,7 @@ import { ProgressBar, SpinnerDots } from "./sprites";
 import { useSession } from "../context/session";
 import { useRoute } from "../context/route";
 import { useInput } from "../context/input";
+import { useDialog } from "../context/dialog";
 import { useTheme } from "../theme";
 
 interface FooterProps {
@@ -64,6 +65,8 @@ export default function Footer({
       </box>
     );
   }
+
+  if (dialogOpen) return null;
 
   const hotkeys = isExecuting
     ? [{ key: "Ctrl+C", label: "Stop Execution" }]

--- a/src/tui/components/footer.tsx
+++ b/src/tui/components/footer.tsx
@@ -73,6 +73,10 @@ export default function Footer({
         ...(isInputEmpty ? [{ key: "?", label: "Shortcuts" }] : []),
       ];
 
+  if (dialogOpen) {
+    return <box width="100%" height={1} flexShrink={0} />;
+  }
+
   return (
     <box
       flexDirection="row"
@@ -82,7 +86,6 @@ export default function Footer({
       height={1}
       flexShrink={0}
       overflow="hidden"
-      backgroundColor={dialogOpen ? colors.backgroundOverlay : undefined}
     >
       <box flexDirection="row" gap={1} flexShrink={1} overflow="hidden">
         <text fg={colors.textMuted}>{displayCwd}</text>

--- a/src/tui/components/footer.tsx
+++ b/src/tui/components/footer.tsx
@@ -4,7 +4,6 @@ import { ProgressBar, SpinnerDots } from "./sprites";
 import { useSession } from "../context/session";
 import { useRoute } from "../context/route";
 import { useInput } from "../context/input";
-import { useDialog } from "../context/dialog";
 import { useTheme } from "../theme";
 
 interface FooterProps {
@@ -72,10 +71,6 @@ export default function Footer({
         { key: "Ctrl+C", label: "Clear/Exit" },
         ...(isInputEmpty ? [{ key: "?", label: "Shortcuts" }] : []),
       ];
-
-  if (dialogOpen) {
-    return <box width="100%" height={1} flexShrink={0} />;
-  }
 
   return (
     <box

--- a/src/tui/components/footer.tsx
+++ b/src/tui/components/footer.tsx
@@ -66,8 +66,6 @@ export default function Footer({
     );
   }
 
-  if (dialogOpen) return null;
-
   const hotkeys = isExecuting
     ? [{ key: "Ctrl+C", label: "Stop Execution" }]
     : [
@@ -84,6 +82,7 @@ export default function Footer({
       height={1}
       flexShrink={0}
       overflow="hidden"
+      backgroundColor={dialogOpen ? colors.backgroundOverlay : undefined}
     >
       <box flexDirection="row" gap={1} flexShrink={1} overflow="hidden">
         <text fg={colors.textMuted}>{displayCwd}</text>

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -445,15 +445,17 @@ export function ModelPicker({
       overflow="hidden"
     >
       {/* Search indicator */}
-      {searchQuery ? (
-        <PickerRow>
-          <text fg={colors.text}>Search: {searchQuery}</text>
-        </PickerRow>
-      ) : (
-        <PickerRow>
-          <text fg={colors.textMuted}>Type to search models...</text>
-        </PickerRow>
-      )}
+      <box flexShrink={0}>
+        {searchQuery ? (
+          <PickerRow>
+            <text fg={colors.text}>Search: {searchQuery}</text>
+          </PickerRow>
+        ) : (
+          <PickerRow>
+            <text fg={colors.textMuted}>Type to search models...</text>
+          </PickerRow>
+        )}
+      </box>
 
       {/* Scrollable provider/model list */}
       <scrollbox
@@ -662,13 +664,15 @@ export function ModelPicker({
       </scrollbox>
 
       {/* Help text */}
-      <PickerRow>
-        <text fg={colors.textMuted}>
-          {editingLocalField
-            ? "Type or paste | Enter/Esc to confirm"
-            : "↑/↓ navigate | ←/→ collapse/expand | Type to search"}
-        </text>
-      </PickerRow>
+      <box flexShrink={0}>
+        <PickerRow>
+          <text fg={colors.textMuted}>
+            {editingLocalField
+              ? "Type or paste | Enter/Esc to confirm"
+              : "↑/↓ navigate | ←/→ collapse/expand | Type to search"}
+          </text>
+        </PickerRow>
+      </box>
     </box>
   );
 }

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -1424,7 +1424,13 @@ export default function OperatorDashboard({
     pendingApprovals.length > 0 ? pendingApprovals[0] : undefined;
 
   return (
-    <box flexDirection="column" width="100%" height="100%" flexGrow={1} overflow="hidden">
+    <box
+      flexDirection="column"
+      width="100%"
+      height="100%"
+      flexGrow={1}
+      overflow="hidden"
+    >
       {/* Header bar */}
       <box
         flexDirection="row"

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -1424,7 +1424,7 @@ export default function OperatorDashboard({
     pendingApprovals.length > 0 ? pendingApprovals[0] : undefined;
 
   return (
-    <box flexDirection="column" width="100%" height="100%" flexGrow={1}>
+    <box flexDirection="column" width="100%" height="100%" flexGrow={1} overflow="hidden">
       {/* Header bar */}
       <box
         flexDirection="row"

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -1140,7 +1140,13 @@ export default function Pentest({
   // -------------------------------------------------------------------------
 
   return (
-    <box flexDirection="column" width="100%" height="100%" flexGrow={1} overflow="hidden">
+    <box
+      flexDirection="column"
+      width="100%"
+      height="100%"
+      flexGrow={1}
+      overflow="hidden"
+    >
       <box
         flexDirection="row"
         flexGrow={1}
@@ -1712,7 +1718,13 @@ function AgentDetailView({
   }[agent.status];
 
   return (
-    <box flexDirection="column" width="100%" height="100%" flexGrow={1} overflow="hidden">
+    <box
+      flexDirection="column"
+      width="100%"
+      height="100%"
+      flexGrow={1}
+      overflow="hidden"
+    >
       <box
         width="100%"
         border={["bottom"]}

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -1140,7 +1140,7 @@ export default function Pentest({
   // -------------------------------------------------------------------------
 
   return (
-    <box flexDirection="column" width="100%" height="100%" flexGrow={1}>
+    <box flexDirection="column" width="100%" height="100%" flexGrow={1} overflow="hidden">
       <box
         flexDirection="row"
         flexGrow={1}
@@ -1712,7 +1712,7 @@ function AgentDetailView({
   }[agent.status];
 
   return (
-    <box flexDirection="column" width="100%" height="100%" flexGrow={1}>
+    <box flexDirection="column" width="100%" height="100%" flexGrow={1} overflow="hidden">
       <box
         width="100%"
         border={["bottom"]}
@@ -1720,6 +1720,7 @@ function AgentDetailView({
         flexDirection="row"
         justifyContent="space-between"
         padding={1}
+        flexShrink={0}
       >
         <box flexDirection="row" gap={1}>
           <text fg={colors.textMuted}></text>

--- a/src/tui/components/swarm-dashboard/index.tsx
+++ b/src/tui/components/swarm-dashboard/index.tsx
@@ -244,9 +244,9 @@ export default function SwarmDashboard({
 
   // Overview view
   return (
-    <box flexDirection="column" width="100%" height="100%" flexGrow={1}>
+    <box flexDirection="column" width="100%" height="100%" flexGrow={1} overflow="hidden">
       {/* Main content area */}
-      <box flexDirection="row" flexGrow={1} gap={2} padding={1}>
+      <box flexDirection="row" flexGrow={1} gap={2} padding={1} overflow="hidden">
         {/* Left: Discovery panel */}
         <DiscoveryPanel
           agent={discoveryAgent}
@@ -799,7 +799,7 @@ function AgentDetailView({ agent, onBack, onResume }: AgentDetailViewProps) {
   }[agent.status];
 
   return (
-    <box flexDirection="column" width="100%" height="100%" flexGrow={1}>
+    <box flexDirection="column" width="100%" height="100%" flexGrow={1} overflow="hidden">
       {/* Header */}
       <box
         width="100%"
@@ -808,6 +808,7 @@ function AgentDetailView({ agent, onBack, onResume }: AgentDetailViewProps) {
         flexDirection="row"
         justifyContent="space-between"
         padding={1}
+        flexShrink={0}
       >
         <box flexDirection="row" gap={1}>
           <text fg={colors.textMuted}></text>
@@ -840,6 +841,7 @@ function AgentDetailView({ agent, onBack, onResume }: AgentDetailViewProps) {
         border={["top"]}
         borderColor={colors.primary}
         padding={1}
+        flexShrink={0}
       >
         <text>
           <span fg={colors.textMuted}>{agent.messages.length} messages</span>

--- a/src/tui/components/swarm-dashboard/index.tsx
+++ b/src/tui/components/swarm-dashboard/index.tsx
@@ -244,9 +244,21 @@ export default function SwarmDashboard({
 
   // Overview view
   return (
-    <box flexDirection="column" width="100%" height="100%" flexGrow={1} overflow="hidden">
+    <box
+      flexDirection="column"
+      width="100%"
+      height="100%"
+      flexGrow={1}
+      overflow="hidden"
+    >
       {/* Main content area */}
-      <box flexDirection="row" flexGrow={1} gap={2} padding={1} overflow="hidden">
+      <box
+        flexDirection="row"
+        flexGrow={1}
+        gap={2}
+        padding={1}
+        overflow="hidden"
+      >
         {/* Left: Discovery panel */}
         <DiscoveryPanel
           agent={discoveryAgent}
@@ -799,7 +811,13 @@ function AgentDetailView({ agent, onBack, onResume }: AgentDetailViewProps) {
   }[agent.status];
 
   return (
-    <box flexDirection="column" width="100%" height="100%" flexGrow={1} overflow="hidden">
+    <box
+      flexDirection="column"
+      width="100%"
+      height="100%"
+      flexGrow={1}
+      overflow="hidden"
+    >
       {/* Header */}
       <box
         width="100%"

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -53,6 +53,7 @@ interface CommandProviderProps {
   onOpenProvidersDialog?: () => void;
   onOpenConfigDialog?: () => void;
   onOpenCreditsDialog?: () => void;
+  onOpenHelpDialog?: () => void;
   onOpenAuthDialog?: () => void;
   onOpenPentestDialog?: (flags?: WebCommandOptions) => void;
 }
@@ -65,6 +66,7 @@ export function CommandProvider({
   onOpenProvidersDialog,
   onOpenConfigDialog,
   onOpenCreditsDialog,
+  onOpenHelpDialog,
   onOpenAuthDialog,
   onOpenPentestDialog,
 }: CommandProviderProps) {
@@ -82,6 +84,7 @@ export function CommandProvider({
       openProvidersDialog: onOpenProvidersDialog,
       openConfigDialog: onOpenConfigDialog,
       openCreditsDialog: onOpenCreditsDialog,
+      openHelpDialog: onOpenHelpDialog,
       openAuthDialog: onOpenAuthDialog,
       openPentestDialog: onOpenPentestDialog,
     };
@@ -94,6 +97,7 @@ export function CommandProvider({
     onOpenProvidersDialog,
     onOpenConfigDialog,
     onOpenCreditsDialog,
+    onOpenHelpDialog,
     onOpenAuthDialog,
     onOpenPentestDialog,
   ]);

--- a/src/tui/context/dialog.tsx
+++ b/src/tui/context/dialog.tsx
@@ -5,7 +5,6 @@ import {
   useContext,
   useState,
   useCallback,
-  useEffect,
   useRef,
   type ReactNode,
 } from "react";
@@ -22,10 +21,6 @@ export function Dialog({ size = "medium", onClose, children }: DialogProps) {
   const dimensions = useDimensions();
   const renderer = useRenderer();
   const { colors: themeColors } = useTheme();
-  const { registerDialog } = useDialog();
-
-  useEffect(() => registerDialog(), [registerDialog]);
-
   return (
     <box
       onMouseUp={async () => {
@@ -74,8 +69,6 @@ interface DialogContextValue {
   setSize: (size: "medium" | "large") => void;
   externalDialogOpen: boolean;
   setExternalDialogOpen: (open: boolean) => void;
-  registerDialog: () => () => void;
-  directDialogCount: number;
 }
 
 const DialogContext = createContext<DialogContextValue | null>(null);
@@ -84,12 +77,6 @@ export function DialogProvider({ children }: { children: ReactNode }) {
   const [stack, setStack] = useState<DialogStackItem[]>([]);
   const [size, setSize] = useState<"medium" | "large">("medium");
   const [externalDialogOpen, setExternalDialogOpen] = useState(false);
-  const [directDialogCount, setDirectDialogCount] = useState(0);
-
-  const registerDialog = useCallback(() => {
-    setDirectDialogCount((c) => c + 1);
-    return () => setDirectDialogCount((c) => c - 1);
-  }, []);
   const renderer = useRenderer();
   const focusRef = useRef<Renderable | null>(null);
 
@@ -154,8 +141,6 @@ export function DialogProvider({ children }: { children: ReactNode }) {
     setSize,
     externalDialogOpen,
     setExternalDialogOpen,
-    registerDialog,
-    directDialogCount,
   };
 
   return (

--- a/src/tui/context/dialog.tsx
+++ b/src/tui/context/dialog.tsx
@@ -5,6 +5,7 @@ import {
   useContext,
   useState,
   useCallback,
+  useEffect,
   useRef,
   type ReactNode,
 } from "react";
@@ -21,6 +22,9 @@ export function Dialog({ size = "medium", onClose, children }: DialogProps) {
   const dimensions = useDimensions();
   const renderer = useRenderer();
   const { colors: themeColors } = useTheme();
+  const { registerDialog } = useDialog();
+
+  useEffect(() => registerDialog(), [registerDialog]);
 
   return (
     <box
@@ -70,6 +74,8 @@ interface DialogContextValue {
   setSize: (size: "medium" | "large") => void;
   externalDialogOpen: boolean;
   setExternalDialogOpen: (open: boolean) => void;
+  registerDialog: () => () => void;
+  directDialogCount: number;
 }
 
 const DialogContext = createContext<DialogContextValue | null>(null);
@@ -78,6 +84,12 @@ export function DialogProvider({ children }: { children: ReactNode }) {
   const [stack, setStack] = useState<DialogStackItem[]>([]);
   const [size, setSize] = useState<"medium" | "large">("medium");
   const [externalDialogOpen, setExternalDialogOpen] = useState(false);
+  const [directDialogCount, setDirectDialogCount] = useState(0);
+
+  const registerDialog = useCallback(() => {
+    setDirectDialogCount((c) => c + 1);
+    return () => setDirectDialogCount((c) => c - 1);
+  }, []);
   const renderer = useRenderer();
   const focusRef = useRef<Renderable | null>(null);
 
@@ -142,6 +154,8 @@ export function DialogProvider({ children }: { children: ReactNode }) {
     setSize,
     externalDialogOpen,
     setExternalDialogOpen,
+    registerDialog,
+    directDialogCount,
   };
 
   return (

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -81,6 +81,7 @@ function App({ appConfig }: AppProps) {
   const [showProvidersDialog, setShowProvidersDialog] = useState(false);
   const [showConfigDialog, setShowConfigDialog] = useState(false);
   const [showCreditsDialog, setShowCreditsDialog] = useState(false);
+  const [showHelpDialog, setShowHelpDialog] = useState(false);
   const [showPentestDialog, setShowPentestDialog] = useState(false);
   const [pendingPentestFlags, setPendingPentestFlags] = useState<
     WebCommandOptions | undefined
@@ -104,6 +105,7 @@ function App({ appConfig }: AppProps) {
                     onOpenProvidersDialog={() => setShowProvidersDialog(true)}
                     onOpenConfigDialog={() => setShowConfigDialog(true)}
                     onOpenCreditsDialog={() => setShowCreditsDialog(true)}
+                    onOpenHelpDialog={() => setShowHelpDialog(true)}
                     onOpenAuthDialog={() => setShowAuthDialog(true)}
                     onOpenPentestDialog={(flags) => {
                       setPendingPentestFlags(flags);
@@ -138,6 +140,8 @@ function App({ appConfig }: AppProps) {
                         setShowConfigDialog={setShowConfigDialog}
                         showCreditsDialog={showCreditsDialog}
                         setShowCreditsDialog={setShowCreditsDialog}
+                        showHelpDialog={showHelpDialog}
+                        setShowHelpDialog={setShowHelpDialog}
                         showAuthDialog={showAuthDialog}
                         setShowAuthDialog={setShowAuthDialog}
                         showPentestDialog={showPentestDialog}
@@ -179,6 +183,8 @@ function AppContent({
   setShowConfigDialog,
   showCreditsDialog,
   setShowCreditsDialog,
+  showHelpDialog,
+  setShowHelpDialog,
   showAuthDialog,
   setShowAuthDialog,
   showPentestDialog,
@@ -207,6 +213,8 @@ function AppContent({
   setShowConfigDialog: (show: boolean) => void;
   showCreditsDialog: boolean;
   setShowCreditsDialog: (show: boolean) => void;
+  showHelpDialog: boolean;
+  setShowHelpDialog: (show: boolean) => void;
   showAuthDialog: boolean;
   setShowAuthDialog: (show: boolean) => void;
   showPentestDialog: boolean;
@@ -268,6 +276,7 @@ function AppContent({
     showProvidersDialog ||
     showConfigDialog ||
     showCreditsDialog ||
+    showHelpDialog ||
     showAuthDialog ||
     showPentestDialog;
 
@@ -329,6 +338,15 @@ function AppContent({
 
   const handleCloseCreditsDialog = () => {
     setShowCreditsDialog(false);
+    setInputKey((prev) => prev + 1);
+    refocusPrompt();
+  };
+
+  const handleCloseHelpDialog = () => {
+    setShowHelpDialog(false);
+    setTimeout(() => {
+      setExternalDialogOpen(false);
+    }, 0);
     setInputKey((prev) => prev + 1);
     refocusPrompt();
   };
@@ -421,6 +439,8 @@ function AppContent({
           }}
         />
       )}
+
+      {showHelpDialog && <HelpDialog onClose={handleCloseHelpDialog} />}
 
       {showAuthDialog && <AuthFlow onClose={handleCloseAuthDialog} />}
 
@@ -520,8 +540,16 @@ function CommandDisplay({
           <RouteSwitch.Case when="providers">
             <ProviderManager onOpenModelDialog={onOpenModelDialog} />
           </RouteSwitch.Case>
+<<<<<<< HEAD
           <RouteSwitch.Case when="help">
             <HelpDialog />
+=======
+          <RouteSwitch.Case when="models">
+            <ModelsDisplay />
+          </RouteSwitch.Case>
+          <RouteSwitch.Case when="credits">
+            <CreditsFlow onOpenAuthDialog={onOpenAuthDialog} />
+>>>>>>> ed763f61 (fix: render help dialog as overlay and dim footer when dialogs are open)
           </RouteSwitch.Case>
           <RouteSwitch.Case when="skills">
             <SkillsDialog />

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -35,6 +35,7 @@ import { writeErrorLog } from "../core/logger";
 import { checkForUpdate } from "../core/installation";
 import ShortcutsDialog from "./components/commands/shortcuts-dialog";
 import HelpDialog from "./components/commands/help-dialog";
+import ModelsDisplay from "./components/commands/models-display";
 import { ModelPickerDialog } from "./components/model-picker";
 import AuthFlow from "./components/commands/auth-flow";
 import CreditsFlow from "./components/commands/credits-flow";
@@ -540,16 +541,11 @@ function CommandDisplay({
           <RouteSwitch.Case when="providers">
             <ProviderManager onOpenModelDialog={onOpenModelDialog} />
           </RouteSwitch.Case>
-<<<<<<< HEAD
-          <RouteSwitch.Case when="help">
-            <HelpDialog />
-=======
           <RouteSwitch.Case when="models">
             <ModelsDisplay />
           </RouteSwitch.Case>
           <RouteSwitch.Case when="credits">
             <CreditsFlow onOpenAuthDialog={onOpenAuthDialog} />
->>>>>>> ed763f61 (fix: render help dialog as overlay and dim footer when dialogs are open)
           </RouteSwitch.Case>
           <RouteSwitch.Case when="skills">
             <SkillsDialog />

--- a/src/tui/keybindings/registry.ts
+++ b/src/tui/keybindings/registry.ts
@@ -84,13 +84,12 @@ export function createKeybindings(
         }
 
         const isHome = route.data.type === "base" && route.data.path === "home";
-        const isHelp = route.data.type === "base" && route.data.path === "help";
         const isOperator =
           route.data.type === "base" && route.data.path === "operator";
         const isSession =
           route.data.type === "pentest" || route.data.type === "operator";
 
-        if (!isHome && !isHelp && !isOperator && !isSession) {
+        if (!isHome && !isOperator && !isSession) {
           route.navigate({
             type: "base",
             path: "home",


### PR DESCRIPTION
When the terminal is too short for the home page content, Yoga compresses child elements into overlapping Y positions — garbling titles, menu items, and other text. This applies the same fix across all views:

- `overflow="hidden"` on root containers so overflow clips cleanly instead of garbling
- `flexShrink={0}` on fixed-height elements (headers, footers, inputs) so only flexible/decorative content absorbs compression
- Responsive content tiers on the home page that progressively hide animation, reduce margins, and drop decorative elements as terminal height shrinks

Closes #400

https://github.com/user-attachments/assets/a98a788b-fa85-4b33-a8e5-c8157fbbf305


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily layout/overflow tweaks across TUI views plus a small routing change to open `help` as a modal dialog; low risk but could affect focus/keyboard behavior in edge terminal sizes.
> 
> **Overview**
> Prevents text overlap/garbling on short terminals by applying `overflow="hidden"` broadly to root containers and adding `flexShrink={0}` to fixed header/footer/input areas across chat, operator, pentest, swarm dashboards, and model picker UI.
> 
> Makes the home screen *responsive* to terminal height by progressively hiding the animation/command list, reducing margins/padding, and dynamically limiting autocomplete suggestions.
> 
> Switches `/help` from route navigation to an overlay dialog: introduces `openHelpDialog` in the command context, wires it through `CommandProvider` and `index.tsx`, refactors `HelpDialog` to use the shared `Dialog` component with an `onClose` callback, and removes `help` from route switching/escape handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4aaccb3daa841451e330c56224580c936198611. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->