### PR TITLE
fix: remove merge conflict marker from PLAN_MODE JSDoc

### DIFF
--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -253,10 +253,9 @@ export const ALL_TOOL_NAMES: ToolName[] = [
  * Tool names available in plan mode (read-only / non-mutating).
  *
  * Excludes: create_file, update_file, document_vulnerability,
-<<<<<<< HEAD
- * document_app, document_endpoint, spawn_pentest_swarm, spawn_coding_agent
- * — file writes, findings, and orchestration tools that spawn autonomous
- * sub-agents are not available in plan mode.
+ * document_app, document_endpoint, spawn_pentest_swarm, spawn_coding_agent,
+ * run_pentest_workflow, checkpoint_state — file writes, findings, orchestration
+ * tools that spawn autonomous sub-agents, and observability hooks are not available in plan mode.
  */
 export const PLAN_MODE_TOOL_NAMES: ToolName[] = [
   // Browser automation (read-only navigation and inspection)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Removes the stray `<<<<<<< HEAD` line left inside the JSDoc for `PLAN_MODE_TOOL_NAMES` in `src/core/agents/offSecAgent/tools/index.ts` (an incomplete merge/rebase artifact). The comment now lists the tools excluded from plan mode without conflict markers, including `run_pentest_workflow` and `checkpoint_state`, which are absent from `PLAN_MODE_TOOL_NAMES` but were not mentioned before.

### How did you verify your code works?

Ran `bun run test` and `bun run lint`; both succeeded.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb32d3f4-e4a5-483e-bc43-6f56d33e6279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb32d3f4-e4a5-483e-bc43-6f56d33e6279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

