### PR TITLE
Structured Step Trace + Agent State Checkpoints

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -254,9 +254,7 @@ Model:    ${model}
 
   const threatBus = new AgentEventBus();
   threatBus.on("text-delta", (d) => process.stdout.write(d.text));
-  threatBus.on("tool-call-complete", (d) =>
-    console.log(`\n  → ${d.toolName}`),
-  );
+  threatBus.on("tool-call-complete", (d) => console.log(`\n  → ${d.toolName}`));
   threatBus.on("tool-result", (d) => console.log(`  ✓ ${d.toolName}`));
   threatBus.on("error", (d) => console.error("Error:", d.error));
 

--- a/src/core/agents/offSecAgent/index.ts
+++ b/src/core/agents/offSecAgent/index.ts
@@ -16,6 +16,19 @@ export { AgentEventBus } from "../../eventBus";
 export type { AgentEventMap } from "../../eventBus";
 
 // ---------------------------------------------------------------------------
+// Trace
+// ---------------------------------------------------------------------------
+export { StepTraceWriter } from "./trace";
+export type {
+  StepRecord,
+  StateCheckpoint,
+  CheckpointInput,
+  TraceRecord,
+  ToolOutputType,
+  StepTraceWriterOpts,
+} from "./trace";
+
+// ---------------------------------------------------------------------------
 // Tools
 // ---------------------------------------------------------------------------
 export {

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -7,10 +7,7 @@ import type {
   ToolSet,
 } from "ai";
 import { hasToolCall } from "ai";
-import type {
-  OffensiveSecurityAgentInput,
-  CreateAgentInput,
-} from "./types";
+import type { OffensiveSecurityAgentInput, CreateAgentInput } from "./types";
 import {
   createAllTools,
   EMAIL_TOOL_NAMES_ACTIVE,
@@ -26,6 +23,7 @@ import { AgentEventBus } from "../../eventBus";
 import { join } from "path";
 import { mkdirSync, existsSync } from "fs";
 import { writeFile } from "fs/promises";
+import { StepTraceWriter } from "./trace";
 
 /**
  * General-purpose offensive security agent harness.
@@ -137,6 +135,21 @@ export class OffensiveSecurityAgent<TResult = void> {
       }
     }
 
+    // -- Step trace (trace.jsonl) ---------------------------------------------
+    // Created before tools so the checkpoint_state tool can reference it.
+    const messagesDir = input.messagesDir ?? input.session.rootPath;
+    const tracePath = input.subagentId
+      ? join(
+          input.session.rootPath,
+          "subagents",
+          `${input.subagentId}.trace.jsonl`,
+        )
+      : join(messagesDir, "trace.jsonl");
+    const traceWriter = new StepTraceWriter({
+      tracePath,
+      agentId: input.subagentId ?? null,
+    });
+
     // -- Tools ----------------------------------------------------------------
     const credentialManager =
       input.credentialManager ?? input.session.credentialManager;
@@ -155,6 +168,7 @@ export class OffensiveSecurityAgent<TResult = void> {
       credentialManager,
       persistentShell: this.persistentShell,
       skillsRegistry: input.skillsRegistry,
+      traceWriter,
     });
 
     let tools: ToolSet = input.extraTools
@@ -220,7 +234,6 @@ export class OffensiveSecurityAgent<TResult = void> {
     }
 
     // -- Messages persistence -------------------------------------------------
-    const messagesDir = input.messagesDir ?? input.session.rootPath;
     if (!existsSync(messagesDir)) {
       mkdirSync(messagesDir, { recursive: true });
     }
@@ -276,6 +289,10 @@ export class OffensiveSecurityAgent<TResult = void> {
           ...event.response.messages,
         ];
         schedulePersist();
+        traceWriter.recordStep(event.response.messages as ModelMessage[], {
+          inputTokens: event.usage.inputTokens ?? 0,
+          outputTokens: event.usage.outputTokens ?? 0,
+        });
         this.eventBus.emit("step-finish", {
           messages: event.response.messages,
           subagentId: this.subagentId,
@@ -286,6 +303,7 @@ export class OffensiveSecurityAgent<TResult = void> {
         // Context was reset by summarization — discard the old history so
         // subsequent onStepFinish writes only persist post-summary messages.
         initialMessagesRef.current = [];
+        traceWriter.markSummarized();
       },
       onFinish: async (event) => {
         // Flush any pending persistence before finishing

--- a/src/core/agents/offSecAgent/tools/checkpointState.ts
+++ b/src/core/agents/offSecAgent/tools/checkpointState.ts
@@ -1,0 +1,79 @@
+import { tool } from "ai";
+import { z } from "zod";
+import type { ToolContext } from "./types";
+
+const checkpointInputSchema = z.object({
+  discoveredSurface: z
+    .array(z.string())
+    .describe("Endpoints, services, and technologies discovered so far"),
+  credentialsObtained: z
+    .array(z.string())
+    .describe(
+      "Credentials, tokens, or auth material obtained (redact secrets)",
+    ),
+  confirmedVulnerabilities: z
+    .array(z.string())
+    .describe("Vulnerabilities confirmed with evidence"),
+  actionsAttempted: z
+    .array(
+      z.object({
+        description: z.string(),
+        outcome: z.enum(["success", "failure", "partial", "in-progress"]),
+      }),
+    )
+    .describe("What you've tried and the outcome of each"),
+  nextSteps: z
+    .array(
+      z.object({
+        action: z.string(),
+        rationale: z.string(),
+        priority: z.enum(["high", "medium", "low"]),
+      }),
+    )
+    .describe("What you plan to do next, ordered by priority"),
+  blockers: z
+    .array(z.string())
+    .describe("Anything blocking progress — errors, missing info, dead ends"),
+  assessment: z
+    .string()
+    .describe("Overall assessment of the engagement so far"),
+});
+
+export function checkpointState(ctx: ToolContext) {
+  return tool({
+    description:
+      "Record a structured snapshot of your current understanding of the target, " +
+      "what you've tried, what worked, what's blocked, and what you plan to do next. " +
+      "Call this after completing a phase of work (e.g., after recon, after finding " +
+      "a vulnerability, when changing strategy). This does not affect your workflow — " +
+      "it's purely for observability.",
+    inputSchema: checkpointInputSchema,
+    execute: async ({
+      discoveredSurface,
+      credentialsObtained,
+      confirmedVulnerabilities,
+      actionsAttempted,
+      nextSteps,
+      blockers,
+      assessment,
+    }) => {
+      if (!ctx.traceWriter) {
+        return "Checkpoint skipped — trace writer not available.";
+      }
+
+      ctx.traceWriter.appendCheckpoint({
+        targetState: {
+          discoveredSurface,
+          credentialsObtained,
+          confirmedVulnerabilities,
+        },
+        actionsAttempted,
+        nextSteps,
+        blockers,
+        assessment,
+      });
+
+      return "Checkpoint recorded.";
+    },
+  });
+}

--- a/src/core/agents/offSecAgent/tools/documentApp.ts
+++ b/src/core/agents/offSecAgent/tools/documentApp.ts
@@ -68,17 +68,19 @@ Each application creates a JSON file in the apps directory for tracking and anal
       url: z
         .string()
         .optional()
-        .describe("Base URL of the application (e.g., 'https://example.com', 'https://api.example.com')"),
+        .describe(
+          "Base URL of the application (e.g., 'https://example.com', 'https://api.example.com')",
+        ),
       technology: z
         .array(z.string())
         .optional()
-        .describe(
-          "Technology stack (e.g., ['Node.js', 'Express', 'MongoDB'])",
-        ),
+        .describe("Technology stack (e.g., ['Node.js', 'Express', 'MongoDB'])"),
       authentication: z
         .string()
         .optional()
-        .describe("Authentication type if known (e.g., 'OAuth2', 'JWT', 'session-based')"),
+        .describe(
+          "Authentication type if known (e.g., 'OAuth2', 'JWT', 'session-based')",
+        ),
       notes: z
         .string()
         .optional()

--- a/src/core/agents/offSecAgent/tools/documentEndpoint.ts
+++ b/src/core/agents/offSecAgent/tools/documentEndpoint.ts
@@ -78,9 +78,7 @@ Each endpoint creates a JSON file in the assets directory for tracking and analy
       handler: z
         .string()
         .optional()
-        .describe(
-          "Handler function or component name (whitebox analysis)",
-        ),
+        .describe("Handler function or component name (whitebox analysis)"),
       file: z
         .string()
         .optional()
@@ -153,10 +151,7 @@ Each endpoint creates a JSON file in the assets directory for tracking and analy
         }
       }
 
-      const targetDir = join(
-        baseAssetsPath,
-        sanitizeName(input.appName),
-      );
+      const targetDir = join(baseAssetsPath, sanitizeName(input.appName));
 
       if (!existsSync(targetDir)) {
         mkdirSync(targetDir, { recursive: true });

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -177,8 +177,7 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
         try {
           const normalizedTimeout = normalizeExecuteCommandTimeout(timeout);
           const onData = ctx.eventBus
-            ? (data: string) =>
-                ctx.eventBus!.emit("command-output", { data })
+            ? (data: string) => ctx.eventBus!.emit("command-output", { data })
             : undefined;
           const result = await ctx.persistentShell.execute(
             command,

--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -72,6 +72,9 @@ export { getPage } from "./getPage";
 // Skill tools
 export { readSkill } from "./readSkill";
 
+// Observability tools
+export { checkpointState } from "./checkpointState";
+
 // ---------------------------------------------------------------------------
 // Tool registry
 // ---------------------------------------------------------------------------
@@ -116,6 +119,7 @@ import { emailGetMessage } from "./email/getMessage";
 import { webSearch } from "./webSearch";
 import { getPage } from "./getPage";
 import { readSkill } from "./readSkill";
+import { checkpointState } from "./checkpointState";
 
 /**
  * Create the full toolset for the OffensiveSecurityAgent.
@@ -185,6 +189,9 @@ export function createAllTools(ctx: ToolContext & { subagentId?: string }) {
 
     // Skill tools (conditional — only when registry is provided)
     ...(ctx.skillsRegistry ? { read_skill: readSkill(ctx) } : {}),
+
+    // Observability tools (conditional — only when trace writer is provided)
+    ...(ctx.traceWriter ? { checkpoint_state: checkpointState(ctx) } : {}),
   } as const;
 }
 
@@ -238,6 +245,8 @@ export const ALL_TOOL_NAMES: ToolName[] = [
   // Web search (requires Pensar account)
   "web_search",
   "get_page",
+  // Observability
+  "checkpoint_state",
 ];
 
 /**

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -1,10 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { ToolContext } from "./types";
-import {
-  AgentEventBus,
-  type AgentEventMap,
-} from "../../../eventBus";
+import { AgentEventBus, type AgentEventMap } from "../../../eventBus";
 
 /** Default max concurrent coding agents */
 const DEFAULT_CONCURRENCY = 5;

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -9,6 +9,7 @@ import type { SkillsRegistry } from "../../../skills/registry";
 import type { AgentEventBus } from "../../../eventBus";
 import type { PersistentShell } from "./persistentShell";
 import type { UnifiedSandbox } from "./sandbox";
+import type { StepTraceWriter } from "../trace";
 
 /**
  * Shared context passed to every tool factory.
@@ -75,4 +76,10 @@ export type ToolContext = {
    * When present, read_skill is available.
    */
   skillsRegistry?: SkillsRegistry;
+
+  /**
+   * Step trace writer for appending records to trace.jsonl.
+   * When present, checkpoint_state tool is available.
+   */
+  traceWriter?: StepTraceWriter;
 };

--- a/src/core/agents/offSecAgent/trace.test.ts
+++ b/src/core/agents/offSecAgent/trace.test.ts
@@ -1,0 +1,674 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  StepTraceWriter,
+  type StepRecord,
+  type StateCheckpoint,
+  type TraceRecord,
+} from "./trace";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import type { ModelMessage } from "ai";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "trace-test-"));
+}
+
+function readTraceRecords(tracePath: string): TraceRecord[] {
+  return readFileSync(tracePath, "utf-8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as TraceRecord);
+}
+
+function readStepRecords(tracePath: string): StepRecord[] {
+  return readTraceRecords(tracePath).filter(
+    (r): r is StepRecord => r.type === "step",
+  );
+}
+
+/**
+ * Build a minimal ModelMessage[] that simulates a multi-step agent run.
+ * Step 0: assistant emits text + tool-call
+ * Step 1: tool-result (from step 0) + assistant emits reasoning + tool-call
+ * Step 2: tool-result (from step 1) + assistant emits text only (final)
+ */
+function buildMessages(): {
+  afterStep0: ModelMessage[];
+  afterStep1: ModelMessage[];
+  afterStep2: ModelMessage[];
+} {
+  const step0Assistant: ModelMessage = {
+    role: "assistant",
+    content: [
+      { type: "text", text: "Let me check the target." },
+      {
+        type: "tool-call",
+        toolCallId: "tc_001",
+        toolName: "http_request",
+        input: { url: "https://example.com", method: "GET" },
+      },
+    ],
+  };
+
+  const step1ToolResult: ModelMessage = {
+    role: "tool",
+    content: [
+      {
+        type: "tool-result",
+        toolCallId: "tc_001",
+        toolName: "http_request",
+        output: {
+          type: "text",
+          value: "HTTP 200 OK - <html>Hello World</html>",
+        },
+      },
+    ],
+  };
+
+  const step1Assistant: ModelMessage = {
+    role: "assistant",
+    content: [
+      {
+        type: "reasoning",
+        text: "The target is reachable. I should test for XSS.",
+      },
+      {
+        type: "tool-call",
+        toolCallId: "tc_002",
+        toolName: "execute_command",
+        input: {
+          command: "curl -s 'https://example.com?q=<script>alert(1)</script>'",
+        },
+      },
+    ],
+  };
+
+  const step2ToolResult: ModelMessage = {
+    role: "tool",
+    content: [
+      {
+        type: "tool-result",
+        toolCallId: "tc_002",
+        toolName: "execute_command",
+        output: {
+          type: "text",
+          value: "HTTP 200 - reflected <script>alert(1)</script>",
+        },
+      },
+    ],
+  };
+
+  const step2Assistant: ModelMessage = {
+    role: "assistant",
+    content: [
+      {
+        type: "text",
+        text: "XSS vulnerability confirmed. Documenting finding.",
+      },
+    ],
+  };
+
+  return {
+    afterStep0: [step0Assistant],
+    afterStep1: [step0Assistant, step1ToolResult, step1Assistant],
+    afterStep2: [
+      step0Assistant,
+      step1ToolResult,
+      step1Assistant,
+      step2ToolResult,
+      step2Assistant,
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("StepTraceWriter", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes one JSON line per step with type discriminator", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+    writer.recordStep(msgs.afterStep1, { inputTokens: 200, outputTokens: 80 });
+    writer.recordStep(msgs.afterStep2, { inputTokens: 150, outputTokens: 60 });
+
+    const records = readStepRecords(tracePath);
+    expect(records).toHaveLength(3);
+    for (const r of records) {
+      expect(r.type).toBe("step");
+    }
+  });
+
+  it("assigns monotonically increasing stepIndex starting at 0", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+    writer.recordStep(msgs.afterStep1, { inputTokens: 200, outputTokens: 80 });
+    writer.recordStep(msgs.afterStep2, { inputTokens: 150, outputTokens: 60 });
+
+    const records = readStepRecords(tracePath);
+    expect(records.map((r) => r.stepIndex)).toEqual([0, 1, 2]);
+  });
+
+  it("sets observations to null on step 0", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+
+    const [step0] = readStepRecords(tracePath);
+    expect(step0.observations).toBeNull();
+  });
+
+  it("extracts observations from tool-result parts on subsequent steps", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+    writer.recordStep(msgs.afterStep1, { inputTokens: 200, outputTokens: 80 });
+
+    const records = readStepRecords(tracePath);
+    const step1 = records[1];
+    expect(step1.observations).not.toBeNull();
+    expect(step1.observations).toHaveLength(1);
+    expect(step1.observations![0].toolCallId).toBe("tc_001");
+    expect(step1.observations![0].toolName).toBe("http_request");
+    expect(step1.observations![0].outputType).toBe("text");
+    expect(step1.observations![0].outputPreview).toContain("HTTP 200 OK");
+  });
+
+  it("extracts text from text parts", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+
+    const [step0] = readStepRecords(tracePath);
+    expect(step0.text).toBe("Let me check the target.");
+  });
+
+  it("extracts reasoning from reasoning parts", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+    writer.recordStep(msgs.afterStep1, { inputTokens: 200, outputTokens: 80 });
+
+    const records = readStepRecords(tracePath);
+    expect(records[1].reasoning).toContain("The target is reachable");
+  });
+
+  it("extracts actions from tool-call parts", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+
+    const [step0] = readStepRecords(tracePath);
+    expect(step0.actions).toHaveLength(1);
+    expect(step0.actions[0].toolCallId).toBe("tc_001");
+    expect(step0.actions[0].toolName).toBe("http_request");
+    expect(step0.actions[0].inputPreview).toContain("example.com");
+  });
+
+  it("returns empty actions array when model emits only text", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+    writer.recordStep(msgs.afterStep1, { inputTokens: 200, outputTokens: 80 });
+    writer.recordStep(msgs.afterStep2, { inputTokens: 150, outputTokens: 60 });
+
+    const records = readStepRecords(tracePath);
+    expect(records[2].actions).toEqual([]);
+    expect(records[2].text).toContain("XSS vulnerability confirmed");
+  });
+
+  it("computes cumulative usage correctly", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+    writer.recordStep(msgs.afterStep1, { inputTokens: 200, outputTokens: 80 });
+    writer.recordStep(msgs.afterStep2, { inputTokens: 150, outputTokens: 60 });
+
+    const records = readStepRecords(tracePath);
+
+    expect(records[0].usage).toEqual({ inputTokens: 100, outputTokens: 50 });
+    expect(records[0].cumulativeUsage).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+    });
+
+    expect(records[1].usage).toEqual({ inputTokens: 200, outputTokens: 80 });
+    expect(records[1].cumulativeUsage).toEqual({
+      inputTokens: 300,
+      outputTokens: 130,
+    });
+
+    expect(records[2].usage).toEqual({ inputTokens: 150, outputTokens: 60 });
+    expect(records[2].cumulativeUsage).toEqual({
+      inputTokens: 450,
+      outputTokens: 190,
+    });
+  });
+
+  it("tracks step duration and elapsed time", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+    writer.recordStep(msgs.afterStep1, { inputTokens: 200, outputTokens: 80 });
+
+    const records = readStepRecords(tracePath);
+    // Can't assert exact values, but structure and non-negativity
+    expect(records[0].stepDurationMs).toBeGreaterThanOrEqual(0);
+    expect(records[0].elapsedMs).toBeGreaterThanOrEqual(0);
+    expect(records[1].elapsedMs).toBeGreaterThanOrEqual(records[0].elapsedMs);
+  });
+
+  it("records summarized flag from markSummarized()", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+    expect(readStepRecords(tracePath)[0].summarized).toBe(false);
+
+    writer.markSummarized();
+
+    // After summarization, the next step records against fresh messages
+    const postSummaryMsg: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Continuing after summarization." }],
+      },
+    ];
+    writer.recordStep(postSummaryMsg, { inputTokens: 80, outputTokens: 30 });
+
+    const records = readStepRecords(tracePath);
+    expect(records[1].summarized).toBe(true);
+    expect(records[1].text).toBe("Continuing after summarization.");
+    // stepIndex continues (does not reset)
+    expect(records[1].stepIndex).toBe(1);
+  });
+
+  it("sets agentId correctly for orchestrator (null) and subagent", () => {
+    const orchestratorPath = join(tmpDir, "orch.jsonl");
+    const subagentPath = join(tmpDir, "sub.jsonl");
+    const orchestrator = new StepTraceWriter({
+      tracePath: orchestratorPath,
+      agentId: null,
+    });
+    const subagent = new StepTraceWriter({
+      tracePath: subagentPath,
+      agentId: "pentest-agent-1",
+    });
+
+    const msgs: ModelMessage[] = [
+      { role: "assistant", content: [{ type: "text", text: "hello" }] },
+    ];
+
+    orchestrator.recordStep(msgs, { inputTokens: 10, outputTokens: 5 });
+    subagent.recordStep(msgs, { inputTokens: 10, outputTokens: 5 });
+
+    const [orchRecord] = readStepRecords(orchestratorPath);
+    const [subRecord] = readStepRecords(subagentPath);
+
+    expect(orchRecord.agentId).toBeNull();
+    expect(subRecord.agentId).toBe("pentest-agent-1");
+  });
+
+  it("caps outputPreview at 2000 chars", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+
+    const longOutput = "x".repeat(5000);
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "tc_setup",
+            toolName: "setup",
+            input: {},
+          },
+        ],
+      },
+    ];
+
+    // Step 0 — just to advance past the "observations: null" step
+    writer.recordStep(msgs, { inputTokens: 10, outputTokens: 5 });
+
+    // Step 1 — with a huge tool result
+    const msgs2: ModelMessage[] = [
+      ...msgs,
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc_setup",
+            toolName: "setup",
+            output: { type: "text", value: longOutput },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+      },
+    ];
+    writer.recordStep(msgs2, { inputTokens: 10, outputTokens: 5 });
+
+    const records = readStepRecords(tracePath);
+    const obs = records[1].observations!;
+    expect(obs[0].outputPreview.length).toBe(2000);
+    expect(obs[0].outputLength).toBe(5000);
+  });
+
+  it("caps inputPreview at 1000 chars", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+
+    const longInput = { data: "y".repeat(5000) };
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "tc_big",
+            toolName: "http_request",
+            input: longInput,
+          },
+        ],
+      },
+    ];
+
+    writer.recordStep(msgs, { inputTokens: 10, outputTokens: 5 });
+
+    const [record] = readStepRecords(tracePath);
+    expect(record.actions[0].inputPreview.length).toBe(1000);
+    expect(record.actions[0].inputLength).toBeGreaterThan(1000);
+  });
+
+  it("produces valid JSON on every line", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+    writer.recordStep(msgs.afterStep1, { inputTokens: 200, outputTokens: 80 });
+    writer.recordStep(msgs.afterStep2, { inputTokens: 150, outputTokens: 60 });
+
+    const lines = readFileSync(tracePath, "utf-8").trim().split("\n");
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+  });
+
+  it("creates parent directories if they don't exist", () => {
+    const nestedPath = join(tmpDir, "deep", "nested", "trace.jsonl");
+    const writer = new StepTraceWriter({
+      tracePath: nestedPath,
+      agentId: null,
+    });
+
+    const msgs: ModelMessage[] = [
+      { role: "assistant", content: [{ type: "text", text: "test" }] },
+    ];
+    writer.recordStep(msgs, { inputTokens: 10, outputTokens: 5 });
+
+    const records = readStepRecords(nestedPath);
+    expect(records).toHaveLength(1);
+  });
+
+  it("handles error output types correctly", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+
+    // Step 0 with a tool call
+    const msgs0: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "tc_err",
+            toolName: "execute_command",
+            input: { command: "cat /nonexistent" },
+          },
+        ],
+      },
+    ];
+    writer.recordStep(msgs0, { inputTokens: 10, outputTokens: 5 });
+
+    // Step 1 with error-text result
+    const msgs1: ModelMessage[] = [
+      ...msgs0,
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc_err",
+            toolName: "execute_command",
+            output: {
+              type: "error-text",
+              value: "No such file or directory",
+            },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "File not found." }],
+      },
+    ];
+    writer.recordStep(msgs1, { inputTokens: 20, outputTokens: 10 });
+
+    const records = readStepRecords(tracePath);
+    const obs = records[1].observations!;
+    expect(obs[0].outputType).toBe("error-text");
+    expect(obs[0].outputPreview).toContain("No such file or directory");
+  });
+
+  it("handles text-only assistant messages with no tool calls", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "I have completed the assessment." }],
+      },
+    ];
+
+    writer.recordStep(msgs, { inputTokens: 50, outputTokens: 30 });
+
+    const [record] = readStepRecords(tracePath);
+    expect(record.text).toBe("I have completed the assessment.");
+    expect(record.actions).toEqual([]);
+    expect(record.reasoning).toBeNull();
+  });
+
+  it("handles string content in assistant messages", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+
+    // Some model responses may use string content instead of parts
+    const msgs: ModelMessage[] = [
+      { role: "assistant", content: "Simple string response" },
+    ];
+
+    writer.recordStep(msgs, { inputTokens: 10, outputTokens: 5 });
+
+    const [record] = readStepRecords(tracePath);
+    expect(record.text).toBe("Simple string response");
+  });
+
+  // -------------------------------------------------------------------------
+  // Checkpoint tests (PRD 2)
+  // -------------------------------------------------------------------------
+
+  it("appendCheckpoint writes a checkpoint record with type discriminator", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({
+      tracePath,
+      agentId: "pentest-agent-1",
+    });
+
+    writer.appendCheckpoint({
+      targetState: {
+        discoveredSurface: ["GET /api/users", "POST /api/login"],
+        credentialsObtained: [],
+        confirmedVulnerabilities: [],
+      },
+      actionsAttempted: [
+        { description: "Probed /api/users for SQLi", outcome: "failure" },
+      ],
+      nextSteps: [
+        {
+          action: "Test XSS on /api/search",
+          rationale: "Reflected input detected",
+          priority: "high",
+        },
+      ],
+      blockers: [],
+      assessment: "Initial recon complete, no vulns found yet.",
+    });
+
+    const records = readTraceRecords(tracePath);
+    expect(records).toHaveLength(1);
+
+    const cp = records[0] as StateCheckpoint;
+    expect(cp.type).toBe("checkpoint");
+    expect(cp.stepIndex).toBe(0);
+    expect(cp.agentId).toBe("pentest-agent-1");
+    expect(cp.targetState.discoveredSurface).toHaveLength(2);
+    expect(cp.actionsAttempted[0].outcome).toBe("failure");
+    expect(cp.nextSteps[0].priority).toBe("high");
+    expect(cp.assessment).toContain("Initial recon");
+    expect(cp.timestamp).toBeTruthy();
+  });
+
+  it("checkpoint stepIndex matches the current in-flight step", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    // Complete step 0
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+    // Now during step 1 (tools executing), checkpoint is called
+    writer.appendCheckpoint({
+      targetState: {
+        discoveredSurface: [],
+        credentialsObtained: [],
+        confirmedVulnerabilities: [],
+      },
+      actionsAttempted: [],
+      nextSteps: [],
+      blockers: [],
+      assessment: "Mid-run checkpoint",
+    });
+    // Step 1 completes
+    writer.recordStep(msgs.afterStep1, { inputTokens: 200, outputTokens: 80 });
+
+    const records = readTraceRecords(tracePath);
+    expect(records).toHaveLength(3);
+    expect(records[0].type).toBe("step");
+    expect(records[0].stepIndex).toBe(0);
+    expect(records[1].type).toBe("checkpoint");
+    expect(records[1].stepIndex).toBe(1); // matches the step it was emitted during
+    expect(records[2].type).toBe("step");
+    expect(records[2].stepIndex).toBe(1);
+  });
+
+  it("checkpoints interleave with step records in trace.jsonl", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+    writer.appendCheckpoint({
+      targetState: {
+        discoveredSurface: ["endpoint-a"],
+        credentialsObtained: [],
+        confirmedVulnerabilities: ["XSS on /search"],
+      },
+      actionsAttempted: [{ description: "Tested XSS", outcome: "success" }],
+      nextSteps: [],
+      blockers: [],
+      assessment: "Found XSS",
+    });
+    writer.recordStep(msgs.afterStep1, { inputTokens: 200, outputTokens: 80 });
+
+    const records = readTraceRecords(tracePath);
+    expect(records.map((r) => r.type)).toEqual(["step", "checkpoint", "step"]);
+  });
+
+  it("checkpoint works with empty arrays (early in run)", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+
+    writer.appendCheckpoint({
+      targetState: {
+        discoveredSurface: [],
+        credentialsObtained: [],
+        confirmedVulnerabilities: [],
+      },
+      actionsAttempted: [],
+      nextSteps: [],
+      blockers: [],
+      assessment: "Just started.",
+    });
+
+    const records = readTraceRecords(tracePath);
+    const cp = records[0] as StateCheckpoint;
+    expect(cp.type).toBe("checkpoint");
+    expect(cp.targetState.discoveredSurface).toEqual([]);
+    expect(cp.actionsAttempted).toEqual([]);
+  });
+
+  it("currentStepIndex getter reflects the writer state", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    expect(writer.currentStepIndex).toBe(0);
+    writer.recordStep(msgs.afterStep0, { inputTokens: 10, outputTokens: 5 });
+    expect(writer.currentStepIndex).toBe(1);
+    writer.recordStep(msgs.afterStep1, { inputTokens: 10, outputTokens: 5 });
+    expect(writer.currentStepIndex).toBe(2);
+  });
+});

--- a/src/core/agents/offSecAgent/trace.ts
+++ b/src/core/agents/offSecAgent/trace.ts
@@ -417,6 +417,10 @@ export class StepTraceWriter {
 
   /** Sync append — ~1-3KB per line, sub-ms. Sync ensures crash safety. */
   private appendRecord(record: TraceRecord): void {
-    appendFileSync(this.tracePath, JSON.stringify(record) + "\n");
+    try {
+      appendFileSync(this.tracePath, JSON.stringify(record) + "\n");
+    } catch {
+      // Trace is non-critical observability — never crash the agent for it.
+    }
   }
 }

--- a/src/core/agents/offSecAgent/trace.ts
+++ b/src/core/agents/offSecAgent/trace.ts
@@ -1,0 +1,422 @@
+/**
+ * Structured Step Trace — append-only per-step JSONL log.
+ *
+ * Each line in trace.jsonl is either a {@link StepRecord} (type: "step")
+ * or a {@link StateCheckpoint} (type: "checkpoint"). Together they form
+ * a {@link TraceRecord} discriminated union.
+ *
+ * Consumers: evalgate (failure classification), debugging (cat | jq),
+ * metrics pipeline (step-level cost analysis), post-training data curation.
+ */
+
+import { appendFileSync, mkdirSync } from "fs";
+import { dirname } from "path";
+import type { ModelMessage } from "ai";
+
+// ---------------------------------------------------------------------------
+// Shared type aliases
+// ---------------------------------------------------------------------------
+
+/** Known output types from the AI SDK's ToolResultOutput variants. */
+export type ToolOutputType =
+  | "text"
+  | "json"
+  | "error-text"
+  | "error-json"
+  | "content"
+  | "execution-denied";
+
+// ---------------------------------------------------------------------------
+// StepRecord — one line in trace.jsonl
+// ---------------------------------------------------------------------------
+
+export interface StepRecord {
+  /** Discriminator — distinguishes from StateCheckpoint in trace.jsonl */
+  type: "step";
+
+  /** Monotonically increasing within this agent, starting at 0 */
+  stepIndex: number;
+
+  /** ISO 8601 timestamp when onStepFinish fired */
+  timestamp: string;
+
+  /** Agent identifier — null for orchestrator, "pentest-agent-1" etc. for subagents */
+  agentId: string | null;
+
+  // -- Observation (what the agent received from prior step's tool execution) --
+
+  /**
+   * Tool results that were injected before this step's model call.
+   * Extracted from tool-result parts in the messages added since last step.
+   * null on step 0 (no prior tool execution).
+   */
+  observations: Array<{
+    toolCallId: string;
+    toolName: string;
+    outputType: ToolOutputType;
+    /** First 2000 chars of stringified output — enough for analysis, bounded for size */
+    outputPreview: string;
+    /** True byte length of full output */
+    outputLength: number;
+  }> | null;
+
+  // -- Reasoning (what the model emitted before acting) --
+
+  /**
+   * Extended thinking content, if the model produced reasoning parts.
+   * null if no reasoning parts were emitted this step.
+   */
+  reasoning: string | null;
+
+  /**
+   * Free-form text the model emitted before tool calls (the "inner monologue").
+   * null if the model went straight to a tool call.
+   */
+  text: string | null;
+
+  // -- Action (what the agent decided to do) --
+
+  /**
+   * Tool calls made in this step. Empty array if the model produced only text
+   * (e.g., final response).
+   */
+  actions: Array<{
+    toolCallId: string;
+    toolName: string;
+    /** First 1000 chars of JSON.stringify(input) */
+    inputPreview: string;
+    /** True byte length of full serialized input */
+    inputLength: number;
+  }>;
+
+  // -- Metrics --
+
+  /** Tokens consumed in this step */
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+
+  /** Cumulative tokens across all steps so far (including this one) */
+  cumulativeUsage: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+
+  /** Wall-clock ms from previous step's completion (or agent start) to this step's completion */
+  stepDurationMs: number;
+
+  /** Wall-clock ms from agent creation to this step's completion */
+  elapsedMs: number;
+
+  /** True if this step triggered context summarization */
+  summarized: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// StateCheckpoint — agent state snapshot in trace.jsonl
+// ---------------------------------------------------------------------------
+
+export interface StateCheckpoint {
+  /** Discriminator — distinguishes from StepRecord in trace.jsonl */
+  type: "checkpoint";
+
+  /** Step index at which the checkpoint was emitted */
+  stepIndex: number;
+
+  /** ISO 8601 */
+  timestamp: string;
+
+  agentId: string | null;
+
+  /** What the agent knows about the target */
+  targetState: {
+    /** Discovered endpoints, services, technologies */
+    discoveredSurface: string[];
+    /** Credentials or auth tokens obtained */
+    credentialsObtained: string[];
+    /** Vulnerabilities confirmed so far */
+    confirmedVulnerabilities: string[];
+  };
+
+  /** What the agent has attempted */
+  actionsAttempted: Array<{
+    description: string;
+    outcome: "success" | "failure" | "partial" | "in-progress";
+  }>;
+
+  /** What the agent plans to do next and why */
+  nextSteps: Array<{
+    action: string;
+    rationale: string;
+    priority: "high" | "medium" | "low";
+  }>;
+
+  /** Explicit assessment of what's not working or blocked */
+  blockers: string[];
+
+  /** Free-form assessment — captures anything not covered above */
+  assessment: string;
+}
+
+/** Data fields provided by the checkpoint_state tool (metadata is filled by the writer). */
+export type CheckpointInput = Omit<
+  StateCheckpoint,
+  "type" | "stepIndex" | "timestamp" | "agentId"
+>;
+
+/** Discriminated union of all trace record types. */
+export type TraceRecord = StepRecord | StateCheckpoint;
+
+// ---------------------------------------------------------------------------
+// Extraction helpers
+// ---------------------------------------------------------------------------
+
+const OUTPUT_PREVIEW_LIMIT = 2000;
+const INPUT_PREVIEW_LIMIT = 1000;
+
+/**
+ * Resolve ToolResultOutput to a string representation and its type tag.
+ * Handles all ToolResultOutput variants from the AI SDK.
+ */
+function stringifyOutput(output: unknown): {
+  text: string;
+  type: ToolOutputType;
+} {
+  if (output == null) return { text: "", type: "text" };
+
+  if (
+    typeof output === "object" &&
+    "type" in (output as Record<string, unknown>)
+  ) {
+    const typed = output as {
+      type: string;
+      value?: unknown;
+      reason?: string;
+    };
+
+    switch (typed.type) {
+      case "text":
+      case "error-text":
+        return {
+          text: String(typed.value ?? ""),
+          type: typed.type as ToolOutputType,
+        };
+      case "json":
+      case "error-json":
+        return {
+          text: JSON.stringify(typed.value ?? null),
+          type: typed.type as ToolOutputType,
+        };
+      case "execution-denied":
+        return {
+          text: typed.reason ?? "execution denied",
+          type: typed.type,
+        };
+      case "content":
+        return { text: JSON.stringify(typed.value ?? []), type: typed.type };
+      default:
+        // Unknown SDK output type — fall back to "text" rather than lose type safety
+        return { text: JSON.stringify(output), type: "text" };
+    }
+  }
+
+  if (typeof output === "string") return { text: output, type: "text" };
+  return { text: JSON.stringify(output), type: "json" };
+}
+
+function preview(str: string, maxLen: number): string {
+  return str.length <= maxLen ? str : str.slice(0, maxLen);
+}
+
+// ---------------------------------------------------------------------------
+// StepTraceWriter
+// ---------------------------------------------------------------------------
+
+export interface StepTraceWriterOpts {
+  /** Absolute path to the trace.jsonl file */
+  tracePath: string;
+
+  /** Agent identifier — null for orchestrator */
+  agentId: string | null;
+}
+
+/**
+ * Append-only writer for per-step trace records.
+ *
+ * Create one instance per agent at construction time. Call
+ * {@link recordStep} from every `onStepFinish` invocation and
+ * {@link markSummarized} from `onSummarized`.
+ */
+export class StepTraceWriter {
+  private readonly tracePath: string;
+  private readonly agentId: string | null;
+
+  private stepIndex = 0;
+  private cumulativeUsage = { inputTokens: 0, outputTokens: 0 };
+  private lastStepTime: number;
+  private readonly agentStartTime: number;
+  private summarized = false;
+  private previousMessageCount = 0;
+
+  constructor(opts: StepTraceWriterOpts) {
+    this.tracePath = opts.tracePath;
+    this.agentId = opts.agentId;
+
+    const now = Date.now();
+    this.agentStartTime = now;
+    this.lastStepTime = now;
+
+    mkdirSync(dirname(this.tracePath), { recursive: true });
+  }
+
+  /**
+   * Mark that context summarization occurred.
+   * The next step record will have `summarized: true` and
+   * previousMessageCount resets to 0 (messages are rebuilt post-summary).
+   */
+  markSummarized(): void {
+    this.summarized = true;
+    this.previousMessageCount = 0;
+  }
+
+  /**
+   * Record a single step. Called from onStepFinish.
+   *
+   * @param responseMessages - `event.response.messages` from the AI SDK
+   *   (cumulative response messages, NOT including initial prompt messages)
+   * @param usage - `event.usage` from the AI SDK (this step's token counts)
+   */
+  recordStep(
+    responseMessages: ModelMessage[],
+    usage: { inputTokens: number; outputTokens: number },
+  ): void {
+    const now = Date.now();
+    const newMessages = responseMessages.slice(this.previousMessageCount);
+    this.previousMessageCount = responseMessages.length;
+
+    const observations: NonNullable<StepRecord["observations"]> = [];
+    const reasoningParts: string[] = [];
+    const textParts: string[] = [];
+    const actions: StepRecord["actions"] = [];
+
+    for (const msg of newMessages) {
+      if (!Array.isArray(msg.content)) {
+        if (typeof msg.content === "string" && msg.role === "assistant") {
+          textParts.push(msg.content);
+        }
+        continue;
+      }
+
+      for (const part of msg.content) {
+        switch (part.type) {
+          case "tool-result": {
+            const { text, type } = stringifyOutput(
+              (part as { output?: unknown }).output,
+            );
+            observations.push({
+              toolCallId: part.toolCallId,
+              toolName: part.toolName,
+              outputType: type,
+              outputPreview: preview(text, OUTPUT_PREVIEW_LIMIT),
+              outputLength: Buffer.byteLength(text, "utf-8"),
+            });
+            break;
+          }
+          case "reasoning": {
+            reasoningParts.push((part as { text: string }).text);
+            break;
+          }
+          case "text": {
+            textParts.push((part as { text: string }).text);
+            break;
+          }
+          case "tool-call": {
+            const serialized = JSON.stringify(
+              (part as { input: unknown }).input,
+            );
+            actions.push({
+              toolCallId: part.toolCallId,
+              toolName: part.toolName,
+              inputPreview: preview(serialized, INPUT_PREVIEW_LIMIT),
+              inputLength: Buffer.byteLength(serialized, "utf-8"),
+            });
+            break;
+          }
+          // Silently skip other part types (file, tool-approval-request, etc.)
+        }
+      }
+    }
+
+    const inputTokens = usage.inputTokens ?? 0;
+    const outputTokens = usage.outputTokens ?? 0;
+    this.cumulativeUsage.inputTokens += inputTokens;
+    this.cumulativeUsage.outputTokens += outputTokens;
+
+    const record: StepRecord = {
+      type: "step",
+      stepIndex: this.stepIndex,
+      timestamp: new Date(now).toISOString(),
+      agentId: this.agentId,
+
+      observations:
+        this.stepIndex === 0
+          ? null
+          : observations.length > 0
+            ? observations
+            : null,
+
+      reasoning: reasoningParts.length > 0 ? reasoningParts.join("") : null,
+      text: textParts.length > 0 ? textParts.join("") : null,
+      actions,
+
+      usage: { inputTokens, outputTokens },
+      cumulativeUsage: { ...this.cumulativeUsage },
+
+      stepDurationMs: now - this.lastStepTime,
+      elapsedMs: now - this.agentStartTime,
+      summarized: this.summarized,
+    };
+
+    this.appendRecord(record);
+    this.stepIndex++;
+    this.lastStepTime = now;
+    this.summarized = false;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Checkpoint support (PRD 2)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The step index that will be assigned to the next record.
+   * During tool execution (between steps), this is the index of the
+   * current in-flight step — use it for checkpoint records.
+   */
+  get currentStepIndex(): number {
+    return this.stepIndex;
+  }
+
+  /**
+   * Append a {@link StateCheckpoint} record to trace.jsonl.
+   *
+   * Called by the `checkpoint_state` tool during tool execution.
+   * The writer fills in metadata (type, stepIndex, timestamp, agentId);
+   * the caller provides the data fields.
+   */
+  appendCheckpoint(data: CheckpointInput): void {
+    const record: StateCheckpoint = {
+      type: "checkpoint",
+      stepIndex: this.stepIndex,
+      timestamp: new Date().toISOString(),
+      agentId: this.agentId,
+      ...data,
+    };
+    this.appendRecord(record);
+  }
+
+  /** Sync append — ~1-3KB per line, sub-ms. Sync ensures crash safety. */
+  private appendRecord(record: TraceRecord): void {
+    appendFileSync(this.tracePath, JSON.stringify(record) + "\n");
+  }
+}

--- a/src/core/agents/specialized/attackSurface/blackboxRiskScoring.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxRiskScoring.ts
@@ -100,7 +100,10 @@ export function computeBlackboxRiskScore(
 // Dimension helpers
 // ---------------------------------------------------------------------------
 
-function computeExposure(riskLevel: RiskLevel, details?: EndpointDetails): number {
+function computeExposure(
+  riskLevel: RiskLevel,
+  details?: EndpointDetails,
+): number {
   let base = EXPOSURE_BY_RISK[riskLevel] ?? 1;
 
   if (details?.authentication) {

--- a/src/core/agents/specialized/attackSurface/schemas.ts
+++ b/src/core/agents/specialized/attackSurface/schemas.ts
@@ -119,10 +119,7 @@ export const DocumentAppSchema = z.object({
     .describe(
       "Technology framework or stack (e.g., 'Next.js', 'Express + React', 'Django')",
     ),
-  url: z
-    .string()
-    .optional()
-    .describe("Base URL of the application"),
+  url: z.string().optional().describe("Base URL of the application"),
   technology: z
     .array(z.string())
     .optional()
@@ -242,9 +239,7 @@ export const DocumentedEndpointRecordSchema = DocumentEndpointSchema.extend({
     .string()
     .describe("ISO timestamp when endpoint was discovered"),
   sessionId: z.string().describe("Session ID where endpoint was discovered"),
-  target: z
-    .string()
-    .describe("Target being analyzed when endpoint was found"),
+  target: z.string().describe("Target being analyzed when endpoint was found"),
   riskScore: RiskScoreSchema.optional().describe(
     "Computed risk score with breakdown",
   ),
@@ -263,4 +258,3 @@ export type DocumentedEndpointRecord = z.infer<
 export type PentestTarget = z.infer<typeof PentestTargetSchema>;
 export type AttackSurfaceSummary = z.infer<typeof AttackSurfaceSummarySchema>;
 export type AttackSurfaceReport = z.infer<typeof AttackSurfaceReportSchema>;
-

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -49,7 +49,9 @@ export interface PentestResult {
 const ObjectiveResultSchema = z.object({
   objective: z
     .string()
-    .describe("The objective text, exactly as it was provided or a refined version"),
+    .describe(
+      "The objective text, exactly as it was provided or a refined version",
+    ),
   completed: z
     .boolean()
     .describe(
@@ -203,6 +205,8 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
         // Web search tools — look up CVEs, exploit techniques, vulnerability details
         "web_search",
         "get_page",
+        // Observability — structured state checkpoints for eval and analysis
+        "checkpoint_state",
       ],
 
       responseSchema: PentestResponseSchema,
@@ -213,7 +217,8 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
         try {
           const response = await streamResult.response;
           for (const msg of response.messages ?? []) {
-            if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+            if (msg.role !== "assistant" || !Array.isArray(msg.content))
+              continue;
             for (const part of msg.content) {
               if (
                 part.type === "tool-call" &&
@@ -310,7 +315,15 @@ Authentication:
 - If the prompt includes an "Existing Authentication Session" section, USE those cookies/headers on every request. Do NOT attempt to re-authenticate.
 - For http_request: include the provided Cookie and Authorization headers in every call.
 - For execute_command (curl): include -H "Cookie: ..." and/or -H "Authorization: ..." flags.
-- If a request returns 401/403, the session may have expired — note it in your findings but do not try to log in again.`;
+- If a request returns 401/403, the session may have expired — note it in your findings but do not try to log in again.
+
+State Checkpointing:
+You have a \`checkpoint_state\` tool. Call it:
+- After completing reconnaissance and before starting exploitation
+- After confirming a vulnerability
+- When changing strategy due to a dead end
+- Before wrapping up your session
+This is lightweight and does not count against your task. It helps track your reasoning for later analysis.`;
 
 const PENTEST_SYSTEM_PROMPT_EXFIL = `You are an expert penetration tester performing a targeted security assessment with the goal of demonstrating full exploit impact.
 
@@ -344,7 +357,15 @@ Authentication:
 - If the prompt includes an "Existing Authentication Session" section, USE those cookies/headers on every request. Do NOT attempt to re-authenticate.
 - For http_request: include the provided Cookie and Authorization headers in every call.
 - For execute_command (curl): include -H "Cookie: ..." and/or -H "Authorization: ..." flags.
-- If a request returns 401/403, the session may have expired — note it in your findings but do not try to log in again.`;
+- If a request returns 401/403, the session may have expired — note it in your findings but do not try to log in again.
+
+State Checkpointing:
+You have a \`checkpoint_state\` tool. Call it:
+- After completing reconnaissance and before starting exploitation
+- After confirming a vulnerability
+- When changing strategy due to a dead end
+- Before wrapping up your session
+This is lightweight and does not count against your task. It helps track your reasoning for later analysis.`;
 
 function buildSystemPrompt(session: {
   config?: { exfilMode?: boolean };

--- a/src/core/agents/specialized/whiteboxAttackSurface/types.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/types.ts
@@ -95,7 +95,9 @@ export const AppSchema = z.object({
       "storage",
     ])
     .default("web_application")
-    .describe("Type of application (web_application, api, full_stack, database, cloud_resource, storage, etc.)"),
+    .describe(
+      "Type of application (web_application, api, full_stack, database, cloud_resource, storage, etc.)",
+    ),
   framework: z
     .string()
     .describe(

--- a/src/core/api/environment.ts
+++ b/src/core/api/environment.ts
@@ -4,7 +4,9 @@ import type { EnvironmentResult } from "../agents/specialized/environment/types"
 
 export type { EnvironmentResult, EnvironmentAgentInput };
 
-function attachDefaultEnvironmentStreamListeners(agent: EnvironmentAgent): void {
+function attachDefaultEnvironmentStreamListeners(
+  agent: EnvironmentAgent,
+): void {
   agent.eventBus.on("text-delta", (e) => {
     process.stdout.write(e.text);
   });

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -123,10 +123,7 @@ export class AgentEventBus {
    *   tool-result       → tool-result
    *   error             → error
    */
-  emitStreamPart(
-    chunk: TextStreamPart<ToolSet>,
-    subagentId?: string,
-  ): void {
+  emitStreamPart(chunk: TextStreamPart<ToolSet>, subagentId?: string): void {
     switch (chunk.type) {
       case "text-delta":
         this.emit("text-delta", { text: chunk.text, subagentId });

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -117,7 +117,9 @@ const AppInfoSchema = z.object({
   description: z.string().describe("Brief description of what this app does"),
   location: z
     .string()
-    .describe("Path to the app root relative to the repository root, or resource identifier for cloud resources"),
+    .describe(
+      "Path to the app root relative to the repository root, or resource identifier for cloud resources",
+    ),
   type: z
     .enum([
       "web_application",
@@ -132,8 +134,8 @@ const AppInfoSchema = z.object({
     .default("web_application")
     .describe(
       "Application type — web_application for frontend apps, api for backend services, " +
-      "full_stack for frameworks like Next.js/Remix that serve both, " +
-      "database for databases, cloud_resource for owned cloud infra, storage for S3/GCS/blob storage",
+        "full_stack for frameworks like Next.js/Remix that serve both, " +
+        "database for databases, cloud_resource for owned cloud infra, storage for S3/GCS/blob storage",
     ),
 });
 
@@ -249,7 +251,9 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     responseSchema: AppsDiscoveryResultSchema,
   });
 
-  console.log(`[whitebox-workflow] Phase 1: discovering apps in ${codebasePath}${domains?.length ? ` (${domains.length} known domains)` : ""}`);
+  console.log(
+    `[whitebox-workflow] Phase 1: discovering apps in ${codebasePath}${domains?.length ? ` (${domains.length} known domains)` : ""}`,
+  );
 
   const appsResult = await appsAgent.consume();
 
@@ -317,8 +321,12 @@ export async function runWhiteboxAttackSurfaceWorkflow(
   };
 
   const NON_SERVICE_TYPES = ["cloud_resource", "storage", "database"];
-  const serviceApps = appsResult.apps.filter((app) => !NON_SERVICE_TYPES.includes(app.type));
-  const cloudApps = appsResult.apps.filter((app) => NON_SERVICE_TYPES.includes(app.type));
+  const serviceApps = appsResult.apps.filter(
+    (app) => !NON_SERVICE_TYPES.includes(app.type),
+  );
+  const cloudApps = appsResult.apps.filter((app) =>
+    NON_SERVICE_TYPES.includes(app.type),
+  );
 
   console.log(
     `[whitebox-workflow] Phase 2: ${serviceApps.length} service apps (pages+api each), ${cloudApps.length} cloud resources → ${serviceApps.length * 2 + cloudApps.length} total tasks`,
@@ -530,7 +538,9 @@ function readAppsFromAssetsDirectory(
   }
 
   const entries = readdirSync(assetsPath);
-  console.log(`[readAssets] Found ${entries.length} entries in ${assetsPath}: [${entries.join(", ")}]`);
+  console.log(
+    `[readAssets] Found ${entries.length} entries in ${assetsPath}: [${entries.join(", ")}]`,
+  );
   const apps: App[] = [];
 
   for (const entry of entries) {
@@ -549,7 +559,9 @@ function readAppsFromAssetsDirectory(
           readFileSync(appJsonPath, "utf-8"),
         ) as AppMetadata;
       } catch {
-        console.warn(`[readAssets] Skipping app folder with unreadable app.json: ${entry}`);
+        console.warn(
+          `[readAssets] Skipping app folder with unreadable app.json: ${entry}`,
+        );
         continue;
       }
     } else {
@@ -576,7 +588,9 @@ function readAppsFromAssetsDirectory(
 
         const endpoint = assetRecordToEndpoint(data);
         if (!endpoint) {
-          console.log(`[readAssets]   ${file}: failed schema validation (assetRecordToEndpoint returned null)`);
+          console.log(
+            `[readAssets]   ${file}: failed schema validation (assetRecordToEndpoint returned null)`,
+          );
           parseFailed++;
           continue;
         }
@@ -587,7 +601,9 @@ function readAppsFromAssetsDirectory(
           apiEndpoints.push(endpoint);
         }
       } catch {
-        console.warn(`[readAssets] Skipping unreadable asset file: ${entry}/${file}`);
+        console.warn(
+          `[readAssets] Skipping unreadable asset file: ${entry}/${file}`,
+        );
         parseFailed++;
       }
     }
@@ -614,7 +630,9 @@ function readAppsFromAssetsDirectory(
  * Convert a {@link DocumentedEndpointRecord} (from document_endpoint) to an
  * {@link Endpoint} (for the whitebox result schema).
  */
-function assetRecordToEndpoint(record: DocumentedEndpointRecord): Endpoint | null {
+function assetRecordToEndpoint(
+  record: DocumentedEndpointRecord,
+): Endpoint | null {
   const rawMethod = record.method;
   const method = Array.isArray(rawMethod)
     ? rawMethod.join(", ")
@@ -658,7 +676,10 @@ function isPageEndpoint(record: DocumentedEndpointRecord): boolean {
 // Objective builders
 // ---------------------------------------------------------------------------
 
-function buildAppsDiscoveryObjective(codebasePath: string, domains?: string[]): string {
+function buildAppsDiscoveryObjective(
+  codebasePath: string,
+  domains?: string[],
+): string {
   const domainSection = domains?.length
     ? `\n## Known Domains\nThe following domains are associated with this project. When you document an application, set the \`domain\` field on \`document_app\` if you can determine which domain the app is served from:\n${domains.map((d) => `- ${d}`).join("\n")}\n`
     : "";

--- a/src/tests/authPentestHandoff.test.ts
+++ b/src/tests/authPentestHandoff.test.ts
@@ -160,9 +160,7 @@ describe.skip("Auth → Pentest Cookie Handoff", () => {
       pentestBus.on("tool-call-complete", (d) => {
         const inputStr = JSON.stringify(d.args, null, 2);
         toolCallLog.push({ tool: d.toolName, input: inputStr });
-        console.log(
-          `\n→ [pentest] ${d.toolName}\n  ${inputStr.slice(0, 500)}`,
-        );
+        console.log(`\n→ [pentest] ${d.toolName}\n  ${inputStr.slice(0, 500)}`);
       });
       pentestBus.on("tool-result", (d) =>
         console.log(`✓ [pentest] ${d.toolName} completed`),

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -866,9 +866,7 @@ export default function OperatorDashboard({
           return;
         }
         console.error("Agent error:", d.error);
-        setError(
-          d.error instanceof Error ? d.error.message : "Unknown error",
-        );
+        setError(d.error instanceof Error ? d.error.message : "Unknown error");
       });
 
       eventBus.on("subagent-spawn", ({ subagentId, name }) => {

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -824,11 +824,7 @@ export default function Pentest({
           } else if (d.subagentId === "attack-surface-agent") {
             addPanelStreamingToolCall(d.toolCallId, d.toolName);
           } else {
-            addPentestStreamingToolCall(
-              d.subagentId,
-              d.toolCallId,
-              d.toolName,
-            );
+            addPentestStreamingToolCall(d.subagentId, d.toolCallId, d.toolName);
           }
         });
 
@@ -871,12 +867,7 @@ export default function Pentest({
           if (d.subagentId === "attack-surface-agent") {
             addPanelToolCall(d.toolCallId, d.toolName, args);
           } else {
-            addPentestToolCall(
-              d.subagentId,
-              d.toolCallId,
-              d.toolName,
-              args,
-            );
+            addPentestToolCall(d.subagentId, d.toolCallId, d.toolName, args);
           }
         });
 


### PR DESCRIPTION
### Summary

Emits a per-step, append-only JSONL trace alongside existing message persistence. Each line is a self-contained record of one agent step (observations, reasoning, actions, token usage, timing) or a structured state checkpoint emitted by the agent at phase transitions.

- `StepTraceWriter` appends to `trace.jsonl` on every `onStepFinish`
- Orchestrator writes to `{rootPath}/trace.jsonl`, subagents to `{rootPath}/subagents/{id}.trace.jsonl`
- `checkpoint_state` tool lets pentest agents emit structured state snapshots (target knowledge, actions attempted, next steps, blockers)
- `TraceRecord = StepRecord | StateCheckpoint` discriminated union
- Summarization tracked via `markSummarized()` flag
- 24 unit tests covering step records, checkpoints, interleaving, cumulative usage, size bounds, and edge cases

---

### What does this PR do?

Adds two complementary features for agent observability and post-training data curation.

**1. Structured Step Trace (`trace.jsonl`)**

The agent persists its full `ModelMessage[]` as a monolithic JSON blob (`messages.json`), which is expensive to parse and lacks per-step metadata. This PR adds an append-only, newline-delimited JSON log (`trace.jsonl`) that emits one self-contained record per agent step. Each record captures:

- **Observations** — tool results injected from the prior step's execution
- **Reasoning** — extended thinking content, if the model produced it
- **Text** — inner monologue before tool calls
- **Actions** — tool calls with input previews (capped at 1000 chars)
- **Metrics** — per-step and cumulative token usage, wall-clock timing, summarization flag

The trace writer hooks into the existing `onStepFinish` callback in `OffensiveSecurityAgent`. Orchestrator traces go to `{rootPath}/trace.jsonl`, subagent traces to `{rootPath}/subagents/{id}.trace.jsonl`. Writes are synchronous (`appendFileSync`)—each line is ~1–3KB, sub-ms, and the trace is always readable even if the agent crashes mid-run. Existing `messages.json` persistence is unchanged.

**2. Agent State Checkpoint Tool (`checkpoint_state`)**

Adds a tool that the pentest agent calls at phase transitions (post-recon, post-vulnerability-confirmation, strategy changes) to emit a structured state snapshot. Checkpoints capture what the agent knows about the target, what it has tried, what's blocked, and what it plans next. They are appended to the same `trace.jsonl` as a distinct record type (`type: "checkpoint"` vs `type: "step"`), forming a `TraceRecord` discriminated union.

The checkpoint tool is wired through `ToolContext` and conditionally available when a trace writer is present. System prompt additions guide the model to checkpoint 3–6 times per run at natural phase boundaries.

**Changes:**
- New `trace.ts` — `StepRecord`, `StateCheckpoint`, `TraceRecord` types + `StepTraceWriter` class
- New `tools/checkpointState.ts` — `checkpoint_state` tool factory
- `offensiveSecurityAgent.ts` — trace writer creation + integration into `onStepFinish`/`onSummarized`
- `tools/types.ts` — `traceWriter` added to `ToolContext`
- `tools/index.ts` — checkpoint tool registered in `createAllTools` + `ALL_TOOL_NAMES`
- `pentest/agent.ts` — `checkpoint_state` added to `activeTools`, system prompt section added to both base and exfil prompts

---

### How did you verify this works?

**24 unit tests** covering step records, checkpoint records, interleaving, `stepIndex` monotonicity, cumulative usage math, output/input preview truncation, size bounds, summarization flag, `agentId` tagging, directory creation, error output types, string content handling, and the `currentStepIndex` getter.

**Production trace inspection** from a real 10-agent pentest swarm run (`ses_2c57f0d44ffeaUm4o6dLs23Qi9`): 12 trace files generated (1 orchestrator + 1 attack-surface + 10 pentest agents), totaling ~235 step records. 8 of 10 pentest agents emitted checkpoints with rich structured state (discovered surfaces, credentials obtained, confirmed vulnerabilities, prioritized next steps). Cumulative token usage is monotonically increasing across all agents. Step 0 observations are correctly null; subsequent steps correctly extract tool results from prior actions.

**Lint and format checks** pass (`bun run lint`, `bun run format:check` on changed files).

---

### Post-training / finetuning value

The trace format is designed to be directly consumable as training data for finetuning agent models. Each step record is a self-contained `(state, action)` tuple—`observations` represent what the agent saw, `reasoning`/`text` represent what it thought, and `actions` represent what it decided to do. This maps cleanly to SFT trajectories without needing to deserialize and reconstruct step boundaries from the full `messages.json` blob.

Checkpoints add a layer that `messages.json` can never provide: the agent's own structured assessment of its beliefs at key decision points. This enables:

- **Trajectory quality filtering** — compare checkpoint state against actual outcomes to score runs (e.g., "agent said it had 3 confirmed vulns at step 8, findings dir has 3 validated findings → high-quality trajectory")
- **Decision-quality evals** — extract a checkpoint + the next N steps and ask "given this state, was the next action correct?"—this is the Layer 1 eval pattern
- **Reward signal construction** — `cumulativeUsage` and `elapsedMs` per step provide cost signals; checkpoint `blockers` and action `outcome` fields provide progress signals for RLHF reward modeling
- **Per-agent dataset slicing** — `agentId` lets you build separate datasets for orchestrator vs. pentest agent finetuning, or filter to only high-performing agents in a swarm
- **Failure mode labeling** — the last checkpoint before a failed run tells you exactly what the agent believed when it went wrong, enabling root-cause classification at the reasoning level rather than just "it failed"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new always-on trace writing and a new tool available to pentest agents, which could impact performance/disk usage and may capture sensitive tool inputs/outputs if not handled carefully.
> 
> **Overview**
> Adds structured agent observability by introducing `StepTraceWriter` and emitting an append-only `trace.jsonl` record on every agent step (plus a summarized flag and token/timing metadata), with subagents writing to `subagents/{id}.trace.jsonl`.
> 
> Introduces a new `checkpoint_state` tool that lets pentest agents append structured state snapshots to the same trace, wires it through `ToolContext`/tool registry, and updates the pentest agent prompts/`activeTools` to encourage checkpointing. Includes extensive unit tests for trace/ checkpoint record formatting and edge cases; remaining changes are mostly formatting/logging cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce2d9eb8f2aed57fd4b6287e42df3491ed7ab437. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->