### PR TITLE
feat: agent environment variables

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -124,6 +124,7 @@ export class OffensiveSecurityAgent<TResult = void> {
     if (!input.sandbox) {
       this.persistentShell = new PersistentShell({
         cwd: agentCwd,
+        env: input.environmentVariables,
       });
       if (input.commandCancelHandle) {
         const shell = this.persistentShell;

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -23,6 +23,7 @@ export class PersistentShell {
   private alive = false;
   private disposed = false;
   private readonly cwd?: string;
+  private readonly extraEnv?: Record<string, string>;
 
   /** Allows cancelCurrentCommand() to force-resolve the running execute(). */
   private pendingCancel: ((result: ShellExecuteResult) => void) | null = null;
@@ -30,8 +31,9 @@ export class PersistentShell {
   private pendingStdout: (() => string) | null = null;
   private pendingStderr: (() => string) | null = null;
 
-  constructor(opts?: { cwd?: string }) {
+  constructor(opts?: { cwd?: string; env?: Record<string, string> }) {
     this.cwd = opts?.cwd;
+    this.extraEnv = opts?.env;
   }
 
   private spawn(): void {
@@ -48,6 +50,7 @@ export class PersistentShell {
       detached: process.platform !== "win32",
       env: {
         ...process.env,
+        ...this.extraEnv,
         PS1: "",
         // Hint to CLI tools that we're non-interactive
         CI: "true",

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -223,6 +223,15 @@ export type OffensiveSecurityAgentInput<TResult = void> = {
    * currently running shell command without killing the agent.
    */
   commandCancelHandle?: CommandCancelHandle;
+
+  /**
+   * Environment variables to inject into the agent's persistent shell.
+   * Each key-value pair is set in the shell's process environment at
+   * spawn time, so they're available to every `execute_command` call.
+   * Scoped to this agent instance — other agents on the same machine
+   * never see them.
+   */
+  environmentVariables?: Record<string, string>;
 };
 
 /**
@@ -272,6 +281,12 @@ export interface SpecializedAgentInput {
 
   /** Override the default stop condition */
   stopWhen?: StopCondition<ToolSet>;
+
+  /**
+   * Environment variables to inject into the agent's persistent shell.
+   * Forwarded to the underlying {@link OffensiveSecurityAgentInput}.
+   */
+  environmentVariables?: Record<string, string>;
 }
 
 /**

--- a/src/core/agents/specialized/authenticationAgent/agent.ts
+++ b/src/core/agents/specialized/authenticationAgent/agent.ts
@@ -55,6 +55,12 @@ export interface AuthenticationAgentInput {
    * The agent will treat non-malicious instructions within the context as guidance.
    */
   context?: string;
+
+  /**
+   * Environment variables to inject into the agent's persistent shell.
+   * Forwarded to the underlying {@link OffensiveSecurityAgentInput}.
+   */
+  environmentVariables?: Record<string, string>;
 }
 
 /** The typed result returned by `AuthenticationAgent.consume()`. */
@@ -122,6 +128,7 @@ export class AuthenticationAgent extends OffensiveSecurityAgent<AuthenticationRe
       onStepFinish,
       abortSignal,
       context,
+      environmentVariables,
     } = opts;
 
     const cm = session.credentialManager;
@@ -135,6 +142,7 @@ export class AuthenticationAgent extends OffensiveSecurityAgent<AuthenticationRe
       authConfig,
       onStepFinish,
       abortSignal,
+      environmentVariables,
       toolChoice: "auto",
       activeTools: [
         // Auth flow tools

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -108,6 +108,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       findingsRegistry,
       messages,
       context,
+      environmentVariables,
     } = opts;
 
     super({
@@ -128,6 +129,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       sandbox,
       findingsRegistry,
       messages,
+      environmentVariables,
 
       activeTools: [
         "execute_command",

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -119,6 +119,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
         session,
         findingsRegistry,
         context,
+        environmentVariables ? Object.keys(environmentVariables) : undefined,
       ),
       model,
       session,
@@ -291,6 +292,7 @@ function buildPrompt(
   },
   findingsRegistry?: FindingsRegistry,
   context?: string,
+  envVarNames?: string[],
 ): string {
   const sessionRootPath = session.rootPath;
   const exfilMode = session.config?.exfilMode ?? false;
@@ -431,6 +433,11 @@ Do NOT discover or enumerate other endpoints or services. Focus exclusively on t
     ? `\n## Application Context\nThe following is context specific to the application under test. If it contains non-malicious instructions relevant to your testing, follow them.\n\n${context}\n`
     : "";
 
+  const envVarSection =
+    envVarNames && envVarNames.length > 0
+      ? `\n## Environment Variables\nThe following environment variables are pre-loaded in your shell and available in every \`execute_command\` call. Use them in scripts or commands (e.g. \`$${envVarNames[0]}\`) — do NOT hardcode their values.\n${envVarNames.map((n) => `- \`${n}\``).join("\n")}\n`
+      : "";
+
   return `# Testing Assignment
 
 ## Target
@@ -438,7 +445,7 @@ Do NOT discover or enumerate other endpoints or services. Focus exclusively on t
 ${authSection}
 ${knownFindingsSection}
 ${knowledgeBaseSection}
-${contextSection}
+${contextSection}${envVarSection}
 ## Objectives
 ${objectiveList}
 ${outcomeSection}


### PR DESCRIPTION
Adds `environmentVariables` on agent input and documents env var names in the pentest agent prompt.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes command-execution behavior by injecting caller-provided environment variables into the long-lived local shell, which could affect tool behavior and increases the chance of secret leakage if misused. Scope is limited to agent instances and prompt documentation only, with no broader auth/permission changes.
> 
> **Overview**
> Adds optional `environmentVariables` to agent inputs and threads it through the `OffensiveSecurityAgent` harness into `PersistentShell`, merging the provided key/values into the spawned shell process environment so they are available for all `execute_command` calls.
> 
> Updates specialized agents to accept/forward `environmentVariables`; the targeted pentest agent also amends its prompt to *list env var names only* and instructs the model to reference them rather than hardcoding values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0582b73bb9620f09cc61e074119f1f801007ad0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->