### PR TITLE
feat: severity dependency awareness in CVSS scoring

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -21,6 +21,7 @@ import {
   type FindingJudgeInput,
 } from "../../specialized/findingJudge";
 import type { Finding } from "../types";
+import { normalizeEndpoint } from "../../../findings/registry";
 
 export const documentVulnerabilityInputSchema = z.object({
   title: z.string().describe("Finding title"),
@@ -260,6 +261,23 @@ CRITICAL RULES — READ BEFORE CALLING:
           };
           cvssWarning = `Classified as ${judgeResult.findingType} — not scored.`;
         } else {
+          const normalizedEndpoint = normalizeEndpoint(input.endpoint);
+          const relatedFindings =
+            ctx.findingsRegistry
+              ?.getFindings()
+              .filter(
+                (f) =>
+                  normalizeEndpoint(f.endpoint) === normalizedEndpoint &&
+                  f.title !== input.title,
+              )
+              .map((f) => ({
+                title: f.title,
+                severity: f.severity,
+                endpoint: f.endpoint,
+                vulnerabilityClass: (f as Record<string, unknown>)
+                  .vulnerabilityClass as string | undefined,
+              })) ?? [];
+
           const cvssInput: CVSSScorerInput = {
             finding: {
               title: input.title,
@@ -271,6 +289,7 @@ CRITICAL RULES — READ BEFORE CALLING:
               vulnerabilityClass: input.vulnerabilityClass,
             },
             agentMessages: [],
+            relatedFindings,
           };
 
           const MAX_CVSS_ATTEMPTS = 2;

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -270,13 +270,19 @@ CRITICAL RULES — READ BEFORE CALLING:
                   normalizeEndpoint(f.endpoint) === normalizedEndpoint &&
                   f.title !== input.title,
               )
-              .map((f) => ({
-                title: f.title,
-                severity: f.severity,
-                endpoint: f.endpoint,
-                vulnerabilityClass: (f as Record<string, unknown>)
-                  .vulnerabilityClass as string | undefined,
-              })) ?? [];
+              .map((f) => {
+                const raw = f as Record<string, unknown>;
+                const cvss = raw.cvss as { score?: number } | undefined;
+                return {
+                  title: f.title,
+                  severity: f.severity,
+                  endpoint: f.endpoint,
+                  vulnerabilityClass: raw.vulnerabilityClass as
+                    | string
+                    | undefined,
+                  score: cvss?.score,
+                };
+              }) ?? [];
 
           const cvssInput: CVSSScorerInput = {
             finding: {

--- a/src/core/agents/specialized/cvssScorer/cvssScorer.test.ts
+++ b/src/core/agents/specialized/cvssScorer/cvssScorer.test.ts
@@ -111,9 +111,7 @@ describe("buildScoringPrompt", () => {
     const prompt = buildScoringPrompt(input);
 
     expect(prompt).toContain("**Title:** Test Vulnerability");
-    expect(prompt).toContain(
-      "**Vulnerability Class:** information-disclosure",
-    );
+    expect(prompt).toContain("**Vulnerability Class:** information-disclosure");
     expect(prompt).toContain("**Endpoint:** https://target.com/api/test");
   });
 });

--- a/src/core/agents/specialized/cvssScorer/cvssScorer.test.ts
+++ b/src/core/agents/specialized/cvssScorer/cvssScorer.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { buildScoringPrompt, type CVSSScorerInput } from "./index";
+
+function makeInput(overrides: Partial<CVSSScorerInput> = {}): CVSSScorerInput {
+  return {
+    finding: {
+      title: "Test Vulnerability",
+      description: "A test vulnerability description.",
+      impact: "High impact on confidentiality.",
+      evidence: "HTTP 200 OK with sensitive data.",
+      endpoint: "https://target.com/api/test",
+      vulnerabilityClass: "information-disclosure",
+    },
+    agentMessages: [],
+    ...overrides,
+  };
+}
+
+describe("buildScoringPrompt", () => {
+  it("includes related findings section when relatedFindings is provided", () => {
+    const input = makeInput({
+      relatedFindings: [
+        {
+          title: "Missing Rate Limiting on Email API",
+          severity: "CRITICAL",
+          endpoint: "https://target.com/api/test",
+          vulnerabilityClass: "missing-rate-limiting",
+          score: 9.2,
+        },
+      ],
+    });
+
+    const prompt = buildScoringPrompt(input);
+
+    expect(prompt).toContain("## Related Findings on Same Endpoint");
+    expect(prompt).toContain("Missing Rate Limiting on Email API");
+    expect(prompt).toContain("[CRITICAL 9.2]");
+    expect(prompt).toContain("(class: missing-rate-limiting)");
+  });
+
+  it("does NOT include related findings section when relatedFindings is empty", () => {
+    const input = makeInput({ relatedFindings: [] });
+    const prompt = buildScoringPrompt(input);
+
+    expect(prompt).not.toContain("## Related Findings on Same Endpoint");
+  });
+
+  it("does NOT include related findings section when relatedFindings is undefined", () => {
+    const input = makeInput({ relatedFindings: undefined });
+    const prompt = buildScoringPrompt(input);
+
+    expect(prompt).not.toContain("## Related Findings on Same Endpoint");
+  });
+
+  it("formats multiple related findings with severity, title, and class", () => {
+    const input = makeInput({
+      relatedFindings: [
+        {
+          title: "Missing Rate Limiting",
+          severity: "CRITICAL",
+          endpoint: "https://target.com/api/test",
+          vulnerabilityClass: "missing-rate-limiting",
+          score: 9.2,
+        },
+        {
+          title: "Information Disclosure via Error Messages",
+          severity: "MEDIUM",
+          endpoint: "https://target.com/api/test",
+          vulnerabilityClass: "information-disclosure",
+        },
+      ],
+    });
+
+    const prompt = buildScoringPrompt(input);
+
+    expect(prompt).toContain(
+      '- [CRITICAL 9.2] "Missing Rate Limiting" (class: missing-rate-limiting)',
+    );
+    expect(prompt).toContain(
+      '- [MEDIUM] "Information Disclosure via Error Messages" (class: information-disclosure)',
+    );
+  });
+
+  it("uses 'unknown' for class when vulnerabilityClass is not provided", () => {
+    const input = makeInput({
+      relatedFindings: [
+        {
+          title: "Some Finding",
+          severity: "HIGH",
+          endpoint: "https://target.com/api/test",
+        },
+      ],
+    });
+
+    const prompt = buildScoringPrompt(input);
+
+    expect(prompt).toContain('- [HIGH] "Some Finding" (class: unknown)');
+  });
+
+  it("always includes finding details regardless of related findings", () => {
+    const input = makeInput({
+      relatedFindings: [
+        {
+          title: "Related Finding",
+          severity: "HIGH",
+          endpoint: "https://target.com/api/test",
+        },
+      ],
+    });
+
+    const prompt = buildScoringPrompt(input);
+
+    expect(prompt).toContain("**Title:** Test Vulnerability");
+    expect(prompt).toContain(
+      "**Vulnerability Class:** information-disclosure",
+    );
+    expect(prompt).toContain("**Endpoint:** https://target.com/api/test");
+  });
+});

--- a/src/core/agents/specialized/cvssScorer/index.ts
+++ b/src/core/agents/specialized/cvssScorer/index.ts
@@ -31,6 +31,14 @@ export interface CVSSScorerInput {
   };
   /** Messages from the meta testing agent's conversation (for context) */
   agentMessages: Record<string, unknown>[];
+  /** Other findings on the same endpoint for dependency-aware scoring */
+  relatedFindings?: Array<{
+    title: string;
+    severity: string;
+    endpoint: string;
+    vulnerabilityClass?: string;
+    score?: number;
+  }>;
 }
 
 export interface CVSSScorerResult {
@@ -271,6 +279,15 @@ const CVSS_SCORER_SYSTEM_PROMPT = `You are a CVSS 4.0 scoring specialist. Your t
 - If production-like or confirmed unintentional: **E:A**
 - Severity: typically **HIGH-CRITICAL** for real bypasses, **MEDIUM** for intentional test credentials in sandbox
 
+## Prerequisite & Dependency Scoring
+
+If related findings on the same endpoint are provided below, consider whether this finding ENABLES or is a PREREQUISITE for those findings.
+
+- A prerequisite finding (e.g., missing authentication that enables rate limiting abuse) MUST score at least as high as the findings it enables.
+- When the current finding provides the attack surface that makes other findings exploitable, elevate its impact metrics accordingly.
+- Example: if "Unauthenticated Access" (this finding) enables "Missing Rate Limiting" (scored CRITICAL 9.2), this finding should score >= 9.2 because without the unauthenticated access, the rate limiting issue would not be exploitable.
+- Do NOT lower scores of independent findings — only elevate prerequisites that enable higher-scored dependents.
+
 ## Analysis Instructions
 
 1. Read the finding description and evidence carefully
@@ -378,7 +395,7 @@ function truncateField(value: string, limit: number): string {
   return value.substring(0, limit) + "\n... [truncated]";
 }
 
-function buildScoringPrompt(input: CVSSScorerInput): string {
+export function buildScoringPrompt(input: CVSSScorerInput): string {
   const { finding, agentMessages } = input;
 
   const description = truncateField(finding.description, MAX_DESCRIPTION_CHARS);
@@ -405,6 +422,20 @@ ${evidence}
 \`\`\`
 
 `;
+
+  // Add related findings for dependency-aware scoring
+  if (input.relatedFindings && input.relatedFindings.length > 0) {
+    prompt += `## Related Findings on Same Endpoint
+
+The following findings exist on the same endpoint/target. Consider dependency relationships:
+
+`;
+    for (const rf of input.relatedFindings) {
+      const scoreTag = rf.score != null ? ` ${rf.score}` : "";
+      prompt += `- [${rf.severity}${scoreTag}] "${rf.title}" (class: ${rf.vulnerabilityClass || "unknown"})\n`;
+    }
+    prompt += "\n";
+  }
 
   // Add context from agent conversation if available
   if (agentMessages && agentMessages.length > 0) {


### PR DESCRIPTION
## Summary
- Extend `CVSSScorerInput` with optional `relatedFindings` field for same-endpoint context
- Add prerequisite scoring guidance to CVSS system prompt so prerequisite findings score >= dependent findings
- Inject same-endpoint findings from `FindingsRegistry` into scorer at scoring time

Closes #554

## Test plan
- [x] Unit tests for prompt formatting with/without related findings
- [x] Verified related findings section renders correctly with severity, title, class
- [x] Typecheck clean
- [x] Lint clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CVSS prompt construction and scoring inputs, which can materially alter reported severity for findings on shared endpoints. Risk is contained to scoring/reporting logic but may impact downstream triage and dedup expectations.
> 
> **Overview**
> Improves CVSS scoring to be *dependency-aware* by passing same-endpoint context into the scorer and instructing the model to elevate prerequisite findings to at least the severity of the findings they enable.
> 
> `documentFinding` now pulls other findings from `FindingsRegistry` with a normalized endpoint match and includes them as `relatedFindings` in `CVSSScorerInput`. The CVSS scorer prompt generator is exported, appends a "Related Findings" section when present, and is covered by new unit tests validating prompt inclusion/formatting behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b85eed24aae33728176c763f2daf8c92734d7fe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->