### PR TITLE
fix: handle opentui PasteEvent API change (bytes instead of text)

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -24,8 +24,8 @@ jobs:
               'jorgeraad',
             ];
 
-            const author = context.payload.pull_request.user.login;
-            const eligible = team.filter((m) => m !== author);
+            const author = context.payload.pull_request.user.login.toLowerCase();
+            const eligible = team.filter((m) => m.toLowerCase() !== author);
             if (eligible.length === 0) return;
 
             const { data: recentPRs } = await github.rest.pulls.list({

--- a/src/tui/components/chat/input-area.tsx
+++ b/src/tui/components/chat/input-area.tsx
@@ -463,8 +463,14 @@ function ApprovalInputArea({
           width="100%"
           value={redirectInput}
           onInput={setRedirectInput}
-          onPaste={(event) => {
-            const cleaned = String(event.text).replace(/\r?\n/g, " ");
+          onPaste={(event: any) => {
+            const raw =
+              typeof event.text === "string"
+                ? event.text
+                : event.bytes instanceof Uint8Array
+                  ? new TextDecoder().decode(event.bytes)
+                  : String(event.text ?? "");
+            const cleaned = raw.replace(/\r?\n/g, " ");
             setRedirectInput(cleaned);
           }}
           focused={focusedElement === 2}

--- a/src/tui/components/shared/approval-prompt.tsx
+++ b/src/tui/components/shared/approval-prompt.tsx
@@ -136,8 +136,14 @@ export function ApprovalInputArea({
           width="100%"
           value={redirectInput}
           onInput={setRedirectInput}
-          onPaste={(event) => {
-            const cleaned = String(event.text).replace(/\r?\n/g, " ");
+          onPaste={(event: any) => {
+            const raw =
+              typeof event.text === "string"
+                ? event.text
+                : event.bytes instanceof Uint8Array
+                  ? new TextDecoder().decode(event.bytes)
+                  : String(event.text ?? "");
+            const cleaned = raw.replace(/\r?\n/g, " ");
             setRedirectInput(cleaned);
           }}
           focused={focusedElement === 2}

--- a/src/tui/components/shared/use-paste-extmarks.ts
+++ b/src/tui/components/shared/use-paste-extmarks.ts
@@ -9,6 +9,21 @@ interface PasteEntry {
 const LARGE_PASTE_MIN_LINES = 5;
 const LARGE_PASTE_MIN_CHARS = 500;
 
+const pasteDecoder = new TextDecoder();
+
+/**
+ * Extract the pasted text string from a PasteEvent.
+ *
+ * @opentui/core ≤0.1.84 provides `event.text` (string).
+ * @opentui/core ≥0.1.95 provides `event.bytes` (Uint8Array) instead.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractPasteText(event: any): string {
+  if (typeof event.text === "string") return event.text;
+  if (event.bytes instanceof Uint8Array) return pasteDecoder.decode(event.bytes);
+  return String(event.text ?? event.bytes ?? "");
+}
+
 /**
  * Manages virtual extmarks for large pasted text.
  *
@@ -35,11 +50,12 @@ export function usePasteExtmarks(
    * Intercepts large pastes (5+ lines or 500+ chars) and inserts a
    * virtual extmark placeholder instead.
    */
-  const handlePaste = (event: { text: string; preventDefault: () => void }) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handlePaste = (event: any) => {
     const textarea = textareaRef.current;
     if (!textarea) return;
 
-    const text = event.text;
+    const text = extractPasteText(event);
     const lineCount = text.split("\n").length;
 
     if (

--- a/src/tui/components/shared/use-paste-extmarks.ts
+++ b/src/tui/components/shared/use-paste-extmarks.ts
@@ -20,7 +20,8 @@ const pasteDecoder = new TextDecoder();
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function extractPasteText(event: any): string {
   if (typeof event.text === "string") return event.text;
-  if (event.bytes instanceof Uint8Array) return pasteDecoder.decode(event.bytes);
+  if (event.bytes instanceof Uint8Array)
+    return pasteDecoder.decode(event.bytes);
   return String(event.text ?? event.bytes ?? "");
 }
 


### PR DESCRIPTION
## Summary
- `@opentui/core` ≥0.1.95 changed `PasteEvent` from `.text` (string) to `.bytes` (Uint8Array). Since `package.json` specifies `^0.1.80`, any fresh `npm install` resolves to 0.1.95.
- All three paste handlers (`use-paste-extmarks.ts`, `input-area.tsx`, `approval-prompt.tsx`) read `event.text` which is now `undefined`, causing `text.split()` to throw. The error is silently swallowed by `processPaste`'s try/catch in opentui, making paste completely non-functional.
- Adds `extractPasteText()` helper that handles both the old `.text` API and the new `.bytes` API, so paste works regardless of which opentui version is resolved.

## Test plan
- [ ] `bun run dev` — paste large text (≥500 chars) in operator directive input, verify placeholder appears and resolves on submit
- [ ] `npm pack && npm install -g` — paste in the npm-installed version (which gets opentui 0.1.95), verify paste works
- [ ] Paste in approval redirect input, verify text appears

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized input-handling changes to tolerate both `event.text` and `event.bytes`, plus a minor workflow tweak; main risk is regressions in paste decoding/line counting across terminals.
> 
> **Overview**
> Fixes broken paste handling after `@opentui/core` changed `PasteEvent` from `text` to `bytes` by decoding paste content from either shape.
> 
> Updates the TUI paste handlers in `use-paste-extmarks`, `chat/input-area`, and `shared/approval-prompt` to normalize pasted content (including newline cleanup) before processing, and adjusts the PR auto-assign workflow to compare author/team logins case-insensitively.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 356ace54b32ab9e35fbd3d554104f8c829c3aa22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->