### PR TITLE
Fix: Resume Session Re-enters Most Recent Mode

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -326,6 +326,13 @@ export default function OperatorDashboard({
                   })),
                 );
               }
+
+              // Restore plan content from a prior session so the cycleMode
+              // gate doesn't force a redundant re-approval on Shift+Tab.
+              const planContent = readPlan(s.rootPath);
+              if (planContent) {
+                setApprovedPlanContent(planContent);
+              }
             }
           } else if (s.config?.operatorSettings) {
             const settings = s.config.operatorSettings;
@@ -1760,6 +1767,14 @@ export default function OperatorDashboard({
       requireApproval: next === "manual",
     }));
     setOperatorMode(next);
+
+    // Persist mode so resumed sessions start in the correct mode
+    const sid = sessionRef.current?.id;
+    if (sid) {
+      sessions
+        .updateOperatorSettings(sid, { initialMode: next })
+        .catch((e) => console.error("[operator] Failed to persist mode:", e));
+    }
   }, []);
 
   // Cycle through operator modes: approvals-on → approvals-off → plan

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -329,9 +329,13 @@ export default function OperatorDashboard({
 
               // Restore plan content from a prior session so the cycleMode
               // gate doesn't force a redundant re-approval on Shift+Tab.
-              const planContent = readPlan(s.rootPath);
-              if (planContent) {
-                setApprovedPlanContent(planContent);
+              // Only mark the plan as approved if the user previously left
+              // plan mode (restoredMode !== "plan"), which signals prior approval.
+              if (restoredMode !== "plan") {
+                const planContent = readPlan(s.rootPath);
+                if (planContent) {
+                  setApprovedPlanContent(planContent);
+                }
               }
             }
           } else if (s.config?.operatorSettings) {


### PR DESCRIPTION
## Summary

Fixes a bug where resuming an operator session that previously had a plan would incorrectly re-enter plan mode and trap the user — Shift+Tab would show the plan approval prompt instead of cycling modes, even when the plan had already been submitted and executed.

## Root Cause

Two persistence gaps in `operator-dashboard/index.tsx`:

**1. Operator mode was never persisted on transition.**
When the user (or agent) transitioned out of plan mode (e.g. plan approved → manual mode), `transitionToMode()` only updated React state. The session config on disk still had `initialMode: "plan"`. On resume, `loadOperatorState()` in `session/index.ts:633` read the stale `initialMode` from config and restored the session into plan mode regardless of what mode the user was actually in when they closed the session.

**2. `approvedPlanContent` was never restored on resume.**
`approvedPlanContent` is initialized as `null` and was never populated during session restore. The `cycleMode` gate checks `!approvedPlanRef.current` — if a plan file exists but `approvedPlanContent` is null, it assumes the plan hasn't been approved yet and blocks Shift+Tab with a plan review prompt. This created an inescapable loop: the user couldn't cycle away from plan mode because the gate kept forcing re-approval of an already-executed plan.

## Fix

**`transitionToMode` now persists the mode to session config.** Calls `sessions.updateOperatorSettings(sid, { initialMode: next })` as a fire-and-forget write. On next resume, `loadOperatorState` reads the correct mode instead of the stale original.

**`loadSession` now restores plan content from disk on resume.** If a plan file exists (regardless of current mode), it's loaded into `approvedPlanContent`. This satisfies the `cycleMode` gate so Shift+Tab works immediately without forcing redundant re-approval.

## Test plan

- [x] Create an operator session with `--mode=plan`
- [x] Let the agent create and submit a plan
- [x] Approve the plan and let it execute
- [x] Close the session
- [x] Resume the session via `/resume`
- [x] Verify the session resumes in the correct mode (not forced back into plan)
- [x] Verify Shift+Tab cycles through modes freely without showing plan review
- [x] Verify that resuming a session mid-plan (plan not yet submitted) still works correctly
- [x] Verify that resuming a non-plan session is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session-resume behavior and writes operator settings to persisted session config, which could impact how existing sessions reopen or how mode gating behaves if the persisted state is inconsistent.
> 
> **Overview**
> Fixes operator session resume getting stuck in `plan` mode by **persisting operator mode transitions** to session config and **rehydrating approved plan content** on load.
> 
> `transitionToMode()` now calls `sessions.updateOperatorSettings(..., { initialMode: next })` so resumed sessions start in the last-used mode. During `loadSession()`, when restoring a session that previously left `plan` mode, the dashboard reads the on-disk plan and sets `approvedPlanContent` to prevent `cycleMode` from forcing redundant plan re-approval on Shift+Tab.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee2ed13d3dd6f9585904c2a9d028e930054daa5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->