### PR TITLE
feat: export event types and domain types from API barrel

### DIFF
--- a/src/core/api/attackSurface.ts
+++ b/src/core/api/attackSurface.ts
@@ -51,10 +51,6 @@ async function runBlackboxAttackSurface(
 
   const { results, targets, resultsPath, assetsPath } = await agent.consume();
 
-  console.log(`\nIdentified ${targets.length} targets for deep testing`);
-  console.log(`Results: ${resultsPath}`);
-  console.log(`Assets: ${assetsPath}`);
-
   return { results, targets, resultsPath, assetsPath };
 }
 
@@ -74,12 +70,6 @@ async function runWhiteboxAttackSurface(
     attackSurfaceRegistry: input.attackSurfaceRegistry,
     eventBus: input.eventBus,
   });
-
-  console.log(
-    `\nWhitebox analysis complete: ${result.summary.totalApps} apps, ` +
-      `${result.summary.totalApiEndpoints} API endpoints, ` +
-      `${result.summary.totalPages} pages`,
-  );
 
   return result;
 }

--- a/src/core/api/benchmark.ts
+++ b/src/core/api/benchmark.ts
@@ -11,25 +11,7 @@ export async function runBenchmarkComparisonAgent(
 ) {
   const agent = new BenchmarkComparisonAgent(input);
 
-  agent.eventBus.on("text-delta", (d) => process.stdout.write(d.text));
-  agent.eventBus.on("tool-call-complete", (d) =>
-    console.log(`→ calling ${d.toolName}`),
-  );
-  agent.eventBus.on("tool-result", (d) =>
-    console.log(`✓ ${d.toolName} completed`),
-  );
-  agent.eventBus.on("error", (d) => console.error("Agent error:", d.error));
-
   const { comparison, resultsPath } = await agent.consume();
-
-  if (comparison) {
-    console.log(
-      `\nComparison: ${comparison.matched.length}/${comparison.totalExpected} matched, ` +
-        `Precision: ${Math.round(comparison.precision * 100)}%, ` +
-        `Recall: ${Math.round(comparison.recall * 100)}%`,
-    );
-  }
-  console.log(`Results: ${resultsPath}`);
 
   return { comparison, resultsPath };
 }

--- a/src/core/api/blackboxPentest.ts
+++ b/src/core/api/blackboxPentest.ts
@@ -32,10 +32,5 @@ export async function runPentestAgent(
       eventBus: input.eventBus,
     });
 
-  console.log(`\nFound ${findings.length} vulnerabilities`);
-  console.log(`Findings: ${findingsPath}`);
-  console.log(`POCs: ${pocsPath}`);
-  if (reportPath) console.log(`Report: ${reportPath}`);
-
   return { findings, findingsPath, pocsPath, reportPath };
 }

--- a/src/core/api/environment.ts
+++ b/src/core/api/environment.ts
@@ -4,32 +4,12 @@ import type { EnvironmentResult } from "../agents/specialized/environment/types"
 
 export type { EnvironmentResult, EnvironmentAgentInput };
 
-function attachDefaultEnvironmentStreamListeners(
-  agent: EnvironmentAgent,
-): void {
-  agent.eventBus.on("text-delta", (e) => {
-    process.stdout.write(e.text);
-  });
-  agent.eventBus.on("tool-call-complete", (e) => {
-    console.log(`→ calling ${e.toolName}`);
-  });
-  agent.eventBus.on("tool-result", (e) => {
-    console.log(`✓ ${e.toolName} completed`);
-  });
-  agent.eventBus.on("error", (e) => {
-    console.error("Environment agent error:", e.error);
-  });
-}
-
 /**
  * Run the environment agent to set up a development environment in a sandbox.
  *
  * The agent reads project files, starts services, and validates the
  * environment is healthy. When a sandbox is provided in the input,
  * tools automatically route operations through it.
- *
- * When no `eventBus` is passed on the input, default stdout / console
- * listeners are attached to the agent's bus for local CLI use.
  *
  * @returns Structured result with application URL, status, steps taken,
  *          and authentication details.
@@ -38,8 +18,5 @@ export async function runEnvironmentAgent(
   input: EnvironmentAgentInput,
 ): Promise<EnvironmentResult> {
   const agent = new EnvironmentAgent(input);
-  if (!input.eventBus) {
-    attachDefaultEnvironmentStreamListeners(agent);
-  }
   return agent.consume();
 }

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -12,11 +12,7 @@ export { runOffensiveSecurityAgent, type RunAgentResult } from "./offesecAgent";
 // ---- Event types ----
 // AgentEventBus class is NOT exported — it's an internal implementation
 // detail. Consumers interact with events via AgentRun<T> (Phase 3).
-export type {
-  AgentEventName,
-  AgentEvent,
-  AgentEventOf,
-} from "../eventBus";
+export type { AgentEventName, AgentEvent, AgentEventOf } from "../eventBus";
 
 // ---- Domain types — findings ----
 export { ApexFindingObject } from "../agents/offSecAgent/types";

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -1,3 +1,4 @@
+// ---- Agent runners ----
 export * from "./attackSurface";
 export * from "./authentication";
 export * from "./benchmark";
@@ -6,3 +7,60 @@ export * from "./targetedPentest";
 export * from "./threatModel";
 export * from "./patching";
 export * from "./environment";
+export { runOffensiveSecurityAgent, type RunAgentResult } from "./offesecAgent";
+
+// ---- Event types ----
+// AgentEventBus class is NOT exported — it's an internal implementation
+// detail. Consumers interact with events via AgentRun<T> (Phase 3).
+export type {
+  AgentEventName,
+  AgentEvent,
+  AgentEventOf,
+} from "../eventBus";
+
+// ---- Domain types — findings ----
+export { ApexFindingObject } from "../agents/offSecAgent/types";
+export type { Finding } from "../agents/offSecAgent/types";
+
+// ---- Domain types — attack surface ----
+export type {
+  DocumentedAppRecord,
+  DocumentedEndpointRecord,
+  AppType,
+  EndpointType,
+  RiskLevel,
+  AttackSurfaceReport,
+  AttackSurfaceSummary,
+  PentestTarget,
+} from "../agents/specialized/attackSurface/schemas";
+
+// ---- Domain types — authentication ----
+export type {
+  AuthCredentials,
+  AuthFlowHints,
+  AuthMethod,
+  AuthBarrier,
+  AuthenticationSubagentInput,
+  AuthenticationSubagentResult,
+} from "../agents/specialized/authenticationAgent/types";
+
+// ---- Agent input/result types ----
+export type { PentestAgentInput } from "../agents/specialized/pentest/agent";
+export type { PentestResult } from "../agents/specialized/pentest/agent";
+export type {
+  AttackSurfaceAgentInput,
+  AttackSurfaceResult,
+} from "../agents/specialized/attackSurface/blackboxAgent";
+export type { WhiteboxAttackSurfaceResult } from "../agents/specialized/whiteboxAttackSurface";
+// Note: EnvironmentResult is already re-exported via ./environment
+export type {
+  PentestWorkflowInput,
+  PentestWorkflowResult,
+} from "../workflows/pentest";
+
+// ---- AI types ----
+export type { AIModel } from "../ai";
+export type { AIAuthConfig } from "../ai/utils";
+
+// ---- Session types ----
+export type { SessionInfo, SessionConfig } from "../session";

--- a/src/core/api/patching.ts
+++ b/src/core/api/patching.ts
@@ -4,21 +4,6 @@ import type { PatchResult } from "../agents/specialized/patching/types";
 
 export type { PatchResult, PatchingAgentInput };
 
-function attachDefaultPatchingStreamListeners(agent: PatchingAgent): void {
-  agent.eventBus.on("text-delta", (e) => {
-    process.stdout.write(e.text);
-  });
-  agent.eventBus.on("tool-call-complete", (e) => {
-    console.log(`→ calling ${e.toolName}`);
-  });
-  agent.eventBus.on("tool-result", (e) => {
-    console.log(`✓ ${e.toolName} completed`);
-  });
-  agent.eventBus.on("error", (e) => {
-    console.error("Patching agent error:", e.error);
-  });
-}
-
 /**
  * Run the patching agent to fix a security vulnerability in a codebase.
  *
@@ -26,17 +11,11 @@ function attachDefaultPatchingStreamListeners(agent: PatchingAgent): void {
  * lint, type-check, and tests. When a sandbox is provided in the input,
  * tools automatically route operations through it.
  *
- * When no `eventBus` is passed on the input, default stdout / console
- * listeners are attached to the agent's bus for local CLI use.
- *
  * @returns Structured patch result with file changes and PR metadata.
  */
 export async function runPatchingAgent(
   input: PatchingAgentInput,
 ): Promise<PatchResult> {
   const agent = new PatchingAgent(input);
-  if (!input.eventBus) {
-    attachDefaultPatchingStreamListeners(agent);
-  }
   return agent.consume();
 }

--- a/src/core/api/targetedPentest.ts
+++ b/src/core/api/targetedPentest.ts
@@ -5,24 +5,8 @@ import {
 
 export async function runTargetedPentestAgent(input: PentestAgentInput) {
   const agent = new TargetedPentestAgent(input);
-
-  if (!input.eventBus) {
-    agent.eventBus.on("text-delta", (d) => process.stdout.write(d.text));
-    agent.eventBus.on("tool-call-complete", (d) =>
-      console.log(`→ calling ${d.toolName}`),
-    );
-    agent.eventBus.on("tool-result", (d) =>
-      console.log(`✓ ${d.toolName} completed`),
-    );
-    agent.eventBus.on("error", (d) => console.error("Agent error:", d.error));
-  }
-
   const { findings, findingsPath, pocsPath, objectiveResults } =
     await agent.consume();
-
-  console.log(`\nFound ${findings.length} vulnerabilities`);
-  console.log(`Findings: ${findingsPath}`);
-  console.log(`POCs: ${pocsPath}`);
 
   return { findings, findingsPath, pocsPath, objectiveResults };
 }

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -63,6 +63,35 @@ export type AgentEventMap = {
   };
 };
 
+/** Union of all event names on the AgentEventBus. */
+export type AgentEventName = keyof AgentEventMap;
+
+/**
+ * Discriminated union of all agent events, suitable for streaming.
+ * Each variant carries a `type` discriminator matching the event name
+ * and a `data` field with the event-specific payload.
+ */
+export type AgentEvent =
+  | { type: "text-delta"; data: AgentEventMap["text-delta"] }
+  | { type: "tool-call-start"; data: AgentEventMap["tool-call-start"] }
+  | { type: "tool-call-delta"; data: AgentEventMap["tool-call-delta"] }
+  | { type: "tool-call-complete"; data: AgentEventMap["tool-call-complete"] }
+  | { type: "tool-result"; data: AgentEventMap["tool-result"] }
+  | { type: "subagent-spawn"; data: AgentEventMap["subagent-spawn"] }
+  | { type: "subagent-complete"; data: AgentEventMap["subagent-complete"] }
+  | { type: "workflow-phase-start"; data: AgentEventMap["workflow-phase-start"] }
+  | { type: "workflow-phase-complete"; data: AgentEventMap["workflow-phase-complete"] }
+  | { type: "step-finish"; data: AgentEventMap["step-finish"] }
+  | { type: "command-output"; data: AgentEventMap["command-output"] }
+  | { type: "error"; data: AgentEventMap["error"] }
+  | { type: "trace-record"; data: AgentEventMap["trace-record"] };
+
+/**
+ * Extract the event type for a specific event name.
+ * Usage: `AgentEventOf<"text-delta">` → `{ text: string; subagentId?: string }`
+ */
+export type AgentEventOf<K extends AgentEventName> = AgentEventMap[K];
+
 /**
  * Centralized, typed event bus for agent streaming output.
  *

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -112,6 +112,10 @@ export class AgentEventBus {
 
   constructor() {
     this.emitter.setMaxListeners(50);
+    // Prevent Node.js EventEmitter from throwing when "error" is emitted
+    // with no registered listeners (e.g. when API runners call consume()
+    // without attaching an external error handler).
+    this.emitter.on("error", () => {});
   }
 
   on<K extends keyof AgentEventMap>(

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -79,8 +79,14 @@ export type AgentEvent =
   | { type: "tool-result"; data: AgentEventMap["tool-result"] }
   | { type: "subagent-spawn"; data: AgentEventMap["subagent-spawn"] }
   | { type: "subagent-complete"; data: AgentEventMap["subagent-complete"] }
-  | { type: "workflow-phase-start"; data: AgentEventMap["workflow-phase-start"] }
-  | { type: "workflow-phase-complete"; data: AgentEventMap["workflow-phase-complete"] }
+  | {
+      type: "workflow-phase-start";
+      data: AgentEventMap["workflow-phase-start"];
+    }
+  | {
+      type: "workflow-phase-complete";
+      data: AgentEventMap["workflow-phase-complete"];
+    }
   | { type: "step-finish"; data: AgentEventMap["step-finish"] }
   | { type: "command-output"; data: AgentEventMap["command-output"] }
   | { type: "error"; data: AgentEventMap["error"] }


### PR DESCRIPTION
## Summary

Phase 1 of [Apex SDK Surface design](https://github.com/pensarai/apex/blob/canary/.jraad/docs/design-docs/20260406141012-apex-sdk-surface.md). Establishes a single import entry point for all SDK consumers.

- Add `AgentEventName`, `AgentEvent` (discriminated union), and `AgentEventOf<K>` type exports to `eventBus.ts`
- Expand `src/core/api/index.ts` barrel to re-export domain types (findings, attack surface, auth, session, AI), agent input/result types, and event types
- Remove `console.log` / stdout listeners from all API runner functions — SDK functions should have no stdout side effects
- `runOffensiveSecurityAgent` and `RunAgentResult` now exported from the barrel

After this PR, Console can consolidate all Apex imports to `@pensar/apex/src/core/api`.

## Test plan

- [x] `bun run build` passes
- [x] All 584 tests pass
- [ ] Verify Console can import types from the barrel (Phase 4 — separate repo)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to API surface changes (new re-exports and removed default stdout/log side effects) that can affect downstream SDK consumers, though core agent logic is largely untouched.
> 
> **Overview**
> **SDK API surface is consolidated** by expanding `src/core/api/index.ts` into a primary barrel export for agent runners plus key domain/input/output types (findings, attack surface, auth, AI, session) and `runOffensiveSecurityAgent`.
> 
> **Streaming/event typing is formalized** by exporting `AgentEventName`, a discriminated-union `AgentEvent`, and `AgentEventOf<K>` from `src/core/eventBus.ts`, and making `AgentEventBus` safe to use without an explicit `error` listener.
> 
> **All API runner functions are made side-effect free** by removing default `console.log`/`process.stdout` event listeners and summary printing from the attack surface, benchmark, pentest, patching, and environment runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5790863cc5ec14ba3b32f28b9fbc319205227733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->