### PR TITLE
feat: scrollable pentest wizard with Advanced dropdown

### DIFF
--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -730,13 +730,14 @@ export default function WebWizard({
               overflow: "hidden",
             },
             contentOptions: { flexDirection: "column" },
-            scrollbarOptions: { visible: false },
+            scrollbarOptions: { visible: true },
           }}
           stickyScroll={false}
         >
           {/* Target URL */}
           <box id="field-target" paddingLeft={4} paddingRight={2}>
             <Input
+              compact
               label="Target URL"
               description="e.g., https://example.com"
               placeholder="https://example.com"
@@ -784,6 +785,7 @@ export default function WebWizard({
           {state.sourceCodeAccess && (
             <box id="field-cwd" paddingLeft={4} paddingRight={2}>
               <Input
+                compact
                 label="Codebase Path"
                 description="Path to the source code directory"
                 placeholder={process.cwd()}
@@ -837,6 +839,7 @@ export default function WebWizard({
                 <>
                   <box id="field-loginUrl" paddingLeft={8} paddingRight={2}>
                     <Input
+                      compact
                       label="Login URL"
                       placeholder="https://example.com/login"
                       value={state.auth.loginUrl}
@@ -864,6 +867,7 @@ export default function WebWizard({
                   </box>
                   <box id="field-username" paddingLeft={8} paddingRight={2}>
                     <Input
+                      compact
                       label="Username"
                       placeholder="admin"
                       value={state.auth.username}
@@ -891,6 +895,7 @@ export default function WebWizard({
                   </box>
                   <box id="field-password" paddingLeft={8} paddingRight={2}>
                     <Input
+                      compact
                       label="Password"
                       placeholder="••••••••"
                       value={state.auth.password}
@@ -918,6 +923,7 @@ export default function WebWizard({
                   </box>
                   <box id="field-instructions" paddingLeft={8} paddingRight={2}>
                     <Input
+                      compact
                       label="Auth Instructions"
                       placeholder="Use OAuth flow, extract bearer token..."
                       value={state.auth.instructions}
@@ -966,6 +972,7 @@ export default function WebWizard({
                 <>
                   <box id="field-host" paddingLeft={8} paddingRight={2}>
                     <Input
+                      compact
                       label="Add Allowed Host"
                       description="Press Enter to add"
                       placeholder="example.com"
@@ -985,6 +992,7 @@ export default function WebWizard({
                   )}
                   <box id="field-port" paddingLeft={8} paddingRight={2}>
                     <Input
+                      compact
                       label="Add Allowed Port"
                       description="Press Enter to add"
                       placeholder="443"
@@ -1133,6 +1141,7 @@ export default function WebWizard({
                         paddingRight={2}
                       >
                         <Input
+                          compact
                           label="Header Name"
                           placeholder="X-Custom-Header"
                           value={headerNameInput}
@@ -1146,6 +1155,7 @@ export default function WebWizard({
                         paddingRight={2}
                       >
                         <Input
+                          compact
                           label="Header Value"
                           description="Press Enter to add header"
                           placeholder="value"

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -137,8 +137,7 @@ export default function WebWizard({
       }
 
       if (models.length > 0) {
-        const currentModel =
-          models.find((m) => m.id === model.id) || models[0];
+        const currentModel = models.find((m) => m.id === model.id) || models[0];
         if (currentModel) {
           setExpandedProviders(new Set([currentModel.provider]));
         }
@@ -292,9 +291,7 @@ export default function WebWizard({
 
   // Clamp focused index when items change
   useEffect(() => {
-    setFocusedIndex((prev) =>
-      Math.min(prev, Math.max(0, navItems.length - 1)),
-    );
+    setFocusedIndex((prev) => Math.min(prev, Math.max(0, navItems.length - 1)));
   }, [navItems.length]);
 
   // Scroll to focused item
@@ -637,9 +634,7 @@ export default function WebWizard({
       }
       if (focusedItem?.type === "model") {
         key.preventDefault();
-        const modelInfo = availableModels.find(
-          (m) => m.id === focusedItem.key,
-        );
+        const modelInfo = availableModels.find((m) => m.id === focusedItem.key);
         if (modelInfo && key.name === "left") {
           setExpandedProviders((prev) => {
             const next = new Set(prev);
@@ -846,11 +841,7 @@ export default function WebWizard({
                         : colors.textMuted
                   }
                 >
-                  {isFocused("section-auth")
-                    ? "❯"
-                    : authExpanded
-                      ? "▾"
-                      : "▸"}{" "}
+                  {isFocused("section-auth") ? "❯" : authExpanded ? "▾" : "▸"}{" "}
                   Authentication
                 </text>
               </box>
@@ -938,11 +929,7 @@ export default function WebWizard({
                       focused={isFocused("field-password")}
                     />
                   </box>
-                  <box
-                    id="field-instructions"
-                    paddingLeft={8}
-                    paddingRight={2}
-                  >
+                  <box id="field-instructions" paddingLeft={8} paddingRight={2}>
                     <Input
                       label="Auth Instructions"
                       placeholder="Use OAuth flow, extract bearer token..."
@@ -983,11 +970,7 @@ export default function WebWizard({
                         : colors.textMuted
                   }
                 >
-                  {isFocused("section-scope")
-                    ? "❯"
-                    : scopeExpanded
-                      ? "▾"
-                      : "▸"}{" "}
+                  {isFocused("section-scope") ? "❯" : scopeExpanded ? "▾" : "▸"}{" "}
                   Scope Constraints
                 </text>
               </box>

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -703,14 +703,7 @@ export default function WebWizard({
   // Render single-page scrollable form
   return (
     <Dialog size="large" onClose={onClose}>
-      <box
-        width="100%"
-        height="100%"
-        flexDirection="column"
-        flexGrow={1}
-        flexShrink={1}
-        overflow="hidden"
-      >
+      <box width="100%" flexDirection="column" flexShrink={1} overflow="hidden">
         {/* Header (pinned) */}
         <box
           flexDirection="column"
@@ -767,7 +760,6 @@ export default function WebWizard({
             paddingLeft={4}
             flexDirection="row"
             gap={1}
-            paddingBottom={1}
           >
             <text
               fg={
@@ -803,12 +795,7 @@ export default function WebWizard({
           )}
 
           {/* Advanced section header */}
-          <box
-            id="section-advanced"
-            paddingLeft={4}
-            paddingTop={1}
-            paddingBottom={1}
-          >
+          <box id="section-advanced" paddingLeft={4} paddingTop={1}>
             <text
               fg={
                 isFocused("section-advanced")

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { useKeyboard } from "@opentui/react";
+import { ScrollBoxRenderable } from "@opentui/core";
 import Input from "../input";
 import { useConfig } from "../../context/config";
 import { useAgent } from "../../context/agent";
@@ -9,9 +10,14 @@ import { type ModelInfo } from "../../../core/ai";
 import { getAvailableModels } from "../../../core/providers/utils";
 import { useTheme } from "../../theme";
 import { Dialog } from "../../context/dialog";
+import { scrollToChild } from "../../utils/scroll";
 
-// Wizard step types
-type WizardStep = "target" | "configure" | "creating";
+// Navigation item for flat keyboard navigation
+interface NavItem {
+  id: string;
+  type: "input" | "toggle" | "section" | "radio" | "provider" | "model";
+  key: string;
+}
 
 // Wizard state interface
 interface WizardState {
@@ -70,12 +76,20 @@ interface WebWizardProps {
   initialModel?: string;
 }
 
+const providerNames: Record<string, string> = {
+  anthropic: "Claude",
+  openai: "OpenAI",
+  openrouter: "OpenRouter",
+  bedrock: "Bedrock",
+};
+
+const providerOrder = ["anthropic", "openai", "openrouter", "bedrock"];
+
 export default function WebWizard({
   onClose,
   onStartPentest,
   initialTarget,
   autoMode = false,
-  initialName,
   initialAuthUrl,
   initialAuthUser,
   initialAuthPass,
@@ -90,62 +104,22 @@ export default function WebWizard({
   const { colors } = useTheme();
   const config = useConfig();
   const { model, setModel, isModelUserSelected } = useAgent();
+  const scrollBoxRef = useRef<ScrollBoxRenderable | null>(null);
 
-  // Available models based on configured API keys
+  // Model state
   const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
-  const [selectedModelIndex, setSelectedModelIndex] = useState(0);
-
-  // Model picker state
-  const [modelSearchQuery, setModelSearchQuery] = useState("");
   const [expandedProviders, setExpandedProviders] = useState<Set<string>>(
     new Set(["anthropic"]),
   );
 
-  // Provider display names
-  const providerNames: Record<string, string> = {
-    anthropic: "Claude",
-    openai: "OpenAI",
-    openrouter: "OpenRouter",
-    bedrock: "Bedrock",
-  };
-
-  // Provider order
-  const providerOrder = ["anthropic", "openai", "openrouter", "bedrock"];
-
-  // Group models by provider and filter by search
   const groupedModels = useMemo(() => {
     const groups: Record<string, ModelInfo[]> = {};
-    const query = modelSearchQuery.toLowerCase().trim();
-
     for (const m of availableModels) {
-      // Fuzzy match: check if query matches model name or id
-      if (
-        query &&
-        !m.name.toLowerCase().includes(query) &&
-        !m.id.toLowerCase().includes(query)
-      ) {
-        continue;
-      }
-      if (!groups[m.provider]) {
-        groups[m.provider] = [];
-      }
+      if (!groups[m.provider]) groups[m.provider] = [];
       groups[m.provider].push(m);
     }
     return groups;
-  }, [availableModels, modelSearchQuery]);
-
-  // Flat list of visible models for keyboard navigation
-  const visibleModels = useMemo(() => {
-    const result: ModelInfo[] = [];
-    for (const provider of providerOrder) {
-      const models = groupedModels[provider];
-      if (!models || models.length === 0) continue;
-      if (expandedProviders.has(provider)) {
-        result.push(...models);
-      }
-    }
-    return result;
-  }, [groupedModels, expandedProviders]);
+  }, [availableModels]);
 
   // Load available models when config changes
   useEffect(() => {
@@ -153,28 +127,18 @@ export default function WebWizard({
       const models = getAvailableModels(config.data);
       setAvailableModels(models);
 
-      // If initialModel was provided, try to set it
       if (initialModel) {
         const targetModel = models.find((m) => m.id === initialModel);
         if (targetModel) {
           setModel(targetModel, false);
-          const newIndex = models.findIndex((m) => m.id === targetModel.id);
-          if (newIndex >= 0) {
-            setSelectedModelIndex(newIndex);
-          }
           setExpandedProviders(new Set([targetModel.provider]));
           return;
         }
       }
 
-      // Find current model in the list
-      const currentIndex = models.findIndex((m) => m.id === model.id);
-      if (currentIndex >= 0) {
-        setSelectedModelIndex(currentIndex);
-      }
-      // Auto-expand provider of current model
       if (models.length > 0) {
-        const currentModel = models.find((m) => m.id === model.id) || models[0];
+        const currentModel =
+          models.find((m) => m.id === model.id) || models[0];
         if (currentModel) {
           setExpandedProviders(new Set([currentModel.provider]));
         }
@@ -182,11 +146,10 @@ export default function WebWizard({
     }
   }, [config.data, model.id, initialModel]);
 
-  // Determine initial step based on whether target was provided
-  const initialStep: WizardStep = initialTarget ? "configure" : "target";
+  // UI state
+  const [isCreating, setIsCreating] = useState(false);
 
-  // Wizard state
-  const [currentStep, setCurrentStep] = useState<WizardStep>(initialStep);
+  // Form state
   const [state, setState] = useState<WizardState>(() => ({
     target: initialTarget || "",
     sourceCodeAccess: false,
@@ -209,12 +172,17 @@ export default function WebWizard({
     },
   }));
 
-  // UI state for target step
-  const [targetFocusedField, setTargetFocusedField] = useState(0); // 0=target, 1=source code access, 2=cwd (if enabled)
+  // Section expansion state
+  const [advancedExpanded, setAdvancedExpanded] = useState(false);
+  const [authExpanded, setAuthExpanded] = useState(false);
+  const [scopeExpanded, setScopeExpanded] = useState(false);
+  const [headersExpanded, setHeadersExpanded] = useState(false);
+  const [modelSectionExpanded, setModelSectionExpanded] = useState(false);
 
-  // UI state for configure step
-  const [focusedSection, setFocusedSection] = useState(0); // 0=auth, 1=scope, 2=headers
-  const [focusedField, setFocusedField] = useState(0);
+  // Navigation state
+  const [focusedIndex, setFocusedIndex] = useState(0);
+
+  // Input state for list-adder fields
   const [hostInput, setHostInput] = useState("");
   const [portInput, setPortInput] = useState("");
   const [headerNameInput, setHeaderNameInput] = useState("");
@@ -224,17 +192,216 @@ export default function WebWizard({
   const [error, setError] = useState<string | null>(null);
   const [targetError, setTargetError] = useState<string | null>(null);
 
-  // Create session and navigate to session route
+  // Build flat navigation items list
+  const navItems = useMemo(() => {
+    const items: NavItem[] = [];
+
+    items.push({ id: "field-target", type: "input", key: "target" });
+    items.push({
+      id: "field-sourceCodeAccess",
+      type: "toggle",
+      key: "sourceCodeAccess",
+    });
+    if (state.sourceCodeAccess) {
+      items.push({ id: "field-cwd", type: "input", key: "cwd" });
+    }
+
+    items.push({ id: "section-advanced", type: "section", key: "advanced" });
+
+    if (advancedExpanded) {
+      items.push({ id: "section-auth", type: "section", key: "auth" });
+      if (authExpanded) {
+        items.push({ id: "field-loginUrl", type: "input", key: "loginUrl" });
+        items.push({ id: "field-username", type: "input", key: "username" });
+        items.push({ id: "field-password", type: "input", key: "password" });
+        items.push({
+          id: "field-instructions",
+          type: "input",
+          key: "instructions",
+        });
+      }
+
+      items.push({ id: "section-scope", type: "section", key: "scope" });
+      if (scopeExpanded) {
+        items.push({ id: "field-host", type: "input", key: "host" });
+        items.push({ id: "field-port", type: "input", key: "port" });
+        items.push({
+          id: "field-strictScope",
+          type: "toggle",
+          key: "strictScope",
+        });
+        items.push({
+          id: "field-enumerateSubdomains",
+          type: "toggle",
+          key: "enumerateSubdomains",
+        });
+      }
+
+      items.push({ id: "section-headers", type: "section", key: "headers" });
+      if (headersExpanded) {
+        items.push({
+          id: "field-headersMode",
+          type: "radio",
+          key: "headersMode",
+        });
+        if (state.headers.mode === "custom") {
+          items.push({
+            id: "field-headerName",
+            type: "input",
+            key: "headerName",
+          });
+          items.push({
+            id: "field-headerValue",
+            type: "input",
+            key: "headerValue",
+          });
+        }
+      }
+
+      items.push({ id: "section-model", type: "section", key: "model" });
+      if (modelSectionExpanded) {
+        for (const provider of providerOrder) {
+          const models = groupedModels[provider];
+          if (!models || models.length === 0) continue;
+          items.push({
+            id: `provider-${provider}`,
+            type: "provider",
+            key: provider,
+          });
+          if (expandedProviders.has(provider)) {
+            for (const m of models) {
+              items.push({ id: `model-${m.id}`, type: "model", key: m.id });
+            }
+          }
+        }
+      }
+    }
+
+    return items;
+  }, [
+    state.sourceCodeAccess,
+    state.headers.mode,
+    advancedExpanded,
+    authExpanded,
+    scopeExpanded,
+    headersExpanded,
+    modelSectionExpanded,
+    groupedModels,
+    expandedProviders,
+  ]);
+
+  // Clamp focused index when items change
+  useEffect(() => {
+    setFocusedIndex((prev) =>
+      Math.min(prev, Math.max(0, navItems.length - 1)),
+    );
+  }, [navItems.length]);
+
+  // Scroll to focused item
+  useEffect(() => {
+    const item = navItems[focusedIndex];
+    if (item) scrollToChild(scrollBoxRef.current, item.id);
+  }, [focusedIndex, navItems]);
+
+  const focusedItem = navItems[focusedIndex];
+
+  // Section helpers
+  function toggleSection(key: string) {
+    switch (key) {
+      case "advanced":
+        setAdvancedExpanded((p) => !p);
+        break;
+      case "auth":
+        setAuthExpanded((p) => !p);
+        break;
+      case "scope":
+        setScopeExpanded((p) => !p);
+        break;
+      case "headers":
+        setHeadersExpanded((p) => !p);
+        break;
+      case "model":
+        setModelSectionExpanded((p) => !p);
+        break;
+    }
+  }
+
+  function expandSection(key: string) {
+    switch (key) {
+      case "advanced":
+        setAdvancedExpanded(true);
+        break;
+      case "auth":
+        setAuthExpanded(true);
+        break;
+      case "scope":
+        setScopeExpanded(true);
+        break;
+      case "headers":
+        setHeadersExpanded(true);
+        break;
+      case "model":
+        setModelSectionExpanded(true);
+        break;
+    }
+  }
+
+  function collapseSection(key: string) {
+    switch (key) {
+      case "advanced":
+        setAdvancedExpanded(false);
+        break;
+      case "auth":
+        setAuthExpanded(false);
+        break;
+      case "scope":
+        setScopeExpanded(false);
+        break;
+      case "headers":
+        setHeadersExpanded(false);
+        break;
+      case "model":
+        setModelSectionExpanded(false);
+        break;
+    }
+  }
+
+  // Toggle value handler
+  function handleToggle(key: string) {
+    switch (key) {
+      case "sourceCodeAccess":
+        setState((prev) => ({
+          ...prev,
+          sourceCodeAccess: !prev.sourceCodeAccess,
+        }));
+        break;
+      case "strictScope":
+        setState((prev) => ({
+          ...prev,
+          scope: { ...prev.scope, strictScope: !prev.scope.strictScope },
+        }));
+        break;
+      case "enumerateSubdomains":
+        setState((prev) => ({
+          ...prev,
+          scope: {
+            ...prev.scope,
+            enumerateSubdomains: !prev.scope.enumerateSubdomains,
+          },
+        }));
+        break;
+    }
+  }
+
+  // Create session and navigate to pentest
   async function createSessionAndNavigate() {
     if (!state.target.trim()) return;
 
-    setCurrentStep("creating");
+    setIsCreating(true);
     setError(null);
 
     try {
-      // Build session config
       const sessionConfig: SessionConfig = {
-        // Set session type and mode for web app pentesting
         sessionType: "web-app",
         mode: autoMode ? "auto" : "driver",
       };
@@ -289,318 +456,236 @@ export default function WebWizard({
       onStartPentest([state.target], sessionConfig);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create session");
-      setCurrentStep(initialTarget ? "configure" : "target");
+      setIsCreating(false);
     }
   }
 
-  // Keyboard handling
+  // Navigate to a new index, auto-selecting model if applicable
+  function navigateTo(newIndex: number) {
+    setFocusedIndex(newIndex);
+    const newItem = navItems[newIndex];
+    if (newItem?.type === "model") {
+      const modelInfo = availableModels.find((m) => m.id === newItem.key);
+      if (modelInfo) setModel(modelInfo);
+    }
+  }
+
+  // Keyboard handler
   useKeyboard((key) => {
-    // ESC - Go back or close
+    if (isCreating) return;
+
+    // ESC - close dialog
     if (key.name === "escape") {
       key.preventDefault();
-      if (currentStep === "creating") {
-        // Can't cancel while creating
-        return;
-      }
-      if (currentStep === "configure") {
-        // If we have an initial target, close dialog instead of back to target step
-        if (initialTarget) {
-          onClose();
-        } else {
-          setCurrentStep("target");
-          setFocusedSection(0);
-          setFocusedField(0);
-        }
-        return;
-      }
       onClose();
       return;
     }
 
-    // Don't allow navigation while creating
-    if (currentStep === "creating") return;
+    // Up/Down - navigate between items
+    if (key.name === "up" || key.name === "down") {
+      key.preventDefault();
+      const newIndex =
+        key.name === "up"
+          ? Math.max(0, focusedIndex - 1)
+          : Math.min(navItems.length - 1, focusedIndex + 1);
+      navigateTo(newIndex);
+      return;
+    }
 
-    // Target step: Enter to start, Tab to configure options
-    if (currentStep === "target") {
-      const maxTargetField = state.sourceCodeAccess ? 2 : 1; // 0=target, 1=toggle, 2=cwd (if enabled)
-      // Tab - go directly to configure step when target is filled
-      if (key.name === "tab" && !key.shift) {
+    // Tab/Shift+Tab - navigate (same as Down/Up)
+    if (key.name === "tab") {
+      key.preventDefault();
+      const newIndex = key.shift
+        ? Math.max(0, focusedIndex - 1)
+        : Math.min(navItems.length - 1, focusedIndex + 1);
+      navigateTo(newIndex);
+      return;
+    }
+
+    // Space - toggle/cycle for non-input items
+    if (key.sequence === " ") {
+      if (focusedItem?.type === "toggle") {
         key.preventDefault();
-        if (state.target.trim()) {
-          setTargetError(null);
-          setCurrentStep("configure");
-        } else {
-          setTargetError("Target URL is required");
-        }
+        handleToggle(focusedItem.key);
         return;
       }
-      // Shift+Tab - navigate backwards through fields
-      if (key.name === "tab" && key.shift) {
+      if (focusedItem?.type === "section") {
         key.preventDefault();
-        setTargetFocusedField((prev) => Math.max(0, prev - 1));
+        toggleSection(focusedItem.key);
         return;
       }
-      // Down arrow - navigate to next field
-      if (key.name === "down") {
+      if (focusedItem?.type === "provider") {
         key.preventDefault();
-        if (targetFocusedField < maxTargetField) {
-          setTargetFocusedField((prev) => prev + 1);
-        }
+        setExpandedProviders((prev) => {
+          const next = new Set(prev);
+          if (next.has(focusedItem.key)) next.delete(focusedItem.key);
+          else next.add(focusedItem.key);
+          return next;
+        });
         return;
       }
-      // Up arrow - navigate to previous field
-      if (key.name === "up") {
+      if (focusedItem?.type === "radio" && focusedItem.key === "headersMode") {
         key.preventDefault();
-        if (targetFocusedField > 0) {
-          setTargetFocusedField((prev) => prev - 1);
-        }
-        return;
-      }
-      // Space - toggle source code access when on that field
-      if (key.sequence === " " && targetFocusedField === 1) {
-        key.preventDefault();
+        const modes: Array<"none" | "default" | "custom"> = [
+          "none",
+          "default",
+          "custom",
+        ];
+        const idx = modes.indexOf(state.headers.mode);
         setState((prev) => ({
           ...prev,
-          sourceCodeAccess: !prev.sourceCodeAccess,
+          headers: {
+            ...prev.headers,
+            mode: modes[(idx + 1) % modes.length]!,
+          },
         }));
         return;
       }
-      // Enter to start if target is filled
-      if (key.name === "return" && state.target.trim()) {
-        key.preventDefault();
-        createSessionAndNavigate();
+      // Don't prevent default for input fields - space is a valid character
+      return;
+    }
+
+    // Enter - toggle sections, add list items, or start pentest
+    if (key.name === "return") {
+      key.preventDefault();
+
+      // Section headers toggle expansion
+      if (focusedItem?.type === "section") {
+        toggleSection(focusedItem.key);
         return;
+      }
+
+      // Provider headers toggle expansion
+      if (focusedItem?.type === "provider") {
+        setExpandedProviders((prev) => {
+          const next = new Set(prev);
+          if (next.has(focusedItem.key)) next.delete(focusedItem.key);
+          else next.add(focusedItem.key);
+          return next;
+        });
+        return;
+      }
+
+      // List-adder inputs: add items on Enter
+      if (focusedItem?.key === "host" && hostInput.trim()) {
+        setState((prev) => ({
+          ...prev,
+          scope: {
+            ...prev.scope,
+            allowedHosts: [...prev.scope.allowedHosts, hostInput.trim()],
+          },
+        }));
+        setHostInput("");
+        return;
+      }
+      if (focusedItem?.key === "port" && portInput.trim()) {
+        setState((prev) => ({
+          ...prev,
+          scope: {
+            ...prev.scope,
+            allowedPorts: [...prev.scope.allowedPorts, portInput.trim()],
+          },
+        }));
+        setPortInput("");
+        return;
+      }
+      if (focusedItem?.key === "headerValue" && headerNameInput.trim()) {
+        setState((prev) => ({
+          ...prev,
+          headers: {
+            ...prev.headers,
+            customHeaders: {
+              ...prev.headers.customHeaders,
+              [headerNameInput.trim()]: headerValueInput,
+            },
+          },
+        }));
+        setHeaderNameInput("");
+        setHeaderValueInput("");
+        return;
+      }
+
+      // Default: start pentest
+      if (state.target.trim()) {
+        createSessionAndNavigate();
+      } else {
+        setTargetError("Target URL is required");
       }
       return;
     }
 
-    // Configure step keyboard handling
-    if (currentStep === "configure") {
-      // Enter to create session
-      if (key.name === "return") {
+    // Left/Right - expand/collapse sections & providers, cycle radios
+    if (key.name === "left" || key.name === "right") {
+      if (focusedItem?.type === "section") {
         key.preventDefault();
-        // Check if we should add an item instead of starting
-        if (focusedSection === 1 && focusedField === 0 && hostInput.trim()) {
-          setState((prev) => ({
-            ...prev,
-            scope: {
-              ...prev.scope,
-              allowedHosts: [...prev.scope.allowedHosts, hostInput.trim()],
-            },
-          }));
-          setHostInput("");
-          return;
-        }
-        if (focusedSection === 1 && focusedField === 1 && portInput.trim()) {
-          setState((prev) => ({
-            ...prev,
-            scope: {
-              ...prev.scope,
-              allowedPorts: [...prev.scope.allowedPorts, portInput.trim()],
-            },
-          }));
-          setPortInput("");
-          return;
-        }
-        if (
-          focusedSection === 2 &&
-          state.headers.mode === "custom" &&
-          focusedField === 2 &&
-          headerNameInput.trim()
-        ) {
-          setState((prev) => ({
-            ...prev,
-            headers: {
-              ...prev.headers,
-              customHeaders: {
-                ...prev.headers.customHeaders,
-                [headerNameInput.trim()]: headerValueInput,
-              },
-            },
-          }));
-          setHeaderNameInput("");
-          setHeaderValueInput("");
-          return;
-        }
-        // Otherwise create session
-        createSessionAndNavigate();
+        if (key.name === "right") expandSection(focusedItem.key);
+        else collapseSection(focusedItem.key);
         return;
       }
-
-      // Tab navigation between sections and fields
-      if (key.name === "tab") {
+      if (focusedItem?.type === "provider") {
         key.preventDefault();
-        if (key.shift) {
-          if (focusedField > 0) {
-            setFocusedField(focusedField - 1);
-          } else if (focusedSection > 0) {
-            setFocusedSection(focusedSection - 1);
-            setFocusedField(getMaxFieldsForSection(focusedSection - 1) - 1);
-          }
+        if (key.name === "right") {
+          setExpandedProviders((prev) => new Set([...prev, focusedItem.key]));
         } else {
-          const maxFields = getMaxFieldsForSection(focusedSection);
-          if (focusedField < maxFields - 1) {
-            setFocusedField(focusedField + 1);
-          } else if (focusedSection < 3) {
-            setFocusedSection(focusedSection + 1);
-            setFocusedField(0);
-          }
+          setExpandedProviders((prev) => {
+            const next = new Set(prev);
+            next.delete(focusedItem.key);
+            return next;
+          });
         }
         return;
       }
-
-      // Arrow keys for toggles
-      if (key.name === "up" || key.name === "down") {
+      if (focusedItem?.type === "model") {
         key.preventDefault();
-        if (focusedSection === 1 && focusedField === 2) {
-          setState((prev) => ({
-            ...prev,
-            scope: { ...prev.scope, strictScope: !prev.scope.strictScope },
-          }));
-          return;
-        }
-        if (focusedSection === 1 && focusedField === 3) {
-          setState((prev) => ({
-            ...prev,
-            scope: {
-              ...prev.scope,
-              enumerateSubdomains: !prev.scope.enumerateSubdomains,
-            },
-          }));
-          return;
-        }
-        if (focusedSection === 2 && focusedField === 0) {
-          const modes: Array<"none" | "default" | "custom"> = [
-            "none",
-            "default",
-            "custom",
-          ];
-          const currentIndex = modes.indexOf(state.headers.mode);
-          const newIndex =
-            key.name === "up"
-              ? (currentIndex - 1 + modes.length) % modes.length
-              : (currentIndex + 1) % modes.length;
-          setState((prev) => ({
-            ...prev,
-            headers: { ...prev.headers, mode: modes[newIndex]! },
-          }));
-          return;
-        }
-        // Model selection - navigate through visible models
-        if (focusedSection === 3 && visibleModels.length > 0) {
-          const currentVisibleIndex = visibleModels.findIndex(
-            (m) => m.id === model.id,
+        const modelInfo = availableModels.find(
+          (m) => m.id === focusedItem.key,
+        );
+        if (modelInfo && key.name === "left") {
+          setExpandedProviders((prev) => {
+            const next = new Set(prev);
+            next.delete(modelInfo.provider);
+            return next;
+          });
+          const provIdx = navItems.findIndex(
+            (i) => i.id === `provider-${modelInfo.provider}`,
           );
-          const newVisibleIndex =
-            key.name === "up"
-              ? Math.max(0, currentVisibleIndex - 1)
-              : Math.min(visibleModels.length - 1, currentVisibleIndex + 1);
-          const newModel = visibleModels[newVisibleIndex];
-          if (newModel) {
-            setModel(newModel);
-            const newGlobalIndex = availableModels.findIndex(
-              (m) => m.id === newModel.id,
-            );
-            if (newGlobalIndex >= 0) {
-              setSelectedModelIndex(newGlobalIndex);
-            }
-          }
-          return;
+          if (provIdx >= 0) setFocusedIndex(provIdx);
         }
+        return;
       }
-
-      // Model section: handle typing for search, backspace, escape
-      if (focusedSection === 3) {
-        // Backspace - remove last char from search
-        if (key.name === "backspace") {
-          key.preventDefault();
-          setModelSearchQuery((prev) => prev.slice(0, -1));
-          return;
-        }
-        // Escape - clear search
-        if (key.name === "escape" && modelSearchQuery) {
-          setModelSearchQuery("");
-          return;
-        }
-        // Left/Right - toggle provider expansion
-        if (key.name === "left" || key.name === "right") {
-          key.preventDefault();
-          // Find which provider the current model belongs to
-          const currentProvider = model.provider;
-          if (key.name === "left") {
-            setExpandedProviders((prev) => {
-              const next = new Set(prev);
-              next.delete(currentProvider);
-              return next;
-            });
-          } else {
-            setExpandedProviders((prev) => new Set([...prev, currentProvider]));
-          }
-          return;
-        }
-        // Tab in model section - toggle next provider expansion
-        if (key.name === "tab" && !key.shift) {
-          key.preventDefault();
-          const availableProviders = providerOrder.filter(
-            (p) => groupedModels[p]?.length > 0,
-          );
-          if (availableProviders.length > 0) {
-            // Find next provider to toggle
-            const currentExpanded = [...expandedProviders];
-            const nextToExpand = availableProviders.find(
-              (p) => !expandedProviders.has(p),
-            );
-            if (nextToExpand) {
-              setExpandedProviders((prev) => new Set([...prev, nextToExpand]));
-            } else {
-              // All expanded, go to next section
-              setFocusedSection(0);
-              setFocusedField(0);
-            }
-            return;
-          }
-        }
-        // Printable character - add to search
-        if (
-          key.sequence &&
-          key.sequence.length === 1 &&
-          /[a-zA-Z0-9\-_.]/.test(key.sequence)
-        ) {
-          key.preventDefault();
-          setModelSearchQuery((prev) => prev + key.sequence);
-          // Auto-expand all providers when searching
-          if (!modelSearchQuery) {
-            setExpandedProviders(new Set(providerOrder));
-          }
-          return;
-        }
+      if (focusedItem?.type === "radio" && focusedItem.key === "headersMode") {
+        key.preventDefault();
+        const modes: Array<"none" | "default" | "custom"> = [
+          "none",
+          "default",
+          "custom",
+        ];
+        const idx = modes.indexOf(state.headers.mode);
+        const newIdx =
+          key.name === "left"
+            ? (idx - 1 + modes.length) % modes.length
+            : (idx + 1) % modes.length;
+        setState((prev) => ({
+          ...prev,
+          headers: { ...prev.headers, mode: modes[newIdx]! },
+        }));
+        return;
       }
+      // Don't intercept left/right for input fields (cursor movement)
     }
   });
 
-  function getMaxFieldsForSection(section: number): number {
-    switch (section) {
-      case 0:
-        return 4; // Auth
-      case 1:
-        return 4; // Scope (host, port, strictScope, enumerateSubdomains)
-      case 2:
-        return state.headers.mode === "custom" ? 3 : 1; // Headers
-      case 3:
-        return 1; // Model
-      default:
-        return 1;
-    }
-  }
-
-  // Get mode label for display
+  // Mode labels
   const modeLabel = autoMode ? "Auto Mode" : "Driver Mode";
   const modeDescription = autoMode
     ? "Automated pentesting - agents run autonomously"
     : "Manual orchestration - you direct the agents";
 
+  // Helper to check if an item is focused
+  const isFocused = (id: string) => focusedItem?.id === id;
+
   // Render creating state
-  if (currentStep === "creating") {
+  if (isCreating) {
     return (
       <Dialog size="large" onClose={onClose}>
         <box
@@ -620,14 +705,21 @@ export default function WebWizard({
     );
   }
 
-  // Render target step
-  if (currentStep === "target") {
-    return (
-      <Dialog size="large" onClose={onClose}>
+  // Render single-page scrollable form
+  return (
+    <Dialog size="large" onClose={onClose}>
+      <box
+        width="100%"
+        height="100%"
+        flexDirection="column"
+        flexGrow={1}
+        flexShrink={1}
+        overflow="hidden"
+      >
+        {/* Header (pinned) */}
         <box
-          width="100%"
           flexDirection="column"
-          gap={2}
+          flexShrink={0}
           paddingLeft={4}
           paddingBottom={1}
         >
@@ -636,439 +728,567 @@ export default function WebWizard({
           <text fg={colors.textMuted}>
             Model: {model.name} [{isModelUserSelected ? "user" : "default"}]
           </text>
-
           {error && <text fg={colors.error}>Error: {error}</text>}
+        </box>
 
-          <Input
-            label="Target URL"
-            description="e.g., https://example.com"
-            placeholder="https://example.com"
-            value={state.target}
-            onInput={(v) => {
-              setTargetError(null);
-              setState((prev) => ({ ...prev, target: v }));
-            }}
-            onSubmit={() => {
-              if (state.target.trim()) {
+        {/* Scrollable form content */}
+        <scrollbox
+          ref={scrollBoxRef}
+          style={{
+            rootOptions: {
+              flexGrow: 1,
+              flexShrink: 1,
+              width: "100%",
+              overflow: "hidden",
+            },
+            contentOptions: { flexDirection: "column" },
+            scrollbarOptions: { visible: false },
+          }}
+          stickyScroll={false}
+        >
+          {/* Target URL */}
+          <box id="field-target" paddingLeft={4} paddingRight={2}>
+            <Input
+              label="Target URL"
+              description="e.g., https://example.com"
+              placeholder="https://example.com"
+              value={state.target}
+              onInput={(v) => {
                 setTargetError(null);
-                setCurrentStep("configure");
-              } else {
-                setTargetError("Target URL is required");
-              }
-            }}
-            focused={targetFocusedField === 0}
-          />
-          {targetError && <text fg={colors.error}>{targetError}</text>}
-
-          <box flexDirection="column" gap={1}>
-            <box flexDirection="row" gap={1}>
-              <text
-                fg={
-                  targetFocusedField === 1 ? colors.primary : colors.textMuted
-                }
-              >
-                Source Code Access:
-              </text>
-              <text
-                fg={state.sourceCodeAccess ? colors.primary : colors.textMuted}
-              >
-                {state.sourceCodeAccess ? "● Enabled" : "○ Disabled"}
-              </text>
-              {targetFocusedField === 1 && (
-                <text fg={colors.textMuted}>(Space to toggle)</text>
-              )}
+                setState((prev) => ({ ...prev, target: v }));
+              }}
+              focused={isFocused("field-target")}
+            />
+          </box>
+          {targetError && (
+            <box paddingLeft={4}>
+              <text fg={colors.error}>{targetError}</text>
             </box>
-            {state.sourceCodeAccess && (
+          )}
+
+          {/* Source Code Access toggle */}
+          <box
+            id="field-sourceCodeAccess"
+            paddingLeft={4}
+            flexDirection="row"
+            gap={1}
+            paddingBottom={1}
+          >
+            <text
+              fg={
+                isFocused("field-sourceCodeAccess")
+                  ? colors.primary
+                  : colors.textMuted
+              }
+            >
+              Source Code Access:
+            </text>
+            <text
+              fg={state.sourceCodeAccess ? colors.primary : colors.textMuted}
+            >
+              {state.sourceCodeAccess ? "● Enabled" : "○ Disabled"}
+            </text>
+            {isFocused("field-sourceCodeAccess") && (
+              <text fg={colors.textMuted}>(Space to toggle)</text>
+            )}
+          </box>
+
+          {/* Codebase Path (conditional on source code access) */}
+          {state.sourceCodeAccess && (
+            <box id="field-cwd" paddingLeft={4} paddingRight={2}>
               <Input
                 label="Codebase Path"
                 description="Path to the source code directory"
                 placeholder={process.cwd()}
                 value={state.cwd}
                 onInput={(v) => setState((prev) => ({ ...prev, cwd: v }))}
-                focused={targetFocusedField === 2}
-              />
-            )}
-          </box>
-
-          <box flexDirection="column" gap={0} marginTop={1}>
-            <text>
-              <span fg={colors.primary}>█ </span>
-              <span fg={colors.textMuted}>Press </span>
-              <span fg={colors.text}>[Enter]</span>
-              <span fg={colors.textMuted}> to start immediately</span>
-            </text>
-            <text>
-              <span fg={colors.primary}>█ </span>
-              <span fg={colors.textMuted}>Press </span>
-              <span fg={colors.text}>[Tab]</span>
-              <span fg={colors.textMuted}> to configure options</span>
-            </text>
-            <text>
-              <span fg={colors.primary}>█ </span>
-              <span fg={colors.textMuted}>Press </span>
-              <span fg={colors.text}>[ESC]</span>
-              <span fg={colors.textMuted}> to cancel</span>
-            </text>
-          </box>
-        </box>
-      </Dialog>
-    );
-  }
-
-  // Render configure step
-  return (
-    <Dialog size="large" onClose={onClose}>
-      <box
-        width="100%"
-        flexDirection="column"
-        gap={2}
-        paddingLeft={4}
-        paddingBottom={1}
-      >
-        <box flexDirection="column">
-          <text fg={colors.text}>Configure Web App Pentest - {modeLabel}</text>
-          <text fg={colors.textMuted}>Target: {state.target}</text>
-          <text fg={colors.textMuted}>
-            All fields are optional - configure only what you need
-          </text>
-        </box>
-
-        {/* Auth Section */}
-        <box flexDirection="column" gap={1}>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={focusedSection === 0 ? colors.text : colors.textMuted}>
-              Authentication
-            </span>
-          </text>
-          {focusedSection === 0 && (
-            <box flexDirection="column" gap={1} paddingLeft={2}>
-              <Input
-                label="Login URL"
-                placeholder="https://example.com/login"
-                value={state.auth.loginUrl}
-                onInput={(v) =>
-                  setState((prev) => ({
-                    ...prev,
-                    auth: { ...prev.auth, loginUrl: v },
-                  }))
-                }
-                onPaste={(event) => {
-                  const cleaned = String(event.text).replace(/\r?\n/g, " ");
-                  setState((prev) => ({
-                    ...prev,
-                    auth: {
-                      ...prev.auth,
-                      loginUrl: prev.auth.loginUrl + cleaned,
-                    },
-                  }));
-                }}
-                focused={focusedField === 0}
-              />
-              <Input
-                label="Username"
-                placeholder="admin"
-                value={state.auth.username}
-                onInput={(v) =>
-                  setState((prev) => ({
-                    ...prev,
-                    auth: { ...prev.auth, username: v },
-                  }))
-                }
-                onPaste={(event) => {
-                  const cleaned = String(event.text).replace(/\r?\n/g, " ");
-                  setState((prev) => ({
-                    ...prev,
-                    auth: {
-                      ...prev.auth,
-                      username: prev.auth.username + cleaned,
-                    },
-                  }));
-                }}
-                focused={focusedField === 1}
-              />
-              <Input
-                label="Password"
-                placeholder="••••••••"
-                value={state.auth.password}
-                onInput={(v) =>
-                  setState((prev) => ({
-                    ...prev,
-                    auth: { ...prev.auth, password: v },
-                  }))
-                }
-                onPaste={(event) => {
-                  const cleaned = String(event.text).replace(/\r?\n/g, " ");
-                  setState((prev) => ({
-                    ...prev,
-                    auth: {
-                      ...prev.auth,
-                      password: prev.auth.password + cleaned,
-                    },
-                  }));
-                }}
-                focused={focusedField === 2}
-              />
-              <Input
-                label="Auth Instructions"
-                placeholder="Use OAuth flow, extract bearer token..."
-                value={state.auth.instructions}
-                onInput={(v) =>
-                  setState((prev) => ({
-                    ...prev,
-                    auth: { ...prev.auth, instructions: v },
-                  }))
-                }
-                onPaste={(event) => {
-                  const cleaned = String(event.text).replace(/\r?\n/g, " ");
-                  setState((prev) => ({
-                    ...prev,
-                    auth: {
-                      ...prev.auth,
-                      instructions: prev.auth.instructions + cleaned,
-                    },
-                  }));
-                }}
-                focused={focusedField === 3}
+                focused={isFocused("field-cwd")}
               />
             </box>
           )}
-        </box>
 
-        {/* Scope Section */}
-        <box flexDirection="column" gap={1}>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={focusedSection === 1 ? colors.text : colors.textMuted}>
-              Scope Constraints
-            </span>
-          </text>
-          {focusedSection === 1 && (
-            <box flexDirection="column" gap={1} paddingLeft={2}>
-              <Input
-                label="Add Allowed Host"
-                description="Press Enter to add"
-                placeholder="example.com"
-                value={hostInput}
-                onInput={setHostInput}
-                focused={focusedField === 0}
-              />
-              {state.scope.allowedHosts.length > 0 && (
-                <box flexDirection="column" paddingLeft={2}>
-                  {state.scope.allowedHosts.map((h, i) => (
-                    <text key={i} fg={colors.textMuted}>
-                      • {h}
-                    </text>
-                  ))}
-                </box>
-              )}
-              <Input
-                label="Add Allowed Port"
-                description="Press Enter to add"
-                placeholder="443"
-                value={portInput}
-                onInput={setPortInput}
-                focused={focusedField === 1}
-              />
-              {state.scope.allowedPorts.length > 0 && (
-                <box flexDirection="column" paddingLeft={2}>
-                  {state.scope.allowedPorts.map((p, i) => (
-                    <text key={i} fg={colors.textMuted}>
-                      • {p}
-                    </text>
-                  ))}
-                </box>
-              )}
-              <box flexDirection="row" gap={1}>
-                <text fg={focusedField === 2 ? colors.text : colors.textMuted}>
-                  Strict Scope:
-                </text>
-                <text
-                  fg={
-                    state.scope.strictScope ? colors.primary : colors.textMuted
-                  }
-                >
-                  {state.scope.strictScope ? "● Enabled" : "○ Disabled"}
-                </text>
-                {focusedField === 2 && (
-                  <text fg={colors.textMuted}>(↑/↓ to toggle)</text>
-                )}
-              </box>
-              <box flexDirection="row" gap={1}>
-                <text
-                  fg={focusedField === 3 ? colors.primary : colors.textMuted}
-                >
-                  Enumerate Subdomains:
-                </text>
-                <text
-                  fg={
-                    state.scope.enumerateSubdomains
-                      ? colors.primary
-                      : colors.textMuted
-                  }
-                >
-                  {state.scope.enumerateSubdomains ? "● Enabled" : "○ Disabled"}
-                </text>
-                {focusedField === 3 && (
-                  <text fg={colors.textMuted}>(↑/↓ to toggle)</text>
-                )}
-              </box>
-            </box>
-          )}
-        </box>
+          {/* Advanced section header */}
+          <box
+            id="section-advanced"
+            paddingLeft={4}
+            paddingTop={1}
+            paddingBottom={1}
+          >
+            <text
+              fg={
+                isFocused("section-advanced")
+                  ? colors.primary
+                  : advancedExpanded
+                    ? colors.text
+                    : colors.textMuted
+              }
+            >
+              {isFocused("section-advanced")
+                ? "❯"
+                : advancedExpanded
+                  ? "▾"
+                  : "▸"}{" "}
+              Advanced
+            </text>
+          </box>
 
-        {/* Headers Section */}
-        <box flexDirection="column" gap={1}>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={focusedSection === 2 ? colors.text : colors.textMuted}>
-              Request Headers
-            </span>
-          </text>
-          {focusedSection === 2 && (
-            <box flexDirection="column" gap={1} paddingLeft={2}>
-              <box flexDirection="column">
+          {/* Advanced contents */}
+          {advancedExpanded && (
+            <>
+              {/* Authentication section */}
+              <box id="section-auth" paddingLeft={6}>
                 <text
                   fg={
-                    state.headers.mode === "none"
+                    isFocused("section-auth")
                       ? colors.primary
-                      : colors.textMuted
+                      : authExpanded
+                        ? colors.text
+                        : colors.textMuted
                   }
                 >
-                  {state.headers.mode === "none" ? "●" : "○"} None
-                </text>
-                <text
-                  fg={
-                    state.headers.mode === "default"
-                      ? colors.primary
-                      : colors.textMuted
-                  }
-                >
-                  {state.headers.mode === "default" ? "●" : "○"} Default
-                  (User-Agent: pensar-apex)
-                </text>
-                <text
-                  fg={
-                    state.headers.mode === "custom"
-                      ? colors.primary
-                      : colors.textMuted
-                  }
-                >
-                  {state.headers.mode === "custom" ? "●" : "○"} Custom
+                  {isFocused("section-auth")
+                    ? "❯"
+                    : authExpanded
+                      ? "▾"
+                      : "▸"}{" "}
+                  Authentication
                 </text>
               </box>
-              {focusedField === 0 && (
-                <text fg={colors.textMuted}>Use ↑/↓ to select</text>
+
+              {authExpanded && (
+                <>
+                  <box id="field-loginUrl" paddingLeft={8} paddingRight={2}>
+                    <Input
+                      label="Login URL"
+                      placeholder="https://example.com/login"
+                      value={state.auth.loginUrl}
+                      onInput={(v) =>
+                        setState((prev) => ({
+                          ...prev,
+                          auth: { ...prev.auth, loginUrl: v },
+                        }))
+                      }
+                      onPaste={(event) => {
+                        const cleaned = String(event.text).replace(
+                          /\r?\n/g,
+                          " ",
+                        );
+                        setState((prev) => ({
+                          ...prev,
+                          auth: {
+                            ...prev.auth,
+                            loginUrl: prev.auth.loginUrl + cleaned,
+                          },
+                        }));
+                      }}
+                      focused={isFocused("field-loginUrl")}
+                    />
+                  </box>
+                  <box id="field-username" paddingLeft={8} paddingRight={2}>
+                    <Input
+                      label="Username"
+                      placeholder="admin"
+                      value={state.auth.username}
+                      onInput={(v) =>
+                        setState((prev) => ({
+                          ...prev,
+                          auth: { ...prev.auth, username: v },
+                        }))
+                      }
+                      onPaste={(event) => {
+                        const cleaned = String(event.text).replace(
+                          /\r?\n/g,
+                          " ",
+                        );
+                        setState((prev) => ({
+                          ...prev,
+                          auth: {
+                            ...prev.auth,
+                            username: prev.auth.username + cleaned,
+                          },
+                        }));
+                      }}
+                      focused={isFocused("field-username")}
+                    />
+                  </box>
+                  <box id="field-password" paddingLeft={8} paddingRight={2}>
+                    <Input
+                      label="Password"
+                      placeholder="••••••••"
+                      value={state.auth.password}
+                      onInput={(v) =>
+                        setState((prev) => ({
+                          ...prev,
+                          auth: { ...prev.auth, password: v },
+                        }))
+                      }
+                      onPaste={(event) => {
+                        const cleaned = String(event.text).replace(
+                          /\r?\n/g,
+                          " ",
+                        );
+                        setState((prev) => ({
+                          ...prev,
+                          auth: {
+                            ...prev.auth,
+                            password: prev.auth.password + cleaned,
+                          },
+                        }));
+                      }}
+                      focused={isFocused("field-password")}
+                    />
+                  </box>
+                  <box
+                    id="field-instructions"
+                    paddingLeft={8}
+                    paddingRight={2}
+                  >
+                    <Input
+                      label="Auth Instructions"
+                      placeholder="Use OAuth flow, extract bearer token..."
+                      value={state.auth.instructions}
+                      onInput={(v) =>
+                        setState((prev) => ({
+                          ...prev,
+                          auth: { ...prev.auth, instructions: v },
+                        }))
+                      }
+                      onPaste={(event) => {
+                        const cleaned = String(event.text).replace(
+                          /\r?\n/g,
+                          " ",
+                        );
+                        setState((prev) => ({
+                          ...prev,
+                          auth: {
+                            ...prev.auth,
+                            instructions: prev.auth.instructions + cleaned,
+                          },
+                        }));
+                      }}
+                      focused={isFocused("field-instructions")}
+                    />
+                  </box>
+                </>
               )}
 
-              {state.headers.mode === "custom" && (
-                <box flexDirection="column" gap={1}>
-                  <Input
-                    label="Header Name"
-                    placeholder="X-Custom-Header"
-                    value={headerNameInput}
-                    onInput={setHeaderNameInput}
-                    focused={focusedField === 1}
-                  />
-                  <Input
-                    label="Header Value"
-                    placeholder="value"
-                    value={headerValueInput}
-                    onInput={setHeaderValueInput}
-                    focused={focusedField === 2}
-                  />
-                  {Object.keys(state.headers.customHeaders).length > 0 && (
-                    <box flexDirection="column">
-                      {Object.entries(state.headers.customHeaders).map(
-                        ([k, v]) => (
-                          <text key={k} fg={colors.textMuted}>
-                            • {k}: {v}
-                          </text>
-                        ),
-                      )}
+              {/* Scope Constraints section */}
+              <box id="section-scope" paddingLeft={6}>
+                <text
+                  fg={
+                    isFocused("section-scope")
+                      ? colors.primary
+                      : scopeExpanded
+                        ? colors.text
+                        : colors.textMuted
+                  }
+                >
+                  {isFocused("section-scope")
+                    ? "❯"
+                    : scopeExpanded
+                      ? "▾"
+                      : "▸"}{" "}
+                  Scope Constraints
+                </text>
+              </box>
+
+              {scopeExpanded && (
+                <>
+                  <box id="field-host" paddingLeft={8} paddingRight={2}>
+                    <Input
+                      label="Add Allowed Host"
+                      description="Press Enter to add"
+                      placeholder="example.com"
+                      value={hostInput}
+                      onInput={setHostInput}
+                      focused={isFocused("field-host")}
+                    />
+                  </box>
+                  {state.scope.allowedHosts.length > 0 && (
+                    <box flexDirection="column" paddingLeft={10}>
+                      {state.scope.allowedHosts.map((h, i) => (
+                        <text key={i} fg={colors.textMuted}>
+                          • {h}
+                        </text>
+                      ))}
                     </box>
                   )}
-                </box>
-              )}
-            </box>
-          )}
-        </box>
-
-        {/* Model Section */}
-        <box flexDirection="column" gap={1}>
-          <text>
-            <span fg={colors.primary}>█ </span>
-            <span fg={focusedSection === 3 ? colors.text : colors.textMuted}>
-              AI Model
-            </span>
-            <span fg={colors.textMuted}> ({model.name})</span>
-            <span fg={colors.textMuted}>
-              {" "}
-              [{isModelUserSelected ? "user" : "default"}]
-            </span>
-          </text>
-          {focusedSection === 3 && (
-            <box flexDirection="column" gap={0} paddingLeft={2}>
-              {/* Search input */}
-              {modelSearchQuery && (
-                <text fg={colors.text}>Search: {modelSearchQuery}_</text>
-              )}
-              {!modelSearchQuery && (
-                <text fg={colors.textMuted}>Type to search models...</text>
-              )}
-
-              {/* Provider groups */}
-              {providerOrder.map((provider) => {
-                const models = groupedModels[provider];
-                if (!models || models.length === 0) return null;
-
-                const isExpanded = expandedProviders.has(provider);
-                const providerName = providerNames[provider] || provider;
-
-                return (
-                  <box key={provider} flexDirection="column" gap={0}>
-                    {/* Provider header */}
-                    <text fg={isExpanded ? colors.text : colors.textMuted}>
-                      {isExpanded ? "▾" : "▸"} {providerName} ({models.length})
+                  <box id="field-port" paddingLeft={8} paddingRight={2}>
+                    <Input
+                      label="Add Allowed Port"
+                      description="Press Enter to add"
+                      placeholder="443"
+                      value={portInput}
+                      onInput={setPortInput}
+                      focused={isFocused("field-port")}
+                    />
+                  </box>
+                  {state.scope.allowedPorts.length > 0 && (
+                    <box flexDirection="column" paddingLeft={10}>
+                      {state.scope.allowedPorts.map((p, i) => (
+                        <text key={i} fg={colors.textMuted}>
+                          • {p}
+                        </text>
+                      ))}
+                    </box>
+                  )}
+                  <box
+                    id="field-strictScope"
+                    paddingLeft={8}
+                    flexDirection="row"
+                    gap={1}
+                  >
+                    <text
+                      fg={
+                        isFocused("field-strictScope")
+                          ? colors.primary
+                          : colors.textMuted
+                      }
+                    >
+                      Strict Scope:
                     </text>
-
-                    {/* Models list (when expanded) */}
-                    {isExpanded && (
-                      <box flexDirection="column" gap={0} paddingLeft={2}>
-                        {models.map((m) => {
-                          const isSelected = m.id === model.id;
-                          const isDefault =
-                            m.id === "claude-haiku-4-5" ||
-                            m.id === "gpt-4o-mini";
-                          return (
-                            <text
-                              key={m.id}
-                              fg={
-                                isSelected ? colors.primary : colors.textMuted
-                              }
-                            >
-                              {isSelected ? "●" : "○"} {m.name}
-                              {isDefault && !isModelUserSelected && isSelected
-                                ? " [default]"
-                                : ""}
-                            </text>
-                          );
-                        })}
-                      </box>
+                    <text
+                      fg={
+                        state.scope.strictScope
+                          ? colors.primary
+                          : colors.textMuted
+                      }
+                    >
+                      {state.scope.strictScope ? "● Enabled" : "○ Disabled"}
+                    </text>
+                    {isFocused("field-strictScope") && (
+                      <text fg={colors.textMuted}>(Space to toggle)</text>
                     )}
                   </box>
-                );
-              })}
+                  <box
+                    id="field-enumerateSubdomains"
+                    paddingLeft={8}
+                    flexDirection="row"
+                    gap={1}
+                  >
+                    <text
+                      fg={
+                        isFocused("field-enumerateSubdomains")
+                          ? colors.primary
+                          : colors.textMuted
+                      }
+                    >
+                      Enumerate Subdomains:
+                    </text>
+                    <text
+                      fg={
+                        state.scope.enumerateSubdomains
+                          ? colors.primary
+                          : colors.textMuted
+                      }
+                    >
+                      {state.scope.enumerateSubdomains
+                        ? "● Enabled"
+                        : "○ Disabled"}
+                    </text>
+                    {isFocused("field-enumerateSubdomains") && (
+                      <text fg={colors.textMuted}>(Space to toggle)</text>
+                    )}
+                  </box>
+                </>
+              )}
 
-              {/* Help text */}
-              <text fg={colors.textMuted}>
-                ↑/↓ select • Type to search • ←/→ collapse/expand
-              </text>
-            </box>
+              {/* Request Headers section */}
+              <box id="section-headers" paddingLeft={6}>
+                <text
+                  fg={
+                    isFocused("section-headers")
+                      ? colors.primary
+                      : headersExpanded
+                        ? colors.text
+                        : colors.textMuted
+                  }
+                >
+                  {isFocused("section-headers")
+                    ? "❯"
+                    : headersExpanded
+                      ? "▾"
+                      : "▸"}{" "}
+                  Request Headers
+                </text>
+              </box>
+
+              {headersExpanded && (
+                <>
+                  <box
+                    id="field-headersMode"
+                    paddingLeft={8}
+                    flexDirection="column"
+                  >
+                    <box flexDirection="column">
+                      <text
+                        fg={
+                          state.headers.mode === "none"
+                            ? colors.primary
+                            : colors.textMuted
+                        }
+                      >
+                        {state.headers.mode === "none" ? "●" : "○"} None
+                      </text>
+                      <text
+                        fg={
+                          state.headers.mode === "default"
+                            ? colors.primary
+                            : colors.textMuted
+                        }
+                      >
+                        {state.headers.mode === "default" ? "●" : "○"} Default
+                        (User-Agent: pensar-apex)
+                      </text>
+                      <text
+                        fg={
+                          state.headers.mode === "custom"
+                            ? colors.primary
+                            : colors.textMuted
+                        }
+                      >
+                        {state.headers.mode === "custom" ? "●" : "○"} Custom
+                      </text>
+                    </box>
+                    {isFocused("field-headersMode") && (
+                      <text fg={colors.textMuted}>Space or ←/→ to change</text>
+                    )}
+                  </box>
+
+                  {state.headers.mode === "custom" && (
+                    <>
+                      <box
+                        id="field-headerName"
+                        paddingLeft={8}
+                        paddingRight={2}
+                      >
+                        <Input
+                          label="Header Name"
+                          placeholder="X-Custom-Header"
+                          value={headerNameInput}
+                          onInput={setHeaderNameInput}
+                          focused={isFocused("field-headerName")}
+                        />
+                      </box>
+                      <box
+                        id="field-headerValue"
+                        paddingLeft={8}
+                        paddingRight={2}
+                      >
+                        <Input
+                          label="Header Value"
+                          description="Press Enter to add header"
+                          placeholder="value"
+                          value={headerValueInput}
+                          onInput={setHeaderValueInput}
+                          focused={isFocused("field-headerValue")}
+                        />
+                      </box>
+                      {Object.keys(state.headers.customHeaders).length > 0 && (
+                        <box flexDirection="column" paddingLeft={10}>
+                          {Object.entries(state.headers.customHeaders).map(
+                            ([k, v]) => (
+                              <text key={k} fg={colors.textMuted}>
+                                • {k}: {v}
+                              </text>
+                            ),
+                          )}
+                        </box>
+                      )}
+                    </>
+                  )}
+                </>
+              )}
+
+              {/* AI Model section */}
+              <box id="section-model" paddingLeft={6}>
+                <text>
+                  <span
+                    fg={
+                      isFocused("section-model")
+                        ? colors.primary
+                        : modelSectionExpanded
+                          ? colors.text
+                          : colors.textMuted
+                    }
+                  >
+                    {isFocused("section-model")
+                      ? "❯"
+                      : modelSectionExpanded
+                        ? "▾"
+                        : "▸"}{" "}
+                    AI Model
+                  </span>
+                  <span fg={colors.textMuted}>
+                    {" "}
+                    ({model.name}) [{isModelUserSelected ? "user" : "default"}]
+                  </span>
+                </text>
+              </box>
+
+              {modelSectionExpanded &&
+                providerOrder.map((provider) => {
+                  const models = groupedModels[provider];
+                  if (!models || models.length === 0) return null;
+                  const isExpanded = expandedProviders.has(provider);
+                  const provName = providerNames[provider] || provider;
+
+                  return (
+                    <box key={provider} flexDirection="column">
+                      <box id={`provider-${provider}`} paddingLeft={8}>
+                        <text
+                          fg={
+                            isFocused(`provider-${provider}`)
+                              ? colors.primary
+                              : isExpanded
+                                ? colors.text
+                                : colors.textMuted
+                          }
+                        >
+                          {isFocused(`provider-${provider}`)
+                            ? "❯"
+                            : isExpanded
+                              ? "▾"
+                              : "▸"}{" "}
+                          {provName} ({models.length})
+                        </text>
+                      </box>
+                      {isExpanded &&
+                        models.map((m) => {
+                          const isSelected = m.id === model.id;
+                          return (
+                            <box
+                              key={m.id}
+                              id={`model-${m.id}`}
+                              paddingLeft={10}
+                            >
+                              <text
+                                fg={
+                                  isFocused(`model-${m.id}`)
+                                    ? colors.primary
+                                    : colors.textMuted
+                                }
+                              >
+                                {isSelected ? "●" : "○"} {m.name}
+                              </text>
+                            </box>
+                          );
+                        })}
+                    </box>
+                  );
+                })}
+            </>
           )}
-        </box>
+        </scrollbox>
 
-        <box flexDirection="column" gap={0} marginTop={1}>
+        {/* Footer help text (pinned) */}
+        <box
+          flexDirection="column"
+          flexShrink={0}
+          paddingLeft={4}
+          paddingTop={1}
+          paddingBottom={1}
+        >
           <text>
             <span fg={colors.primary}>█ </span>
             <span fg={colors.textMuted}>Press </span>
@@ -1078,14 +1298,14 @@ export default function WebWizard({
           <text>
             <span fg={colors.primary}>█ </span>
             <span fg={colors.textMuted}>Press </span>
-            <span fg={colors.text}>[Tab]</span>
-            <span fg={colors.textMuted}> to navigate fields</span>
+            <span fg={colors.text}>[↑/↓]</span>
+            <span fg={colors.textMuted}> to navigate</span>
           </text>
           <text>
             <span fg={colors.primary}>█ </span>
             <span fg={colors.textMuted}>Press </span>
             <span fg={colors.text}>[ESC]</span>
-            <span fg={colors.textMuted}> to go back</span>
+            <span fg={colors.textMuted}> to cancel</span>
           </text>
         </box>
       </box>

--- a/src/tui/components/input.tsx
+++ b/src/tui/components/input.tsx
@@ -6,20 +6,26 @@ import { useTheme } from "../theme";
 interface InputComponentProps extends InputProps {
   label: string;
   description?: string;
+  compact?: boolean;
 }
 
 const Input = forwardRef<InputRenderable, InputComponentProps>(
   function Input(opts, ref) {
     const { colors } = useTheme();
-    const { label, focused = true, description, ...inputProps } = opts;
+    const {
+      label,
+      focused = true,
+      description,
+      compact = false,
+      ...inputProps
+    } = opts;
 
     return (
       <box
         width="100%"
         backgroundColor="transparent"
         flexDirection="column"
-        paddingBottom={1}
-        // paddingTop={1}
+        paddingBottom={compact ? 0 : 1}
         border={["left"]}
         borderColor={colors.primary}
       >


### PR DESCRIPTION
## Summary

Addresses the navigation issues raised in #391 by redesigning the pentest wizard as a single scrollable form.

- **Single-page form**: Merges the two-step wizard (target + configure) into one scrollable view
- **Arrow key navigation**: Up/Down arrows move between all fields (Tab also works as an alias)
- **Advanced dropdown**: Non-essential fields (Authentication, Scope Constraints, Request Headers, AI Model) are hidden under a collapsible "Advanced" section, collapsed by default
- **Nested expandable sections**: Each sub-section within Advanced uses ▸/▾/❯ indicators matching the models dialog pattern
- **ScrollBox integration**: Uses `scrollToChild` to keep the focused item visible as the user navigates

### Navigation scheme
- **↑/↓** — Navigate between fields
- **Space** — Toggle checkboxes, cycle radio options, expand/collapse sections
- **Enter** — Start pentest, toggle sections, or add list items (hosts/ports/headers)
- **←/→** — Expand/collapse sections and providers, cycle header modes
- **ESC** — Close dialog

## Test plan

- [x] Build passes (`bun run build`)
- [x] All 476 tests pass (`bun run test`)
- [x] Linter passes (`bun run lint`)
- [x] Formatter applied (`bun run format`)
- [ ] Manual test: launch TUI, open pentest wizard, verify up/down navigation
- [ ] Manual test: verify Advanced section expands/collapses correctly
- [ ] Manual test: verify scrolling works when all sections are expanded
- [ ] Manual test: verify Enter starts pentest from any field
- [ ] Manual test: verify model selection via arrow keys in model sub-section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it rewires the wizard’s UI flow and keyboard navigation logic (focus/scroll/section expansion), which can easily introduce usability regressions or broken shortcuts, but it does not change backend session creation semantics.
> 
> **Overview**
> Refactors the `WebWizard` TUI from a two-step flow into a **single scrollable form** with a pinned header/footer, using a `scrollbox` plus `scrollToChild` to keep the focused field visible.
> 
> Introduces a flat `navItems`-based focus system and new keyboard scheme (↑/↓/Tab to navigate, Space/Enter/←/→ for toggles, section/provider expansion, radio cycling, and list-item adds), and moves optional configuration under a collapsed-by-default **Advanced** section with nested expandable subsections (Auth/Scope/Headers/Model).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24d3a293dc14b8f1e53cb17f57649d5eb8458b1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->