### PR TITLE
fix: auto-disable extended thinking for unsupported models & add Space shortcut hint

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentEndpoint.ts
+++ b/src/core/agents/offSecAgent/tools/documentEndpoint.ts
@@ -208,8 +208,10 @@ Each endpoint creates a JSON file in the assets directory for tracking and analy
         pentestObjectives: input.pentestObjectives,
       };
 
-      const threatModelOutput =
-        await generateThreatModelForEndpoint(ctx, subagentInput);
+      const threatModelOutput = await generateThreatModelForEndpoint(
+        ctx,
+        subagentInput,
+      );
 
       const riskScore = threatModelOutput?.riskScore ?? heuristicRiskScore;
 

--- a/src/tui/components/model-picker/ModelPickerDialog.tsx
+++ b/src/tui/components/model-picker/ModelPickerDialog.tsx
@@ -10,7 +10,9 @@ import { useConfig } from "../../context/config";
 import { useTheme } from "../../theme";
 import { Dialog } from "../../context/dialog";
 import DialogLayout from "../dialog-layout";
+import type { FooterAction } from "../dialog-layout";
 import { ModelPicker } from "./ModelPicker";
+import { modelSupportsThinking } from "../../../core/ai";
 
 interface ModelPickerDialogProps {
   onClose: () => void;
@@ -27,6 +29,15 @@ export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
     setReasoningEnabled,
   } = useAgent();
 
+  const thinkingSupported = modelSupportsThinking(model.id);
+
+  const footerActions: FooterAction[] = [
+    { key: "Enter", label: "confirm", variant: "primary" },
+  ];
+  if (thinkingSupported) {
+    footerActions.push({ key: "Space", label: "Extended Thinking" });
+  }
+
   const title = (
     <text>
       <span fg={colors.primary}>Select AI Model</span>
@@ -40,10 +51,7 @@ export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
 
   return (
     <Dialog size="large" onClose={onClose}>
-      <DialogLayout
-        title={title}
-        footerActions={[{ key: "Enter", label: "confirm", variant: "primary" }]}
-      >
+      <DialogLayout title={title} footerActions={footerActions}>
         <box
           flexDirection="column"
           paddingLeft={1}

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -18,7 +18,7 @@ import {
 import { runOffensiveSecurityAgent } from "../../../core/api/offesecAgent";
 import { attachWandbToEventBus } from "../../../core/integrations/wandb/upload";
 import { buildAuthConfig } from "../../../core/ai/utils";
-import type { CacheMetrics } from "../../../core/ai";
+import { modelSupportsThinking, type CacheMetrics } from "../../../core/ai";
 import {
   ALL_TOOL_NAMES,
   PLAN_MODE_TOOL_NAMES,
@@ -1180,7 +1180,7 @@ export default function OperatorDashboard({
         approvalGate: approvalGateRef.current,
         commandCancelHandle: cancelHandleRef.current,
         skillsRegistry,
-        enableThinking: reasoningEnabled,
+        enableThinking: reasoningEnabled && modelSupportsThinking(model.id),
         onStepFinish,
         onCacheMetrics: (metrics: CacheMetrics) => {
           addCacheUsage(

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useCallback,
   useEffect,
+  useRef,
   type ReactNode,
 } from "react";
 import { type ModelInfo, modelSupportsThinking } from "../../core/ai";
@@ -88,6 +89,9 @@ export function AgentProvider({ children }: AgentProviderProps) {
   const [isExecuting, setIsExecuting] = useState<boolean>(false);
   const [sessionCwd, setSessionCwd] = useState<string | null>(null);
 
+  const reasoningEnabledRef = useRef(reasoningEnabled);
+  reasoningEnabledRef.current = reasoningEnabled;
+
   // Wrapper that marks model as user-selected and persists to config.
   // Pass `persist = false` for programmatic/initialization calls so the
   // user's previously saved preference is not silently overwritten.
@@ -95,7 +99,17 @@ export function AgentProvider({ children }: AgentProviderProps) {
     setModelInternal(newModel);
     if (persist) {
       setIsModelUserSelected(true);
-      updateConfig({ selectedModelId: newModel.id }).catch((err) => {
+      const configUpdate: {
+        selectedModelId: string;
+        reasoningEnabled?: boolean;
+      } = {
+        selectedModelId: newModel.id,
+      };
+      if (reasoningEnabledRef.current && !modelSupportsThinking(newModel.id)) {
+        configUpdate.reasoningEnabled = false;
+        setReasoningEnabledInternal(false);
+      }
+      updateConfig(configUpdate).catch((err) => {
         writeErrorLog(err, "AGENT_CONTEXT");
       });
     }
@@ -114,13 +128,6 @@ export function AgentProvider({ children }: AgentProviderProps) {
       setReasoningEnabledInternal(appConfig.data.reasoningEnabled);
     }
   }, [appConfig.data?.reasoningEnabled]);
-
-  // Auto-disable extended thinking when switching to a model that doesn't support it
-  useEffect(() => {
-    if (reasoningEnabled && !modelSupportsThinking(model.id)) {
-      setReasoningEnabled(false);
-    }
-  }, [model.id, reasoningEnabled, setReasoningEnabled]);
 
   // Re-evaluate the default model whenever config changes (e.g. after
   // provider setup) unless the user has explicitly picked a model.

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -7,7 +7,7 @@ import {
   useEffect,
   type ReactNode,
 } from "react";
-import { type ModelInfo } from "../../core/ai";
+import { type ModelInfo, modelSupportsThinking } from "../../core/ai";
 import { AVAILABLE_MODELS } from "../../core/ai/models";
 import { update as updateConfig } from "../../core/config/config";
 import {
@@ -114,6 +114,13 @@ export function AgentProvider({ children }: AgentProviderProps) {
       setReasoningEnabledInternal(appConfig.data.reasoningEnabled);
     }
   }, [appConfig.data?.reasoningEnabled]);
+
+  // Auto-disable extended thinking when switching to a model that doesn't support it
+  useEffect(() => {
+    if (reasoningEnabled && !modelSupportsThinking(model.id)) {
+      setReasoningEnabled(false);
+    }
+  }, [model.id, reasoningEnabled, setReasoningEnabled]);
 
   // Re-evaluate the default model whenever config changes (e.g. after
   // provider setup) unless the user has explicitly picked a model.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes the bug where switching to a model that doesn't support extended thinking would hide the toggle UI but leave `reasoningEnabled` set to `true` in state/config. This caused errors when attempting to use the unsupported model because the system would still pass extended thinking options to the provider.

**Root cause:** The UI correctly hid the toggle for unsupported models, but the persisted `reasoningEnabled` flag in config and in-memory state was never cleared when switching models. So the flag was silently carried forward.

**Changes:**

1. **Save-time guard** (`src/tui/context/agent.tsx` — `setModel`): When persisting a model switch, if `reasoningEnabled` is `true` and the new model doesn't support thinking, clear `reasoningEnabled` in both React state and the config file in a single atomic write. This is the primary fix — it ensures stale config can never persist.

2. **Runtime guard** (`src/tui/components/operator-dashboard/index.tsx`): Gate `enableThinking` with `modelSupportsThinking(model.id)` before passing it to the agent. This is defense-in-depth — even if config is somehow stale (e.g. manually edited, race condition), thinking is never requested for an unsupported model at the call site.

3. **`[Space] Extended Thinking` shortcut hint** (`src/tui/components/model-picker/ModelPickerDialog.tsx`): The model picker dialog footer now conditionally shows a `[Space] Extended Thinking` control hint when the selected model supports thinking. Disappears for non-thinking models, matching the checkbox visibility.

**What was considered and rejected:** An initial approach used a `useEffect` to auto-disable `reasoningEnabled` whenever the model changed. This was removed per review feedback — the UI already hides the toggle for unsupported models, so the effect was redundant. The save-time + runtime guard approach is simpler and more targeted.

### How did you verify your code works?

- All CI checks pass: `bun run tsc`, `bun run lint`, `bun run format:check`, `bun run test` (586 tests pass)
- Manual TUI testing with the following flow:
  1. Selected Claude 3.7 Sonnet (thinking-capable) — footer shows `[Enter] confirm · [Space] Extended Thinking`
  2. Pressed Space to enable extended thinking — checkbox toggles to `[x]`
  3. Navigated to Claude 3.5 Haiku (non-thinking) — footer shows only `[Enter] confirm`, checkbox hidden
  4. Navigated back to Claude 3.7 Sonnet — checkbox shows `[ ]` (unchecked), confirming the save-time guard cleared the state

**Demo video:**

<a href="https://cursor.com/agents/bc-c5b159e5-01d7-44a9-a0ff-1cdd8fb82a21/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fextended_thinking_save_time_guard_demo.mp4"><img src="https://cursor.com/artifacts/c/art-fda5bc2d-045b-4ee5-840c-cc248e3b15b8" alt="extended_thinking_save_time_guard_demo.mp4" /></a>

**Key screenshots:**

Thinking-capable model with `[Space]` hint:
![Thinking model with Space hint](https://cursor.com/artifacts/c/art-d8dd2879-14b5-4e09-a8c1-ea1d157fb6c5)

Extended thinking toggled ON:
![Extended thinking toggled on](https://cursor.com/artifacts/c/art-b4dc439d-fd5d-46af-bcf2-60c2cb86230e)

Non-thinking model — no hint, checkbox hidden:
![Non-thinking model without hint](https://cursor.com/artifacts/c/art-68e3c291-15c1-447a-beb8-397f6f85b794)

After switching back — save-time guard cleared the state (unchecked):
![Save-time guard cleared state](https://cursor.com/artifacts/c/art-21527b33-7611-477d-a457-fac7f42d1358)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5b159e5-01d7-44a9-a0ff-1cdd8fb82a21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5b159e5-01d7-44a9-a0ff-1cdd8fb82a21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

