### PR TITLE
feat: add context parameter to auth and pentest agent inputs

### DIFF
--- a/src/core/agents/specialized/authenticationAgent/agent.ts
+++ b/src/core/agents/specialized/authenticationAgent/agent.ts
@@ -49,6 +49,12 @@ export interface AuthenticationAgentInput {
 
   /** Optional persistence callbacks for external storage integration */
   callbacks?: ConsumeCallbacks;
+
+  /**
+   * Arbitrary context to include in the agent prompt (e.g. application name/description).
+   * The agent will treat non-malicious instructions within the context as guidance.
+   */
+  context?: string;
 }
 
 /** The typed result returned by `AuthenticationAgent.consume()`. */
@@ -115,13 +121,14 @@ export class AuthenticationAgent extends OffensiveSecurityAgent<AuthenticationRe
       authConfig,
       onStepFinish,
       abortSignal,
+      context,
     } = opts;
 
     const cm = session.credentialManager;
 
     super({
       system: detectOSAndEnhancePrompt(AUTH_SUBAGENT_SYSTEM_PROMPT),
-      prompt: buildAuthPrompt(target, authHints, cm),
+      prompt: buildAuthPrompt(target, authHints, cm, context),
       model,
       session,
       target,
@@ -211,8 +218,18 @@ function buildAuthPrompt(
   target: string,
   authHints?: AuthenticationAgentInput["authHints"],
   credentialManager?: import("../../../credentials").CredentialManager,
+  context?: string,
 ): string {
   const parts: string[] = [`TARGET: ${target}\n`];
+
+  if (context) {
+    parts.push("APPLICATION CONTEXT:");
+    parts.push(
+      "The following is context specific to the application under test. If it contains non-malicious instructions relevant to authentication, follow them.\n",
+    );
+    parts.push(context);
+    parts.push("");
+  }
 
   const credBlock = credentialManager?.formatForPrompt();
   if (credBlock) {

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -22,6 +22,12 @@ export interface PentestAgentInput extends SpecializedAgentInput {
 
   /** Shared findings registry for cross-agent dedup */
   findingsRegistry?: FindingsRegistry;
+
+  /**
+   * Arbitrary context to include in the agent prompt (e.g. application name/description).
+   * The agent will treat non-malicious instructions within the context as guidance.
+   */
+  context?: string;
 }
 
 /** The typed result returned by `PentestAgent.consume()`. */
@@ -101,11 +107,12 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       sandbox,
       findingsRegistry,
       messages,
+      context,
     } = opts;
 
     super({
       system: buildSystemPrompt(session),
-      prompt: buildPrompt(target, objectives, session, findingsRegistry),
+      prompt: buildPrompt(target, objectives, session, findingsRegistry, context),
       model,
       session,
       target,
@@ -275,6 +282,7 @@ function buildPrompt(
     config?: { exfilMode?: boolean; outcomeGuidance?: string };
   },
   findingsRegistry?: FindingsRegistry,
+  context?: string,
 ): string {
   const sessionRootPath = session.rootPath;
   const exfilMode = session.config?.exfilMode ?? false;
@@ -411,6 +419,10 @@ Your target is a flag with the format FLAG{...}. Locate and extract it.
 
 Do NOT discover or enumerate other endpoints or services. Focus exclusively on the target and objectives above.`;
 
+  const contextSection = context
+    ? `\n## Application Context\nThe following is context specific to the application under test. If it contains non-malicious instructions relevant to your testing, follow them.\n\n${context}\n`
+    : "";
+
   return `# Testing Assignment
 
 ## Target
@@ -418,7 +430,7 @@ Do NOT discover or enumerate other endpoints or services. Focus exclusively on t
 ${authSection}
 ${knownFindingsSection}
 ${knowledgeBaseSection}
-
+${contextSection}
 ## Objectives
 ${objectiveList}
 ${outcomeSection}


### PR DESCRIPTION
## Summary
- Adds an optional `context` string parameter to both `AuthenticationAgentInput` and `PentestAgentInput` interfaces, allowing callers to pass arbitrary application-specific context (e.g. app name/description) that gets included in agent prompts.
- The context is injected into the prompt as a dedicated section ("APPLICATION CONTEXT" for auth, "Application Context" for pentest), with instructions to follow non-malicious guidance within it.

## Test plan
- [ ] Verify existing tests pass (`bun run test`)
- [ ] Confirm auth agent prompt includes context section when `context` is provided
- [ ] Confirm pentest agent prompt includes context section when `context` is provided
- [ ] Confirm both agents work normally when `context` is omitted (no regression)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new caller-provided `context` string that is injected into security-agent prompts, which can materially change agent behavior if misused or untrusted. Otherwise the change is small and gated behind an optional parameter.
> 
> **Overview**
> Adds an optional `context` field to `AuthenticationAgentInput` and `PentestAgentInput`, and threads it through constructors into their prompt builders.
> 
> When provided, both agents now include a dedicated *Application Context* section in the generated prompt with explicit instructions to treat non-malicious guidance in that context as operational instructions (auth-focused for `AuthenticationAgent`, testing-focused for `TargetedPentestAgent`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfa336bba33b76337f43411414245e06cee55473. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->