### PR TITLE
Add truncation to tool results inflating input tokens

### DIFF
--- a/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
+++ b/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
@@ -4,6 +4,7 @@ import {
   extractJavascriptEndpoints,
   type EndpointInfo,
 } from "../../specialized/attackSurface/jsExtraction";
+import { MAX_TOOL_RESULT_LENGTH } from "./truncation";
 
 /**
  * Factory for the `crawl_authenticated_area` tool.
@@ -112,15 +113,36 @@ export function crawlAuthenticated(_ctx: unknown) {
           }
         }
 
-        return {
+        const pagesForResult = pages.map((p) => ({
+          url: p.url,
+          status: p.status,
+          linkCount: p.links.length,
+          formCount: p.forms.length,
+          jsEndpointCount: p.jsEndpoints.length,
+          links: p.links.slice(0, 20),
+          forms: p.forms.slice(0, 10),
+        }));
+
+        const result = {
           success: true,
           startUrl,
           pagesVisited: visited.size,
           totalPages: pages.length,
-          pages,
+          pages: pagesForResult,
           allDiscoveredEndpoints: Array.from(allEndpoints),
           message: `Crawled ${visited.size} pages. Discovered ${allEndpoints.size} unique endpoints from JavaScript.`,
         };
+
+        const serialized = JSON.stringify(result);
+        if (serialized.length > MAX_TOOL_RESULT_LENGTH) {
+          return {
+            ...result,
+            pages: pagesForResult.slice(0, 10),
+            _note: `Page details truncated to first 10 of ${pagesForResult.length} pages`,
+          };
+        }
+
+        return result;
       } catch (error: unknown) {
         const errorMsg = error instanceof Error ? error.message : String(error);
         return {

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -478,7 +478,19 @@ ${finding.references ? `## References\n\n${finding.references}` : ""}
 
         return {
           success: true,
-          finding: findingWithMeta,
+          finding: {
+            title: finding.title,
+            severity: finding.severity,
+            endpoint: finding.endpoint,
+            pocPath: finding.pocPath,
+            vulnerabilityClass: input.vulnerabilityClass,
+            cvss: {
+              score: cvssResult.score,
+              severity: cvssResult.severity,
+              vectorString: cvssResult.vectorString,
+            },
+            cwes: cvssResult.cwes,
+          },
           filepath: mdPath,
           message: resultMessage,
         };

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { join } from "path";
 import { writeFileSync, mkdirSync, existsSync } from "fs";
 import type { ToolContext } from "./types";
+import { truncateHeaders } from "./truncation";
 
 const MAX_INLINE_BODY = 5_000;
 
@@ -176,9 +177,9 @@ COMMON TESTING PATTERNS:
 
         clearTimeout(timeoutId);
 
-        const responseHeaders: Record<string, string> = {};
+        const rawHeaders: Record<string, string> = {};
         response.headers.forEach((value, key) => {
-          responseHeaders[key] = value;
+          rawHeaders[key] = value;
         });
 
         let responseBody = "";
@@ -194,7 +195,7 @@ COMMON TESTING PATTERNS:
           success: true,
           status: response.status,
           statusText: response.statusText,
-          headers: responseHeaders,
+          headers: truncateHeaders(rawHeaders),
           body: truncatedBody,
           url: response.url,
           redirected: response.redirected,
@@ -306,7 +307,7 @@ async function executeSandboxHttpRequest(
       success: status >= 200 && status < 400,
       status,
       statusText,
-      headers: responseHeaders,
+      headers: truncateHeaders(responseHeaders),
       body: truncatedBody,
       url,
       redirected: false,

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -16,6 +16,12 @@ import { createRequire } from "module";
 import { writeFileSync, mkdirSync, existsSync } from "fs";
 import { join, dirname } from "path";
 import type { Logger } from "../../../logger";
+import {
+  truncateToolResult,
+  truncateJsonResult,
+  MAX_SNAPSHOT_LENGTH,
+  MAX_BROWSER_RESULT_LENGTH,
+} from "./truncation";
 
 // Types for tool results
 export interface BrowserNavigateResult {
@@ -724,11 +730,19 @@ export function createBrowserTools(
       toolCallDescription,
     }): Promise<BrowserNavigateResult> => {
       try {
-        const result = await session.callTool(
+        const rawResult = await session.callTool(
           "browser_navigate",
           { url },
           abortSignal,
         );
+        const result =
+          rawResult != null
+            ? truncateJsonResult(
+                rawResult,
+                MAX_SNAPSHOT_LENGTH,
+                "call browser_snapshot separately for full DOM tree",
+              )
+            : undefined;
         return {
           success: true,
           url,
@@ -836,12 +850,15 @@ Example workflow:
           {},
           abortSignal,
         );
+        const raw =
+          typeof result === "string" ? result : JSON.stringify(result, null, 2);
         return {
           success: true,
-          snapshot:
-            typeof result === "string"
-              ? result
-              : JSON.stringify(result, null, 2),
+          snapshot: truncateToolResult(
+            raw,
+            MAX_SNAPSHOT_LENGTH,
+            "use browser_evaluate for targeted DOM queries",
+          ),
         };
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
@@ -866,11 +883,19 @@ Example workflow:
         if (ref) {
           args.ref = ref;
         }
-        const result = await session.callTool(
+        const rawResult = await session.callTool(
           "browser_click",
           args,
           abortSignal,
         );
+        const result =
+          rawResult != null
+            ? truncateJsonResult(
+                rawResult,
+                MAX_SNAPSHOT_LENGTH,
+                "call browser_snapshot separately for full DOM tree",
+              )
+            : undefined;
         return { success: true, element, result };
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
@@ -892,16 +917,23 @@ Example workflow:
       toolCallDescription,
     }): Promise<BrowserFillResult> => {
       try {
-        // Note: Playwright MCP uses "browser_type" for filling fields
         const args: Record<string, unknown> = { element, text: value };
         if (ref) {
           args.ref = ref;
         }
-        const result = await session.callTool(
+        const rawResult = await session.callTool(
           "browser_type",
           args,
           abortSignal,
         );
+        const result =
+          rawResult != null
+            ? truncateJsonResult(
+                rawResult,
+                MAX_SNAPSHOT_LENGTH,
+                "call browser_snapshot separately for full DOM tree",
+              )
+            : undefined;
         return { success: true, element, result };
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
@@ -921,10 +953,15 @@ Example workflow:
       try {
         const fnScript = transformScriptToFunction(script);
 
-        const result = await session.callTool(
+        const rawResult = await session.callTool(
           "browser_evaluate",
           { function: fnScript },
           abortSignal,
+        );
+        const result = truncateJsonResult(
+          rawResult,
+          MAX_BROWSER_RESULT_LENGTH,
+          "narrow your script to return less data",
         );
         return { success: true, script, result };
       } catch (error: unknown) {
@@ -958,7 +995,18 @@ Example workflow:
           messages = result as Array<{ type: string; text: string }>;
         }
 
-        return { success: true, messages, result };
+        const truncatedResult = truncateJsonResult(
+          result ?? messages ?? [],
+          MAX_BROWSER_RESULT_LENGTH,
+          "console messages truncated",
+        );
+        if (
+          messages &&
+          JSON.stringify(messages).length > MAX_BROWSER_RESULT_LENGTH
+        ) {
+          messages = messages.slice(-50);
+        }
+        return { success: true, messages, result: truncatedResult };
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
         logger?.error(`browser_console failed: ${message}`);

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -32,6 +32,12 @@ import type {
   BrowserEvaluateResult,
   BrowserConsoleResult,
 } from "./playwrightMcp";
+import {
+  truncateToolResult,
+  truncateJsonResult,
+  MAX_SNAPSHOT_LENGTH,
+  MAX_BROWSER_RESULT_LENGTH,
+} from "./truncation";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -637,6 +643,14 @@ Example workflow:
           30,
         )) as { success: boolean; snapshot?: string; error?: string };
 
+        if (result.snapshot) {
+          result.snapshot = truncateToolResult(
+            result.snapshot,
+            MAX_SNAPSHOT_LENGTH,
+            "use browser_evaluate for targeted DOM queries",
+          );
+        }
+
         return result;
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
@@ -839,6 +853,15 @@ The JavaScript is executed in the page context and the result is returned.`,
           30,
         )) as BrowserEvaluateResult;
 
+        if (result.result !== undefined) {
+          const serialized = truncateJsonResult(
+            result.result,
+            MAX_BROWSER_RESULT_LENGTH,
+            "narrow your script to return less data",
+          );
+          result.result = serialized;
+        }
+
         return result;
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
@@ -875,6 +898,20 @@ Use this to check for:
           `,
           15,
         )) as BrowserConsoleResult;
+
+        if (result.messages) {
+          const serialized = truncateJsonResult(
+            result.messages,
+            MAX_BROWSER_RESULT_LENGTH,
+            "console messages truncated",
+          );
+          result.result = serialized;
+          if (
+            JSON.stringify(result.messages).length > MAX_BROWSER_RESULT_LENGTH
+          ) {
+            result.messages = result.messages.slice(-50);
+          }
+        }
 
         return result;
       } catch (error: unknown) {

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -2,6 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 import { AgentEventBus, type AgentEventMap } from "../../../eventBus";
+import { truncateToolResult, MAX_SUBAGENT_OUTPUT_LENGTH } from "./truncation";
 
 /** Default max concurrent coding agents */
 const DEFAULT_CONCURRENCY = 5;
@@ -157,7 +158,11 @@ Returns an array of results with the text output from each agent.`,
         results: results.map((r) => ({
           codebasePath: r.codebasePath,
           objective: r.objective,
-          output: r.output,
+          output: truncateToolResult(
+            r.output,
+            MAX_SUBAGENT_OUTPUT_LENGTH,
+            "sub-agent output truncated",
+          ),
           error: r.error,
         })),
         message: `Coding agents complete. ${total - failedTasks.length}/${total} succeeded.${

--- a/src/core/agents/offSecAgent/tools/truncation.ts
+++ b/src/core/agents/offSecAgent/tools/truncation.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared truncation utilities for tool results.
+ *
+ * Every tool that can return unbounded text to the model should use these
+ * helpers to cap output size, keeping input-token costs predictable.
+ */
+
+/** Default cap for generic tool text results (chars). */
+export const MAX_TOOL_RESULT_LENGTH = 50_000;
+
+/** Cap for browser accessibility snapshots (chars). */
+export const MAX_SNAPSHOT_LENGTH = 30_000;
+
+/** Cap for browser evaluate / console results (chars). */
+export const MAX_BROWSER_RESULT_LENGTH = 20_000;
+
+/** Cap for sub-agent text output (chars). */
+export const MAX_SUBAGENT_OUTPUT_LENGTH = 30_000;
+
+/** Cap for headers serialized as part of an HTTP response (chars). */
+export const MAX_HEADERS_LENGTH = 4_000;
+
+/**
+ * Truncate a string to `maxLen` characters, appending a notice when cut.
+ * Returns the original string unchanged when within limits.
+ */
+export function truncateToolResult(
+  text: string,
+  maxLen: number,
+  hint?: string,
+): string {
+  if (text.length <= maxLen) return text;
+  const suffix = hint
+    ? `\n\n(truncated at ${maxLen} chars — ${hint})`
+    : `\n\n(truncated at ${maxLen} chars)`;
+  return text.substring(0, maxLen) + suffix;
+}
+
+/**
+ * Truncate a JSON-serializable value and return it as a string.
+ * Useful for tool results that return structured objects which can be
+ * arbitrarily large (e.g. browser evaluate results).
+ */
+export function truncateJsonResult(
+  value: unknown,
+  maxLen: number,
+  hint?: string,
+): string {
+  const text =
+    typeof value === "string" ? value : JSON.stringify(value, null, 2);
+  return truncateToolResult(text, maxLen, hint);
+}
+
+/**
+ * Cap the number of entries in a response headers record and
+ * truncate individual header values that are excessively long.
+ */
+export function truncateHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  let totalLen = 0;
+
+  for (const [key, value] of Object.entries(headers)) {
+    const truncatedValue =
+      value.length > 1_000
+        ? value.substring(0, 1_000) + "...(truncated)"
+        : value;
+
+    totalLen += key.length + truncatedValue.length;
+
+    if (totalLen > MAX_HEADERS_LENGTH) {
+      result["_truncated"] =
+        `Headers truncated at ${MAX_HEADERS_LENGTH} chars — ${Object.keys(headers).length - Object.keys(result).length} headers omitted`;
+      break;
+    }
+
+    result[key] = truncatedValue;
+  }
+
+  return result;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Multiple tools were returning unbounded data to the LLM, inflating input tokens on every subsequent turn since tool results accumulate in the conversation history until context overflow triggers summarization.

**Audit findings and fixes:**

| Tool | Problem | Fix |
|------|---------|-----|
| `browser_snapshot` | Full accessibility tree returned with no cap (both sandbox Playwright and MCP paths) | Capped at 30k chars |
| `browser_evaluate` | Arbitrary JS evaluation results passed through untruncated | Capped at 20k chars |
| `browser_console` | Full console message history returned unbounded | Capped at 20k chars, keep last 50 entries |
| `browser_navigate/click/fill` (MCP) | Playwright MCP server returns full accessibility snapshot after every action, piped through as `result` field | Truncated MCP results at 30k chars |
| `spawn_coding_agent` | Full accumulated sub-agent text output returned per task | Capped at 30k chars per task |
| `crawl_authenticated_area` | Full per-page arrays of links, forms, and JS endpoints returned | Summarized to counts + sliced arrays; page details capped at first 10 if total exceeds 50k |
| `http_request` | Response headers returned without any cap (could be huge with large Set-Cookie, CSP, etc.) | Headers capped at 4k total, individual values at 1k |
| `document_vulnerability` | Full `findingWithMeta` object returned (includes evidence, description, POC stdout/stderr, CVSS reasoning) | Returns concise summary: title, severity, endpoint, pocPath, CVSS score/vector, CWEs |

**Additional context — input token review of the targeted pentest workflow:**

The pentest agent accumulates full conversation history (tool calls + tool results) with no proactive pruning. Summarization only triggers reactively on context overflow errors. The biggest contributors to input token inflation are:
1. Browser tool results (especially `browser_snapshot` after every navigate/click/fill returning the full DOM tree)
2. `http_request` making dozens of requests, each with full response headers staying in history
3. `document_vulnerability` returning the entire finding object (evidence, POC output, CVSS reasoning)
4. `execute_command` results (already capped at 50k, but still large)

This PR addresses the tool-result side. The conversation-level context management (proactive pruning, sliding window, etc.) would be a separate effort.

**New shared utility:** `truncation.ts` provides reusable truncation functions and configurable limits per tool category.

### How did you verify your code works?

- `bun run tsc` — type check passes
- `bun run lint` — lint passes  
- `bun run format:check` — formatting passes
- `bun run test` — all 559 tests pass (15 skipped as expected)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b92c6115-fca6-419f-a401-2b2ad7e33ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b92c6115-fca6-419f-a401-2b2ad7e33ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

