### PR TITLE
fix: distinguish sensitive secrets from expected-public config in findings

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -34,7 +34,7 @@ export const documentVulnerabilityInputSchema = z.object({
     .string()
     .optional()
     .describe(
-      "The class of vulnerability (e.g., sqli, xss, command-injection, idor, ssrf, path-traversal, crypto, cve)",
+      "The class of vulnerability (e.g., sqli, xss, command-injection, idor, ssrf, path-traversal, crypto, cve, hardcoded-credentials, information-disclosure, missing-authentication)",
     ),
   toolCallDescription: z
     .string()

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -318,6 +318,16 @@ Authentication:
 - For execute_command (curl): include -H "Cookie: ..." and/or -H "Authorization: ..." flags.
 - If a request returns 401/403, the session may have expired — note it in your findings but do not try to log in again.
 
+Credential & Secret Discovery:
+- When you find exposed configuration in client-side code (JS bundles, HTML source, config files), distinguish between:
+  - SENSITIVE SECRETS (API keys granting backend access, database credentials, JWT signing keys, private keys, service account tokens) — document as a HIGH/CRITICAL finding
+  - EXPECTED-PUBLIC IDENTIFIERS (OAuth Client IDs, Cognito User Pool IDs, Firebase config, reCAPTCHA site keys, public API endpoints, AWS regions) — these are designed to be in client code and are NOT secrets
+- Do NOT combine these in a single finding. If you discover both types in the same source (e.g., a JS bundle contains both an API key and a Cognito Pool ID):
+  - Document the sensitive secret as its own finding (e.g., "Hardcoded Backend API Key in Client-Side JavaScript")
+  - Mention the public identifiers only as supporting context, not as additional secrets
+- When validating an exposed key, verify what access it actually grants. A key that returns 200 on a single endpoint is less severe than a key that provides access to user data, admin functions, or billing APIs.
+- Title findings precisely: "Exposed Backend API Key" is better than "Hardcoded API Keys and AWS Infrastructure Configuration" which conflates secret and non-secret data.
+
 State Checkpointing:
 You have a \`checkpoint_state\` tool. Call it:
 - After completing reconnaissance and before starting exploitation

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -156,7 +156,7 @@ export function getProviderModel(
       // Bun's fetch has a 300-second default timeout that can't be disabled
       // via AbortSignal. Pass a custom fetch that explicitly sets a 1-hour
       // timeout to support long-running streaming requests at large context sizes.
-      const bedrockFetch: typeof globalThis.fetch = (input, init) => {
+      const bedrockFetch = (input: RequestInfo | URL, init?: RequestInit) => {
         const longTimeout = AbortSignal.timeout(60 * 60 * 1000);
         const signal = init?.signal
           ? AbortSignal.any([init.signal, longTimeout])
@@ -173,7 +173,7 @@ export function getProviderModel(
           ?.credentialProvider as NonNullable<
           Parameters<typeof createAmazonBedrock>[0]
         >["credentialProvider"],
-        fetch: bedrockFetch,
+        fetch: bedrockFetch as typeof globalThis.fetch,
       });
       providerModel = bedrock(model);
       break;


### PR DESCRIPTION
## Summary
- Add "Credential & Secret Discovery" guidance to pentest agent prompt so the agent separates sensitive secrets (API keys, DB creds) from expected-public identifiers (OAuth Client IDs, Cognito Pool IDs) instead of lumping them into one finding
- Expand `vulnerabilityClass` examples with `hardcoded-credentials`, `information-disclosure`, `missing-authentication`

## Context
Professional pentester reviewing a generated report flagged that Finding 7.4 conflated a functional backend API key with Cognito User Pool IDs (which are designed to be public) under a single "Hardcoded API Keys and AWS Infrastructure Configuration" finding. The CVSS scorer and finding judge already distinguish these correctly — the gap was the agent prompt having no guidance to separate them at discovery time.

## Test plan
- [ ] Typecheck passes (string-only changes)
- [ ] Lint passes
- [ ] Prompt reads naturally between "Authentication" and "State Checkpointing" sections

Closes #561

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to agent prompt guidance and schema description text, affecting how findings are categorized/written but not runtime execution logic.
> 
> **Overview**
> Improves pentest agent reporting guidance to **separate true secrets from expected-public client configuration** when documenting credential/config exposures, preventing conflated findings and encouraging validation of actual access granted.
> 
> Expands `document_vulnerability` input schema `vulnerabilityClass` examples to include `hardcoded-credentials`, `information-disclosure`, and `missing-authentication` for clearer classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e888ea5a74ac11b42c9e67bccb97718fa429c22. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->