### PR TITLE
Environment-aware CVSS scoring

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -23,6 +23,7 @@ import {
 import type { Finding } from "../types";
 import { hasCanonicalName } from "../../../../lib/cwe/types";
 import type { EvidenceFileEntry } from "../../../../lib/evidence/types";
+import { detectTargetEnvironment } from "../../../../util/environment";
 
 export const documentVulnerabilityInputSchema = z.object({
   title: z.string().describe("Finding title"),
@@ -264,6 +265,11 @@ CRITICAL RULES — READ BEFORE CALLING:
         let cvssResult: CVSSScorerResult = FALLBACK_CVSS;
         let cvssWarning: string | undefined;
 
+        const environmentContext = detectTargetEnvironment(
+          session.targets,
+          session.config?.environmentContext,
+        );
+
         if (!isVulnerability) {
           cvssResult = {
             score: 0,
@@ -287,6 +293,7 @@ CRITICAL RULES — READ BEFORE CALLING:
               vulnerabilityClass: input.vulnerabilityClass,
             },
             agentMessages: [],
+            environmentContext,
           };
 
           const MAX_CVSS_ATTEMPTS = 2;
@@ -379,6 +386,15 @@ CRITICAL RULES — READ BEFORE CALLING:
           timestamp,
           sessionId: session.id,
           target: session.targets[0],
+          environment: {
+            signals: environmentContext.signals,
+            isProduction: environmentContext.isProduction,
+            description: environmentContext.description,
+            ...(environmentContext.userContext && {
+              userContext: environmentContext.userContext,
+            }),
+          },
+          ...(evidenceFilePath && { evidenceFile: evidenceFilePath }),
           pocOutput: {
             stdout: stdout || "",
             stderr: stderr || "",
@@ -463,6 +479,7 @@ ${finding.evidenceFiles.map((ef) => `- **[${ef.type}]** \`${ef.path}\` — ${ef.
             ...(cvssWarning
               ? []
               : [`**Vector:** \`${cvssResult.vectorString}\``]),
+            `**Environment:** ${environmentContext.isProduction ? "Production" : "Non-Production"}${environmentContext.signals.length > 0 ? ` (${environmentContext.signals.join(", ")})` : ""}`,
             `**Target:** ${session.targets[0]}`,
             `**Endpoint:** ${finding.endpoint}`,
             `**Date:** ${timestamp}`,

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -128,6 +128,16 @@ CRITICAL RULES — READ BEFORE CALLING:
     inputSchema: documentVulnerabilityInputSchema,
     execute: async (input) => {
       try {
+        // Validate session has targets
+        if (!session.targets || session.targets.length === 0) {
+          return {
+            success: false,
+            error: "Session has no targets defined",
+            message:
+              "Cannot document finding: session.targets is empty. Ensure the session was created with at least one target URL.",
+          };
+        }
+
         // Early dedup check — avoid POC execution + LLM calls for known vulns
         if (ctx.findingsRegistry) {
           const quickCheck = ctx.findingsRegistry.isDuplicate({

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -256,10 +256,11 @@ CRITICAL RULES — READ BEFORE CALLING:
         }
 
         let evidenceForPrompt = input.evidence;
+        let evidenceFilePath: string | undefined;
 
         if (input.evidence.length > EVIDENCE_FILE_THRESHOLD) {
           const evidenceFilename = `${timestamp.split("T")[0]}-${slugify(input.title, 40)}-evidence.txt`;
-          const evidenceFilePath = join(outputDir, evidenceFilename);
+          evidenceFilePath = join(outputDir, evidenceFilename);
           writeFileSync(evidenceFilePath, input.evidence);
           evidenceForPrompt =
             input.evidence.substring(0, EVIDENCE_FILE_THRESHOLD) +

--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -306,8 +306,9 @@ export const ALL_TOOL_NAMES: ToolName[] = [
  * Tool names available in plan mode (read-only / non-mutating).
  *
  * Excludes: create_file, update_file, document_vulnerability,
- * document_app, document_endpoint. These are the mutation tools that should not be available
- * when the operator is in plan (read-only) mode.
+ * document_app, document_endpoint, spawn_pentest_swarm, spawn_coding_agent
+ * — file writes, findings, and orchestration tools that spawn autonomous
+ * sub-agents are not available in plan mode.
  */
 export const PLAN_MODE_TOOL_NAMES: ToolName[] = [
   // Browser automation (read-only navigation and inspection)

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -87,7 +87,8 @@ export type OffensiveSecurityAgentInput<TResult = void> = {
    * When set to `"plan"`, the agent's `activeTools` are intersected with
    * {@link PLAN_MODE_TOOL_NAMES} so that mutation tools (create_file,
    * update_file, document_vulnerability, document_app,
-   * document_endpoint) are excluded.
+   * document_endpoint) and orchestration tools that spawn autonomous
+   * sub-agents (spawn_pentest_swarm, spawn_coding_agent) are excluded.
    *
    * @default "default"
    */

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -53,6 +53,14 @@ export const ApexFindingObject = z.object({
   rootCauseGroup: z.string().optional(),
   relatedFindings: z.array(z.string()).optional(),
   evidenceFiles: z.array(EvidenceFileEntrySchema).optional(),
+  environment: z
+    .object({
+      signals: z.array(z.string()),
+      isProduction: z.boolean(),
+      description: z.string(),
+      userContext: z.string().optional(),
+    })
+    .optional(),
 });
 
 export type Finding = z.infer<typeof ApexFindingObject>;

--- a/src/core/agents/specialized/cvssScorer/index.ts
+++ b/src/core/agents/specialized/cvssScorer/index.ts
@@ -22,6 +22,17 @@ import { validateCweEntries } from "../../../../lib/cwe/validate";
 // Types
 // =============================================================================
 
+export interface EnvironmentContext {
+  /** Auto-detected indicators from URL/target analysis */
+  signals: string[];
+  /** Human-readable summary for the LLM */
+  description: string;
+  /** Whether this appears to be a production environment */
+  isProduction: boolean;
+  /** Freeform operator-provided notes */
+  userContext?: string;
+}
+
 export interface CVSSScorerInput {
   /** The finding to score */
   finding: {
@@ -35,6 +46,8 @@ export interface CVSSScorerInput {
   };
   /** Messages from the meta testing agent's conversation (for context) */
   agentMessages: Record<string, unknown>[];
+  /** Environment context for scoring adjustments */
+  environmentContext?: EnvironmentContext;
 }
 
 export interface CVSSScorerResult {
@@ -324,7 +337,27 @@ In addition to CVSS metrics, assign one or more CWE identifiers to the finding. 
 3. Assign **1-3 CWEs** per finding. Multiple CWEs are appropriate when the vulnerability spans categories (e.g., an IDOR that also leaks PII: CWE-639 + CWE-200).
 4. Order CWEs by relevance — the primary weakness first.
 5. When the vulnerability class is provided, use it as a strong hint but verify against the evidence.
-6. For each CWE, provide a specific reasoning explaining why it applies to *this* finding — not a generic definition of the CWE.`;
+6. For each CWE, provide a specific reasoning explaining why it applies to *this* finding — not a generic definition of the CWE.
+
+## Environment Context Guidelines
+
+When environment context is provided, factor it into your scoring:
+
+### Non-Production Environments (sandbox, staging, demo, dev, test, QA, localhost)
+- **Attack Requirements (AT):** Consider P if the vulnerability relies on intentionally weakened non-production controls (disabled captcha, test credentials, relaxed rate limits).
+- **Confidentiality Impact (VC):** Downgrade if the environment contains only synthetic/test data (e.g., H→L when no real user data is at risk).
+- **Subsequent System Impact (SC/SI/SA):** Typically N — non-production environments rarely connect to production data stores or downstream services.
+- **Exploit Maturity (E):** Use U if the vulnerability is specific to the non-production implementation (e.g., hardcoded test OTP) and production does not share the same code path.
+- Public keys (pk_*) or test API keys exposed on demo/sandbox sites are expected behavior, not vulnerabilities.
+
+### Production Environments
+- Score normally using standard CVSS 4.0 methodology. No adjustments.
+
+### Ambiguous or Custom Environments
+- When operator-provided context describes a novel setup, reason about it directly.
+- Consider: Does this environment contain real user data? Is it internet-facing? Could exploitation affect production systems?
+
+Environment context is additional signal for scoring — it does not override evidence. A critical RCE in a sandbox is still a real vulnerability, but its contextual impact differs.`;
 
 // =============================================================================
 // Main Function
@@ -415,6 +448,19 @@ ${evidence}
 
 `;
 
+  // Add environment context if available
+  if (input.environmentContext) {
+    const env = input.environmentContext;
+    prompt += `## Environment Context
+
+**Classification:** ${env.isProduction ? "PRODUCTION" : "NON-PRODUCTION"}
+**Description:** ${env.description}
+${env.signals.length > 0 ? `**Detected Signals:** ${env.signals.join(", ")}` : ""}
+${env.userContext ? `**Operator Notes:** ${env.userContext}` : ""}
+
+`;
+  }
+
   // Add context from agent conversation if available
   if (agentMessages && agentMessages.length > 0) {
     prompt += `## Discovery Context
@@ -438,6 +484,7 @@ Consider:
 3. Whether user interaction is required
 4. The actual impact demonstrated in the evidence
 5. Potential for lateral movement or subsequent system compromise
+6. The target environment context and its effect on real-world impact
 
 Provide your metrics assessment and brief reasoning.
 `;

--- a/src/core/agents/specialized/cvssScorer/index.ts
+++ b/src/core/agents/specialized/cvssScorer/index.ts
@@ -17,21 +17,14 @@ import {
   type ValidatedCweEntry,
 } from "../../../../lib/cwe/types";
 import { validateCweEntries } from "../../../../lib/cwe/validate";
+import type { EnvironmentContext } from "../../../../util/environment";
+
+export type { EnvironmentContext } from "../../../../util/environment";
+>>>>>>> 9072e18a (refactor: move EnvironmentContext type to util, fix prompt blank lines)
 
 // =============================================================================
 // Types
 // =============================================================================
-
-export interface EnvironmentContext {
-  /** Auto-detected indicators from URL/target analysis */
-  signals: string[];
-  /** Human-readable summary for the LLM */
-  description: string;
-  /** Whether this appears to be a production environment */
-  isProduction: boolean;
-  /** Freeform operator-provided notes */
-  userContext?: string;
-}
 
 export interface CVSSScorerInput {
   /** The finding to score */
@@ -451,14 +444,17 @@ ${evidence}
   // Add environment context if available
   if (input.environmentContext) {
     const env = input.environmentContext;
-    prompt += `## Environment Context
-
-**Classification:** ${env.isProduction ? "PRODUCTION" : "NON-PRODUCTION"}
-**Description:** ${env.description}
-${env.signals.length > 0 ? `**Detected Signals:** ${env.signals.join(", ")}` : ""}
-${env.userContext ? `**Operator Notes:** ${env.userContext}` : ""}
-
-`;
+    const lines = [
+      `**Classification:** ${env.isProduction ? "PRODUCTION" : "NON-PRODUCTION"}`,
+      `**Description:** ${env.description}`,
+    ];
+    if (env.signals.length > 0) {
+      lines.push(`**Detected Signals:** ${env.signals.join(", ")}`);
+    }
+    if (env.userContext) {
+      lines.push(`**Operator Notes:** ${env.userContext}`);
+    }
+    prompt += `## Environment Context\n\n${lines.join("\n")}\n\n`;
   }
 
   // Add context from agent conversation if available

--- a/src/core/agents/specialized/cvssScorer/index.ts
+++ b/src/core/agents/specialized/cvssScorer/index.ts
@@ -20,7 +20,7 @@ import { validateCweEntries } from "../../../../lib/cwe/validate";
 import type { EnvironmentContext } from "../../../../util/environment";
 
 export type { EnvironmentContext } from "../../../../util/environment";
->>>>>>> 9072e18a (refactor: move EnvironmentContext type to util, fix prompt blank lines)
+export { createDefaultEnvironmentContext } from "../../../../util/environment";
 
 // =============================================================================
 // Types
@@ -39,8 +39,12 @@ export interface CVSSScorerInput {
   };
   /** Messages from the meta testing agent's conversation (for context) */
   agentMessages: Record<string, unknown>[];
-  /** Environment context for scoring adjustments */
-  environmentContext?: EnvironmentContext;
+  /**
+   * Environment context for scoring adjustments.
+   * REQUIRED: All callers must provide this to ensure consistent CVSS scoring.
+   * Use createDefaultEnvironmentContext() for callers without environment info.
+   */
+  environmentContext: EnvironmentContext;
 }
 
 export interface CVSSScorerResult {
@@ -441,21 +445,19 @@ ${evidence}
 
 `;
 
-  // Add environment context if available
-  if (input.environmentContext) {
-    const env = input.environmentContext;
-    const lines = [
-      `**Classification:** ${env.isProduction ? "PRODUCTION" : "NON-PRODUCTION"}`,
-      `**Description:** ${env.description}`,
-    ];
-    if (env.signals.length > 0) {
-      lines.push(`**Detected Signals:** ${env.signals.join(", ")}`);
-    }
-    if (env.userContext) {
-      lines.push(`**Operator Notes:** ${env.userContext}`);
-    }
-    prompt += `## Environment Context\n\n${lines.join("\n")}\n\n`;
+  // Add environment context (always present)
+  const env = input.environmentContext;
+  const lines = [
+    `**Classification:** ${env.isProduction ? "PRODUCTION" : "NON-PRODUCTION"}`,
+    `**Description:** ${env.description}`,
+  ];
+  if (env.signals.length > 0) {
+    lines.push(`**Detected Signals:** ${env.signals.join(", ")}`);
   }
+  if (env.userContext) {
+    lines.push(`**Operator Notes:** ${env.userContext}`);
+  }
+  prompt += `## Environment Context\n\n${lines.join("\n")}\n\n`;
 
   // Add context from agent conversation if available
   if (agentMessages && agentMessages.length > 0) {

--- a/src/core/agents/specialized/cvssScorer/index.ts
+++ b/src/core/agents/specialized/cvssScorer/index.ts
@@ -20,7 +20,6 @@ import { validateCweEntries } from "../../../../lib/cwe/validate";
 import type { EnvironmentContext } from "../../../../util/environment";
 
 export type { EnvironmentContext } from "../../../../util/environment";
-export { createDefaultEnvironmentContext } from "../../../../util/environment";
 
 // =============================================================================
 // Types
@@ -42,7 +41,6 @@ export interface CVSSScorerInput {
   /**
    * Environment context for scoring adjustments.
    * REQUIRED: All callers must provide this to ensure consistent CVSS scoring.
-   * Use createDefaultEnvironmentContext() for callers without environment info.
    */
   environmentContext: EnvironmentContext;
 }

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -164,6 +164,8 @@ const SessionConfigObject = z.object({
   taskDriven: z.boolean().optional(),
   /** When true, pentest agents run a plan phase before execution (default: false) */
   requirePlan: z.boolean().optional(),
+  /** Freeform environment context for CVSS scoring (e.g., "this is a sandbox", "testing against staging") */
+  environmentContext: z.string().optional(),
 });
 
 export type SessionConfig = z.infer<typeof SessionConfigObject>;

--- a/src/util/environment.ts
+++ b/src/util/environment.ts
@@ -10,6 +10,19 @@ export interface EnvironmentContext {
 }
 
 /**
+ * Create a default environment context for cases where no target information is available.
+ * Used when CVSS scoring is invoked without session context.
+ */
+export function createDefaultEnvironmentContext(): EnvironmentContext {
+  return {
+    signals: [],
+    description:
+      "Environment type unknown (no target information provided). Scoring assumes production-level impact.",
+    isProduction: true,
+  };
+}
+
+/**
  * Patterns that indicate non-production environments.
  * Each entry: [regex applied to the full URL or hostname, signal label].
  */

--- a/src/util/environment.ts
+++ b/src/util/environment.ts
@@ -67,7 +67,12 @@ export function detectTargetEnvironment(
 
   const isProduction = signals.length === 0;
 
-  const description = buildDescription(targets, signals, isProduction, userContext);
+  const description = buildDescription(
+    targets,
+    signals,
+    isProduction,
+    userContext,
+  );
 
   return {
     signals,

--- a/src/util/environment.ts
+++ b/src/util/environment.ts
@@ -1,4 +1,13 @@
-import type { EnvironmentContext } from "../core/agents/specialized/cvssScorer";
+export interface EnvironmentContext {
+  /** Auto-detected indicators from URL/target analysis */
+  signals: string[];
+  /** Human-readable summary for the LLM */
+  description: string;
+  /** Whether this appears to be a production environment */
+  isProduction: boolean;
+  /** Freeform operator-provided notes */
+  userContext?: string;
+}
 
 /**
  * Patterns that indicate non-production environments.

--- a/src/util/environment.ts
+++ b/src/util/environment.ts
@@ -10,19 +10,6 @@ export interface EnvironmentContext {
 }
 
 /**
- * Create a default environment context for cases where no target information is available.
- * Used when CVSS scoring is invoked without session context.
- */
-export function createDefaultEnvironmentContext(): EnvironmentContext {
-  return {
-    signals: [],
-    description:
-      "Environment type unknown (no target information provided). Scoring assumes production-level impact.",
-    isProduction: true,
-  };
-}
-
-/**
  * Patterns that indicate non-production environments.
  * Each entry: [regex applied to the full URL or hostname, signal label].
  */
@@ -31,7 +18,7 @@ const NON_PRODUCTION_PATTERNS: [RegExp, string][] = [
   [/\bsandbox\b/i, "sandbox-keyword"],
   [/\bstaging\b/i, "staging-keyword"],
   [/\bdemo\b/i, "demo-keyword"],
-  [/\bdev\b/i, "dev-keyword"],
+  [/(?<!\.)\bdev\b/i, "dev-keyword"], // Negative lookbehind to exclude ".dev" TLD
   [/\btest\b/i, "test-keyword"],
   [/\bqa\b/i, "qa-keyword"],
   [/\buat\b/i, "uat-keyword"],
@@ -49,9 +36,9 @@ const NON_PRODUCTION_PATTERNS: [RegExp, string][] = [
   [/:8443\b/, "non-standard-port-8443"],
   [/:5000\b/, "non-standard-port-5000"],
   // Platform-specific patterns
-  [/\.herokuapp\.com$/i, "heroku-app"],
-  [/\.vercel\.app$/i, "vercel-preview"],
-  [/\.netlify\.app$/i, "netlify-preview"],
+  [/\.herokuapp\.com\b/i, "heroku-app"],
+  [/\.vercel\.app\b/i, "vercel-preview"],
+  [/\.netlify\.app\b/i, "netlify-preview"],
   [/\.ngrok\b/i, "ngrok-tunnel"],
   [/\.local\b/i, "local-domain"],
   // Protocol

--- a/src/util/environment.ts
+++ b/src/util/environment.ts
@@ -1,0 +1,94 @@
+import type { EnvironmentContext } from "../core/agents/specialized/cvssScorer";
+
+/**
+ * Patterns that indicate non-production environments.
+ * Each entry: [regex applied to the full URL or hostname, signal label].
+ */
+const NON_PRODUCTION_PATTERNS: [RegExp, string][] = [
+  // Subdomain / path keywords
+  [/\bsandbox\b/i, "sandbox-keyword"],
+  [/\bstaging\b/i, "staging-keyword"],
+  [/\bdemo\b/i, "demo-keyword"],
+  [/\bdev\b/i, "dev-keyword"],
+  [/\btest\b/i, "test-keyword"],
+  [/\bqa\b/i, "qa-keyword"],
+  [/\buat\b/i, "uat-keyword"],
+  [/\bpreview\b/i, "preview-keyword"],
+  // Localhost / local development
+  [/\blocalhost\b/i, "localhost"],
+  [/^https?:\/\/127\.0\.0\.1/i, "loopback-address"],
+  [/^https?:\/\/0\.0\.0\.0/i, "all-interfaces-address"],
+  [/^https?:\/\/192\.168\./i, "private-network"],
+  [/^https?:\/\/10\./i, "private-network"],
+  [/^https?:\/\/172\.(1[6-9]|2\d|3[01])\./i, "private-network"],
+  // Non-standard ports (common in dev/staging)
+  [/:3000\b/, "non-standard-port-3000"],
+  [/:8080\b/, "non-standard-port-8080"],
+  [/:8443\b/, "non-standard-port-8443"],
+  [/:5000\b/, "non-standard-port-5000"],
+  // Platform-specific patterns
+  [/\.herokuapp\.com$/i, "heroku-app"],
+  [/\.vercel\.app$/i, "vercel-preview"],
+  [/\.netlify\.app$/i, "netlify-preview"],
+  [/\.ngrok\b/i, "ngrok-tunnel"],
+  [/\.local\b/i, "local-domain"],
+  // Protocol
+  [/^http:\/\//i, "plain-http"],
+];
+
+/**
+ * Detect environment context from target URLs and optional user context.
+ *
+ * Returns a structured EnvironmentContext with auto-detected signals
+ * and a human-readable description for the CVSS scorer LLM.
+ */
+export function detectTargetEnvironment(
+  targets: string[],
+  userContext?: string,
+): EnvironmentContext {
+  const signals: string[] = [];
+
+  for (const target of targets) {
+    for (const [pattern, label] of NON_PRODUCTION_PATTERNS) {
+      if (pattern.test(target) && !signals.includes(label)) {
+        signals.push(label);
+      }
+    }
+  }
+
+  const isProduction = signals.length === 0;
+
+  const description = buildDescription(targets, signals, isProduction, userContext);
+
+  return {
+    signals,
+    description,
+    isProduction,
+    ...(userContext ? { userContext } : {}),
+  };
+}
+
+function buildDescription(
+  targets: string[],
+  signals: string[],
+  isProduction: boolean,
+  userContext?: string,
+): string {
+  const parts: string[] = [];
+
+  if (isProduction) {
+    parts.push(
+      `Target appears to be a production environment. No non-production indicators detected in: ${targets.join(", ")}`,
+    );
+  } else {
+    parts.push(
+      `Target appears to be a NON-PRODUCTION environment. Detected indicators: ${signals.join(", ")}. Target(s): ${targets.join(", ")}`,
+    );
+  }
+
+  if (userContext) {
+    parts.push(`Operator-provided context: ${userContext}`);
+  }
+
+  return parts.join(". ");
+}


### PR DESCRIPTION
## Summary
- Signal-based environment detection from target URLs (sandbox, staging, demo, localhost, private IPs, etc.) with freeform operator context via `session.config.environmentContext`
- CVSS scorer system prompt now includes environment-aware guidance for non-production findings
- Environment metadata persisted in finding JSON and markdown reports

## Files changed
- `src/util/environment.ts` — new `detectTargetEnvironment()` utility
- `src/core/agents/specialized/cvssScorer/index.ts` — `EnvironmentContext` type, updated prompt + builder
- `src/core/agents/offSecAgent/tools/documentFinding.ts` — propagates environment to scorer and findings
- `src/core/agents/offSecAgent/types.ts` — optional `environment` field on `ApexFindingObject`
- `src/core/session/index.ts` — optional `environmentContext` on `SessionConfig`

## Test plan
- [ ] Typecheck and lint pass (verified)
- [ ] Run pentest against sandbox URL, verify finding JSON contains `environment` block with detected signals
- [ ] Run pentest against production URL, verify `isProduction: true` and no signals
- [ ] Pass `--env-context "sandbox with test data"` and verify operator notes appear in CVSS scorer prompt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scoring and reporting paths for all documented vulnerabilities and changes the CVSS scorer input contract to require `environmentContext`, which could affect downstream callers and severity outputs.
> 
> **Overview**
> Adds environment-aware context to vulnerability documentation and CVSS scoring by auto-detecting non-production indicators from `session.targets` (plus optional operator notes via `session.config.environmentContext`). The `cvssScorer` now requires and embeds this `EnvironmentContext` in its prompt with guidance to adjust scoring for sandbox/staging vs production.
> 
> Findings produced by `document_vulnerability` now validate that `session.targets` is set, persist environment metadata (and large-evidence file path when applicable) into the finding JSON, and include an **Environment** line in the generated markdown report.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bb1c352a80862bcf5d60b2ec9a5202b1554d711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->