### PR TITLE
fix: rate limiting testing threshold and evidence requirements

### DIFF
--- a/src/core/agents/specialized/findingJudge/index.ts
+++ b/src/core/agents/specialized/findingJudge/index.ts
@@ -121,6 +121,7 @@ Does the POC output actually demonstrate the claimed vulnerability?
 - For IDOR: Does the output show access to resources belonging to other users/accounts?
 - For authentication bypass: Does the output show access to protected resources without valid credentials?
 - For email injection / HTML injection: The PoC must show more than "server accepted HTML input." Verify: (a) the email was actually sent (success response confirming delivery), AND (b) ideally, the email was retrieved via IMAP/POP3 or confirmed via out-of-band callback. If only (a) is met, reduce confidence and note "HTML rendering in email client was not independently verified."
+- For missing rate limiting / anti-automation: Does the output show a statistically significant number of requests (minimum 50) that all succeeded without throttling? A handful of successful requests (fewer than 20) is insufficient — rate limiting may use sliding windows, IP-based quotas, or progressive delays that only trigger at higher volumes. The finding should document the exact request count and distribution.
 
 ### 2. Hallucination Detection
 Could the POC be manufacturing fake evidence rather than demonstrating real exploitation?
@@ -175,6 +176,7 @@ Ask: "Would a knowledgeable developer of this application consider this a bug, o
 - When in doubt about whether behavior is by-design, **classify as informational** rather than vulnerability — documenting expected behavior as a vulnerability undermines report credibility.
 - Email/HTML injection findings without independent rendering verification (e.g., only a 200 OK response): confidence must be < 0.7. Add a concern noting that HTML rendering in the recipient's email client was not independently verified.
 - Below 0.7 confidence: always populate the concerns array explaining what makes the finding marginal.
+- For rate-limiting / anti-automation findings: If the POC sent fewer than 50 requests, assign confidence below 0.7 and add a concern: "Insufficient test volume — only N requests were sent. Rate limiting mechanisms may use thresholds above this volume." If the finding does not state the exact number of requests sent, add a concern: "Finding does not specify the number of test requests sent."
 
 ## Output Instructions
 

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -296,6 +296,13 @@ Rate Limiting:
 - Use execute_command with "sleep N" where N increases: 5 seconds, then 30 seconds, then 120 seconds
 - After sleeping, retry the request. If rate limiting persists after 3 attempts, note it in your summary and move on to other objectives
 
+Testing for Rate Limiting Deficiencies:
+- When an objective involves testing for missing rate limiting or anti-automation controls, send a MINIMUM of 50 requests in rapid succession before concluding that no rate limiting exists. Fewer than 50 requests is not sufficient — rate limiting mechanisms may use sliding windows, IP quotas, or progressive delays that only trigger at higher volumes.
+- In your finding evidence, always state the EXACT number of requests sent, their distribution (e.g. "50 requests to /api/login over 10 seconds, all from a single IP"), and all HTTP status codes observed. Vague claims like "multiple requests" or "rapid requests" are insufficient.
+- Frame findings as "Insufficient Anti-Automation Controls" rather than definitively "No Rate Limiting" unless you sent 100+ requests without encountering any throttling, delays, or 429 responses. Even with no rate limiting, a throttled bot can bypass simple rate limits — the absence of CAPTCHA, device fingerprinting, or behavioral analysis is the broader concern.
+- Always note existing mitigations and their impact on exploitability. For example, if the target has account lockout after 5 failed attempts, this significantly limits credential stuffing even without IP-based rate limiting. Document what protections DO exist, not just what is missing.
+- When documenting rate limiting findings, clearly state what was tested (authentication endpoint, API endpoint, password reset, etc.) and how the test was conducted (sequential vs concurrent, single IP vs distributed, single account vs multiple accounts).
+
 CRITICAL — document_vulnerability usage rules:
 - document_vulnerability is ONLY for confirmed, exploitable security vulnerabilities
 - Provide your POC script inline in the pocContent field — the tool will create, execute, and validate it automatically


### PR DESCRIPTION
Closes #556

## Summary
- Pentest agent must now send minimum 50 requests before declaring "no rate limiting"
- Findings reframed as "Insufficient Anti-Automation Controls" unless 100+ requests sent
- Evidence must include exact request count, distribution, and observed status codes
- Existing mitigations (lockout, CAPTCHA) must be documented and factored into severity
- Finding judge flags rate-limit findings with <50 requests as low-confidence

## Test plan
- [ ] Typecheck passes (`npx tsc --noEmit` — pre-existing weave errors only)
- [ ] Lint passes on changed files
- [ ] Run pentest against target with rate-limit objective, verify agent sends 50+ requests before documenting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates AI-agent prompts that govern automated pentest behavior and finding validation; incorrect prompting could change what gets documented or rejected, impacting report accuracy.
> 
> **Overview**
> Tightens guidance for rate-limiting / anti-automation findings across both the pentest agent and the finding judge.
> 
> The pentest agent is now instructed to send **at least 50 rapid requests** before concluding missing throttling, to include **exact request counts/distribution/status codes** in evidence, to *prefer* framing as `Insufficient Anti-Automation Controls` unless testing is very high-volume, and to document existing mitigations (e.g. lockouts/CAPTCHA). The finding judge prompt now treats <50-request rate-limit POCs as **low-confidence** and requires an explicit concern when request volume is insufficient or unspecified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b15cf8844ac9c788258fe435f641587dc9522eb7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->