### PR TITLE
feat: add AgentRun<T> async iterable wrapper for SDK consumers

### DIFF
--- a/scripts/attack-surface.ts
+++ b/scripts/attack-surface.ts
@@ -5,7 +5,6 @@ import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { sessions } from "../src/core/session";
 import { runAttackSurfaceAgent } from "../src/core/api";
-import { AgentEventBus } from "../src/core/eventBus";
 import { config } from "dotenv";
 
 config();
@@ -100,22 +99,32 @@ async function runAttackSurface(options: AttackSurfaceOptions): Promise<void> {
       },
     });
 
-    const bus = new AgentEventBus();
-    bus.on("text-delta", (d) => process.stdout.write(d.text));
-    bus.on("tool-call-complete", (d) =>
-      console.log(
-        `\n→ calling ${d.toolName} \n ${JSON.stringify(d.args, null, 2)}`,
-      ),
-    );
-    bus.on("tool-result", (d) => console.log(`✓ ${d.toolName} completed`));
-    bus.on("error", (d) => console.error(d.error));
-
-    const result = await runAttackSurfaceAgent({
+    const run = runAttackSurfaceAgent({
       target: TARGET_URL,
       model: "claude-haiku-4-5",
       session,
-      eventBus: bus,
     });
+
+    for await (const event of run) {
+      switch (event.type) {
+        case "text-delta":
+          process.stdout.write(event.data.text);
+          break;
+        case "tool-call-complete":
+          console.log(
+            `\n→ calling ${event.data.toolName} \n ${JSON.stringify(event.data.args, null, 2)}`,
+          );
+          break;
+        case "tool-result":
+          console.log(`✓ ${event.data.toolName} completed`);
+          break;
+        case "error":
+          console.error(event.data.error);
+          break;
+      }
+    }
+
+    const result = await run.result;
 
     console.log(`Session ID: ${session.id}`);
     console.log(`Session Path: ${session.rootPath}`);

--- a/scripts/auth.ts
+++ b/scripts/auth.ts
@@ -26,7 +26,6 @@ import type { AuthCredentials } from "../src/core/agents/specialized/authenticat
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { runAuthenticationAgent } from "../src/core/api";
-import { AgentEventBus } from "../src/core/eventBus";
 import { config } from "dotenv";
 
 config();
@@ -128,20 +127,30 @@ async function runAuth(options: AuthOptions): Promise<void> {
       console.log("=".repeat(80));
       console.log();
 
-      const bus = new AgentEventBus();
-      bus.on("text-delta", (d) => process.stdout.write(d.text));
-      bus.on("tool-call-complete", (d) =>
-        console.log(`→ calling ${d.toolName}`),
-      );
-      bus.on("tool-result", (d) => console.log(`✓ ${d.toolName} completed`));
-      bus.on("error", (d) => console.error("Agent error:", d.error));
-
-      const result = await runAuthenticationAgent({
+      const run = runAuthenticationAgent({
         session,
         model: model as AIModel,
         target,
-        eventBus: bus,
       });
+
+      for await (const event of run) {
+        switch (event.type) {
+          case "text-delta":
+            process.stdout.write(event.data.text);
+            break;
+          case "tool-call-complete":
+            console.log(`→ calling ${event.data.toolName}`);
+            break;
+          case "tool-result":
+            console.log(`✓ ${event.data.toolName} completed`);
+            break;
+          case "error":
+            console.error("Agent error:", event.data.error);
+            break;
+        }
+      }
+
+      const result = await run.result;
 
       console.log();
       console.log("=".repeat(80));
@@ -180,7 +189,7 @@ async function runAuth(options: AuthOptions): Promise<void> {
       target,
       session,
       model: model as AIModel,
-    });
+    }).result;
 
     console.log();
     console.log("=".repeat(80));

--- a/scripts/blackbox-pentest.ts
+++ b/scripts/blackbox-pentest.ts
@@ -1,6 +1,5 @@
 import { runPentestAgent } from "../src/core/api";
 import { sessions } from "../src/core/session";
-import { AgentEventBus } from "../src/core/eventBus";
 import { config } from "dotenv";
 
 config();
@@ -20,19 +19,30 @@ export async function runBlackboxPentest() {
     },
   });
 
-  const bus = new AgentEventBus();
-  bus.on("text-delta", (d) => process.stdout.write(d.text));
-  bus.on("tool-call-complete", (d) => console.log(`→ calling ${d.toolName}`));
-  bus.on("tool-result", (d) => console.log(`✓ ${d.toolName} completed`));
-  bus.on("error", (d) => console.error(d.error));
+  const run = runPentestAgent({
+    target: TARGET_URL,
+    session,
+    model: "claude-haiku-4-5",
+  });
 
-  const { findings, findingsPath, pocsPath, reportPath } =
-    await runPentestAgent({
-      target: TARGET_URL,
-      session,
-      model: "claude-haiku-4-5",
-      eventBus: bus,
-    });
+  for await (const event of run) {
+    switch (event.type) {
+      case "text-delta":
+        process.stdout.write(event.data.text);
+        break;
+      case "tool-call-complete":
+        console.log(`→ calling ${event.data.toolName}`);
+        break;
+      case "tool-result":
+        console.log(`✓ ${event.data.toolName} completed`);
+        break;
+      case "error":
+        console.error(event.data.error);
+        break;
+    }
+  }
+
+  const { findings, findingsPath, pocsPath, reportPath } = await run.result;
 }
 
 runBlackboxPentest().catch(console.error);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,6 @@ import packageJson from "../package.json";
 import { getCurrentVersion, upgrade } from "./core/installation";
 import { buildAuthConfig } from "./core/ai/utils";
 import { resolvePentestMode } from "./core/cli/pentestMode";
-import { AgentEventBus } from "./core/eventBus";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -43,13 +42,6 @@ function getAllArgs(flag: string, argv = args): string[] {
     }
   }
   return values;
-}
-
-function attachCliAgentStreamListeners(bus: AgentEventBus): void {
-  bus.on("text-delta", (d) => process.stdout.write(d.text));
-  bus.on("tool-call-complete", (d) => console.log(`\n→ ${d.toolName}`));
-  bus.on("tool-result", (d) => console.log(`✓ ${d.toolName} completed`));
-  bus.on("error", (d) => console.error("Error:", d.error));
 }
 
 // ---------------------------------------------------------------------------
@@ -142,18 +134,32 @@ Model:   ${model}
     },
   });
 
-  const pentestBus = new AgentEventBus();
-  attachCliAgentStreamListeners(pentestBus);
+  const run = runPentestAgent({
+    target,
+    ...(cwd ? { cwd } : {}),
+    session,
+    model,
+    authConfig: buildAuthConfig(pensarConfig),
+  });
 
-  const { findings, findingsPath, pocsPath, reportPath } =
-    await runPentestAgent({
-      target,
-      ...(cwd ? { cwd } : {}),
-      session,
-      model,
-      authConfig: buildAuthConfig(pensarConfig),
-      eventBus: pentestBus,
-    });
+  for await (const event of run) {
+    switch (event.type) {
+      case "text-delta":
+        process.stdout.write(event.data.text);
+        break;
+      case "tool-call-complete":
+        console.log(`\n→ ${event.data.toolName}`);
+        break;
+      case "tool-result":
+        console.log(`✓ ${event.data.toolName} completed`);
+        break;
+      case "error":
+        console.error("Error:", event.data.error);
+        break;
+    }
+  }
+
+  const { findings, findingsPath, pocsPath, reportPath } = await run.result;
 
   console.log(`
 ${sep}
@@ -212,7 +218,7 @@ ${objectivesList}
     session,
     model,
     authConfig: buildAuthConfig(pensarConfig),
-  });
+  }).result;
 
   console.log(`
 ${sep}
@@ -252,19 +258,31 @@ Output:   ${resolvedPath}
 Model:    ${model}
 `);
 
-  const threatBus = new AgentEventBus();
-  threatBus.on("text-delta", (d) => process.stdout.write(d.text));
-  threatBus.on("tool-call-complete", (d) => console.log(`\n  → ${d.toolName}`));
-  threatBus.on("tool-result", (d) => console.log(`  ✓ ${d.toolName}`));
-  threatBus.on("error", (d) => console.error("Error:", d.error));
-
-  await runThreatModelWorkflow({
+  const run = runThreatModelWorkflow({
     codebasePath: process.cwd(),
     outputPath: resolvedPath,
     model,
     authConfig: buildAuthConfig(pensarConfig),
-    eventBus: threatBus,
   });
+
+  for await (const event of run) {
+    switch (event.type) {
+      case "text-delta":
+        process.stdout.write(event.data.text);
+        break;
+      case "tool-call-complete":
+        console.log(`\n  → ${event.data.toolName}`);
+        break;
+      case "tool-result":
+        console.log(`  ✓ ${event.data.toolName}`);
+        break;
+      case "error":
+        console.error("Error:", event.data.error);
+        break;
+    }
+  }
+
+  await run.result;
 
   console.log(
     `\n${sep}\nCOMPLETE\n${sep}\nThreat model written to: ${resolvedPath}`,

--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -293,11 +293,12 @@ When to use delegate_to_auth_subagent vs authenticate_session:
         }
 
         // Dynamic import to break circular dependency:
-        // authAgent → offensiveSecurityAgent → tools/index → delegateAuth → api/authentication → authAgent
-        const { runAuthenticationAgent } =
-          await import("../../../api/authentication");
+        // authAgent → offensiveSecurityAgent → tools/index → delegateAuth → authAgent
+        const { AuthenticationAgent } = await import(
+          "../../specialized/authenticationAgent/agent"
+        );
 
-        const result = await runAuthenticationAgent({
+        const authAgent = new AuthenticationAgent({
           target,
           session: ctx.session,
           authHints,
@@ -307,6 +308,8 @@ When to use delegate_to_auth_subagent vs authenticate_session:
           eventBus: ctx.eventBus,
           subagentId,
         });
+
+        const result = await authAgent.consume();
 
         ctx.eventBus?.emit("subagent-complete", {
           subagentId,

--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -294,9 +294,8 @@ When to use delegate_to_auth_subagent vs authenticate_session:
 
         // Dynamic import to break circular dependency:
         // authAgent → offensiveSecurityAgent → tools/index → delegateAuth → authAgent
-        const { AuthenticationAgent } = await import(
-          "../../specialized/authenticationAgent/agent"
-        );
+        const { AuthenticationAgent } =
+          await import("../../specialized/authenticationAgent/agent");
 
         const authAgent = new AuthenticationAgent({
           target,

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -166,7 +166,9 @@ async function runSingleCodingAgent(
 
   const localBus = ctx.eventBus?.child(subagentId) ?? new AgentEventBus();
   let textOutput = "";
-  localBus.on("text-delta", (e) => { textOutput += e.text; });
+  localBus.on("text-delta", (e) => {
+    textOutput += e.text;
+  });
 
   const agent = new CodeAgent({
     codebasePath,

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -1,37 +1,10 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { ToolContext } from "./types";
-import { AgentEventBus, type AgentEventMap } from "../../../eventBus";
+import { AgentEventBus } from "../../../eventBus";
 
 /** Default max concurrent coding agents */
 const DEFAULT_CONCURRENCY = 5;
-
-const CHILD_BUS_EVENT_KEYS = [
-  "text-delta",
-  "tool-call-start",
-  "tool-call-delta",
-  "tool-call-complete",
-  "tool-result",
-  "subagent-spawn",
-  "subagent-complete",
-  "command-output",
-  "error",
-] as const satisfies readonly (keyof AgentEventMap)[];
-
-function attachChildEventBus(
-  localBus: AgentEventBus,
-  parentBus: AgentEventBus | undefined,
-  accumulateText: (chunk: string) => void,
-): void {
-  for (const key of CHILD_BUS_EVENT_KEYS) {
-    localBus.on(key, (payload: AgentEventMap[typeof key]) => {
-      if (key === "text-delta") {
-        accumulateText((payload as AgentEventMap["text-delta"]).text);
-      }
-      parentBus?.emit(key, payload);
-    });
-  }
-}
 
 /**
  * Factory for the `spawn_coding_agent` tool.
@@ -191,11 +164,9 @@ async function runSingleCodingAgent(
     input: { codebasePath, objective },
   });
 
-  const localBus = new AgentEventBus();
+  const localBus = ctx.eventBus?.child(subagentId) ?? new AgentEventBus();
   let textOutput = "";
-  attachChildEventBus(localBus, ctx.eventBus, (t) => {
-    textOutput += t;
-  });
+  localBus.on("text-delta", (e) => { textOutput += e.text; });
 
   const agent = new CodeAgent({
     codebasePath,

--- a/src/core/api/agentRun.ts
+++ b/src/core/api/agentRun.ts
@@ -86,18 +86,20 @@ export class AgentRun<TResult> implements AsyncIterable<AgentEvent> {
         continue;
       }
       if (this.done) return;
-      const result = await new Promise<IteratorResult<AgentEvent>>((resolve) => {
-        // Check again after microtask — events may have arrived
-        if (this.buffer.length > 0) {
-          resolve({ value: this.buffer.shift()!, done: false });
-          return;
-        }
-        if (this.done) {
-          resolve({ value: undefined as unknown as AgentEvent, done: true });
-          return;
-        }
-        this.waiting = resolve;
-      });
+      const result = await new Promise<IteratorResult<AgentEvent>>(
+        (resolve) => {
+          // Check again after microtask — events may have arrived
+          if (this.buffer.length > 0) {
+            resolve({ value: this.buffer.shift()!, done: false });
+            return;
+          }
+          if (this.done) {
+            resolve({ value: undefined as unknown as AgentEvent, done: true });
+            return;
+          }
+          this.waiting = resolve;
+        },
+      );
       if (result.done) return;
       yield result.value;
     }

--- a/src/core/api/agentRun.ts
+++ b/src/core/api/agentRun.ts
@@ -54,6 +54,9 @@ export class AgentRun<TResult> implements AsyncIterable<AgentEvent> {
         throw err;
       },
     );
+
+    // Prevent unhandled rejection when only the iterator is consumed (Pattern 3)
+    this.result.catch(() => {});
   }
 
   private subscribeAll(): void {
@@ -75,7 +78,10 @@ export class AgentRun<TResult> implements AsyncIterable<AgentEvent> {
     if (this.waiting) {
       const resolve = this.waiting;
       this.waiting = null;
-      resolve({ value: undefined as unknown as AgentEvent, done: true });
+      resolve({
+        value: (this.error ?? undefined) as unknown as AgentEvent,
+        done: true,
+      });
     }
   }
 
@@ -85,7 +91,10 @@ export class AgentRun<TResult> implements AsyncIterable<AgentEvent> {
         yield this.buffer.shift()!;
         continue;
       }
-      if (this.done) return;
+      if (this.done) {
+        if (this.error) throw this.error;
+        return;
+      }
       const result = await new Promise<IteratorResult<AgentEvent>>(
         (resolve) => {
           // Check again after microtask — events may have arrived
@@ -94,13 +103,19 @@ export class AgentRun<TResult> implements AsyncIterable<AgentEvent> {
             return;
           }
           if (this.done) {
-            resolve({ value: undefined as unknown as AgentEvent, done: true });
+            resolve({
+              value: (this.error ?? undefined) as unknown as AgentEvent,
+              done: true,
+            });
             return;
           }
           this.waiting = resolve;
         },
       );
-      if (result.done) return;
+      if (result.done) {
+        if (this.error) throw this.error;
+        return;
+      }
       yield result.value;
     }
   }

--- a/src/core/api/agentRun.ts
+++ b/src/core/api/agentRun.ts
@@ -1,0 +1,105 @@
+import {
+  AgentEventBus,
+  AGENT_EVENT_NAMES,
+  type AgentEvent,
+  type AgentEventMap,
+} from "../eventBus";
+
+/**
+ * A handle to a running agent. Implements `AsyncIterable<AgentEvent>` for
+ * pull-based streaming and exposes `.result` for the final typed result.
+ *
+ * Three consumption patterns:
+ *
+ * 1. Stream events + get result:
+ *    ```ts
+ *    const run = runPentestAgent({ ... });
+ *    for await (const event of run) { switch (event.type) { ... } }
+ *    const { findings } = await run.result;
+ *    ```
+ *
+ * 2. Just get the result (events are buffered and discarded):
+ *    ```ts
+ *    const { findings } = await runPentestAgent({ ... }).result;
+ *    ```
+ *
+ * 3. Ignore the result, just stream:
+ *    ```ts
+ *    for await (const event of runPentestAgent({ ... })) { ... }
+ *    ```
+ */
+export class AgentRun<TResult> implements AsyncIterable<AgentEvent> {
+  readonly result: Promise<TResult>;
+
+  private readonly eventBus: AgentEventBus;
+  private buffer: AgentEvent[] = [];
+  private waiting: ((value: IteratorResult<AgentEvent>) => void) | null = null;
+  private done = false;
+  private error: unknown = undefined;
+
+  constructor(executor: (eventBus: AgentEventBus) => Promise<TResult>) {
+    this.eventBus = new AgentEventBus();
+    this.subscribeAll();
+
+    this.result = executor(this.eventBus).then(
+      (result) => {
+        this.done = true;
+        this.flush();
+        return result;
+      },
+      (err) => {
+        this.done = true;
+        this.error = err;
+        this.flush();
+        throw err;
+      },
+    );
+  }
+
+  private subscribeAll(): void {
+    for (const key of AGENT_EVENT_NAMES) {
+      this.eventBus.on(key, (payload: AgentEventMap[typeof key]) => {
+        const event: AgentEvent = { type: key, data: payload } as AgentEvent;
+        if (this.waiting) {
+          const resolve = this.waiting;
+          this.waiting = null;
+          resolve({ value: event, done: false });
+        } else {
+          this.buffer.push(event);
+        }
+      });
+    }
+  }
+
+  private flush(): void {
+    if (this.waiting) {
+      const resolve = this.waiting;
+      this.waiting = null;
+      resolve({ value: undefined as unknown as AgentEvent, done: true });
+    }
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<AgentEvent> {
+    while (true) {
+      if (this.buffer.length > 0) {
+        yield this.buffer.shift()!;
+        continue;
+      }
+      if (this.done) return;
+      const result = await new Promise<IteratorResult<AgentEvent>>((resolve) => {
+        // Check again after microtask — events may have arrived
+        if (this.buffer.length > 0) {
+          resolve({ value: this.buffer.shift()!, done: false });
+          return;
+        }
+        if (this.done) {
+          resolve({ value: undefined as unknown as AgentEvent, done: true });
+          return;
+        }
+        this.waiting = resolve;
+      });
+      if (result.done) return;
+      yield result.value;
+    }
+  }
+}

--- a/src/core/api/attackSurface.test.ts
+++ b/src/core/api/attackSurface.test.ts
@@ -16,7 +16,7 @@ describe.skip("Attack Surface", () => {
         target: TARGET_URL,
         model: "claude-haiku-4-5",
         session,
-      });
+      }).result;
       expect(result).toBeDefined();
     },
     { timeout: 300_000 },

--- a/src/core/api/attackSurface.ts
+++ b/src/core/api/attackSurface.ts
@@ -51,10 +51,6 @@ async function runBlackboxAttackSurface(
 
   const { results, targets, resultsPath, assetsPath } = await agent.consume();
 
-  console.log(`\nIdentified ${targets.length} targets for deep testing`);
-  console.log(`Results: ${resultsPath}`);
-  console.log(`Assets: ${assetsPath}`);
-
   return { results, targets, resultsPath, assetsPath };
 }
 
@@ -74,12 +70,6 @@ async function runWhiteboxAttackSurface(
     attackSurfaceRegistry: input.attackSurfaceRegistry,
     eventBus: input.eventBus,
   });
-
-  console.log(
-    `\nWhitebox analysis complete: ${result.summary.totalApps} apps, ` +
-      `${result.summary.totalApiEndpoints} API endpoints, ` +
-      `${result.summary.totalPages} pages`,
-  );
 
   return result;
 }

--- a/src/core/api/attackSurface.ts
+++ b/src/core/api/attackSurface.ts
@@ -41,8 +41,7 @@ export function runAttackSurfaceAgent(
       ...input,
       eventBus,
     } as AttackSurfaceAgentInput);
-    const { results, targets, resultsPath, assetsPath } =
-      await agent.consume();
+    const { results, targets, resultsPath, assetsPath } = await agent.consume();
     return { results, targets, resultsPath, assetsPath };
   });
 }

--- a/src/core/api/attackSurface.ts
+++ b/src/core/api/attackSurface.ts
@@ -5,16 +5,9 @@ import {
 } from "../agents/specialized/attackSurface/blackboxAgent";
 import type { WhiteboxAttackSurfaceResult } from "../agents/specialized/whiteboxAttackSurface";
 import { runWhiteboxAttackSurfaceWorkflow } from "../workflows/whiteboxAttackSurface";
-
-// ---------------------------------------------------------------------------
-// Unified input — accepts both blackbox and whitebox configurations
-// ---------------------------------------------------------------------------
+import { AgentRun } from "./agentRun";
 
 export type AttackSurfaceInput = AttackSurfaceAgentInput;
-
-// ---------------------------------------------------------------------------
-// Convenience runners
-// ---------------------------------------------------------------------------
 
 /**
  * Run the appropriate attack surface agent based on the input.
@@ -26,50 +19,30 @@ export type AttackSurfaceInput = AttackSurfaceAgentInput;
  *
  * `target` is always required (the live URL to test against).
  */
-export async function runAttackSurfaceAgent(
-  input: AttackSurfaceAgentInput,
-): Promise<AttackSurfaceResult | WhiteboxAttackSurfaceResult> {
-  const isWhitebox = "cwd" in input && !!input.cwd;
+export function runAttackSurfaceAgent(
+  input: Omit<AttackSurfaceAgentInput, "eventBus">,
+): AgentRun<AttackSurfaceResult | WhiteboxAttackSurfaceResult> {
+  return new AgentRun(async (eventBus) => {
+    const isWhitebox = "cwd" in input && !!input.cwd;
 
-  if (isWhitebox) {
-    return runWhiteboxAttackSurface(
-      input as AttackSurfaceAgentInput & { cwd: string },
-    );
-  }
+    if (isWhitebox) {
+      return runWhiteboxAttackSurfaceWorkflow({
+        codebasePath: (input as AttackSurfaceAgentInput & { cwd: string }).cwd,
+        model: input.model,
+        session: input.session,
+        authConfig: input.authConfig,
+        abortSignal: input.abortSignal,
+        attackSurfaceRegistry: input.attackSurfaceRegistry,
+        eventBus,
+      });
+    }
 
-  return runBlackboxAttackSurface(input);
-}
-
-// ---------------------------------------------------------------------------
-// Blackbox (live target probing)
-// ---------------------------------------------------------------------------
-
-async function runBlackboxAttackSurface(
-  input: AttackSurfaceAgentInput,
-): Promise<AttackSurfaceResult> {
-  const agent = new BlackboxAttackSurfaceAgent(input);
-
-  const { results, targets, resultsPath, assetsPath } = await agent.consume();
-
-  return { results, targets, resultsPath, assetsPath };
-}
-
-// ---------------------------------------------------------------------------
-// Whitebox (source code analysis)
-// ---------------------------------------------------------------------------
-
-async function runWhiteboxAttackSurface(
-  input: AttackSurfaceAgentInput & { cwd: string },
-): Promise<WhiteboxAttackSurfaceResult> {
-  const result = await runWhiteboxAttackSurfaceWorkflow({
-    codebasePath: input.cwd,
-    model: input.model,
-    session: input.session,
-    authConfig: input.authConfig,
-    abortSignal: input.abortSignal,
-    attackSurfaceRegistry: input.attackSurfaceRegistry,
-    eventBus: input.eventBus,
+    const agent = new BlackboxAttackSurfaceAgent({
+      ...input,
+      eventBus,
+    } as AttackSurfaceAgentInput);
+    const { results, targets, resultsPath, assetsPath } =
+      await agent.consume();
+    return { results, targets, resultsPath, assetsPath };
   });
-
-  return result;
 }

--- a/src/core/api/authentication.ts
+++ b/src/core/api/authentication.ts
@@ -1,8 +1,17 @@
 import {
-  runAuthenticationAgent as _runAuthAgent,
+  AuthenticationAgent,
   type AuthenticationAgentInput,
+  type AuthenticationResult,
 } from "../agents/specialized/authenticationAgent/agent";
+import { AgentRun } from "./agentRun";
 
-// Re-export from the canonical location
-export const runAuthenticationAgent = _runAuthAgent;
 export type { AuthenticationAgentInput };
+
+export function runAuthenticationAgent(
+  input: Omit<AuthenticationAgentInput, "eventBus">,
+): AgentRun<AuthenticationResult> {
+  return new AgentRun(async (eventBus) => {
+    const agent = new AuthenticationAgent({ ...input, eventBus });
+    return agent.consume();
+  });
+}

--- a/src/core/api/benchmark.ts
+++ b/src/core/api/benchmark.ts
@@ -11,25 +11,7 @@ export async function runBenchmarkComparisonAgent(
 ) {
   const agent = new BenchmarkComparisonAgent(input);
 
-  agent.eventBus.on("text-delta", (d) => process.stdout.write(d.text));
-  agent.eventBus.on("tool-call-complete", (d) =>
-    console.log(`→ calling ${d.toolName}`),
-  );
-  agent.eventBus.on("tool-result", (d) =>
-    console.log(`✓ ${d.toolName} completed`),
-  );
-  agent.eventBus.on("error", (d) => console.error("Agent error:", d.error));
-
   const { comparison, resultsPath } = await agent.consume();
-
-  if (comparison) {
-    console.log(
-      `\nComparison: ${comparison.matched.length}/${comparison.totalExpected} matched, ` +
-        `Precision: ${Math.round(comparison.precision * 100)}%, ` +
-        `Recall: ${Math.round(comparison.recall * 100)}%`,
-    );
-  }
-  console.log(`Results: ${resultsPath}`);
 
   return { comparison, resultsPath };
 }

--- a/src/core/api/benchmark.ts
+++ b/src/core/api/benchmark.ts
@@ -2,16 +2,14 @@ import {
   BenchmarkComparisonAgent,
   type BenchmarkComparisonAgentInput,
 } from "../agents/specialized/benchmarkComparisonAgent";
-// ---------------------------------------------------------------------------
-// Convenience runner
-// ---------------------------------------------------------------------------
+import { AgentRun } from "./agentRun";
 
-export async function runBenchmarkComparisonAgent(
+export function runBenchmarkComparisonAgent(
   input: BenchmarkComparisonAgentInput,
 ) {
-  const agent = new BenchmarkComparisonAgent(input);
-
-  const { comparison, resultsPath } = await agent.consume();
-
-  return { comparison, resultsPath };
+  return new AgentRun(async (_eventBus) => {
+    const agent = new BenchmarkComparisonAgent(input);
+    const { comparison, resultsPath } = await agent.consume();
+    return { comparison, resultsPath };
+  });
 }

--- a/src/core/api/blackboxPentest.ts
+++ b/src/core/api/blackboxPentest.ts
@@ -1,13 +1,9 @@
-//
 import {
   runPentestWorkflow,
   type PentestWorkflowInput,
   type PentestWorkflowResult,
 } from "../workflows/pentest";
-
-// ---------------------------------------------------------------------------
-// Convenience runner
-// ---------------------------------------------------------------------------
+import { AgentRun } from "./agentRun";
 
 /**
  * Run the deterministic pentest workflow (blackbox or whitebox based on input).
@@ -18,19 +14,10 @@ import {
  * Phase 1: Runs attack surface discovery (whitebox workflow or blackbox agent)
  * Phase 2: Spawns targeted pentest agents for each discovered target
  */
-export async function runPentestAgent(
-  input: PentestWorkflowInput,
-): Promise<PentestWorkflowResult> {
-  const { findings, findingsPath, pocsPath, reportPath } =
-    await runPentestWorkflow({
-      target: input.target,
-      cwd: input.cwd,
-      model: input.model,
-      session: input.session,
-      authConfig: input.authConfig,
-      abortSignal: input.abortSignal,
-      eventBus: input.eventBus,
-    });
-
-  return { findings, findingsPath, pocsPath, reportPath };
+export function runPentestAgent(
+  input: Omit<PentestWorkflowInput, "eventBus">,
+): AgentRun<PentestWorkflowResult> {
+  return new AgentRun(async (eventBus) => {
+    return runPentestWorkflow({ ...input, eventBus });
+  });
 }

--- a/src/core/api/blackboxPentest.ts
+++ b/src/core/api/blackboxPentest.ts
@@ -32,10 +32,5 @@ export async function runPentestAgent(
       eventBus: input.eventBus,
     });
 
-  console.log(`\nFound ${findings.length} vulnerabilities`);
-  console.log(`Findings: ${findingsPath}`);
-  console.log(`POCs: ${pocsPath}`);
-  if (reportPath) console.log(`Report: ${reportPath}`);
-
   return { findings, findingsPath, pocsPath, reportPath };
 }

--- a/src/core/api/environment.ts
+++ b/src/core/api/environment.ts
@@ -4,32 +4,12 @@ import type { EnvironmentResult } from "../agents/specialized/environment/types"
 
 export type { EnvironmentResult, EnvironmentAgentInput };
 
-function attachDefaultEnvironmentStreamListeners(
-  agent: EnvironmentAgent,
-): void {
-  agent.eventBus.on("text-delta", (e) => {
-    process.stdout.write(e.text);
-  });
-  agent.eventBus.on("tool-call-complete", (e) => {
-    console.log(`→ calling ${e.toolName}`);
-  });
-  agent.eventBus.on("tool-result", (e) => {
-    console.log(`✓ ${e.toolName} completed`);
-  });
-  agent.eventBus.on("error", (e) => {
-    console.error("Environment agent error:", e.error);
-  });
-}
-
 /**
  * Run the environment agent to set up a development environment in a sandbox.
  *
  * The agent reads project files, starts services, and validates the
  * environment is healthy. When a sandbox is provided in the input,
  * tools automatically route operations through it.
- *
- * When no `eventBus` is passed on the input, default stdout / console
- * listeners are attached to the agent's bus for local CLI use.
  *
  * @returns Structured result with application URL, status, steps taken,
  *          and authentication details.
@@ -38,8 +18,5 @@ export async function runEnvironmentAgent(
   input: EnvironmentAgentInput,
 ): Promise<EnvironmentResult> {
   const agent = new EnvironmentAgent(input);
-  if (!input.eventBus) {
-    attachDefaultEnvironmentStreamListeners(agent);
-  }
   return agent.consume();
 }

--- a/src/core/api/environment.ts
+++ b/src/core/api/environment.ts
@@ -1,6 +1,7 @@
 import { EnvironmentAgent } from "../agents/specialized/environment/agent";
 import type { EnvironmentAgentInput } from "../agents/specialized/environment/types";
 import type { EnvironmentResult } from "../agents/specialized/environment/types";
+import { AgentRun } from "./agentRun";
 
 export type { EnvironmentResult, EnvironmentAgentInput };
 
@@ -14,9 +15,11 @@ export type { EnvironmentResult, EnvironmentAgentInput };
  * @returns Structured result with application URL, status, steps taken,
  *          and authentication details.
  */
-export async function runEnvironmentAgent(
-  input: EnvironmentAgentInput,
-): Promise<EnvironmentResult> {
-  const agent = new EnvironmentAgent(input);
-  return agent.consume();
+export function runEnvironmentAgent(
+  input: Omit<EnvironmentAgentInput, "eventBus">,
+): AgentRun<EnvironmentResult> {
+  return new AgentRun(async (eventBus) => {
+    const agent = new EnvironmentAgent({ ...input, eventBus });
+    return agent.consume();
+  });
 }

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -15,11 +15,7 @@ export { runOffensiveSecurityAgent, type RunAgentResult } from "./offesecAgent";
 // ---- Event types ----
 // AgentEventBus class is NOT exported — it's an internal implementation
 // detail. Consumers interact with events via AgentRun<T> (Phase 3).
-export type {
-  AgentEventName,
-  AgentEvent,
-  AgentEventOf,
-} from "../eventBus";
+export type { AgentEventName, AgentEvent, AgentEventOf } from "../eventBus";
 
 // ---- Domain types — findings ----
 export { ApexFindingObject } from "../agents/offSecAgent/types";

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -1,3 +1,6 @@
+// ---- AgentRun ----
+export { AgentRun } from "./agentRun";
+
 // ---- Agent runners ----
 export * from "./attackSurface";
 export * from "./authentication";
@@ -43,6 +46,7 @@ export type {
   AuthenticationSubagentInput,
   AuthenticationSubagentResult,
 } from "../agents/specialized/authenticationAgent/types";
+export type { AuthenticationResult } from "../agents/specialized/authenticationAgent/agent";
 
 // ---- Agent input/result types ----
 export type { PentestAgentInput } from "../agents/specialized/pentest/agent";

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -1,3 +1,4 @@
+// ---- Agent runners ----
 export * from "./attackSurface";
 export * from "./authentication";
 export * from "./benchmark";
@@ -6,3 +7,60 @@ export * from "./targetedPentest";
 export * from "./threatModel";
 export * from "./patching";
 export * from "./environment";
+export { runOffensiveSecurityAgent, type RunAgentResult } from "./offesecAgent";
+
+// ---- Event types ----
+// AgentEventBus class is NOT exported — it's an internal implementation
+// detail. Consumers interact with events via AgentRun<T> (Phase 3).
+export type {
+  AgentEventName,
+  AgentEvent,
+  AgentEventOf,
+} from "../eventBus";
+
+// ---- Domain types — findings ----
+export { ApexFindingObject } from "../agents/offSecAgent/types";
+export type { Finding } from "../agents/offSecAgent/types";
+
+// ---- Domain types — attack surface ----
+export type {
+  DocumentedAppRecord,
+  DocumentedEndpointRecord,
+  AppType,
+  EndpointType,
+  RiskLevel,
+  AttackSurfaceReport,
+  AttackSurfaceSummary,
+  PentestTarget,
+} from "../agents/specialized/attackSurface/schemas";
+
+// ---- Domain types — authentication ----
+export type {
+  AuthCredentials,
+  AuthFlowHints,
+  AuthMethod,
+  AuthBarrier,
+  AuthenticationSubagentInput,
+  AuthenticationSubagentResult,
+} from "../agents/specialized/authenticationAgent/types";
+
+// ---- Agent input/result types ----
+export type { PentestAgentInput } from "../agents/specialized/pentest/agent";
+export type { PentestResult } from "../agents/specialized/pentest/agent";
+export type {
+  AttackSurfaceAgentInput,
+  AttackSurfaceResult,
+} from "../agents/specialized/attackSurface/blackboxAgent";
+export type { WhiteboxAttackSurfaceResult } from "../agents/specialized/whiteboxAttackSurface";
+// Note: EnvironmentResult is already re-exported via ./environment
+export type {
+  PentestWorkflowInput,
+  PentestWorkflowResult,
+} from "../workflows/pentest";
+
+// ---- AI types ----
+export type { AIModel } from "../ai";
+export type { AIAuthConfig } from "../ai/utils";
+
+// ---- Session types ----
+export type { SessionInfo, SessionConfig } from "../session";

--- a/src/core/api/offesecAgent.ts
+++ b/src/core/api/offesecAgent.ts
@@ -6,11 +6,17 @@ import type { StreamTextResult, ToolSet } from "ai";
 import type { SessionInfo } from "../session";
 
 import { OffensiveSecurityAgent } from "../agents/offSecAgent/offensiveSecurityAgent";
+import { AgentRun } from "./agentRun";
 
 export interface RunAgentResult {
   streamResult: StreamTextResult<ToolSet, never>;
   session: SessionInfo;
 }
+
+type RunnerInput = (
+  | Omit<OffensiveSecurityAgentInput, "eventBus">
+  | Omit<CreateAgentInput, "eventBus">
+) & { onSessionReady?: (session: SessionInfo) => void };
 
 /**
  * Run the offensive security agent, consuming its stream to completion.
@@ -22,17 +28,18 @@ export interface RunAgentResult {
  * Returns the stream result **and** the session so callers can access a
  * session that was auto-created by the factory.
  */
-export async function runOffensiveSecurityAgent(
-  input: (OffensiveSecurityAgentInput | CreateAgentInput) & {
-    onSessionReady?: (session: SessionInfo) => void;
-  },
-): Promise<RunAgentResult> {
-  const agent = input.session
-    ? new OffensiveSecurityAgent(input as OffensiveSecurityAgentInput)
-    : await OffensiveSecurityAgent.create(input as CreateAgentInput);
+export function runOffensiveSecurityAgent(
+  input: RunnerInput,
+): AgentRun<RunAgentResult> {
+  return new AgentRun(async (eventBus) => {
+    const fullInput = { ...input, eventBus };
+    const agent = fullInput.session
+      ? new OffensiveSecurityAgent(fullInput as OffensiveSecurityAgentInput)
+      : await OffensiveSecurityAgent.create(fullInput as CreateAgentInput);
 
-  input.onSessionReady?.(agent.session);
+    input.onSessionReady?.(agent.session);
 
-  await agent.consume();
-  return { streamResult: agent.streamResult, session: agent.session };
+    await agent.consume();
+    return { streamResult: agent.streamResult, session: agent.session };
+  });
 }

--- a/src/core/api/patching.ts
+++ b/src/core/api/patching.ts
@@ -4,21 +4,6 @@ import type { PatchResult } from "../agents/specialized/patching/types";
 
 export type { PatchResult, PatchingAgentInput };
 
-function attachDefaultPatchingStreamListeners(agent: PatchingAgent): void {
-  agent.eventBus.on("text-delta", (e) => {
-    process.stdout.write(e.text);
-  });
-  agent.eventBus.on("tool-call-complete", (e) => {
-    console.log(`→ calling ${e.toolName}`);
-  });
-  agent.eventBus.on("tool-result", (e) => {
-    console.log(`✓ ${e.toolName} completed`);
-  });
-  agent.eventBus.on("error", (e) => {
-    console.error("Patching agent error:", e.error);
-  });
-}
-
 /**
  * Run the patching agent to fix a security vulnerability in a codebase.
  *
@@ -26,17 +11,11 @@ function attachDefaultPatchingStreamListeners(agent: PatchingAgent): void {
  * lint, type-check, and tests. When a sandbox is provided in the input,
  * tools automatically route operations through it.
  *
- * When no `eventBus` is passed on the input, default stdout / console
- * listeners are attached to the agent's bus for local CLI use.
- *
  * @returns Structured patch result with file changes and PR metadata.
  */
 export async function runPatchingAgent(
   input: PatchingAgentInput,
 ): Promise<PatchResult> {
   const agent = new PatchingAgent(input);
-  if (!input.eventBus) {
-    attachDefaultPatchingStreamListeners(agent);
-  }
   return agent.consume();
 }

--- a/src/core/api/patching.ts
+++ b/src/core/api/patching.ts
@@ -1,6 +1,7 @@
 import { PatchingAgent } from "../agents/specialized/patching/agent";
 import type { PatchingAgentInput } from "../agents/specialized/patching/types";
 import type { PatchResult } from "../agents/specialized/patching/types";
+import { AgentRun } from "./agentRun";
 
 export type { PatchResult, PatchingAgentInput };
 
@@ -13,9 +14,11 @@ export type { PatchResult, PatchingAgentInput };
  *
  * @returns Structured patch result with file changes and PR metadata.
  */
-export async function runPatchingAgent(
-  input: PatchingAgentInput,
-): Promise<PatchResult> {
-  const agent = new PatchingAgent(input);
-  return agent.consume();
+export function runPatchingAgent(
+  input: Omit<PatchingAgentInput, "eventBus">,
+): AgentRun<PatchResult> {
+  return new AgentRun(async (eventBus) => {
+    const agent = new PatchingAgent({ ...input, eventBus });
+    return agent.consume();
+  });
 }

--- a/src/core/api/targetedPentest.ts
+++ b/src/core/api/targetedPentest.ts
@@ -5,24 +5,8 @@ import {
 
 export async function runTargetedPentestAgent(input: PentestAgentInput) {
   const agent = new TargetedPentestAgent(input);
-
-  if (!input.eventBus) {
-    agent.eventBus.on("text-delta", (d) => process.stdout.write(d.text));
-    agent.eventBus.on("tool-call-complete", (d) =>
-      console.log(`→ calling ${d.toolName}`),
-    );
-    agent.eventBus.on("tool-result", (d) =>
-      console.log(`✓ ${d.toolName} completed`),
-    );
-    agent.eventBus.on("error", (d) => console.error("Agent error:", d.error));
-  }
-
   const { findings, findingsPath, pocsPath, objectiveResults } =
     await agent.consume();
-
-  console.log(`\nFound ${findings.length} vulnerabilities`);
-  console.log(`Findings: ${findingsPath}`);
-  console.log(`POCs: ${pocsPath}`);
 
   return { findings, findingsPath, pocsPath, objectiveResults };
 }

--- a/src/core/api/targetedPentest.ts
+++ b/src/core/api/targetedPentest.ts
@@ -1,12 +1,18 @@
 import {
   TargetedPentestAgent,
   type PentestAgentInput,
+  type PentestResult,
 } from "../agents/specialized/pentest/agent";
+import { AgentRun } from "./agentRun";
 
-export async function runTargetedPentestAgent(input: PentestAgentInput) {
-  const agent = new TargetedPentestAgent(input);
-  const { findings, findingsPath, pocsPath, objectiveResults } =
-    await agent.consume();
+export function runTargetedPentestAgent(
+  input: Omit<PentestAgentInput, "eventBus">,
+): AgentRun<PentestResult> {
+  return new AgentRun(async (eventBus) => {
+    const agent = new TargetedPentestAgent({ ...input, eventBus });
+    const { findings, findingsPath, pocsPath, objectiveResults } =
+      await agent.consume();
 
-  return { findings, findingsPath, pocsPath, objectiveResults };
+    return { findings, findingsPath, pocsPath, objectiveResults };
+  });
 }

--- a/src/core/api/threatModel.ts
+++ b/src/core/api/threatModel.ts
@@ -1,5 +1,16 @@
-export {
-  runThreatModelWorkflow,
+import {
+  runThreatModelWorkflow as _runThreatModelWorkflow,
   type ThreatModelWorkflowInput,
   type ThreatModelWorkflowResult,
 } from "../workflows/threatModel";
+import { AgentRun } from "./agentRun";
+
+export type { ThreatModelWorkflowInput, ThreatModelWorkflowResult };
+
+export function runThreatModelWorkflow(
+  input: Omit<ThreatModelWorkflowInput, "eventBus">,
+): AgentRun<ThreatModelWorkflowResult> {
+  return new AgentRun(async (eventBus) => {
+    return _runThreatModelWorkflow({ ...input, eventBus });
+  });
+}

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -64,6 +64,33 @@ export type AgentEventMap = {
 };
 
 /**
+ * Ensures a readonly tuple contains every member of a union type.
+ * Compile error if any AgentEventName is missing from the array.
+ */
+type ExhaustiveEventNames<T extends readonly (keyof AgentEventMap)[]> =
+  Exclude<keyof AgentEventMap, T[number]> extends never ? T : never;
+
+/**
+ * Every event name in AgentEventMap. Adding a new event to the map
+ * without adding it here is a compile error.
+ */
+export const AGENT_EVENT_NAMES = [
+  "text-delta",
+  "tool-call-start",
+  "tool-call-delta",
+  "tool-call-complete",
+  "tool-result",
+  "subagent-spawn",
+  "subagent-complete",
+  "workflow-phase-start",
+  "workflow-phase-complete",
+  "step-finish",
+  "command-output",
+  "error",
+  "trace-record",
+] as const satisfies ExhaustiveEventNames<typeof AGENT_EVENT_NAMES>;
+
+/**
  * Centralized, typed event bus for agent streaming output.
  *
  * Replaces the callback-based `ConsumeCallbacks` / `SubagentConsumeCallbacks`
@@ -123,6 +150,35 @@ export class AgentEventBus {
       this.emitter.removeAllListeners();
     }
     return this;
+  }
+
+  /**
+   * Create a child bus whose events automatically bubble to this
+   * (parent) bus with `subagentId` injected into every payload.
+   *
+   * Usage:
+   * ```ts
+   * const childBus = parentBus.child("pentest-agent-0");
+   * const agent = new TargetedPentestAgent({ ...input, eventBus: childBus });
+   * await agent.consume();
+   * // All events from the child arrive on the parent with subagentId set
+   * ```
+   */
+  child(subagentId: string): AgentEventBus {
+    const childBus = new AgentEventBus();
+
+    for (const key of AGENT_EVENT_NAMES) {
+      childBus.on(key, (payload: Record<string, unknown>) => {
+        const tagged = { ...payload };
+        // Preserve innermost subagentId for nested child-of-child buses
+        if (!("subagentId" in tagged) || tagged.subagentId == null) {
+          tagged.subagentId = subagentId;
+        }
+        this.emit(key, tagged as AgentEventMap[typeof key]);
+      });
+    }
+
+    return childBus;
   }
 
   /**

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -63,6 +63,35 @@ export type AgentEventMap = {
   };
 };
 
+/** Union of all event names on the AgentEventBus. */
+export type AgentEventName = keyof AgentEventMap;
+
+/**
+ * Discriminated union of all agent events, suitable for streaming.
+ * Each variant carries a `type` discriminator matching the event name
+ * and a `data` field with the event-specific payload.
+ */
+export type AgentEvent =
+  | { type: "text-delta"; data: AgentEventMap["text-delta"] }
+  | { type: "tool-call-start"; data: AgentEventMap["tool-call-start"] }
+  | { type: "tool-call-delta"; data: AgentEventMap["tool-call-delta"] }
+  | { type: "tool-call-complete"; data: AgentEventMap["tool-call-complete"] }
+  | { type: "tool-result"; data: AgentEventMap["tool-result"] }
+  | { type: "subagent-spawn"; data: AgentEventMap["subagent-spawn"] }
+  | { type: "subagent-complete"; data: AgentEventMap["subagent-complete"] }
+  | { type: "workflow-phase-start"; data: AgentEventMap["workflow-phase-start"] }
+  | { type: "workflow-phase-complete"; data: AgentEventMap["workflow-phase-complete"] }
+  | { type: "step-finish"; data: AgentEventMap["step-finish"] }
+  | { type: "command-output"; data: AgentEventMap["command-output"] }
+  | { type: "error"; data: AgentEventMap["error"] }
+  | { type: "trace-record"; data: AgentEventMap["trace-record"] };
+
+/**
+ * Extract the event type for a specific event name.
+ * Usage: `AgentEventOf<"text-delta">` → `{ text: string; subagentId?: string }`
+ */
+export type AgentEventOf<K extends AgentEventName> = AgentEventMap[K];
+
 /**
  * Centralized, typed event bus for agent streaming output.
  *

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -99,15 +99,8 @@ export type AgentEvent =
 export type AgentEventOf<K extends AgentEventName> = AgentEventMap[K];
 
 /**
- * Ensures a readonly tuple contains every member of a union type.
- * Compile error if any AgentEventName is missing from the array.
- */
-type ExhaustiveEventNames<T extends readonly (keyof AgentEventMap)[]> =
-  Exclude<keyof AgentEventMap, T[number]> extends never ? T : never;
-
-/**
  * Every event name in AgentEventMap. Adding a new event to the map
- * without adding it here is a compile error.
+ * without adding it here is a compile error (see assertion below).
  */
 export const AGENT_EVENT_NAMES = [
   "text-delta",
@@ -123,7 +116,16 @@ export const AGENT_EVENT_NAMES = [
   "command-output",
   "error",
   "trace-record",
-] as const satisfies ExhaustiveEventNames<typeof AGENT_EVENT_NAMES>;
+] as const satisfies readonly (keyof AgentEventMap)[];
+
+/** Compile-time check: fails if any AgentEventMap key is missing above. */
+type _MissingEvents = Exclude<
+  keyof AgentEventMap,
+  (typeof AGENT_EVENT_NAMES)[number]
+>;
+type _AssertAllEventsPresent = [_MissingEvents] extends [never]
+  ? true
+  : ["Missing events in AGENT_EVENT_NAMES:", _MissingEvents];
 
 /**
  * Centralized, typed event bus for agent streaming output.

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -79,8 +79,14 @@ export type AgentEvent =
   | { type: "tool-result"; data: AgentEventMap["tool-result"] }
   | { type: "subagent-spawn"; data: AgentEventMap["subagent-spawn"] }
   | { type: "subagent-complete"; data: AgentEventMap["subagent-complete"] }
-  | { type: "workflow-phase-start"; data: AgentEventMap["workflow-phase-start"] }
-  | { type: "workflow-phase-complete"; data: AgentEventMap["workflow-phase-complete"] }
+  | {
+      type: "workflow-phase-start";
+      data: AgentEventMap["workflow-phase-start"];
+    }
+  | {
+      type: "workflow-phase-complete";
+      data: AgentEventMap["workflow-phase-complete"];
+    }
   | { type: "step-finish"; data: AgentEventMap["step-finish"] }
   | { type: "command-output"; data: AgentEventMap["command-output"] }
   | { type: "error"; data: AgentEventMap["error"] }

--- a/src/core/workflows/threatModel.ts
+++ b/src/core/workflows/threatModel.ts
@@ -4,7 +4,7 @@ import type { SessionInfo } from "../session";
 import type { AgentEventBus } from "../eventBus";
 import { ALL_TOOL_NAMES, SKILL_TOOL_NAMES } from "../agents/offSecAgent";
 import { buildBaseSystemPrompt } from "../agents/offSecAgent/prompt";
-import { runOffensiveSecurityAgent } from "../api/offesecAgent";
+import { OffensiveSecurityAgent } from "../agents/offSecAgent/offensiveSecurityAgent";
 import { sessions } from "../session";
 import { createSkillsRegistry } from "../skills";
 import { buildThreatModelPrompt } from "../skills/builtins/threatModel";
@@ -83,7 +83,7 @@ You are generating an application-centric threat model from source code analysis
 Working directory: ${input.codebasePath}`;
 
   // Run the agent
-  await runOffensiveSecurityAgent({
+  const agent = new OffensiveSecurityAgent({
     system,
     prompt,
     model,
@@ -94,6 +94,7 @@ Working directory: ${input.codebasePath}`;
     skillsRegistry: registry,
     eventBus: input.eventBus,
   });
+  await agent.consume();
 
   return { session, outputPath: input.outputPath };
 }

--- a/src/tests/attackSurface.test.ts
+++ b/src/tests/attackSurface.test.ts
@@ -27,7 +27,7 @@ describe.skip("Attack Surface", () => {
         target: TARGET_URL,
         model: "claude-haiku-4-5",
         session,
-      });
+      }).result;
       expect(result).toBeDefined();
     },
     { timeout: 300_000 },

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -1,4 +1,7 @@
-import { runAuthenticationAgent } from "../core/api/authentication";
+import {
+  AuthenticationAgent,
+  type AuthenticationAgentInput,
+} from "../core/agents/specialized/authenticationAgent/agent";
 import { AgentEventBus } from "../core/eventBus";
 import { sessions } from "../core/session";
 import { describe, it, expect } from "vitest";
@@ -60,12 +63,13 @@ describe.skip("Authentication Agent", () => {
     bus.on("tool-result", (d) => console.log(`✓ ${d.toolName} completed`));
     bus.on("error", (d) => console.error("Agent error:", d.error));
 
-    const result = await runAuthenticationAgent({
+    const agent = new AuthenticationAgent({
       target: TARGET_URL,
       model: "claude-haiku-4-5",
       session,
       eventBus: bus,
     });
+    const result = await agent.consume();
 
     console.log(
       `\nResult: ${result.success ? "SUCCESS" : "FAILED"} — ${result.summary}`,
@@ -103,12 +107,13 @@ describe.skip("Authentication Agent", () => {
     bus2.on("tool-result", (d) => console.log(`✓ ${d.toolName} completed`));
     bus2.on("error", (d) => console.error("Agent error:", d.error));
 
-    const result = await runAuthenticationAgent({
+    const agent2 = new AuthenticationAgent({
       target: TARGET_URL,
       model: "claude-haiku-4-5",
       session,
       eventBus: bus2,
     });
+    const result = await agent2.consume();
 
     console.log(
       `\nResult: ${result.success ? "SUCCESS" : "FAILED"} — ${result.summary}`,
@@ -162,7 +167,7 @@ describe.skip("Authentication Agent", () => {
     bus3.on("tool-result", (d) => console.log(`✓ ${d.toolName} completed`));
     bus3.on("error", (d) => console.error("Agent error:", d.error));
 
-    const result = await runAuthenticationAgent({
+    const agent3 = new AuthenticationAgent({
       target: TARGET_URL,
       model: "claude-haiku-4-5",
       session,
@@ -176,6 +181,7 @@ describe.skip("Authentication Agent", () => {
       },
       eventBus: bus3,
     });
+    const result = await agent3.consume();
 
     console.log(
       `\nResult: ${result.success ? "SUCCESS" : "FAILED"} — ${result.summary}`,

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -1,7 +1,4 @@
-import {
-  AuthenticationAgent,
-  type AuthenticationAgentInput,
-} from "../core/agents/specialized/authenticationAgent/agent";
+import { AuthenticationAgent } from "../core/agents/specialized/authenticationAgent/agent";
 import { AgentEventBus } from "../core/eventBus";
 import { sessions } from "../core/session";
 import { describe, it, expect } from "vitest";

--- a/src/tests/authCookieExport.test.ts
+++ b/src/tests/authCookieExport.test.ts
@@ -1,4 +1,4 @@
-import { runAuthenticationAgent } from "../core/api/authentication";
+import { AuthenticationAgent } from "../core/agents/specialized/authenticationAgent/agent";
 import { AgentEventBus } from "../core/eventBus";
 import { sessions } from "../core/session";
 import { describe, it, expect } from "vitest";
@@ -63,7 +63,7 @@ describe.skip("Authentication Agent — Cookie Export", () => {
       });
       bus.on("error", (d) => console.error("Agent error:", d.error));
 
-      const result = await runAuthenticationAgent({
+      const agent = new AuthenticationAgent({
         target: TARGET_URL,
         model: "claude-haiku-4-5",
         session,
@@ -77,6 +77,7 @@ describe.skip("Authentication Agent — Cookie Export", () => {
         },
         eventBus: bus,
       });
+      const result = await agent.consume();
 
       console.log("\n========== AUTH RESULT ==========");
       console.log("success:", result.success);

--- a/src/tests/authPentestHandoff.test.ts
+++ b/src/tests/authPentestHandoff.test.ts
@@ -9,7 +9,7 @@
  *
  * No mocking — both agents actually run against staging.
  */
-import { runAuthenticationAgent } from "../core/api/authentication";
+import { AuthenticationAgent } from "../core/agents/specialized/authenticationAgent/agent";
 import { TargetedPentestAgent } from "../core/agents/specialized/pentest/agent";
 import { AgentEventBus } from "../core/eventBus";
 import { sessions } from "../core/session";
@@ -81,7 +81,7 @@ describe.skip("Auth → Pentest Cookie Handoff", () => {
       );
       authBus.on("error", (d) => console.error("Auth error:", d.error));
 
-      const authResult = await runAuthenticationAgent({
+      const authAgent = new AuthenticationAgent({
         target: TARGET_URL,
         model: "claude-haiku-4-5",
         session,
@@ -95,6 +95,7 @@ describe.skip("Auth → Pentest Cookie Handoff", () => {
         },
         eventBus: authBus,
       });
+      const authResult = await authAgent.consume();
 
       console.log("\n========== AUTH RESULT ==========");
       console.log("success:", authResult.success);

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -15,7 +15,8 @@ import {
   type SessionConfig,
   normalizeMessages,
 } from "../../../core/session";
-import { runOffensiveSecurityAgent } from "../../../core/api/offesecAgent";
+import { OffensiveSecurityAgent } from "../../../core/agents/offSecAgent/offensiveSecurityAgent";
+import type { OffensiveSecurityAgentInput, CreateAgentInput } from "../../../core/agents/offSecAgent";
 import { attachWandbToEventBus } from "../../../core/integrations/wandb/upload";
 import { buildAuthConfig } from "../../../core/ai/utils";
 import type { CacheMetrics } from "../../../core/ai";
@@ -1268,11 +1269,14 @@ export default function OperatorDashboard({
         );
 
         if (session) {
-          agentResult = await runOffensiveSecurityAgent({
+          const agent = new OffensiveSecurityAgent({
             ...commonInput,
             system: systemPrompt,
             session,
-          });
+          } as OffensiveSecurityAgentInput);
+          commonInput.onSessionReady?.(agent.session);
+          await agent.consume();
+          agentResult = { streamResult: agent.streamResult, session: agent.session };
         } else {
           // First call — let the agent factory create the session
           const sessionConfig: SessionConfig = {
@@ -1285,7 +1289,7 @@ export default function OperatorDashboard({
             },
             agentCwd: initialConfig?.sandbox ? undefined : process.cwd(),
           };
-          agentResult = await runOffensiveSecurityAgent({
+          const agent = await OffensiveSecurityAgent.create({
             ...commonInput,
             system: systemPrompt,
             sessionConfig,
@@ -1293,7 +1297,10 @@ export default function OperatorDashboard({
               pendingNameRef.current = name;
               setSession((prev) => (prev ? { ...prev, name } : prev));
             },
-          });
+          } as CreateAgentInput);
+          commonInput.onSessionReady?.(agent.session);
+          await agent.consume();
+          agentResult = { streamResult: agent.streamResult, session: agent.session };
           // Apply any AI-generated name that arrived while the stream was running
           const created = agentResult.session;
           if (pendingNameRef.current) {

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -16,7 +16,10 @@ import {
   normalizeMessages,
 } from "../../../core/session";
 import { OffensiveSecurityAgent } from "../../../core/agents/offSecAgent/offensiveSecurityAgent";
-import type { OffensiveSecurityAgentInput, CreateAgentInput } from "../../../core/agents/offSecAgent";
+import type {
+  OffensiveSecurityAgentInput,
+  CreateAgentInput,
+} from "../../../core/agents/offSecAgent";
 import { attachWandbToEventBus } from "../../../core/integrations/wandb/upload";
 import { buildAuthConfig } from "../../../core/ai/utils";
 import type { CacheMetrics } from "../../../core/ai";
@@ -1276,7 +1279,10 @@ export default function OperatorDashboard({
           } as OffensiveSecurityAgentInput);
           commonInput.onSessionReady?.(agent.session);
           await agent.consume();
-          agentResult = { streamResult: agent.streamResult, session: agent.session };
+          agentResult = {
+            streamResult: agent.streamResult,
+            session: agent.session,
+          };
         } else {
           // First call — let the agent factory create the session
           const sessionConfig: SessionConfig = {
@@ -1300,7 +1306,10 @@ export default function OperatorDashboard({
           } as CreateAgentInput);
           commonInput.onSessionReady?.(agent.session);
           await agent.consume();
-          agentResult = { streamResult: agent.streamResult, session: agent.session };
+          agentResult = {
+            streamResult: agent.streamResult,
+            session: agent.session,
+          };
           // Apply any AI-generated name that arrived while the stream was running
           const created = agentResult.session;
           if (pendingNameRef.current) {

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -13,7 +13,7 @@ import {
   loadSessionState,
   type UISubagent,
 } from "../../../core/session/loader";
-import { runPentestAgent } from "../../../core/api/blackboxPentest";
+import { runPentestWorkflow as runPentestAgent } from "../../../core/workflows/pentest";
 import { AgentEventBus } from "../../../core/agents/offSecAgent";
 import { buildAuthConfig } from "../../../core/ai/utils";
 import { useAgent } from "../../context/agent";


### PR DESCRIPTION
## Summary

Phase 3 of [Apex SDK Surface design](https://github.com/pensarai/apex/blob/canary/.jraad/docs/design-docs/20260406141012-apex-sdk-surface.md). Wraps the event bus behind a pull-based async iterable API. **Breaking change** — runner functions return `AgentRun<T>` instead of `Promise<T>`.

**Depends on:** #548 (Phase 1) and #549 (Phase 2) — this branch includes both.

### New: `AgentRun<T>` class
- Implements `AsyncIterable<AgentEvent>` for pull-based streaming
- Exposes `.result: Promise<T>` for the final typed result
- Three consumption patterns: stream + result, result-only, stream-only
- Handles buffering, completion, and error propagation

### API runner conversions (9 functions)
All public runners now return `AgentRun<T>` with `eventBus` removed from input types:
`runPentestAgent`, `runTargetedPentestAgent`, `runAttackSurfaceAgent`, `runOffensiveSecurityAgent`, `runAuthenticationAgent`, `runThreatModelWorkflow`, `runEnvironmentAgent`, `runPatchingAgent`, `runBenchmarkComparisonAgent`

### Caller migration
- **CLI**: Converted to `for await (const event of run)` iteration pattern
- **TUI**: Imports from internal paths (workflows/agents) to retain `eventBus` access — full TUI migration is Phase 4 scope
- **Internal callers** (workflows, tools): Import from internal modules
- **Scripts**: Converted to AgentRun iteration
- **Tests**: Use `.result` or import agents directly

## Test plan

- [x] `bun run build` passes
- [x] All 584 tests pass
- [ ] Console updates (Phase 4 — separate repo, out of scope)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change: public `run*` API runners no longer return `Promise<T>` and now require consumers to use `AgentRun` (`for await` streaming and/or `.result`). Moderate risk of integration regressions in downstream SDK/CLI/TUI callers due to signature and streaming-behavior changes.
> 
> **Overview**
> **Introduces `AgentRun<T>`** (`src/core/api/agentRun.ts`) as an `AsyncIterable<AgentEvent>` wrapper that buffers `AgentEventBus` output for pull-based consumption and provides a typed `.result` promise.
> 
> **Public runner APIs now return `AgentRun` (breaking)** and remove `eventBus` from their input types, converting `runPentestAgent`, `runTargetedPentestAgent`, `runAttackSurfaceAgent`, `runAuthenticationAgent`, `runThreatModelWorkflow`, `runEnvironmentAgent`, `runPatchingAgent`, `runBenchmarkComparisonAgent`, and `runOffensiveSecurityAgent` to internally create/own the bus.
> 
> **Call sites are migrated** (CLI + scripts + some tests) to iterate `for await (const event of run)` and then await `run.result`; the TUI/workflows that still need direct bus control switch to importing internal agents/workflows directly. Event plumbing is tightened by adding `AGENT_EVENT_NAMES`, a discriminated `AgentEvent` type, and a `AgentEventBus.child(subagentId)` helper for subagent event bubbling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9319d1b78613d285dc2369e24dac33ea0ffb335c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->