### PR TITLE
Consolidate dialog footer controls into reusable DialogControls component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,3 +62,11 @@ On first launch, the TUI shows a "Responsible Use Disclosure" screen that must b
 - Bun must be on `PATH`. After installing via `curl -fsSL https://bun.sh/install | bash`, add `$HOME/.bun/bin` to PATH.
 - No database or Docker required for development or running the TUI.
 - AI provider API key (e.g. `ANTHROPIC_API_KEY`) is needed for pentesting features and integration tests, but not for basic TUI operation or unit tests.
+
+### UI/UX conventions
+
+**Reuse shared components.** Before building inline UI for controls, indicators, or dialog chrome, check `src/tui/components/shared/` for existing components. If you see the same pattern implemented inline in 2+ places, extract it into a shared component rather than duplicating it — duplication is how conventions silently diverge.
+
+**Dialog shortcut controls.** Use the `DialogControls` component (`src/tui/components/shared/dialog-controls.tsx`) for keyboard hint bars at the bottom of dialogs. It supports three variants: `default` (muted — for secondary actions), `primary` (bright — for the main CTA), and `danger` (red — for irreversible actions like Delete/Disconnect). Ordering: primary action first, secondary actions next, danger actions after, Esc always last. `[Esc] Close` is rendered automatically by the `Dialog` component's top-right chrome — don't add it to the controls array. Only show non-obvious shortcuts; intuitive actions like ↑/↓ navigation don't need hints. Key capitalization: Title Case for named keys (`Enter`, `Esc`, `Tab`), uppercase for single letters (`D`, `R`, `M`), arrows as `↑/↓`.
+
+**Consistency over novelty.** When adding a new dialog or view, match the patterns of existing ones. Don't invent new shortcut formatting, separator styles, color schemes, or layouts. Open a few existing dialogs as reference before starting — small inconsistencies compound quickly across a codebase.

--- a/src/tui/components/alert-dialog.tsx
+++ b/src/tui/components/alert-dialog.tsx
@@ -2,7 +2,6 @@ import { useKeyboard, useRenderer } from "@opentui/react";
 import { useDimensions } from "../context/dimensions";
 import type { JSX } from "react";
 import { useTheme } from "../theme";
-import { DialogControls } from "./shared/dialog-controls";
 
 export interface AlertDialogProps {
   title?: string;
@@ -70,6 +69,16 @@ export default function AlertDialog({
         padding={1}
         paddingTop={1}
       >
+        {!disableEscape && (
+          <box
+            width="100%"
+            flexDirection="row"
+            justifyContent="flex-end"
+            marginBottom={1}
+          >
+            <text fg={colors.textMuted}>Esc to close</text>
+          </box>
+        )}
         {title ? (
           <box marginBottom={1}>
             <text fg={colors.primary}>{title}</text>
@@ -78,11 +87,6 @@ export default function AlertDialog({
         <box flexDirection="column">
           {message ? <text fg={colors.text}>{message}</text> : children}
         </box>
-        {!disableEscape ? (
-          <box marginTop={1}>
-            <DialogControls controls={[{ key: "Esc", label: "Close" }]} />
-          </box>
-        ) : null}
       </box>
     </box>
   );

--- a/src/tui/components/alert-dialog.tsx
+++ b/src/tui/components/alert-dialog.tsx
@@ -2,6 +2,7 @@ import { useKeyboard, useRenderer } from "@opentui/react";
 import { useDimensions } from "../context/dimensions";
 import type { JSX } from "react";
 import { useTheme } from "../theme";
+import { DialogControls } from "./shared/dialog-controls";
 
 export interface AlertDialogProps {
   title?: string;
@@ -79,7 +80,7 @@ export default function AlertDialog({
         </box>
         {!disableEscape ? (
           <box marginTop={1}>
-            <text fg={colors.textMuted}>Press Esc to close</text>
+            <DialogControls controls={[{ key: "Esc", label: "Close" }]} />
           </box>
         ) : null}
       </box>

--- a/src/tui/components/alert-dialog.tsx
+++ b/src/tui/components/alert-dialog.tsx
@@ -76,7 +76,9 @@ export default function AlertDialog({
             justifyContent="flex-end"
             marginBottom={1}
           >
-            <text fg={colors.textMuted}>Esc to close</text>
+            <text fg={colors.textMuted}>
+              <span fg={colors.textMuted}>[Esc]</span> Close
+            </text>
           </box>
         )}
         {title ? (

--- a/src/tui/components/commands/api-key-input.tsx
+++ b/src/tui/components/commands/api-key-input.tsx
@@ -4,6 +4,7 @@ import Input from "../input";
 import { type ProviderType, verifyApiKey } from "../../../core/providers";
 import { useTheme } from "../../theme";
 import { Dialog } from "../../context/dialog";
+import { DialogControls } from "../shared/dialog-controls";
 
 type VerifyState = "idle" | "verifying" | "error";
 
@@ -72,10 +73,7 @@ export default function APIKeyInput({
     <Dialog size="large" onClose={onCancel}>
       <box flexDirection="column" padding={1} width="100%">
         {/* Header */}
-        <box flexDirection="row" justifyContent="space-between" width="100%">
-          <text fg={colors.primary}>Connect {providerName}</text>
-          <text fg={colors.textMuted}>esc to cancel</text>
-        </box>
+        <text fg={colors.primary}>Connect {providerName}</text>
 
         {/* Instructions */}
         <box marginTop={1} marginBottom={1}>
@@ -114,9 +112,10 @@ export default function APIKeyInput({
         )}
 
         {/* Footer */}
-        <box marginTop={1}>
-          <text fg={colors.textMuted}>[enter] save [esc] cancel</text>
-        </box>
+        <DialogControls controls={[
+          { key: "Enter", label: "Save", variant: "primary" },
+          { key: "Esc", label: "Cancel" },
+        ]} />
       </box>
     </Dialog>
   );

--- a/src/tui/components/commands/api-key-input.tsx
+++ b/src/tui/components/commands/api-key-input.tsx
@@ -113,10 +113,7 @@ export default function APIKeyInput({
 
         {/* Footer */}
         <DialogControls
-          controls={[
-            { key: "Enter", label: "Save", variant: "primary" },
-            { key: "Esc", label: "Cancel" },
-          ]}
+          controls={[{ key: "Enter", label: "Save", variant: "primary" }]}
         />
       </box>
     </Dialog>

--- a/src/tui/components/commands/api-key-input.tsx
+++ b/src/tui/components/commands/api-key-input.tsx
@@ -112,10 +112,12 @@ export default function APIKeyInput({
         )}
 
         {/* Footer */}
-        <DialogControls controls={[
-          { key: "Enter", label: "Save", variant: "primary" },
-          { key: "Esc", label: "Cancel" },
-        ]} />
+        <DialogControls
+          controls={[
+            { key: "Enter", label: "Save", variant: "primary" },
+            { key: "Esc", label: "Cancel" },
+          ]}
+        />
       </box>
     </Dialog>
   );

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../../core/auth";
 import type { DeviceFlowInfo, WorkspaceInfo } from "../../../core/auth";
 import { Dialog } from "../../context/dialog";
+import { DialogControls } from "../shared/dialog-controls";
 import { useTheme } from "../../theme";
 
 interface AuthFlowProps {
@@ -500,10 +501,10 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               </text>
             </box>
             <box marginTop={1}>
-              <text fg={colors.textMuted}>
-                <span fg={colors.primary}>[ENTER]</span> Connect ·{" "}
-                <span fg={colors.primary}>[ESC]</span> Cancel
-              </text>
+              <DialogControls controls={[
+                { key: "Enter", label: "Connect", variant: "primary" },
+                { key: "Esc", label: "Cancel" },
+              ]} />
             </box>
           </box>
         )}
@@ -535,9 +536,9 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               </text>
             </box>
             <box marginTop={1}>
-              <text fg={colors.textMuted}>
-                <span fg={colors.primary}>[ESC]</span> Cancel
-              </text>
+              <DialogControls controls={[
+                { key: "Esc", label: "Cancel" },
+              ]} />
             </box>
           </box>
         )}
@@ -564,12 +565,12 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               ))}
             </box>
             <box marginTop={1}>
-              <text fg={colors.textMuted}>
-                <span fg={colors.primary}>[↑/↓]</span> Navigate ·{" "}
-                <span fg={colors.primary}>[ENTER]</span> Select ·{" "}
-                <span fg={colors.error}>[D]</span> Disconnect ·{" "}
-                <span fg={colors.primary}>[ESC]</span> Cancel
-              </text>
+              <DialogControls controls={[
+                { key: "↑/↓", label: "Navigate" },
+                { key: "Enter", label: "Select", variant: "primary" },
+                { key: "D", label: "Disconnect", variant: "danger" },
+                { key: "Esc", label: "Cancel" },
+              ]} />
             </box>
           </box>
         )}
@@ -599,9 +600,9 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               </text>
             </box>
             <box marginTop={1}>
-              <text fg={colors.textMuted}>
-                <span fg={colors.primary}>[ESC]</span> Cancel
-              </text>
+              <DialogControls controls={[
+                { key: "Esc", label: "Cancel" },
+              ]} />
             </box>
           </box>
         )}
@@ -665,12 +666,11 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               </text>
             </box>
             <box marginTop={1}>
-              <text fg={colors.textMuted}>
-                <span fg={colors.primary}>[ENTER]</span>{" "}
-                {showBillingWarning ? "Open billing" : "Done"} ·{" "}
-                <span fg={colors.error}>[D]</span> Disconnect ·{" "}
-                <span fg={colors.primary}>[ESC]</span> Back
-              </text>
+              <DialogControls controls={[
+                { key: "Enter", label: showBillingWarning ? "Open Billing" : "Done", variant: "primary" },
+                { key: "D", label: "Disconnect", variant: "danger" },
+                { key: "Esc", label: "Back" },
+              ]} />
             </box>
           </box>
         )}
@@ -682,10 +682,10 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               <text fg={colors.error}>{error}</text>
             </box>
             <box marginTop={1}>
-              <text fg={colors.textMuted}>
-                <span fg={colors.primary}>[ENTER]</span> Try again ·{" "}
-                <span fg={colors.primary}>[ESC]</span> Cancel
-              </text>
+              <DialogControls controls={[
+                { key: "Enter", label: "Try Again", variant: "primary" },
+                { key: "Esc", label: "Cancel" },
+              ]} />
             </box>
           </box>
         )}

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -501,10 +501,12 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               </text>
             </box>
             <box marginTop={1}>
-              <DialogControls controls={[
-                { key: "Enter", label: "Connect", variant: "primary" },
-                { key: "Esc", label: "Cancel" },
-              ]} />
+              <DialogControls
+                controls={[
+                  { key: "Enter", label: "Connect", variant: "primary" },
+                  { key: "Esc", label: "Cancel" },
+                ]}
+              />
             </box>
           </box>
         )}
@@ -536,9 +538,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               </text>
             </box>
             <box marginTop={1}>
-              <DialogControls controls={[
-                { key: "Esc", label: "Cancel" },
-              ]} />
+              <DialogControls controls={[{ key: "Esc", label: "Cancel" }]} />
             </box>
           </box>
         )}
@@ -565,12 +565,14 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               ))}
             </box>
             <box marginTop={1}>
-              <DialogControls controls={[
-                { key: "↑/↓", label: "Navigate" },
-                { key: "Enter", label: "Select", variant: "primary" },
-                { key: "D", label: "Disconnect", variant: "danger" },
-                { key: "Esc", label: "Cancel" },
-              ]} />
+              <DialogControls
+                controls={[
+                  { key: "↑/↓", label: "Navigate" },
+                  { key: "Enter", label: "Select", variant: "primary" },
+                  { key: "D", label: "Disconnect", variant: "danger" },
+                  { key: "Esc", label: "Cancel" },
+                ]}
+              />
             </box>
           </box>
         )}
@@ -600,9 +602,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               </text>
             </box>
             <box marginTop={1}>
-              <DialogControls controls={[
-                { key: "Esc", label: "Cancel" },
-              ]} />
+              <DialogControls controls={[{ key: "Esc", label: "Cancel" }]} />
             </box>
           </box>
         )}
@@ -666,11 +666,17 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               </text>
             </box>
             <box marginTop={1}>
-              <DialogControls controls={[
-                { key: "Enter", label: showBillingWarning ? "Open Billing" : "Done", variant: "primary" },
-                { key: "D", label: "Disconnect", variant: "danger" },
-                { key: "Esc", label: "Back" },
-              ]} />
+              <DialogControls
+                controls={[
+                  {
+                    key: "Enter",
+                    label: showBillingWarning ? "Open Billing" : "Done",
+                    variant: "primary",
+                  },
+                  { key: "D", label: "Disconnect", variant: "danger" },
+                  { key: "Esc", label: "Back" },
+                ]}
+              />
             </box>
           </box>
         )}
@@ -682,10 +688,12 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               <text fg={colors.error}>{error}</text>
             </box>
             <box marginTop={1}>
-              <DialogControls controls={[
-                { key: "Enter", label: "Try Again", variant: "primary" },
-                { key: "Esc", label: "Cancel" },
-              ]} />
+              <DialogControls
+                controls={[
+                  { key: "Enter", label: "Try Again", variant: "primary" },
+                  { key: "Esc", label: "Cancel" },
+                ]}
+              />
             </box>
           </box>
         )}

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -504,7 +504,6 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               <DialogControls
                 controls={[
                   { key: "Enter", label: "Connect", variant: "primary" },
-                  { key: "Esc", label: "Cancel" },
                 ]}
               />
             </box>
@@ -537,9 +536,6 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
                 {verificationUrl}
               </text>
             </box>
-            <box marginTop={1}>
-              <DialogControls controls={[{ key: "Esc", label: "Cancel" }]} />
-            </box>
           </box>
         )}
 
@@ -568,9 +564,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               <DialogControls
                 controls={[
                   { key: "Enter", label: "Select", variant: "primary" },
-                  { key: "↑/↓", label: "Navigate" },
                   { key: "D", label: "Disconnect", variant: "danger" },
-                  { key: "Esc", label: "Cancel" },
                 ]}
               />
             </box>
@@ -600,9 +594,6 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
                 If the browser didn't open, visit:{"\n"}
                 {consoleUrlRef.current}/create-workspace
               </text>
-            </box>
-            <box marginTop={1}>
-              <DialogControls controls={[{ key: "Esc", label: "Cancel" }]} />
             </box>
           </box>
         )}
@@ -674,7 +665,6 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
                     variant: "primary",
                   },
                   { key: "D", label: "Disconnect", variant: "danger" },
-                  { key: "Esc", label: "Back" },
                 ]}
               />
             </box>
@@ -691,7 +681,6 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
               <DialogControls
                 controls={[
                   { key: "Enter", label: "Try Again", variant: "primary" },
-                  { key: "Esc", label: "Cancel" },
                 ]}
               />
             </box>

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -567,8 +567,8 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
             <box marginTop={1}>
               <DialogControls
                 controls={[
-                  { key: "↑/↓", label: "Navigate" },
                   { key: "Enter", label: "Select", variant: "primary" },
+                  { key: "↑/↓", label: "Navigate" },
                   { key: "D", label: "Disconnect", variant: "danger" },
                   { key: "Esc", label: "Cancel" },
                 ]}

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -23,6 +23,7 @@ import { useTheme } from "../../theme";
 
 interface AuthFlowProps {
   onClose: () => void;
+  hideEsc?: boolean;
 }
 
 type AuthStep =
@@ -35,7 +36,7 @@ type AuthStep =
   | "success"
   | "error";
 
-export default function AuthFlow({ onClose }: AuthFlowProps) {
+export default function AuthFlow({ onClose, hideEsc }: AuthFlowProps) {
   const { colors } = useTheme();
   const appConfig = useConfig();
 
@@ -472,7 +473,7 @@ export default function AuthFlow({ onClose }: AuthFlowProps) {
   // ── Render ──────────────────────────────────────────────────────────
 
   return (
-    <Dialog size="large" onClose={goHome}>
+    <Dialog size="large" onClose={goHome} hideEsc={hideEsc}>
       <box
         flexDirection="column"
         width="100%"

--- a/src/tui/components/commands/credits-flow.tsx
+++ b/src/tui/components/commands/credits-flow.tsx
@@ -147,10 +147,12 @@ export default function CreditsFlow({
               </text>
             </box>
             <box marginTop={1}>
-              <DialogControls controls={[
-                { key: "Enter", label: "Run /auth", variant: "primary" },
-                { key: "Esc", label: "Back" },
-              ]} />
+              <DialogControls
+                controls={[
+                  { key: "Enter", label: "Run /auth", variant: "primary" },
+                  { key: "Esc", label: "Back" },
+                ]}
+              />
             </box>
           </box>
         )}
@@ -195,11 +197,17 @@ export default function CreditsFlow({
               <text fg={colors.textMuted}>Buy credits at: {creditsUrl}</text>
             </box>
             <box marginTop={1}>
-              <DialogControls controls={[
-                { key: "Enter", label: "Open in Browser", variant: "primary" },
-                { key: "R", label: "Refresh" },
-                { key: "Esc", label: "Back" },
-              ]} />
+              <DialogControls
+                controls={[
+                  {
+                    key: "Enter",
+                    label: "Open in Browser",
+                    variant: "primary",
+                  },
+                  { key: "R", label: "Refresh" },
+                  { key: "Esc", label: "Back" },
+                ]}
+              />
             </box>
           </box>
         )}
@@ -219,10 +227,16 @@ export default function CreditsFlow({
               </text>
             </box>
             <box marginTop={1}>
-              <DialogControls controls={[
-                { key: "Enter", label: "Refresh Balance", variant: "primary" },
-                { key: "Esc", label: "Back" },
-              ]} />
+              <DialogControls
+                controls={[
+                  {
+                    key: "Enter",
+                    label: "Refresh Balance",
+                    variant: "primary",
+                  },
+                  { key: "Esc", label: "Back" },
+                ]}
+              />
             </box>
           </box>
         )}

--- a/src/tui/components/commands/credits-flow.tsx
+++ b/src/tui/components/commands/credits-flow.tsx
@@ -4,6 +4,7 @@ import { useRoute } from "../../context/route";
 import { getPensarConsoleUrl } from "../../../core/api/constants";
 import { validateGateway } from "../../../core/auth";
 import { Dialog } from "../../context/dialog";
+import { DialogControls } from "../shared/dialog-controls";
 import { useTheme } from "../../theme";
 
 type CreditsStep = "loading" | "no-auth" | "display" | "browser-opened";
@@ -146,10 +147,10 @@ export default function CreditsFlow({
               </text>
             </box>
             <box marginTop={1}>
-              <text fg={colors.textMuted}>
-                <span fg={colors.primary}>[ENTER]</span> Run /auth ·{" "}
-                <span fg={colors.primary}>[ESC]</span> Back
-              </text>
+              <DialogControls controls={[
+                { key: "Enter", label: "Run /auth", variant: "primary" },
+                { key: "Esc", label: "Back" },
+              ]} />
             </box>
           </box>
         )}
@@ -194,11 +195,11 @@ export default function CreditsFlow({
               <text fg={colors.textMuted}>Buy credits at: {creditsUrl}</text>
             </box>
             <box marginTop={1}>
-              <text fg={colors.textMuted}>
-                <span fg={colors.primary}>[ENTER]</span> Open in browser ·{" "}
-                <span fg={colors.primary}>[R]</span> Refresh ·{" "}
-                <span fg={colors.primary}>[ESC]</span> Back
-              </text>
+              <DialogControls controls={[
+                { key: "Enter", label: "Open in Browser", variant: "primary" },
+                { key: "R", label: "Refresh" },
+                { key: "Esc", label: "Back" },
+              ]} />
             </box>
           </box>
         )}
@@ -218,10 +219,10 @@ export default function CreditsFlow({
               </text>
             </box>
             <box marginTop={1}>
-              <text fg={colors.textMuted}>
-                <span fg={colors.primary}>[ENTER]</span> Refresh balance ·{" "}
-                <span fg={colors.primary}>[ESC]</span> Back
-              </text>
+              <DialogControls controls={[
+                { key: "Enter", label: "Refresh Balance", variant: "primary" },
+                { key: "Esc", label: "Back" },
+              ]} />
             </box>
           </box>
         )}

--- a/src/tui/components/commands/credits-flow.tsx
+++ b/src/tui/components/commands/credits-flow.tsx
@@ -150,7 +150,6 @@ export default function CreditsFlow({
               <DialogControls
                 controls={[
                   { key: "Enter", label: "Run /auth", variant: "primary" },
-                  { key: "Esc", label: "Back" },
                 ]}
               />
             </box>
@@ -205,7 +204,6 @@ export default function CreditsFlow({
                     variant: "primary",
                   },
                   { key: "R", label: "Refresh" },
-                  { key: "Esc", label: "Back" },
                 ]}
               />
             </box>
@@ -234,7 +232,6 @@ export default function CreditsFlow({
                     label: "Refresh Balance",
                     variant: "primary",
                   },
-                  { key: "Esc", label: "Back" },
                 ]}
               />
             </box>

--- a/src/tui/components/commands/help-dialog.tsx
+++ b/src/tui/components/commands/help-dialog.tsx
@@ -172,9 +172,11 @@ export default function HelpDialog({ onClose }: HelpDialogProps) {
 
           {/* Footer hint */}
           <box marginTop={1}>
-            <DialogControls controls={[
-              { key: "Enter/Esc", label: "Back", variant: "primary" },
-            ]} />
+            <DialogControls
+              controls={[
+                { key: "Enter/Esc", label: "Back", variant: "primary" },
+              ]}
+            />
           </box>
         </box>
       </Dialog>
@@ -241,11 +243,13 @@ export default function HelpDialog({ onClose }: HelpDialogProps) {
         </scrollbox>
 
         {/* Footer */}
-        <DialogControls controls={[
-          { key: "↑/↓", label: "Navigate" },
-          { key: "Enter", label: "Details", variant: "primary" },
-          { key: "Esc", label: "Close" },
-        ]} />
+        <DialogControls
+          controls={[
+            { key: "↑/↓", label: "Navigate" },
+            { key: "Enter", label: "Details", variant: "primary" },
+            { key: "Esc", label: "Close" },
+          ]}
+        />
       </box>
     </Dialog>
   );

--- a/src/tui/components/commands/help-dialog.tsx
+++ b/src/tui/components/commands/help-dialog.tsx
@@ -16,6 +16,7 @@ import {
   categories,
 } from "../../command-registry";
 import { Dialog } from "../../context/dialog";
+import { DialogControls } from "../shared/dialog-controls";
 import { useTheme } from "../../theme";
 
 interface HelpDialogProps {
@@ -134,9 +135,8 @@ export default function HelpDialog({ onClose }: HelpDialogProps) {
       <Dialog size="large" onClose={onClose}>
         <box flexDirection="column" padding={2} gap={1} width="100%">
           {/* Header */}
-          <box flexDirection="row" justifyContent="space-between" width="100%">
+          <box width="100%">
             <text fg={colors.primary}>/{selectedCommand.name}</text>
-            <text fg={colors.textMuted}>esc to close</text>
           </box>
 
           {/* Description */}
@@ -172,7 +172,9 @@ export default function HelpDialog({ onClose }: HelpDialogProps) {
 
           {/* Footer hint */}
           <box marginTop={1}>
-            <text fg={colors.textMuted}>[enter/esc] back</text>
+            <DialogControls controls={[
+              { key: "Enter/Esc", label: "Back", variant: "primary" },
+            ]} />
           </box>
         </box>
       </Dialog>
@@ -184,9 +186,8 @@ export default function HelpDialog({ onClose }: HelpDialogProps) {
     <Dialog size="large" onClose={onClose}>
       <box flexDirection="column" padding={2} gap={1} width="100%">
         {/* Header */}
-        <box flexDirection="row" justifyContent="space-between" width="100%">
+        <box width="100%">
           <text fg={colors.text}>Commands</text>
-          <text fg={colors.textMuted}>esc to close</text>
         </box>
 
         {/* Commands list grouped by category */}
@@ -240,9 +241,11 @@ export default function HelpDialog({ onClose }: HelpDialogProps) {
         </scrollbox>
 
         {/* Footer */}
-        <text fg={colors.textMuted}>
-          [↑/↓] navigate [enter] details [esc] close
-        </text>
+        <DialogControls controls={[
+          { key: "↑/↓", label: "Navigate" },
+          { key: "Enter", label: "Details", variant: "primary" },
+          { key: "Esc", label: "Close" },
+        ]} />
       </box>
     </Dialog>
   );

--- a/src/tui/components/commands/help-dialog.tsx
+++ b/src/tui/components/commands/help-dialog.tsx
@@ -169,15 +169,6 @@ export default function HelpDialog({ onClose }: HelpDialogProps) {
               ))}
             </box>
           )}
-
-          {/* Footer hint */}
-          <box marginTop={1}>
-            <DialogControls
-              controls={[
-                { key: "Enter/Esc", label: "Back", variant: "primary" },
-              ]}
-            />
-          </box>
         </box>
       </Dialog>
     );
@@ -244,11 +235,7 @@ export default function HelpDialog({ onClose }: HelpDialogProps) {
 
         {/* Footer */}
         <DialogControls
-          controls={[
-            { key: "Enter", label: "Details", variant: "primary" },
-            { key: "↑/↓", label: "Navigate" },
-            { key: "Esc", label: "Close" },
-          ]}
+          controls={[{ key: "Enter", label: "Details", variant: "primary" }]}
         />
       </box>
     </Dialog>

--- a/src/tui/components/commands/help-dialog.tsx
+++ b/src/tui/components/commands/help-dialog.tsx
@@ -245,8 +245,8 @@ export default function HelpDialog({ onClose }: HelpDialogProps) {
         {/* Footer */}
         <DialogControls
           controls={[
-            { key: "↑/↓", label: "Navigate" },
             { key: "Enter", label: "Details", variant: "primary" },
+            { key: "↑/↓", label: "Navigate" },
             { key: "Esc", label: "Close" },
           ]}
         />

--- a/src/tui/components/commands/init-wizard.tsx
+++ b/src/tui/components/commands/init-wizard.tsx
@@ -321,7 +321,6 @@ export default function InitWizard() {
             controls={[
               { key: "Enter", label: "Start Immediately", variant: "primary" },
               { key: "Tab", label: "Configure Options" },
-              { key: "Esc", label: "Cancel" },
             ]}
           />
         </box>
@@ -544,7 +543,6 @@ export default function InitWizard() {
           controls={[
             { key: "Enter", label: "Start Pentest", variant: "primary" },
             { key: "Tab", label: "Navigate Fields" },
-            { key: "Esc", label: "Go Back" },
           ]}
         />
       </box>

--- a/src/tui/components/commands/init-wizard.tsx
+++ b/src/tui/components/commands/init-wizard.tsx
@@ -4,6 +4,7 @@ import Input from "../input";
 import { useRoute } from "../../context/route";
 import type { SessionConfig } from "../../../core/session";
 import { SpinnerDots } from "../sprites";
+import { DialogControls } from "../shared/dialog-controls";
 import { useTheme } from "../../theme";
 
 // Simplified wizard step types
@@ -315,25 +316,12 @@ export default function InitWizard() {
           focused={targetFocusedField === 0}
         />
 
-        <box flexDirection="column" gap={0} marginTop={1}>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={colors.textMuted}>Press </span>
-            <span fg={colors.text}>[Enter]</span>
-            <span fg={colors.textMuted}> to start immediately</span>
-          </text>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={colors.textMuted}>Press </span>
-            <span fg={colors.text}>[Tab]</span>
-            <span fg={colors.textMuted}> to configure options</span>
-          </text>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={colors.textMuted}>Press </span>
-            <span fg={colors.text}>[ESC]</span>
-            <span fg={colors.textMuted}> to cancel</span>
-          </text>
+        <box marginTop={1}>
+          <DialogControls controls={[
+            { key: "Enter", label: "Start Immediately", variant: "primary" },
+            { key: "Tab", label: "Configure Options" },
+            { key: "Esc", label: "Cancel" },
+          ]} />
         </box>
       </box>
     );
@@ -549,25 +537,12 @@ export default function InitWizard() {
         )}
       </box>
 
-      <box flexDirection="column" gap={0} marginTop={1}>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={colors.textMuted}>Press </span>
-          <span fg={colors.text}>[Enter]</span>
-          <span fg={colors.textMuted}> to start pentest</span>
-        </text>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={colors.textMuted}>Press </span>
-          <span fg={colors.text}>[Tab]</span>
-          <span fg={colors.textMuted}> to navigate fields</span>
-        </text>
-        <text>
-          <span fg={colors.primary}>█ </span>
-          <span fg={colors.textMuted}>Press </span>
-          <span fg={colors.text}>[ESC]</span>
-          <span fg={colors.textMuted}> to go back</span>
-        </text>
+      <box marginTop={1}>
+        <DialogControls controls={[
+          { key: "Enter", label: "Start Pentest", variant: "primary" },
+          { key: "Tab", label: "Navigate Fields" },
+          { key: "Esc", label: "Go Back" },
+        ]} />
       </box>
     </box>
   );

--- a/src/tui/components/commands/init-wizard.tsx
+++ b/src/tui/components/commands/init-wizard.tsx
@@ -317,11 +317,13 @@ export default function InitWizard() {
         />
 
         <box marginTop={1}>
-          <DialogControls controls={[
-            { key: "Enter", label: "Start Immediately", variant: "primary" },
-            { key: "Tab", label: "Configure Options" },
-            { key: "Esc", label: "Cancel" },
-          ]} />
+          <DialogControls
+            controls={[
+              { key: "Enter", label: "Start Immediately", variant: "primary" },
+              { key: "Tab", label: "Configure Options" },
+              { key: "Esc", label: "Cancel" },
+            ]}
+          />
         </box>
       </box>
     );
@@ -538,11 +540,13 @@ export default function InitWizard() {
       </box>
 
       <box marginTop={1}>
-        <DialogControls controls={[
-          { key: "Enter", label: "Start Pentest", variant: "primary" },
-          { key: "Tab", label: "Navigate Fields" },
-          { key: "Esc", label: "Go Back" },
-        ]} />
+        <DialogControls
+          controls={[
+            { key: "Enter", label: "Start Pentest", variant: "primary" },
+            { key: "Tab", label: "Navigate Fields" },
+            { key: "Esc", label: "Go Back" },
+          ]}
+        />
       </box>
     </box>
   );

--- a/src/tui/components/commands/models-display.tsx
+++ b/src/tui/components/commands/models-display.tsx
@@ -5,6 +5,7 @@ import { useRoute } from "../../context/route";
 import { useConfig } from "../../context/config";
 import { ModelPicker } from "../model-picker";
 import { useTheme } from "../../theme";
+import { DialogControls } from "../shared/dialog-controls";
 
 function ClippedLine({
   children,
@@ -96,31 +97,12 @@ export default function ModelsDisplay() {
       </box>
 
       {/* Footer */}
-      <box flexDirection="column" marginTop={2} flexShrink={0}>
-        <ClippedLine>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={colors.textMuted}>Press </span>
-            <span fg={colors.text}>[Enter]</span>
-            <span fg={colors.textMuted}> to confirm</span>
-          </text>
-        </ClippedLine>
-        <ClippedLine>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={colors.textMuted}>Press </span>
-            <span fg={colors.text}>[ESC]</span>
-            <span fg={colors.textMuted}> to go back</span>
-          </text>
-        </ClippedLine>
-        <ClippedLine>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={colors.textMuted}>Press </span>
-            <span fg={colors.text}>[Ctrl+P]</span>
-            <span fg={colors.textMuted}> to connect provider</span>
-          </text>
-        </ClippedLine>
+      <box marginTop={1}>
+        <DialogControls controls={[
+          { key: "Enter", label: "Confirm", variant: "primary" },
+          { key: "Ctrl+P", label: "Connect Provider" },
+          { key: "Esc", label: "Go Back" },
+        ]} />
       </box>
     </box>
   );

--- a/src/tui/components/commands/models-display.tsx
+++ b/src/tui/components/commands/models-display.tsx
@@ -98,11 +98,13 @@ export default function ModelsDisplay() {
 
       {/* Footer */}
       <box marginTop={1}>
-        <DialogControls controls={[
-          { key: "Enter", label: "Confirm", variant: "primary" },
-          { key: "Ctrl+P", label: "Connect Provider" },
-          { key: "Esc", label: "Go Back" },
-        ]} />
+        <DialogControls
+          controls={[
+            { key: "Enter", label: "Confirm", variant: "primary" },
+            { key: "Ctrl+P", label: "Connect Provider" },
+            { key: "Esc", label: "Go Back" },
+          ]}
+        />
       </box>
     </box>
   );

--- a/src/tui/components/commands/operator-wizard.tsx
+++ b/src/tui/components/commands/operator-wizard.tsx
@@ -317,9 +317,9 @@ export default function HITLWizard(props: HITLWizardProps) {
       <box flexDirection="column" gap={0} marginTop={2}>
         <DialogControls
           controls={[
+            { key: "Enter", label: "Select", variant: "primary" },
             { key: "↑/↓", label: "Navigate" },
             { key: "←/→", label: "Change Value" },
-            { key: "Enter", label: "Select", variant: "primary" },
             { key: "Esc", label: "Back" },
           ]}
         />

--- a/src/tui/components/commands/operator-wizard.tsx
+++ b/src/tui/components/commands/operator-wizard.tsx
@@ -315,12 +315,14 @@ export default function HITLWizard(props: HITLWizardProps) {
 
       {/* Help text */}
       <box flexDirection="column" gap={0} marginTop={2}>
-        <DialogControls controls={[
-          { key: "↑/↓", label: "Navigate" },
-          { key: "←/→", label: "Change Value" },
-          { key: "Enter", label: "Select", variant: "primary" },
-          { key: "Esc", label: "Back" },
-        ]} />
+        <DialogControls
+          controls={[
+            { key: "↑/↓", label: "Navigate" },
+            { key: "←/→", label: "Change Value" },
+            { key: "Enter", label: "Select", variant: "primary" },
+            { key: "Esc", label: "Back" },
+          ]}
+        />
       </box>
     </box>
   );

--- a/src/tui/components/commands/operator-wizard.tsx
+++ b/src/tui/components/commands/operator-wizard.tsx
@@ -316,12 +316,7 @@ export default function HITLWizard(props: HITLWizardProps) {
       {/* Help text */}
       <box flexDirection="column" gap={0} marginTop={2}>
         <DialogControls
-          controls={[
-            { key: "Enter", label: "Select", variant: "primary" },
-            { key: "↑/↓", label: "Navigate" },
-            { key: "←/→", label: "Change Value" },
-            { key: "Esc", label: "Back" },
-          ]}
+          controls={[{ key: "Enter", label: "Select", variant: "primary" }]}
         />
       </box>
     </box>

--- a/src/tui/components/commands/operator-wizard.tsx
+++ b/src/tui/components/commands/operator-wizard.tsx
@@ -7,6 +7,7 @@ import { SpinnerDots } from "../sprites";
 import type { ModelInfo } from "../../../core/ai";
 import { getAvailableModels } from "../../../core/providers/utils";
 import { useTheme } from "../../theme";
+import { DialogControls } from "../shared/dialog-controls";
 
 type WizardStep = "config" | "creating";
 
@@ -314,9 +315,12 @@ export default function HITLWizard(props: HITLWizardProps) {
 
       {/* Help text */}
       <box flexDirection="column" gap={0} marginTop={2}>
-        <text fg={colors.textMuted}>
-          ↑/↓ navigate | ←/→ change value | Enter select | ESC back
-        </text>
+        <DialogControls controls={[
+          { key: "↑/↓", label: "Navigate" },
+          { key: "←/→", label: "Change Value" },
+          { key: "Enter", label: "Select", variant: "primary" },
+          { key: "Esc", label: "Back" },
+        ]} />
       </box>
     </box>
   );

--- a/src/tui/components/commands/provider-manager.tsx
+++ b/src/tui/components/commands/provider-manager.tsx
@@ -13,6 +13,7 @@ import APIKeyInput from "./api-key-input";
 import AuthFlow from "./auth-flow";
 import { useTheme } from "../../theme";
 import { Dialog } from "../../context/dialog";
+import { DialogControls } from "../shared/dialog-controls";
 
 type FlowState = "choosing" | "selecting" | "inputting" | "auth";
 
@@ -136,7 +137,9 @@ export default function ProviderManager({
             onCancel={handleAPIKeyCancel}
           />
         )}
-      {flowState === "auth" && <AuthFlow onClose={handleAuthClose} />}
+      {flowState === "auth" && (
+        <AuthFlow onClose={handleAuthClose} hideEsc={isOnboarding} />
+      )}
     </>
   );
 }
@@ -184,7 +187,7 @@ function OnboardingChoice({
   });
 
   return (
-    <Dialog size="large" onClose={() => {}}>
+    <Dialog size="large" onClose={() => {}} hideEsc>
       <box flexDirection="column" padding={1} width="100%">
         {/* Header */}
         <box>
@@ -227,7 +230,12 @@ function OnboardingChoice({
 
         {/* Footer */}
         <box marginTop={1}>
-          <text fg={colors.textMuted}>[↑↓] browse [enter] select</text>
+          <DialogControls
+            controls={[
+              { key: "Enter", label: "Select", variant: "primary" },
+              { key: "↑/↓", label: "Browse" },
+            ]}
+          />
         </box>
       </box>
     </Dialog>

--- a/src/tui/components/commands/provider-selection.tsx
+++ b/src/tui/components/commands/provider-selection.tsx
@@ -121,8 +121,8 @@ export default function ProviderSelection({
         {/* Footer */}
         <DialogControls
           controls={[
-            { key: "↑/↓", label: "Browse" },
             { key: "Enter", label: "Select", variant: "primary" },
+            { key: "↑/↓", label: "Browse" },
             { key: "Esc", label: "Close" },
           ]}
         />

--- a/src/tui/components/commands/provider-selection.tsx
+++ b/src/tui/components/commands/provider-selection.tsx
@@ -119,11 +119,13 @@ export default function ProviderSelection({
         </scrollbox>
 
         {/* Footer */}
-        <DialogControls controls={[
-          { key: "↑/↓", label: "Browse" },
-          { key: "Enter", label: "Select", variant: "primary" },
-          { key: "Esc", label: "Close" },
-        ]} />
+        <DialogControls
+          controls={[
+            { key: "↑/↓", label: "Browse" },
+            { key: "Enter", label: "Select", variant: "primary" },
+            { key: "Esc", label: "Close" },
+          ]}
+        />
       </box>
     </Dialog>
   );

--- a/src/tui/components/commands/provider-selection.tsx
+++ b/src/tui/components/commands/provider-selection.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../../core/providers";
 import { useTheme } from "../../theme";
 import { Dialog } from "../../context/dialog";
+import { DialogControls } from "../shared/dialog-controls";
 
 interface ProviderSelectionProps {
   providers?: Provider[];
@@ -65,10 +66,7 @@ export default function ProviderSelection({
     <Dialog size="large" onClose={onClose}>
       <box flexDirection="column" padding={1} width="100%">
         {/* Header */}
-        <box flexDirection="row" justifyContent="space-between" width="100%">
-          <text fg={colors.primary}>Select provider</text>
-          <text fg={colors.textMuted}>esc to close</text>
-        </box>
+        <text fg={colors.primary}>Select provider</text>
 
         {/* Provider List */}
         <scrollbox
@@ -121,11 +119,11 @@ export default function ProviderSelection({
         </scrollbox>
 
         {/* Footer */}
-        <box marginTop={1}>
-          <text fg={colors.textMuted}>
-            [↑↓] browse [enter] select [esc] close
-          </text>
-        </box>
+        <DialogControls controls={[
+          { key: "↑/↓", label: "Browse" },
+          { key: "Enter", label: "Select", variant: "primary" },
+          { key: "Esc", label: "Close" },
+        ]} />
       </box>
     </Dialog>
   );

--- a/src/tui/components/commands/provider-selection.tsx
+++ b/src/tui/components/commands/provider-selection.tsx
@@ -120,11 +120,7 @@ export default function ProviderSelection({
 
         {/* Footer */}
         <DialogControls
-          controls={[
-            { key: "Enter", label: "Select", variant: "primary" },
-            { key: "↑/↓", label: "Browse" },
-            { key: "Esc", label: "Close" },
-          ]}
+          controls={[{ key: "Enter", label: "Select", variant: "primary" }]}
         />
       </box>
     </Dialog>

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -343,11 +343,9 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
           <DialogControls
             controls={[
               { key: "Enter", label: "Open", variant: "primary" },
-              { key: "↑/↓", label: "Navigate" },
               { key: "O", label: "Operator" },
               { key: "R", label: "Report" },
               { key: "Ctrl+D", label: "Delete", variant: "danger" },
-              { key: "Esc", label: "Close" },
             ]}
           />
         )}

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -342,8 +342,8 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
         {visualOrderSessions.length > 0 && (
           <DialogControls
             controls={[
-              { key: "↑/↓", label: "Navigate" },
               { key: "Enter", label: "Open", variant: "primary" },
+              { key: "↑/↓", label: "Navigate" },
               { key: "O", label: "Operator" },
               { key: "R", label: "Report" },
               { key: "Ctrl+D", label: "Delete", variant: "danger" },

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -12,6 +12,7 @@ import { scrollToIndex } from "../../utils/scroll";
 import { useTheme } from "../../theme";
 import { useSessionsList } from "../../hooks/use-sessions-list";
 import { useToast } from "../../context/toast";
+import { DialogControls } from "../shared/dialog-controls";
 
 interface SessionsDisplayProps {
   onClose: () => void;
@@ -204,9 +205,8 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
     <Dialog size="large" onClose={handleClose}>
       <box flexDirection="column" padding={2} gap={2} width="100%">
         {/* Header */}
-        <box flexDirection="row" justifyContent="space-between" width="100%">
+        <box flexDirection="row" width="100%">
           <text fg={colors.text}>Sessions</text>
-          <text fg={colors.textMuted}>esc to close</text>
         </box>
 
         {/* Search Input */}
@@ -340,14 +340,14 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
 
         {/* Actions Footer */}
         {visualOrderSessions.length > 0 && (
-          <box flexDirection="row" gap={2}>
-            <text fg={colors.textMuted}>
-              <span fg={colors.primary}>[Enter]</span> Open ·{" "}
-              <span fg={colors.primary}>[O]</span> Operator ·{" "}
-              <span fg={colors.primary}>[R]</span> Report ·{" "}
-              <span fg={colors.primary}>[Ctrl+D]</span> Delete
-            </text>
-          </box>
+          <DialogControls controls={[
+            { key: "↑/↓", label: "Navigate" },
+            { key: "Enter", label: "Open", variant: "primary" },
+            { key: "O", label: "Operator" },
+            { key: "R", label: "Report" },
+            { key: "Ctrl+D", label: "Delete", variant: "danger" },
+            { key: "Esc", label: "Close" },
+          ]} />
         )}
       </box>
     </Dialog>

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -340,14 +340,16 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
 
         {/* Actions Footer */}
         {visualOrderSessions.length > 0 && (
-          <DialogControls controls={[
-            { key: "↑/↓", label: "Navigate" },
-            { key: "Enter", label: "Open", variant: "primary" },
-            { key: "O", label: "Operator" },
-            { key: "R", label: "Report" },
-            { key: "Ctrl+D", label: "Delete", variant: "danger" },
-            { key: "Esc", label: "Close" },
-          ]} />
+          <DialogControls
+            controls={[
+              { key: "↑/↓", label: "Navigate" },
+              { key: "Enter", label: "Open", variant: "primary" },
+              { key: "O", label: "Operator" },
+              { key: "R", label: "Report" },
+              { key: "Ctrl+D", label: "Delete", variant: "danger" },
+              { key: "Esc", label: "Close" },
+            ]}
+          />
         )}
       </box>
     </Dialog>

--- a/src/tui/components/commands/shortcuts-dialog.tsx
+++ b/src/tui/components/commands/shortcuts-dialog.tsx
@@ -3,6 +3,7 @@ import { useFocus } from "../../context/focus";
 import { Dialog } from "../../context/dialog";
 import { keybindings } from "../../keybindings-registry";
 import { useTheme } from "../../theme";
+import { DialogControls } from "../shared/dialog-controls";
 
 interface ShortcutsDialogProps {
   open: boolean;
@@ -35,9 +36,8 @@ export default function ShortcutsDialog({
     <Dialog size="large" onClose={handleClose}>
       <box flexDirection="column" padding={2} gap={2} width="100%">
         {/* Header */}
-        <box flexDirection="row" justifyContent="space-between" width="100%">
+        <box width="100%">
           <text fg={colors.text}>Keyboard Shortcuts</text>
-          <text fg={colors.textMuted}>esc to close</text>
         </box>
 
         {/* Shortcuts List */}
@@ -51,6 +51,7 @@ export default function ShortcutsDialog({
             </box>
           ))}
         </box>
+        <DialogControls controls={[{ key: "Esc", label: "Close" }]} />
       </box>
     </Dialog>
   );

--- a/src/tui/components/commands/shortcuts-dialog.tsx
+++ b/src/tui/components/commands/shortcuts-dialog.tsx
@@ -3,7 +3,6 @@ import { useFocus } from "../../context/focus";
 import { Dialog } from "../../context/dialog";
 import { keybindings } from "../../keybindings-registry";
 import { useTheme } from "../../theme";
-import { DialogControls } from "../shared/dialog-controls";
 
 interface ShortcutsDialogProps {
   open: boolean;
@@ -51,7 +50,6 @@ export default function ShortcutsDialog({
             </box>
           ))}
         </box>
-        <DialogControls controls={[{ key: "Esc", label: "Close" }]} />
       </box>
     </Dialog>
   );

--- a/src/tui/components/commands/skills-dialog.tsx
+++ b/src/tui/components/commands/skills-dialog.tsx
@@ -349,9 +349,7 @@ export default function SkillsDialog({
         {/* Footer */}
         <box width="100%" flexDirection="row">
           <DialogControls
-            controls={[
-              { key: "Enter", label: "Details", variant: "primary" },
-            ]}
+            controls={[{ key: "Enter", label: "Details", variant: "primary" }]}
           />
         </box>
       </box>

--- a/src/tui/components/commands/skills-dialog.tsx
+++ b/src/tui/components/commands/skills-dialog.tsx
@@ -13,6 +13,7 @@ import { useDimensions } from "../../context/dimensions";
 import { useTheme } from "../../theme";
 import { Dialog } from "../../context/dialog";
 import type { SkillEntry, SkillSource } from "../../../core/skills/types";
+import { DialogControls } from "../shared/dialog-controls";
 
 /** Rough token estimate: ~4 chars per token */
 function estimateTokens(text: string): number {
@@ -251,11 +252,6 @@ export default function SkillsDialog({
           <box width="100%" height={1}>
             <text fg={colors.border}>{"─".repeat(panelWidth - 2)}</text>
           </box>
-
-          {/* Footer */}
-          <box width="100%" flexDirection="row">
-            <text fg={colors.textMuted}>[↑↓] scroll [esc] back</text>
-          </box>
         </box>
       </Dialog>
     );
@@ -352,9 +348,9 @@ export default function SkillsDialog({
 
         {/* Footer */}
         <box width="100%" flexDirection="row">
-          <text fg={colors.textMuted}>
-            [↑↓] browse [enter] details [esc] close
-          </text>
+          <DialogControls controls={[
+            { key: "Enter", label: "Details", variant: "primary" },
+          ]} />
         </box>
       </box>
     </Dialog>

--- a/src/tui/components/commands/skills-dialog.tsx
+++ b/src/tui/components/commands/skills-dialog.tsx
@@ -348,9 +348,11 @@ export default function SkillsDialog({
 
         {/* Footer */}
         <box width="100%" flexDirection="row">
-          <DialogControls controls={[
-            { key: "Enter", label: "Details", variant: "primary" },
-          ]} />
+          <DialogControls
+            controls={[
+              { key: "Enter", label: "Details", variant: "primary" },
+            ]}
+          />
         </box>
       </box>
     </Dialog>

--- a/src/tui/components/commands/theme-picker.tsx
+++ b/src/tui/components/commands/theme-picker.tsx
@@ -156,12 +156,14 @@ export default function ThemePicker({ onClose }: ThemePickerProps) {
 
         {/* Footer */}
         <box width="100%" flexDirection="row">
-          <DialogControls controls={[
-            { key: "↑/↓", label: "Browse" },
-            { key: "Enter", label: "Select", variant: "primary" },
-            { key: "M", label: "Toggle Mode" },
-            { key: "Esc", label: "Cancel" },
-          ]} />
+          <DialogControls
+            controls={[
+              { key: "↑/↓", label: "Browse" },
+              { key: "Enter", label: "Select", variant: "primary" },
+              { key: "M", label: "Toggle Mode" },
+              { key: "Esc", label: "Cancel" },
+            ]}
+          />
         </box>
       </box>
     </Dialog>

--- a/src/tui/components/commands/theme-picker.tsx
+++ b/src/tui/components/commands/theme-picker.tsx
@@ -158,8 +158,8 @@ export default function ThemePicker({ onClose }: ThemePickerProps) {
         <box width="100%" flexDirection="row">
           <DialogControls
             controls={[
-              { key: "↑/↓", label: "Browse" },
               { key: "Enter", label: "Select", variant: "primary" },
+              { key: "↑/↓", label: "Browse" },
               { key: "M", label: "Toggle Mode" },
               { key: "Esc", label: "Cancel" },
             ]}

--- a/src/tui/components/commands/theme-picker.tsx
+++ b/src/tui/components/commands/theme-picker.tsx
@@ -159,9 +159,7 @@ export default function ThemePicker({ onClose }: ThemePickerProps) {
           <DialogControls
             controls={[
               { key: "Enter", label: "Select", variant: "primary" },
-              { key: "↑/↓", label: "Browse" },
               { key: "M", label: "Toggle Mode" },
-              { key: "Esc", label: "Cancel" },
             ]}
           />
         </box>

--- a/src/tui/components/commands/theme-picker.tsx
+++ b/src/tui/components/commands/theme-picker.tsx
@@ -12,6 +12,7 @@ import { useDimensions } from "../../context/dimensions";
 import { useTheme } from "../../theme";
 import { config } from "../../../core/config";
 import { Dialog } from "../../context/dialog";
+import { DialogControls } from "../shared/dialog-controls";
 
 interface ThemePickerProps {
   onClose: () => void;
@@ -155,9 +156,12 @@ export default function ThemePicker({ onClose }: ThemePickerProps) {
 
         {/* Footer */}
         <box width="100%" flexDirection="row">
-          <text fg={colors.textMuted}>
-            [↑↓] browse [enter] select [m] toggle mode [esc] cancel
-          </text>
+          <DialogControls controls={[
+            { key: "↑/↓", label: "Browse" },
+            { key: "Enter", label: "Select", variant: "primary" },
+            { key: "M", label: "Toggle Mode" },
+            { key: "Esc", label: "Cancel" },
+          ]} />
         </box>
       </box>
     </Dialog>

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -692,11 +692,17 @@ export default function WebWizard({
           </box>
 
           <box marginTop={1}>
-            <DialogControls controls={[
-              { key: "Enter", label: "Start Immediately", variant: "primary" },
-              { key: "Tab", label: "Configure Options" },
-              { key: "Esc", label: "Cancel" },
-            ]} />
+            <DialogControls
+              controls={[
+                {
+                  key: "Enter",
+                  label: "Start Immediately",
+                  variant: "primary",
+                },
+                { key: "Tab", label: "Configure Options" },
+                { key: "Esc", label: "Cancel" },
+              ]}
+            />
           </box>
         </box>
       </Dialog>
@@ -1057,11 +1063,17 @@ export default function WebWizard({
         </box>
 
         <box marginTop={1}>
-          <DialogControls controls={[
-            { key: "Enter", label: `Start Pentest (${modeLabel})`, variant: "primary" },
-            { key: "Tab", label: "Navigate Fields" },
-            { key: "Esc", label: "Go Back" },
-          ]} />
+          <DialogControls
+            controls={[
+              {
+                key: "Enter",
+                label: `Start Pentest (${modeLabel})`,
+                variant: "primary",
+              },
+              { key: "Tab", label: "Navigate Fields" },
+              { key: "Esc", label: "Go Back" },
+            ]}
+          />
         </box>
       </box>
     </Dialog>

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -9,6 +9,7 @@ import { type ModelInfo } from "../../../core/ai";
 import { getAvailableModels } from "../../../core/providers/utils";
 import { useTheme } from "../../theme";
 import { Dialog } from "../../context/dialog";
+import { DialogControls } from "../shared/dialog-controls";
 
 // Wizard step types
 type WizardStep = "target" | "configure" | "creating";
@@ -690,25 +691,12 @@ export default function WebWizard({
             )}
           </box>
 
-          <box flexDirection="column" gap={0} marginTop={1}>
-            <text>
-              <span fg={colors.primary}>█ </span>
-              <span fg={colors.textMuted}>Press </span>
-              <span fg={colors.text}>[Enter]</span>
-              <span fg={colors.textMuted}> to start immediately</span>
-            </text>
-            <text>
-              <span fg={colors.primary}>█ </span>
-              <span fg={colors.textMuted}>Press </span>
-              <span fg={colors.text}>[Tab]</span>
-              <span fg={colors.textMuted}> to configure options</span>
-            </text>
-            <text>
-              <span fg={colors.primary}>█ </span>
-              <span fg={colors.textMuted}>Press </span>
-              <span fg={colors.text}>[ESC]</span>
-              <span fg={colors.textMuted}> to cancel</span>
-            </text>
+          <box marginTop={1}>
+            <DialogControls controls={[
+              { key: "Enter", label: "Start Immediately", variant: "primary" },
+              { key: "Tab", label: "Configure Options" },
+              { key: "Esc", label: "Cancel" },
+            ]} />
           </box>
         </box>
       </Dialog>
@@ -1068,25 +1056,12 @@ export default function WebWizard({
           )}
         </box>
 
-        <box flexDirection="column" gap={0} marginTop={1}>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={colors.textMuted}>Press </span>
-            <span fg={colors.text}>[Enter]</span>
-            <span fg={colors.textMuted}> to start pentest ({modeLabel})</span>
-          </text>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={colors.textMuted}>Press </span>
-            <span fg={colors.text}>[Tab]</span>
-            <span fg={colors.textMuted}> to navigate fields</span>
-          </text>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={colors.textMuted}>Press </span>
-            <span fg={colors.text}>[ESC]</span>
-            <span fg={colors.textMuted}> to go back</span>
-          </text>
+        <box marginTop={1}>
+          <DialogControls controls={[
+            { key: "Enter", label: `Start Pentest (${modeLabel})`, variant: "primary" },
+            { key: "Tab", label: "Navigate Fields" },
+            { key: "Esc", label: "Go Back" },
+          ]} />
         </box>
       </box>
     </Dialog>

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -700,7 +700,6 @@ export default function WebWizard({
                   variant: "primary",
                 },
                 { key: "Tab", label: "Configure Options" },
-                { key: "Esc", label: "Cancel" },
               ]}
             />
           </box>
@@ -1071,7 +1070,6 @@ export default function WebWizard({
                 variant: "primary",
               },
               { key: "Tab", label: "Navigate Fields" },
-              { key: "Esc", label: "Go Back" },
             ]}
           />
         </box>

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -663,16 +663,16 @@ export function ModelPicker({
         })}
       </scrollbox>
 
-      {/* Help text */}
-      <box flexShrink={0}>
-        <PickerRow>
-          <text fg={colors.textMuted}>
-            {editingLocalField
-              ? "Type or paste | Enter/Esc to confirm"
-              : "↑/↓ navigate | ←/→ collapse/expand | Type to search"}
-          </text>
-        </PickerRow>
-      </box>
+      {/* Help text for inline editing only — general controls are in ModelPickerDialog */}
+      {editingLocalField && (
+        <box flexShrink={0}>
+          <PickerRow>
+            <text fg={colors.textMuted}>
+              Type or paste | Enter/Esc to confirm
+            </text>
+          </PickerRow>
+        </box>
+      )}
     </box>
   );
 }

--- a/src/tui/components/model-picker/ModelPickerDialog.tsx
+++ b/src/tui/components/model-picker/ModelPickerDialog.tsx
@@ -53,9 +53,11 @@ export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
           />
         </box>
         <box marginTop={1} paddingLeft={1} flexShrink={0}>
-          <DialogControls controls={[
-            { key: "Enter", label: "Confirm", variant: "primary" },
-          ]} />
+          <DialogControls
+            controls={[
+              { key: "Enter", label: "Confirm", variant: "primary" },
+            ]}
+          />
         </box>
       </box>
     </Dialog>

--- a/src/tui/components/model-picker/ModelPickerDialog.tsx
+++ b/src/tui/components/model-picker/ModelPickerDialog.tsx
@@ -55,6 +55,8 @@ export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
         <box marginTop={1} paddingLeft={1} flexShrink={0}>
           <DialogControls
             controls={[
+              { key: "↑/↓", label: "Navigate" },
+              { key: "←/→", label: "Collapse/Expand" },
               { key: "Enter", label: "Confirm", variant: "primary" },
             ]}
           />

--- a/src/tui/components/model-picker/ModelPickerDialog.tsx
+++ b/src/tui/components/model-picker/ModelPickerDialog.tsx
@@ -54,11 +54,7 @@ export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
         </box>
         <box marginTop={1} paddingLeft={1} flexShrink={0}>
           <DialogControls
-            controls={[
-              { key: "Enter", label: "Confirm", variant: "primary" },
-              { key: "↑/↓", label: "Navigate" },
-              { key: "←/→", label: "Collapse/Expand" },
-            ]}
+            controls={[{ key: "Enter", label: "Confirm", variant: "primary" }]}
           />
         </box>
       </box>

--- a/src/tui/components/model-picker/ModelPickerDialog.tsx
+++ b/src/tui/components/model-picker/ModelPickerDialog.tsx
@@ -9,6 +9,7 @@ import { useAgent } from "../../context/agent";
 import { useConfig } from "../../context/config";
 import { useTheme } from "../../theme";
 import { Dialog } from "../../context/dialog";
+import { DialogControls } from "../shared/dialog-controls";
 import { ModelPicker } from "./ModelPicker";
 
 interface ModelPickerDialogProps {
@@ -37,7 +38,6 @@ export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
           flexDirection="column"
           paddingLeft={1}
           marginTop={1}
-          flexGrow={1}
           flexShrink={1}
           overflow="hidden"
         >
@@ -53,7 +53,9 @@ export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
           />
         </box>
         <box marginTop={1} paddingLeft={1} flexShrink={0}>
-          <text fg={colors.textMuted}>[Enter] confirm • [ESC] close</text>
+          <DialogControls controls={[
+            { key: "Enter", label: "Confirm", variant: "primary" },
+          ]} />
         </box>
       </box>
     </Dialog>

--- a/src/tui/components/model-picker/ModelPickerDialog.tsx
+++ b/src/tui/components/model-picker/ModelPickerDialog.tsx
@@ -55,9 +55,9 @@ export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
         <box marginTop={1} paddingLeft={1} flexShrink={0}>
           <DialogControls
             controls={[
+              { key: "Enter", label: "Confirm", variant: "primary" },
               { key: "↑/↓", label: "Navigate" },
               { key: "←/→", label: "Collapse/Expand" },
-              { key: "Enter", label: "Confirm", variant: "primary" },
             ]}
           />
         </box>

--- a/src/tui/components/report-viewer-dialog.tsx
+++ b/src/tui/components/report-viewer-dialog.tsx
@@ -172,11 +172,21 @@ export default function ReportViewerDialog({
           flexDirection="row"
           justifyContent="space-between"
         >
-          <DialogControls controls={[
-            { key: "↑/↓", label: "Scroll" },
-            ...(onOpenExternal ? [{ key: "E", label: "Open in Editor", variant: "primary" as const }] : []),
-            { key: "Esc", label: "Close" },
-          ]} />
+          <DialogControls
+            controls={[
+              { key: "↑/↓", label: "Scroll" },
+              ...(onOpenExternal
+                ? [
+                    {
+                      key: "E",
+                      label: "Open in Editor",
+                      variant: "primary" as const,
+                    },
+                  ]
+                : []),
+              { key: "Esc", label: "Close" },
+            ]}
+          />
           <text fg={colors.textMuted}>{lineCount} lines</text>
         </box>
       </box>

--- a/src/tui/components/report-viewer-dialog.tsx
+++ b/src/tui/components/report-viewer-dialog.tsx
@@ -183,8 +183,6 @@ export default function ReportViewerDialog({
                     },
                   ]
                 : []),
-              { key: "↑/↓", label: "Scroll" },
-              { key: "Esc", label: "Close" },
             ]}
           />
           <text fg={colors.textMuted}>{lineCount} lines</text>

--- a/src/tui/components/report-viewer-dialog.tsx
+++ b/src/tui/components/report-viewer-dialog.tsx
@@ -9,6 +9,7 @@ import {
 } from "@opentui/core";
 import type { Token } from "marked";
 import { useTheme } from "../theme";
+import { DialogControls } from "./shared/dialog-controls";
 
 interface ReportViewerDialogProps {
   content: string;
@@ -171,16 +172,11 @@ export default function ReportViewerDialog({
           flexDirection="row"
           justifyContent="space-between"
         >
-          <text fg={colors.textMuted}>
-            <span fg={colors.primary}>[↑/↓]</span> Scroll{" "}
-            {onOpenExternal && (
-              <>
-                <span fg={colors.primary}>[E]</span>
-                {" Open in Editor "}
-              </>
-            )}
-            <span fg={colors.primary}>[Esc]</span> Close
-          </text>
+          <DialogControls controls={[
+            { key: "↑/↓", label: "Scroll" },
+            ...(onOpenExternal ? [{ key: "E", label: "Open in Editor", variant: "primary" as const }] : []),
+            { key: "Esc", label: "Close" },
+          ]} />
           <text fg={colors.textMuted}>{lineCount} lines</text>
         </box>
       </box>

--- a/src/tui/components/report-viewer-dialog.tsx
+++ b/src/tui/components/report-viewer-dialog.tsx
@@ -174,7 +174,6 @@ export default function ReportViewerDialog({
         >
           <DialogControls
             controls={[
-              { key: "↑/↓", label: "Scroll" },
               ...(onOpenExternal
                 ? [
                     {
@@ -184,6 +183,7 @@ export default function ReportViewerDialog({
                     },
                   ]
                 : []),
+              { key: "↑/↓", label: "Scroll" },
               { key: "Esc", label: "Close" },
             ]}
           />

--- a/src/tui/components/shared/dialog-controls.tsx
+++ b/src/tui/components/shared/dialog-controls.tsx
@@ -1,0 +1,76 @@
+/**
+ * DialogControls — Shared footer control hints for dialogs and views.
+ *
+ * Renders a horizontal row of keyboard shortcut hints separated by ` · `.
+ * Supports three visual tiers via the `variant` prop on each control item:
+ *
+ * - `"default"` (implicit) — `colors.textMuted` key color. Use for secondary
+ *   and navigation actions (↑/↓, Esc, Tab, etc.).
+ * - `"primary"` — `colors.primary` key color. Use for the main CTA — typically
+ *   one per dialog (Enter to confirm/submit).
+ * - `"danger"` — `colors.error` key color. Use for irreversible actions
+ *   (Delete, Disconnect).
+ *
+ * Labels are always `colors.textMuted` regardless of variant.
+ *
+ * ## Capitalization conventions
+ *
+ * - Named keys: Title Case — `Enter`, `Esc`, `Tab`, `Space`
+ * - Single letter keys: Uppercase — `D`, `R`, `M`, `O`, `E`
+ * - Arrows: `↑/↓`, `←/→`
+ * - Combos: `Ctrl+D`, `Ctrl+P`
+ * - Labels: Title Case — `Open in Editor`, `Go Back`
+ *
+ * ## Ordering convention (enforced by caller)
+ *
+ * 1. Navigation (↑/↓, Tab)
+ * 2. Primary action (Enter)
+ * 3. Secondary actions (letter keys)
+ * 4. Danger actions (D, Ctrl+D)
+ * 5. Dismiss (Esc) — always last
+ */
+
+import { useTheme } from "../../theme";
+
+export interface ControlItem {
+  /** Key name displayed in brackets, e.g. "Enter", "Esc", "↑/↓", "D", "Ctrl+D" */
+  key: string;
+  /** Action label, e.g. "Confirm", "Close", "Navigate" */
+  label: string;
+  /** Visual variant: "default" (muted), "primary" (bright CTA), "danger" (red) */
+  variant?: "default" | "primary" | "danger";
+}
+
+export interface DialogControlsProps {
+  /** Ordered list of control items to display */
+  controls: ControlItem[];
+}
+
+export function DialogControls({ controls }: DialogControlsProps) {
+  const { colors } = useTheme();
+
+  if (controls.length === 0) return null;
+
+  const keyColor = (variant: ControlItem["variant"]) => {
+    switch (variant) {
+      case "primary":
+        return colors.primary;
+      case "danger":
+        return colors.error;
+      default:
+        return colors.textMuted;
+    }
+  };
+
+  return (
+    <text fg={colors.textMuted}>
+      {controls.map((control, i) => (
+        <span key={i}>
+          {i > 0 && " · "}
+          <span fg={keyColor(control.variant)}>[{control.key}]</span>
+          {" " + control.label}
+        </span>
+      ))}
+    </text>
+  );
+}

--- a/src/tui/components/shared/dialog-controls.tsx
+++ b/src/tui/components/shared/dialog-controls.tsx
@@ -23,8 +23,8 @@
  *
  * ## Ordering convention (enforced by caller)
  *
- * 1. Navigation (↑/↓, Tab)
- * 2. Primary action (Enter)
+ * 1. Primary action (Enter) — always first
+ * 2. Navigation (↑/↓, Tab, ←/→)
  * 3. Secondary actions (letter keys)
  * 4. Danger actions (D, Ctrl+D)
  * 5. Dismiss (Esc) — always last

--- a/src/tui/components/shared/index.ts
+++ b/src/tui/components/shared/index.ts
@@ -39,6 +39,7 @@ export {
 } from "./result-registry";
 
 // Components
+export { DialogControls, type ControlItem, type DialogControlsProps } from "./dialog-controls";
 export { AsciiSpinner } from "./ascii-spinner";
 export { ToolRenderer } from "./tool-renderer";
 export { MessageRenderer } from "./message-renderer";

--- a/src/tui/components/shared/index.ts
+++ b/src/tui/components/shared/index.ts
@@ -39,7 +39,11 @@ export {
 } from "./result-registry";
 
 // Components
-export { DialogControls, type ControlItem, type DialogControlsProps } from "./dialog-controls";
+export {
+  DialogControls,
+  type ControlItem,
+  type DialogControlsProps,
+} from "./dialog-controls";
 export { AsciiSpinner } from "./ascii-spinner";
 export { ToolRenderer } from "./tool-renderer";
 export { MessageRenderer } from "./message-renderer";

--- a/src/tui/context/dialog.tsx
+++ b/src/tui/context/dialog.tsx
@@ -14,10 +14,17 @@ import { useTheme } from "../theme";
 interface DialogProps {
   size?: "medium" | "large";
   onClose: () => void;
+  /** Hide the top-right "Esc" dismiss indicator */
+  hideEsc?: boolean;
   children?: ReactNode;
 }
 
-export function Dialog({ size = "medium", onClose, children }: DialogProps) {
+export function Dialog({
+  size = "medium",
+  onClose,
+  hideEsc = false,
+  children,
+}: DialogProps) {
   const dimensions = useDimensions();
   const renderer = useRenderer();
   const { colors: themeColors } = useTheme();
@@ -48,8 +55,20 @@ export function Dialog({ size = "medium", onClose, children }: DialogProps) {
         maxHeight={dimensions.height - 4}
         overflow="hidden"
         backgroundColor={themeColors.backgroundElement}
+        flexDirection="column"
         paddingTop={1}
       >
+        {!hideEsc && (
+          <box
+            width="100%"
+            flexDirection="row"
+            justifyContent="flex-end"
+            paddingRight={2}
+            flexShrink={0}
+          >
+            <text fg={themeColors.textMuted}>Esc to close</text>
+          </box>
+        )}
         {children}
       </box>
     </box>

--- a/src/tui/context/dialog.tsx
+++ b/src/tui/context/dialog.tsx
@@ -66,7 +66,9 @@ export function Dialog({
             paddingRight={2}
             flexShrink={0}
           >
-            <text fg={themeColors.textMuted}>Esc to close</text>
+            <text fg={themeColors.textMuted}>
+              <span fg={themeColors.textMuted}>[Esc]</span> Close
+            </text>
           </box>
         )}
         {children}

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -546,6 +546,7 @@ function CommandDisplay({
           </RouteSwitch.Case>
           <RouteSwitch.Case when="auth">
             <AuthFlow
+              hideEsc
               onClose={() => {
                 if (hasAnyProviderConfigured(config.data)) {
                   route.navigate({ type: "base", path: "home" });


### PR DESCRIPTION
## Summary

- Creates a shared `DialogControls` component with three-tier visual hierarchy (`default`/`primary`/`danger`) for dialog footer shortcut hints
- Migrates all 19 dialog files to use it — consistent capitalization, separators, and colors
- Primary CTA always first, danger actions styled red, `[Esc] Close` in Dialog chrome (top-right)
- Removes intuitive hints (↑/↓ navigate, ←/→) to minimize clutter — only non-obvious shortcuts shown
- Removes duplicate "esc to close" from dialog headers
- Fixes ModelPickerDialog expanding to full height and removes its duplicate internal help text

Closes #475

## Test plan

- [x] `bun run build` passes
- [x] `bun run test` passes — 476 tests
- [x] Open each dialog and verify: single horizontal controls row with `·` separators
- [x] Primary CTA (Enter) is bright and listed first; secondary controls are muted; danger actions are red
- [x] `[Esc] Close` appears in top-right of Dialog chrome, not in controls bar
- [x] No duplicate Esc indicators
- [x] ModelPickerDialog height shrinks to content
- [x] Full-page views (skills, models-display) still show Esc in their controls bar

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that mainly changes TUI hint rendering and dialog chrome; primary risk is minor UX regressions (missing/duplicated shortcuts or layout overflow) across many dialogs.
> 
> **Overview**
> Consolidates dialog/footer keyboard shortcut hints into a new shared `DialogControls` component with `default`/`primary`/`danger` styling and standardized separators/capitalization.
> 
> Moves `[Esc] Close` into the `Dialog` (and `AlertDialog`) top-right chrome via a new `hideEsc` prop, removing duplicated “esc to close” header text and trimming redundant navigation hints across multiple dialogs/wizards.
> 
> Tweaks model picker UI to avoid duplicate help text and fixes `ModelPickerDialog` layout so it no longer expands to full height, and documents these UI/UX conventions in `AGENTS.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8904001be60c0822cf5112c1feb402288ad352b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->