### PR TITLE
fix: set step limit for threat model workflow

### DIFF
--- a/src/core/workflows/threatModel.ts
+++ b/src/core/workflows/threatModel.ts
@@ -1,3 +1,4 @@
+import { stepCountIs } from "ai";
 import type { AIModel } from "../ai";
 import type { AIAuthConfig } from "../ai/utils";
 import type { SessionInfo } from "../session";
@@ -93,6 +94,7 @@ Working directory: ${input.codebasePath}`;
     abortSignal: input.abortSignal,
     skillsRegistry: registry,
     eventBus: input.eventBus,
+    stopWhen: stepCountIs(10000),
   });
 
   return { session, outputPath: input.outputPath };


### PR DESCRIPTION
## Summary

Set `stopWhen: stepCountIs(10000)` on the threat model workflow's agent invocation, matching the convention used by all other agent workflows in the codebase.

> **Note:** This also fixes an issue where the threat model agent only executes a single tool call and exits — `streamText` defaults to `stepCountIs(1)` when `stopWhen` is not specified.

## Test plan

- [x] Threat model agent completes successfully with multiple tool calls (tested locally)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the threat model workflow’s agent invocation to allow multi-step tool execution, with potential impact limited to longer/extra agent runtime and token usage.
> 
> **Overview**
> Fixes the threat model workflow exiting after a single step by explicitly passing `stopWhen: stepCountIs(10000)` to `runOffensiveSecurityAgent` (and importing `stepCountIs`).
> 
> This aligns threat modeling with other agent workflows by allowing multi-step tool calls before stopping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10900bc359a518479991906a18ff764cfb979c55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->