### PR TITLE
fix: use Bun timeout: false for Bedrock fetch

### DIFF
--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -153,15 +153,14 @@ export function getProviderModel(
     }
 
     case "bedrock": {
-      // Bun's fetch has a 300-second default timeout that can't be disabled
-      // via AbortSignal. Pass a custom fetch that explicitly sets a 1-hour
-      // timeout to support long-running streaming requests at large context sizes.
-      const bedrockFetch = (input: RequestInfo | URL, init?: RequestInit) => {
-        const longTimeout = AbortSignal.timeout(60 * 60 * 1000);
-        const signal = init?.signal
-          ? AbortSignal.any([init.signal, longTimeout])
-          : longTimeout;
-        return globalThis.fetch(input, { ...init, signal });
+      // Bun's fetch enforces a 300-second internal timeout that cannot be
+      // overridden via AbortSignal alone. Use Bun's proprietary `timeout`
+      // option to disable it for long-running Bedrock streaming requests.
+      const bedrockFetch: typeof globalThis.fetch = (input, init) => {
+        return globalThis.fetch(input, {
+          ...init,
+          timeout: false,
+        } as RequestInit);
       };
       const bedrock = createAmazonBedrock({
         apiKey: bedrockApiKey,


### PR DESCRIPTION
## Summary

Replace the `AbortSignal.timeout(1hr)` approach for Bedrock fetch with Bun's proprietary `timeout: false` option.

The previous approach (`AbortSignal.timeout`) doesn't actually prevent Bun's internal 300-second fetch timeout from firing — Bun enforces it independently of any `AbortSignal`. This causes `DOMException: The operation timed out` errors on long-running Bedrock streaming requests (e.g., threat model generation with large context, which can take 5-8 minutes).

The `timeout: false` option is Bun-specific and directly disables the internal timeout. Since the cluster service runs on Bun, this is the correct fix. The `as RequestInit` cast is needed because `timeout` isn't in the standard `RequestInit` type.

## Test plan

- [x] Threat model generation completes successfully (previously failed at ~300s)
- [ ] Verify no regression on other Bedrock-backed agents (recon, pentest)