### PR TITLE
fix: handle malformed tool names from non-Anthropic Bedrock models

### DIFF
--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -2,6 +2,7 @@ import type { AnthropicMessagesModelId } from "@ai-sdk/anthropic/internal";
 import type { OpenAIChatModelId } from "@ai-sdk/openai/internal";
 import {
   generateText,
+  NoSuchToolError,
   Output,
   streamText,
   type LanguageModel,
@@ -459,16 +460,45 @@ export function streamResponse(
             }
           }
 
-          // Get the actual tool definition which contains the Zod schema
-          const tool = tools[toolCall.toolName];
-          if (!tool || !tool.inputSchema) {
-            throw new Error(
-              `Tool ${toolCall.toolName} not found or has no schema`,
+          // Get the actual tool definition which contains the Zod schema.
+          // Some models (e.g. Kimi K2.5) emit malformed tool names that
+          // include internal tokens or partial JSON. When the tool name
+          // doesn't match, try to fuzzy-match against available tools.
+          let resolvedToolName = toolCall.toolName;
+          let tool = tools[resolvedToolName];
+
+          if (!tool && NoSuchToolError.isInstance(error)) {
+            const available = Object.keys(tools);
+            // Try to find a known tool name embedded in the garbage string
+            const match = available.find(
+              (name) =>
+                toolCall.toolName.includes(name) ||
+                (toolCall.input && toolCall.input.includes(`"${name}"`)),
             );
+            if (match) {
+              resolvedToolName = match;
+              tool = tools[resolvedToolName];
+              if (!silent) {
+                console.log(
+                  `   Resolved malformed tool name "${toolCall.toolName}" -> "${resolvedToolName}"`,
+                );
+              }
+            }
+          }
+
+          if (!tool || !tool.inputSchema) {
+            // Cannot repair — return null so AI SDK marks it as an
+            // invalid tool call instead of crashing the stream.
+            if (!silent) {
+              console.error(
+                `Tool "${toolCall.toolName}" not found or has no schema, skipping repair`,
+              );
+            }
+            return null;
           }
 
           // Get JSONSchema7 for display purposes
-          const jsonSchema = inputSchema({ toolName: toolCall.toolName });
+          const jsonSchema = inputSchema({ toolName: resolvedToolName });
 
           const { output: repairedArgs, usage: repairUsage } =
             await generateText({
@@ -477,7 +507,7 @@ export function streamResponse(
                 schema: tool.inputSchema, // Use the actual Zod schema from the tool
               }),
               prompt: [
-                `The model tried to call the tool "${toolCall.toolName}"` +
+                `The model tried to call the tool "${resolvedToolName}"` +
                   ` with the following inputs:`,
                 toolCall.input,
                 `The tool accepts the following schema:`,
@@ -523,13 +553,17 @@ export function streamResponse(
             >[0]);
           }
 
-          // Return the tool call with stringified repaired arguments
+          // Return the tool call with repaired tool name and arguments
           if (repairedArgs === undefined || repairedArgs === null) {
             throw new Error(
-              `Tool call repair for "${toolCall.toolName}" produced no valid output`,
+              `Tool call repair for "${resolvedToolName}" produced no valid output`,
             );
           }
-          return { ...toolCall, input: JSON.stringify(repairedArgs) };
+          return {
+            ...toolCall,
+            toolName: resolvedToolName,
+            input: JSON.stringify(repairedArgs),
+          };
         } catch (repairError) {
           if (!silent) {
             console.error(
@@ -539,7 +573,9 @@ export function streamResponse(
                 : String(repairError),
             );
           }
-          throw repairError;
+          // Return null instead of throwing so the AI SDK gracefully
+          // marks this as an invalid tool call rather than crashing.
+          return null;
         }
       },
       onFinish,

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -128,7 +128,11 @@ function wrapStreamWithErrorHandler(
           wrappedStream = (async function* () {
             try {
               for await (const chunk of originalStream.fullStream) {
-                if (chunk.type === "error" || "error" in chunk) {
+                // Only treat explicit error stream parts as fatal.
+                // Other chunk types (tool-call, tool-error) may carry an
+                // `error` property for informational purposes (e.g. invalid
+                // tool calls) and should be yielded normally.
+                if (chunk.type === "error") {
                   const error =
                     "error" in chunk
                       ? (chunk as unknown as { error: unknown }).error

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -436,7 +436,24 @@ export function createPensarModel(
                     });
                   } else if (cbType === "tool_use") {
                     activeToolId = (cb?.id as string) ?? `tool-${Date.now()}`;
-                    activeToolName = (cb?.name as string) ?? "unknown";
+                    // Some non-Anthropic Bedrock models (e.g. Kimi K2.5)
+                    // leak internal tokens into the tool name, producing
+                    // strings like "tooluse_<id> <|token|> {\"arg...".
+                    // Sanitize to the first valid identifier segment so
+                    // the name stays within Bedrock's constraints
+                    // ([a-zA-Z0-9_-]{1,64}).
+                    const rawToolName =
+                      (cb?.name as string) ?? "unknown";
+                    const sanitized = rawToolName
+                      .split(/[\s<|{]/)[0]
+                      .replace(/[^a-zA-Z0-9_-]/g, "")
+                      .slice(0, 64);
+                    activeToolName = sanitized || "unknown_tool";
+                    if (activeToolName !== rawToolName) {
+                      logInfo(
+                        `  sanitized tool name: "${rawToolName}" -> "${activeToolName}"`,
+                      );
+                    }
                     activeToolInput = "";
                     controller.enqueue({
                       type: "tool-input-start",


### PR DESCRIPTION
## Summary
- Models like Kimi K2.5 leak internal tokens (`<|tool_call_argument_begin|>`) into the tool name field during Bedrock streaming, causing `NoSuchToolError` crashes that kill the eval run
- The `experimental_repairToolCall` callback now fuzzy-matches malformed tool names against available tools by checking if a valid name is embedded in the garbage string
- Returns `null` instead of throwing when repair isn't possible, so the AI SDK gracefully marks the call as invalid instead of crashing the stream

## Test plan
- [ ] Re-run argus validation with Kimi K2.5
- [ ] Verify Anthropic models (Claude) still work normally with tool calling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming/tool-call repair paths; behavior changes from throwing to yielding/marking invalid tool calls could mask some errors but should prevent eval runs from aborting.
> 
> **Overview**
> Prevents Bedrock/non-Anthropic model tool-calling glitches from crashing `streamResponse`.
> 
> In `ai.ts`, stream consumption now only treats `TextStreamPart` chunks with `type === "error"` as fatal (instead of any chunk carrying an `error` field), and `experimental_repairToolCall` now (1) fuzzy-resolves malformed tool names when the failure is a `NoSuchToolError`, (2) repairs against the resolved tool’s schema, and (3) returns `null` (not thrown errors) when a tool can’t be found/repaired so the AI SDK marks the call invalid.
> 
> In `providers/pensar.ts`, tool names emitted during Bedrock SSE streaming are sanitized to a Bedrock-safe identifier segment (stripping leaked tokens/JSON, filtering characters, and truncating to 64 chars) with logging when a rename occurs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcc9e239f611f5be8450ad6474ab425f0489d320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->