### PR TITLE
Strengthen injection finding evidence requirements

### DIFF
--- a/src/core/agents/specialized/findingJudge/index.ts
+++ b/src/core/agents/specialized/findingJudge/index.ts
@@ -120,6 +120,7 @@ Does the POC output actually demonstrate the claimed vulnerability?
 - For path traversal: Does the output show file contents from outside the intended directory?
 - For IDOR: Does the output show access to resources belonging to other users/accounts?
 - For authentication bypass: Does the output show access to protected resources without valid credentials?
+- For email injection / HTML injection: The PoC must show more than "server accepted HTML input." Verify: (a) the email was actually sent (success response confirming delivery), AND (b) ideally, the email was retrieved via IMAP/POP3 or confirmed via out-of-band callback. If only (a) is met, reduce confidence and note "HTML rendering in email client was not independently verified."
 
 ### 2. Hallucination Detection
 Could the POC be manufacturing fake evidence rather than demonstrating real exploitation?
@@ -172,6 +173,7 @@ Ask: "Would a knowledgeable developer of this application consider this a bug, o
 ### Confidence calibration
 - When in doubt about exploitation legitimacy, **ACCEPT as vulnerability** — a borderline-real finding is worth documenting.
 - When in doubt about whether behavior is by-design, **classify as informational** rather than vulnerability — documenting expected behavior as a vulnerability undermines report credibility.
+- Email/HTML injection findings without independent rendering verification (e.g., only a 200 OK response): confidence must be < 0.7. Add a concern noting that HTML rendering in the recipient's email client was not independently verified.
 - Below 0.7 confidence: always populate the concerns array explaining what makes the finding marginal.
 
 ## Output Instructions

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -289,6 +289,7 @@ Guidelines:
 - When you have finished testing ALL objectives, call the response tool with a summary of your results. Do NOT call response until you have completed all testing.
 - In your response, include objectiveResults for EVERY objective: mark each as completed (true) if you thoroughly tested it and either found and documented a vulnerability OR conclusively determined the endpoint is not vulnerable to that attack. Mark as incomplete (false) if you were unable to fully test it (e.g., rate limited, timed out, need different approach). Also add NEW objectives you discovered during testing that should be tested in future runs (mark these as completed=false).
 - Do NOT write report files to scratchpad/ (no executive summaries, comprehensive reports, finding compilations, or vulnerability rollups). Reports are generated automatically from findings/. Use the response tool for your final summary.
+- Email Injection: For email injection findings, confirm the email was actually delivered and rendered as HTML. If you have email inbox access (email_get_message tool), retrieve the sent email to verify HTML rendering. If inbox access is unavailable, explicitly note in your evidence that rendering was not independently verified.
 
 Rate Limiting:
 - If you encounter rate limiting (HTTP 429), use exponential backoff before retrying

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -156,7 +156,7 @@ export function getProviderModel(
       // Bun's fetch has a 300-second default timeout that can't be disabled
       // via AbortSignal. Pass a custom fetch that explicitly sets a 1-hour
       // timeout to support long-running streaming requests at large context sizes.
-      const bedrockFetch: typeof globalThis.fetch = (input, init) => {
+      const bedrockFetch = (input: RequestInfo | URL, init?: RequestInit) => {
         const longTimeout = AbortSignal.timeout(60 * 60 * 1000);
         const signal = init?.signal
           ? AbortSignal.any([init.signal, longTimeout])
@@ -173,7 +173,7 @@ export function getProviderModel(
           ?.credentialProvider as NonNullable<
           Parameters<typeof createAmazonBedrock>[0]
         >["credentialProvider"],
-        fetch: bedrockFetch,
+        fetch: bedrockFetch as typeof globalThis.fetch,
       });
       providerModel = bedrock(model);
       break;


### PR DESCRIPTION
## Summary
- Finding judge now requires email/HTML injection PoCs to demonstrate actual delivery, not just server acceptance
- Confidence capped at <0.7 when rendering is not independently verified
- Pentest agent guided to retrieve sent emails via IMAP when possible

Closes #559

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validation and agent instructions that influence which findings get accepted and their confidence scores, which may affect automated reporting outcomes. No runtime logic changes beyond prompt text, but it can shift false-positive/false-negative rates for email injection cases.
> 
> **Overview**
> **Tightens automated handling of email/HTML injection findings.** The `FindingJudge` prompt now requires PoCs to demonstrate *actual email delivery* (not just acceptance of HTML input) and advises lowering confidence when HTML rendering cannot be independently verified.
> 
> The pentest agent guidance is updated to explicitly retrieve sent emails via `email_get_message` when inbox access is available, and to clearly state when rendering verification isn’t possible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b65006cece473b7f7ceb341e4115053561e51ed3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->