### PR TITLE
fix: prevent model picker dialog text garbling on small terminals

### DIFF
--- a/src/tui/components/commands/models-display.tsx
+++ b/src/tui/components/commands/models-display.tsx
@@ -6,9 +6,15 @@ import { useConfig } from "../../context/config";
 import { ModelPicker } from "../model-picker";
 import { useTheme } from "../../theme";
 
-function ClippedLine({ children }: { children: ReactNode }) {
+function ClippedLine({
+  children,
+  flexShrink,
+}: {
+  children: ReactNode;
+  flexShrink?: number;
+}) {
   return (
-    <box width="100%" overflow="hidden">
+    <box width="100%" overflow="hidden" flexShrink={flexShrink}>
       {children}
     </box>
   );
@@ -55,7 +61,7 @@ export default function ModelsDisplay() {
       overflow="hidden"
     >
       {/* Header */}
-      <ClippedLine>
+      <ClippedLine flexShrink={0}>
         <text>
           <span fg={colors.primary}>█ </span>
           <span fg={colors.text}>Select AI Model</span>

--- a/src/tui/components/model-picker/ModelPickerDialog.tsx
+++ b/src/tui/components/model-picker/ModelPickerDialog.tsx
@@ -23,14 +23,16 @@ export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
   return (
     <Dialog size="large" onClose={onClose}>
       <box flexDirection="column" width="100%" paddingLeft={2} paddingTop={1}>
-        <text>
-          <span fg={colors.primary}>Select AI Model</span>
-          <span fg={colors.textMuted}> ({model.name})</span>
-          <span fg={colors.textMuted}>
-            {" "}
-            [{isModelUserSelected ? "user" : "default"}]
-          </span>
-        </text>
+        <box flexShrink={0} width="100%" overflow="hidden">
+          <text>
+            <span fg={colors.primary}>Select AI Model</span>
+            <span fg={colors.textMuted}> ({model.name})</span>
+            <span fg={colors.textMuted}>
+              {" "}
+              [{isModelUserSelected ? "user" : "default"}]
+            </span>
+          </text>
+        </box>
         <box
           flexDirection="column"
           paddingLeft={1}
@@ -50,7 +52,7 @@ export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
             isModelUserSelected={isModelUserSelected}
           />
         </box>
-        <box marginTop={1} paddingLeft={1}>
+        <box marginTop={1} paddingLeft={1} flexShrink={0}>
           <text fg={colors.textMuted}>[Enter] confirm • [ESC] close</text>
         </box>
       </box>


### PR DESCRIPTION
## Summary

- Adds `flexShrink={0}` to the title and footer elements in `ModelPickerDialog.tsx` so Yoga doesn't compress them to overlapping Y positions on short terminals
- Adds `flexShrink={0}` support to the `ClippedLine` component in `models-display.tsx` and applies it to the header

Same root cause as #400 — these elements were missed in the original fix (#439).

Fixes #465

## Test plan

- [x] Open model picker dialog (`/models`) with a short terminal height and verify the title and bottom help text render without garbling
- [x] Open the route-based model selector and verify the header renders cleanly on short terminals
- [x] Verify normal-height terminals are unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI layout adjustment that only affects TUI flexbox sizing to avoid text overlap in short terminal heights.
> 
> **Overview**
> Prevents the model picker UI from garbling on short terminals by ensuring the dialog title/footer and route-based header don’t get flex-shrunk into overlapping rows.
> 
> `ModelPickerDialog` now wraps the title in a non-shrinking clipped container and marks the footer help text as `flexShrink={0}`. `ClippedLine` is extended to accept `flexShrink`, and `ModelsDisplay` applies `flexShrink={0}` to its header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 062b8bea3de68ea7eabf06c47b3bce78407bda9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->