### PR TITLE
feat: export sub-agent prompts for evalgate evals

### DIFF
--- a/.github/workflows/eval-dispatch.yml
+++ b/.github/workflows/eval-dispatch.yml
@@ -1,0 +1,50 @@
+# Eval Dispatch
+# =============
+# Detects prompt changes in PRs and dispatches evalgate capability evals
+# for the affected sub-agents. Results are posted back as a PR comment.
+
+name: Eval Dispatch
+
+on:
+  pull_request:
+    paths:
+      - "src/core/agents/specialized/**/prompts.ts"
+      - "src/core/agents/specialized/pentest/agent.ts"
+      - "src/core/agents/specialized/findingJudge/**"
+      - "src/core/agents/specialized/cvssScorer/**"
+      - "src/core/agents/offSecAgent/prompt.ts"
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install --frozen-lockfile
+
+      - name: Detect affected agents
+        id: detect
+        run: |
+          AGENTS=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | bun run scripts/detect-affected-agents.ts)
+          echo "agents=$AGENTS" >> $GITHUB_OUTPUT
+          if [ -n "$AGENTS" ]; then
+            echo "Affected agents: $AGENTS"
+          else
+            echo "No prompt files changed"
+          fi
+
+      - name: Dispatch evalgate
+        if: steps.detect.outputs.agents != ''
+        run: |
+          gh workflow run eval-apex-agents.yml \
+            --repo pensarai/evalgate \
+            --ref main \
+            -f agents="${{ steps.detect.outputs.agents }}" \
+            -f apex_branch="${{ github.head_ref }}" \
+            -f apex_pr="${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ secrets.EVALGATE_DISPATCH_TOKEN }}

--- a/.github/workflows/eval-dispatch.yml
+++ b/.github/workflows/eval-dispatch.yml
@@ -28,8 +28,10 @@ jobs:
 
       - name: Detect affected agents
         id: detect
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          AGENTS=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | bun run scripts/detect-affected-agents.ts)
+          AGENTS=$(git diff --name-only origin/$BASE_REF...HEAD | bun run scripts/detect-affected-agents.ts)
           echo "agents=$AGENTS" >> $GITHUB_OUTPUT
           if [ -n "$AGENTS" ]; then
             echo "Affected agents: $AGENTS"
@@ -39,12 +41,13 @@ jobs:
 
       - name: Dispatch evalgate
         if: steps.detect.outputs.agents != ''
+        env:
+          GH_TOKEN: ${{ secrets.EVALGATE_DISPATCH_TOKEN }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           gh workflow run eval-apex-agents.yml \
             --repo pensarai/evalgate \
             --ref main \
             -f agents="${{ steps.detect.outputs.agents }}" \
-            -f apex_branch="${{ github.head_ref }}" \
+            -f apex_branch="$HEAD_REF" \
             -f apex_pr="${{ github.event.pull_request.number }}"
-        env:
-          GH_TOKEN: ${{ secrets.EVALGATE_DISPATCH_TOKEN }}

--- a/scripts/detect-affected-agents.ts
+++ b/scripts/detect-affected-agents.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env bun
+
+/**
+ * Detect Affected Agents
+ *
+ * Reads changed file paths from stdin (one per line) and outputs a
+ * comma-separated list of agent IDs whose prompts were affected.
+ *
+ * Usage:
+ *   git diff --name-only origin/canary...HEAD | bun run scripts/detect-affected-agents.ts
+ *   echo "src/core/agents/specialized/findingJudge/index.ts" | bun run scripts/detect-affected-agents.ts
+ */
+
+import { getAffectedAgents } from "../src/core/evals/promptRegistry";
+
+const input = await Bun.stdin.text();
+const files = input
+  .split("\n")
+  .map((l) => l.trim())
+  .filter(Boolean);
+
+const agents = getAffectedAgents(files);
+
+if (agents.length > 0) {
+  process.stdout.write(agents.join(","));
+}

--- a/src/core/agents/specialized/cvssScorer/index.ts
+++ b/src/core/agents/specialized/cvssScorer/index.ts
@@ -54,7 +54,7 @@ export interface CVSSScorerResult {
 // Schema for AI Output
 // =============================================================================
 
-const CVSSMetricsOutputSchema = z.object({
+export const CVSSMetricsOutputSchema = z.object({
   metrics: z.object({
     // Base Metrics - Exploitability
     AV: z
@@ -140,7 +140,7 @@ const CVSSMetricsOutputSchema = z.object({
 // System Prompt
 // =============================================================================
 
-const CVSS_SCORER_SYSTEM_PROMPT = `You are a CVSS 4.0 scoring specialist. Your task is to analyze vulnerability findings and determine the appropriate CVSS 4.0 Base metrics.
+export const CVSS_SCORER_SYSTEM_PROMPT = `You are a CVSS 4.0 scoring specialist. Your task is to analyze vulnerability findings and determine the appropriate CVSS 4.0 Base metrics.
 
 ## CVSS 4.0 Metrics Guide
 

--- a/src/core/agents/specialized/findingJudge/index.ts
+++ b/src/core/agents/specialized/findingJudge/index.ts
@@ -70,7 +70,7 @@ export interface FindingJudgeResult {
 // Schema for AI Output
 // =============================================================================
 
-const FindingJudgeOutputSchema = z.object({
+export const FindingJudgeOutputSchema = z.object({
   valid: z
     .boolean()
     .describe(
@@ -102,7 +102,7 @@ const FindingJudgeOutputSchema = z.object({
 // System Prompt
 // =============================================================================
 
-const FINDING_JUDGE_SYSTEM_PROMPT = `You are a security finding validation specialist. Your task is to analyze a proof-of-concept (POC) script and its execution output to determine whether it legitimately demonstrates the claimed vulnerability.
+export const FINDING_JUDGE_SYSTEM_PROMPT = `You are a security finding validation specialist. Your task is to analyze a proof-of-concept (POC) script and its execution output to determine whether it legitimately demonstrates the claimed vulnerability.
 
 ## Your Role
 

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -256,7 +256,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
 // Prompts
 // ---------------------------------------------------------------------------
 
-const PENTEST_SYSTEM_PROMPT_BASE = `You are an expert penetration tester performing a targeted security assessment.
+export const PENTEST_SYSTEM_PROMPT_BASE = `You are an expert penetration tester performing a targeted security assessment.
 
 You are given a specific target and specific objectives. Do NOT perform broad reconnaissance or service/endpoint discovery — that has already been done for you. Your job is to deeply test the provided target against the provided objectives.
 
@@ -352,7 +352,7 @@ You have a \`checkpoint_state\` tool. Call it:
 - Before wrapping up your session
 This is lightweight and does not count against your task. It helps track your reasoning for later analysis.`;
 
-const PENTEST_SYSTEM_PROMPT_EXFIL = `You are an expert penetration tester performing a targeted security assessment with the goal of demonstrating full exploit impact.
+export const PENTEST_SYSTEM_PROMPT_EXFIL = `You are an expert penetration tester performing a targeted security assessment with the goal of demonstrating full exploit impact.
 
 You are given a specific target and specific objectives. Your job is to deeply test the provided target, and when vulnerabilities are confirmed, pivot through them to discover and extract sensitive data.
 

--- a/src/core/evals/promptRegistry.ts
+++ b/src/core/evals/promptRegistry.ts
@@ -1,0 +1,54 @@
+/**
+ * Prompt Registry
+ *
+ * Maps source file paths to the agent IDs whose prompts they contain.
+ * Used by scripts/detect-affected-agents.ts to determine which agents
+ * are affected by a given set of file changes (e.g., in a PR).
+ */
+
+export type EvalAgentId =
+  | "pentest"
+  | "attack-surface"
+  | "authentication"
+  | "code"
+  | "whitebox"
+  | "patching"
+  | "environment"
+  | "finding-judge"
+  | "cvss-scorer"
+  | "base";
+
+/**
+ * Maps normalized file paths (relative to repo root) to the agent IDs
+ * whose prompts live in that file. A single file may affect multiple agents.
+ */
+export const PROMPT_FILE_MAP: Record<string, EvalAgentId[]> = {
+  "src/core/agents/specialized/pentest/agent.ts": ["pentest"],
+  "src/core/agents/specialized/attackSurface/prompts.ts": ["attack-surface"],
+  "src/core/agents/specialized/authenticationAgent/prompts.ts": [
+    "authentication",
+  ],
+  "src/core/agents/specialized/codeAgent/prompts.ts": ["code"],
+  "src/core/agents/specialized/whiteboxAttackSurface/prompts.ts": ["whitebox"],
+  "src/core/agents/specialized/patching/prompts.ts": ["patching"],
+  "src/core/agents/specialized/environment/prompts.ts": ["environment"],
+  "src/core/agents/specialized/findingJudge/index.ts": ["finding-judge"],
+  "src/core/agents/specialized/cvssScorer/index.ts": ["cvss-scorer"],
+  "src/core/agents/offSecAgent/prompt.ts": ["base"],
+};
+
+/**
+ * Given a list of changed file paths, returns the deduplicated set of
+ * agent IDs whose prompts may have been affected.
+ */
+export function getAffectedAgents(changedFiles: string[]): EvalAgentId[] {
+  const agents = new Set<EvalAgentId>();
+  for (const file of changedFiles) {
+    const normalized = file.replace(/^\.\//, "");
+    const match = PROMPT_FILE_MAP[normalized];
+    if (match) {
+      for (const id of match) agents.add(id);
+    }
+  }
+  return [...agents];
+}


### PR DESCRIPTION
## Summary
- Export private prompt constants and Zod schemas from FindingJudge, CVSSScorer, and Pentest agents
- Add `src/core/evals/promptRegistry.ts` mapping prompt files → agent IDs
- Add `scripts/detect-affected-agents.ts` for PR-level prompt change detection
- Add `.github/workflows/eval-dispatch.yml` to trigger evalgate capability evals on prompt-changing PRs

## Context
Apex-side of #569. Evalgate-side PR adds the actual eval scenarios and scoring infrastructure.

## Test plan
- [x] `echo "src/core/agents/specialized/findingJudge/index.ts" | bun run scripts/detect-affected-agents.ts` → `finding-judge`
- [x] Lint clean
- [x] Typecheck clean (no new errors)
- [x] All exports verified post-rebase

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new PR-triggered GitHub Actions workflow that uses a secret token to dispatch workflows in an external repo, so misconfiguration could cause unintended CI triggers or secret/permissions issues. Code changes are otherwise limited to exporting prompt/schema constants and adding a simple path→agent mapping helper.
> 
> **Overview**
> **Adds automated eval dispatching for prompt changes.** A new `Eval Dispatch` GitHub Action runs on PRs that touch prompt-related files, detects which agent prompts were modified, and dispatches `eval-apex-agents.yml` in the `pensarai/evalgate` repo with the affected agent IDs and PR metadata.
> 
> To support this, the PR introduces `src/core/evals/promptRegistry.ts` (file-path → agent ID mapping + `getAffectedAgents`) and `scripts/detect-affected-agents.ts` (stdin-based changed-file parser). It also **exports** previously-internal prompt constants and Zod schemas from the `pentest`, `findingJudge`, and `cvssScorer` agents for consumption by eval tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 550ccd15c8e8abc9eff3bd3f9b1388f74381394c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->