### PR TITLE
Reduce finding judge false positives from expected behavior

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -210,6 +210,8 @@ CRITICAL RULES — READ BEFORE CALLING:
           };
         }
 
+        const isVulnerability = judgeResult.findingType === "vulnerability";
+
         // Write sidecar only after judge acceptance (avoid wasted I/O on rejection)
         writePocOutputSidecar(
           ctx.session.pocsPath,
@@ -223,12 +225,20 @@ CRITICAL RULES — READ BEFORE CALLING:
         // Phase 3: CVSS 4.0 scoring
         const timestamp = new Date().toISOString();
 
+        const outputDir = isVulnerability
+          ? session.findingsPath
+          : join(session.rootPath, "informational");
+
+        if (!isVulnerability) {
+          mkdirSync(outputDir, { recursive: true });
+        }
+
         let evidenceForPrompt = input.evidence;
         let evidenceFilePath: string | undefined;
 
         if (input.evidence.length > EVIDENCE_FILE_THRESHOLD) {
           const evidenceFilename = `${timestamp.split("T")[0]}-${slugify(input.title, 40)}-evidence.txt`;
-          evidenceFilePath = join(session.findingsPath, evidenceFilename);
+          evidenceFilePath = join(outputDir, evidenceFilename);
           writeFileSync(evidenceFilePath, input.evidence);
           evidenceForPrompt =
             input.evidence.substring(0, EVIDENCE_FILE_THRESHOLD) +
@@ -238,60 +248,76 @@ CRITICAL RULES — READ BEFORE CALLING:
         let cvssResult: CVSSScorerResult = FALLBACK_CVSS;
         let cvssWarning: string | undefined;
 
-        const cvssInput: CVSSScorerInput = {
-          finding: {
-            title: input.title,
-            description: input.description,
-            impact: input.impact,
-            evidence: evidenceForPrompt,
-            endpoint: input.endpoint,
-            remediation: input.remediation,
-            vulnerabilityClass: input.vulnerabilityClass,
-          },
-          agentMessages: [],
-        };
+        if (!isVulnerability) {
+          cvssResult = {
+            score: 0,
+            severity: "LOW",
+            vectorString: "",
+            metrics: FALLBACK_CVSS.metrics,
+            scoreType: "N/A",
+            reasoning: `Classified as ${judgeResult.findingType} — CVSS scoring skipped.`,
+            cwes: [],
+          };
+          cvssWarning = `Classified as ${judgeResult.findingType} — not scored.`;
+        } else {
+          const cvssInput: CVSSScorerInput = {
+            finding: {
+              title: input.title,
+              description: input.description,
+              impact: input.impact,
+              evidence: evidenceForPrompt,
+              endpoint: input.endpoint,
+              remediation: input.remediation,
+              vulnerabilityClass: input.vulnerabilityClass,
+            },
+            agentMessages: [],
+          };
 
-        const MAX_CVSS_ATTEMPTS = 2;
-        for (let attempt = 0; attempt < MAX_CVSS_ATTEMPTS; attempt++) {
-          try {
-            cvssResult = await scoreFindingWithCVSS(
-              cvssInput,
-              ctx.model!,
-              ctx.authConfig,
-              ctx.abortSignal,
-            );
-            break;
-          } catch (err: unknown) {
-            const msg = err instanceof Error ? err.message : String(err);
-
-            if (attempt >= MAX_CVSS_ATTEMPTS - 1 || ctx.abortSignal?.aborted) {
-              cvssWarning = `CVSS scoring failed after ${attempt + 1} attempt(s) (${msg}), using estimated MEDIUM severity.`;
-              cvssResult = FALLBACK_CVSS;
+          const MAX_CVSS_ATTEMPTS = 2;
+          for (let attempt = 0; attempt < MAX_CVSS_ATTEMPTS; attempt++) {
+            try {
+              cvssResult = await scoreFindingWithCVSS(
+                cvssInput,
+                ctx.model!,
+                ctx.authConfig,
+                ctx.abortSignal,
+              );
               break;
-            }
+            } catch (err: unknown) {
+              const msg = err instanceof Error ? err.message : String(err);
 
-            await new Promise<void>((resolve) => {
-              const timer = setTimeout(resolve, 2_000);
-              if (ctx.abortSignal) {
-                const onAbort = () => {
-                  clearTimeout(timer);
-                  resolve();
-                };
-                if (ctx.abortSignal.aborted) {
-                  clearTimeout(timer);
-                  resolve();
-                } else {
-                  ctx.abortSignal.addEventListener("abort", onAbort, {
-                    once: true,
-                  });
-                }
+              if (
+                attempt >= MAX_CVSS_ATTEMPTS - 1 ||
+                ctx.abortSignal?.aborted
+              ) {
+                cvssWarning = `CVSS scoring failed after ${attempt + 1} attempt(s) (${msg}), using estimated MEDIUM severity.`;
+                cvssResult = FALLBACK_CVSS;
+                break;
               }
-            });
 
-            if (ctx.abortSignal?.aborted) {
-              cvssWarning = `CVSS scoring cancelled, using estimated MEDIUM severity.`;
-              cvssResult = FALLBACK_CVSS;
-              break;
+              await new Promise<void>((resolve) => {
+                const timer = setTimeout(resolve, 2_000);
+                if (ctx.abortSignal) {
+                  const onAbort = () => {
+                    clearTimeout(timer);
+                    resolve();
+                  };
+                  if (ctx.abortSignal.aborted) {
+                    clearTimeout(timer);
+                    resolve();
+                  } else {
+                    ctx.abortSignal.addEventListener("abort", onAbort, {
+                      once: true,
+                    });
+                  }
+                }
+              });
+
+              if (ctx.abortSignal?.aborted) {
+                cvssWarning = `CVSS scoring cancelled, using estimated MEDIUM severity.`;
+                cvssResult = FALLBACK_CVSS;
+                break;
+              }
             }
           }
         }
@@ -315,7 +341,7 @@ CRITICAL RULES — READ BEFORE CALLING:
           severity: severity as Finding["severity"],
         };
 
-        if (ctx.findingsRegistry) {
+        if (isVulnerability && ctx.findingsRegistry) {
           const check = await ctx.findingsRegistry.register(finding);
           if (check.duplicate) {
             cleanupPocFiles(ctx, filename);
@@ -355,6 +381,7 @@ CRITICAL RULES — READ BEFORE CALLING:
           },
           judge: {
             valid: judgeResult.valid,
+            findingType: judgeResult.findingType,
             confidence: judgeResult.confidence,
             reasoning: judgeResult.reasoning,
             ...(judgeResult.error && { error: judgeResult.error }),
@@ -363,9 +390,9 @@ CRITICAL RULES — READ BEFORE CALLING:
 
         const findingId = `${timestamp.split("T")[0]}-${slugify(finding.title, 50)}`;
         const jsonFilename = `${findingId}.json`;
-        const jsonPath = join(session.findingsPath, jsonFilename);
         const mdFilename = `${findingId}.md`;
-        const mdPath = join(session.findingsPath, mdFilename);
+        const jsonPath = join(outputDir, jsonFilename);
+        const mdPath = join(outputDir, mdFilename);
 
         try {
           writeFileSync(jsonPath, JSON.stringify(findingWithMeta, null, 2));
@@ -450,31 +477,36 @@ ${finding.references ? `## References\n\n${finding.references}` : ""}
 
           writeFileSync(mdPath, markdown);
 
-          const summaryPath = join(session.rootPath, "findings-summary.md");
-          const cweTag = cvssResult.cwes?.length
-            ? ` (${cvssResult.cwes.map((c) => c.id).join(", ")})`
-            : "";
-          const cvssTag = cvssWarning
-            ? "(estimated)"
-            : `(CVSS ${cvssResult.score})`;
-          const summaryEntry = `- [${finding.severity}] ${cvssTag}${cweTag} ${finding.title} - \`findings/${mdFilename}\`\n`;
+          if (isVulnerability) {
+            const summaryPath = join(session.rootPath, "findings-summary.md");
+            const cweTag = cvssResult.cwes?.length
+              ? ` (${cvssResult.cwes.map((c) => c.id).join(", ")})`
+              : "";
+            const cvssTag = cvssWarning
+              ? "(estimated)"
+              : `(CVSS ${cvssResult.score})`;
+            const summaryEntry = `- [${finding.severity}] ${cvssTag}${cweTag} ${finding.title} - \`findings/${mdFilename}\`\n`;
 
-          try {
-            appendFileSync(summaryPath, summaryEntry);
-          } catch {
-            const header = `# Findings Summary\n\n**Target:** ${session.targets[0]}  \n**Session:** ${session.id}\n\n## All Findings\n\n`;
-            writeFileSync(summaryPath, header + summaryEntry);
+            try {
+              appendFileSync(summaryPath, summaryEntry);
+            } catch {
+              const header = `# Findings Summary\n\n**Target:** ${session.targets[0]}  \n**Session:** ${session.id}\n\n## All Findings\n\n`;
+              writeFileSync(summaryPath, header + summaryEntry);
+            }
           }
         } catch (writeError: unknown) {
-          if (ctx.findingsRegistry) {
+          if (isVulnerability && ctx.findingsRegistry) {
             await ctx.findingsRegistry.unregister(finding);
           }
           throw writeError;
         }
 
+        const typeTag = isVulnerability
+          ? finding.severity
+          : judgeResult.findingType.toUpperCase();
         const resultMessage = cvssWarning
-          ? `Finding documented: [${finding.severity}] ${finding.title} (${cvssWarning})`
-          : `Finding documented: [${finding.severity}] ${finding.title}`;
+          ? `Finding documented: [${typeTag}] ${finding.title} (${cvssWarning})`
+          : `Finding documented: [${typeTag}] ${finding.title}`;
 
         return {
           success: true,

--- a/src/core/agents/specialized/findingJudge/index.ts
+++ b/src/core/agents/specialized/findingJudge/index.ts
@@ -17,6 +17,13 @@ import { type AIAuthConfig } from "../../../ai/utils";
 // Types
 // =============================================================================
 
+export const FINDING_TYPES = [
+  "vulnerability",
+  "informational",
+  "expected-behavior",
+] as const;
+export type FindingType = (typeof FINDING_TYPES)[number];
+
 export interface FindingJudgeInput {
   /** The full POC script content */
   pocScript: string;
@@ -42,6 +49,8 @@ export interface FindingJudgeInput {
 export interface FindingJudgeResult {
   /** Whether the finding is legitimate and well-demonstrated */
   valid: boolean;
+  /** Classification of the finding */
+  findingType: FindingType;
   /** Confidence in the judgment (0.0-1.0) */
   confidence: number;
   /** Explanation of the judgment */
@@ -66,6 +75,11 @@ const FindingJudgeOutputSchema = z.object({
     .boolean()
     .describe(
       "Whether the POC legitimately demonstrates the claimed vulnerability",
+    ),
+  findingType: z
+    .enum(FINDING_TYPES)
+    .describe(
+      "Classification: 'vulnerability' for genuine security issues, 'informational' for low-risk observations worth noting, 'expected-behavior' for findings that describe intentional design decisions",
     ),
   confidence: z
     .number()
@@ -135,16 +149,36 @@ Does the demonstrated impact match the claimed vulnerability and impact?
 - Information disclosure evidence should not be described as a critical RCE
 - The endpoint tested should match the endpoint claimed in the finding
 
+### 5. Design Intent / Expected Behavior
+Is the "vulnerability" actually expected behavior for this context?
+
+Red flags for expected behavior (classify as expected-behavior or informational, not vulnerability):
+- Public API keys designed for client-side use (Stripe publishable keys \`pk_*\`, Google Maps API keys, Firebase config, reCAPTCHA site keys)
+- Sandbox/demo environments with intentionally relaxed security controls (disabled captcha, test credentials, test OTP codes)
+- Checkout/payment widgets accepting postMessages from any origin (required for cross-origin merchant embedding)
+- CORS configurations that are permissive by design for public APIs
+- Features working exactly as documented by the application
+- Security headers missing on endpoints serving only static/public content
+
+Ask: "Would a knowledgeable developer of this application consider this a bug, or an intentional design choice?"
+
 ## Decision Framework
 
-- **ACCEPT** when: The POC makes a real request to the target, receives a response that contains genuine evidence of the vulnerability, and the evidence matches the claim. Minor issues (verbose output, imperfect error handling) are acceptable.
+- **ACCEPT as vulnerability** when: The POC makes a real request to the target, receives a response containing genuine evidence of the vulnerability, the evidence matches the claim, and the behavior is clearly unintentional or exploitable beyond the application's designed functionality.
+- **ACCEPT as informational** when: The finding describes a real observation but is low-risk, describes a common default configuration, or could be intentional. Examples: missing security headers on non-sensitive endpoints, verbose error messages, permissive CORS on a public API.
+- **ACCEPT as expected-behavior** when: The finding describes behavior that is clearly by design. Examples: public API keys intended for client-side use, checkout widgets accepting cross-origin postMessages, sandbox environments with relaxed security.
 - **REJECT** when: The POC fabricates evidence, the output does not demonstrate the claimed vulnerability, the success condition is hardcoded, or there is a fundamental mismatch between what was demonstrated and what was claimed.
-- **When in doubt, ACCEPT.** False negatives (rejecting a real finding) are worse than false positives (accepting a marginal finding) because rejected findings require the agent to retry, costing time and tokens. Only reject when you have specific, articulable concerns.
+
+### Confidence calibration
+- When in doubt about exploitation legitimacy, **ACCEPT as vulnerability** — a borderline-real finding is worth documenting.
+- When in doubt about whether behavior is by-design, **classify as informational** rather than vulnerability — documenting expected behavior as a vulnerability undermines report credibility.
+- Below 0.7 confidence: always populate the concerns array explaining what makes the finding marginal.
 
 ## Output Instructions
 
 Provide your judgment as a structured assessment:
-- \`valid\`: true if the finding should be accepted, false if it should be rejected
+- \`valid\`: true if the finding should be accepted (as vulnerability, informational, or expected-behavior), false if it should be rejected
+- \`findingType\`: "vulnerability" for genuine security issues, "informational" for low-risk observations, "expected-behavior" for intentional design decisions
 - \`confidence\`: your confidence level from 0.0 to 1.0
 - \`reasoning\`: 2-4 sentences explaining your key observations
 - \`concerns\`: specific issues found (empty array if valid). Each concern should be a single actionable sentence.`;
@@ -215,6 +249,7 @@ export async function judgeFinding(
 
     return {
       valid: true,
+      findingType: "vulnerability",
       confidence: 0.5,
       reasoning: `Finding judge failed (${type}${statusStr}: ${message.substring(0, 200)}), accepting with low confidence.`,
       concerns: [],
@@ -283,5 +318,6 @@ Consider:
 2. Does the output contain genuine evidence of the vulnerability (not fabricated by the script)?
 3. Is the success condition based on real exploitation results, not hardcoded values?
 4. Does the demonstrated impact align with the claimed vulnerability class and severity?
+5. Could the observed behavior be an intentional design decision rather than a vulnerability?
 `;
 }


### PR DESCRIPTION
## Summary
- Add design-intent evaluation criterion  to the finding judge — detects public API keys, sandbox relaxations, cross-origin widgets, and other expected behavior
- Rebalance "when in doubt" guidance: accept for exploitation legitimacy doubts, classify as informational for design-intent doubts
- Add `findingType` field (`vulnerability | informational | expected-behavior`) to judge output
- Route non-vulnerability findings to `informational/` directory, skip CVSS scoring and dedup registry

## Test plan
- [x] Run pentest against target with known public API keys — verify they land in `informational/`
- [x] Run pentest against target with real vulns — verify they still land in `findings/` with CVSS scores
- [x] Verify report only includes findings from `findings/`
- [x] Verify `bun run tsc` and `bun run lint` pass clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the finding pipeline to classify and persist non-vulnerability results differently (skipping CVSS/dedup/summary), which could affect reporting output and downstream assumptions about where findings live and how they’re scored.
> 
> **Overview**
> Updates the Finding Judge to return a new `findingType` (`vulnerability` | `informational` | `expected-behavior`) and extends the judging prompt to explicitly account for design-intent/expected behavior to reduce false positives.
> 
> Updates `documentVulnerability` to branch on `findingType`: non-vulnerability findings are written under an `informational/` directory, skip CVSS scoring, skip registry dedup/register/unregister, and are excluded from `findings-summary.md`; result messages and persisted metadata now include the judge’s `findingType`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f1459d4f567ccf08a16c1f11cc04761cebf750a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->