### PR TITLE
Enhanced Operator Plan Mode

### DIFF
--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -286,22 +286,25 @@ export const PLAN_MODE_TOOL_NAMES: ToolName[] = [
   "read_file",
   "list_files",
   "grep",
-  // Authentication (read-only probing)
+  // Recon (read-only probing and discovery)
   "authenticate_session",
   "delegate_to_auth_subagent",
   "complete_authentication",
+  "extract_js_endpoints",
+  "crawl_authenticated_area",
+  "detect_auth_scheme",
+  "probe_auth_endpoints",
   "provide_comparison_results",
   // Memory
   "add_memory",
   "list_memories",
   "get_memory",
-  // Email
+  // Email (read-only)
   "email_list_inboxes",
   "email_list_messages",
   "email_get_message",
   "email_search_messages",
   "email_get_attachments",
-  "email_mark_read",
   // Web search
   "web_search",
   "get_page",

--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -75,6 +75,10 @@ export { readSkill } from "./readSkill";
 // Observability tools
 export { checkpointState } from "./checkpointState";
 
+// Plan mode tools
+export { writePlan } from "./writePlan";
+export { submitPlan } from "./submitPlan";
+
 // ---------------------------------------------------------------------------
 // Tool registry
 // ---------------------------------------------------------------------------
@@ -120,6 +124,8 @@ import { webSearch } from "./webSearch";
 import { getPage } from "./getPage";
 import { readSkill } from "./readSkill";
 import { checkpointState } from "./checkpointState";
+import { writePlan } from "./writePlan";
+import { submitPlan } from "./submitPlan";
 
 /**
  * Create the full toolset for the OffensiveSecurityAgent.
@@ -192,6 +198,10 @@ export function createAllTools(ctx: ToolContext & { subagentId?: string }) {
 
     // Observability tools (conditional — only when trace writer is provided)
     ...(ctx.traceWriter ? { checkpoint_state: checkpointState(ctx) } : {}),
+
+    // Plan mode tools
+    write_plan: writePlan(ctx),
+    submit_plan: submitPlan(ctx),
   } as const;
 }
 
@@ -247,6 +257,9 @@ export const ALL_TOOL_NAMES: ToolName[] = [
   "get_page",
   // Observability
   "checkpoint_state",
+  // Plan mode
+  "write_plan",
+  "submit_plan",
 ];
 
 /**
@@ -273,15 +286,10 @@ export const PLAN_MODE_TOOL_NAMES: ToolName[] = [
   "read_file",
   "list_files",
   "grep",
-  // Attack surface / recon
+  // Authentication (read-only probing)
   "authenticate_session",
   "delegate_to_auth_subagent",
-  "create_attack_surface_report",
   "complete_authentication",
-  "run_attack_surface",
-  "spawn_pentest_swarm",
-  "spawn_coding_agent",
-  "run_pentest_workflow",
   "provide_comparison_results",
   // Memory
   "add_memory",
@@ -297,6 +305,9 @@ export const PLAN_MODE_TOOL_NAMES: ToolName[] = [
   // Web search
   "web_search",
   "get_page",
+  // Plan mode tools
+  "write_plan",
+  "submit_plan",
 ];
 
 /** Skill tool names — conditionally included when a skills registry is provided. */

--- a/src/core/agents/offSecAgent/tools/submitPlan.ts
+++ b/src/core/agents/offSecAgent/tools/submitPlan.ts
@@ -3,15 +3,13 @@ import { z } from "zod";
 import type { ToolContext } from "./types";
 import { readPlan, planFilePath } from "../../../plan";
 
-export const submitPlanInputSchema = z.object({
+const submitPlanInputSchema = z.object({
   toolCallDescription: z
     .string()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Submitting pentest plan for operator review')",
     ),
 });
-
-type SubmitPlanInput = z.infer<typeof submitPlanInputSchema>;
 
 type SubmitPlanResult = {
   success: boolean;

--- a/src/core/agents/offSecAgent/tools/submitPlan.ts
+++ b/src/core/agents/offSecAgent/tools/submitPlan.ts
@@ -34,7 +34,8 @@ Only call this when the plan is complete and ready for review.`,
       if (!plan || !plan.trim()) {
         return {
           success: false,
-          error: "Plan file not found or empty. Write the plan first using write_plan.",
+          error:
+            "Plan file not found or empty. Write the plan first using write_plan.",
           path: planPath,
         };
       }

--- a/src/core/agents/offSecAgent/tools/submitPlan.ts
+++ b/src/core/agents/offSecAgent/tools/submitPlan.ts
@@ -1,0 +1,47 @@
+import { tool } from "ai";
+import { z } from "zod";
+import type { ToolContext } from "./types";
+import { readPlan, planFilePath } from "../../../plan";
+
+export const submitPlanInputSchema = z.object({
+  toolCallDescription: z
+    .string()
+    .describe(
+      "A concise, human-readable description of what this tool call is doing (e.g., 'Submitting pentest plan for operator review')",
+    ),
+});
+
+type SubmitPlanInput = z.infer<typeof submitPlanInputSchema>;
+
+type SubmitPlanResult = {
+  success: boolean;
+  error: string;
+  path: string;
+};
+
+export function submitPlan(ctx: ToolContext) {
+  return tool({
+    description: `Submit the pentest plan for operator review and approval.
+
+Call this tool AFTER you have written the plan via write_plan. It reads the plan
+from disk and presents it to the operator for approval. The operator can approve,
+reject (sending you back to refine), or edit the plan before approving.
+
+Only call this when the plan is complete and ready for review.`,
+    inputSchema: submitPlanInputSchema,
+    execute: async (): Promise<SubmitPlanResult> => {
+      const planPath = planFilePath(ctx.session.rootPath);
+      console.error(`[submit_plan] enter: path=${planPath}`);
+      const plan = readPlan(ctx.session.rootPath);
+      if (!plan || !plan.trim()) {
+        return {
+          success: false,
+          error: "Plan file not found or empty. Write the plan first using write_plan.",
+          path: planPath,
+        };
+      }
+      console.error(`[submit_plan] done: planLen=${plan.length}`);
+      return { success: true, error: "", path: planPath };
+    },
+  });
+}

--- a/src/core/agents/offSecAgent/tools/writePlan.ts
+++ b/src/core/agents/offSecAgent/tools/writePlan.ts
@@ -4,7 +4,7 @@ import { writeFile } from "fs/promises";
 import type { ToolContext } from "./types";
 import { planFilePath } from "../../../plan";
 
-export const writePlanInputSchema = z.object({
+const writePlanInputSchema = z.object({
   content: z
     .string()
     .describe("The full markdown content of the pentest plan"),
@@ -14,8 +14,6 @@ export const writePlanInputSchema = z.object({
       "A concise, human-readable description of what this tool call is doing (e.g., 'Writing initial pentest plan with recon findings')",
     ),
 });
-
-type WritePlanInput = z.infer<typeof writePlanInputSchema>;
 
 type WritePlanResult = {
   success: boolean;

--- a/src/core/agents/offSecAgent/tools/writePlan.ts
+++ b/src/core/agents/offSecAgent/tools/writePlan.ts
@@ -5,9 +5,7 @@ import type { ToolContext } from "./types";
 import { planFilePath } from "../../../plan";
 
 const writePlanInputSchema = z.object({
-  content: z
-    .string()
-    .describe("The full markdown content of the pentest plan"),
+  content: z.string().describe("The full markdown content of the pentest plan"),
   toolCallDescription: z
     .string()
     .describe(

--- a/src/core/agents/offSecAgent/tools/writePlan.ts
+++ b/src/core/agents/offSecAgent/tools/writePlan.ts
@@ -1,0 +1,61 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { writeFile } from "fs/promises";
+import type { ToolContext } from "./types";
+import { planFilePath } from "../../../plan";
+
+export const writePlanInputSchema = z.object({
+  content: z
+    .string()
+    .describe("The full markdown content of the pentest plan"),
+  toolCallDescription: z
+    .string()
+    .describe(
+      "A concise, human-readable description of what this tool call is doing (e.g., 'Writing initial pentest plan with recon findings')",
+    ),
+});
+
+type WritePlanInput = z.infer<typeof writePlanInputSchema>;
+
+type WritePlanResult = {
+  success: boolean;
+  error: string;
+  path: string;
+};
+
+export function writePlan(ctx: ToolContext) {
+  return tool({
+    description: `Write or update the pentest plan file for this session.
+
+The plan is stored at a fixed path in the session directory (plan.md).
+Always provide the complete plan content — the file is overwritten each time.
+
+Required plan sections:
+- **Objective** — engagement goals
+- **Scope** — in-scope targets, exclusions
+- **Reconnaissance Findings** — tech stack, endpoints, auth mechanisms discovered
+- **Attack Surface Map** — entry points ranked by exposure
+- **Prioritized Attack Vectors** — ordered by impact, with endpoint, vuln class, rationale, test approach per vector
+- **Testing Methodology** — concrete techniques/payloads per vector (OWASP categories)
+- **Estimated Action Tiers** — anticipated T1-T5 action counts so the operator can make an informed approval`,
+    inputSchema: writePlanInputSchema,
+    execute: async ({ content }): Promise<WritePlanResult> => {
+      const planPath = planFilePath(ctx.session.rootPath);
+      console.error(
+        `[write_plan] enter: contentLen=${content.length}, path=${planPath}`,
+      );
+      try {
+        await writeFile(planPath, content, "utf-8");
+        console.error(`[write_plan] done`);
+        return { success: true, error: "", path: planPath };
+      } catch (err: unknown) {
+        console.error(`[write_plan] error: ${err}`);
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+          path: planPath,
+        };
+      }
+    },
+  });
+}

--- a/src/core/plan/index.ts
+++ b/src/core/plan/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Plan File I/O Utilities
+ *
+ * Minimal sync helpers for reading/checking the pentest plan file
+ * stored in each session directory at {session.rootPath}/plan.md.
+ */
+
+import { join } from "path";
+import { existsSync, readFileSync } from "fs";
+
+const PLAN_FILENAME = "plan.md";
+
+/** Returns the absolute path to the plan file for a given session root. */
+export function planFilePath(sessionRootPath: string): string {
+  return join(sessionRootPath, PLAN_FILENAME);
+}
+
+/** Reads the plan file content. Returns null if the file doesn't exist. */
+export function readPlan(sessionRootPath: string): string | null {
+  const path = planFilePath(sessionRootPath);
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+/** Returns true if a plan file exists in the session directory. */
+export function hasPlan(sessionRootPath: string): boolean {
+  return existsSync(planFilePath(sessionRootPath));
+}

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -229,6 +229,14 @@ export const commands: CommandConfig[] = [
     },
   },
   {
+    name: "plan",
+    description: "Show current pentest plan",
+    category: "Pentesting",
+    handler: async () => {
+      // Handled by the operator dashboard — this is a no-op for routing
+    },
+  },
+  {
     name: "threat-model",
     aliases: ["tm"],
     description: "Generate application-centric threat model",

--- a/src/tui/components/agent-display.tsx
+++ b/src/tui/components/agent-display.tsx
@@ -96,6 +96,9 @@ export type DisplayMessage = {
   subagentLogs?: Record<string, SubagentLogEntry>;
   // Pentest workflow display (present for run_pentest_workflow tool)
   workflowData?: WorkflowData;
+  // Plan review display (present when isPlanReview === true)
+  isPlanReview?: boolean;
+  planContent?: string;
 };
 
 function getStableKey(

--- a/src/tui/components/chat/plan-review-message.tsx
+++ b/src/tui/components/chat/plan-review-message.tsx
@@ -1,0 +1,52 @@
+/**
+ * Plan Review Message
+ *
+ * Renders the pentest plan in a bordered box with approval hints.
+ * Displayed when the agent calls submit_plan or the operator cycles
+ * out of plan mode with an unapproved plan.
+ */
+
+import { useTheme } from "../../theme";
+import {
+  useMarkdownSyntaxStyle,
+  useMarkdownRenderNode,
+} from "../shared/markdown-viewer";
+
+interface PlanReviewMessageProps {
+  planContent: string;
+}
+
+export function PlanReviewMessage({ planContent }: PlanReviewMessageProps) {
+  const { colors } = useTheme();
+  const syntaxStyle = useMarkdownSyntaxStyle();
+  const renderNode = useMarkdownRenderNode();
+
+  return (
+    <box flexDirection="column" marginTop={1} marginLeft={1} marginRight={1}>
+      {/* Plan content in a bordered box */}
+      <box
+        flexDirection="column"
+        border={true}
+        borderColor={colors.secondary}
+        paddingLeft={1}
+        paddingRight={1}
+        paddingTop={1}
+        paddingBottom={1}
+      >
+        <markdown
+          content={planContent}
+          syntaxStyle={syntaxStyle}
+          conceal={true}
+          renderNode={renderNode}
+        />
+      </box>
+
+      {/* Hints */}
+      <box flexDirection="row" marginTop={1} marginLeft={1}>
+        <text fg={colors.textMuted}>
+          Y approve · N reject · or type feedback to refine
+        </text>
+      </box>
+    </box>
+  );
+}

--- a/src/tui/components/chat/plan-review-message.tsx
+++ b/src/tui/components/chat/plan-review-message.tsx
@@ -43,7 +43,7 @@ export function PlanReviewMessage({ planContent }: PlanReviewMessageProps) {
 
       {/* Hints */}
       <box flexDirection="row" marginTop={1} marginLeft={1}>
-        <text fg={colors.textMuted}>
+        <text fg={colors.text}>
           Y approve · N reject · or type feedback to refine
         </text>
       </box>

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -26,6 +26,7 @@ import {
   AgentEventBus,
   type AgentMode,
 } from "../../../core/agents/offSecAgent";
+import { readPlan, hasPlan, planFilePath as getPlanFilePath } from "../../../core/plan";
 import {
   convertModelMessagesToUI,
   type UIMessage,
@@ -76,6 +77,7 @@ import { QueuedMessages } from "./queued-messages";
 import { navigateUp, navigateDown, selectionAfterRemove } from "./queue";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { isAbsolute, join, resolve } from "path";
+
 import { buildThreatModelPrompt } from "../../../core/skills/builtins/threatModel";
 import { buildPentestPrompt } from "../../../core/skills/builtins/pentest";
 
@@ -215,6 +217,20 @@ export default function OperatorDashboard({
   );
   const agentMode: AgentMode = operatorMode === "plan" ? "plan" : "default";
   const requireApproval = operatorMode === "manual";
+  // Plan mode review state
+  const [approvedPlanContent, setApprovedPlanContent] = useState<string | null>(
+    null,
+  );
+  const [showPlanReview, setShowPlanReview] = useState(false);
+  const planSubmittedRef = useRef(false);
+  const operatorModeRef = useRef(operatorMode);
+  useEffect(() => {
+    operatorModeRef.current = operatorMode;
+  }, [operatorMode]);
+  const approvedPlanRef = useRef(approvedPlanContent);
+  useEffect(() => {
+    approvedPlanRef.current = approvedPlanContent;
+  }, [approvedPlanContent]);
   const tokenUsageRef = useRef(tokenUsage);
 
   useEffect(() => {
@@ -982,6 +998,14 @@ export default function OperatorDashboard({
         }
         setThinking(true);
         updateToolResult(d.toolCallId, d.toolName, d.result);
+
+        // Track submit_plan success — review triggers after the run completes
+        if (
+          d.toolName === "submit_plan" &&
+          (d.result as Record<string, unknown> | null)?.success === true
+        ) {
+          planSubmittedRef.current = true;
+        }
       });
 
       eventBus.on("command-output", (d) => {
@@ -1203,19 +1227,30 @@ export default function OperatorDashboard({
       try {
         let agentResult;
 
+        const systemPrompt = buildOperatorSystemPrompt(
+          initialConfig?.target,
+          operatorState,
+          agentMode,
+          {
+            requireApproval,
+            sandboxMode: !!initialConfig?.sandbox,
+            skillsCatalog,
+            planFilePath: sessionRef.current
+              ? getPlanFilePath(sessionRef.current.rootPath)
+              : undefined,
+            existingPlanContent:
+              agentMode === "plan" && sessionRef.current
+                ? readPlan(sessionRef.current.rootPath)
+                : null,
+            approvedPlanContent:
+              agentMode !== "plan" ? approvedPlanContent : null,
+          },
+        );
+
         if (session) {
           agentResult = await runOffensiveSecurityAgent({
             ...commonInput,
-            system: buildOperatorSystemPrompt(
-              initialConfig?.target,
-              operatorState,
-              agentMode,
-              {
-                requireApproval,
-                sandboxMode: !!initialConfig?.sandbox,
-                skillsCatalog,
-              },
-            ),
+            system: systemPrompt,
             session,
           });
         } else {
@@ -1232,16 +1267,7 @@ export default function OperatorDashboard({
           };
           agentResult = await runOffensiveSecurityAgent({
             ...commonInput,
-            system: buildOperatorSystemPrompt(
-              initialConfig?.target,
-              operatorState,
-              agentMode,
-              {
-                requireApproval,
-                sandboxMode: !!initialConfig?.sandbox,
-                skillsCatalog,
-              },
-            ),
+            system: systemPrompt,
             sessionConfig,
             onNameGenerated: (name: string) => {
               pendingNameRef.current = name;
@@ -1334,6 +1360,12 @@ export default function OperatorDashboard({
           setThinking(false);
           setIsExecuting(false);
           abortControllerRef.current = null;
+
+          // Show plan review after the full response is rendered
+          if (planSubmittedRef.current) {
+            planSubmittedRef.current = false;
+            setShowPlanReview(true);
+          }
         }
       }
     },
@@ -1526,6 +1558,17 @@ export default function OperatorDashboard({
           }
           return;
         }
+        case "show-plan": {
+          const planContent = sessionRef.current
+            ? readPlan(sessionRef.current.rootPath)
+            : null;
+          addSystemMessage(
+            planContent
+              ? `## Current Plan\n\n${planContent}`
+              : "No plan exists yet. Switch to plan mode (Shift+Tab) to create one.",
+          );
+          return;
+        }
         case "execute-command":
           await executeCommand(action.command);
           return;
@@ -1689,22 +1732,51 @@ export default function OperatorDashboard({
     });
   }, [setThinking, setIsExecuting]);
 
-  // Cycle through operator modes: approvals-on → approvals-off → plan
-  const cycleMode = useCallback(() => {
-    setOperatorMode((prev) => {
-      const idx = OPERATOR_MODE_CYCLE.indexOf(prev);
-      const next = OPERATOR_MODE_CYCLE[(idx + 1) % OPERATOR_MODE_CYCLE.length];
-      approvalGateRef.current.updateConfig({
-        requireApproval: next === "manual",
-      });
-      setOperatorState((s) => ({
-        ...s,
-        mode: next,
-        requireApproval: next === "manual",
-      }));
-      return next;
-    });
+  const addSystemMessage = useCallback((content: string) => {
+    setMessages((prev) => [
+      ...prev,
+      { role: "system" as const, content, createdAt: new Date() },
+    ]);
   }, []);
+
+  // Complete a mode transition (shared by cycleMode and plan approval)
+  const transitionToMode = useCallback((next: OperatorMode) => {
+    approvalGateRef.current.updateConfig({
+      requireApproval: next === "manual",
+    });
+    setOperatorState((s) => ({
+      ...s,
+      mode: next,
+      requireApproval: next === "manual",
+    }));
+    setOperatorMode(next);
+  }, []);
+
+  // Cycle through operator modes: approvals-on → approvals-off → plan
+  // Reads from refs to avoid stale closures — safe for rapid keypresses.
+  const cycleMode = useCallback(() => {
+    const current = operatorModeRef.current;
+    const idx = OPERATOR_MODE_CYCLE.indexOf(current);
+    const next = OPERATOR_MODE_CYCLE[(idx + 1) % OPERATOR_MODE_CYCLE.length];
+
+    // Gate: if leaving plan mode and a plan exists but isn't approved, show review
+    if (
+      current === "plan" &&
+      sessionRef.current &&
+      hasPlan(sessionRef.current.rootPath) &&
+      !approvedPlanRef.current
+    ) {
+      setShowPlanReview(true);
+      return;
+    }
+
+    // Entering plan mode — reset approved plan
+    if (next === "plan") {
+      setApprovedPlanContent(null);
+    }
+
+    transitionToMode(next);
+  }, [transitionToMode]);
 
   // Keyboard shortcuts
   useKeyboard((key) => {
@@ -1774,6 +1846,30 @@ export default function OperatorDashboard({
       }
     }
 
+    if (showPlanReview && !inputValue.trim()) {
+      if (key.name === "y" || key.raw === "Y") {
+        key.preventDefault?.();
+        const planContent = sessionRef.current
+          ? readPlan(sessionRef.current.rootPath)
+          : null;
+        setApprovedPlanContent(planContent);
+        setShowPlanReview(false);
+        transitionToMode("manual");
+        addSystemMessage(
+          "Plan approved. Switching to manual mode for execution.",
+        );
+        return;
+      }
+      if (key.name === "n" || key.raw === "N") {
+        key.preventDefault?.();
+        setShowPlanReview(false);
+        addSystemMessage(
+          "Plan rejected. Refine the plan based on operator feedback.",
+        );
+        return;
+      }
+    }
+
     const dialogOpen = stack.length > 0 || externalDialogOpen;
     const action = resolveKeyboardShortcut(
       key,
@@ -1814,6 +1910,33 @@ export default function OperatorDashboard({
         return;
     }
   });
+
+  // Show plan review prompt when triggered.
+  // Guard ref prevents duplicate injection (e.g., React StrictMode double-fire).
+  const planReviewInjectedRef = useRef(false);
+  useEffect(() => {
+    if (!showPlanReview) {
+      planReviewInjectedRef.current = false;
+      return;
+    }
+    if (planReviewInjectedRef.current || !sessionRef.current) return;
+    const planContent = readPlan(sessionRef.current.rootPath);
+    if (!planContent) {
+      setShowPlanReview(false);
+      return;
+    }
+    planReviewInjectedRef.current = true;
+    setMessages((prev) => [
+      ...prev,
+      {
+        role: "system" as const,
+        content: "",
+        createdAt: new Date(),
+        isPlanReview: true,
+        planContent,
+      },
+    ]);
+  }, [showPlanReview]);
 
   // Loading state
   if (loading) {
@@ -1913,13 +2036,24 @@ export default function OperatorDashboard({
       <InputArea
         value={inputValue}
         onChange={setInputValue}
-        onSubmit={handleSubmit}
+        onSubmit={
+          showPlanReview
+            ? (value: string) => {
+                const trimmed = value.trim();
+                if (!trimmed) return;
+                setShowPlanReview(false);
+                handleSubmit(trimmed);
+              }
+            : handleSubmit
+        }
         placeholder={
-          status === "running"
-            ? "Queue a follow-up message..."
-            : status === "waiting"
-              ? "Type to redirect agent, or Y/A to approve..."
-              : "Enter directive or / for commands & skills..."
+          showPlanReview
+            ? "Type feedback to refine, or Y to approve, N to reject..."
+            : status === "running"
+              ? "Queue a follow-up message..."
+              : status === "waiting"
+                ? "Type to redirect agent, or Y/A to approve..."
+                : "Enter directive or / for commands & skills..."
         }
         focused={
           status === "running"

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -1517,6 +1517,13 @@ export default function OperatorDashboard({
     runAgentRef.current(next);
   }, [status]);
 
+  const addSystemMessage = useCallback((content: string) => {
+    setMessages((prev) => [
+      ...prev,
+      { role: "system" as const, content, createdAt: new Date() },
+    ]);
+  }, []);
+
   const showModelPicker = useCallback(() => {
     executeCommand("/models");
   }, [executeCommand]);
@@ -1736,13 +1743,6 @@ export default function OperatorDashboard({
       ];
     });
   }, [setThinking, setIsExecuting]);
-
-  const addSystemMessage = useCallback((content: string) => {
-    setMessages((prev) => [
-      ...prev,
-      { role: "system" as const, content, createdAt: new Date() },
-    ]);
-  }, []);
 
   // Complete a mode transition (shared by cycleMode and plan approval)
   const transitionToMode = useCallback((next: OperatorMode) => {

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -26,7 +26,11 @@ import {
   AgentEventBus,
   type AgentMode,
 } from "../../../core/agents/offSecAgent";
-import { readPlan, hasPlan, planFilePath as getPlanFilePath } from "../../../core/plan";
+import {
+  readPlan,
+  hasPlan,
+  planFilePath as getPlanFilePath,
+} from "../../../core/plan";
 import {
   convertModelMessagesToUI,
   type UIMessage,

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -227,6 +227,7 @@ export default function OperatorDashboard({
   );
   const [showPlanReview, setShowPlanReview] = useState(false);
   const planSubmittedRef = useRef(false);
+  const planRejectedRef = useRef(false);
   const operatorModeRef = useRef(operatorMode);
   useEffect(() => {
     operatorModeRef.current = operatorMode;
@@ -1243,7 +1244,9 @@ export default function OperatorDashboard({
               ? getPlanFilePath(sessionRef.current.rootPath)
               : undefined,
             existingPlanContent:
-              agentMode === "plan" && sessionRef.current
+              agentMode === "plan" &&
+              planRejectedRef.current &&
+              sessionRef.current
                 ? readPlan(sessionRef.current.rootPath)
                 : null,
             approvedPlanContent:
@@ -1775,9 +1778,10 @@ export default function OperatorDashboard({
       return;
     }
 
-    // Entering plan mode — reset approved plan
+    // Entering plan mode — reset plan state for fresh cycle
     if (next === "plan") {
       setApprovedPlanContent(null);
+      planRejectedRef.current = false;
     }
 
     transitionToMode(next);
@@ -1872,6 +1876,7 @@ export default function OperatorDashboard({
       }
       if (key.name === "n" || key.raw === "N") {
         key.preventDefault?.();
+        planRejectedRef.current = true;
         setShowPlanReview(false);
         addSystemMessage(
           "Plan rejected. Refine the plan based on operator feedback.",
@@ -2051,6 +2056,7 @@ export default function OperatorDashboard({
             ? (value: string) => {
                 const trimmed = value.trim();
                 if (!trimmed) return;
+                planRejectedRef.current = true;
                 setShowPlanReview(false);
                 handleSubmit(trimmed);
               }

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -1247,7 +1247,7 @@ export default function OperatorDashboard({
                 ? readPlan(sessionRef.current.rootPath)
                 : null,
             approvedPlanContent:
-              agentMode !== "plan" ? approvedPlanContent : null,
+              agentMode !== "plan" ? approvedPlanRef.current : null,
           },
         );
 

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -1584,6 +1584,7 @@ export default function OperatorDashboard({
       handleSubmit,
       executeCommand,
       showModelPicker,
+      addSystemMessage,
     ],
   );
 
@@ -1856,6 +1857,11 @@ export default function OperatorDashboard({
         const planContent = sessionRef.current
           ? readPlan(sessionRef.current.rootPath)
           : null;
+        if (!planContent?.trim()) {
+          setShowPlanReview(false);
+          addSystemMessage("Plan file is missing or empty. Cannot approve.");
+          return;
+        }
         setApprovedPlanContent(planContent);
         setShowPlanReview(false);
         transitionToMode("manual");

--- a/src/tui/components/operator-dashboard/logic.test.ts
+++ b/src/tui/components/operator-dashboard/logic.test.ts
@@ -153,6 +153,14 @@ describe("routeCommand", () => {
     expect(resolveSkill).toHaveBeenCalledWith("/my-skill");
   });
 
+  it("routes /plan to show-plan", () => {
+    expect(routeCommand("/plan", noSkill)).toEqual({ type: "show-plan" });
+  });
+
+  it("routes /plan with args to show-plan", () => {
+    expect(routeCommand("/plan open", noSkill)).toEqual({ type: "show-plan" });
+  });
+
   it("falls back to execute-command for unknown commands", () => {
     const result = routeCommand("/unknown-cmd", noSkill);
     expect(result).toEqual({
@@ -499,15 +507,32 @@ describe("buildOperatorSystemPrompt", () => {
     expect(prompt).toContain("# Tool Reference");
   });
 
-  it("includes plan mode note when agentMode is plan", () => {
+  it("includes plan mode prompt when agentMode is plan", () => {
     const prompt = buildOperatorSystemPrompt(target, state, "plan");
-    expect(prompt).toContain("Agent mode: PLAN");
-    expect(prompt).toContain("read-only tools only");
+    expect(prompt).toContain("PLAN MODE");
+    expect(prompt).toContain("write_plan");
+    expect(prompt).toContain("submit_plan");
   });
 
-  it("does not include plan mode note when agentMode is default", () => {
+  it("does not include plan mode prompt when agentMode is default", () => {
     const prompt = buildOperatorSystemPrompt(target, state, "default");
-    expect(prompt).not.toContain("Agent mode: PLAN");
+    expect(prompt).not.toContain("PLAN MODE");
+  });
+
+  it("includes approved plan content when provided outside plan mode", () => {
+    const prompt = buildOperatorSystemPrompt(target, state, "default", {
+      approvedPlanContent: "Test plan content",
+    });
+    expect(prompt).toContain("Approved Plan");
+    expect(prompt).toContain("Test plan content");
+  });
+
+  it("includes refinement block when existingPlanContent provided in plan mode", () => {
+    const prompt = buildOperatorSystemPrompt(target, state, "plan", {
+      existingPlanContent: "Old plan content",
+    });
+    expect(prompt).toContain("Do NOT Rewrite");
+    expect(prompt).toContain("Old plan content");
   });
 
   it("does not include plan mode note when agentMode is omitted", () => {

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -14,6 +14,7 @@ const OPERATOR_ALLOWED_COMMANDS = new Set([
   "/operator",
   "/pentest",
   "/skills",
+  "/plan",
 ]);
 
 export function filterOperatorAutocomplete(
@@ -52,6 +53,7 @@ export function resolveSubmit(
 
 export type CommandAction =
   | { type: "show-models" }
+  | { type: "show-plan" }
   | { type: "run-skill"; slug: string; autopilot: boolean }
   | { type: "execute-command"; command: string };
 
@@ -63,6 +65,10 @@ export function routeCommand(
 
   if (commandLower === "models" || commandLower === "model") {
     return { type: "show-models" };
+  }
+
+  if (commandLower === "plan" || commandLower.startsWith("plan ")) {
+    return { type: "show-plan" };
   }
 
   if (commandLower === "skills") {
@@ -189,16 +195,34 @@ export function buildOperatorSystemPrompt(
     sandboxMode?: boolean;
     skillsCatalog?: string;
     activeSkillInstructions?: Array<{ name: string; instructions: string }>;
+    planFilePath?: string;
+    existingPlanContent?: string | null;
+    approvedPlanContent?: string | null;
   },
 ): string {
   const { skillsCatalog, activeSkillInstructions } = opts ?? {};
-  const modeNote =
-    agentMode === "plan"
-      ? "\nAgent mode: PLAN — read-only tools only, no mutations allowed"
-      : "";
 
   const approvalEnabled =
     opts?.requireApproval ?? operatorState.requireApproval;
+
+  let modeSection = "";
+
+  if (agentMode === "plan") {
+    modeSection = buildPlanModePrompt(
+      opts?.planFilePath,
+      opts?.existingPlanContent,
+    );
+  } else if (opts?.approvedPlanContent) {
+    modeSection = `
+
+# Approved Plan
+
+The operator has approved the following pentest plan. Execute it systematically, following the prioritized attack vectors and testing methodology outlined below.
+
+<plan>
+${opts.approvedPlanContent}
+</plan>`;
+  }
 
   let prompt = `${buildBaseSystemPrompt({ sandboxMode: opts?.sandboxMode })}
 
@@ -208,7 +232,7 @@ You are operating in interactive operator mode. The human operator will guide yo
 
 Target: ${target || "unknown"}
 Stage: ${operatorState.currentStage}
-Command approval: ${approvalEnabled ? "enabled — the operator will approve each tool call" : "disabled — tool calls execute automatically"}${modeNote}`;
+Command approval: ${approvalEnabled ? "enabled — the operator will approve each tool call" : "disabled — tool calls execute automatically"}${modeSection}`;
 
   if (skillsCatalog) {
     prompt += `\n\n# Skills\n\n${skillsCatalog}`;
@@ -221,6 +245,50 @@ Command approval: ${approvalEnabled ? "enabled — the operator will approve eac
   }
 
   return prompt;
+}
+
+// ---------------------------------------------------------------------------
+// Plan mode system prompt
+// ---------------------------------------------------------------------------
+
+function buildPlanModePrompt(
+  planFilePath?: string,
+  existingPlanContent?: string | null,
+): string {
+  const refinementBlock = existingPlanContent
+    ? `
+
+## Current Plan (Refine — Do NOT Rewrite)
+
+The operator has reviewed this plan and requested changes. Read the existing plan on disk via \`read_file\`, then use \`write_plan\` to apply targeted modifications. Do NOT regenerate the plan from scratch — modify specific sections based on the operator's feedback.
+
+<current-plan>
+${existingPlanContent}
+</current-plan>
+`
+    : "";
+
+  return `
+
+# PLAN MODE — Read-Only Reconnaissance & Planning
+
+You are in PLAN MODE. This is a read-only phase for reconnaissance and pentest planning. You MUST NOT:
+- Mutate the target's state (no POST/PUT/DELETE that changes data, no account creation, no data modification)
+- Write to the filesystem except via the \`write_plan\` tool
+- Execute exploit payloads or state-changing attacks
+- Document vulnerabilities (use the plan to propose what to test)
+
+Actively reconnoiter the target using the available read-only tools before planning.
+
+## Workflow
+
+1. **Recon** — Actively reconnoiter the target. Crawl the application, fingerprint tech stack, enumerate endpoints, discover authentication mechanisms, identify input surfaces.
+2. **Analyze** — Map what you found into an attack surface. Identify which areas are most exposed and which vulnerability classes are most likely.
+3. **Plan** — Write a structured pentest plan using \`write_plan\`.${planFilePath ? ` The plan is stored at: ${planFilePath}` : ""}
+4. **Submit** — When the plan is complete, call \`submit_plan\` to present it to the operator for approval.
+
+The \`write_plan\` tool description specifies the required plan sections. Follow that structure.
+${refinementBlock}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -260,7 +260,7 @@ function buildPlanModePrompt(
 
 ## Current Plan (Refine — Do NOT Rewrite)
 
-The operator has reviewed this plan and requested changes. Read the existing plan on disk via \`read_file\`, then use \`write_plan\` to apply targeted modifications. Do NOT regenerate the plan from scratch — modify specific sections based on the operator's feedback.
+The operator has reviewed this plan and requested changes. Read the existing plan on disk via \`read_file\`, then use \`write_plan\` to apply targeted modifications. The \`write_plan\` tool overwrites the file, so include the full plan content — but only change the sections the operator requested. Do NOT regenerate the plan from scratch.
 
 <current-plan>
 ${existingPlanContent}

--- a/src/tui/components/shared/message-renderer.tsx
+++ b/src/tui/components/shared/message-renderer.tsx
@@ -11,6 +11,7 @@ import { markdownToStyledText } from "./markdown";
 import { ToolRenderer } from "./tool-renderer";
 import { isToolMessage } from "./type-guards";
 import type { DisplayMessage } from "../agent-display";
+import { PlanReviewMessage } from "../chat/plan-review-message";
 
 interface MessageRendererProps {
   message: DisplayMessage;
@@ -116,6 +117,11 @@ export const MessageRenderer = memo(function MessageRenderer({
         )}
       </box>
     );
+  }
+
+  // Plan review messages
+  if (message.isPlanReview && message.planContent) {
+    return <PlanReviewMessage planContent={message.planContent} />;
   }
 
   // System messages


### PR DESCRIPTION
## Summary

- Adds a proper read-only planning workflow to operator mode. When the operator Shift+Tabs into plan mode, the agent reconnoiters the target using read-only tools, writes a structured pentest plan via `write_plan`, and submits it via `submit_plan` for operator approval before any testing begins.
- Plan review UI renders the plan in a themed bordered box with markdown highlighting. The operator can approve (Y), reject (N), or type natural language feedback to refine the plan.
- Approved plans are injected into the agent's system prompt for systematic execution. Refinement instructs the agent to modify specific sections, not rewrite from scratch.

## Key changes

- **New tools**: `write_plan` (writes plan.md to session dir) and `submit_plan` (triggers operator review)
- **New component**: `PlanReviewMessage` — bordered plan display with themed markdown rendering
- **System prompt**: ~340-token plan mode addendum with constraints, workflow, and recon-first instructions. Plan structure template lives in `write_plan` tool description.
- **Tool filtering**: Removed orchestration/mutation tools (`spawn_pentest_swarm`, `run_attack_surface`, etc.) from `PLAN_MODE_TOOL_NAMES`. Added read-only recon tools (`extract_js_endpoints`, `crawl_authenticated_area`, `detect_auth_scheme`).
- **Mode transition gating**: Shift+Tab out of plan mode triggers review if an unapproved plan exists
- **`/plan` command**: Shows current plan inline

## New files
- `src/core/plan/index.ts` — plan file I/O utilities
- `src/core/agents/offSecAgent/tools/writePlan.ts`
- `src/core/agents/offSecAgent/tools/submitPlan.ts`
- `src/tui/components/chat/plan-review-message.tsx`

## Test plan
- [x] Build passes (`bun run build`)
- [x] 75 unit tests pass (`bun test logic.test.ts`)
- [x] `/operator --target <url>` → Shift+Tab to plan mode → agent recons and writes plan → submit_plan triggers review
- [x] Y approves, N rejects, typed feedback refines without rewriting from scratch
- [x] `/plan` shows current plan inline
- [x] Mutation tools unavailable in plan mode


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator-mode tool gating and adds a new plan approval loop that affects when/which tools can execute; bugs could block workflows or accidentally allow/skip plan enforcement. Also introduces new session file I/O for `plan.md` and new UI state transitions that need careful testing.
> 
> **Overview**
> Adds a **plan-first workflow** to operator sessions: the agent can now author a structured pentest plan via new `write_plan`/`submit_plan` tools (persisted to `{session}/plan.md`) and require explicit operator approval before leaving plan mode.
> 
> Updates plan-mode tool filtering to be *recon-only* (removing orchestration/mutation-style tools and adding targeted read-only recon/auth probes), expands the operator system prompt to include plan-mode constraints/refinement guidance, and injects the **approved plan** into the execution prompt outside plan mode.
> 
> Introduces a plan review UI (`PlanReviewMessage`) and dashboard gating: submitting a plan (or exiting plan mode with an unapproved plan) shows a markdown-rendered review box where the operator can approve/reject with Y/N or provide freeform feedback; adds a `/plan` command to display the current plan inline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f5dd7b38651b43838ee9fe752290f18f3b56d51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




https://github.com/user-attachments/assets/0a6d2d1a-e8b4-483f-be9c-a9c4eb749900