### PR TITLE
feat: add --option autocomplete for slash commands

### DIFF
--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -36,7 +36,13 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
   const config = useConfig();
   const route = useRoute();
 
-  const { executeCommand, autocompleteOptions, skillsRegistry } = useCommand();
+  const {
+    executeCommand,
+    autocompleteOptions,
+    commandOptionMap,
+    commandNames,
+    skillsRegistry,
+  } = useCommand();
   const { setInputValue } = useInput();
   const { promptRef } = useFocus();
   const { externalDialogOpen, stack } = useDialog();
@@ -225,6 +231,8 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
           focusedBackgroundColor="transparent"
           enableAutocomplete={true}
           autocompleteOptions={autocompleteOptions}
+          commandOptionMap={commandOptionMap}
+          commandNames={commandNames}
           maxVisibleSuggestions={maxSuggestions}
           enableCommands={true}
           onCommandExecute={handleCommandExecute}

--- a/src/tui/components/chat/input-area.tsx
+++ b/src/tui/components/chat/input-area.tsx
@@ -71,6 +71,13 @@ export interface InputAreaProps {
   autocompletePlacement?: "above" | "below";
   /** Highlight /slash-command patterns in the input text */
   highlightSlashCommands?: boolean;
+  /** Map from command name/alias → autocomplete options for --flags */
+  commandOptionMap?: Map<
+    string,
+    import("../shared/prompt-input").AutocompleteOption[]
+  >;
+  /** Set of known command names for option detection */
+  commandNames?: Set<string>;
 }
 
 /**
@@ -193,6 +200,8 @@ function NormalInputAreaInner({
   disableHistoryNavigation = false,
   autocompletePlacement = "below",
   highlightSlashCommands = false,
+  commandOptionMap,
+  commandNames,
 }: Omit<
   InputAreaProps,
   "pendingApproval" | "onApprove" | "onAutoApprove" | "lastDeclineNote"
@@ -266,6 +275,8 @@ function NormalInputAreaInner({
           disableHistoryNavigation={disableHistoryNavigation}
           autocompletePlacement={autocompletePlacement}
           highlightSlashCommands={highlightSlashCommands}
+          commandOptionMap={commandOptionMap}
+          commandNames={commandNames}
         />
       </box>
 

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -105,6 +105,8 @@ export default function OperatorDashboard({
   } = useAgent();
   const {
     autocompleteOptions: allAutocompleteOptions,
+    commandOptionMap,
+    commandNames,
     executeCommand,
     resolveSkillContent,
     skillsRegistry,
@@ -1516,6 +1518,8 @@ export default function OperatorDashboard({
         onAutoApprove={handleAutoApprove}
         enableAutocomplete={true}
         autocompleteOptions={autocompleteOptions}
+        commandOptionMap={commandOptionMap}
+        commandNames={commandNames}
         autocompletePlacement="above"
         enableCommands={true}
         onCommandExecute={handleCommandExecute}

--- a/src/tui/components/shared/prompt-input-logic.test.ts
+++ b/src/tui/components/shared/prompt-input-logic.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   filterInlineSuggestions,
+  filterInlineOptionSuggestions,
   detectInlineSlash,
+  detectInlineOption,
   computeInlineCompletion,
   resolveSubmitValue,
   computeUpArrow,
@@ -643,5 +645,165 @@ describe("computeInlineCompletion", () => {
     );
     expect(result.newText).toBe("test /help");
     expect(result.cursorOffset).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectInlineOption
+// ---------------------------------------------------------------------------
+
+const knownCommands = new Set(["pentest", "p", "operator", "o", "themes"]);
+
+describe("detectInlineOption", () => {
+  it("detects -- after a known command", () => {
+    expect(detectInlineOption("/pentest --", 11, knownCommands)).toEqual({
+      commandName: "pentest",
+      token: "--",
+      start: 9,
+      end: 11,
+    });
+  });
+
+  it("detects partial option", () => {
+    expect(detectInlineOption("/pentest --tar", 14, knownCommands)).toEqual({
+      commandName: "pentest",
+      token: "--tar",
+      start: 9,
+      end: 14,
+    });
+  });
+
+  it("detects option after existing flags", () => {
+    const text = "/pentest --target http://foo --na";
+    expect(detectInlineOption(text, text.length, knownCommands)).toEqual({
+      commandName: "pentest",
+      token: "--na",
+      start: 29,
+      end: 33,
+    });
+  });
+
+  it("works with aliases", () => {
+    expect(detectInlineOption("/p --target", 11, knownCommands)).toEqual({
+      commandName: "p",
+      token: "--target",
+      start: 3,
+      end: 11,
+    });
+  });
+
+  it("returns null for unknown command", () => {
+    expect(detectInlineOption("/unknown --tar", 14, knownCommands)).toBeNull();
+  });
+
+  it("returns null when no command prefix", () => {
+    expect(detectInlineOption("hello --tar", 11, knownCommands)).toBeNull();
+  });
+
+  it("returns null when -- is not preceded by whitespace", () => {
+    expect(detectInlineOption("/pentest x--tar", 15, knownCommands)).toBeNull();
+  });
+
+  it("returns null when cursor is at 0", () => {
+    expect(detectInlineOption("--target", 0, knownCommands)).toBeNull();
+  });
+
+  it("returns null for single dash", () => {
+    expect(detectInlineOption("/pentest -t", 11, knownCommands)).toBeNull();
+  });
+
+  it("returns null with empty known commands", () => {
+    expect(detectInlineOption("/pentest --tar", 14, new Set())).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterInlineOptionSuggestions
+// ---------------------------------------------------------------------------
+
+const optionSuggestions: AutocompleteOption[] = [
+  { value: "--target", label: "--target <url>", description: "Target URL" },
+  { value: "--name", label: "--name <name>", description: "Session name" },
+  { value: "--tier", label: "--tier <1-5>", description: "Permission tier" },
+  { value: "--strict", label: "--strict", description: "Strict scope mode" },
+];
+
+describe("filterInlineOptionSuggestions", () => {
+  it("returns all options for just --", () => {
+    const result = filterInlineOptionSuggestions(
+      "--",
+      optionSuggestions,
+      "/pentest --",
+      10,
+    );
+    expect(result.length).toBe(optionSuggestions.length);
+  });
+
+  it("filters by prefix", () => {
+    const result = filterInlineOptionSuggestions(
+      "--t",
+      optionSuggestions,
+      "/pentest --t",
+      10,
+    );
+    expect(result.every((o) => o.value.startsWith("--t"))).toBe(true);
+    expect(result.length).toBe(2); // --target, --tier
+  });
+
+  it("returns empty for exact match", () => {
+    expect(
+      filterInlineOptionSuggestions(
+        "--target",
+        optionSuggestions,
+        "/pentest --target",
+        10,
+      ),
+    ).toEqual([]);
+  });
+
+  it("excludes already-used options from results", () => {
+    const fullText = "/pentest --target http://foo --";
+    const result = filterInlineOptionSuggestions(
+      "--",
+      optionSuggestions,
+      fullText,
+      10,
+    );
+    expect(result.some((o) => o.value === "--target")).toBe(false);
+    expect(result.length).toBe(3); // --name, --tier, --strict
+  });
+
+  it("respects maxSuggestions", () => {
+    expect(
+      filterInlineOptionSuggestions("--", optionSuggestions, "/pentest --", 2)
+        .length,
+    ).toBe(2);
+  });
+
+  it("returns empty for non-dash token", () => {
+    expect(
+      filterInlineOptionSuggestions(
+        "target",
+        optionSuggestions,
+        "/pentest target",
+        10,
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns empty for empty options", () => {
+    expect(
+      filterInlineOptionSuggestions("--t", [], "/pentest --t", 10),
+    ).toEqual([]);
+  });
+
+  it("is case-insensitive", () => {
+    const result = filterInlineOptionSuggestions(
+      "--T",
+      optionSuggestions,
+      "/pentest --T",
+      10,
+    );
+    expect(result.length).toBe(2); // --target, --tier
   });
 });

--- a/src/tui/components/shared/prompt-input-logic.test.ts
+++ b/src/tui/components/shared/prompt-input-logic.test.ts
@@ -5,7 +5,6 @@ import {
   detectInlineSlash,
   detectInlineOption,
   computeInlineCompletion,
-  resolveSubmitValue,
   computeUpArrow,
   computeDownArrow,
   computeTab,
@@ -28,32 +27,6 @@ const options: AutocompleteOption[] = [
 ];
 
 const history = ["first cmd", "second cmd", "third cmd"];
-
-// ---------------------------------------------------------------------------
-// resolveSubmitValue
-// ---------------------------------------------------------------------------
-
-describe("resolveSubmitValue", () => {
-  it("returns selected suggestion value when valid index", () => {
-    expect(resolveSubmitValue("typed text", options, 1)).toBe("/pentest");
-  });
-
-  it("returns trimmed raw text when no suggestions", () => {
-    expect(resolveSubmitValue("  hello  ", [], -1)).toBe("hello");
-  });
-
-  it("returns trimmed raw text when selectedIndex is -1", () => {
-    expect(resolveSubmitValue("  hello  ", options, -1)).toBe("hello");
-  });
-
-  it("returns trimmed raw text when selectedIndex is out of bounds", () => {
-    expect(resolveSubmitValue("hello", options, 999)).toBe("hello");
-  });
-
-  it("returns empty string for whitespace-only raw text with no selection", () => {
-    expect(resolveSubmitValue("   ", [], -1)).toBe("");
-  });
-});
 
 // ---------------------------------------------------------------------------
 // computeUpArrow

--- a/src/tui/components/shared/prompt-input-logic.ts
+++ b/src/tui/components/shared/prompt-input-logic.ts
@@ -1,26 +1,6 @@
 import type { AutocompleteOption } from "./prompt-input";
 
 // ---------------------------------------------------------------------------
-// Autocomplete filtering
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// Submit value resolution
-// ---------------------------------------------------------------------------
-
-export function resolveSubmitValue(
-  rawText: string,
-  suggestions: AutocompleteOption[],
-  selectedIndex: number,
-): string {
-  if (suggestions.length > 0 && selectedIndex >= 0) {
-    const selected = suggestions[selectedIndex];
-    if (selected) return selected.value;
-  }
-  return rawText.trim();
-}
-
-// ---------------------------------------------------------------------------
 // Keyboard navigation state helpers
 //
 // Each function returns the next state (or null when the key should be

--- a/src/tui/components/shared/prompt-input-logic.ts
+++ b/src/tui/components/shared/prompt-input-logic.ts
@@ -268,6 +268,92 @@ export function computeInlineCompletion(
 }
 
 // ---------------------------------------------------------------------------
+// Inline option detection (for --flag autocomplete after a /command)
+// ---------------------------------------------------------------------------
+
+export interface InlineOptionContext {
+  /** The resolved command name (e.g., "pentest") */
+  commandName: string;
+  /** The partial --token text (e.g., "--tar" or "--") */
+  token: string;
+  /** Character offset where the "--" starts */
+  start: number;
+  /** Character offset at the cursor */
+  end: number;
+}
+
+/**
+ * Detect a --flag token at the cursor position, only when the input starts
+ * with a known /command. Returns null when no option is being typed.
+ */
+export function detectInlineOption(
+  text: string,
+  cursorOffset: number,
+  knownCommands: Set<string>,
+): InlineOptionContext | null {
+  if (cursorOffset <= 0 || cursorOffset > text.length) return null;
+
+  // Walk backwards from cursor through valid option characters (including -)
+  let i = cursorOffset - 1;
+  while (i >= 0 && /[a-zA-Z0-9-]/.test(text[i]!)) i--;
+
+  // i is now just before the token start. The token must begin with "--"
+  const tokenStart = i + 1;
+  const token = text.slice(tokenStart, cursorOffset);
+  if (!token.startsWith("--")) return null;
+
+  // The "--" must be preceded by whitespace
+  if (tokenStart > 0 && !/\s/.test(text[tokenStart - 1]!)) return null;
+
+  // Extract the leading /command from the text
+  const cmdMatch = text.match(/^\/([a-zA-Z0-9][-a-zA-Z0-9]*)/);
+  if (!cmdMatch) return null;
+
+  const commandName = cmdMatch[1]!;
+  if (!knownCommands.has(commandName)) return null;
+
+  return {
+    commandName,
+    token,
+    start: tokenStart,
+    end: cursorOffset,
+  };
+}
+
+/**
+ * Filter command option suggestions against a partial --token.
+ * Excludes options already present in the full input text.
+ */
+export function filterInlineOptionSuggestions(
+  token: string,
+  options: AutocompleteOption[],
+  fullText: string,
+  maxSuggestions: number,
+): AutocompleteOption[] {
+  if (!options.length || !token.startsWith("--")) return [];
+  const lower = token.toLowerCase();
+
+  // Don't show suggestions for exact matches
+  if (options.some((opt) => opt.value.toLowerCase() === lower)) return [];
+
+  // Find all --flags already used in the input
+  const usedFlags = new Set<string>();
+  const flagPattern = /--[a-zA-Z][-a-zA-Z0-9]*/g;
+  let match: RegExpExecArray | null;
+  while ((match = flagPattern.exec(fullText)) !== null) {
+    usedFlags.add(match[0].toLowerCase());
+  }
+
+  return options
+    .filter((opt) => {
+      const optLower = opt.value.toLowerCase();
+      if (usedFlags.has(optLower) && optLower !== lower) return false;
+      return optLower.startsWith(lower);
+    })
+    .slice(0, maxSuggestions);
+}
+
+// ---------------------------------------------------------------------------
 // Content change — should we reset history browsing?
 // ---------------------------------------------------------------------------
 

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -322,6 +322,52 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       }
     };
 
+    // Accept the currently selected autocomplete suggestion.
+    // Shared by both Tab and Enter key handlers.
+    const acceptSelectedSuggestion = (
+      currentSuggestions: AutocompleteOption[],
+      currentSelectedIndex: number,
+    ): boolean => {
+      const tabResult = computeTab(currentSuggestions, currentSelectedIndex);
+      if (!tabResult) return false;
+
+      setSelectedSuggestionIndex(tabResult.selectedSuggestionIndex);
+      if (tabResult.acceptedValue === null) return true;
+
+      clearPaste();
+      const slashCtx = inlineSlashContextRef.current;
+      const optCtx = inlineOptionContextRef.current;
+      const completionCtx =
+        slashCtx ??
+        (optCtx
+          ? { token: optCtx.token, start: optCtx.start, end: optCtx.end }
+          : null);
+      if (completionCtx) {
+        const text = textareaRef.current?.plainText ?? "";
+        // Append trailing space after option completions for UX
+        const completedValue =
+          optCtx && !slashCtx
+            ? tabResult.acceptedValue + " "
+            : tabResult.acceptedValue;
+        const { newText, cursorOffset } = computeInlineCompletion(
+          text,
+          completionCtx,
+          completedValue,
+        );
+        textareaRef.current?.setText(newText);
+        setInputValue(newText);
+        const ta = textareaRef.current;
+        setTimeout(() => {
+          if (ta) ta.cursorOffset = cursorOffset;
+        }, 0);
+      } else {
+        textareaRef.current?.setText(tabResult.acceptedValue);
+        setInputValue(tabResult.acceptedValue);
+        textareaRef.current?.gotoLineEnd();
+      }
+      return true;
+    };
+
     // Handle keyboard navigation for suggestions and command history.
     //
     // Priority: up/down navigate command history. When the user reaches
@@ -345,43 +391,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       // --- Tab: accept the highlighted autocomplete suggestion -----------
       if (suggestions.length > 0 && key.name === "tab") {
         key.preventDefault?.();
-        const tabResult = computeTab(suggestions, selectedIndexRef.current);
-        if (tabResult) {
-          setSelectedSuggestionIndex(tabResult.selectedSuggestionIndex);
-          if (tabResult.acceptedValue !== null) {
-            clearPaste();
-            const slashCtx = inlineSlashContextRef.current;
-            const optCtx = inlineOptionContextRef.current;
-            const completionCtx =
-              slashCtx ??
-              (optCtx
-                ? { token: optCtx.token, start: optCtx.start, end: optCtx.end }
-                : null);
-            if (completionCtx) {
-              const text = textareaRef.current?.plainText ?? "";
-              // Append trailing space after option completions for UX
-              const completedValue =
-                optCtx && !slashCtx
-                  ? tabResult.acceptedValue + " "
-                  : tabResult.acceptedValue;
-              const { newText, cursorOffset } = computeInlineCompletion(
-                text,
-                completionCtx,
-                completedValue,
-              );
-              textareaRef.current?.setText(newText);
-              setInputValue(newText);
-              const ta = textareaRef.current;
-              setTimeout(() => {
-                if (ta) ta.cursorOffset = cursorOffset;
-              }, 0);
-            } else {
-              textareaRef.current?.setText(tabResult.acceptedValue);
-              setInputValue(tabResult.acceptedValue);
-              textareaRef.current?.gotoLineEnd();
-            }
-          }
-        }
+        acceptSelectedSuggestion(suggestions, selectedIndexRef.current);
         return;
       }
 
@@ -462,39 +472,9 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       // When autocomplete suggestions are visible with a selection,
       // Enter accepts the suggestion (same as Tab) instead of submitting.
       if (currentSuggestions.length > 0 && currentSelectedIndex >= 0) {
-        const tabResult = computeTab(currentSuggestions, currentSelectedIndex);
-        if (tabResult?.acceptedValue !== null && tabResult) {
-          clearPaste();
-          const slashCtx = inlineSlashContextRef.current;
-          const optCtx = inlineOptionContextRef.current;
-          const completionCtx =
-            slashCtx ??
-            (optCtx
-              ? { token: optCtx.token, start: optCtx.start, end: optCtx.end }
-              : null);
-          if (completionCtx) {
-            const text = textareaRef.current?.plainText ?? "";
-            const completedValue =
-              optCtx && !slashCtx
-                ? tabResult.acceptedValue + " "
-                : tabResult.acceptedValue;
-            const { newText, cursorOffset } = computeInlineCompletion(
-              text,
-              completionCtx,
-              completedValue,
-            );
-            textareaRef.current?.setText(newText);
-            setInputValue(newText);
-            const ta = textareaRef.current;
-            setTimeout(() => {
-              if (ta) ta.cursorOffset = cursorOffset;
-            }, 0);
-          } else {
-            textareaRef.current?.setText(tabResult.acceptedValue);
-            setInputValue(tabResult.acceptedValue);
-            textareaRef.current?.gotoLineEnd();
-          }
-          setSelectedSuggestionIndex(-1);
+        if (
+          acceptSelectedSuggestion(currentSuggestions, currentSelectedIndex)
+        ) {
           return;
         }
       }

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -18,15 +18,17 @@ import { useInput } from "../../context/input";
 import { useFocus } from "../../context/focus";
 import {
   filterInlineSuggestions,
+  filterInlineOptionSuggestions,
   detectInlineSlash,
+  detectInlineOption,
   computeInlineCompletion,
-  resolveSubmitValue,
   computeUpArrow,
   computeDownArrow,
   computeTab,
   shouldResetHistory,
   computeVisibleWindow,
   type InlineSlashContext,
+  type InlineOptionContext,
 } from "./prompt-input-logic";
 import { usePasteExtmarks } from "./use-paste-extmarks";
 export interface AutocompleteOption {
@@ -104,6 +106,10 @@ interface PromptInputProps {
 
   // Slash command highlighting — colors /slug patterns in the input
   highlightSlashCommands?: boolean;
+
+  // Option autocomplete — shows --flag suggestions after a known /command
+  commandOptionMap?: Map<string, AutocompleteOption[]>;
+  commandNames?: Set<string>;
 }
 
 export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
@@ -131,6 +137,8 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       showPromptIndicator = false,
       autocompletePlacement = "below",
       highlightSlashCommands = false,
+      commandOptionMap,
+      commandNames,
     },
     ref,
   ) {
@@ -166,6 +174,14 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
     );
     const inlineSlashContextRef = useRef<InlineSlashContext | null>(null);
 
+    // Inline option detection state — drives --flag autocomplete
+    const [inlineOptionToken, setInlineOptionToken] = useState<string | null>(
+      null,
+    );
+    const inlineOptionContextRef = useRef<InlineOptionContext | null>(null);
+    // Cache full text for option dedup filtering (avoids extra reads in memo)
+    const fullTextRef = useRef("");
+
     const suggestions = useMemo(() => {
       if (!enableAutocomplete) return [];
       // Inline slash detection drives suggestions for both start-of-line
@@ -177,11 +193,31 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
           maxSuggestions,
         );
       }
+      // Inline option detection for --flags after a /command
+      if (
+        inlineOptionToken &&
+        inlineOptionContextRef.current &&
+        commandOptionMap
+      ) {
+        const cmdOpts = commandOptionMap.get(
+          inlineOptionContextRef.current.commandName,
+        );
+        if (cmdOpts) {
+          return filterInlineOptionSuggestions(
+            inlineOptionToken,
+            cmdOpts,
+            fullTextRef.current,
+            maxSuggestions,
+          );
+        }
+      }
       return [];
     }, [
       enableAutocomplete,
       autocompleteOptions,
       inlineSlashToken,
+      inlineOptionToken,
+      commandOptionMap,
       maxSuggestions,
     ]);
 
@@ -315,12 +351,23 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
           if (tabResult.acceptedValue !== null) {
             clearPaste();
             const slashCtx = inlineSlashContextRef.current;
-            if (slashCtx) {
+            const optCtx = inlineOptionContextRef.current;
+            const completionCtx =
+              slashCtx ??
+              (optCtx
+                ? { token: optCtx.token, start: optCtx.start, end: optCtx.end }
+                : null);
+            if (completionCtx) {
               const text = textareaRef.current?.plainText ?? "";
+              // Append trailing space after option completions for UX
+              const completedValue =
+                optCtx && !slashCtx
+                  ? tabResult.acceptedValue + " "
+                  : tabResult.acceptedValue;
               const { newText, cursorOffset } = computeInlineCompletion(
                 text,
-                slashCtx,
-                tabResult.acceptedValue,
+                completionCtx,
+                completedValue,
               );
               textareaRef.current?.setText(newText);
               setInputValue(newText);
@@ -411,23 +458,50 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
     const handleSubmit = async () => {
       const currentSuggestions = suggestionsRef.current;
       const currentSelectedIndex = selectedIndexRef.current;
+
+      // When autocomplete suggestions are visible with a selection,
+      // Enter accepts the suggestion (same as Tab) instead of submitting.
+      if (currentSuggestions.length > 0 && currentSelectedIndex >= 0) {
+        const tabResult = computeTab(currentSuggestions, currentSelectedIndex);
+        if (tabResult?.acceptedValue !== null && tabResult) {
+          clearPaste();
+          const slashCtx = inlineSlashContextRef.current;
+          const optCtx = inlineOptionContextRef.current;
+          const completionCtx =
+            slashCtx ??
+            (optCtx
+              ? { token: optCtx.token, start: optCtx.start, end: optCtx.end }
+              : null);
+          if (completionCtx) {
+            const text = textareaRef.current?.plainText ?? "";
+            const completedValue =
+              optCtx && !slashCtx
+                ? tabResult.acceptedValue + " "
+                : tabResult.acceptedValue;
+            const { newText, cursorOffset } = computeInlineCompletion(
+              text,
+              completionCtx,
+              completedValue,
+            );
+            textareaRef.current?.setText(newText);
+            setInputValue(newText);
+            const ta = textareaRef.current;
+            setTimeout(() => {
+              if (ta) ta.cursorOffset = cursorOffset;
+            }, 0);
+          } else {
+            textareaRef.current?.setText(tabResult.acceptedValue);
+            setInputValue(tabResult.acceptedValue);
+            textareaRef.current?.gotoLineEnd();
+          }
+          setSelectedSuggestionIndex(-1);
+          return;
+        }
+      }
+
       // Resolve paste placeholders to full text before submit
       const rawText = resolveText(textareaRef.current?.plainText ?? "");
-
-      // For inline slash (mid-text), Enter submits raw text — Tab is for
-      // completion. For start-of-line commands, keep the current behavior
-      // where Enter accepts the selected suggestion.
-      const isInlineSlash =
-        inlineSlashContextRef.current != null &&
-        inlineSlashContextRef.current.start > 0;
-
-      const valueToSubmit = isInlineSlash
-        ? rawText.trim()
-        : resolveSubmitValue(rawText, currentSuggestions, currentSelectedIndex);
-
-      if (currentSuggestions.length > 0 && currentSelectedIndex >= 0) {
-        setSelectedSuggestionIndex(-1);
-      }
+      const valueToSubmit = rawText.trim();
 
       if (!valueToSubmit) return;
 
@@ -451,11 +525,28 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       const text = textareaRef.current?.plainText ?? "";
       const cursorOffset = textareaRef.current?.cursorOffset ?? text.length;
       setInputValue(text);
+      fullTextRef.current = text;
 
       // Detect inline /token at cursor for autocomplete
       const slashCtx = detectInlineSlash(text, cursorOffset);
-      inlineSlashContextRef.current = slashCtx;
-      setInlineSlashToken(slashCtx?.token ?? null);
+      if (slashCtx) {
+        inlineSlashContextRef.current = slashCtx;
+        inlineOptionContextRef.current = null;
+        setInlineSlashToken(slashCtx.token);
+        setInlineOptionToken(null);
+      } else if (commandNames?.size) {
+        // No slash context — try option detection for --flags
+        const optCtx = detectInlineOption(text, cursorOffset, commandNames);
+        inlineOptionContextRef.current = optCtx;
+        inlineSlashContextRef.current = null;
+        setInlineSlashToken(null);
+        setInlineOptionToken(optCtx?.token ?? null);
+      } else {
+        inlineSlashContextRef.current = null;
+        inlineOptionContextRef.current = null;
+        setInlineSlashToken(null);
+        setInlineOptionToken(null);
+      }
 
       applySlashHighlights(text);
 

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -20,6 +20,10 @@ import { createSkillsRegistry, type SkillsRegistry } from "../../core/skills";
 interface CommandContextValue {
   router: CommandRouter<AppCommandContext>;
   autocompleteOptions: AutocompleteOption[];
+  /** Map from command name/alias → AutocompleteOption[] for that command's --options */
+  commandOptionMap: Map<string, AutocompleteOption[]>;
+  /** Set of all command names + aliases (for option detection) */
+  commandNames: Set<string>;
   executeCommand: (input: string) => Promise<boolean>;
   commands: typeof commands;
   /** Reload skills from disk (e.g. after creating a new one) */
@@ -168,6 +172,38 @@ export function CommandProvider({
     return options;
   }, [router, registry, registryVersion]);
 
+  // Build option map: command name/alias → AutocompleteOption[] for --flags
+  const commandOptionMap = useMemo(() => {
+    const map = new Map<string, AutocompleteOption[]>();
+    for (const cmd of commands) {
+      if (!cmd.options?.length) continue;
+      const opts: AutocompleteOption[] = cmd.options
+        .filter((o) => o.name.startsWith("--"))
+        .map((o) => ({
+          value: o.name,
+          label: o.name + (o.valueHint ? ` ${o.valueHint}` : ""),
+          description: o.description,
+        }));
+      if (opts.length === 0) continue;
+      map.set(cmd.name, opts);
+      for (const alias of cmd.aliases ?? []) {
+        map.set(alias, opts);
+      }
+    }
+    return map;
+  }, []);
+
+  // Set of all command names + aliases for option detection
+  const commandNames = useMemo(() => {
+    const names = new Set<string>();
+    for (const cmd of commands) {
+      if (cmd.hidden) continue;
+      names.add(cmd.name);
+      for (const alias of cmd.aliases ?? []) names.add(alias);
+    }
+    return names;
+  }, []);
+
   const executeCommand = useCallback(
     async (input: string): Promise<boolean> => {
       return await router.execute(input, ctx);
@@ -179,6 +215,8 @@ export function CommandProvider({
     () => ({
       router,
       autocompleteOptions,
+      commandOptionMap,
+      commandNames,
       executeCommand,
       commands,
       refreshSkills,
@@ -189,6 +227,8 @@ export function CommandProvider({
     [
       router,
       autocompleteOptions,
+      commandOptionMap,
+      commandNames,
       executeCommand,
       refreshSkills,
       resolveSkillContent,


### PR DESCRIPTION
Adds autocomplete for command flags — after typing a known command like `/pentest`, typing `--` shows a dropdown of that command's available options with descriptions and value hints. Already-used flags are filtered out. Tab or Enter accepts the selected suggestion.

Also fixes Enter behavior when any autocomplete dropdown is visible: Enter now accepts the selected suggestion instead of submitting, so you won't accidentally fire off an incomplete command.


https://github.com/user-attachments/assets/4716fbba-9908-40cf-a329-29e3ba5ea6d3



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes core TUI input/autocomplete behavior (new flag parsing + Enter/Tab acceptance), which could affect command submission and editing flows across home and operator screens.
> 
> **Overview**
> Adds **context-aware autocomplete for slash-command `--flags`**: after a known `/command`, typing `--` (or a partial flag) now shows that command’s available options (with value hints/descriptions) while filtering out already-used flags.
> 
> Updates `PromptInput` to detect inline option tokens, reuse a shared accept-suggestion path for Tab/Enter (Enter now accepts a highlighted suggestion instead of submitting), and plumbs new `commandOptionMap`/`commandNames` from `useCommand` through `HomeView`, `InputArea`, and `OperatorDashboard`. Includes new unit tests for `detectInlineOption` and `filterInlineOptionSuggestions`, and removes the old `resolveSubmitValue` submit-selection logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5bb3923337b8451da743d22814cfa90d61927c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->