### PR TITLE
Remove spawn_pentest_swarm and spawn_coding_agent from plan mode tools

### DIFF
--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -253,8 +253,10 @@ export const ALL_TOOL_NAMES: ToolName[] = [
  * Tool names available in plan mode (read-only / non-mutating).
  *
  * Excludes: create_file, update_file, document_vulnerability,
- * document_app, document_endpoint. These are the mutation tools that should not be available
- * when the operator is in plan (read-only) mode.
+<<<<<<< HEAD
+ * document_app, document_endpoint, spawn_pentest_swarm, spawn_coding_agent
+ * — file writes, findings, and orchestration tools that spawn autonomous
+ * sub-agents are not available in plan mode.
  */
 export const PLAN_MODE_TOOL_NAMES: ToolName[] = [
   // Browser automation (read-only navigation and inspection)
@@ -279,9 +281,6 @@ export const PLAN_MODE_TOOL_NAMES: ToolName[] = [
   "create_attack_surface_report",
   "complete_authentication",
   "run_attack_surface",
-  "spawn_pentest_swarm",
-  "spawn_coding_agent",
-  "run_pentest_workflow",
   "provide_comparison_results",
   // Memory
   "add_memory",

--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -253,10 +253,9 @@ export const ALL_TOOL_NAMES: ToolName[] = [
  * Tool names available in plan mode (read-only / non-mutating).
  *
  * Excludes: create_file, update_file, document_vulnerability,
-<<<<<<< HEAD
- * document_app, document_endpoint, spawn_pentest_swarm, spawn_coding_agent
- * — file writes, findings, and orchestration tools that spawn autonomous
- * sub-agents are not available in plan mode.
+ * document_app, document_endpoint, spawn_pentest_swarm, spawn_coding_agent,
+ * run_pentest_workflow, checkpoint_state — file writes, findings, orchestration
+ * tools that spawn autonomous sub-agents, and observability hooks are not available in plan mode.
  */
 export const PLAN_MODE_TOOL_NAMES: ToolName[] = [
   // Browser automation (read-only navigation and inspection)

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -80,7 +80,8 @@ export type OffensiveSecurityAgentInput<TResult = void> = {
    * When set to `"plan"`, the agent's `activeTools` are intersected with
    * {@link PLAN_MODE_TOOL_NAMES} so that mutation tools (create_file,
    * update_file, document_vulnerability, document_app,
-   * document_endpoint) are excluded.
+   * document_endpoint) and orchestration tools that spawn autonomous
+   * sub-agents (spawn_pentest_swarm, spawn_coding_agent) are excluded.
    *
    * @default "default"
    */


### PR DESCRIPTION
## Summary
- Removes `spawn_pentest_swarm`, `spawn_coding_agent`, and `run_pentest_workflow` from `PLAN_MODE_TOOL_NAMES` so autonomous sub-agents cannot be spawned in read-only plan mode.

> Originally authored by @ArshAnan in #508. Rebased onto canary and reopened from origin to fix Integration CI (fork PRs can't access repo secrets).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the `PLAN_MODE_TOOL_NAMES` allowlist to block orchestration tools in plan mode, and the current diff appears to leave an unresolved merge-conflict marker (`<<<<<<< HEAD`) in `tools/index.ts`, which will likely break builds/CI.
> 
> **Overview**
> **Plan mode is tightened to be strictly read-only.** `PLAN_MODE_TOOL_NAMES` no longer includes orchestration entries like `spawn_pentest_swarm`, `spawn_coding_agent`, and `run_pentest_workflow`, preventing autonomous sub-agent execution when `mode: "plan"` filters `activeTools`.
> 
> Docs/comments in `types.ts` are updated to explicitly call out that sub-agent spawning tools are excluded in plan mode, but `tools/index.ts` currently contains an unresolved merge-conflict marker around the plan-mode exclusion comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa8cb0dd07cebb1d935e0f4779410fb3df5781af. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->