### PR TITLE
fix: update CORS and security header guidance in agent prompts

### DIFF
--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -98,7 +98,7 @@ export function httpRequest(ctx: ToolContext) {
 
 USAGE GUIDANCE:
 - Always check response headers for security misconfigurations
-- Look for: X-Frame-Options, CSP, HSTS, X-Content-Type-Options, Permissions-Policy, Cross-Origin-Embedder-Policy, Cross-Origin-Opener-Policy
+- Look for: X-Frame-Options, Content-Security-Policy, Strict-Transport-Security, X-Content-Type-Options, Permissions-Policy, Cross-Origin-Embedder-Policy, Cross-Origin-Opener-Policy (NOTE: X-XSS-Protection is deprecated by all major browsers — do NOT recommend it; recommend Content-Security-Policy instead)
 - Analyze cookies for HttpOnly, Secure, SameSite flags
 - Check for verbose error messages that leak information
 - Test for common web vulnerabilities (SQL injection, XSS, IDOR)
@@ -111,6 +111,7 @@ CORS TESTING (per Fetch specification browser enforcement rules):
 - Reflected Origin + Access-Control-Allow-Credentials: true = ACTUAL HIGH SEVERITY. The server echoes back whatever Origin the attacker sends, allowing any site to make credentialed cross-origin requests. To test: send a request with header "Origin: https://evil.example.com" and check if Access-Control-Allow-Origin in the response reflects that exact value.
 - Access-Control-Allow-Origin: null + Access-Control-Allow-Credentials: true = exploitable from sandboxed iframes (data: URIs, sandboxed frames). Severity: MEDIUM-HIGH.
 - ALWAYS actively test for origin reflection: send an OPTIONS or GET request with "Origin: https://evil.example.com" header and inspect whether Access-Control-Allow-Origin echoes it back. This is the most dangerous CORS pattern.
+- IMPORTANT: CORS is only relevant for endpoints that use cookie-based or token-based authentication. If the endpoint requires NO authentication at all, CORS configuration does not change the risk — the endpoint is directly callable from any client regardless of CORS headers. Do not document CORS misconfigurations on unauthenticated endpoints.
 
 COMMON TESTING PATTERNS:
 - Test with/without authentication

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -336,6 +336,14 @@ Credential & Secret Discovery:
 - When validating an exposed key, verify what access it actually grants. A key that returns 200 on a single endpoint is less severe than a key that provides access to user data, admin functions, or billing APIs.
 - Title findings precisely: "Exposed Backend API Key" is better than "Hardcoded API Keys and AWS Infrastructure Configuration" which conflates secret and non-secret data.
 
+Security Headers & CORS:
+- Do NOT recommend X-XSS-Protection — it is deprecated by all major browsers (Chrome, Firefox, Edge). Recommend Content-Security-Policy instead.
+- CORS analysis must account for the endpoint's authentication model:
+  - If the endpoint requires NO authentication, CORS configuration is irrelevant — the endpoint can be called directly from any client regardless of CORS. Do not flag CORS as a finding or recommend CORS fixes for unauthenticated endpoints.
+  - Wildcard CORS (Access-Control-Allow-Origin: *) WITHOUT Access-Control-Allow-Credentials: true is LOW risk — browsers block credentialed requests to wildcard origins per the Fetch spec.
+  - Reflected Origin WITH Access-Control-Allow-Credentials: true is HIGH risk — this is an actual CORS bypass enabling credential theft.
+- When documenting missing security headers, do NOT list X-XSS-Protection. The recommended headers to check are: Content-Security-Policy, Strict-Transport-Security, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy.
+
 State Checkpointing:
 You have a \`checkpoint_state\` tool. Call it:
 - After completing reconnaissance and before starting exploitation


### PR DESCRIPTION
Closes #562

## Summary
- Add `Security Headers & CORS` section to pentest agent system prompt with three key rules
- Mark X-XSS-Protection as deprecated in httpRequest tool description, recommend CSP
- Add CORS-irrelevant-for-unauth-endpoints rule to httpRequest CORS testing guidance

## What changed

**Pentest agent prompt** (`agent.ts`):
- New section after Authentication guidelines covering X-XSS-Protection deprecation, CORS-auth-model awareness, and recommended header checklist

**HTTP request tool** (`httpRequest.ts`):
- Spelled out full header names (CSP, HSTS) instead of abbreviations
- Added X-XSS-Protection deprecation note to header checklist
- Added rule: don't flag CORS on unauthenticated endpoints

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 535 passed, 0 failed
- [ ] Generate pentest report against target with unauthenticated endpoints — verify no CORS recommendation
- [ ] Generate pentest report — verify X-XSS-Protection not listed as missing header

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: refactors streaming and subagent orchestration from callback-based consumption to a new `AgentEventBus` across multiple agents/workflows, which could break logs/UI event handling if event mapping is incomplete. Also introduces a new `run_pentest_workflow` tool and routes `/pentest` through operator skill execution, affecting core pentest entry points.
> 
> **Overview**
> **Consolidates `/pentest` into the operator dashboard** by introducing a built-in `pentest` skill that auto-invokes the new `run_pentest_workflow` tool, and updates the TUI `/pentest` command + wizard + session-opening behavior to route into `operator` with `initialSkill` args.
> 
> **Refactors agent streaming plumbing** from `ConsumeCallbacks`/`SubagentConsumeCallbacks` to a typed pub/sub `AgentEventBus` (`text-delta`, tool-call lifecycle, subagent spawn/complete, command output, errors), wiring it through `OffensiveSecurityAgent`, orchestration tools (`run_attack_surface`, `spawn_*`), and workflows (pentest, whitebox attack-surface, risk scoring, threat-model), plus updating scripts/tests to attach bus listeners.
> 
> **Tightens recon/pentest schemas & guidance** by renaming documented endpoint `url` → `routePath`, expanding `document_app` types (e.g., `full_stack`, `database`), adjusting whitebox asset parsing for legacy records, and updating prompts to deprecate `X-XSS-Protection` and avoid flagging CORS issues on unauthenticated endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7501fcd5a1b698a512118fb50d25b5b552558e1c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->