### PR TITLE
feat: add --prompt and --threat-model flags to pentest command

### DIFF
--- a/fern/docs/cli/pentest.mdx
+++ b/fern/docs/cli/pentest.mdx
@@ -21,6 +21,8 @@ pensar pentest --target <url> [options]
 | `--cwd <path>`    | Source code path — enables whitebox attack surface analysis   |
 | `--mode <mode>`   | Pentest mode: `exfil` (pivoting & flag extraction)           |
 | `--model <model>` | AI model to use (defaults to your configured provider's default) |
+| `--prompt <text\|@file>` | Guidance for the pentest agent (inline text or @filepath) |
+| `--threat-model <text\|@file>` | Threat model to guide the pentest (inline text or @filepath) |
 
 ## Examples
 
@@ -36,7 +38,27 @@ pensar pentest --target https://example.com --model claude-sonnet-4-5
 
 # Exfil mode for CTF-style flag extraction
 pensar pentest --target https://example.com --mode exfil
+
+# Provide inline guidance
+pensar pentest --target https://example.com --prompt "Focus on authentication bypass"
+
+# Load guidance from a file
+pensar pentest --target https://example.com --prompt @./pentest-notes.md
+
+# Feed a threat model document
+pensar pentest --target https://example.com --threat-model @./threat-model.md
+
+# Combine both
+pensar pentest --target https://example.com --threat-model @./threat-model.md --prompt "Focus on critical paths"
 ```
+
+## Guiding the Pentest
+
+The `--prompt` and `--threat-model` flags let you steer the pentest agent with additional context.
+
+Both flags accept inline text or an `@file` reference. Prefix a file path with `@` to read its contents instead of passing the path as a literal string.
+
+When `--threat-model` is used, the content is automatically wrapped with guidance explaining how the agent should use it — prioritizing attack paths by severity, following pentest guidance sections, and verifying control gaps.
 
 ## How It Works
 

--- a/fern/docs/commands/pentest.mdx
+++ b/fern/docs/commands/pentest.mdx
@@ -133,6 +133,30 @@ You can bypass the wizard entirely by passing flags:
 | `--strict`            | Enable strict scope mode               |
 | `--headers <mode>`    | Headers mode: none, default, or custom |
 | `--header <Name:Val>` | Custom header (repeatable)             |
+| `--prompt <text\|@file>` | Guidance for the pentest agent (inline text or @filepath) |
+| `--threat-model <text\|@file>` | Threat model to guide the pentest (inline text or @filepath) |
+
+## Guiding the Pentest
+
+You can provide guidance to the pentest agent using `--prompt` for general instructions or `--threat-model` to feed in a threat model document.
+
+Both flags support inline text and `@file` references — prefix a file path with `@` to read its contents:
+
+```bash
+# Inline guidance
+/pentest --target https://example.com --prompt "Focus on authentication bypass"
+
+# File-based guidance
+/pentest --target https://example.com --prompt @./pentest-notes.md
+
+# Feed a threat model
+/pentest --target https://example.com --threat-model @./threat-model.md
+
+# Combine both
+/pentest --target https://example.com --threat-model @./threat-model.md --prompt "Focus on critical paths"
+```
+
+When `--threat-model` is used, the content is automatically wrapped with guidance explaining how the agent should use it — prioritizing attack paths by severity, following pentest guidance sections, and verifying control gaps.
 
 ## Keyboard Navigation
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,11 @@ import { getCurrentVersion, upgrade } from "./core/installation";
 import { buildAuthConfig } from "./core/ai/utils";
 import { resolvePentestMode } from "./core/cli/pentestMode";
 import { AgentEventBus } from "./core/eventBus";
+import {
+  resolveFlagValue,
+  resolveThreatModelPrompt,
+  combinePromptParts,
+} from "./tui/utils/command-flags";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -77,10 +82,12 @@ Usage:
   pensar version                      Show version number
 
 pentest options:
-  --target <url>     (required) Target URL / domain / IP
-  --cwd <path>       Source code path — enables whitebox attack surface
-  --mode <mode>      Pentest mode: exfil (pivoting & flag extraction)
-  --model <model>    AI model (default: claude-sonnet-4-5)
+  --target <url>           (required) Target URL / domain / IP
+  --cwd <path>             Source code path — enables whitebox attack surface
+  --mode <mode>            Pentest mode: exfil (pivoting & flag extraction)
+  --model <model>          AI model (default: claude-sonnet-4-5)
+  --prompt <text|@file>    Guidance for the pentest agent (inline text or @filepath)
+  --threat-model <text|@file>  Threat model to guide the pentest (inline or @filepath)
 
 targeted-pentest options:
   --target <url>          (required) Target URL / domain / IP
@@ -114,6 +121,15 @@ async function runPentest() {
   const target = getArgRequired("--target");
   const cwd = getArg("--cwd");
   const mode = getArg("--mode");
+  const promptRaw = getArg("--prompt");
+  const threatModelRaw = getArg("--threat-model");
+
+  // Resolve and combine threat model + prompt
+  const resolvedTm = threatModelRaw
+    ? resolveThreatModelPrompt(threatModelRaw)
+    : undefined;
+  const resolvedPrompt = promptRaw ? resolveFlagValue(promptRaw) : undefined;
+  const prompt = combinePromptParts(resolvedTm, resolvedPrompt);
 
   const pensarConfig = await appConfig.get();
   const dynamicDefault =
@@ -139,6 +155,7 @@ Model:   ${model}
     config: {
       ...(cwd ? { cwd } : {}),
       ...(exfilMode ? { exfilMode: true } : {}),
+      ...(prompt ? { prompt } : {}),
     },
   });
 

--- a/src/core/agents/specialized/attackSurface/blackboxAgent.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxAgent.ts
@@ -179,6 +179,7 @@ function buildPrompt(target: string, session: SessionInfo): string {
   const scopeConstraints = session.config?.scopeConstraints;
   const authenticationInstructions = session.config?.authenticationInstructions;
   const enumerateSubdomains = session.config?.enumerateSubdomains ?? false;
+  const operatorPrompt = session.config?.prompt;
 
   const cm = session.credentialManager;
   const credBlock = cm?.formatForPrompt();
@@ -238,6 +239,10 @@ Note any login pages you find as assets and flag them for pentest agents.`;
       ? `Begin NOW by logging in. Your first tool call must be browser_navigate to ${loginTarget}. After login, continue with the remaining phases.`
       : `Begin attack surface analysis now. Follow the phases defined in your system prompt in order.`;
 
+  const operatorGuidanceBlock = operatorPrompt
+    ? `\n## Operator Guidance\n${operatorPrompt}\n`
+    : "";
+
   return `TARGET: ${target}
 
 Session: ${session.id}
@@ -249,6 +254,6 @@ SCOPE:
 ${scopeRules}
 
 ${subdomainBlock}
-
+${operatorGuidanceBlock}
 ${startDirective}`;
 }

--- a/src/core/agents/specialized/whiteboxAttackSurface/agent.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/agent.ts
@@ -84,7 +84,7 @@ This ends the agent run — make sure all data is included.`,
 
     super({
       system: WHITEBOX_ATTACK_SURFACE_SYSTEM_PROMPT,
-      prompt: buildPrompt(codebasePath, domains),
+      prompt: buildPrompt(codebasePath, domains, session.config?.prompt),
       model,
       session,
       authConfig,
@@ -138,16 +138,23 @@ This ends the agent run — make sure all data is included.`,
 // Prompt builder
 // ---------------------------------------------------------------------------
 
-function buildPrompt(codebasePath: string, domains?: string[]): string {
+function buildPrompt(
+  codebasePath: string,
+  domains?: string[],
+  operatorPrompt?: string,
+): string {
   const domainSection = domains?.length
     ? `\n## Known Domains\nThe following domains are associated with this project. When documenting apps, set the \`domain\` field on \`document_app\` if you can determine which domain serves the app:\n${domains.map((d) => `- ${d}`).join("\n")}\n`
+    : "";
+  const operatorGuidanceBlock = operatorPrompt
+    ? `\n## Operator Guidance\n${operatorPrompt}\n`
     : "";
 
   return `# Whitebox Attack Surface Analysis
 
 ## Codebase
 - **Path:** ${codebasePath}
-${domainSection}
+${domainSection}${operatorGuidanceBlock}
 ## Task
 Analyze this codebase and produce a complete attack surface map:
 1. Identify the repo type and package manager

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -158,6 +158,8 @@ const SessionConfigObject = z.object({
   exfilMode: z.boolean().optional(),
   /** Agent working directory — resolved to process.cwd() by default, undefined in sandbox mode */
   agentCwd: z.string().optional(),
+  /** Operator-provided guidance injected into the orchestrator/agent system prompts */
+  prompt: z.string().optional(),
 });
 
 export type SessionConfig = z.infer<typeof SessionConfigObject>;

--- a/src/core/skills/builtins/pentest.ts
+++ b/src/core/skills/builtins/pentest.ts
@@ -14,6 +14,7 @@ export function buildPentestPrompt(opts: {
   hosts?: string[];
   ports?: string[];
   strict?: boolean;
+  prompt?: string;
   skillContent: string;
 }): string {
   const contextParts: string[] = [`Target URL: ${opts.target}`];
@@ -40,6 +41,12 @@ export function buildPentestPrompt(opts: {
     if (opts.ports?.length)
       contextParts.push(`  Allowed ports: ${opts.ports.join(", ")}`);
     if (opts.strict) contextParts.push("  Strict scope: enabled");
+  }
+
+  if (opts.prompt) {
+    contextParts.push("");
+    contextParts.push("Operator Guidance:");
+    contextParts.push(opts.prompt);
   }
 
   const runtimeContext = contextParts.join("\n");

--- a/src/core/utils/prompt.ts
+++ b/src/core/utils/prompt.ts
@@ -1,0 +1,28 @@
+/**
+ * Core utility for threat model content wrapping.
+ *
+ * Provides the preamble template used by both the CLI (via resolveThreatModelPrompt)
+ * and the programmatic API (via runPentestWorkflow). Does NOT handle @file resolution —
+ * that is the caller's responsibility.
+ */
+
+/**
+ * Wrap raw threat model content with the standard preamble that instructs
+ * the pentest agent on how to use the threat model.
+ */
+export function createThreatModelPrompt(content: string): string {
+  return `## Threat Model
+
+The following threat model was generated for this application. Use it to guide your pentest:
+
+1. **Prioritize attack paths by severity** — start with Critical and High severity paths.
+2. **Use the pentest guidance** — each attack path includes specific objectives, techniques, and example payloads. Follow these when testing.
+3. **Check existing controls** — the threat model documents existing security controls. Verify they work as documented and look for bypasses.
+4. **Verify control gaps** — each attack path lists control gaps. These are your highest-value targets.
+5. **Reference attacker profiles** — understand who would attack this application and what they control. This shapes your testing perspective.
+6. **Don't limit yourself** — the threat model is guidance, not an exhaustive list. If you discover attack vectors not covered by the model, pursue them.
+
+<threat-model>
+${content}
+</threat-model>`;
+}

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -290,6 +290,7 @@ export async function runPentestWorkflow(
     onCacheMetrics,
     enableThinking,
   } = input;
+
   const startedAt = Date.now();
   const tokenUsageTotals: TokenUsageTotals = {
     inputTokens: 0,

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -3,6 +3,7 @@ import type { Route, WebCommandOptions } from "./context/route";
 import {
   parseWebFlags,
   hasEnoughFlagsToSkipWizard,
+  combinePromptParts,
 } from "./utils/command-flags";
 import { getAllThemeNames } from "./theme";
 import { config } from "../core/config";
@@ -118,6 +119,16 @@ export const commands: CommandConfig[] = [
         description: "Custom header (repeatable)",
       },
       { name: "--model", valueHint: "<model>", description: "AI model to use" },
+      {
+        name: "--prompt",
+        valueHint: "<text|@file>",
+        description: "Guidance for the pentest agent",
+      },
+      {
+        name: "--threat-model",
+        valueHint: "<text|@file>",
+        description: "Threat model to guide the pentest (inline or @filepath)",
+      },
     ],
     handler: async (args, ctx) => {
       const flags = parseWebFlags(args);
@@ -134,6 +145,11 @@ export const commands: CommandConfig[] = [
         if (flags.ports?.length)
           skillArgs.ports = flags.ports.map(String).join(",");
         if (flags.strict) skillArgs.strict = "true";
+        const combinedPrompt = combinePromptParts(
+          flags.threatModel,
+          flags.prompt,
+        );
+        if (combinedPrompt) skillArgs.prompt = combinedPrompt;
 
         ctx.navigate({
           type: "operator",

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -13,6 +13,11 @@ import {
   getAutoPopulatedHosts,
   getAutoPopulatedPorts,
 } from "../../../util/url";
+import { createThreatModelPrompt } from "../../../core/utils/prompt";
+import {
+  combinePromptParts,
+  resolveFlagValue,
+} from "../../utils/command-flags";
 import { scrollToChild } from "../../utils/scroll";
 import { ModelPickerDialog } from "../model-picker";
 
@@ -37,6 +42,8 @@ interface WizardState {
     mode: "none" | "default" | "custom";
     customHeaders: Record<string, string>;
   };
+  prompt: string;
+  threatModel: string;
 }
 
 // Props for the WebWizard
@@ -71,6 +78,10 @@ interface WebWizardProps {
   initialCustomHeaders?: Record<string, string>;
   /** Pre-filled model ID */
   initialModel?: string;
+  /** Operator-provided guidance for the pentest agent */
+  initialPrompt?: string;
+  /** Pre-resolved threat model content (already wrapped by parseWebFlags) */
+  initialThreatModel?: string;
 }
 
 function capitalize(s: string): string {
@@ -93,6 +104,8 @@ export default function WebWizard({
   initialHeadersMode,
   initialCustomHeaders,
   initialModel,
+  initialPrompt,
+  initialThreatModel,
 }: WebWizardProps) {
   const { colors } = useTheme();
   const config = useConfig();
@@ -146,12 +159,17 @@ export default function WebWizard({
         mode: initialHeadersMode || "default",
         customHeaders: initialCustomHeaders || {},
       },
+      prompt: initialPrompt || "",
+      threatModel: initialThreatModel || "",
     };
   });
 
   // UI state — single flat field index
   const [focusedField, setFocusedField] = useState(0);
   const [advancedExpanded, setAdvancedExpanded] = useState(false);
+  // Track whether the threat model value was pre-wrapped by CLI flag parsing
+  const [threatModelPreWrapped, setThreatModelPreWrapped] =
+    useState(!!initialThreatModel);
   const [hostInput, setHostInput] = useState("");
   const [portInput, setPortInput] = useState("");
   const [headerNameInput, setHeaderNameInput] = useState("");
@@ -171,6 +189,8 @@ export default function WebWizard({
   //   2: Cwd path (only when source code access enabled)
   //   next: Advanced toggle
   //   --- when advanced expanded ---
+  //   next: Prompt
+  //   next: Threat Model
   //   next: Auth - Login URL
   //   next: Auth - Username
   //   next: Auth - Password
@@ -187,7 +207,9 @@ export default function WebWizard({
   const advancedToggleIndex = state.sourceCodeAccess ? 3 : 2;
 
   // Advanced sub-field indices (only valid when advancedExpanded)
-  const authLoginUrlIndex = advancedToggleIndex + 1;
+  const promptFieldIndex = advancedToggleIndex + 1;
+  const threatModelFieldIndex = promptFieldIndex + 1;
+  const authLoginUrlIndex = threatModelFieldIndex + 1;
   const authUsernameIndex = authLoginUrlIndex + 1;
   const authPasswordIndex = authUsernameIndex + 1;
   const authInstructionsIndex = authPasswordIndex + 1;
@@ -299,6 +321,24 @@ export default function WebWizard({
               ? state.headers.customHeaders
               : undefined,
         };
+      }
+
+      // Operator guidance — combine threat model and prompt.
+      // Resolve @filepath references for values typed in the wizard.
+      // Values from CLI flags (threatModelPreWrapped) are already resolved.
+      const rawPrompt = state.prompt.trim();
+      const resolvedPrompt = rawPrompt
+        ? resolveFlagValue(rawPrompt)
+        : undefined;
+      const rawTm = state.threatModel.trim();
+      const resolvedTm = rawTm
+        ? threatModelPreWrapped
+          ? rawTm
+          : createThreatModelPrompt(resolveFlagValue(rawTm))
+        : undefined;
+      const combinedPrompt = combinePromptParts(resolvedTm, resolvedPrompt);
+      if (combinedPrompt) {
+        sessionConfig.prompt = combinedPrompt;
       }
 
       onStartPentest([state.target], sessionConfig);
@@ -620,6 +660,48 @@ export default function WebWizard({
 
           {advancedExpanded && (
             <>
+              {/* Prompt */}
+              <box id={`field-${promptFieldIndex}`}>
+                <Input
+                  label="Prompt"
+                  description="Guidance for the pentest agent (use @filepath to load from file)"
+                  placeholder="Focus on authentication bypass..."
+                  value={state.prompt}
+                  onInput={(v) => setState((prev) => ({ ...prev, prompt: v }))}
+                  onPaste={(event) => {
+                    const cleaned = String(event.text).replace(/\r?\n/g, " ");
+                    setState((prev) => ({
+                      ...prev,
+                      prompt: prev.prompt + cleaned,
+                    }));
+                  }}
+                  focused={focusedField === promptFieldIndex}
+                />
+              </box>
+
+              {/* Threat Model */}
+              <box id={`field-${threatModelFieldIndex}`}>
+                <Input
+                  label="Threat Model"
+                  description="Threat model content (use @filepath to load from file)"
+                  placeholder="@./threat-model.md"
+                  value={state.threatModel}
+                  onInput={(v) => {
+                    setThreatModelPreWrapped(false);
+                    setState((prev) => ({ ...prev, threatModel: v }));
+                  }}
+                  onPaste={(event) => {
+                    setThreatModelPreWrapped(false);
+                    const cleaned = String(event.text).replace(/\r?\n/g, " ");
+                    setState((prev) => ({
+                      ...prev,
+                      threatModel: prev.threatModel + cleaned,
+                    }));
+                  }}
+                  focused={focusedField === threatModelFieldIndex}
+                />
+              </box>
+
               {/* Authentication */}
               {sectionDivider("Authentication")}
 

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -236,26 +236,25 @@ export default function WebWizard({
 
   // Auto-populate scope hosts/ports when the user changes the target URL.
   // Only fires when the user hasn't manually edited the scope fields yet.
+  // We pass the CLI-provided initial values (not accumulated state) so each
+  // keystroke replaces the auto-populated value rather than appending.
+  const baseHosts = initialHosts || [];
+  const basePorts = initialPorts || [];
   const [scopeManuallyEdited, setScopeManuallyEdited] = useState(false);
   useEffect(() => {
     if (scopeManuallyEdited) return;
     const target = state.target.trim();
     if (!target) return;
-    setState((prev) => {
-      const autoHosts = getAutoPopulatedHosts(target, prev.scope.allowedHosts);
-      const autoPorts = getAutoPopulatedPorts(
-        target,
-        prev.scope.allowedPorts.map(Number).filter((p) => !isNaN(p)),
-      );
-      return {
-        ...prev,
-        scope: {
-          ...prev.scope,
-          allowedHosts: autoHosts,
-          allowedPorts: autoPorts.map(String),
-        },
-      };
-    });
+    const autoHosts = getAutoPopulatedHosts(target, baseHosts);
+    const autoPorts = getAutoPopulatedPorts(target, basePorts);
+    setState((prev) => ({
+      ...prev,
+      scope: {
+        ...prev.scope,
+        allowedHosts: autoHosts,
+        allowedPorts: autoPorts.map(String),
+      },
+    }));
   }, [state.target]);
 
   // Create session and navigate to session route

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -1493,6 +1493,7 @@ export default function OperatorDashboard({
             hosts: args?.hosts?.split(",").filter(Boolean),
             ports: args?.ports?.split(",").filter(Boolean),
             strict: args?.strict === "true",
+            prompt: args?.prompt,
             skillContent: content,
           });
         } else {

--- a/src/tui/context/route.tsx
+++ b/src/tui/context/route.tsx
@@ -40,6 +40,8 @@ export interface WebCommandOptions {
   headersMode?: "none" | "default" | "custom";
   customHeaders?: Record<string, string>;
   model?: string;
+  prompt?: string;
+  threatModel?: string;
 }
 
 export type Route =

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -409,6 +409,7 @@ function AppContent({
         .map(String)
         .join(",");
     if (sessionConfig.scopeConstraints?.strictScope) skillArgs.strict = "true";
+    if (sessionConfig.prompt) skillArgs.prompt = sessionConfig.prompt;
 
     const isBlackbox = !sessionConfig.codebasePath;
 
@@ -512,6 +513,8 @@ function AppContent({
           initialHeadersMode={pendingPentestFlags?.headersMode}
           initialCustomHeaders={pendingPentestFlags?.customHeaders}
           initialModel={pendingPentestFlags?.model}
+          initialPrompt={pendingPentestFlags?.prompt}
+          initialThreatModel={pendingPentestFlags?.threatModel}
         />
       )}
     </box>

--- a/src/tui/utils/command-flags.test.ts
+++ b/src/tui/utils/command-flags.test.ts
@@ -1,5 +1,16 @@
-import { describe, expect, it } from "vitest";
-import { buildSwarmSessionConfig, parseWebFlags } from "./command-flags";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  resolveFlagValue,
+  buildSwarmSessionConfig,
+  parseWebFlags,
+} from "./command-flags";
+
+// ---------------------------------------------------------------------------
+// parseWebFlags — swarm scope
+// ---------------------------------------------------------------------------
 
 describe("parseWebFlags", () => {
   it("auto-populates the target host and port for skipped-wizard swarm runs", () => {
@@ -33,5 +44,145 @@ describe("parseWebFlags", () => {
 
     expect(flags.hosts).toEqual(["api.example.com", "example.com"]);
     expect(flags.ports).toEqual([8443, 8080]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveFlagValue
+// ---------------------------------------------------------------------------
+
+describe("resolveFlagValue", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "apex-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns inline text as-is when no @ prefix", () => {
+    expect(resolveFlagValue("hello world")).toBe("hello world");
+  });
+
+  it("returns empty string as-is", () => {
+    expect(resolveFlagValue("")).toBe("");
+  });
+
+  it("returns text containing @ in the middle as-is", () => {
+    expect(resolveFlagValue("user@example.com")).toBe("user@example.com");
+  });
+
+  it("reads file contents when value starts with @", () => {
+    const filePath = join(tempDir, "prompt.txt");
+    writeFileSync(filePath, "file content here");
+
+    const result = resolveFlagValue(`@${filePath}`);
+    expect(result).toBe("file content here");
+  });
+
+  it("reads multiline file contents", () => {
+    const filePath = join(tempDir, "multi.txt");
+    const content = "line 1\nline 2\nline 3\n";
+    writeFileSync(filePath, content);
+
+    const result = resolveFlagValue(`@${filePath}`);
+    expect(result).toBe(content);
+  });
+
+  it("resolves relative @ paths against cwd", () => {
+    const filePath = join(tempDir, "relative.txt");
+    writeFileSync(filePath, "relative content");
+
+    // Temporarily change cwd to tempDir
+    const originalCwd = process.cwd();
+    process.chdir(tempDir);
+    try {
+      const result = resolveFlagValue("@relative.txt");
+      expect(result).toBe("relative content");
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it("handles absolute @ paths", () => {
+    const filePath = join(tempDir, "absolute.txt");
+    writeFileSync(filePath, "absolute content");
+
+    const result = resolveFlagValue(`@${filePath}`);
+    expect(result).toBe("absolute content");
+  });
+
+  it("throws when @ references a nonexistent file", () => {
+    expect(() => resolveFlagValue("@/nonexistent/file.txt")).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseWebFlags — prompt and threatModel flags
+// ---------------------------------------------------------------------------
+
+describe("parseWebFlags prompt/threatModel", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "apex-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("parses --prompt with inline text", () => {
+    const flags = parseWebFlags(["--prompt", "Focus on auth bypass"]);
+    expect(flags.prompt).toBe("Focus on auth bypass");
+  });
+
+  it("parses --prompt with =value syntax", () => {
+    const flags = parseWebFlags(["--prompt=Focus on SSRF"]);
+    expect(flags.prompt).toBe("Focus on SSRF");
+  });
+
+  it("parses --prompt with @file reference", () => {
+    const filePath = join(tempDir, "custom-prompt.txt");
+    writeFileSync(filePath, "Test all API endpoints");
+
+    const flags = parseWebFlags(["--prompt", `@${filePath}`]);
+    expect(flags.prompt).toBe("Test all API endpoints");
+  });
+
+  it("parses --threat-model with inline text", () => {
+    const flags = parseWebFlags(["--threat-model", "XSS on login"]);
+    expect(flags.threatModel).toContain("XSS on login");
+  });
+
+  it("parses --threat-model with @file reference", () => {
+    const filePath = join(tempDir, "tm.md");
+    writeFileSync(filePath, "IDOR on user profiles");
+
+    const flags = parseWebFlags(["--threat-model", `@${filePath}`]);
+    expect(flags.threatModel).toContain("IDOR on user profiles");
+  });
+
+  it("parses both --prompt and --threat-model together", () => {
+    const flags = parseWebFlags([
+      "--target",
+      "http://example.com",
+      "--prompt",
+      "Be thorough",
+      "--threat-model",
+      "SQL injection risk",
+    ]);
+
+    expect(flags.target).toBe("http://example.com");
+    expect(flags.prompt).toBe("Be thorough");
+    expect(flags.threatModel).toContain("SQL injection risk");
+  });
+
+  it("does not set prompt or threatModel when flags are absent", () => {
+    const flags = parseWebFlags(["--target", "http://example.com"]);
+    expect(flags.prompt).toBeUndefined();
+    expect(flags.threatModel).toBeUndefined();
   });
 });

--- a/src/tui/utils/command-flags.ts
+++ b/src/tui/utils/command-flags.ts
@@ -5,10 +5,64 @@
  * Supports: --flag value, --flag=value, --boolean-flag
  */
 
+import { readFileSync } from "fs";
+import { resolve, isAbsolute } from "path";
 import type { SessionConfig } from "../../core/session";
 import type { OperatorMode } from "../../core/operator";
 import { createToolsetState } from "../../core/toolset";
 import { parseTargetUrl } from "../../util/url";
+import { createThreatModelPrompt } from "../../core/utils/prompt";
+
+/**
+ * Combine resolved threat model and prompt into a single prompt string.
+ * Threat model comes first (if present), then user prompt.
+ * Returns undefined if both are empty.
+ */
+export function combinePromptParts(
+  threatModel?: string,
+  prompt?: string,
+): string | undefined {
+  const parts: string[] = [];
+  if (threatModel) parts.push(threatModel);
+  if (prompt) parts.push(prompt);
+  return parts.length > 0 ? parts.join("\n\n") : undefined;
+}
+
+// ============================================================================
+// Value Resolution
+// ============================================================================
+
+/**
+ * Resolve a flag value that may be an inline string or a file reference.
+ *
+ * If `value` starts with `@`, the remainder is treated as a file path:
+ * - Absolute paths are used as-is
+ * - Relative paths are resolved against `process.cwd()`
+ * - The file contents are returned as a UTF-8 string
+ *
+ * Otherwise the value is returned as-is.
+ */
+export function resolveFlagValue(value: string): string {
+  if (value.startsWith("@")) {
+    const filePath = value.slice(1);
+    const resolved = isAbsolute(filePath)
+      ? filePath
+      : resolve(process.cwd(), filePath);
+    return readFileSync(resolved, "utf-8");
+  }
+  return value;
+}
+
+/**
+ * Resolve a threat model value and wrap it with a usage preamble.
+ *
+ * Uses `resolveFlagValue()` for `@file` support, then wraps the content
+ * with instructions on how the pentest agent should use the threat model.
+ */
+export function resolveThreatModelPrompt(value: string): string {
+  const content = resolveFlagValue(value);
+  return createThreatModelPrompt(content);
+}
 
 // ============================================================================
 // General Flag Parsing
@@ -145,6 +199,12 @@ export interface WebCommandFlags {
   _hostsExplicitlyProvided?: boolean;
   // Sandbox option
   sandbox?: boolean;
+
+  // Prompt option
+  prompt?: string;
+
+  // Threat model option
+  threatModel?: string;
 }
 
 /**
@@ -171,6 +231,8 @@ const webFlagSchema: FlagSchema = {
   // Legacy --auto flag maps to --swarm
   auto: { type: "boolean" },
   sandbox: { type: "boolean" },
+  prompt: { type: "string" },
+  "threat-model": { type: "string" },
 };
 
 /**
@@ -266,6 +328,13 @@ export function parseWebFlags(args: string[]): WebCommandFlags {
   // Sandbox option
   if (raw.sandbox) flags.sandbox = true;
 
+  // Prompt option — resolve @file references
+  if (raw.prompt) flags.prompt = resolveFlagValue(String(raw.prompt));
+
+  // Threat model option — resolve @file references and wrap with preamble
+  if (raw.threatModel)
+    flags.threatModel = resolveThreatModelPrompt(String(raw.threatModel));
+
   return flags;
 }
 
@@ -348,6 +417,12 @@ export function buildOperatorSessionConfig(
 
   sessionConfig.agentCwd = flags.sandbox ? undefined : process.cwd();
 
+  // Combine threat model and prompt into a single prompt field
+  const combinedPrompt = combinePromptParts(flags.threatModel, flags.prompt);
+  if (combinedPrompt) {
+    sessionConfig.prompt = combinedPrompt;
+  }
+
   return {
     targets: flags.target ? [flags.target] : [],
     name: flags.name || undefined,
@@ -391,6 +466,12 @@ export function buildSwarmSessionConfig(
       mode: flags.headersMode,
       headers: flags.headersMode === "custom" ? flags.customHeaders : undefined,
     };
+  }
+
+  // Combine threat model and prompt into a single prompt field
+  const combinedPrompt = combinePromptParts(flags.threatModel, flags.prompt);
+  if (combinedPrompt) {
+    sessionConfig.prompt = combinedPrompt;
   }
 
   return {


### PR DESCRIPTION
## Summary

- Adds `--prompt <text|@file>` and `--threat-model <text|@file>` flags to the pentest CLI and TUI `/pentest` command
- Supports `@filepath` syntax to load content from files (both absolute and relative paths)
- Adds Prompt and Threat Model input fields in the wizard's Advanced section
- Injects operator guidance as "Operator Guidance" blocks in blackbox/whitebox discovery agents and the pentest skill prompt
- Wraps threat model content with a structured preamble guiding the agent on how to use it
- Adds `prompt` field to `SessionConfig` for end-to-end propagation

**Depends on:** #551

## Test plan

- [ ] Run `pensar pentest --target https://example.com --prompt "Focus on auth bypass"` and verify the prompt reaches the agent
- [ ] Run `pensar pentest --target https://example.com --threat-model @./threat-model.md` and verify file loading works
- [ ] Run `pensar pentest --target https://example.com --prompt "Focus" --threat-model "XSS risk"` and verify both are combined
- [ ] Open the TUI wizard, expand Advanced, fill in Prompt and Threat Model fields, and verify they flow through
- [ ] Run `bun run test` to verify the new `resolveFlagValue` and `parseWebFlags` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces new user-provided prompt/file ingestion (`@file`) that propagates into multiple agent prompts and session config, which could affect agent behavior and error handling (missing files, large inputs). No changes to auth or data persistence beyond adding an optional `SessionConfig.prompt` field.
> 
> **Overview**
> Adds `--prompt` and `--threat-model` to both `pensar pentest` and TUI `/pentest`, including `@file` support and a shared threat-model preamble wrapper (`createThreatModelPrompt`).
> 
> Propagates the combined operator guidance end-to-end via a new optional `SessionConfig.prompt`, injects it into blackbox/whitebox attack-surface prompts and the `pentest` skill runtime context, and extends the TUI wizard (Advanced) to collect/resolve these values. Updates docs/help text and adds unit tests for flag parsing and `@file` resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 752c97057c072102c47cad396873882f70b2703a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->