### PR TITLE
docs: add UI/UX and code hygiene guidelines to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,21 @@ On first launch, the TUI shows a "Responsible Use Disclosure" screen that must b
 **Dialog shortcut controls.** Use the `DialogControls` component (`src/tui/components/shared/dialog-controls.tsx`) for keyboard hint bars at the bottom of dialogs. It supports three variants: `default` (muted — for secondary actions), `primary` (bright — for the main CTA), and `danger` (red — for irreversible actions like Delete/Disconnect). Ordering: primary action first, secondary actions next, danger actions after, Esc always last. `[Esc] Close` is rendered automatically by the `Dialog` component's top-right chrome — don't add it to the controls array. Only show non-obvious shortcuts; intuitive actions like ↑/↓ navigation don't need hints. Key capitalization: Title Case for named keys (`Enter`, `Esc`, `Tab`), uppercase for single letters (`D`, `R`, `M`), arrows as `↑/↓`.
 
 **Consistency over novelty.** When adding a new dialog or view, match the patterns of existing ones. Don't invent new shortcut formatting, separator styles, color schemes, or layouts. Open a few existing dialogs as reference before starting — small inconsistencies compound quickly across a codebase.
+
+**Dialogs, not routes.** Commands that show supplementary information (settings, model selection, help, credits, skills) must open as dialog overlays, not full-page route navigation. Full-page routes break the user's context and are reserved for primary workflows (pentest, operator mode). Use the `DialogLayout` component for consistent structure.
+
+**Terminal size resilience.** Layouts must degrade gracefully on small terminals. All text containers must set `overflow="hidden"`. Fixed-height elements (headers, footers, control bars) must use `flexShrink={0}`. Use terminal dimensions (`stdout.columns`, `stdout.rows`) to compute available space and hide non-essential decorative elements (animations, verbose help text) when space is tight. Never assume a minimum terminal size.
+
+**Theme-aware colors.** All color values must respect the current `ColorMode` (dark/light). Never hardcode RGBA values for a single theme. Use dual-palette maps keyed by `ColorMode` (see `syntax-highlight.ts` for the pattern). This applies to syntax highlighting, status indicators, and any styled text output.
+
+**Stable React keys.** Never include mutable content (message text, streaming output) in React `key` props. Use stable identifiers like `role + timestamp`, tool call IDs, or array indices. Content-derived keys cause unmount/remount on every frame during streaming, which resets scroll position and causes visual flicker.
+
+**No state toggling in streaming callbacks.** Avoid calling `setState` to toggle visual indicators (like "Thinking...") directly in high-frequency streaming callbacks (`onTextDelta`, `onToolCallStreaming`). This causes per-frame flicker. Instead, derive display state from the underlying data model (e.g., check if the last message is a tool result rather than toggling a boolean).
+
+**Scrollbar visibility.** Scrollable content (lists, logs, long text) must have `scrollbarOptions={{ visible: true }}` so users can see their scroll position. Never hide scrollbars in scrollable regions.
+
+### Code hygiene
+
+**Clean up dead code.** When removing a feature or command, delete all associated code paths — route entries, component files, registry entries. Don't leave orphaned code "in case we need it later."
+
+**Use typed enumerations.** Finite sets (command categories, provider types, agent phases) must use TypeScript union types or enums, not free-form strings. This catches invalid values at compile time and keeps ordering/grouping explicit.


### PR DESCRIPTION
## Summary
- Adds UI/UX conventions to AGENTS.md: dialogs vs routes, terminal size resilience, theme-aware colors, stable React keys, streaming state management, scrollbar visibility
- Adds code hygiene rules for dead code cleanup and typed enumerations

Derived from patterns found while cleaning up the TUI the week of March 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or behavioral impact; risk is limited to teams interpreting and applying the new conventions inconsistently.
> 
> **Overview**
> Adds new guidance to `AGENTS.md` codifying additional TUI UI/UX conventions: prefer dialogs over route navigation for secondary screens, design layouts to degrade on small terminals, require theme-aware color palettes, enforce stable React `key`s and streaming-friendly state patterns, and keep scrollbars visible in scrollable regions.
> 
> Also introduces a short **code hygiene** section requiring deletion of dead/orphaned code when removing features and using typed enums/union types for finite string sets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3e091b0828baad32e0978ab16a5bd4e627737a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->