### PR TITLE
fix: replace deprecated X-XSS-Protection with modern headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Want to run from the cloud or integrate it with your CI/CD? See <a href="https:/
 
 ## Installation
 
-| Method | Command |
-|--------|---------|
+| Method                          | Command                                              |
+| ------------------------------- | ---------------------------------------------------- |
 | **Quick Install** (macOS/Linux) | `curl -fsSL https://pensarai.com/install.sh \| bash` |
-| **Homebrew** | `brew tap pensarai/tap && brew install apex` |
-| **npm** | `npm install -g @pensar/apex` |
-| **Windows** (PowerShell) | `irm https://www.pensarai.com/apex.ps1 \| iex` |
+| **Homebrew**                    | `brew tap pensarai/tap && brew install apex`         |
+| **npm**                         | `npm install -g @pensar/apex`                        |
+| **Windows** (PowerShell)        | `irm https://www.pensarai.com/apex.ps1 \| iex`       |
 
 ## Usage
 

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -98,7 +98,7 @@ export function httpRequest(ctx: ToolContext) {
 
 USAGE GUIDANCE:
 - Always check response headers for security misconfigurations
-- Look for: X-Frame-Options, X-XSS-Protection, CSP, HSTS, X-Content-Type-Options
+- Look for: X-Frame-Options, CSP, HSTS, X-Content-Type-Options, Permissions-Policy, Cross-Origin-Embedder-Policy, Cross-Origin-Opener-Policy
 - Analyze cookies for HttpOnly, Secure, SameSite flags
 - Check for verbose error messages that leak information
 - Test for common web vulnerabilities (SQL injection, XSS, IDOR)


### PR DESCRIPTION
Closes #459

## Summary
- Removed deprecated `X-XSS-Protection` from security headers checklist
- Added modern replacements: `Permissions-Policy`, `Cross-Origin-Embedder-Policy`, `Cross-Origin-Opener-Policy`

## Test plan
- [ ] Run pentest and verify no findings flag missing X-XSS-Protection

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation/tool description strings and README formatting, with no runtime logic modifications.
> 
> **Overview**
> Updates the `httpRequest` tool’s guidance to remove deprecated `X-XSS-Protection` and instead prompt checks for modern headers like `Permissions-Policy` and COEP/COOP.
> 
> Cleans up the README installation table formatting for better alignment and readability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d639b590c5591cfa986bf0581e581b8d4b893ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->