### PR TITLE
fix: make syntax highlighting theme-aware for dark/light mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Want to run from the cloud or integrate it with your CI/CD? See <a href="https:/
 
 ## Installation
 
-| Method | Command |
-|--------|---------|
+| Method                          | Command                                              |
+| ------------------------------- | ---------------------------------------------------- |
 | **Quick Install** (macOS/Linux) | `curl -fsSL https://pensarai.com/install.sh \| bash` |
-| **Homebrew** | `brew tap pensarai/tap && brew install apex` |
-| **npm** | `npm install -g @pensar/apex` |
-| **Windows** (PowerShell) | `irm https://www.pensarai.com/apex.ps1 \| iex` |
+| **Homebrew**                    | `brew tap pensarai/tap && brew install apex`         |
+| **npm**                         | `npm install -g @pensar/apex`                        |
+| **Windows** (PowerShell)        | `irm https://www.pensarai.com/apex.ps1 \| iex`       |
 
 ## Usage
 

--- a/src/tui/components/chat/tool-message.tsx
+++ b/src/tui/components/chat/tool-message.tsx
@@ -46,7 +46,7 @@ export const ToolMessage = memo(function ToolMessage({
   verbose = false,
   expandedLogs = false,
 }: ToolMessageProps) {
-  const { colors } = useTheme();
+  const { colors, mode } = useTheme();
   const [showArgs, setShowArgs] = useState(false);
   const [showOutput, setShowOutput] = useState(false);
 
@@ -67,7 +67,9 @@ export const ToolMessage = memo(function ToolMessage({
 
   // Get result summary for completed tools
   const resultDisplay: ResultSummary | null =
-    isCompleted || isError ? getResultSummary(result, toolName, args) : null;
+    isCompleted || isError
+      ? getResultSummary(result, toolName, args, mode)
+      : null;
 
   // Get tool icon
   const icon = TOOL_ICONS[toolName] || TOOL_ICONS.default;

--- a/src/tui/components/report-viewer-dialog.tsx
+++ b/src/tui/components/report-viewer-dialog.tsx
@@ -1,7 +1,13 @@
-import { useRef, useMemo } from "react";
+import { useRef, useMemo, useCallback } from "react";
 import { useKeyboard } from "@opentui/react";
 import { useDimensions } from "../context/dimensions";
-import { ScrollBoxRenderable, SyntaxStyle } from "@opentui/core";
+import {
+  Renderable,
+  ScrollBoxRenderable,
+  SyntaxStyle,
+  type CodeRenderable,
+} from "@opentui/core";
+import type { Token } from "marked";
 import { useTheme } from "../theme";
 
 interface ReportViewerDialogProps {
@@ -39,6 +45,26 @@ export default function ReportViewerDialog({
         "punctuation.special": { fg: colors.border },
       }),
     [colors],
+  );
+
+  // Override code block rendering to set theme-aware fg color.
+  // Without this, CodeRenderable defaults to white text (opentui default),
+  // which is invisible on light backgrounds.
+  const renderNode = useCallback(
+    (
+      token: Token,
+      ctx: { defaultRender: () => Renderable | null },
+    ): Renderable | undefined | null => {
+      if (token.type === "code") {
+        const renderable = ctx.defaultRender();
+        if (renderable) {
+          (renderable as CodeRenderable).fg = colors.markdownCode;
+        }
+        return renderable;
+      }
+      return undefined;
+    },
+    [colors.markdownCode],
   );
 
   const lineCount = useMemo(() => content.split("\n").length, [content]);
@@ -129,6 +155,7 @@ export default function ReportViewerDialog({
             content={content}
             syntaxStyle={syntaxStyle}
             conceal={true}
+            renderNode={renderNode}
           />
         </scrollbox>
 

--- a/src/tui/components/shared/result-registry.ts
+++ b/src/tui/components/shared/result-registry.ts
@@ -230,7 +230,8 @@ export function getResultSummary(
               text: `${n} replacement${n !== 1 ? "s" : ""}\n${codePreview}`,
               isError: false,
               label: `${n} replacement${n !== 1 ? "s" : ""}`,
-              styledText: highlightCode(codePreview, filePath, mode) ?? undefined,
+              styledText:
+                highlightCode(codePreview, filePath, mode) ?? undefined,
               fullText:
                 newContent.length > 400 ? newContent.slice(0, 2000) : undefined,
             };
@@ -721,7 +722,10 @@ export function getResultSummary(
 // Web search styled text helpers
 // ---------------------------------------------------------------------------
 
-const WS_COLORS: Record<ColorMode, { globe: RGBA; domain: RGBA; title: RGBA; snippet: RGBA }> = {
+const WS_COLORS: Record<
+  ColorMode,
+  { globe: RGBA; domain: RGBA; title: RGBA; snippet: RGBA }
+> = {
   dark: {
     globe: RGBA.fromInts(106, 115, 125, 255), // gray
     domain: RGBA.fromInts(86, 182, 194, 255), // cyan

--- a/src/tui/components/shared/result-registry.ts
+++ b/src/tui/components/shared/result-registry.ts
@@ -7,6 +7,7 @@
 
 import { RGBA, StyledText, type TextChunk } from "@opentui/core";
 import { highlightCode } from "./syntax-highlight";
+import type { ColorMode } from "../../theme/types";
 
 export interface ResultSummary {
   text: string;
@@ -25,12 +26,14 @@ export interface ResultSummary {
  * @param result - The raw tool result
  * @param toolName - Optional tool name for tool-specific summaries
  * @param args - Optional tool args (used by file tools to show content previews)
+ * @param mode - Color mode for syntax highlighting ("dark" or "light")
  * @returns Summary object with text and error flag, or null if no summary available
  */
 export function getResultSummary(
   result: unknown,
   toolName?: string,
   args?: Record<string, unknown>,
+  mode: ColorMode = "dark",
 ): ResultSummary | null {
   if (result === null || result === undefined) {
     return null;
@@ -65,7 +68,7 @@ export function getResultSummary(
               isError: false,
               label: `${totalLines} lines`,
               styledText:
-                highlightCode(preview + suffix, filePath) ?? undefined,
+                highlightCode(preview + suffix, filePath, mode) ?? undefined,
               fullText:
                 content.length > 400 ? content.slice(0, 2000) : undefined,
             };
@@ -140,6 +143,7 @@ export function getResultSummary(
           const styledChunks = buildWebSearchStyledText(
             shown,
             results.length > 5 ? results.length : undefined,
+            mode,
           );
           return {
             text: `${results.length} result${results.length !== 1 ? "s" : ""}`,
@@ -194,7 +198,7 @@ export function getResultSummary(
               text: preview + suffix,
               isError: false,
               styledText:
-                highlightCode(preview + suffix, filePath) ?? undefined,
+                highlightCode(preview + suffix, filePath, mode) ?? undefined,
               fullText:
                 content.length > 400 ? content.slice(0, 2000) : undefined,
             };
@@ -226,7 +230,7 @@ export function getResultSummary(
               text: `${n} replacement${n !== 1 ? "s" : ""}\n${codePreview}`,
               isError: false,
               label: `${n} replacement${n !== 1 ? "s" : ""}`,
-              styledText: highlightCode(codePreview, filePath) ?? undefined,
+              styledText: highlightCode(codePreview, filePath, mode) ?? undefined,
               fullText:
                 newContent.length > 400 ? newContent.slice(0, 2000) : undefined,
             };
@@ -717,12 +721,20 @@ export function getResultSummary(
 // Web search styled text helpers
 // ---------------------------------------------------------------------------
 
-const WS_COLORS = {
-  globe: RGBA.fromInts(106, 115, 125, 255), // gray
-  domain: RGBA.fromInts(86, 182, 194, 255), // cyan
-  title: RGBA.fromInts(97, 175, 239, 255), // blue
-  snippet: RGBA.fromInts(140, 148, 160, 255), // muted
-} as const;
+const WS_COLORS: Record<ColorMode, { globe: RGBA; domain: RGBA; title: RGBA; snippet: RGBA }> = {
+  dark: {
+    globe: RGBA.fromInts(106, 115, 125, 255), // gray
+    domain: RGBA.fromInts(86, 182, 194, 255), // cyan
+    title: RGBA.fromInts(97, 175, 239, 255), // blue
+    snippet: RGBA.fromInts(140, 148, 160, 255), // muted
+  },
+  light: {
+    globe: RGBA.fromInts(106, 115, 125, 255), // gray
+    domain: RGBA.fromInts(28, 120, 134, 255), // darker cyan
+    title: RGBA.fromInts(30, 100, 200, 255), // darker blue
+    snippet: RGBA.fromInts(100, 108, 120, 255), // darker muted
+  },
+};
 
 function chunk(text: string, fg?: RGBA): TextChunk {
   return { __isChunk: true, text, fg, attributes: 0 };
@@ -740,7 +752,9 @@ function extractDomain(url: string): string {
 function buildWebSearchStyledText(
   results: Array<Record<string, unknown>>,
   totalCount?: number,
+  mode: ColorMode = "dark",
 ): StyledText {
+  const wsColors = WS_COLORS[mode];
   const chunks: TextChunk[] = [];
   for (let i = 0; i < results.length; i++) {
     const r = results[i];
@@ -748,13 +762,13 @@ function buildWebSearchStyledText(
     const title = String(r.title || "").slice(0, 70);
 
     if (i > 0) chunks.push(chunk("\n"));
-    chunks.push(chunk("🌐 ", WS_COLORS.globe));
-    chunks.push(chunk(domain, WS_COLORS.domain));
-    chunks.push(chunk(" — ", WS_COLORS.globe));
-    chunks.push(chunk(title, WS_COLORS.title));
+    chunks.push(chunk("🌐 ", wsColors.globe));
+    chunks.push(chunk(domain, wsColors.domain));
+    chunks.push(chunk(" — ", wsColors.globe));
+    chunks.push(chunk(title, wsColors.title));
   }
   if (totalCount && totalCount > results.length) {
-    chunks.push(chunk(`\n… (${totalCount} total)`, WS_COLORS.snippet));
+    chunks.push(chunk(`\n… (${totalCount} total)`, wsColors.snippet));
   }
   return new StyledText(chunks);
 }

--- a/src/tui/components/shared/syntax-highlight.ts
+++ b/src/tui/components/shared/syntax-highlight.ts
@@ -8,12 +8,29 @@
 import { RGBA, StyledText, type TextChunk } from "@opentui/core";
 import hljs from "highlight.js";
 import { extname } from "path";
+import type { ColorMode } from "../../theme/types";
 
 // ---------------------------------------------------------------------------
-// Color palette — dark-theme-friendly terminal colors
+// Color palettes — dark and light mode variants
 // ---------------------------------------------------------------------------
 
-const C = {
+interface SyntaxPalette {
+  keyword: RGBA;
+  string: RGBA;
+  comment: RGBA;
+  number: RGBA;
+  function: RGBA;
+  title: RGBA;
+  attr: RGBA;
+  tag: RGBA;
+  type: RGBA;
+  literal: RGBA;
+  regexp: RGBA;
+  meta: RGBA;
+  punctuation: RGBA;
+}
+
+const DARK_PALETTE: SyntaxPalette = {
   keyword: RGBA.fromInts(198, 120, 221, 255), // purple
   string: RGBA.fromInts(152, 195, 121, 255), // green
   comment: RGBA.fromInts(106, 115, 125, 255), // gray
@@ -27,38 +44,61 @@ const C = {
   regexp: RGBA.fromInts(152, 195, 121, 255), // green
   meta: RGBA.fromInts(106, 115, 125, 255), // gray
   punctuation: RGBA.fromInts(171, 178, 191, 255), // light gray
-} as const;
+};
 
-const CLASS_COLOR_MAP: Record<string, RGBA> = {
-  "hljs-keyword": C.keyword,
-  "hljs-built_in": C.keyword,
-  "hljs-type": C.type,
-  "hljs-literal": C.literal,
-  "hljs-number": C.number,
-  "hljs-string": C.string,
-  "hljs-regexp": C.regexp,
-  "hljs-template-variable": C.string,
-  "hljs-subst": C.string,
-  "hljs-comment": C.comment,
-  "hljs-doctag": C.comment,
-  "hljs-function": C.function,
-  "hljs-title": C.title,
-  "hljs-title.class_": C.type,
-  "hljs-title.function_": C.function,
-  "hljs-params": C.attr,
-  "hljs-attr": C.attr,
-  "hljs-attribute": C.attr,
-  "hljs-property": C.attr,
-  "hljs-variable": C.tag,
-  "hljs-tag": C.tag,
-  "hljs-name": C.tag,
-  "hljs-selector-tag": C.tag,
-  "hljs-selector-class": C.attr,
-  "hljs-selector-id": C.attr,
-  "hljs-meta": C.meta,
-  "hljs-meta keyword": C.keyword,
-  "hljs-symbol": C.literal,
-  "hljs-punctuation": C.punctuation,
+const LIGHT_PALETTE: SyntaxPalette = {
+  keyword: RGBA.fromInts(137, 63, 168, 255), // darker purple
+  string: RGBA.fromInts(56, 124, 56, 255), // darker green
+  comment: RGBA.fromInts(106, 115, 125, 255), // gray (works on both)
+  number: RGBA.fromInts(152, 104, 40, 255), // darker orange
+  function: RGBA.fromInts(30, 100, 200, 255), // darker blue
+  title: RGBA.fromInts(30, 100, 200, 255), // darker blue
+  attr: RGBA.fromInts(150, 120, 30, 255), // darker yellow
+  tag: RGBA.fromInts(180, 50, 55, 255), // darker red
+  type: RGBA.fromInts(28, 120, 134, 255), // darker cyan
+  literal: RGBA.fromInts(152, 104, 40, 255), // darker orange
+  regexp: RGBA.fromInts(56, 124, 56, 255), // darker green
+  meta: RGBA.fromInts(106, 115, 125, 255), // gray
+  punctuation: RGBA.fromInts(80, 85, 95, 255), // dark gray
+};
+
+function buildClassColorMap(p: SyntaxPalette): Record<string, RGBA> {
+  return {
+    "hljs-keyword": p.keyword,
+    "hljs-built_in": p.keyword,
+    "hljs-type": p.type,
+    "hljs-literal": p.literal,
+    "hljs-number": p.number,
+    "hljs-string": p.string,
+    "hljs-regexp": p.regexp,
+    "hljs-template-variable": p.string,
+    "hljs-subst": p.string,
+    "hljs-comment": p.comment,
+    "hljs-doctag": p.comment,
+    "hljs-function": p.function,
+    "hljs-title": p.title,
+    "hljs-title.class_": p.type,
+    "hljs-title.function_": p.function,
+    "hljs-params": p.attr,
+    "hljs-attr": p.attr,
+    "hljs-attribute": p.attr,
+    "hljs-property": p.attr,
+    "hljs-variable": p.tag,
+    "hljs-tag": p.tag,
+    "hljs-name": p.tag,
+    "hljs-selector-tag": p.tag,
+    "hljs-selector-class": p.attr,
+    "hljs-selector-id": p.attr,
+    "hljs-meta": p.meta,
+    "hljs-meta keyword": p.keyword,
+    "hljs-symbol": p.literal,
+    "hljs-punctuation": p.punctuation,
+  };
+}
+
+const CLASS_COLOR_MAPS: Record<ColorMode, Record<string, RGBA>> = {
+  dark: buildClassColorMap(DARK_PALETTE),
+  light: buildClassColorMap(LIGHT_PALETTE),
 };
 
 // ---------------------------------------------------------------------------
@@ -159,7 +199,10 @@ function decodeEntities(s: string): string {
  * The HTML is simple: flat or shallowly nested `<span class="hljs-*">` tags.
  * We track a color stack so nested spans inherit/override correctly.
  */
-function parseHljsHtml(html: string): TextChunk[] {
+function parseHljsHtml(
+  html: string,
+  classColorMap: Record<string, RGBA>,
+): TextChunk[] {
   const chunks: TextChunk[] = [];
   const colorStack: (RGBA | undefined)[] = [undefined];
 
@@ -172,14 +215,14 @@ function parseHljsHtml(html: string): TextChunk[] {
       const classes = m[1].split(/\s+/);
       let color: RGBA | undefined;
       for (const cls of classes) {
-        if (CLASS_COLOR_MAP[cls]) {
-          color = CLASS_COLOR_MAP[cls];
+        if (classColorMap[cls]) {
+          color = classColorMap[cls];
           break;
         }
       }
       // Also try combined class (e.g. "hljs-title function_")
       if (!color && classes.length > 1) {
-        color = CLASS_COLOR_MAP[classes.join(" ")];
+        color = classColorMap[classes.join(" ")];
       }
       colorStack.push(color ?? colorStack[colorStack.length - 1]);
     } else if (m[0] === "</span>") {
@@ -211,11 +254,13 @@ function parseHljsHtml(html: string): TextChunk[] {
  *
  * @param code - Source code to highlight
  * @param filePath - Optional file path to infer language from extension
+ * @param mode - Color mode ("dark" or "light"), defaults to "dark"
  * @returns StyledText with per-token colors, or null if highlighting fails
  */
 export function highlightCode(
   code: string,
   filePath?: string,
+  mode: ColorMode = "dark",
 ): StyledText | null {
   if (!code.trim()) return null;
 
@@ -229,7 +274,7 @@ export function highlightCode(
 
     if (!result.value) return null;
 
-    const chunks = parseHljsHtml(result.value);
+    const chunks = parseHljsHtml(result.value, CLASS_COLOR_MAPS[mode]);
     if (chunks.length === 0) return null;
 
     return new StyledText(chunks);

--- a/src/tui/components/shared/tool-renderer.tsx
+++ b/src/tui/components/shared/tool-renderer.tsx
@@ -42,7 +42,7 @@ export const ToolRenderer = memo(function ToolRenderer({
   verbose = false,
   expandedLogs = false,
 }: ToolRendererProps) {
-  const { colors } = useTheme();
+  const { colors, mode } = useTheme();
   const [showOutput, setShowOutput] = useState(false);
 
   // Type guard ensures we have a tool message
@@ -62,7 +62,9 @@ export const ToolRenderer = memo(function ToolRenderer({
 
   // Get result summary for completed tools
   const resultDisplay: ResultSummary | null =
-    isCompleted || isError ? getResultSummary(result, toolName, args) : null;
+    isCompleted || isError
+      ? getResultSummary(result, toolName, args, mode)
+      : null;
 
   // Determine border color based on status
   const borderColor = isError


### PR DESCRIPTION
## Summary

- Adds a light-mode color palette to `syntax-highlight.ts` alongside the existing dark palette
- Threads `ColorMode` through `getResultSummary` → `highlightCode` so components select the correct palette based on the active theme mode
- Also makes web search result colors in `result-registry.ts` mode-aware

Fixes #472

## Test plan

- [x] Switch to light mode and verify code blocks in tool output (file reads, file writes, file edits) are readable
- [x] Verify dark mode rendering is unchanged
- [x] Check web search results display correctly in both modes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts color selection for syntax highlighting and markdown code rendering; main risk is minor regressions in readability across modes.
> 
> **Overview**
> Improves light-mode readability in the TUI by making syntax highlighting and select rich renderables **theme-mode aware**.
> 
> Threads `ColorMode` from `useTheme()` through `ToolMessage`/`ToolRenderer` into `getResultSummary()` and `highlightCode()`, adding a dedicated light palette and mode-specific web-search result colors. Also overrides markdown code block rendering in `ReportViewerDialog` to force a theme-appropriate foreground color (fixing white-on-light code blocks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9f72bc91e8164b3983a10016187acabfd96f812. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->