### PR TITLE
fix: removed "spawn coding agents", and "spawn pentest swarm" from plan tool calls

### DIFF
--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -253,8 +253,10 @@ export const ALL_TOOL_NAMES: ToolName[] = [
  * Tool names available in plan mode (read-only / non-mutating).
  *
  * Excludes: create_file, update_file, document_vulnerability,
- * document_app, document_endpoint. These are the mutation tools that should not be available
- * when the operator is in plan (read-only) mode.
+<<<<<<< HEAD
+ * document_app, document_endpoint, spawn_pentest_swarm, spawn_coding_agent
+ * — file writes, findings, and orchestration tools that spawn autonomous
+ * sub-agents are not available in plan mode.
  */
 export const PLAN_MODE_TOOL_NAMES: ToolName[] = [
   // Browser automation (read-only navigation and inspection)
@@ -279,9 +281,6 @@ export const PLAN_MODE_TOOL_NAMES: ToolName[] = [
   "create_attack_surface_report",
   "complete_authentication",
   "run_attack_surface",
-  "spawn_pentest_swarm",
-  "spawn_coding_agent",
-  "run_pentest_workflow",
   "provide_comparison_results",
   // Memory
   "add_memory",

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -80,7 +80,8 @@ export type OffensiveSecurityAgentInput<TResult = void> = {
    * When set to `"plan"`, the agent's `activeTools` are intersected with
    * {@link PLAN_MODE_TOOL_NAMES} so that mutation tools (create_file,
    * update_file, document_vulnerability, document_app,
-   * document_endpoint) are excluded.
+   * document_endpoint) and orchestration tools that spawn autonomous
+   * sub-agents (spawn_pentest_swarm, spawn_coding_agent) are excluded.
    *
    * @default "default"
    */


### PR DESCRIPTION
Fixes #506

### What does this PR do?

In Plan mode, the operator’s tool set is filtered to PLAN_MODE_TOOL_NAMES, which is documented as read-only / non-mutating. Despite that, spawn_pentest_swarm was still in that list, so the model could launch the full parallel pentest swarm while the UI showed Plan mode—confusing and inconsistent with “read-only” intent. spawn_coding_agent was in the same category: it spawns autonomous sub-agents that can change the environment, so it did not belong in plan mode either.

### How did you verify your code works?

Didn't really do much. Just the following checks:

bun run tsc
bun run test
bun run lint
bun run format:check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only tightens the plan-mode tool allowlist, reducing what the model can execute; main impact is potential behavior change for users relying on these tools in plan mode.
> 
> **Overview**
> Plan mode for the OffensiveSecurityAgent is now **strictly read-only** by removing orchestration/spawn tools from `PLAN_MODE_TOOL_NAMES`.
> 
> Specifically, `spawn_pentest_swarm`, `spawn_coding_agent`, and `run_pentest_workflow` are no longer available when `input.mode === "plan"`, preventing autonomous sub-agent execution while the UI is in plan mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89a1f38ff464923427a1ef17202227020099fc9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->