### PR TITLE
feat: unify model selection as dialog for home and operator mode

### DIFF
--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -112,7 +112,13 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
 
     super({
       system: buildSystemPrompt(session),
-      prompt: buildPrompt(target, objectives, session, findingsRegistry, context),
+      prompt: buildPrompt(
+        target,
+        objectives,
+        session,
+        findingsRegistry,
+        context,
+      ),
       model,
       session,
       target,

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -16,6 +16,7 @@ export interface AppCommandContext {
   navigate: (route: Route) => void;
   openSessionsDialog?: () => void;
   openThemeDialog?: () => void;
+  openModelDialog?: () => void;
   openAuthDialog?: () => void;
   openPentestDialog?: (flags?: WebCommandOptions) => void;
 }
@@ -221,10 +222,7 @@ export const commands: CommandConfig[] = [
     description: "Show available AI models",
     category: "General",
     handler: async (args, ctx) => {
-      ctx.navigate({
-        type: "base",
-        path: "models",
-      });
+      ctx.openModelDialog?.();
     },
   },
   {

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -17,6 +17,9 @@ export interface AppCommandContext {
   openSessionsDialog?: () => void;
   openThemeDialog?: () => void;
   openModelDialog?: () => void;
+  openProvidersDialog?: () => void;
+  openConfigDialog?: () => void;
+  openCreditsDialog?: () => void;
   openAuthDialog?: () => void;
   openPentestDialog?: (flags?: WebCommandOptions) => void;
 }
@@ -211,10 +214,7 @@ export const commands: CommandConfig[] = [
     category: "General",
     hidden: true,
     handler: async (args, ctx) => {
-      ctx.navigate({
-        type: "base",
-        path: "config",
-      });
+      ctx.openConfigDialog?.();
     },
   },
   {
@@ -230,10 +230,7 @@ export const commands: CommandConfig[] = [
     description: "Manage AI providers and API keys",
     category: "General",
     handler: async (args, ctx) => {
-      ctx.navigate({
-        type: "base",
-        path: "providers",
-      });
+      ctx.openProvidersDialog?.();
     },
   },
   {
@@ -354,10 +351,7 @@ export const commands: CommandConfig[] = [
     description: "Buy credits / check balance",
     category: "General",
     handler: async (args, ctx) => {
-      ctx.navigate({
-        type: "base",
-        path: "credits",
-      });
+      ctx.openCreditsDialog?.();
     },
   },
 

--- a/src/tui/components/alert-dialog.tsx
+++ b/src/tui/components/alert-dialog.tsx
@@ -28,10 +28,10 @@ export default function AlertDialog({
 
   useKeyboard((key) => {
     if (!open) return;
+    key.preventDefault();
     // Escape closes dialog
     if (key.name === "escape" && !disableEscape) {
       onClose();
-      key.preventDefault();
     }
   });
 

--- a/src/tui/components/commands/api-key-input.tsx
+++ b/src/tui/components/commands/api-key-input.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import Input from "../input";
 import { type ProviderType, verifyApiKey } from "../../../core/providers";
 import { useTheme } from "../../theme";
+import { Dialog } from "../../context/dialog";
 
 type VerifyState = "idle" | "verifying" | "error";
 
@@ -69,42 +70,21 @@ export default function APIKeyInput({
   };
 
   return (
-    <box
-      position="absolute"
-      top={0}
-      left={0}
-      zIndex={1001}
-      width="100%"
-      height="100%"
-      justifyContent="center"
-      alignItems="center"
-      backgroundColor={colors.backgroundOverlay}
-    >
-      <box
-        width={70}
-        border={true}
-        borderColor={colors.primary}
-        backgroundColor={colors.backgroundPanel}
-        flexDirection="column"
-        padding={2}
-      >
+    <Dialog size="large" onClose={onCancel}>
+      <box flexDirection="column" padding={1} width="100%">
         {/* Header */}
-        <box
-          flexDirection="row"
-          justifyContent="space-between"
-          marginBottom={2}
-        >
+        <box flexDirection="row" justifyContent="space-between" width="100%">
           <text fg={colors.primary}>Connect {providerName}</text>
-          <text fg={colors.textMuted}>esc</text>
+          <text fg={colors.textMuted}>esc to cancel</text>
         </box>
 
         {/* Instructions */}
-        <box marginBottom={2}>
+        <box marginTop={1} marginBottom={1}>
           <text fg={colors.textMuted}>{getProviderInstructions(provider)}</text>
         </box>
 
         {/* Input */}
-        <box marginBottom={2}>
+        <box marginBottom={1}>
           <Input
             label="API Key"
             description="Your API key will be stored locally in ~/.pensar/config.json"
@@ -134,14 +114,11 @@ export default function APIKeyInput({
           </box>
         )}
 
-        {/* Footer help text */}
+        {/* Footer */}
         <box marginTop={1}>
-          <text fg={colors.textMuted}>
-            <span fg={colors.primary}>[ENTER]</span> Save ·{" "}
-            <span fg={colors.primary}>[ESC]</span> Cancel
-          </text>
+          <text fg={colors.textMuted}>[enter] save [esc] cancel</text>
         </box>
       </box>
-    </box>
+    </Dialog>
   );
 }

--- a/src/tui/components/commands/api-key-input.tsx
+++ b/src/tui/components/commands/api-key-input.tsx
@@ -25,6 +25,8 @@ export default function APIKeyInput({
   const [errorMessage, setErrorMessage] = useState("");
 
   useKeyboard((key) => {
+    key.preventDefault();
+
     if (key.name === "escape") {
       if (verifyState === "verifying") return;
       onCancel();

--- a/src/tui/components/commands/api-key-input.tsx
+++ b/src/tui/components/commands/api-key-input.tsx
@@ -26,9 +26,8 @@ export default function APIKeyInput({
   const [errorMessage, setErrorMessage] = useState("");
 
   useKeyboard((key) => {
-    key.preventDefault();
-
     if (key.name === "escape") {
+      key.preventDefault();
       if (verifyState === "verifying") return;
       onCancel();
       return;

--- a/src/tui/components/commands/config-dialog.tsx
+++ b/src/tui/components/commands/config-dialog.tsx
@@ -2,27 +2,17 @@ import { useEffect, useState } from "react";
 import AlertDialog from "../alert-dialog";
 import { config } from "../../../core/config";
 import type { Config } from "../../../core/config/config";
-import { useRoute } from "../../context/route";
 
-export default function ConfigDialog() {
-  const route = useRoute();
+interface ConfigDialogProps {
+  onClose?: () => void;
+}
 
-  const [open, setOpen] = useState(false);
-
-  useEffect(() => {
-    if (route.data.type === "base" && route.data.path === "config") {
-      setOpen(true);
-    } else {
-      setOpen(false);
-    }
-  }, [route]);
+export default function ConfigDialog({ onClose }: ConfigDialogProps = {}) {
+  const [open, setOpen] = useState(true);
 
   const closeAlert = () => {
     setOpen(false);
-    route.navigate({
-      type: "base",
-      path: "home",
-    });
+    onClose?.();
   };
 
   const [appConfig, setAppConfig] = useState<Config | null>(null);

--- a/src/tui/components/commands/credits-flow.tsx
+++ b/src/tui/components/commands/credits-flow.tsx
@@ -4,6 +4,7 @@ import { useRoute } from "../../context/route";
 import { getPensarConsoleUrl } from "../../../core/api/constants";
 import { validateGateway } from "../../../core/auth";
 import { Dialog } from "../../context/dialog";
+import { useTheme } from "../../theme";
 
 type CreditsStep = "loading" | "no-auth" | "display" | "browser-opened";
 
@@ -22,6 +23,7 @@ export default function CreditsFlow({
   onOpenAuthDialog,
 }: CreditsFlowProps) {
   const route = useRoute();
+  const { colors } = useTheme();
   const [step, setStep] = useState<CreditsStep>("loading");
   const [credits, setCredits] = useState<CreditsInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -121,13 +123,13 @@ export default function CreditsFlow({
       >
         {/* Header */}
         <box marginBottom={1}>
-          <text fg="green">Credits</text>
+          <text fg={colors.primary}>Credits</text>
         </box>
 
         {/* Loading */}
         {step === "loading" && (
           <box>
-            <text fg="yellow">Fetching balance...</text>
+            <text fg={colors.warning}>Fetching balance...</text>
           </box>
         )}
 
@@ -135,17 +137,18 @@ export default function CreditsFlow({
         {step === "no-auth" && (
           <box flexDirection="column" gap={1}>
             <box>
-              <text fg="yellow">Not connected to Pensar Console.</text>
+              <text fg={colors.warning}>Not connected to Pensar Console.</text>
             </box>
             <box>
-              <text fg="gray">
-                Run <span fg="green">/auth</span> first to connect your account.
+              <text fg={colors.textMuted}>
+                Run <span fg={colors.primary}>/auth</span> first to connect your
+                account.
               </text>
             </box>
             <box marginTop={1}>
-              <text fg="gray">
-                <span fg="green">[ENTER]</span> Run /auth ·{" "}
-                <span fg="green">[ESC]</span> Back
+              <text fg={colors.textMuted}>
+                <span fg={colors.primary}>[ENTER]</span> Run /auth ·{" "}
+                <span fg={colors.primary}>[ESC]</span> Back
               </text>
             </box>
           </box>
@@ -156,24 +159,29 @@ export default function CreditsFlow({
           <box flexDirection="column" gap={1}>
             {error ? (
               <box>
-                <text fg="red">Error: {error}</text>
+                <text fg={colors.error}>Error: {error}</text>
               </box>
             ) : credits ? (
               <>
                 <box>
-                  <text fg="white">Workspace: {credits.workspace}</text>
+                  <text>
+                    <span fg={colors.textMuted}>Workspace: </span>
+                    <span fg={colors.text}>{credits.workspace}</span>
+                  </text>
                 </box>
                 <box>
-                  <text fg="white">
-                    Balance:{" "}
-                    <span fg={credits.balance < 5 ? "yellow" : "green"}>
+                  <text>
+                    <span fg={colors.textMuted}>Balance: </span>
+                    <span
+                      fg={credits.balance < 5 ? colors.warning : colors.success}
+                    >
                       ${credits.balance.toFixed(2)}
                     </span>
                   </text>
                 </box>
                 {credits.balance < 5 && (
                   <box marginTop={1}>
-                    <text fg="yellow">
+                    <text fg={colors.warning}>
                       Low balance. We recommend at least $30 for uninterrupted
                       pentest runs.
                     </text>
@@ -183,19 +191,13 @@ export default function CreditsFlow({
             ) : null}
 
             <box marginTop={1}>
-              <text fg="gray">
-                Press <span fg="green">[ENTER]</span> to buy credits in your
-                browser.
-              </text>
-            </box>
-            <box>
-              <text fg="gray">Or visit: {creditsUrl}</text>
+              <text fg={colors.textMuted}>Buy credits at: {creditsUrl}</text>
             </box>
             <box marginTop={1}>
-              <text fg="gray">
-                <span fg="green">[ENTER]</span> Open browser ·{" "}
-                <span fg="green">[R]</span> Refresh ·{" "}
-                <span fg="green">[ESC]</span> Back
+              <text fg={colors.textMuted}>
+                <span fg={colors.primary}>[ENTER]</span> Open in browser ·{" "}
+                <span fg={colors.primary}>[R]</span> Refresh ·{" "}
+                <span fg={colors.primary}>[ESC]</span> Back
               </text>
             </box>
           </box>
@@ -205,20 +207,20 @@ export default function CreditsFlow({
         {step === "browser-opened" && (
           <box flexDirection="column" gap={1}>
             <box>
-              <text fg="green">
+              <text fg={colors.success}>
                 Browser opened. Purchase credits on the Pensar Console.
               </text>
             </box>
             <box marginTop={1}>
-              <text fg="gray">
-                Press <span fg="green">[ENTER]</span> to refresh your balance
-                after purchasing.
+              <text fg={colors.textMuted}>
+                Press <span fg={colors.primary}>[ENTER]</span> to refresh your
+                balance after purchasing.
               </text>
             </box>
             <box marginTop={1}>
-              <text fg="gray">
-                <span fg="green">[ENTER]</span> Refresh balance ·{" "}
-                <span fg="green">[ESC]</span> Back
+              <text fg={colors.textMuted}>
+                <span fg={colors.primary}>[ENTER]</span> Refresh balance ·{" "}
+                <span fg={colors.primary}>[ESC]</span> Back
               </text>
             </box>
           </box>

--- a/src/tui/components/commands/credits-flow.tsx
+++ b/src/tui/components/commands/credits-flow.tsx
@@ -12,10 +12,14 @@ interface CreditsInfo {
 }
 
 interface CreditsFlowProps {
+  onClose?: () => void;
   onOpenAuthDialog?: () => void;
 }
 
-export default function CreditsFlow({ onOpenAuthDialog }: CreditsFlowProps) {
+export default function CreditsFlow({
+  onClose,
+  onOpenAuthDialog,
+}: CreditsFlowProps) {
   const route = useRoute();
   const [step, setStep] = useState<CreditsStep>("loading");
   const [credits, setCredits] = useState<CreditsInfo | null>(null);
@@ -24,7 +28,11 @@ export default function CreditsFlow({ onOpenAuthDialog }: CreditsFlowProps) {
   const creditsUrl = `${getPensarConsoleUrl()}/credits`;
 
   const goHome = () => {
-    route.navigate({ type: "base", path: "home" });
+    if (onClose) {
+      onClose();
+    } else {
+      route.navigate({ type: "base", path: "home" });
+    }
   };
 
   const openBrowser = () => {
@@ -72,6 +80,8 @@ export default function CreditsFlow({ onOpenAuthDialog }: CreditsFlowProps) {
   }, []);
 
   useKeyboard((key) => {
+    key.preventDefault();
+
     if (key.name === "escape") {
       goHome();
       return;

--- a/src/tui/components/commands/credits-flow.tsx
+++ b/src/tui/components/commands/credits-flow.tsx
@@ -3,6 +3,7 @@ import { useKeyboard } from "@opentui/react";
 import { useRoute } from "../../context/route";
 import { getPensarConsoleUrl } from "../../../core/api/constants";
 import { validateGateway } from "../../../core/auth";
+import { Dialog } from "../../context/dialog";
 
 type CreditsStep = "loading" | "no-auth" | "display" | "browser-opened";
 
@@ -110,117 +111,119 @@ export default function CreditsFlow({
   });
 
   return (
-    <box
-      flexDirection="column"
-      width="100%"
-      maxWidth={80}
-      alignItems="flex-start"
-      padding={1}
-    >
-      {/* Header */}
-      <box marginBottom={1}>
-        <text fg="green">Credits</text>
-      </box>
-
-      {/* Loading */}
-      {step === "loading" && (
-        <box>
-          <text fg="yellow">Fetching balance...</text>
+    <Dialog size="large" onClose={goHome}>
+      <box
+        flexDirection="column"
+        width="100%"
+        maxWidth={80}
+        alignItems="flex-start"
+        padding={1}
+      >
+        {/* Header */}
+        <box marginBottom={1}>
+          <text fg="green">Credits</text>
         </box>
-      )}
 
-      {/* No Auth */}
-      {step === "no-auth" && (
-        <box flexDirection="column" gap={1}>
+        {/* Loading */}
+        {step === "loading" && (
           <box>
-            <text fg="yellow">Not connected to Pensar Console.</text>
+            <text fg="yellow">Fetching balance...</text>
           </box>
-          <box>
-            <text fg="gray">
-              Run <span fg="green">/auth</span> first to connect your account.
-            </text>
-          </box>
-          <box marginTop={1}>
-            <text fg="gray">
-              <span fg="green">[ENTER]</span> Run /auth ·{" "}
-              <span fg="green">[ESC]</span> Back
-            </text>
-          </box>
-        </box>
-      )}
+        )}
 
-      {/* Display Balance */}
-      {step === "display" && (
-        <box flexDirection="column" gap={1}>
-          {error ? (
+        {/* No Auth */}
+        {step === "no-auth" && (
+          <box flexDirection="column" gap={1}>
             <box>
-              <text fg="red">Error: {error}</text>
+              <text fg="yellow">Not connected to Pensar Console.</text>
             </box>
-          ) : credits ? (
-            <>
+            <box>
+              <text fg="gray">
+                Run <span fg="green">/auth</span> first to connect your account.
+              </text>
+            </box>
+            <box marginTop={1}>
+              <text fg="gray">
+                <span fg="green">[ENTER]</span> Run /auth ·{" "}
+                <span fg="green">[ESC]</span> Back
+              </text>
+            </box>
+          </box>
+        )}
+
+        {/* Display Balance */}
+        {step === "display" && (
+          <box flexDirection="column" gap={1}>
+            {error ? (
               <box>
-                <text fg="white">Workspace: {credits.workspace}</text>
+                <text fg="red">Error: {error}</text>
               </box>
-              <box>
-                <text fg="white">
-                  Balance:{" "}
-                  <span fg={credits.balance < 5 ? "yellow" : "green"}>
-                    ${credits.balance.toFixed(2)}
-                  </span>
-                </text>
-              </box>
-              {credits.balance < 5 && (
-                <box marginTop={1}>
-                  <text fg="yellow">
-                    Low balance. We recommend at least $30 for uninterrupted
-                    pentest runs.
+            ) : credits ? (
+              <>
+                <box>
+                  <text fg="white">Workspace: {credits.workspace}</text>
+                </box>
+                <box>
+                  <text fg="white">
+                    Balance:{" "}
+                    <span fg={credits.balance < 5 ? "yellow" : "green"}>
+                      ${credits.balance.toFixed(2)}
+                    </span>
                   </text>
                 </box>
-              )}
-            </>
-          ) : null}
+                {credits.balance < 5 && (
+                  <box marginTop={1}>
+                    <text fg="yellow">
+                      Low balance. We recommend at least $30 for uninterrupted
+                      pentest runs.
+                    </text>
+                  </box>
+                )}
+              </>
+            ) : null}
 
-          <box marginTop={1}>
-            <text fg="gray">
-              Press <span fg="green">[ENTER]</span> to buy credits in your
-              browser.
-            </text>
+            <box marginTop={1}>
+              <text fg="gray">
+                Press <span fg="green">[ENTER]</span> to buy credits in your
+                browser.
+              </text>
+            </box>
+            <box>
+              <text fg="gray">Or visit: {creditsUrl}</text>
+            </box>
+            <box marginTop={1}>
+              <text fg="gray">
+                <span fg="green">[ENTER]</span> Open browser ·{" "}
+                <span fg="green">[R]</span> Refresh ·{" "}
+                <span fg="green">[ESC]</span> Back
+              </text>
+            </box>
           </box>
-          <box>
-            <text fg="gray">Or visit: {creditsUrl}</text>
-          </box>
-          <box marginTop={1}>
-            <text fg="gray">
-              <span fg="green">[ENTER]</span> Open browser ·{" "}
-              <span fg="green">[R]</span> Refresh ·{" "}
-              <span fg="green">[ESC]</span> Back
-            </text>
-          </box>
-        </box>
-      )}
+        )}
 
-      {/* Browser Opened */}
-      {step === "browser-opened" && (
-        <box flexDirection="column" gap={1}>
-          <box>
-            <text fg="green">
-              Browser opened. Purchase credits on the Pensar Console.
-            </text>
+        {/* Browser Opened */}
+        {step === "browser-opened" && (
+          <box flexDirection="column" gap={1}>
+            <box>
+              <text fg="green">
+                Browser opened. Purchase credits on the Pensar Console.
+              </text>
+            </box>
+            <box marginTop={1}>
+              <text fg="gray">
+                Press <span fg="green">[ENTER]</span> to refresh your balance
+                after purchasing.
+              </text>
+            </box>
+            <box marginTop={1}>
+              <text fg="gray">
+                <span fg="green">[ENTER]</span> Refresh balance ·{" "}
+                <span fg="green">[ESC]</span> Back
+              </text>
+            </box>
           </box>
-          <box marginTop={1}>
-            <text fg="gray">
-              Press <span fg="green">[ENTER]</span> to refresh your balance
-              after purchasing.
-            </text>
-          </box>
-          <box marginTop={1}>
-            <text fg="gray">
-              <span fg="green">[ENTER]</span> Refresh balance ·{" "}
-              <span fg="green">[ESC]</span> Back
-            </text>
-          </box>
-        </box>
-      )}
-    </box>
+        )}
+      </box>
+    </Dialog>
   );
 }

--- a/src/tui/components/commands/provider-manager.tsx
+++ b/src/tui/components/commands/provider-manager.tsx
@@ -74,6 +74,9 @@ export default function ProviderManager({
       onClose();
     }
     if (onOpenModelDialog) {
+      if (!onClose) {
+        route.navigate({ type: "base", path: "home" });
+      }
       onOpenModelDialog();
     } else if (!onClose) {
       route.navigate({ type: "base", path: "home" });

--- a/src/tui/components/commands/provider-manager.tsx
+++ b/src/tui/components/commands/provider-manager.tsx
@@ -12,6 +12,7 @@ import ProviderSelection from "./provider-selection";
 import APIKeyInput from "./api-key-input";
 import AuthFlow from "./auth-flow";
 import { useTheme } from "../../theme";
+import { Dialog } from "../../context/dialog";
 
 type FlowState = "choosing" | "selecting" | "inputting" | "auth";
 
@@ -178,38 +179,21 @@ function OnboardingChoice({
   });
 
   return (
-    <box
-      position="absolute"
-      top={0}
-      left={0}
-      zIndex={1000}
-      width="100%"
-      height="100%"
-      justifyContent="center"
-      alignItems="center"
-      backgroundColor={"transparent"}
-    >
-      <box
-        width={70}
-        border={true}
-        borderColor={colors.primary}
-        backgroundColor={colors.backgroundPanel}
-        flexDirection="column"
-        padding={2}
-      >
+    <Dialog size="large" onClose={() => {}}>
+      <box flexDirection="column" padding={1} width="100%">
         {/* Header */}
-        <box flexDirection="row" marginBottom={2}>
+        <box>
           <text fg={colors.primary}>Get Started</text>
         </box>
 
-        <box marginBottom={2}>
+        <box marginTop={1}>
           <text fg={colors.textMuted}>
             Choose how to connect an AI provider.
           </text>
         </box>
 
         {/* Choices */}
-        <box flexDirection="column" gap={1}>
+        <box flexDirection="column" gap={1} marginTop={1}>
           {choices.map((choice, index) => {
             const isHighlighted = index === highlightedIndex;
             return (
@@ -237,13 +221,10 @@ function OnboardingChoice({
         </box>
 
         {/* Footer */}
-        <box marginTop={2}>
-          <text fg={colors.textMuted}>
-            <span fg={colors.primary}>[↑↓]</span> Navigate ·{" "}
-            <span fg={colors.primary}>[ENTER]</span> Select
-          </text>
+        <box marginTop={1}>
+          <text fg={colors.textMuted}>[↑↓] browse [enter] select</text>
         </box>
       </box>
-    </box>
+    </Dialog>
   );
 }

--- a/src/tui/components/commands/provider-manager.tsx
+++ b/src/tui/components/commands/provider-manager.tsx
@@ -15,7 +15,13 @@ import { useTheme } from "../../theme";
 
 type FlowState = "choosing" | "selecting" | "inputting" | "auth";
 
-export default function ProviderManager() {
+interface ProviderManagerProps {
+  onClose?: () => void;
+}
+
+export default function ProviderManager({
+  onClose,
+}: ProviderManagerProps = {}) {
   const route = useRoute();
   const _config = useConfig();
 
@@ -61,10 +67,11 @@ export default function ProviderManager() {
     await config.update(configUpdate);
     await _config.reload();
 
-    route.navigate({
-      type: "base",
-      path: "home",
-    });
+    if (onClose) {
+      onClose();
+    } else {
+      route.navigate({ type: "base", path: "home" });
+    }
   };
 
   const handleAPIKeyCancel = () => {
@@ -77,17 +84,18 @@ export default function ProviderManager() {
   };
 
   const handleClose = () => {
-    route.navigate({
-      type: "base",
-      path: "home",
-    });
+    if (onClose) {
+      onClose();
+    } else {
+      route.navigate({ type: "base", path: "home" });
+    }
   };
 
   const handleAuthClose = () => {
     if (isOnboarding) {
       setFlowState("choosing");
     } else {
-      route.navigate({ type: "base", path: "home" });
+      handleClose();
     }
   };
 
@@ -151,6 +159,8 @@ function OnboardingChoice({
   ];
 
   useKeyboard((key) => {
+    key.preventDefault();
+
     if (key.name === "up") {
       setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : choices.length - 1));
       return;

--- a/src/tui/components/commands/provider-manager.tsx
+++ b/src/tui/components/commands/provider-manager.tsx
@@ -18,10 +18,12 @@ type FlowState = "choosing" | "selecting" | "inputting" | "auth";
 
 interface ProviderManagerProps {
   onClose?: () => void;
+  onOpenModelDialog?: () => void;
 }
 
 export default function ProviderManager({
   onClose,
+  onOpenModelDialog,
 }: ProviderManagerProps = {}) {
   const route = useRoute();
   const _config = useConfig();
@@ -70,7 +72,10 @@ export default function ProviderManager({
 
     if (onClose) {
       onClose();
-    } else {
+    }
+    if (onOpenModelDialog) {
+      onOpenModelDialog();
+    } else if (!onClose) {
       route.navigate({ type: "base", path: "home" });
     }
   };

--- a/src/tui/components/commands/provider-manager.tsx
+++ b/src/tui/components/commands/provider-manager.tsx
@@ -70,15 +70,12 @@ export default function ProviderManager({
     await config.update(configUpdate);
     await _config.reload();
 
-    if (onClose) {
-      onClose();
-    }
     if (onOpenModelDialog) {
-      if (!onClose) {
-        route.navigate({ type: "base", path: "home" });
-      }
+      // Transition directly to model dialog — skip prompt cleanup
       onOpenModelDialog();
-    } else if (!onClose) {
+    } else if (onClose) {
+      onClose();
+    } else {
       route.navigate({ type: "base", path: "home" });
     }
   };

--- a/src/tui/components/commands/provider-manager.tsx
+++ b/src/tui/components/commands/provider-manager.tsx
@@ -63,7 +63,7 @@ export default function ProviderManager() {
 
     route.navigate({
       type: "base",
-      path: "models",
+      path: "home",
     });
   };
 

--- a/src/tui/components/commands/provider-selection.tsx
+++ b/src/tui/components/commands/provider-selection.tsx
@@ -30,6 +30,8 @@ export default function ProviderSelection({
   const configuredProviders = getConfiguredProviders(_config.data);
 
   useKeyboard((key) => {
+    key.preventDefault();
+
     if (key.name === "escape") {
       onClose();
       return;

--- a/src/tui/components/commands/provider-selection.tsx
+++ b/src/tui/components/commands/provider-selection.tsx
@@ -71,7 +71,22 @@ export default function ProviderSelection({
         </box>
 
         {/* Provider List */}
-        <box flexDirection="column" marginTop={1} gap={1}>
+        <scrollbox
+          style={{
+            rootOptions: {
+              flexGrow: 1,
+              flexShrink: 1,
+              width: "100%",
+              marginTop: 1,
+            },
+            contentOptions: {
+              flexDirection: "column",
+              gap: 1,
+            },
+          }}
+          stickyScroll={false}
+          focused={true}
+        >
           {providerList.map((provider, index) => {
             const isHighlighted = index === highlightedIndex;
             const configured = configuredProviders.find(
@@ -103,7 +118,7 @@ export default function ProviderSelection({
               </box>
             );
           })}
-        </box>
+        </scrollbox>
 
         {/* Footer */}
         <box marginTop={1}>

--- a/src/tui/components/commands/provider-selection.tsx
+++ b/src/tui/components/commands/provider-selection.tsx
@@ -9,6 +9,7 @@ import {
   type Provider,
 } from "../../../core/providers";
 import { useTheme } from "../../theme";
+import { Dialog } from "../../context/dialog";
 
 interface ProviderSelectionProps {
   providers?: Provider[];
@@ -61,65 +62,16 @@ export default function ProviderSelection({
   });
 
   return (
-    <box
-      position="absolute"
-      top={0}
-      left={0}
-      zIndex={1000}
-      width="100%"
-      height="100%"
-      justifyContent="center"
-      alignItems="center"
-      backgroundColor={"transparent"}
-    >
-      <box
-        width={70}
-        maxHeight="80%"
-        border={true}
-        borderColor={colors.primary}
-        backgroundColor={colors.backgroundPanel}
-        flexDirection="column"
-        padding={2}
-      >
+    <Dialog size="large" onClose={onClose}>
+      <box flexDirection="column" padding={1} width="100%">
         {/* Header */}
-        <box
-          flexDirection="row"
-          justifyContent="space-between"
-          marginBottom={2}
-        >
+        <box flexDirection="row" justifyContent="space-between" width="100%">
           <text fg={colors.primary}>Select provider</text>
-          <text fg={colors.textMuted}>esc</text>
+          <text fg={colors.textMuted}>esc to close</text>
         </box>
 
         {/* Provider List */}
-        <scrollbox
-          style={{
-            rootOptions: {
-              width: "100%",
-              flexGrow: 1,
-              flexShrink: 1,
-              overflow: "hidden",
-            },
-            wrapperOptions: {
-              overflow: "hidden",
-            },
-            contentOptions: {
-              flexDirection: "column",
-              gap: 1,
-            },
-            scrollbarOptions: {
-              trackOptions: {
-                foregroundColor: colors.primary,
-                backgroundColor: colors.backgroundElement,
-              },
-            },
-          }}
-        >
-          {/* Popular providers section */}
-          <text fg={colors.textMuted} marginTop={1} marginBottom={1}>
-            Popular providers
-          </text>
-
+        <box flexDirection="column" marginTop={1} gap={1}>
           {providerList.map((provider, index) => {
             const isHighlighted = index === highlightedIndex;
             const configured = configuredProviders.find(
@@ -151,17 +103,15 @@ export default function ProviderSelection({
               </box>
             );
           })}
-        </scrollbox>
+        </box>
 
-        {/* Footer help text */}
-        <box marginTop={2}>
+        {/* Footer */}
+        <box marginTop={1}>
           <text fg={colors.textMuted}>
-            <span fg={colors.primary}>[↑↓]</span> Navigate ·{" "}
-            <span fg={colors.primary}>[ENTER]</span> Select ·{" "}
-            <span fg={colors.primary}>[ESC]</span> Close
+            [↑↓] browse [enter] select [esc] close
           </text>
         </box>
       </box>
-    </box>
+    </Dialog>
   );
 }

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -394,6 +394,8 @@ export function ModelPicker({
   );
 
   useKeyboard((key) => {
+    // Modal dialog — consume all keystrokes to prevent leaking to components underneath
+    key.preventDefault();
     handleKeyboard(key);
   });
 

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -401,8 +401,10 @@ export function ModelPicker({
   );
 
   useKeyboard((key) => {
-    // Modal dialog — consume all keystrokes to prevent leaking to components underneath
-    key.preventDefault();
+    if (focused) {
+      // Modal dialog — consume all keystrokes to prevent leaking to components underneath
+      key.preventDefault();
+    }
     handleKeyboard(key);
   });
 

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -308,10 +308,13 @@ export function ModelPicker({
       if (key.name === "escape") {
         if (searchQuery) {
           setSearchQuery("");
-        } else {
-          onCancel?.();
+          return true;
         }
-        return true;
+        if (onCancel) {
+          onCancel();
+          return true;
+        }
+        return false;
       }
 
       // Enter - confirm model selection, toggle provider, or start editing local input
@@ -401,11 +404,13 @@ export function ModelPicker({
   );
 
   useKeyboard((key) => {
-    if (focused) {
-      // Modal dialog — consume all keystrokes to prevent leaking to components underneath
+    const handled = handleKeyboard(key);
+    if (handled) {
+      // Only consume keystrokes that the picker actually handled,
+      // so unhandled keys (e.g. ESC without onCancel, Tab) fall through
+      // to parent components like ConfigView.
       key.preventDefault();
     }
-    handleKeyboard(key);
   });
 
   // Helper to check if a navigation item at focusedIndex matches a provider

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -89,6 +89,7 @@ export interface ModelPickerProps {
   selectedModel: ModelInfo;
   onSelectModel: (model: ModelInfo) => void;
   onConfirm?: () => void;
+  onCancel?: () => void;
   onConfigUpdate?: (update: Partial<Config>) => Promise<void>;
   focused?: boolean;
   isModelUserSelected?: boolean;
@@ -99,6 +100,7 @@ export function ModelPicker({
   selectedModel,
   onSelectModel,
   onConfirm,
+  onCancel,
   onConfigUpdate,
   focused = true,
   isModelUserSelected = false,
@@ -302,9 +304,13 @@ export function ModelPicker({
         return true;
       }
 
-      // Escape - clear search (if there is one)
-      if (key.name === "escape" && searchQuery) {
-        setSearchQuery("");
+      // Escape - clear search, or cancel/close
+      if (key.name === "escape") {
+        if (searchQuery) {
+          setSearchQuery("");
+        } else {
+          onCancel?.();
+        }
         return true;
       }
 
@@ -389,6 +395,7 @@ export function ModelPicker({
       focusedIndex,
       onSelectModel,
       onConfirm,
+      onCancel,
       searchQuery,
     ],
   );

--- a/src/tui/components/model-picker/ModelPickerDialog.tsx
+++ b/src/tui/components/model-picker/ModelPickerDialog.tsx
@@ -1,0 +1,60 @@
+/**
+ * Model Picker Dialog — /models command
+ *
+ * Wraps ModelPicker in a Dialog overlay, matching the ThemePicker pattern.
+ * Used from both home page and operator mode.
+ */
+
+import { useAgent } from "../../context/agent";
+import { useConfig } from "../../context/config";
+import { useTheme } from "../../theme";
+import { Dialog } from "../../context/dialog";
+import { ModelPicker } from "./ModelPicker";
+
+interface ModelPickerDialogProps {
+  onClose: () => void;
+}
+
+export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
+  const { colors } = useTheme();
+  const config = useConfig();
+  const { model, setModel, isModelUserSelected } = useAgent();
+
+  return (
+    <Dialog size="large" onClose={onClose}>
+      <box flexDirection="column" width="100%" paddingLeft={2} paddingTop={1}>
+        <text>
+          <span fg={colors.primary}>Select AI Model</span>
+          <span fg={colors.textMuted}> ({model.name})</span>
+          <span fg={colors.textMuted}>
+            {" "}
+            [{isModelUserSelected ? "user" : "default"}]
+          </span>
+        </text>
+        <box
+          flexDirection="column"
+          paddingLeft={1}
+          marginTop={1}
+          flexGrow={1}
+          flexShrink={1}
+          overflow="hidden"
+        >
+          <ModelPicker
+            config={config.data}
+            selectedModel={model}
+            onSelectModel={setModel}
+            onConfirm={onClose}
+            onConfigUpdate={config.update}
+            focused={true}
+            isModelUserSelected={isModelUserSelected}
+          />
+        </box>
+        <box marginTop={1} paddingLeft={1}>
+          <text fg={colors.textMuted}>
+            [Enter] confirm • [ESC] close
+          </text>
+        </box>
+      </box>
+    </Dialog>
+  );
+}

--- a/src/tui/components/model-picker/ModelPickerDialog.tsx
+++ b/src/tui/components/model-picker/ModelPickerDialog.tsx
@@ -44,6 +44,7 @@ export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
             selectedModel={model}
             onSelectModel={setModel}
             onConfirm={onClose}
+            onCancel={onClose}
             onConfigUpdate={config.update}
             focused={true}
             isModelUserSelected={isModelUserSelected}

--- a/src/tui/components/model-picker/ModelPickerDialog.tsx
+++ b/src/tui/components/model-picker/ModelPickerDialog.tsx
@@ -51,9 +51,7 @@ export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
           />
         </box>
         <box marginTop={1} paddingLeft={1}>
-          <text fg={colors.textMuted}>
-            [Enter] confirm • [ESC] close
-          </text>
+          <text fg={colors.textMuted}>[Enter] confirm • [ESC] close</text>
         </box>
       </box>
     </Dialog>

--- a/src/tui/components/model-picker/index.ts
+++ b/src/tui/components/model-picker/index.ts
@@ -1,2 +1,3 @@
 export { ModelPicker, type ModelPickerProps } from "./ModelPicker";
 export { default } from "./ModelPicker";
+export { default as ModelPickerDialog } from "./ModelPickerDialog";

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -54,7 +54,6 @@ import {
   readExecutionMetrics,
   writeExecutionMetrics,
 } from "../../../core/session/execution-metrics";
-import { ModelPicker } from "../model-picker";
 import { stepCountIs, type ModelMessage } from "ai";
 import {
   type DashboardStatus,
@@ -105,13 +104,7 @@ export default function OperatorDashboard({
     skillsRegistry,
     skillsVersion,
   } = useCommand();
-  const {
-    stack,
-    externalDialogOpen,
-    replace: showDialog,
-    clear: clearDialog,
-    setSize: setDialogSize,
-  } = useDialog();
+  const { stack, externalDialogOpen } = useDialog();
   const { refocusPrompt } = useFocus();
 
   const autocompleteOptions = useMemo(() => {
@@ -1050,40 +1043,8 @@ export default function OperatorDashboard({
   }, [status]);
 
   const showModelPicker = useCallback(() => {
-    setDialogSize("large");
-    showDialog(
-      <box flexDirection="column" width="100%" paddingLeft={4} paddingTop={1}>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={colors.text}>Select AI Model</span>
-          <span fg={colors.textMuted}> ({model.name})</span>
-        </text>
-        <box flexDirection="column" paddingLeft={2} marginTop={1}>
-          <ModelPicker
-            config={config.data}
-            selectedModel={model}
-            onSelectModel={setModel}
-            onConfirm={clearDialog}
-            onConfigUpdate={config.update}
-            focused={true}
-            isModelUserSelected={isModelUserSelected}
-          />
-        </box>
-        <box marginTop={1} paddingLeft={2}>
-          <text fg={colors.textMuted}>[Enter] confirm • [ESC] close</text>
-        </box>
-      </box>,
-    );
-  }, [
-    colors,
-    model,
-    setModel,
-    isModelUserSelected,
-    config,
-    showDialog,
-    clearDialog,
-    setDialogSize,
-  ]);
+    executeCommand("/models");
+  }, [executeCommand]);
 
   const handleCommandExecute = useCallback(
     async (command: string) => {

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -49,6 +49,7 @@ interface CommandProviderProps {
   children: ReactNode;
   onOpenSessionsDialog?: () => void;
   onOpenThemeDialog?: () => void;
+  onOpenModelDialog?: () => void;
   onOpenAuthDialog?: () => void;
   onOpenPentestDialog?: (flags?: WebCommandOptions) => void;
 }
@@ -57,6 +58,7 @@ export function CommandProvider({
   children,
   onOpenSessionsDialog,
   onOpenThemeDialog,
+  onOpenModelDialog,
   onOpenAuthDialog,
   onOpenPentestDialog,
 }: CommandProviderProps) {
@@ -70,6 +72,7 @@ export function CommandProvider({
       navigate: route.navigate,
       openSessionsDialog: onOpenSessionsDialog,
       openThemeDialog: onOpenThemeDialog,
+      openModelDialog: onOpenModelDialog,
       openAuthDialog: onOpenAuthDialog,
       openPentestDialog: onOpenPentestDialog,
     };
@@ -78,6 +81,7 @@ export function CommandProvider({
     route,
     onOpenSessionsDialog,
     onOpenThemeDialog,
+    onOpenModelDialog,
     onOpenAuthDialog,
     onOpenPentestDialog,
   ]);

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -50,6 +50,9 @@ interface CommandProviderProps {
   onOpenSessionsDialog?: () => void;
   onOpenThemeDialog?: () => void;
   onOpenModelDialog?: () => void;
+  onOpenProvidersDialog?: () => void;
+  onOpenConfigDialog?: () => void;
+  onOpenCreditsDialog?: () => void;
   onOpenAuthDialog?: () => void;
   onOpenPentestDialog?: (flags?: WebCommandOptions) => void;
 }
@@ -59,6 +62,9 @@ export function CommandProvider({
   onOpenSessionsDialog,
   onOpenThemeDialog,
   onOpenModelDialog,
+  onOpenProvidersDialog,
+  onOpenConfigDialog,
+  onOpenCreditsDialog,
   onOpenAuthDialog,
   onOpenPentestDialog,
 }: CommandProviderProps) {
@@ -73,6 +79,9 @@ export function CommandProvider({
       openSessionsDialog: onOpenSessionsDialog,
       openThemeDialog: onOpenThemeDialog,
       openModelDialog: onOpenModelDialog,
+      openProvidersDialog: onOpenProvidersDialog,
+      openConfigDialog: onOpenConfigDialog,
+      openCreditsDialog: onOpenCreditsDialog,
       openAuthDialog: onOpenAuthDialog,
       openPentestDialog: onOpenPentestDialog,
     };
@@ -82,6 +91,9 @@ export function CommandProvider({
     onOpenSessionsDialog,
     onOpenThemeDialog,
     onOpenModelDialog,
+    onOpenProvidersDialog,
+    onOpenConfigDialog,
+    onOpenCreditsDialog,
     onOpenAuthDialog,
     onOpenPentestDialog,
   ]);

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -82,7 +82,6 @@ function App({ appConfig }: AppProps) {
   const [showConfigDialog, setShowConfigDialog] = useState(false);
   const [showCreditsDialog, setShowCreditsDialog] = useState(false);
   const [showPentestDialog, setShowPentestDialog] = useState(false);
-  const [returnToCredits, setReturnToCredits] = useState(false);
   const [pendingPentestFlags, setPendingPentestFlags] = useState<
     WebCommandOptions | undefined
   >(undefined);
@@ -228,6 +227,7 @@ function AppContent({
 
   const { refocusPrompt } = useFocus();
   const { setExternalDialogOpen } = useDialog();
+  const [returnToCredits, setReturnToCredits] = useState(false);
 
   useEffect(() => {
     checkForUpdate().then(

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -82,6 +82,7 @@ function App({ appConfig }: AppProps) {
   const [showConfigDialog, setShowConfigDialog] = useState(false);
   const [showCreditsDialog, setShowCreditsDialog] = useState(false);
   const [showPentestDialog, setShowPentestDialog] = useState(false);
+  const [returnToCredits, setReturnToCredits] = useState(false);
   const [pendingPentestFlags, setPendingPentestFlags] = useState<
     WebCommandOptions | undefined
   >(undefined);
@@ -334,8 +335,13 @@ function AppContent({
 
   const handleCloseAuthDialog = () => {
     setShowAuthDialog(false);
-    setInputKey((prev) => prev + 1);
-    refocusPrompt();
+    if (returnToCredits) {
+      setReturnToCredits(false);
+      setShowCreditsDialog(true);
+    } else {
+      setInputKey((prev) => prev + 1);
+      refocusPrompt();
+    }
   };
 
   const handleClosePentestDialog = () => {
@@ -396,7 +402,10 @@ function AppContent({
       {showProvidersDialog && (
         <ProviderManager
           onClose={handleCloseProvidersDialog}
-          onOpenModelDialog={() => setShowModelDialog(true)}
+          onOpenModelDialog={() => {
+            setShowProvidersDialog(false);
+            setShowModelDialog(true);
+          }}
         />
       )}
 
@@ -407,6 +416,7 @@ function AppContent({
           onClose={handleCloseCreditsDialog}
           onOpenAuthDialog={() => {
             setShowCreditsDialog(false);
+            setReturnToCredits(true);
             setShowAuthDialog(true);
           }}
         />

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -239,7 +239,12 @@ function AppContent({
   // Track external dialog state for theme/model/auth/pentest dialogs so operator input
   // unfocuses while a dialog overlay is open
   useEffect(() => {
-    if (showThemeDialog || showModelDialog || showAuthDialog || showPentestDialog) {
+    if (
+      showThemeDialog ||
+      showModelDialog ||
+      showAuthDialog ||
+      showPentestDialog
+    ) {
       setExternalDialogOpen(true);
     }
   }, [showThemeDialog, showModelDialog, showAuthDialog, showPentestDialog]);

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -35,7 +35,7 @@ import { writeErrorLog } from "../core/logger";
 import { checkForUpdate } from "../core/installation";
 import ShortcutsDialog from "./components/commands/shortcuts-dialog";
 import HelpDialog from "./components/commands/help-dialog";
-import ModelsDisplay from "./components/commands/models-display";
+import { ModelPickerDialog } from "./components/model-picker";
 import AuthFlow from "./components/commands/auth-flow";
 import CreditsFlow from "./components/commands/credits-flow";
 import { KeybindingProvider } from "./context/keybinding";
@@ -77,6 +77,7 @@ function App({ appConfig }: AppProps) {
   const [showShortcutsDialog, setShowShortcutsDialog] = useState(false);
   const [showThemeDialog, setShowThemeDialog] = useState(false);
   const [showAuthDialog, setShowAuthDialog] = useState(false);
+  const [showModelDialog, setShowModelDialog] = useState(false);
   const [showPentestDialog, setShowPentestDialog] = useState(false);
   const [pendingPentestFlags, setPendingPentestFlags] = useState<
     WebCommandOptions | undefined
@@ -96,6 +97,7 @@ function App({ appConfig }: AppProps) {
                   <CommandProvider
                     onOpenSessionsDialog={() => setShowSessionsDialog(true)}
                     onOpenThemeDialog={() => setShowThemeDialog(true)}
+                    onOpenModelDialog={() => setShowModelDialog(true)}
                     onOpenAuthDialog={() => setShowAuthDialog(true)}
                     onOpenPentestDialog={(flags) => {
                       setPendingPentestFlags(flags);
@@ -122,6 +124,8 @@ function App({ appConfig }: AppProps) {
                         setShowShortcutsDialog={setShowShortcutsDialog}
                         showThemeDialog={showThemeDialog}
                         setShowThemeDialog={setShowThemeDialog}
+                        showModelDialog={showModelDialog}
+                        setShowModelDialog={setShowModelDialog}
                         showAuthDialog={showAuthDialog}
                         setShowAuthDialog={setShowAuthDialog}
                         showPentestDialog={showPentestDialog}
@@ -155,6 +159,8 @@ function AppContent({
   setShowShortcutsDialog,
   showThemeDialog,
   setShowThemeDialog,
+  showModelDialog,
+  setShowModelDialog,
   showAuthDialog,
   setShowAuthDialog,
   showPentestDialog,
@@ -175,6 +181,8 @@ function AppContent({
   setShowShortcutsDialog: (show: boolean) => void;
   showThemeDialog: boolean;
   setShowThemeDialog: (show: boolean) => void;
+  showModelDialog: boolean;
+  setShowModelDialog: (show: boolean) => void;
   showAuthDialog: boolean;
   setShowAuthDialog: (show: boolean) => void;
   showPentestDialog: boolean;
@@ -228,13 +236,13 @@ function AppContent({
     }
   }, [config.data.responsibleUseAccepted, route.data]);
 
-  // Track external dialog state for theme/auth/pentest dialogs so operator input
+  // Track external dialog state for theme/model/auth/pentest dialogs so operator input
   // unfocuses while a dialog overlay is open
   useEffect(() => {
-    if (showThemeDialog || showAuthDialog || showPentestDialog) {
+    if (showThemeDialog || showModelDialog || showAuthDialog || showPentestDialog) {
       setExternalDialogOpen(true);
     }
-  }, [showThemeDialog, showAuthDialog, showPentestDialog]);
+  }, [showThemeDialog, showModelDialog, showAuthDialog, showPentestDialog]);
 
   // Auto-clear the exit warning after 1 second
   useEffect(() => {
@@ -264,6 +272,15 @@ function AppContent({
 
   const handleCloseThemeDialog = () => {
     setShowThemeDialog(false);
+    setTimeout(() => {
+      setExternalDialogOpen(false);
+    }, 0);
+    setInputKey((prev) => prev + 1);
+    refocusPrompt();
+  };
+
+  const handleCloseModelDialog = () => {
+    setShowModelDialog(false);
     setTimeout(() => {
       setExternalDialogOpen(false);
     }, 0);
@@ -335,6 +352,10 @@ function AppContent({
       )}
 
       {showThemeDialog && <ThemePicker onClose={handleCloseThemeDialog} />}
+
+      {showModelDialog && (
+        <ModelPickerDialog onClose={handleCloseModelDialog} />
+      )}
 
       {showAuthDialog && <AuthFlow onClose={handleCloseAuthDialog} />}
 
@@ -421,9 +442,6 @@ function CommandDisplay({
               initialModel={route.data.options?.model}
             />
           </RouteSwitch.Case>
-          <RouteSwitch.Case when="models">
-            <ModelsDisplay />
-          </RouteSwitch.Case>
           <RouteSwitch.Case when="auth">
             <AuthFlow
               onClose={() => {
@@ -440,9 +458,6 @@ function CommandDisplay({
           </RouteSwitch.Case>
           <RouteSwitch.Case when="help">
             <HelpDialog />
-          </RouteSwitch.Case>
-          <RouteSwitch.Case when="models">
-            <ModelsDisplay />
           </RouteSwitch.Case>
           <RouteSwitch.Case when="credits">
             <CreditsFlow onOpenAuthDialog={onOpenAuthDialog} />

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -371,6 +371,7 @@ function AppContent({
         focusIndex={focusIndex}
         inputKey={inputKey}
         onOpenAuthDialog={() => setShowAuthDialog(true)}
+        onOpenModelDialog={() => setShowModelDialog(true)}
       />
 
       <Footer cwd={cwd} showExitWarning={showExitWarning} />
@@ -439,10 +440,12 @@ function CommandDisplay({
   focusIndex,
   inputKey,
   onOpenAuthDialog,
+  onOpenModelDialog,
 }: {
   focusIndex: number;
   inputKey: number;
   onOpenAuthDialog: () => void;
+  onOpenModelDialog: () => void;
 }) {
   const route = useRoute();
   const config = useConfig();
@@ -502,9 +505,7 @@ function CommandDisplay({
             />
           </RouteSwitch.Case>
           <RouteSwitch.Case when="providers">
-            <ProviderManager
-              onOpenModelDialog={() => setShowModelDialog(true)}
-            />
+            <ProviderManager onOpenModelDialog={onOpenModelDialog} />
           </RouteSwitch.Case>
           <RouteSwitch.Case when="help">
             <HelpDialog />

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -393,7 +393,10 @@ function AppContent({
       )}
 
       {showProvidersDialog && (
-        <ProviderManager onClose={handleCloseProvidersDialog} />
+        <ProviderManager
+          onClose={handleCloseProvidersDialog}
+          onOpenModelDialog={() => setShowModelDialog(true)}
+        />
       )}
 
       {showConfigDialog && <ConfigDialog onClose={handleCloseConfigDialog} />}
@@ -499,7 +502,9 @@ function CommandDisplay({
             />
           </RouteSwitch.Case>
           <RouteSwitch.Case when="providers">
-            <ProviderManager />
+            <ProviderManager
+              onOpenModelDialog={() => setShowModelDialog(true)}
+            />
           </RouteSwitch.Case>
           <RouteSwitch.Case when="help">
             <HelpDialog />

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -273,6 +273,9 @@ function AppContent({
   useEffect(() => {
     if (anyExternalDialog) {
       setExternalDialogOpen(true);
+    } else {
+      const timer = setTimeout(() => setExternalDialogOpen(false), 0);
+      return () => clearTimeout(timer);
     }
   }, [anyExternalDialog]);
 
@@ -295,63 +298,42 @@ function AppContent({
 
   const handleCloseShortcutsDialog = () => {
     setShowShortcutsDialog(false);
-    setTimeout(() => {
-      setExternalDialogOpen(false);
-    }, 0);
     setInputKey((prev) => prev + 1);
     refocusPrompt();
   };
 
   const handleCloseThemeDialog = () => {
     setShowThemeDialog(false);
-    setTimeout(() => {
-      setExternalDialogOpen(false);
-    }, 0);
     setInputKey((prev) => prev + 1);
     refocusPrompt();
   };
 
   const handleCloseModelDialog = () => {
     setShowModelDialog(false);
-    setTimeout(() => {
-      setExternalDialogOpen(false);
-    }, 0);
     setInputKey((prev) => prev + 1);
     refocusPrompt();
   };
 
   const handleCloseProvidersDialog = () => {
     setShowProvidersDialog(false);
-    setTimeout(() => {
-      setExternalDialogOpen(false);
-    }, 0);
     setInputKey((prev) => prev + 1);
     refocusPrompt();
   };
 
   const handleCloseConfigDialog = () => {
     setShowConfigDialog(false);
-    setTimeout(() => {
-      setExternalDialogOpen(false);
-    }, 0);
     setInputKey((prev) => prev + 1);
     refocusPrompt();
   };
 
   const handleCloseCreditsDialog = () => {
     setShowCreditsDialog(false);
-    setTimeout(() => {
-      setExternalDialogOpen(false);
-    }, 0);
     setInputKey((prev) => prev + 1);
     refocusPrompt();
   };
 
   const handleCloseAuthDialog = () => {
     setShowAuthDialog(false);
-    setTimeout(() => {
-      setExternalDialogOpen(false);
-    }, 0);
     setInputKey((prev) => prev + 1);
     refocusPrompt();
   };
@@ -359,9 +341,6 @@ function AppContent({
   const handleClosePentestDialog = () => {
     setShowPentestDialog(false);
     setPendingPentestFlags(undefined);
-    setTimeout(() => {
-      setExternalDialogOpen(false);
-    }, 0);
     setInputKey((prev) => prev + 1);
     refocusPrompt();
   };
@@ -372,9 +351,6 @@ function AppContent({
   ) => {
     setShowPentestDialog(false);
     setPendingPentestFlags(undefined);
-    setTimeout(() => {
-      setExternalDialogOpen(false);
-    }, 0);
     route.navigate({ type: "pentest", targets, sessionConfig });
   };
 

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -78,6 +78,9 @@ function App({ appConfig }: AppProps) {
   const [showThemeDialog, setShowThemeDialog] = useState(false);
   const [showAuthDialog, setShowAuthDialog] = useState(false);
   const [showModelDialog, setShowModelDialog] = useState(false);
+  const [showProvidersDialog, setShowProvidersDialog] = useState(false);
+  const [showConfigDialog, setShowConfigDialog] = useState(false);
+  const [showCreditsDialog, setShowCreditsDialog] = useState(false);
   const [showPentestDialog, setShowPentestDialog] = useState(false);
   const [pendingPentestFlags, setPendingPentestFlags] = useState<
     WebCommandOptions | undefined
@@ -98,6 +101,9 @@ function App({ appConfig }: AppProps) {
                     onOpenSessionsDialog={() => setShowSessionsDialog(true)}
                     onOpenThemeDialog={() => setShowThemeDialog(true)}
                     onOpenModelDialog={() => setShowModelDialog(true)}
+                    onOpenProvidersDialog={() => setShowProvidersDialog(true)}
+                    onOpenConfigDialog={() => setShowConfigDialog(true)}
+                    onOpenCreditsDialog={() => setShowCreditsDialog(true)}
                     onOpenAuthDialog={() => setShowAuthDialog(true)}
                     onOpenPentestDialog={(flags) => {
                       setPendingPentestFlags(flags);
@@ -126,6 +132,12 @@ function App({ appConfig }: AppProps) {
                         setShowThemeDialog={setShowThemeDialog}
                         showModelDialog={showModelDialog}
                         setShowModelDialog={setShowModelDialog}
+                        showProvidersDialog={showProvidersDialog}
+                        setShowProvidersDialog={setShowProvidersDialog}
+                        showConfigDialog={showConfigDialog}
+                        setShowConfigDialog={setShowConfigDialog}
+                        showCreditsDialog={showCreditsDialog}
+                        setShowCreditsDialog={setShowCreditsDialog}
                         showAuthDialog={showAuthDialog}
                         setShowAuthDialog={setShowAuthDialog}
                         showPentestDialog={showPentestDialog}
@@ -161,6 +173,12 @@ function AppContent({
   setShowThemeDialog,
   showModelDialog,
   setShowModelDialog,
+  showProvidersDialog,
+  setShowProvidersDialog,
+  showConfigDialog,
+  setShowConfigDialog,
+  showCreditsDialog,
+  setShowCreditsDialog,
   showAuthDialog,
   setShowAuthDialog,
   showPentestDialog,
@@ -183,6 +201,12 @@ function AppContent({
   setShowThemeDialog: (show: boolean) => void;
   showModelDialog: boolean;
   setShowModelDialog: (show: boolean) => void;
+  showProvidersDialog: boolean;
+  setShowProvidersDialog: (show: boolean) => void;
+  showConfigDialog: boolean;
+  setShowConfigDialog: (show: boolean) => void;
+  showCreditsDialog: boolean;
+  setShowCreditsDialog: (show: boolean) => void;
   showAuthDialog: boolean;
   setShowAuthDialog: (show: boolean) => void;
   showPentestDialog: boolean;
@@ -236,18 +260,21 @@ function AppContent({
     }
   }, [config.data.responsibleUseAccepted, route.data]);
 
-  // Track external dialog state for theme/model/auth/pentest dialogs so operator input
-  // unfocuses while a dialog overlay is open
+  // Track external dialog state so operator input unfocuses while a dialog overlay is open
+  const anyExternalDialog =
+    showThemeDialog ||
+    showModelDialog ||
+    showProvidersDialog ||
+    showConfigDialog ||
+    showCreditsDialog ||
+    showAuthDialog ||
+    showPentestDialog;
+
   useEffect(() => {
-    if (
-      showThemeDialog ||
-      showModelDialog ||
-      showAuthDialog ||
-      showPentestDialog
-    ) {
+    if (anyExternalDialog) {
       setExternalDialogOpen(true);
     }
-  }, [showThemeDialog, showModelDialog, showAuthDialog, showPentestDialog]);
+  }, [anyExternalDialog]);
 
   // Auto-clear the exit warning after 1 second
   useEffect(() => {
@@ -286,6 +313,33 @@ function AppContent({
 
   const handleCloseModelDialog = () => {
     setShowModelDialog(false);
+    setTimeout(() => {
+      setExternalDialogOpen(false);
+    }, 0);
+    setInputKey((prev) => prev + 1);
+    refocusPrompt();
+  };
+
+  const handleCloseProvidersDialog = () => {
+    setShowProvidersDialog(false);
+    setTimeout(() => {
+      setExternalDialogOpen(false);
+    }, 0);
+    setInputKey((prev) => prev + 1);
+    refocusPrompt();
+  };
+
+  const handleCloseConfigDialog = () => {
+    setShowConfigDialog(false);
+    setTimeout(() => {
+      setExternalDialogOpen(false);
+    }, 0);
+    setInputKey((prev) => prev + 1);
+    refocusPrompt();
+  };
+
+  const handleCloseCreditsDialog = () => {
+    setShowCreditsDialog(false);
     setTimeout(() => {
       setExternalDialogOpen(false);
     }, 0);
@@ -362,6 +416,19 @@ function AppContent({
         <ModelPickerDialog onClose={handleCloseModelDialog} />
       )}
 
+      {showProvidersDialog && (
+        <ProviderManager onClose={handleCloseProvidersDialog} />
+      )}
+
+      {showConfigDialog && <ConfigDialog onClose={handleCloseConfigDialog} />}
+
+      {showCreditsDialog && (
+        <CreditsFlow
+          onClose={handleCloseCreditsDialog}
+          onOpenAuthDialog={() => setShowAuthDialog(true)}
+        />
+      )}
+
       {showAuthDialog && <AuthFlow onClose={handleCloseAuthDialog} />}
 
       {showPentestDialog && (
@@ -436,9 +503,6 @@ function CommandDisplay({
           <RouteSwitch.Case when="home">
             <ChatApp />
           </RouteSwitch.Case>
-          <RouteSwitch.Case when="config">
-            <ConfigDialog />
-          </RouteSwitch.Case>
           <RouteSwitch.Case when="operator">
             <HITLWizard
               initialTarget={route.data.options?.target}
@@ -463,9 +527,6 @@ function CommandDisplay({
           </RouteSwitch.Case>
           <RouteSwitch.Case when="help">
             <HelpDialog />
-          </RouteSwitch.Case>
-          <RouteSwitch.Case when="credits">
-            <CreditsFlow onOpenAuthDialog={onOpenAuthDialog} />
           </RouteSwitch.Case>
           <RouteSwitch.Case when="skills">
             <SkillsDialog />

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -405,7 +405,10 @@ function AppContent({
       {showCreditsDialog && (
         <CreditsFlow
           onClose={handleCloseCreditsDialog}
-          onOpenAuthDialog={() => setShowAuthDialog(true)}
+          onOpenAuthDialog={() => {
+            setShowCreditsDialog(false);
+            setShowAuthDialog(true);
+          }}
         />
       )}
 


### PR DESCRIPTION
/models now opens as a dialog overlay (same pattern as /themes) instead of navigating to a full-page route. This makes it work identically in both the home page and operator mode.

Also fixes key events leaking through to underlying components when the model picker was open in operator mode — up/down arrows were switching the operator mode underneath.

https://github.com/user-attachments/assets/3a0c3e45-c600-4b32-baef-f39bd7800fd3

## Changes

- **Model selection as dialog**: `/models` opens `ModelPickerDialog` overlay instead of navigating to a route, works in both home and operator mode
- **Escape key handling**: ModelPicker closes on ESC when no search query is active
- **preventDefault gated on focus**: `key.preventDefault()` in ModelPicker only fires when `focused` prop is true, preventing it from breaking ConfigView form inputs
- **Provider manager navigation fix**: After API key submission, navigates to `home` instead of the removed `models` route
- **Model picker after onboarding**: After saving an API key during provider onboarding, the model picker dialog opens automatically so new users are guided to select a model
- **externalDialogOpen race fix**: Centralized `externalDialogOpen` state in a single bidirectional `useEffect` synced with `anyExternalDialog`, fixing a bug where closing the auth dialog would reset focus state while the credits dialog was still open
- **CreditsFlow Dialog wrapper**: Wrapped `CreditsFlow` in a `<Dialog>` overlay to match all other dialog components (was rendering inline as a plain `<box>`)
- **CreditsFlow theme tokens**: Replaced all hardcoded colors (`"green"`, `"yellow"`, `"gray"`, `"white"`, `"red"`) with semantic theme tokens (`colors.primary`, `colors.warning`, `colors.textMuted`, `colors.text`, `colors.error`)
- **CreditsFlow cleanup**: Removed duplicate "press ENTER" instruction in the display step
- **ProviderSelection Dialog**: Converted from manual absolute-positioned overlay to `<Dialog>` component matching themes/sessions pattern
- **APIKeyInput Dialog**: Converted from manual absolute-positioned overlay to `<Dialog>` component
- **OnboardingChoice Dialog**: Converted from manual absolute-positioned overlay to `<Dialog>` component
- **Unified footer style**: All dialog footers now use lowercase keybinding hints consistent with themes and sessions dialogs
- **Providers, config, credits as dialog overlays**: `/providers`, `/config`, and `/credits` commands open as dialog overlays instead of route-based pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/navigation refactor that changes command routing and focus/keyboard handling across multiple dialogs; main risk is regressions in key handling or closing flows, especially in operator mode.
> 
> **Overview**
> **Unifies `/models` into a dialog overlay** by introducing `ModelPickerDialog` and wiring it through the command system so model selection works consistently in both home and operator mode (operator now triggers `/models` instead of rendering an inline picker).
> 
> **Refactors several commands to open dialogs instead of navigating routes**: `/config`, `/providers`, and `/credits` now use `CommandProvider` callbacks and new App-level state flags, removing the `models/config/credits` base routes from the main switch.
> 
> **Hardens dialog keyboard behavior and consistency**: `ModelPicker` adds `onCancel` and only calls `preventDefault` for handled keys (fixing key leakage), ESC now closes when not searching; multiple overlays (`ProviderSelection`, onboarding choice, `APIKeyInput`, `CreditsFlow`) are converted to the shared `Dialog` wrapper with theme-tokenized colors and standardized footer hints, and `externalDialogOpen` tracking is centralized to avoid focus races when dialogs chain (e.g. credits → auth → credits).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a16ae7c2d0a8313d347e4a4dedf2e11b31f0c458. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->