### PR TITLE
fix: pass token expiry to Gmail OAuth2 client to prevent premature refresh

### DIFF
--- a/src/core/agents/offSecAgent/tools/email/adapters.ts
+++ b/src/core/agents/offSecAgent/tools/email/adapters.ts
@@ -66,6 +66,7 @@ export function createEmailAdapter(inbox: EmailInboxConfig): EmailAdapter {
         inbox.refreshToken,
         inbox.clientId,
         inbox.clientSecret,
+        inbox.tokenExpiry,
       );
     case "outlook":
       return new OutlookAdapter(
@@ -127,11 +128,13 @@ class GmailAdapter implements EmailAdapter {
     refreshToken: string,
     clientId?: string,
     clientSecret?: string,
+    tokenExpiry?: number,
   ) {
     const oauth2 = new gauth.OAuth2(clientId, clientSecret);
     oauth2.setCredentials({
       access_token: accessToken,
       refresh_token: refreshToken,
+      expiry_date: tokenExpiry,
     });
     this.client = new gmail_v1.Gmail({ auth: oauth2 });
   }

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -98,6 +98,7 @@ const EmailInboxConfigObject = z.discriminatedUnion("provider", [
     refreshToken: z.string(),
     clientId: z.string().optional(),
     clientSecret: z.string().optional(),
+    tokenExpiry: z.number().optional(),
   }),
   z.object({
     provider: z.literal("outlook"),
@@ -108,6 +109,7 @@ const EmailInboxConfigObject = z.discriminatedUnion("provider", [
     refreshToken: z.string(),
     clientId: z.string().optional(),
     clientSecret: z.string().optional(),
+    tokenExpiry: z.number().optional(),
   }),
   z.object({
     provider: z.literal("imap"),


### PR DESCRIPTION
## Summary

- Add `tokenExpiry` (optional `z.number()`) to the Gmail and Outlook inbox config Zod schemas in the session config
- Pass `tokenExpiry` through the `createEmailAdapter` factory to the `GmailAdapter` constructor
- Set `expiry_date` on the Google OAuth2 client credentials so the SDK knows whether the access token is still valid and doesn't unnecessarily refresh it

**Why this matters**: Without `expiry_date`, the Google auth library can proactively refresh the token. For external users on apps with an unverified OAuth consent screen, the refreshed token may lose the restricted `gmail.readonly` scope — causing "insufficient authentication scopes" errors at agent runtime even though the original token was valid.

Companion console PR: https://github.com/pensarai/console/pull/1039

## Test plan

- [ ] Run a scan with Gmail email integration using an internal account — should work as before
- [ ] Run a scan with Gmail email integration using an external account — token should not be prematurely refreshed when `tokenExpiry` is set and token is still valid


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `tokenExpiry` field and forwards it to Gmail OAuth credentials, affecting only Gmail auth behavior when the field is provided.
> 
> **Overview**
> Prevents premature Gmail access-token refresh by threading an optional `tokenExpiry` value from session `EmailInboxConfig` into `createEmailAdapter`/`GmailAdapter` and setting it as the Google OAuth2 credential `expiry_date`.
> 
> Updates the session email inbox Zod schemas to accept `tokenExpiry` for both `gmail` and `outlook` configs (though only Gmail currently consumes it).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61ae7eedc677d579260ad10c2dc66d90e80b854c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->