### PR TITLE
Rename /sessions to /resume

### DIFF
--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -272,9 +272,9 @@ export const commands: CommandConfig[] = [
     },
   },
   {
-    name: "sessions",
-    aliases: ["s"],
-    description: "Browse previous sessions",
+    name: "resume",
+    aliases: ["sessions", "s"],
+    description: "Resume a previous session",
     category: "Pentesting",
     handler: async (_args, ctx) => {
       ctx.openSessionsDialog?.();


### PR DESCRIPTION
## Summary
- `/resume` is now the primary command (à la Claude Code)
- `/sessions` and `/s` kept as aliases

Closes #420

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small TUI command registry rename with backwards-compatible aliases and no changes to session data or routing logic.
> 
> **Overview**
> Updates the TUI command registry so `/resume` becomes the primary command for reopening prior sessions.
> 
> Keeps `/sessions` and `/s` as aliases, and updates the command description accordingly while preserving the same handler (`openSessionsDialog`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3443d87db61b6f8b1e8d7ca8fac2122398e38581. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->