### PR TITLE
fix: resolve ProcessEnv type error in persistent shell env cast

### DIFF
--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -49,9 +49,9 @@ export class PersistentShell {
       // interactive programs from writing prompts to the TUI's TTY.
       detached: process.platform !== "win32",
       env: {
-        PATH: process.env.PATH,
-        HOME: process.env.HOME,
-        USER: process.env.USER,
+        PATH: process.env.PATH ?? "",
+        HOME: process.env.HOME ?? "",
+        USER: process.env.USER ?? "",
         LANG: process.env.LANG,
         TMPDIR: process.env.TMPDIR,
         ...this.extraEnv,
@@ -59,7 +59,7 @@ export class PersistentShell {
         CI: "true",
         TERM: "dumb",
         NO_COLOR: "1",
-      },
+      } as Record<string, string | undefined> as NodeJS.ProcessEnv,
     });
 
     this.alive = true;


### PR DESCRIPTION
## Summary

- Adds `?? ""` fallbacks for `PATH`, `HOME`, `USER` to eliminate `string | undefined` mismatches
- Casts env object through `Record<string, string | undefined>` to satisfy the augmented `ProcessEnv` type (which requires `NODE_ENV`) without adding `NODE_ENV` to the allowlist

Follow-up to #499 which scoped the persistent shell env to an allowlist.

## Test plan

- [ ] `npm run tsc` passes
- [ ] Pentest agent shell commands still resolve executables via `PATH`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the environment passed to the long-lived shell; setting missing `PATH/HOME/USER` to empty strings could change command resolution in edge environments where those vars are absent.
> 
> **Overview**
> Fixes TypeScript `ProcessEnv` typing issues in `PersistentShell` by making `PATH`, `HOME`, and `USER` default to `""` when unset, and by casting the env allowlist through `Record<string, string | undefined>` before `NodeJS.ProcessEnv`.
> 
> This keeps the allowlisted env shape while unblocking `tsc` without expanding the env list (e.g., no required `NODE_ENV` addition).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36cfa3ad5669f6b1efd29a0d43f172aae3736d0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->