### PR TITLE
Export EndpointSelectionResultSchema from CodeAgent

### DIFF
--- a/src/core/agents/specialized/codeAgent/index.ts
+++ b/src/core/agents/specialized/codeAgent/index.ts
@@ -1,1 +1,5 @@
 export * from "./agent";
+export {
+  EndpointSelectionResultSchema,
+  type EndpointSelectionResult,
+} from "./schemas";

--- a/src/core/agents/specialized/codeAgent/schemas.ts
+++ b/src/core/agents/specialized/codeAgent/schemas.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+/**
+ * Structured result returned by a CodeAgent that analyzes git diffs
+ * to determine which endpoints need re-testing.
+ *
+ * Exported for use by Console — must be defined here with apex's Zod v3
+ * to avoid v3/v4 schema incompatibility at runtime.
+ */
+export const EndpointSelectionResultSchema = z.object({
+  runAll: z
+    .boolean()
+    .describe(
+      "If true, all endpoints should be tested (e.g. global config change, too many indirect effects to determine scope).",
+    ),
+  affectedEndpointIds: z
+    .array(z.string())
+    .describe(
+      "IDs of endpoints affected by the diff. Empty when runAll is true.",
+    ),
+  reasoning: z
+    .string()
+    .describe(
+      "Brief explanation of how the affected endpoints were determined.",
+    ),
+});
+
+export type EndpointSelectionResult = z.infer<
+  typeof EndpointSelectionResultSchema
+>;


### PR DESCRIPTION
## What does this PR do?

Console's `selectAffectedEndpoints` uses a `CodeAgent` to analyze git diffs and determine which endpoints need re-testing. The agent works correctly but crashes when returning its structured response because the `EndpointSelectionResultSchema` is defined in console using **Zod v4**, then passed to apex's `CodeAgent` as `responseSchema`.

`createResponseTool` wraps it in `z.object({ response: responseSchema })` using **Zod v3**, which calls `_parse()` on the v4 schema object — a method that doesn't exist in v4. The agent silently falls back to `"run all endpoints"`, making incremental endpoint selection a no-op.

This PR defines and exports `EndpointSelectionResultSchema` in **apex** using apex's **Zod v3**, following the pattern established by `attackSurface/schemas.ts` for schemas exported for console integration.

Console can now import the schema instead of defining it locally with Zod v4, avoiding the runtime incompatibility.

---

## How did you verify your code works?

- `tsc --noEmit` passes cleanly  
- Schema is exported through `codeAgent/index.ts → specialized/index.ts`, matching the existing export chain  
- Console side:
  - Removed local schema + type from `selectEndpoints.ts`  
  - Imported schema from apex  
  - Removed `@ts-expect-error` on the `responseSchema` line  
  - Verified output returns `Was filtered: true` with specific endpoint IDs instead of falling back to run-all  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small Zod v3 schema and re-exports it for downstream consumers, with no behavior changes outside structured response validation.
> 
> **Overview**
> Fixes Console/Apex Zod version mismatch by **adding a shared, exported structured response schema** for CodeAgent endpoint selection results.
> 
> Introduces `EndpointSelectionResultSchema` (and inferred `EndpointSelectionResult` type) in `codeAgent/schemas.ts` and re-exports them from `codeAgent/index.ts` so Console can import a Zod v3 schema instead of defining its own.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c8aae14939384e96508b4bd77a93820fa44de9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->