### PR TITLE
Adaptive Thinking Toggle

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -170,6 +170,7 @@ export class OffensiveSecurityAgent<TResult = void> {
       persistentShell: this.persistentShell,
       skillsRegistry: input.skillsRegistry,
       traceWriter,
+      enableThinking: input.enableThinking,
     });
 
     let tools: ToolSet = input.extraTools
@@ -354,6 +355,7 @@ export class OffensiveSecurityAgent<TResult = void> {
         };
         input.onCacheMetrics?.(metrics);
       },
+      enableThinking: input.enableThinking,
       silent: true,
     });
   }

--- a/src/core/agents/offSecAgent/tools/runPentestWorkflow.ts
+++ b/src/core/agents/offSecAgent/tools/runPentestWorkflow.ts
@@ -60,6 +60,7 @@ Omit \`cwd\` for blackbox mode (live target probing only).`,
           authConfig: ctx.authConfig,
           abortSignal: ctx.abortSignal,
           eventBus: ctx.eventBus,
+          enableThinking: ctx.enableThinking,
         });
 
         const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -206,6 +206,7 @@ async function runSingleCodingAgent(
     abortSignal: ctx.abortSignal,
     eventBus: localBus,
     subagentId,
+    enableThinking: ctx.enableThinking,
   });
 
   try {

--- a/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
@@ -90,6 +90,7 @@ Pass every target you want tested — the swarm handles concurrency automaticall
         findingsRegistry,
         eventBus: ctx.eventBus,
         concurrency: DEFAULT_CONCURRENCY,
+        enableThinking: ctx.enableThinking,
       });
 
       // Aggregate

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -82,4 +82,7 @@ export type ToolContext = {
    * When present, checkpoint_state tool is available.
    */
   traceWriter?: StepTraceWriter;
+
+  /** Enable extended thinking for sub-agents spawned by orchestration tools. */
+  enableThinking?: boolean;
 };

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -239,6 +239,9 @@ export type OffensiveSecurityAgentInput<TResult = void> = {
    * never see them.
    */
   environmentVariables?: Record<string, string>;
+
+  /** Enable extended thinking (reasoning) for supported models. */
+  enableThinking?: boolean;
 };
 
 /**
@@ -303,6 +306,9 @@ export interface SpecializedAgentInput {
    * Forwarded to the underlying {@link OffensiveSecurityAgentInput}.
    */
   environmentVariables?: Record<string, string>;
+
+  /** Enable extended thinking (reasoning) for supported models. */
+  enableThinking?: boolean;
 }
 
 /**

--- a/src/core/agents/specialized/attackSurface/blackboxAgent.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxAgent.ts
@@ -80,6 +80,7 @@ export class BlackboxAttackSurfaceAgent extends OffensiveSecurityAgent<AttackSur
       attackSurfaceRegistry,
       eventBus,
       subagentId,
+      enableThinking,
     } = opts;
     const target = opts.target ?? opts.cwd!;
 
@@ -118,6 +119,7 @@ export class BlackboxAttackSurfaceAgent extends OffensiveSecurityAgent<AttackSur
       attackSurfaceRegistry,
       eventBus,
       subagentId,
+      enableThinking,
       messages: opts.messages,
       activeTools: [
         // Core recon tools

--- a/src/core/agents/specialized/authenticationAgent/agent.ts
+++ b/src/core/agents/specialized/authenticationAgent/agent.ts
@@ -64,6 +64,9 @@ export interface AuthenticationAgentInput {
    * Forwarded to the underlying {@link OffensiveSecurityAgentInput}.
    */
   environmentVariables?: Record<string, string>;
+
+  /** Enable extended thinking (reasoning) for supported models. */
+  enableThinking?: boolean;
 }
 
 /** The typed result returned by `AuthenticationAgent.consume()`. */
@@ -134,6 +137,7 @@ export class AuthenticationAgent extends OffensiveSecurityAgent<AuthenticationRe
       subagentId,
       context,
       environmentVariables,
+      enableThinking,
     } = opts;
 
     const cm = session.credentialManager;
@@ -150,6 +154,7 @@ export class AuthenticationAgent extends OffensiveSecurityAgent<AuthenticationRe
       eventBus,
       subagentId,
       environmentVariables,
+      enableThinking,
       toolChoice: "auto",
       activeTools: [
         // Auth flow tools

--- a/src/core/agents/specialized/benchmarkComparisonAgent.ts
+++ b/src/core/agents/specialized/benchmarkComparisonAgent.ts
@@ -58,8 +58,15 @@ export interface BenchmarkComparisonResult {
  */
 export class BenchmarkComparisonAgent extends OffensiveSecurityAgent<BenchmarkComparisonResult> {
   constructor(opts: BenchmarkComparisonAgentInput) {
-    const { model, repoPath, session, authConfig, onStepFinish, abortSignal, enableThinking } =
-      opts;
+    const {
+      model,
+      repoPath,
+      session,
+      authConfig,
+      onStepFinish,
+      abortSignal,
+      enableThinking,
+    } = opts;
 
     const expectedResults = loadExpectedResults(repoPath);
     const actualFindings = loadActualFindings(session.rootPath);

--- a/src/core/agents/specialized/benchmarkComparisonAgent.ts
+++ b/src/core/agents/specialized/benchmarkComparisonAgent.ts
@@ -30,6 +30,9 @@ export interface BenchmarkComparisonAgentInput {
 
   /** AbortSignal to cancel mid-run */
   abortSignal?: AbortSignal;
+
+  /** Enable extended thinking (reasoning) for supported models. */
+  enableThinking?: boolean;
 }
 
 /** The typed result returned by `BenchmarkComparisonAgent.consume()`. */
@@ -55,7 +58,7 @@ export interface BenchmarkComparisonResult {
  */
 export class BenchmarkComparisonAgent extends OffensiveSecurityAgent<BenchmarkComparisonResult> {
   constructor(opts: BenchmarkComparisonAgentInput) {
-    const { model, repoPath, session, authConfig, onStepFinish, abortSignal } =
+    const { model, repoPath, session, authConfig, onStepFinish, abortSignal, enableThinking } =
       opts;
 
     const expectedResults = loadExpectedResults(repoPath);
@@ -70,6 +73,7 @@ export class BenchmarkComparisonAgent extends OffensiveSecurityAgent<BenchmarkCo
       authConfig,
       onStepFinish,
       abortSignal,
+      enableThinking,
 
       activeTools: ["provide_comparison_results"],
 

--- a/src/core/agents/specialized/codeAgent/agent.ts
+++ b/src/core/agents/specialized/codeAgent/agent.ts
@@ -77,6 +77,7 @@ export class CodeAgent<TResult = void> extends OffensiveSecurityAgent<TResult> {
       system,
       attackSurfaceRegistry,
       excludeTools,
+      enableThinking,
     } = opts;
 
     let activeTools: string[] = [
@@ -113,6 +114,7 @@ export class CodeAgent<TResult = void> extends OffensiveSecurityAgent<TResult> {
       eventBus,
       subagentId,
       attackSurfaceRegistry,
+      enableThinking,
       stopWhen: stopWhen ?? stepCountIs(10000),
       activeTools,
       responseSchema,

--- a/src/core/agents/specialized/environment/agent.ts
+++ b/src/core/agents/specialized/environment/agent.ts
@@ -54,6 +54,7 @@ export class EnvironmentAgent extends OffensiveSecurityAgent<EnvironmentResult> 
       eventBus,
       subagentId,
       sandbox,
+      enableThinking,
     } = opts;
 
     super({
@@ -67,6 +68,7 @@ export class EnvironmentAgent extends OffensiveSecurityAgent<EnvironmentResult> 
       eventBus,
       subagentId,
       sandbox,
+      enableThinking,
 
       activeTools: [
         "read_file",

--- a/src/core/agents/specialized/patching/agent.ts
+++ b/src/core/agents/specialized/patching/agent.ts
@@ -79,6 +79,7 @@ export class PatchingAgent extends OffensiveSecurityAgent<PatchResult> {
       abortSignal,
       eventBus,
       sandbox,
+      enableThinking,
     } = opts;
 
     const agentsMd = readAgentsMd(cwd);
@@ -93,6 +94,7 @@ export class PatchingAgent extends OffensiveSecurityAgent<PatchResult> {
       abortSignal,
       eventBus,
       sandbox,
+      enableThinking,
 
       activeTools: [
         "read_file",

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -140,6 +140,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       messages,
       context,
       environmentVariables,
+      enableThinking,
     } = opts;
 
     // The base class creates the response tool from responseSchema and
@@ -180,6 +181,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       findingsRegistry,
       messages,
       environmentVariables,
+      enableThinking,
       activeTools: [
         "execute_command",
         "http_request",

--- a/src/core/agents/specialized/whiteboxAttackSurface/agent.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/agent.ts
@@ -63,6 +63,7 @@ export class WhiteboxAttackSurfaceAgent extends OffensiveSecurityAgent<WhiteboxA
       subagentId,
       attackSurfaceRegistry,
       domains,
+      enableThinking,
     } = opts;
 
     // Closure variable that the response tool writes to
@@ -92,6 +93,7 @@ This ends the agent run — make sure all data is included.`,
       eventBus,
       subagentId,
       attackSurfaceRegistry,
+      enableThinking,
       activeTools: [
         // Filesystem tools — for Phase 1 repo identification
         "read_file",

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -243,6 +243,27 @@ export interface ModelInfo {
   contextLength?: number;
 }
 
+/**
+ * Check whether a model supports extended thinking based on its ID.
+ *
+ * Thinking is available on Claude 3.7 Sonnet and all Claude 4.x+ models
+ * (Sonnet, Opus, Haiku 4.5). Works for Anthropic direct, Bedrock, and
+ * Pensar provider IDs.
+ */
+export function modelSupportsThinking(modelId: string): boolean {
+  // Normalize: strip provider prefixes so we match the base Claude model ID
+  const normalized = modelId
+    .replace(/^pensar:/, "")
+    .replace(/^(us\.|eu\.|global\.|ap\.)?anthropic\./, "");
+
+  return (
+    /^claude-3-7-sonnet/.test(normalized) ||
+    /^claude-sonnet-4/.test(normalized) ||
+    /^claude-opus-4/.test(normalized) ||
+    /^claude-haiku-4-5/.test(normalized)
+  );
+}
+
 /** Cache token metrics extracted from Anthropic providerMetadata */
 export interface CacheMetrics {
   cacheReadInputTokens: number;
@@ -274,6 +295,10 @@ export interface StreamResponseOpts {
   onSummarized?: (summary: string) => void;
   /** Called when Anthropic cache metrics are present in a step's providerMetadata */
   onCacheMetrics?: (metrics: CacheMetrics) => void;
+  /** Enable extended thinking for supported models (Anthropic Claude 3.7+) */
+  enableThinking?: boolean;
+  /** Max thinking tokens per turn. Defaults to 10_000. */
+  thinkingBudget?: number;
 }
 
 export function streamResponse(
@@ -294,6 +319,8 @@ export function streamResponse(
     authConfig,
     onFinish,
     onCacheMetrics,
+    enableThinking,
+    thinkingBudget,
   } = opts;
 
   // Wrap onStepFinish to fire usage callback for every step.
@@ -326,6 +353,25 @@ export function streamResponse(
     effectiveSystem = undefined;
   }
 
+  // Build providerOptions for extended thinking when enabled on a supported model.
+  // Caching uses message-level cache_control (withCachedSystemPrompt / withCachedLastMessage),
+  // not providerOptions, so there is no collision.
+  // Note: when thinking is enabled, temperature must not be set (Anthropic rejects it).
+  const useThinking =
+    enableThinking &&
+    isAnthropicProvider(model) &&
+    modelSupportsThinking(model);
+  const providerOptions = useThinking
+    ? {
+        anthropic: {
+          thinking: {
+            type: "enabled" as const,
+            budgetTokens: thinkingBudget ?? 10_000,
+          },
+        },
+      }
+    : undefined;
+
   let rateLimitRetryCount = 0;
 
   try {
@@ -338,6 +384,7 @@ export function streamResponse(
       toolChoice,
       tools,
       maxRetries: 3,
+      providerOptions,
       prepareStep: (opts) => {
         // Update the container with the latest messages
         messagesContainer.current = opts.messages;

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -297,8 +297,6 @@ export interface StreamResponseOpts {
   onCacheMetrics?: (metrics: CacheMetrics) => void;
   /** Enable extended thinking for supported models (Anthropic Claude 3.7+) */
   enableThinking?: boolean;
-  /** Max thinking tokens per turn. Defaults to 10_000. */
-  thinkingBudget?: number;
 }
 
 export function streamResponse(
@@ -320,7 +318,6 @@ export function streamResponse(
     onFinish,
     onCacheMetrics,
     enableThinking,
-    thinkingBudget,
   } = opts;
 
   // Wrap onStepFinish to fire usage callback for every step.

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -365,8 +365,7 @@ export function streamResponse(
     ? {
         anthropic: {
           thinking: {
-            type: "enabled" as const,
-            budgetTokens: thinkingBudget ?? 10_000,
+            type: "adaptive" as const,
           },
         },
       }

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -137,6 +137,7 @@ export function createPensarModel(
       };
 
       const textParts: Record<string, string> = {};
+      const reasoningParts: Record<string, { text: string; providerMetadata?: Record<string, Record<string, unknown>> }> = {};
       const toolInputParts: Record<
         string,
         { toolName: string; input: string }
@@ -149,6 +150,23 @@ export function createPensarModel(
           if (done) break;
 
           switch (value.type) {
+            case "reasoning-start":
+              reasoningParts[value.id] = { text: "" };
+              break;
+            case "reasoning-delta":
+              if (reasoningParts[value.id]) {
+                reasoningParts[value.id].text += value.delta;
+              }
+              break;
+            case "reasoning-end":
+              if (reasoningParts[value.id]) {
+                content.push({
+                  type: "reasoning",
+                  text: reasoningParts[value.id].text,
+                  providerMetadata: value.providerMetadata,
+                });
+              }
+              break;
             case "text-start":
               textParts[value.id] = "";
               break;
@@ -302,6 +320,8 @@ export function createPensarModel(
           let startEmitted = false;
           // Track active content blocks for proper id mapping
           let activeTextId: string | null = null;
+          let activeReasoningId: string | null = null;
+          let activeReasoningSignature: string | null = null;
           let activeToolId: string | null = null;
           let activeToolName: string | null = null;
           let activeToolInput = "";
@@ -395,7 +415,14 @@ export function createPensarModel(
                     | Record<string, unknown>
                     | undefined;
                   const cbType = cb?.type as string | undefined;
-                  if (cbType === "text") {
+                  if (cbType === "thinking") {
+                    activeReasoningId = `reasoning-${Date.now()}-${parsed.index}`;
+                    activeReasoningSignature = null;
+                    controller.enqueue({
+                      type: "reasoning-start",
+                      id: activeReasoningId,
+                    });
+                  } else if (cbType === "text") {
                     activeTextId = `text-${Date.now()}-${parsed.index}`;
                     controller.enqueue({
                       type: "text-start",
@@ -419,7 +446,15 @@ export function createPensarModel(
                     | Record<string, unknown>
                     | undefined;
                   const deltaType = delta?.type as string | undefined;
-                  if (deltaType === "text_delta" && activeTextId) {
+                  if (deltaType === "thinking_delta" && activeReasoningId) {
+                    controller.enqueue({
+                      type: "reasoning-delta",
+                      id: activeReasoningId,
+                      delta: (delta?.thinking as string) ?? "",
+                    });
+                  } else if (deltaType === "signature_delta" && activeReasoningId) {
+                    activeReasoningSignature = (delta?.signature as string) ?? null;
+                  } else if (deltaType === "text_delta" && activeTextId) {
                     controller.enqueue({
                       type: "text-delta",
                       id: activeTextId,
@@ -438,7 +473,19 @@ export function createPensarModel(
                 }
 
                 case "content_block_stop": {
-                  if (activeTextId) {
+                  if (activeReasoningId) {
+                    controller.enqueue({
+                      type: "reasoning-end",
+                      id: activeReasoningId,
+                      ...(activeReasoningSignature && {
+                        providerMetadata: {
+                          anthropic: { signature: activeReasoningSignature },
+                        },
+                      }),
+                    });
+                    activeReasoningId = null;
+                    activeReasoningSignature = null;
+                  } else if (activeTextId) {
                     controller.enqueue({ type: "text-end", id: activeTextId });
                     activeTextId = null;
                   } else if (activeToolId && activeToolName) {

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -463,7 +463,8 @@ export function createPensarModel(
                     activeReasoningId
                   ) {
                     activeReasoningSignature =
-                      (delta?.signature as string) ?? null;
+                      (activeReasoningSignature ?? "") +
+                      ((delta?.signature as string) ?? "");
                   } else if (deltaType === "text_delta" && activeTextId) {
                     controller.enqueue({
                       type: "text-delta",

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -137,7 +137,13 @@ export function createPensarModel(
       };
 
       const textParts: Record<string, string> = {};
-      const reasoningParts: Record<string, { text: string; providerMetadata?: Record<string, Record<string, unknown>> }> = {};
+      const reasoningParts: Record<
+        string,
+        {
+          text: string;
+          providerMetadata?: Record<string, Record<string, unknown>>;
+        }
+      > = {};
       const toolInputParts: Record<
         string,
         { toolName: string; input: string }
@@ -452,8 +458,12 @@ export function createPensarModel(
                       id: activeReasoningId,
                       delta: (delta?.thinking as string) ?? "",
                     });
-                  } else if (deltaType === "signature_delta" && activeReasoningId) {
-                    activeReasoningSignature = (delta?.signature as string) ?? null;
+                  } else if (
+                    deltaType === "signature_delta" &&
+                    activeReasoningId
+                  ) {
+                    activeReasoningSignature =
+                      (delta?.signature as string) ?? null;
                   } else if (deltaType === "text_delta" && activeTextId) {
                     controller.enqueue({
                       type: "text-delta",

--- a/src/core/ai/providers/pensarFormatters.ts
+++ b/src/core/ai/providers/pensarFormatters.ts
@@ -101,22 +101,30 @@ function convertToAnthropicFormat(
           messages.push({ role: "user", content: text });
         }
       } else if (part.role === "assistant") {
-        const assistantContent = part.content as Array<
-          LanguageModelV3TextPart | LanguageModelV3ToolCallPart
-        >;
-        const hasToolCalls = assistantContent.some(
-          (c) => c.type === "tool-call",
+        const assistantContent = part.content as unknown as Array<Record<string, unknown>>;
+        const hasStructuredParts = assistantContent.some(
+          (c) => c.type === "tool-call" || c.type === "reasoning",
         );
 
-        if (hasToolCalls) {
-          // Must use structured content array so Bedrock sees tool_use blocks
+        if (hasStructuredParts) {
+          // Must use structured content array for tool_use / thinking blocks
           const content: Array<Record<string, unknown>> = [];
           for (const c of assistantContent) {
-            if (c.type === "text" && c.text) {
-              content.push({ type: "text", text: c.text });
+            if (c.type === "reasoning") {
+              const sig = (
+                c.providerOptions as Record<string, Record<string, unknown>> | undefined
+              )?.anthropic?.signature as string | undefined;
+              const thinkingBlock: Record<string, unknown> = {
+                type: "thinking",
+                thinking: c.text as string,
+              };
+              if (sig) thinkingBlock.signature = sig;
+              content.push(thinkingBlock);
+            } else if (c.type === "text" && c.text) {
+              content.push({ type: "text", text: c.text as string });
             } else if (c.type === "tool-call") {
               const parsedInput =
-                typeof c.input === "string" ? JSON.parse(c.input) : c.input;
+                typeof c.input === "string" ? JSON.parse(c.input as string) : c.input;
               content.push({
                 type: "tool_use",
                 id: c.toolCallId,
@@ -129,7 +137,7 @@ function convertToAnthropicFormat(
         } else {
           // Text-only assistant messages can use a plain string
           const text = assistantContent
-            .map((c) => (c.type === "text" ? c.text : ""))
+            .map((c) => (c.type === "text" ? (c.text as string) : ""))
             .join("");
           messages.push({ role: "assistant", content: text });
         }
@@ -213,6 +221,27 @@ function convertToAnthropicFormat(
       }));
   }
 
+  // Extended thinking
+  const anthropicOpts = options.providerOptions?.anthropic as
+    | Record<string, unknown>
+    | undefined;
+  const thinking = anthropicOpts?.thinking as
+    | { type: string; budgetTokens?: number }
+    | undefined;
+  if (thinking?.type === "enabled") {
+    const budgetTokens = thinking.budgetTokens ?? 10_000;
+    body.thinking = { type: "enabled", budget_tokens: budgetTokens };
+    // Anthropic requires max_tokens > budget_tokens
+    if ((body.max_tokens as number) <= budgetTokens) {
+      body.max_tokens = budgetTokens + 4096;
+    }
+    // Anthropic rejects temperature when thinking is enabled
+    delete body.temperature;
+  } else if (thinking?.type === "adaptive") {
+    body.thinking = { type: "adaptive" };
+    delete body.temperature;
+  }
+
   // Convert tool choice
   if (options.toolChoice) {
     if (options.toolChoice.type === "auto") {
@@ -288,7 +317,18 @@ function parseAnthropicResponse(
 
   if (rawContent) {
     for (const block of rawContent) {
-      if (block.type === "text") {
+      if (block.type === "thinking") {
+        const reasoningPart: Record<string, unknown> = {
+          type: "reasoning",
+          text: block.thinking as string,
+        };
+        if (block.signature) {
+          reasoningPart.providerMetadata = {
+            anthropic: { signature: block.signature as string },
+          };
+        }
+        content.push(reasoningPart as LanguageModelV3Content);
+      } else if (block.type === "text") {
         content.push({
           type: "text",
           text: block.text as string,

--- a/src/core/ai/providers/pensarFormatters.ts
+++ b/src/core/ai/providers/pensarFormatters.ts
@@ -113,7 +113,7 @@ function convertToAnthropicFormat(
           for (const c of assistantContent) {
             if (c.type === "reasoning") {
               const sig = (
-                c.providerMetadata as
+                c.providerOptions as
                   | Record<string, Record<string, unknown>>
                   | undefined
               )?.anthropic?.signature as string | undefined;

--- a/src/core/ai/providers/pensarFormatters.ts
+++ b/src/core/ai/providers/pensarFormatters.ts
@@ -113,7 +113,7 @@ function convertToAnthropicFormat(
           for (const c of assistantContent) {
             if (c.type === "reasoning") {
               const sig = (
-                c.providerOptions as
+                c.providerMetadata as
                   | Record<string, Record<string, unknown>>
                   | undefined
               )?.anthropic?.signature as string | undefined;

--- a/src/core/ai/providers/pensarFormatters.ts
+++ b/src/core/ai/providers/pensarFormatters.ts
@@ -3,7 +3,6 @@ import type {
   LanguageModelV3Content,
   LanguageModelV3FinishReason,
   LanguageModelV3TextPart,
-  LanguageModelV3ToolCallPart,
   LanguageModelV3ToolResultPart,
 } from "@ai-sdk/provider";
 
@@ -101,7 +100,9 @@ function convertToAnthropicFormat(
           messages.push({ role: "user", content: text });
         }
       } else if (part.role === "assistant") {
-        const assistantContent = part.content as unknown as Array<Record<string, unknown>>;
+        const assistantContent = part.content as unknown as Array<
+          Record<string, unknown>
+        >;
         const hasStructuredParts = assistantContent.some(
           (c) => c.type === "tool-call" || c.type === "reasoning",
         );
@@ -112,7 +113,9 @@ function convertToAnthropicFormat(
           for (const c of assistantContent) {
             if (c.type === "reasoning") {
               const sig = (
-                c.providerOptions as Record<string, Record<string, unknown>> | undefined
+                c.providerOptions as
+                  | Record<string, Record<string, unknown>>
+                  | undefined
               )?.anthropic?.signature as string | undefined;
               const thinkingBlock: Record<string, unknown> = {
                 type: "thinking",
@@ -124,7 +127,9 @@ function convertToAnthropicFormat(
               content.push({ type: "text", text: c.text as string });
             } else if (c.type === "tool-call") {
               const parsedInput =
-                typeof c.input === "string" ? JSON.parse(c.input as string) : c.input;
+                typeof c.input === "string"
+                  ? JSON.parse(c.input as string)
+                  : c.input;
               content.push({
                 type: "tool_use",
                 id: c.toolCallId,

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -29,6 +29,8 @@ export interface Config {
   themeMode?: "dark" | "light" | "auto";
   // Model preference
   selectedModelId?: string | null;
+  // Extended thinking / reasoning
+  reasoningEnabled?: boolean;
   // WorkOS CLI auth (replaces pensarAPIKey for new auth flow)
   accessToken?: string | null;
   refreshToken?: string | null;

--- a/src/core/integrations/wandb/upload.test.ts
+++ b/src/core/integrations/wandb/upload.test.ts
@@ -56,6 +56,7 @@ describe("resolveConfig", () => {
   it("returns available with config when both env vars set", () => {
     process.env.WANDB_API_KEY = "test-key";
     process.env.WANDB_ENTITY = "test-entity";
+    delete process.env.WANDB_PROJECT;
     const result = resolveConfig();
     expect(result.available).toBe(true);
     if (result.available) {

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -71,6 +71,9 @@ export interface PentestWorkflowInput {
 
   /** Called when Anthropic cache metrics are present in a step's providerMetadata */
   onCacheMetrics?: (metrics: CacheMetrics) => void;
+
+  /** Enable extended thinking for supported models */
+  enableThinking?: boolean;
 }
 
 export interface PentestWorkflowResult {
@@ -99,6 +102,7 @@ export interface PentestSwarmInput {
       totalTokens?: number;
     };
   }) => void;
+  enableThinking?: boolean;
 }
 
 interface TokenUsageTotals {
@@ -151,6 +155,7 @@ export async function runPentestSwarm(
     onError,
     concurrency = DEFAULT_CONCURRENCY,
     onStepFinish,
+    enableThinking,
   } = input;
 
   const completedIds = getCompletedAgentIds(session);
@@ -209,6 +214,7 @@ export async function runPentestSwarm(
           messages: previousMessages.length > 0 ? previousMessages : undefined,
           eventBus,
           subagentId,
+          enableThinking,
         });
 
         const result = await agent.consume();
@@ -282,6 +288,7 @@ export async function runPentestWorkflow(
     eventBus,
     onStepFinish,
     onCacheMetrics,
+    enableThinking,
   } = input;
   const startedAt = Date.now();
   const tokenUsageTotals: TokenUsageTotals = {
@@ -428,6 +435,7 @@ export async function runPentestWorkflow(
         findingsRegistry,
         eventBus,
         onStepFinish: wrappedOnStepFinish,
+        enableThinking,
       });
     }
 

--- a/src/tui/components/chat/config-view.tsx
+++ b/src/tui/components/chat/config-view.tsx
@@ -15,6 +15,7 @@ import {
 } from "../../../core/providers/utils";
 import type { Config } from "../../../core/config/config";
 import { useTheme } from "../../theme";
+import { useAgent } from "../../context/agent";
 
 type FocusedField = "url" | "scope" | "model" | "start";
 
@@ -32,6 +33,7 @@ export interface SessionConfig {
 
 export function ConfigView({ config, onBack, onStart }: ConfigViewProps) {
   const { colors } = useTheme();
+  const { reasoningEnabled, setReasoningEnabled } = useAgent();
   // Form state
   const [targetUrl, setTargetUrl] = useState("https://");
   const [strictScope, setStrictScope] = useState(true);
@@ -214,6 +216,8 @@ export function ConfigView({ config, onBack, onStart }: ConfigViewProps) {
             onSelectModel={handleModelSelect}
             focused={focusedField === "model"}
             isModelUserSelected={isModelUserSelected}
+            reasoningEnabled={reasoningEnabled}
+            onReasoningToggle={setReasoningEnabled}
           />
         </box>
       </box>

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -225,12 +225,11 @@ export function ModelPicker({
         }
       }
     }
-    // Reasoning toggle — shown when the callback is provided
-    if (onReasoningToggle) {
+    if (onReasoningToggle && modelSupportsThinking(selectedModel.id)) {
       items.push({ type: "reasoning" });
     }
     return items;
-  }, [groupedModels, expandedProviders, onReasoningToggle]);
+  }, [groupedModels, expandedProviders, onReasoningToggle, selectedModel.id]);
 
   // Sync focusedIndex when selected model changes (e.g. on initial load)
   useEffect(() => {
@@ -347,7 +346,9 @@ export function ModelPicker({
           return true;
         }
 
-        if (currentItem.type === "provider") {
+        if (currentItem.type === "reasoning") {
+          onReasoningToggle?.(!reasoningEnabled);
+        } else if (currentItem.type === "provider") {
           const targetProvider = currentItem.provider;
           setExpandedProviders((prev) => {
             const next = new Set(prev);

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -331,14 +331,10 @@ export function ModelPicker({
         return false;
       }
 
-      // Space - toggle reasoning checkbox
-      if (key.name === "space") {
-        const currentItem = navigationItems[focusedIndex];
-        if (currentItem?.type === "reasoning" && thinkingSupported) {
-          onReasoningToggle?.(!reasoningEnabled);
-          return true;
-        }
-        return false;
+      // Space - toggle reasoning checkbox from any row
+      if (key.name === "space" && onReasoningToggle && thinkingSupported) {
+        onReasoningToggle(!reasoningEnabled);
+        return true;
       }
 
       // Enter - confirm model selection, toggle provider, or start editing local input
@@ -690,21 +686,14 @@ export function ModelPicker({
       </scrollbox>
 
       {/* Reasoning toggle */}
-      {onReasoningToggle && (
+      {onReasoningToggle && thinkingSupported && (
         <box flexShrink={0} paddingTop={1}>
           <PickerRow id="reasoning-toggle">
             <text
-              fg={
-                isReasoningFocused
-                  ? colors.primary
-                  : !thinkingSupported
-                    ? colors.textMuted
-                    : colors.text
-              }
+              fg={isReasoningFocused ? colors.primary : colors.text}
             >
-              {reasoningEnabled && thinkingSupported ? "[x]" : "[ ]"} Extended
-              Thinking
-              {!thinkingSupported ? " (not supported)" : ""}
+              {reasoningEnabled ? "[x]" : "[ ]"} Extended Thinking
+              (Experimental)
             </text>
           </PickerRow>
         </box>

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import { useKeyboard } from "@opentui/react";
 import { ScrollBoxRenderable } from "@opentui/core";
-import type { ModelInfo } from "../../../core/ai";
+import { modelSupportsThinking, type ModelInfo } from "../../../core/ai";
 import { getAvailableModels } from "../../../core/providers/utils";
 import type { Config } from "../../../core/config/config";
 import { useTheme } from "../../theme";
@@ -74,13 +74,15 @@ function PickerRow({
 type NavigationItem =
   | { type: "provider"; provider: string }
   | { type: "model"; model: ModelInfo }
-  | { type: "local-input"; field: LocalInputField };
+  | { type: "local-input"; field: LocalInputField }
+  | { type: "reasoning" };
 
 type LocalInputField = "url" | "model";
 
 function getNavItemId(item: NavigationItem): string {
   if (item.type === "provider") return `provider-${item.provider}`;
   if (item.type === "model") return `model-${item.model.id}`;
+  if (item.type === "reasoning") return "reasoning-toggle";
   return `local-input-${item.field}`;
 }
 
@@ -93,6 +95,8 @@ export interface ModelPickerProps {
   onConfigUpdate?: (update: Partial<Config>) => Promise<void>;
   focused?: boolean;
   isModelUserSelected?: boolean;
+  reasoningEnabled?: boolean;
+  onReasoningToggle?: (enabled: boolean) => void;
 }
 
 export function ModelPicker({
@@ -104,6 +108,8 @@ export function ModelPicker({
   onConfigUpdate,
   focused = true,
   isModelUserSelected = false,
+  reasoningEnabled = false,
+  onReasoningToggle,
 }: ModelPickerProps) {
   const { colors } = useTheme();
   const scrollBoxRef = useRef<ScrollBoxRenderable | null>(null);
@@ -219,8 +225,12 @@ export function ModelPicker({
         }
       }
     }
+    // Reasoning toggle — shown when the callback is provided
+    if (onReasoningToggle) {
+      items.push({ type: "reasoning" });
+    }
     return items;
-  }, [groupedModels, expandedProviders]);
+  }, [groupedModels, expandedProviders, onReasoningToggle]);
 
   // Sync focusedIndex when selected model changes (e.g. on initial load)
   useEffect(() => {
@@ -262,6 +272,10 @@ export function ModelPicker({
     setEditingLocalField(null);
     commitLocalConfig(localUrl, localModelName);
   }, [localUrl, localModelName, commitLocalConfig]);
+
+  const thinkingSupported = modelSupportsThinking(selectedModel.id);
+  const isReasoningFocused =
+    navigationItems[focusedIndex]?.type === "reasoning";
 
   // Handle keyboard navigation (most keys disabled while editing local input)
   const handleKeyboard = useCallback(
@@ -312,6 +326,16 @@ export function ModelPicker({
         }
         if (onCancel) {
           onCancel();
+          return true;
+        }
+        return false;
+      }
+
+      // Space - toggle reasoning checkbox
+      if (key.name === "space") {
+        const currentItem = navigationItems[focusedIndex];
+        if (currentItem?.type === "reasoning" && thinkingSupported) {
+          onReasoningToggle?.(!reasoningEnabled);
           return true;
         }
         return false;
@@ -400,6 +424,9 @@ export function ModelPicker({
       onConfirm,
       onCancel,
       searchQuery,
+      reasoningEnabled,
+      onReasoningToggle,
+      thinkingSupported,
     ],
   );
 
@@ -661,6 +688,27 @@ export function ModelPicker({
           return elements;
         })}
       </scrollbox>
+
+      {/* Reasoning toggle */}
+      {onReasoningToggle && (
+        <box flexShrink={0} paddingTop={1}>
+          <PickerRow id="reasoning-toggle">
+            <text
+              fg={
+                isReasoningFocused
+                  ? colors.primary
+                  : !thinkingSupported
+                    ? colors.textMuted
+                    : colors.text
+              }
+            >
+              {reasoningEnabled && thinkingSupported ? "[x]" : "[ ]"} Extended
+              Thinking
+              {!thinkingSupported ? " (not supported)" : ""}
+            </text>
+          </PickerRow>
+        </box>
+      )}
 
       {/* Help text for inline editing only — general controls are in ModelPickerDialog */}
       {editingLocalField && (

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -689,9 +689,7 @@ export function ModelPicker({
       {onReasoningToggle && thinkingSupported && (
         <box flexShrink={0} paddingTop={1}>
           <PickerRow id="reasoning-toggle">
-            <text
-              fg={isReasoningFocused ? colors.primary : colors.text}
-            >
+            <text fg={isReasoningFocused ? colors.primary : colors.text}>
               {reasoningEnabled ? "[x]" : "[ ]"} Extended Thinking
               (Experimental)
             </text>

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -368,7 +368,7 @@ export function ModelPicker({
       // Left/Right - collapse/expand provider
       if (key.name === "left" || key.name === "right") {
         const currentItem = navigationItems[focusedIndex];
-        if (!currentItem) return false;
+        if (!currentItem || currentItem.type === "reasoning") return false;
 
         const targetProvider =
           currentItem.type === "provider"

--- a/src/tui/components/model-picker/ModelPickerDialog.tsx
+++ b/src/tui/components/model-picker/ModelPickerDialog.tsx
@@ -19,7 +19,13 @@ interface ModelPickerDialogProps {
 export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
   const { colors } = useTheme();
   const config = useConfig();
-  const { model, setModel, isModelUserSelected } = useAgent();
+  const {
+    model,
+    setModel,
+    isModelUserSelected,
+    reasoningEnabled,
+    setReasoningEnabled,
+  } = useAgent();
 
   const title = (
     <text>
@@ -53,6 +59,8 @@ export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
             onConfigUpdate={config.update}
             focused={true}
             isModelUserSelected={isModelUserSelected}
+            reasoningEnabled={reasoningEnabled}
+            onReasoningToggle={setReasoningEnabled}
           />
         </box>
       </DialogLayout>

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -116,6 +116,7 @@ export default function OperatorDashboard({
     addCacheUsage,
     resetTokenUsage,
     setSessionCwd,
+    reasoningEnabled,
   } = useAgent();
   const {
     autocompleteOptions: allAutocompleteOptions,
@@ -1167,6 +1168,7 @@ export default function OperatorDashboard({
         approvalGate: approvalGateRef.current,
         commandCancelHandle: cancelHandleRef.current,
         skillsRegistry,
+        enableThinking: reasoningEnabled,
         onStepFinish,
         onCacheMetrics: (metrics: CacheMetrics) => {
           addCacheUsage(

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -41,6 +41,9 @@ interface AgentContextValue {
   hasExecuted: boolean;
   thinking: boolean;
   setThinking: (thinking: boolean) => void;
+  /** Whether extended thinking is enabled for supported models (persisted to config). */
+  reasoningEnabled: boolean;
+  setReasoningEnabled: (enabled: boolean) => void;
   isExecuting: boolean;
   setIsExecuting: (isExecuting: boolean) => void;
   /** The agent's working directory (session rootPath), shown in footer. */
@@ -79,6 +82,9 @@ export function AgentProvider({ children }: AgentProviderProps) {
   });
   const [hasExecuted, setHasExecuted] = useState<boolean>(false);
   const [thinking, setThinking] = useState<boolean>(false);
+  const [reasoningEnabled, setReasoningEnabledInternal] = useState<boolean>(
+    () => appConfig.data?.reasoningEnabled ?? false,
+  );
   const [isExecuting, setIsExecuting] = useState<boolean>(false);
   const [sessionCwd, setSessionCwd] = useState<string | null>(null);
 
@@ -93,6 +99,13 @@ export function AgentProvider({ children }: AgentProviderProps) {
         writeErrorLog(err, "AGENT_CONTEXT");
       });
     }
+  }, []);
+
+  const setReasoningEnabled = useCallback((enabled: boolean) => {
+    setReasoningEnabledInternal(enabled);
+    updateConfig({ reasoningEnabled: enabled }).catch((err) => {
+      writeErrorLog(err, "AGENT_CONTEXT");
+    });
   }, []);
 
   // Re-evaluate the default model whenever config changes (e.g. after
@@ -162,6 +175,8 @@ export function AgentProvider({ children }: AgentProviderProps) {
       hasExecuted,
       thinking,
       setThinking,
+      reasoningEnabled,
+      setReasoningEnabled,
       isExecuting,
       setIsExecuting,
       sessionCwd,
@@ -174,6 +189,7 @@ export function AgentProvider({ children }: AgentProviderProps) {
       tokenUsage,
       hasExecuted,
       thinking,
+      reasoningEnabled,
       isExecuting,
       sessionCwd,
       addTokenUsage,

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -108,6 +108,13 @@ export function AgentProvider({ children }: AgentProviderProps) {
     });
   }, []);
 
+  // Sync reasoningEnabled when config loads asynchronously
+  useEffect(() => {
+    if (appConfig.data?.reasoningEnabled != null) {
+      setReasoningEnabledInternal(appConfig.data.reasoningEnabled);
+    }
+  }, [appConfig.data?.reasoningEnabled]);
+
   // Re-evaluate the default model whenever config changes (e.g. after
   // provider setup) unless the user has explicitly picked a model.
   useEffect(() => {


### PR DESCRIPTION
## Summary

Adds extended thinking support to the pentest agent pipeline, enabling Apex to reason through complex security decisions before acting. This uses **adaptive thinking mode**, which lets the model decide per-turn how much reasoning to apply based on the complexity of the task at hand.

### Which agents use thinking?

Extended thinking is available to all agent types, but in practice **pentest agents are the primary beneficiaries**. The model naturally adapts its reasoning to the task complexity:

| Agent type | Reasoning usage | Why |
|-----------|----------------|-----|
| **Pentest agents** | 33-86% of steps | Complex security decisions — choosing attack vectors, analyzing responses for vulnerabilities, crafting exploit payloads |
| **Orchestrator** | Initial planning step | High-level session planning and delegation |
| **Attack surface agents** | 0% | Straightforward enumeration (crawl, probe, catalog) — the model correctly determines no deep reasoning is needed |

This distribution is exactly what we want. Attack surface mapping is mechanical — thinking tokens would be wasted. Pentest agents face genuinely ambiguous decisions where reasoning produces better vulnerability discovery.

### Why adaptive thinking? (and what we tried first)

Penetration testing agents face a mix of trivial steps (reading a tool result, issuing the next HTTP request) and genuinely complex decisions (choosing an attack vector, analyzing a response for subtle vulnerabilities, deciding whether a behavior is exploitable). We went through several iterations to find the right approach.

**Attempt 1: `type: "enabled"` with a fixed 10k token budget**

Our first implementation used a fixed thinking budget of 10,000 tokens per turn. In W&B traces, the model only produced reasoning on step 0 of each agent (the initial planning step) and then went silent — 1 out of 305 records had any reasoning content. The fixed budget was too small to be worth the model's effort on subsequent tool-use steps, so it effectively learned to skip thinking entirely after the first turn. We also found that `max_tokens` must exceed `budget_tokens` (Anthropic rejects the request otherwise), and temperature must be omitted — constraints that added complexity to the provider layer for marginal benefit.

**Attempt 2: `type: "adaptive"`**

Switching to adaptive mode removed the budget constraint entirely and let the model decide per-turn whether and how much to think. Results improved dramatically:

| Metric | Fixed budget (10k) | Adaptive |
|--------|-------------------|----------|
| Steps with reasoning | 11/382 (2.9%) | 207/368 (56.2%) |
| Total reasoning chars | 1,405 | 173,082 |
| Agents reasoning beyond step 0 | 0/12 | 12/12 |
| Per-agent reasoning rate | 0-4% | 33-86% |

The model now reasons deeply when the problem warrants it (analyzing whether a 403 response is bypassable, deciding which injection payload to try next) and skips thinking on mechanical steps (reading command output, issuing the next request in a sequence). This is exactly the behavior we want — reasoning where it matters, no wasted tokens where it doesn't.

We kept the `type: "enabled"` code path in the Pensar provider formatter for completeness (callers other than `streamResponse` could use it), but the default and recommended mode is adaptive.

### Verified on both providers

We validated thinking end-to-end on both the direct Anthropic API and the Pensar hosted inference gateway:

| Provider | Steps with reasoning | Reasoning chars | Per-agent range |
|----------|---------------------|-----------------|-----------------|
| **Direct Anthropic** | 207/368 (56.2%) | 173,082 | 33-86% |
| **Pensar Gateway** | 120/274 (43.8%) | 59,816 | 38-67% |

Both show the same pattern: pentest agents reason heavily, attack surface agents skip reasoning entirely, and the orchestrator reasons during initial planning. The Pensar gateway passes thinking params and response blocks through cleanly.

### How to configure

1. **Toggle in the UI**: Open the model picker (either from the config screen or via the `/model` command). An "Extended Thinking" checkbox appears below the model list. Toggle it on for any supported model.

2. **Persisted to config**: The setting is saved to `~/.pensar/config.json` as `reasoningEnabled: true` and persists across sessions.

3. **Supported models**: The selected model must support adaptive thinking. The checkbox is disabled (with a "not supported" label) for models that don't.

4. **Works with all providers**: Direct Anthropic, AWS Bedrock, and Pensar Gateway all support extended thinking. The Pensar provider now handles the full thinking round-trip including `thinking`/`thinking_delta`/`signature_delta` SSE events and multi-turn signature forwarding.

## Changes

### Extended thinking pipeline
- **`src/core/ai/ai.ts`** — `modelSupportsThinking()` function, `providerOptions` construction with adaptive thinking mode, `enableThinking` option on `StreamResponseOpts`
- **`src/core/ai/providers/pensarFormatters.ts`** — Forwards `thinking` config to Bedrock request body (both `enabled` and `adaptive` modes), handles `reasoning` content parts in assistant messages for multi-turn round-trip (including signature), parses `thinking` response blocks into `reasoning` content
- **`src/core/ai/providers/pensar.ts`** — SSE stream handler emits `reasoning-start`/`reasoning-delta`/`reasoning-end` for thinking blocks, captures `signature_delta` for multi-turn, `doGenerate` collects reasoning parts

### Flag threading (all agents)
- **`OffensiveSecurityAgentInput`**, **`SpecializedAgentInput`**, **`ToolContext`** — `enableThinking?: boolean`
- **All 8 specialized agents** — destructure and forward `enableThinking` to `super()`
- **Orchestration tools** (`runPentestWorkflow`, `spawnPentestSwarm`, `spawnCodingAgent`) — forward from `ToolContext`
- **Workflow layer** (`pentest.ts`) — thread through `PentestWorkflowInput` and `PentestSwarmInput`

### UI
- **`ModelPicker.tsx`** — "Extended Thinking" checkbox with model support detection
- **`AgentProvider`** (`context/agent.tsx`) — `reasoningEnabled` state persisted to config
- **`ConfigView`**, **`ModelPickerDialog`** — pass reasoning props through

### Cleanup (separate from thinking)
- Removed plan mode tools (`writePlan`, `submitPlan`) and all associated UI/state
- Fixed W&B test that failed when `WANDB_PROJECT` env var was set

## Test plan

- [x] Verified with W&B Weave traces: 56% of steps produce reasoning with adaptive mode (direct Anthropic)
- [x] Verified with W&B Weave traces: 44% of steps produce reasoning via Pensar Gateway hosted inference
- [x] Pentest agents reason on 33-86% of steps; attack surface agents correctly skip reasoning (0%)
- [x] All pentest sub-agents receive and use thinking (confirmed via per-agent trace breakdown)
- [x] Pensar Gateway passes thinking params and response blocks through cleanly (confirmed end-to-end)
- [x] `bunx tsc --noEmit` — zero type errors
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] W&B upload tests pass
- [x] Verify thinking toggle persists correctly across app restarts

<img width="685" height="536" alt="Screenshot 2026-04-02 at 3 55 45 PM" src="https://github.com/user-attachments/assets/99ce9f2c-9e5d-49ca-9570-0d36c5eedd28" />

<img width="691" height="535" alt="Screenshot 2026-04-02 at 3 56 35 PM" src="https://github.com/user-attachments/assets/b1ae3dbd-0c5c-4109-b042-ee1dc59708c9" />

<img width="690" height="537" alt="Screenshot 2026-04-02 at 3 56 12 PM" src="https://github.com/user-attachments/assets/d42b09dd-d962-48e4-b586-fd22e2bcdff9" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the AI provider layer and threads a new `enableThinking` flag through multiple agent/workflow entry points, which could affect inference request formatting and streaming parsing across providers/models.
> 
> **Overview**
> Adds an **“Extended Thinking” (adaptive reasoning)** capability that can be toggled in the TUI and persisted to config (`reasoningEnabled`). The toggle is shown only for supported Claude models via new `modelSupportsThinking()` detection.
> 
> Threads `enableThinking` through the offensive-security agent harness, orchestration tools, workflows, and specialized agents so sub-agents inherit the setting; the operator dashboard passes the UI flag into agent creation.
> 
> Updates the AI layer to pass Anthropic `providerOptions` for adaptive thinking when enabled, and extends the Pensar provider/formatters to round-trip `thinking` blocks (including signature) by emitting/parsing `reasoning-*` stream events and mapping them into request/response message formats. Includes a small test fix to ensure default W&B project behavior when `WANDB_PROJECT` is set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7ccdf85aeafb4f7b58e4f873696fe369985908c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->