### PR TITLE
feat: add objectiveResults to pentest agent structured response

### DIFF
--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -38,11 +38,32 @@ export interface PentestResult {
   findingsPath: string;
   /** Absolute path to the session's POC scripts directory */
   pocsPath: string;
+  /** Per-objective completion status from the agent's structured response */
+  objectiveResults?: ObjectiveResult[];
 }
 
 // ---------------------------------------------------------------------------
 // Response schema — the agent calls "response" when done testing
 // ---------------------------------------------------------------------------
+
+const ObjectiveResultSchema = z.object({
+  objective: z
+    .string()
+    .describe("The objective text, exactly as it was provided or a refined version"),
+  completed: z
+    .boolean()
+    .describe(
+      "true if this objective was thoroughly tested and can be considered done for this endpoint; false if it still needs further testing in future runs",
+    ),
+  result: z
+    .string()
+    .optional()
+    .describe(
+      "Brief description of what was found or why this objective is complete/incomplete",
+    ),
+});
+
+export type ObjectiveResult = z.infer<typeof ObjectiveResultSchema>;
 
 const PentestResponseSchema = z.object({
   summary: z
@@ -56,6 +77,11 @@ const PentestResponseSchema = z.object({
   objectivesCovered: z
     .array(z.string())
     .describe("Which objectives were tested"),
+  objectiveResults: z
+    .array(ObjectiveResultSchema)
+    .describe(
+      "Status of each objective: mark as completed if thoroughly tested (vulnerability confirmed and documented, OR conclusively not vulnerable), or incomplete if further testing is warranted. Include new objectives discovered during testing that should be added for future runs.",
+    ),
   noFindingsReason: z
     .string()
     .optional()
@@ -112,6 +138,21 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       environmentVariables,
     } = opts;
 
+    // The base class creates the response tool from responseSchema and
+    // invokes onResult with the validated data. We intercept that via
+    // extraTools to also capture objectiveResults before the base class
+    // wires the stop condition. However, the simplest approach is to
+    // not provide responseSchema directly and instead manage the
+    // response tool ourselves. But that would duplicate base class
+    // logic. Instead, we rely on the base class: when responseSchema
+    // is set AND resolveResult is set, the base class still creates
+    // the response tool with an onResult callback that writes to a
+    // local `capturedResponse` variable (typed as TResult). We can't
+    // access that variable directly. So instead we read from the
+    // stream result's tool calls.
+    //
+    // Simpler: override resolveResult to pull objective results from
+    // the stream's response messages.
     super({
       system: buildSystemPrompt(session),
       prompt: buildPrompt(
@@ -162,15 +203,39 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
 
       responseSchema: PentestResponseSchema,
 
-      resolveResult: () => {
-        // Report files are written once by the orchestrator in Phase 3
-        // after all agents complete — no per-agent writes needed.
+      resolveResult: async (streamResult) => {
+        let objectiveResults: ObjectiveResult[] | undefined;
+
+        try {
+          const response = await streamResult.response;
+          for (const msg of response.messages ?? []) {
+            if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+            for (const part of msg.content) {
+              if (
+                part.type === "tool-call" &&
+                part.toolName === "response" &&
+                part.input
+              ) {
+                const input = part.input as {
+                  response?: { objectiveResults?: ObjectiveResult[] };
+                };
+                if (input.response?.objectiveResults) {
+                  objectiveResults = input.response.objectiveResults;
+                }
+              }
+            }
+          }
+        } catch {
+          // Best-effort; objectiveResults will be undefined
+        }
+
         const findings = loadFindings(session.findingsPath);
 
         return {
           findings,
           findingsPath: session.findingsPath,
           pocsPath: session.pocsPath,
+          objectiveResults,
         };
       },
     });
@@ -200,7 +265,7 @@ Your methodology:
 5. TEST — Execute targeted attacks methodically, one payload/technique at a time. Observe responses carefully for indicators of vulnerability.
 6. EXPLOIT & DOCUMENT — When a vulnerability is confirmed, call document_vulnerability with your POC script (in pocContent) and finding details. The tool creates, executes, and validates the POC, then scores and documents the finding. If the POC fails or the validation judge rejects, revise and retry.
 7. LEARN — Before finishing, use add_memory to persist reusable learnings from this engagement (e.g. target-specific behaviors, successful payload patterns, technology fingerprints, false positive patterns, credential formats). This knowledge helps future engagements be more efficient.
-8. FINISH — After testing ALL objectives and saving learnings, call the response tool to submit your final summary. You may document multiple findings before finishing.
+8. FINISH — After testing ALL objectives and saving learnings, call the response tool to submit your final summary. In your response, classify each objective as completed or needing further testing, and include any new objectives discovered during testing. You may document multiple findings before finishing.
 
 Guidelines:
 - Always call list_memories first to check for relevant knowledge before planning your approach
@@ -212,6 +277,7 @@ Guidelines:
 - Include clear remediation steps in every finding
 - Before finishing, use add_memory to save reusable learnings (target behaviors, effective techniques, technology details, false positive patterns)
 - When you have finished testing ALL objectives, call the response tool with a summary of your results. Do NOT call response until you have completed all testing.
+- In your response, include objectiveResults for EVERY objective: mark each as completed (true) if you thoroughly tested it and either found and documented a vulnerability OR conclusively determined the endpoint is not vulnerable to that attack. Mark as incomplete (false) if you were unable to fully test it (e.g., rate limited, timed out, need different approach). Also add NEW objectives you discovered during testing that should be tested in future runs (mark these as completed=false).
 - Do NOT write report files to scratchpad/ (no executive summaries, comprehensive reports, finding compilations, or vulnerability rollups). Reports are generated automatically from findings/. Use the response tool for your final summary.
 
 Rate Limiting:
@@ -256,7 +322,7 @@ Your methodology:
 7. PIVOT — When a vulnerability grants access to internal resources (e.g. SSRF, RCE, LFI), use it to discover and map what's accessible. Reason about what internal services, APIs, and data stores may exist behind the vulnerability — consider common internal hostnames, ports, and paths (e.g. internal DNS names in Docker/Kubernetes environments, common service ports, admin endpoints). Actively explore through the vulnerability to find reachable services.
 8. EXTRACT — The primary goal is to locate and extract a flag, secret, or sensitive data. Don't stop at proving the vulnerability exists — demonstrate full impact by retrieving the target data through the confirmed attack vector.
 9. LEARN — Before finishing, use add_memory to persist reusable learnings from this engagement (e.g. target-specific behaviors, successful payload patterns, technology fingerprints, false positive patterns, credential formats). This knowledge helps future engagements be more efficient.
-10. FINISH — After testing ALL objectives, completing extraction, and saving learnings, call the response tool to submit your final summary. Do NOT call response until you have completed all testing and extraction.
+10. FINISH — After testing ALL objectives, completing extraction, and saving learnings, call the response tool to submit your final summary. In your response, classify each objective as completed or needing further testing, and include any new objectives discovered during testing. Do NOT call response until you have completed all testing and extraction.
 
 Guidelines:
 - Always call list_memories first to check for relevant knowledge before planning your approach
@@ -476,7 +542,7 @@ function loadFindings(findingsPath: string): Finding[] {
 export async function runPentestAgent(input: PentestAgentInput) {
   const agent = new TargetedPentestAgent(input);
 
-  const { findings, findingsPath, pocsPath } = await agent.consume({
+  const { findings, findingsPath, pocsPath, objectiveResults } = await agent.consume({
     onTextDelta: (d) => process.stdout.write(d.text),
     onToolCall: (d) => console.log(`→ calling ${d.toolName}`),
     onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
@@ -487,5 +553,5 @@ export async function runPentestAgent(input: PentestAgentInput) {
   console.log(`Findings: ${findingsPath}`);
   console.log(`POCs: ${pocsPath}`);
 
-  return { findings, findingsPath, pocsPath };
+  return { findings, findingsPath, pocsPath, objectiveResults };
 }

--- a/src/core/api/targetedPentest.ts
+++ b/src/core/api/targetedPentest.ts
@@ -6,7 +6,7 @@ import {
 export async function runTargetedPentestAgent(input: PentestAgentInput) {
   const agent = new TargetedPentestAgent(input);
 
-  const { findings, findingsPath, pocsPath } = await agent.consume({
+  const { findings, findingsPath, pocsPath, objectiveResults } = await agent.consume({
     onTextDelta: (d) => process.stdout.write(d.text),
     onToolCall: (d) => console.log(`→ calling ${d.toolName}`),
     onToolResult: (d) => console.log(`✓ ${d.toolName} completed`),
@@ -17,5 +17,5 @@ export async function runTargetedPentestAgent(input: PentestAgentInput) {
   console.log(`Findings: ${findingsPath}`);
   console.log(`POCs: ${pocsPath}`);
 
-  return { findings, findingsPath, pocsPath };
+  return { findings, findingsPath, pocsPath, objectiveResults };
 }


### PR DESCRIPTION
- PentestResponseSchema now includes objectiveResults array
- Each ObjectiveResult has objective text, completed flag, and result description
- PentestResult type includes optional objectiveResults field
- resolveResult extracts objectiveResults from response tool call messages
- System prompt instructs agent to classify objectives and add new ones

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the pentest agent’s structured `response` schema and result plumbing, including custom parsing of streamed tool-call messages to extract `objectiveResults`, which could break if message formats/tool inputs differ.
> 
> **Overview**
> Adds a new structured `objectiveResults` array to the pentest agent’s `response` output (objective text, `completed` flag, optional `result`) and surfaces it on `PentestResult`/`runPentestAgent`/`runTargetedPentestAgent` return values.
> 
> Updates the pentest prompts to require reporting completion status for every objective (and newly discovered follow-ups), and overrides `resolveResult` to best-effort extract `objectiveResults` by scanning the streamed `response` tool-call inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b7599289a2dcdf08a8b0bfe589306d85086787e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->