### PR TITLE
fix: properly await async onStepFinish callbacks

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -262,13 +262,13 @@ export class OffensiveSecurityAgent<TResult = void> {
       activeTools,
       stopWhen,
       toolChoice: "auto",
-      onStepFinish: (event) => {
+      onStepFinish: async (event) => {
         latestMessages = [
           ...initialMessagesRef.current,
           ...event.response.messages,
         ];
         schedulePersist();
-        input.onStepFinish?.(event);
+        await input.onStepFinish?.(event);
       },
       onSummarized: () => {
         // Context was reset by summarization — discard the old history so

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -285,9 +285,12 @@ export function streamResponse(
     onFinish,
   } = opts;
 
-  // Wrap onStepFinish to fire usage callback for every step
-  const onStepFinish: typeof userOnStepFinish = (step) => {
-    userOnStepFinish?.(step);
+  // Wrap onStepFinish to fire usage callback for every step.
+  // Must be async so that callers returning a Promise (e.g. MessageManager
+  // persisting messages / queuing issues) are fully awaited before the
+  // AI SDK starts the next step.
+  const onStepFinish: typeof userOnStepFinish = async (step) => {
+    await userOnStepFinish?.(step);
     if (_usageCallback) {
       const inp = step.usage?.inputTokens ?? 0;
       const out = step.usage?.outputTokens ?? 0;


### PR DESCRIPTION
## Summary
- Makes `onStepFinish` callbacks `async` and `await`s the caller-provided callback in both `streamResponse` (`ai.ts`) and `OffensiveSecurityAgent`, ensuring that async side-effects (e.g. MessageManager persisting messages, queuing issues) fully complete before the AI SDK starts the next step.

## Test plan
- [ ] Run `bun run test` — all existing tests pass
- [ ] Verify pentest flow with message persistence still works correctly end-to-end


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core AI streaming step lifecycle; awaiting `onStepFinish` can change timing/ordering and surface previously-unobserved callback rejections, potentially impacting throughput or step progression.
> 
> **Overview**
> Ensures streaming step hooks fully complete before the next AI step begins by making the internal `streamResponse` `onStepFinish` wrapper async and awaiting the caller callback before reporting usage.
> 
> Updates `OffensiveSecurityAgent` to treat its `onStepFinish` as async and await the caller-provided handler after scheduling message persistence, preventing async side effects from racing with subsequent steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5f5d2fd1784aad8af713d1878bff00858df004b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->