### PR TITLE
Extract shared MarkdownViewer component and add editor shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Want to run from the cloud or integrate it with your CI/CD? See <a href="https:/
 
 ## Installation
 
-| Method | Command |
-|--------|---------|
+| Method                          | Command                                              |
+| ------------------------------- | ---------------------------------------------------- |
 | **Quick Install** (macOS/Linux) | `curl -fsSL https://pensarai.com/install.sh \| bash` |
-| **Homebrew** | `brew tap pensarai/tap && brew install apex` |
-| **npm** | `npm install -g @pensar/apex` |
-| **Windows** (PowerShell) | `irm https://www.pensarai.com/apex.ps1 \| iex` |
+| **Homebrew**                    | `brew tap pensarai/tap && brew install apex`         |
+| **npm**                         | `npm install -g @pensar/apex`                        |
+| **Windows** (PowerShell)        | `irm https://www.pensarai.com/apex.ps1 \| iex`       |
 
 ## Usage
 

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -23,6 +23,7 @@ export interface AppCommandContext {
   openHelpDialog?: () => void;
   openAuthDialog?: () => void;
   openPentestDialog?: (flags?: WebCommandOptions) => void;
+  openSkillsDialog?: (slug?: string) => void;
 }
 
 /**
@@ -358,10 +359,7 @@ export const commands: CommandConfig[] = [
     description: "View installed skills",
     category: "Skills",
     handler: async (args, ctx) => {
-      ctx.navigate({
-        type: "base",
-        path: "skills",
-      });
+      ctx.openSkillsDialog?.(args[0]);
     },
   },
   // Add more commands here...

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -96,17 +96,13 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
 
       const entry = skillsRegistry.get(slug);
       if (entry) {
-        // Navigate to skills detail page to show skill info
-        route.navigate({
-          type: "base",
-          path: "skills",
-          options: { skillSlug: slug },
-        });
+        // Open skills dialog with this skill's detail view
+        await executeCommand(`/skills ${slug}`);
         return;
       }
       await executeCommand(command);
     },
-    [skillsRegistry, route, executeCommand, pushHistory],
+    [skillsRegistry, executeCommand, pushHistory],
   );
 
   // Responsive layout calculations

--- a/src/tui/components/commands/skills-dialog.tsx
+++ b/src/tui/components/commands/skills-dialog.tsx
@@ -7,11 +7,13 @@
 
 import { useState, useMemo, useEffect } from "react";
 import { useKeyboard } from "@opentui/react";
-import { SyntaxStyle } from "@opentui/core";
 import { useCommand } from "../../context/command";
 import { useDimensions } from "../../context/dimensions";
 import { useTheme } from "../../theme";
+import { useToast } from "../../context/toast";
 import { Dialog } from "../../context/dialog";
+import { MarkdownViewer } from "../shared/markdown-viewer";
+import { openFileInDefaultApp } from "../../utils/open-file";
 import type { SkillEntry, SkillSource } from "../../../core/skills/types";
 
 /** Rough token estimate: ~4 chars per token */
@@ -37,6 +39,7 @@ export default function SkillsDialog({
 }: SkillsDialogProps) {
   const { colors } = useTheme();
   const { skillsRegistry } = useCommand();
+  const { toast } = useToast();
   const dimensions = useDimensions();
 
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -95,11 +98,17 @@ export default function SkillsDialog({
   }, [allSkills]);
 
   useKeyboard((evt) => {
-    // Detail view — only intercept escape to go back; let scrollbox handle scroll keys
+    // Detail view — intercept escape and [E]; let scrollbox handle scroll keys
     if (detailSkill) {
       if (evt.name === "escape") {
         evt.preventDefault();
         setDetailSkill(null);
+      }
+      if ((evt.name === "e" || evt.name === "E") && !evt.ctrl && !evt.meta) {
+        evt.preventDefault();
+        openFileInDefaultApp(detailSkill.filePath).then((err) => {
+          if (err) toast(err, "error");
+        });
       }
       return;
     }
@@ -135,26 +144,6 @@ export default function SkillsDialog({
 
   const panelWidth = Math.min(76, dimensions.width - 4);
 
-  const syntaxStyle = useMemo(
-    () =>
-      SyntaxStyle.fromStyles({
-        default: { fg: colors.text },
-        "markup.heading": { fg: colors.markdownHeading, bold: true },
-        "markup.strong": { fg: colors.markdownStrong, bold: true },
-        "markup.italic": { fg: colors.markdownEmph, italic: true },
-        "markup.raw": { fg: colors.markdownCode },
-        "markup.raw.block": { fg: colors.markdownCode },
-        "markup.link": { fg: colors.markdownLink },
-        "markup.link.url": { fg: colors.markdownLink, dim: true },
-        "markup.link.label": { fg: colors.markdownLink, underline: true },
-        "markup.strikethrough": { fg: colors.textMuted, dim: true },
-        "markup.list": { fg: colors.primary },
-        "markup.quote": { fg: colors.textMuted, italic: true },
-        "punctuation.special": { fg: colors.border },
-      }),
-    [colors],
-  );
-
   // ---------- Detail view ----------
   if (detailSkill) {
     const m = detailSkill.manifest;
@@ -164,99 +153,53 @@ export default function SkillsDialog({
 
     return (
       <Dialog size="large" onClose={() => setDetailSkill(null)}>
-        <box flexDirection="column" width="100%" padding={1}>
-          {/* Header */}
-          <box width="100%" flexDirection="row" justifyContent="space-between">
+        <MarkdownViewer
+          content={instrText}
+          loading={detailInstructions === null}
+          width={panelWidth}
+          headerLeft={
             <text>
               <span fg={colors.primary}>{detailSkill.slug}</span>
               {m.version && <span fg={colors.textMuted}> v{m.version}</span>}
             </text>
+          }
+          headerRight={
             <text fg={colors.textMuted}>
               {detailInstructions !== null
                 ? `~${instrTokens + descTokens} tokens`
                 : "loading..."}
             </text>
-          </box>
-
-          {/* Separator */}
-          <box width="100%" height={1}>
-            <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
-          </box>
-
-          {/* Metadata */}
-          <box flexDirection="column">
-            {m.tags && m.tags.length > 0 && (
+          }
+          beforeContent={
+            <box flexDirection="column" paddingLeft={1}>
+              {m.tags && m.tags.length > 0 && (
+                <text>
+                  <span fg={colors.textMuted}>Tags: </span>
+                  <span fg={colors.text}>{m.tags.join(", ")}</span>
+                </text>
+              )}
               <text>
-                <span fg={colors.textMuted}>Tags: </span>
-                <span fg={colors.text}>{m.tags.join(", ")}</span>
+                <span fg={colors.textMuted}>Source: </span>
+                <span fg={colors.text}>{detailSkill.filePath}</span>
               </text>
-            )}
-            <text>
-              <span fg={colors.textMuted}>Source: </span>
-              <span fg={colors.text}>{detailSkill.filePath}</span>
+              {detailSkill.scripts.length > 0 && (
+                <text>
+                  <span fg={colors.textMuted}>Scripts: </span>
+                  <span fg={colors.text}>
+                    {detailSkill.scripts.map((s) => s.name).join(", ")}
+                  </span>
+                </text>
+              )}
+            </box>
+          }
+          footerLeft={
+            <text fg={colors.textMuted}>
+              <span fg={colors.primary}>[↑/↓]</span> Scroll{" "}
+              <span fg={colors.primary}>[E]</span> Open in Editor{" "}
+              <span fg={colors.primary}>[Esc]</span> Back
             </text>
-            {detailSkill.scripts.length > 0 && (
-              <text>
-                <span fg={colors.textMuted}>Scripts: </span>
-                <span fg={colors.text}>
-                  {detailSkill.scripts.map((s) => s.name).join(", ")}
-                </span>
-              </text>
-            )}
-          </box>
-
-          {/* Separator */}
-          <box width="100%" height={1} marginTop={1}>
-            <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
-          </box>
-
-          {/* Scrollable markdown instructions */}
-          <scrollbox
-            style={{
-              rootOptions: {
-                flexGrow: 1,
-                flexShrink: 1,
-                width: "100%",
-                overflow: "hidden",
-              },
-              contentOptions: {
-                paddingLeft: 2,
-                paddingRight: 2,
-                paddingTop: 1,
-                paddingBottom: 1,
-                flexDirection: "column",
-              },
-              scrollbarOptions: {
-                trackOptions: {
-                  foregroundColor: colors.primary,
-                  backgroundColor: colors.backgroundElement,
-                },
-              },
-            }}
-            stickyScroll={false}
-            focused={true}
-          >
-            {detailInstructions !== null ? (
-              <markdown
-                content={instrText}
-                syntaxStyle={syntaxStyle}
-                conceal={true}
-              />
-            ) : (
-              <text fg={colors.textMuted}>Loading instructions...</text>
-            )}
-          </scrollbox>
-
-          {/* Separator */}
-          <box width="100%" height={1}>
-            <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
-          </box>
-
-          {/* Footer */}
-          <box width="100%" flexDirection="row">
-            <text fg={colors.textMuted}>[↑↓] scroll [esc] back</text>
-          </box>
-        </box>
+          }
+        />
       </Dialog>
     );
   }

--- a/src/tui/components/commands/skills-dialog.tsx
+++ b/src/tui/components/commands/skills-dialog.tsx
@@ -1,16 +1,16 @@
 /**
  * Skills Dialog
  *
- * Full-page display of installed skills grouped by source, with token estimates.
- * Arrow keys to navigate, Enter for detail view, Escape to go back.
- * Matches the /models page layout.
+ * Dialog overlay displaying installed skills grouped by source, with token estimates.
+ * Arrow keys to navigate, Enter for detail view, Escape to close.
  */
 
 import { useState, useMemo, useEffect } from "react";
-import { useKeyboard, useTerminalDimensions } from "@opentui/react";
+import { useKeyboard } from "@opentui/react";
 import { useCommand } from "../../context/command";
-import { useRoute } from "../../context/route";
+import { useDimensions } from "../../context/dimensions";
 import { useTheme } from "../../theme";
+import { Dialog } from "../../context/dialog";
 import type { SkillEntry, SkillSource } from "../../../core/skills/types";
 
 /** Rough token estimate: ~4 chars per token */
@@ -25,15 +25,15 @@ const GROUP_LABELS: Record<SkillSource, string> = {
 
 const GROUP_ORDER: SkillSource[] = ["project", "user"];
 
-export default function SkillsDialog() {
+interface SkillsDialogProps {
+  onClose: () => void;
+  initialSlug?: string;
+}
+
+export default function SkillsDialog({ onClose, initialSlug }: SkillsDialogProps) {
   const { colors } = useTheme();
   const { skillsRegistry } = useCommand();
-  const route = useRoute();
-  const dimensions = useTerminalDimensions();
-
-  // Auto-open detail view when navigated with a specific skill slug
-  const initialSlug =
-    route.data.type === "base" ? route.data.options?.skillSlug : undefined;
+  const dimensions = useDimensions();
 
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [detailSkill, setDetailSkill] = useState<SkillEntry | null>(() => {
@@ -90,15 +90,12 @@ export default function SkillsDialog() {
     return { groups, flatList };
   }, [allSkills]);
 
-  const goHome = () => {
-    route.navigate({ type: "base", path: "home" });
-  };
-
   useKeyboard((evt) => {
-    // Detail view — any key goes back to list
+    evt.preventDefault();
+
+    // Detail view — escape/enter goes back to list
     if (detailSkill) {
       if (evt.name === "escape" || evt.name === "return") {
-        evt.preventDefault();
         setDetailSkill(null);
       }
       return;
@@ -106,8 +103,7 @@ export default function SkillsDialog() {
 
     switch (evt.name) {
       case "escape":
-        evt.preventDefault();
-        goHome();
+        onClose();
         break;
 
       case "up":
@@ -133,7 +129,8 @@ export default function SkillsDialog() {
 
   // Clamp index
   const safeIndex = Math.min(selectedIndex, flatList.length - 1);
-  const maxDescWidth = Math.max(20, dimensions.width - 12);
+
+  const panelWidth = Math.min(76, dimensions.width - 4);
 
   // ---------- Detail view ----------
   if (detailSkill) {
@@ -146,155 +143,186 @@ export default function SkillsDialog() {
       : ["Loading instructions..."];
 
     return (
-      <box
-        flexDirection="column"
-        width="100%"
-        height="100%"
-        paddingLeft={4}
-        paddingTop={2}
-      >
-        {/* Header */}
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={colors.text}>{detailSkill.slug}</span>
-          {m.version && <span fg={colors.textMuted}> v{m.version}</span>}
-          <span fg={colors.textMuted}>
-            {" "}
-            ·{" "}
-            {detailInstructions !== null
-              ? `~${instrTokens + descTokens} tokens`
-              : "loading..."}
-          </span>
-        </text>
-
-        {/* Metadata row */}
-        <box paddingLeft={2} marginTop={1} flexDirection="column">
-          {m.tags && m.tags.length > 0 && (
+      <Dialog size="large" onClose={() => setDetailSkill(null)}>
+        <box flexDirection="column" width="100%" padding={1}>
+          {/* Header */}
+          <box width="100%" flexDirection="row" justifyContent="space-between">
             <text>
-              <span fg={colors.textMuted}>Tags: </span>
-              <span fg={colors.text}>{m.tags.join(", ")}</span>
+              <span fg={colors.primary}>{detailSkill.slug}</span>
+              {m.version && <span fg={colors.textMuted}> v{m.version}</span>}
             </text>
-          )}
-          <text>
-            <span fg={colors.textMuted}>Source: </span>
-            <span fg={colors.text}>{detailSkill.filePath}</span>
-          </text>
-          {detailSkill.scripts.length > 0 && (
+            <text fg={colors.textMuted}>
+              {detailInstructions !== null
+                ? `~${instrTokens + descTokens} tokens`
+                : "loading..."}
+            </text>
+          </box>
+
+          {/* Separator */}
+          <box width="100%" height={1}>
+            <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
+          </box>
+
+          {/* Metadata */}
+          <box flexDirection="column">
+            {m.tags && m.tags.length > 0 && (
+              <text>
+                <span fg={colors.textMuted}>Tags: </span>
+                <span fg={colors.text}>{m.tags.join(", ")}</span>
+              </text>
+            )}
             <text>
-              <span fg={colors.textMuted}>Scripts: </span>
-              <span fg={colors.text}>
-                {detailSkill.scripts.map((s) => s.name).join(", ")}
-              </span>
+              <span fg={colors.textMuted}>Source: </span>
+              <span fg={colors.text}>{detailSkill.filePath}</span>
             </text>
-          )}
-        </box>
+            {detailSkill.scripts.length > 0 && (
+              <text>
+                <span fg={colors.textMuted}>Scripts: </span>
+                <span fg={colors.text}>
+                  {detailSkill.scripts.map((s) => s.name).join(", ")}
+                </span>
+              </text>
+            )}
+          </box>
 
-        {/* Scrollable instructions */}
-        <box paddingLeft={2} marginTop={1} flexDirection="column">
-          <text fg={colors.textMuted}>Instructions:</text>
-        </box>
-        <scrollbox
-          style={{
-            rootOptions: {
-              flexGrow: 1,
-              flexShrink: 1,
-              width: "100%",
-              marginTop: 0,
-            },
-            contentOptions: {
-              paddingLeft: 6,
-              paddingRight: 2,
-              flexDirection: "column",
-            },
-          }}
-          stickyScroll={false}
-          focused={true}
-        >
-          {instrLines.map((line, i) => (
-            <text key={i} fg={colors.text}>
-              {line || " "}
+          {/* Separator */}
+          <box width="100%" height={1} marginTop={1}>
+            <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
+          </box>
+
+          {/* Scrollable instructions */}
+          <scrollbox
+            style={{
+              rootOptions: {
+                flexGrow: 1,
+                flexShrink: 1,
+                width: "100%",
+                marginTop: 0,
+              },
+              contentOptions: {
+                paddingLeft: 1,
+                paddingRight: 1,
+                flexDirection: "column",
+              },
+            }}
+            stickyScroll={false}
+            focused={true}
+          >
+            {instrLines.map((line, i) => (
+              <text key={i} fg={colors.text}>
+                {line || " "}
+              </text>
+            ))}
+          </scrollbox>
+
+          {/* Separator */}
+          <box width="100%" height={1}>
+            <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
+          </box>
+
+          {/* Footer */}
+          <box width="100%" flexDirection="row">
+            <text fg={colors.textMuted}>
+              [↑↓] scroll [esc] back
             </text>
-          ))}
-        </scrollbox>
-
-        {/* Footer */}
-        <box marginTop={1} paddingBottom={1}>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={colors.text}>[↑][↓]</span>
-            <span fg={colors.textMuted}> scroll </span>
-            <span fg={colors.text}>[ESC]</span>
-            <span fg={colors.textMuted}> back</span>
-          </text>
+          </box>
         </box>
-      </box>
+      </Dialog>
     );
   }
 
   // ---------- List view ----------
   let flatIdx = 0;
 
-  return (
-    <box flexDirection="column" width="100%" paddingLeft={4} paddingTop={2}>
-      {/* Header */}
-      <text>
-        <span fg={colors.primary}>█ </span>
-        <span fg={colors.text}>Skills</span>
-      </text>
-      <text>
-        <span fg={colors.primary}>█ </span>
-        <span fg={colors.textMuted}>
-          {allSkills.length} skill{allSkills.length !== 1 ? "s" : ""}
-        </span>
-      </text>
+  // Calculate visible window for scrolling
+  const listHeight = Math.max(1, dimensions.height - 12);
+  const scrollOffset = Math.max(
+    0,
+    Math.min(
+      safeIndex - Math.floor(listHeight / 2),
+      flatList.length - listHeight,
+    ),
+  );
 
-      {/* Skill groups */}
-      <box flexDirection="column" paddingLeft={2} marginTop={1}>
-        {groups.map((group) => (
-          <box key={group.label} flexDirection="column" marginTop={1}>
-            <text fg={colors.textMuted}>{group.label}</text>
-            {group.skills.map((skill) => {
-              const idx = flatIdx++;
-              const selected = idx === safeIndex;
+  // Build visible items with group headers
+  const visibleItems: Array<{ type: "header"; label: string } | { type: "skill"; skill: SkillEntry; index: number }> = [];
+  let runningIdx = 0;
+  for (const group of groups) {
+    const groupStart = runningIdx;
+    const groupEnd = runningIdx + group.skills.length;
+    // Show header if any skill from this group is in the visible window
+    if (groupEnd > scrollOffset && groupStart < scrollOffset + listHeight) {
+      visibleItems.push({ type: "header", label: group.label });
+    }
+    for (const skill of group.skills) {
+      if (runningIdx >= scrollOffset && runningIdx < scrollOffset + listHeight) {
+        visibleItems.push({ type: "skill", skill, index: runningIdx });
+      }
+      runningIdx++;
+    }
+  }
+
+  return (
+    <Dialog size="large" onClose={onClose}>
+      <box flexDirection="column" width="100%" padding={1}>
+        {/* Header */}
+        <box width="100%" flexDirection="row" justifyContent="space-between">
+          <text fg={colors.primary}>Skills</text>
+          <text fg={colors.textMuted}>
+            {allSkills.length} skill{allSkills.length !== 1 ? "s" : ""}
+          </text>
+        </box>
+
+        {/* Separator */}
+        <box width="100%" height={1}>
+          <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
+        </box>
+
+        {/* Skill list */}
+        <box flexDirection="column" flexGrow={1}>
+          {visibleItems.map((item, i) => {
+            if (item.type === "header") {
               return (
-                <text key={skill.slug}>
-                  <span fg={selected ? colors.primary : colors.text}>
-                    {selected ? "▸ " : "  "}
-                    {skill.slug}
-                  </span>
-                  <span fg={colors.textMuted}>
-                    {" "}
-                    · ~{estimateTokens(skill.manifest.description)} description
-                    tokens
-                  </span>
+                <text key={`h-${item.label}`} fg={colors.textMuted}>
+                  {item.label}
                 </text>
               );
-            })}
-          </box>
-        ))}
+            }
+            const selected = item.index === safeIndex;
+            return (
+              <box key={item.skill.slug} flexDirection="row">
+                <text fg={selected ? colors.primary : colors.textMuted}>
+                  {selected ? "❯ " : "  "}
+                </text>
+                <text fg={selected ? colors.primary : colors.text}>
+                  {item.skill.slug}
+                </text>
+                <text fg={colors.textMuted}>
+                  {" "}· ~{estimateTokens(item.skill.manifest.description)} tokens
+                </text>
+              </box>
+            );
+          })}
 
-        {allSkills.length === 0 && (
-          <box marginTop={1}>
+          {allSkills.length === 0 && (
             <text fg={colors.textMuted}>
-              No skills installed. Use `bunx skills add` to install skills.
+              No skills installed.
             </text>
-          </box>
-        )}
-      </box>
+          )}
+        </box>
 
-      {/* Footer */}
-      <box flexDirection="column" marginTop={2}>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={colors.textMuted}>Press </span>
-          <span fg={colors.text}>[↑][↓]</span>
-          <span fg={colors.textMuted}> to navigate </span>
-          <span fg={colors.text}>[Enter]</span>
-          <span fg={colors.textMuted}> for details </span>
-          <span fg={colors.text}>[ESC]</span>
-          <span fg={colors.textMuted}> to go back</span>
-        </text>
+        {/* Separator */}
+        <box width="100%" height={1}>
+          <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
+        </box>
+
+        {/* Footer */}
+        <box width="100%" flexDirection="row">
+          <text fg={colors.textMuted}>
+            [↑↓] browse [enter] details [esc] close
+          </text>
+        </box>
       </box>
-    </box>
+    </Dialog>
   );
 }

--- a/src/tui/components/commands/skills-dialog.tsx
+++ b/src/tui/components/commands/skills-dialog.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useMemo, useEffect } from "react";
 import { useKeyboard } from "@opentui/react";
+import { SyntaxStyle } from "@opentui/core";
 import { useCommand } from "../../context/command";
 import { useDimensions } from "../../context/dimensions";
 import { useTheme } from "../../theme";
@@ -91,15 +92,17 @@ export default function SkillsDialog({ onClose, initialSlug }: SkillsDialogProps
   }, [allSkills]);
 
   useKeyboard((evt) => {
-    evt.preventDefault();
-
-    // Detail view — escape/enter goes back to list
+    // Detail view — only intercept escape to go back; let scrollbox handle scroll keys
     if (detailSkill) {
-      if (evt.name === "escape" || evt.name === "return") {
+      if (evt.name === "escape") {
+        evt.preventDefault();
         setDetailSkill(null);
       }
       return;
     }
+
+    // List view — consume all keys
+    evt.preventDefault();
 
     switch (evt.name) {
       case "escape":
@@ -108,18 +111,15 @@ export default function SkillsDialog({ onClose, initialSlug }: SkillsDialogProps
 
       case "up":
       case "k":
-        evt.preventDefault();
         setSelectedIndex((prev) => (prev > 0 ? prev - 1 : flatList.length - 1));
         break;
 
       case "down":
       case "j":
-        evt.preventDefault();
         setSelectedIndex((prev) => (prev < flatList.length - 1 ? prev + 1 : 0));
         break;
 
       case "return":
-        evt.preventDefault();
         if (flatList[selectedIndex]) {
           setDetailSkill(flatList[selectedIndex]);
         }
@@ -132,15 +132,32 @@ export default function SkillsDialog({ onClose, initialSlug }: SkillsDialogProps
 
   const panelWidth = Math.min(76, dimensions.width - 4);
 
+  const syntaxStyle = useMemo(
+    () =>
+      SyntaxStyle.fromStyles({
+        default: { fg: colors.text },
+        "markup.heading": { fg: colors.markdownHeading, bold: true },
+        "markup.strong": { fg: colors.markdownStrong, bold: true },
+        "markup.italic": { fg: colors.markdownEmph, italic: true },
+        "markup.raw": { fg: colors.markdownCode },
+        "markup.raw.block": { fg: colors.markdownCode },
+        "markup.link": { fg: colors.markdownLink },
+        "markup.link.url": { fg: colors.markdownLink, dim: true },
+        "markup.link.label": { fg: colors.markdownLink, underline: true },
+        "markup.strikethrough": { fg: colors.textMuted, dim: true },
+        "markup.list": { fg: colors.primary },
+        "markup.quote": { fg: colors.textMuted, italic: true },
+        "punctuation.special": { fg: colors.border },
+      }),
+    [colors],
+  );
+
   // ---------- Detail view ----------
   if (detailSkill) {
     const m = detailSkill.manifest;
     const instrText = detailInstructions ?? "";
     const instrTokens = estimateTokens(instrText);
     const descTokens = estimateTokens(m.description);
-    const instrLines = instrText
-      ? instrText.split("\n")
-      : ["Loading instructions..."];
 
     return (
       <Dialog size="large" onClose={() => setDetailSkill(null)}>
@@ -190,29 +207,41 @@ export default function SkillsDialog({ onClose, initialSlug }: SkillsDialogProps
             <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
           </box>
 
-          {/* Scrollable instructions */}
+          {/* Scrollable markdown instructions */}
           <scrollbox
             style={{
               rootOptions: {
                 flexGrow: 1,
                 flexShrink: 1,
                 width: "100%",
-                marginTop: 0,
+                overflow: "hidden",
               },
               contentOptions: {
-                paddingLeft: 1,
-                paddingRight: 1,
+                paddingLeft: 2,
+                paddingRight: 2,
+                paddingTop: 1,
+                paddingBottom: 1,
                 flexDirection: "column",
+              },
+              scrollbarOptions: {
+                trackOptions: {
+                  foregroundColor: colors.primary,
+                  backgroundColor: colors.backgroundElement,
+                },
               },
             }}
             stickyScroll={false}
             focused={true}
           >
-            {instrLines.map((line, i) => (
-              <text key={i} fg={colors.text}>
-                {line || " "}
-              </text>
-            ))}
+            {detailInstructions !== null ? (
+              <markdown
+                content={instrText}
+                syntaxStyle={syntaxStyle}
+                conceal={true}
+              />
+            ) : (
+              <text fg={colors.textMuted}>Loading instructions...</text>
+            )}
           </scrollbox>
 
           {/* Separator */}

--- a/src/tui/components/commands/skills-dialog.tsx
+++ b/src/tui/components/commands/skills-dialog.tsx
@@ -31,7 +31,10 @@ interface SkillsDialogProps {
   initialSlug?: string;
 }
 
-export default function SkillsDialog({ onClose, initialSlug }: SkillsDialogProps) {
+export default function SkillsDialog({
+  onClose,
+  initialSlug,
+}: SkillsDialogProps) {
   const { colors } = useTheme();
   const { skillsRegistry } = useCommand();
   const dimensions = useDimensions();
@@ -251,9 +254,7 @@ export default function SkillsDialog({ onClose, initialSlug }: SkillsDialogProps
 
           {/* Footer */}
           <box width="100%" flexDirection="row">
-            <text fg={colors.textMuted}>
-              [↑↓] scroll [esc] back
-            </text>
+            <text fg={colors.textMuted}>[↑↓] scroll [esc] back</text>
           </box>
         </box>
       </Dialog>
@@ -261,7 +262,6 @@ export default function SkillsDialog({ onClose, initialSlug }: SkillsDialogProps
   }
 
   // ---------- List view ----------
-  let flatIdx = 0;
 
   // Calculate visible window for scrolling
   const listHeight = Math.max(1, dimensions.height - 12);
@@ -274,7 +274,10 @@ export default function SkillsDialog({ onClose, initialSlug }: SkillsDialogProps
   );
 
   // Build visible items with group headers
-  const visibleItems: Array<{ type: "header"; label: string } | { type: "skill"; skill: SkillEntry; index: number }> = [];
+  const visibleItems: Array<
+    | { type: "header"; label: string }
+    | { type: "skill"; skill: SkillEntry; index: number }
+  > = [];
   let runningIdx = 0;
   for (const group of groups) {
     const groupStart = runningIdx;
@@ -284,7 +287,10 @@ export default function SkillsDialog({ onClose, initialSlug }: SkillsDialogProps
       visibleItems.push({ type: "header", label: group.label });
     }
     for (const skill of group.skills) {
-      if (runningIdx >= scrollOffset && runningIdx < scrollOffset + listHeight) {
+      if (
+        runningIdx >= scrollOffset &&
+        runningIdx < scrollOffset + listHeight
+      ) {
         visibleItems.push({ type: "skill", skill, index: runningIdx });
       }
       runningIdx++;
@@ -327,16 +333,15 @@ export default function SkillsDialog({ onClose, initialSlug }: SkillsDialogProps
                   {item.skill.slug}
                 </text>
                 <text fg={colors.textMuted}>
-                  {" "}· ~{estimateTokens(item.skill.manifest.description)} tokens
+                  {" "}
+                  · ~{estimateTokens(item.skill.manifest.description)} tokens
                 </text>
               </box>
             );
           })}
 
           {allSkills.length === 0 && (
-            <text fg={colors.textMuted}>
-              No skills installed.
-            </text>
+            <text fg={colors.textMuted}>No skills installed.</text>
           )}
         </box>
 

--- a/src/tui/components/report-viewer-dialog.tsx
+++ b/src/tui/components/report-viewer-dialog.tsx
@@ -1,8 +1,8 @@
-import { useRef, useMemo } from "react";
+import { useMemo } from "react";
 import { useKeyboard } from "@opentui/react";
 import { useDimensions } from "../context/dimensions";
-import { ScrollBoxRenderable, SyntaxStyle } from "@opentui/core";
 import { useTheme } from "../theme";
+import { MarkdownViewer } from "./shared/markdown-viewer";
 
 interface ReportViewerDialogProps {
   content: string;
@@ -19,28 +19,6 @@ export default function ReportViewerDialog({
 }: ReportViewerDialogProps) {
   const { colors } = useTheme();
   const dimensions = useDimensions();
-  const scrollRef = useRef<ScrollBoxRenderable>(null);
-
-  const syntaxStyle = useMemo(
-    () =>
-      SyntaxStyle.fromStyles({
-        default: { fg: colors.text },
-        "markup.heading": { fg: colors.markdownHeading, bold: true },
-        "markup.strong": { fg: colors.markdownStrong, bold: true },
-        "markup.italic": { fg: colors.markdownEmph, italic: true },
-        "markup.raw": { fg: colors.markdownCode },
-        "markup.raw.block": { fg: colors.markdownCode },
-        "markup.link": { fg: colors.markdownLink },
-        "markup.link.url": { fg: colors.markdownLink, dim: true },
-        "markup.link.label": { fg: colors.markdownLink, underline: true },
-        "markup.strikethrough": { fg: colors.textMuted, dim: true },
-        "markup.list": { fg: colors.primary },
-        "markup.quote": { fg: colors.textMuted, italic: true },
-        "punctuation.special": { fg: colors.border },
-      }),
-    [colors],
-  );
-
   const lineCount = useMemo(() => content.split("\n").length, [content]);
 
   useKeyboard((evt) => {
@@ -83,79 +61,25 @@ export default function ReportViewerDialog({
         borderStyle="single"
         flexDirection="column"
       >
-        {/* Header */}
-        <box
-          width="100%"
-          padding={1}
-          flexDirection="row"
-          justifyContent="space-between"
-        >
-          <text fg={colors.primary}>Pentest Report</text>
-          <text fg={colors.textMuted}>{reportPath}</text>
-        </box>
-
-        {/* Separator */}
-        <box width="100%" height={1}>
-          <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
-        </box>
-
-        {/* Report Content */}
-        <scrollbox
-          ref={scrollRef}
-          style={{
-            rootOptions: {
-              flexGrow: 1,
-              width: "100%",
-              overflow: "hidden",
-            },
-            contentOptions: {
-              paddingLeft: 2,
-              paddingRight: 2,
-              paddingTop: 1,
-              paddingBottom: 1,
-              flexDirection: "column",
-            },
-            scrollbarOptions: {
-              trackOptions: {
-                foregroundColor: colors.primary,
-                backgroundColor: colors.backgroundElement,
-              },
-            },
-          }}
-          stickyScroll={false}
-          focused={true}
-        >
-          <markdown
-            content={content}
-            syntaxStyle={syntaxStyle}
-            conceal={true}
-          />
-        </scrollbox>
-
-        {/* Separator */}
-        <box width="100%" height={1}>
-          <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
-        </box>
-
-        {/* Footer */}
-        <box
-          width="100%"
-          padding={1}
-          flexDirection="row"
-          justifyContent="space-between"
-        >
-          <text fg={colors.textMuted}>
-            <span fg={colors.primary}>[↑/↓]</span> Scroll{" "}
-            {onOpenExternal && (
-              <>
-                <span fg={colors.primary}>[E]</span>
-                {" Open in Editor "}
-              </>
-            )}
-            <span fg={colors.primary}>[Esc]</span> Close
-          </text>
-          <text fg={colors.textMuted}>{lineCount} lines</text>
-        </box>
+        <MarkdownViewer
+          content={content}
+          width={panelWidth}
+          headerLeft={<text fg={colors.primary}>Pentest Report</text>}
+          headerRight={<text fg={colors.textMuted}>{reportPath}</text>}
+          footerLeft={
+            <text fg={colors.textMuted}>
+              <span fg={colors.primary}>[↑/↓]</span> Scroll{" "}
+              {onOpenExternal && (
+                <>
+                  <span fg={colors.primary}>[E]</span>
+                  {" Open in Editor "}
+                </>
+              )}
+              <span fg={colors.primary}>[Esc]</span> Close
+            </text>
+          }
+          footerRight={<text fg={colors.textMuted}>{lineCount} lines</text>}
+        />
       </box>
     </box>
   );

--- a/src/tui/components/shared/index.ts
+++ b/src/tui/components/shared/index.ts
@@ -6,6 +6,7 @@
 
 // Markdown utilities
 export { markdownToStyledText } from "./markdown";
+export { MarkdownViewer } from "./markdown-viewer";
 
 // Message utilities
 export {

--- a/src/tui/components/shared/markdown-viewer.tsx
+++ b/src/tui/components/shared/markdown-viewer.tsx
@@ -1,0 +1,155 @@
+/**
+ * Shared markdown content viewer with themed syntax highlighting.
+ *
+ * Content-only component — does not manage its own overlay or positioning.
+ * Callers wrap it in <Dialog>, a custom overlay, or any other container.
+ */
+
+import { useRef, useMemo, type ReactNode } from "react";
+import { ScrollBoxRenderable, SyntaxStyle } from "@opentui/core";
+import { useTheme } from "../../theme";
+
+interface MarkdownViewerProps {
+  /** Markdown content to render */
+  content: string;
+  /** Show loading placeholder instead of content */
+  loading?: boolean;
+  /** Available width — used for separator line calculation */
+  width: number;
+  /** Header left side (title, name, etc.) */
+  headerLeft: ReactNode;
+  /** Header right side (path, token count, etc.) */
+  headerRight?: ReactNode;
+  /** Optional section between header and scrollable content (e.g. metadata) */
+  beforeContent?: ReactNode;
+  /** Footer left side (keyboard hints) */
+  footerLeft: ReactNode;
+  /** Footer right side (line count, etc.) */
+  footerRight?: ReactNode;
+}
+
+/**
+ * Shared markdown SyntaxStyle derived from theme colors.
+ */
+export function useMarkdownSyntaxStyle() {
+  const { colors } = useTheme();
+  return useMemo(
+    () =>
+      SyntaxStyle.fromStyles({
+        default: { fg: colors.text },
+        "markup.heading": { fg: colors.markdownHeading, bold: true },
+        "markup.strong": { fg: colors.markdownStrong, bold: true },
+        "markup.italic": { fg: colors.markdownEmph, italic: true },
+        "markup.raw": { fg: colors.markdownCode },
+        "markup.raw.block": { fg: colors.markdownCode },
+        "markup.link": { fg: colors.markdownLink },
+        "markup.link.url": { fg: colors.markdownLink, dim: true },
+        "markup.link.label": { fg: colors.markdownLink, underline: true },
+        "markup.strikethrough": { fg: colors.textMuted, dim: true },
+        "markup.list": { fg: colors.primary },
+        "markup.quote": { fg: colors.textMuted, italic: true },
+        "punctuation.special": { fg: colors.border },
+      }),
+    [colors],
+  );
+}
+
+export function MarkdownViewer({
+  content,
+  loading = false,
+  width,
+  headerLeft,
+  headerRight,
+  beforeContent,
+  footerLeft,
+  footerRight,
+}: MarkdownViewerProps) {
+  const { colors } = useTheme();
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const syntaxStyle = useMarkdownSyntaxStyle();
+  const separatorLine = "─".repeat(Math.max(0, width - 2));
+
+  return (
+    <box flexDirection="column" width="100%">
+      {/* Header */}
+      <box
+        width="100%"
+        padding={1}
+        flexDirection="row"
+        justifyContent="space-between"
+      >
+        {headerLeft}
+        {headerRight}
+      </box>
+
+      {/* Separator */}
+      <box width="100%" height={1}>
+        <text fg={colors.border}>{separatorLine}</text>
+      </box>
+
+      {/* Optional metadata section */}
+      {beforeContent}
+
+      {/* Separator after metadata (only when metadata is present) */}
+      {beforeContent && (
+        <box width="100%" height={1} marginTop={1}>
+          <text fg={colors.border}>{separatorLine}</text>
+        </box>
+      )}
+
+      {/* Scrollable markdown content */}
+      <scrollbox
+        ref={scrollRef}
+        style={{
+          rootOptions: {
+            flexGrow: 1,
+            flexShrink: 1,
+            width: "100%",
+            overflow: "hidden",
+          },
+          contentOptions: {
+            paddingLeft: 2,
+            paddingRight: 2,
+            paddingTop: 1,
+            paddingBottom: 1,
+            flexDirection: "column",
+          },
+          scrollbarOptions: {
+            trackOptions: {
+              foregroundColor: colors.primary,
+              backgroundColor: colors.backgroundElement,
+            },
+          },
+        }}
+        stickyScroll={false}
+        focused={true}
+      >
+        {loading ? (
+          <text fg={colors.textMuted}>Loading...</text>
+        ) : (
+          <markdown
+            content={content}
+            syntaxStyle={syntaxStyle}
+            conceal={true}
+          />
+        )}
+      </scrollbox>
+
+      {/* Separator */}
+      <box width="100%" height={1}>
+        <text fg={colors.border}>{separatorLine}</text>
+      </box>
+
+      {/* Footer */}
+      <box
+        width="100%"
+        padding={1}
+        flexDirection="row"
+        justifyContent="space-between"
+      >
+        {footerLeft}
+        {footerRight}
+      </box>
+    </box>
+  );
+}

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -56,6 +56,7 @@ interface CommandProviderProps {
   onOpenHelpDialog?: () => void;
   onOpenAuthDialog?: () => void;
   onOpenPentestDialog?: (flags?: WebCommandOptions) => void;
+  onOpenSkillsDialog?: (slug?: string) => void;
 }
 
 export function CommandProvider({
@@ -69,6 +70,7 @@ export function CommandProvider({
   onOpenHelpDialog,
   onOpenAuthDialog,
   onOpenPentestDialog,
+  onOpenSkillsDialog,
 }: CommandProviderProps) {
   const route = useRoute();
   const [registry] = useState(() => createSkillsRegistry());
@@ -87,6 +89,7 @@ export function CommandProvider({
       openHelpDialog: onOpenHelpDialog,
       openAuthDialog: onOpenAuthDialog,
       openPentestDialog: onOpenPentestDialog,
+      openSkillsDialog: onOpenSkillsDialog,
     };
     return ctx;
   }, [
@@ -100,6 +103,7 @@ export function CommandProvider({
     onOpenHelpDialog,
     onOpenAuthDialog,
     onOpenPentestDialog,
+    onOpenSkillsDialog,
   ]);
 
   const refreshSkills = useCallback(async () => {

--- a/src/tui/context/route.tsx
+++ b/src/tui/context/route.tsx
@@ -21,14 +21,12 @@ export type RoutePath =
   | "disclosure"
   | "theme"
   | "auth"
-  | "credits"
-  | "skills";
+  | "credits";
 
 export interface WebCommandOptions {
   auto?: boolean;
   target?: string;
   name?: string;
-  skillSlug?: string;
   swarm?: boolean;
   mode?: "plan" | "manual" | "auto";
   requireApproval?: boolean;

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -84,6 +84,10 @@ function App({ appConfig }: AppProps) {
   const [showCreditsDialog, setShowCreditsDialog] = useState(false);
   const [showHelpDialog, setShowHelpDialog] = useState(false);
   const [showPentestDialog, setShowPentestDialog] = useState(false);
+  const [showSkillsDialog, setShowSkillsDialog] = useState(false);
+  const [pendingSkillSlug, setPendingSkillSlug] = useState<string | undefined>(
+    undefined,
+  );
   const [pendingPentestFlags, setPendingPentestFlags] = useState<
     WebCommandOptions | undefined
   >(undefined);
@@ -111,6 +115,10 @@ function App({ appConfig }: AppProps) {
                     onOpenPentestDialog={(flags) => {
                       setPendingPentestFlags(flags);
                       setShowPentestDialog(true);
+                    }}
+                    onOpenSkillsDialog={(slug) => {
+                      setPendingSkillSlug(slug);
+                      setShowSkillsDialog(true);
                     }}
                   >
                     <KeybindingProvider
@@ -147,6 +155,10 @@ function App({ appConfig }: AppProps) {
                         setShowAuthDialog={setShowAuthDialog}
                         showPentestDialog={showPentestDialog}
                         setShowPentestDialog={setShowPentestDialog}
+                        showSkillsDialog={showSkillsDialog}
+                        setShowSkillsDialog={setShowSkillsDialog}
+                        pendingSkillSlug={pendingSkillSlug}
+                        setPendingSkillSlug={setPendingSkillSlug}
                         pendingPentestFlags={pendingPentestFlags}
                         setPendingPentestFlags={setPendingPentestFlags}
                         cwd={cwd}
@@ -190,6 +202,10 @@ function AppContent({
   setShowAuthDialog,
   showPentestDialog,
   setShowPentestDialog,
+  showSkillsDialog,
+  setShowSkillsDialog,
+  pendingSkillSlug,
+  setPendingSkillSlug,
   pendingPentestFlags,
   setPendingPentestFlags,
   cwd,
@@ -220,6 +236,10 @@ function AppContent({
   setShowAuthDialog: (show: boolean) => void;
   showPentestDialog: boolean;
   setShowPentestDialog: (show: boolean) => void;
+  showSkillsDialog: boolean;
+  setShowSkillsDialog: (show: boolean) => void;
+  pendingSkillSlug: string | undefined;
+  setPendingSkillSlug: (slug: string | undefined) => void;
   pendingPentestFlags: WebCommandOptions | undefined;
   setPendingPentestFlags: (flags: WebCommandOptions | undefined) => void;
   cwd: string;
@@ -279,7 +299,8 @@ function AppContent({
     showCreditsDialog ||
     showHelpDialog ||
     showAuthDialog ||
-    showPentestDialog;
+    showPentestDialog ||
+    showSkillsDialog;
 
   useEffect(() => {
     if (anyExternalDialog) {
@@ -363,6 +384,13 @@ function AppContent({
     }
   };
 
+  const handleCloseSkillsDialog = () => {
+    setShowSkillsDialog(false);
+    setPendingSkillSlug(undefined);
+    setInputKey((prev) => prev + 1);
+    refocusPrompt();
+  };
+
   const handleClosePentestDialog = () => {
     setShowPentestDialog(false);
     setPendingPentestFlags(undefined);
@@ -442,6 +470,13 @@ function AppContent({
       )}
 
       {showHelpDialog && <HelpDialog onClose={handleCloseHelpDialog} />}
+
+      {showSkillsDialog && (
+        <SkillsDialog
+          onClose={handleCloseSkillsDialog}
+          initialSlug={pendingSkillSlug}
+        />
+      )}
 
       {showAuthDialog && <AuthFlow onClose={handleCloseAuthDialog} />}
 
@@ -546,9 +581,6 @@ function CommandDisplay({
           </RouteSwitch.Case>
           <RouteSwitch.Case when="credits">
             <CreditsFlow onOpenAuthDialog={onOpenAuthDialog} />
-          </RouteSwitch.Case>
-          <RouteSwitch.Case when="skills">
-            <SkillsDialog />
           </RouteSwitch.Case>
         </RouteSwitch>
       </box>

--- a/src/tui/utils/open-file.ts
+++ b/src/tui/utils/open-file.ts
@@ -1,0 +1,37 @@
+const NO_APP_MSG = "No app found to open file — set a default application";
+
+/**
+ * Open a file in the user's default OS application.
+ * Returns "" on success, or an error message string on failure.
+ */
+export async function openFileInDefaultApp(filePath: string): Promise<string> {
+  try {
+    const platform = process.platform;
+    let proc: ReturnType<typeof Bun.spawn>;
+
+    if (platform === "darwin") {
+      proc = Bun.spawn(["open", filePath], {
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+    } else if (platform === "win32") {
+      proc = Bun.spawn(["cmd", "/c", "start", "", filePath], {
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+    } else {
+      proc = Bun.spawn(["xdg-open", filePath], {
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+    }
+
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      return NO_APP_MSG;
+    }
+    return "";
+  } catch {
+    return NO_APP_MSG;
+  }
+}

--- a/src/tui/utils/open-report.ts
+++ b/src/tui/utils/open-report.ts
@@ -1,9 +1,7 @@
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { REPORT_FILENAME_MD } from "../../core/report";
-
-const NO_EDITOR_MSG =
-  "No app found for .md files — set a default markdown editor";
+import { openFileInDefaultApp } from "./open-file";
 
 /**
  * Open the pentest report for a session in the user's default viewer.
@@ -18,35 +16,7 @@ export async function openSessionReport(
     return "Report not found";
   }
 
-  try {
-    const platform = process.platform;
-    let proc: ReturnType<typeof Bun.spawn>;
-
-    if (platform === "darwin") {
-      proc = Bun.spawn(["open", reportPath], {
-        stderr: "pipe",
-        stdout: "pipe",
-      });
-    } else if (platform === "win32") {
-      proc = Bun.spawn(["cmd", "/c", "start", "", reportPath], {
-        stderr: "pipe",
-        stdout: "pipe",
-      });
-    } else {
-      proc = Bun.spawn(["xdg-open", reportPath], {
-        stderr: "pipe",
-        stdout: "pipe",
-      });
-    }
-
-    const exitCode = await proc.exited;
-    if (exitCode !== 0) {
-      return NO_EDITOR_MSG;
-    }
-    return "";
-  } catch {
-    return NO_EDITOR_MSG;
-  }
+  return openFileInDefaultApp(reportPath);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extracts a reusable `MarkdownViewer` component (`src/tui/components/shared/markdown-viewer.tsx`) with themed syntax highlighting, scrollable content, and configurable header/footer/metadata slots
- Extracts a generic `openFileInDefaultApp` utility (`src/tui/utils/open-file.ts`) from the report-specific `openSessionReport`
- Refactors `ReportViewerDialog` to use the shared `MarkdownViewer` (no behavior change)
- Refactors skills detail view to use `MarkdownViewer`
- Adds `[E]` keyboard shortcut in skills detail view to open SKILL.md in the user's default editor

Closes #474
Depends on #471

## Test plan
- [x] Skills detail view renders markdown identically to before
- [x] `[E]` in skills detail opens SKILL.md in the default editor
- [x] Error toast shown if no app is configured for `.md` files
- [x] Pentest report viewer renders and behaves identically to before
- [x] `[E]` in report viewer still opens report in editor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes markdown rendering and file-opening logic; main behavioral change is a new `[E]` shortcut in skills detail view that invokes OS file opening and shows a toast on failure.
> 
> **Overview**
> Introduces a reusable `MarkdownViewer` component to standardize themed markdown rendering with header/footer slots, separators, and a scrollbox.
> 
> Refactors `ReportViewerDialog` and the skills detail view in `skills-dialog.tsx` to use `MarkdownViewer`, removing duplicated `SyntaxStyle`/scrollbox layout code while keeping report behavior the same.
> 
> Adds a cross-platform `openFileInDefaultApp` utility and uses it for `openSessionReport`; the skills detail view now supports **`[E]`** to open the skill file externally and surfaces failures via toast.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b90f537319fce483758a03c3b844f92c6dd6d9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->