### PR TITLE
fix: consolidate url and domain into single domain field on document_app

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentApp.ts
+++ b/src/core/agents/offSecAgent/tools/documentApp.ts
@@ -65,12 +65,6 @@ Each application creates a JSON file in the apps directory for tracking and anal
         .describe(
           "Technology framework or stack (e.g., 'Next.js', 'Express + React', 'Django')",
         ),
-      url: z
-        .string()
-        .optional()
-        .describe(
-          "Base URL of the application (e.g., 'https://example.com', 'https://api.example.com')",
-        ),
       technology: z
         .array(z.string())
         .optional()
@@ -89,8 +83,10 @@ Each application creates a JSON file in the apps directory for tracking and anal
         .string()
         .optional()
         .describe(
-          "Domain URL this application is associated with (e.g., 'https://example.com'). " +
-            "Used to map applications to monitored domains. Only set if a known domain was provided.",
+          "Base URL / domain this application is associated with (e.g., 'https://example.com'). " +
+            "Used to map applications to monitored domains. " +
+            "For cloud resources set this to the canonical resource URL " +
+            "(e.g., 'https://bucket-name.s3.amazonaws.com').",
         ),
       toolCallDescription: z
         .string()

--- a/src/core/agents/specialized/attackSurface/schemas.ts
+++ b/src/core/agents/specialized/attackSurface/schemas.ts
@@ -119,7 +119,6 @@ export const DocumentAppSchema = z.object({
     .describe(
       "Technology framework or stack (e.g., 'Next.js', 'Express + React', 'Django')",
     ),
-  url: z.string().optional().describe("Base URL of the application"),
   technology: z
     .array(z.string())
     .optional()
@@ -133,8 +132,10 @@ export const DocumentAppSchema = z.object({
     .string()
     .optional()
     .describe(
-      "Domain URL this application is associated with (e.g., 'https://example.com'). " +
-        "Used to map applications to monitored domains. Only set if a known domain was provided.",
+      "Base URL / domain this application is associated with (e.g., 'https://example.com'). " +
+        "Used to map applications to monitored domains. " +
+        "For cloud resources set this to the canonical resource URL " +
+        "(e.g., 'https://bucket-name.s3.amazonaws.com').",
     ),
 });
 

--- a/src/core/agents/specialized/whiteboxAttackSurface/prompts.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/prompts.ts
@@ -26,8 +26,8 @@ Your primary search tool. Use it to find route definitions, middleware, controll
 - Each application/service you identify (appType: "web_application" or "api")
 - Notable subdomains hosting distinct services (appType: "subdomain")
 - Cloud resources like S3 buckets, cloud storage, CDN origins (appType: "cloud_resource" or "storage")
-  - For S3 buckets: set url to the bucket endpoint (e.g. "https://bucket-name.s3.amazonaws.com") and use appType "storage"
-  - For other cloud resources: set url to the resource endpoint and use appType "cloud_resource"
+  - For S3 buckets: set \`domain\` to the **canonical virtual-hosted-style** endpoint (e.g. "https://bucket-name.s3.amazonaws.com") and use appType "storage". Do NOT use path-style URLs (e.g. "https://s3.amazonaws.com/bucket-name").
+  - For other cloud resources: set \`domain\` to the primary/canonical resource endpoint and use appType "cloud_resource"
 - If known domains are provided, set the \`domain\` field to associate the app with the correct domain
 
 ## document_endpoint
@@ -65,7 +65,9 @@ Call this LAST with your complete structured results. This ends your run.
    - S3 buckets, GCS buckets, Azure Blob Storage (search for bucket names, s3://, storage URLs)
    - CDN distributions (CloudFront, Cloudflare)
    - Infrastructure-as-code definitions (Terraform, CloudFormation, CDK, SST, Pulumi, serverless.yml)
-   - Document each as an app with appType "cloud_resource" or "storage" and set the url to the resource endpoint
+   - Document each as an app with appType "cloud_resource" or "storage" and set the \`domain\` to the **canonical** resource endpoint
+   - **S3 canonical URL:** Always use virtual-hosted-style "https://bucket-name.s3.amazonaws.com" (or with region: "https://bucket-name.s3.us-east-1.amazonaws.com"). Never use path-style "https://s3.amazonaws.com/bucket-name".
+   - **Do NOT document alternative URL formats** as separate endpoints — only document the canonical/primary URL and any distinct functional paths under it
 
 ## Phase 2: APP ANALYSIS (delegate to coding agents)
 For each app you identified, spawn a coding agent with a detailed objective. The objective should instruct the agent to:


### PR DESCRIPTION
## Summary
- Removes the separate `url` field from the `document_app` tool schema, consolidating it into the existing `domain` field. This eliminates ambiguity about which field agents should populate for application URLs.
- Updates `domain` field descriptions across `documentApp.ts` and `attackSurface/schemas.ts` to clarify it serves as both the base URL and domain mapping, with explicit guidance for cloud resources (e.g. S3 canonical virtual-hosted-style URLs).
- Updates whitebox attack surface prompts to instruct agents to use `domain` (not `url`), enforce canonical S3 URL format (`https://bucket-name.s3.amazonaws.com`), and avoid documenting alternative URL formats as separate endpoints.

## Test plan
- [ ] Run `bun run test` — all unit tests pass
- [ ] Run `bun run tsc` — no type errors
- [ ] Verify attack surface agent correctly populates `domain` for web apps, APIs, and cloud resources

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `document_app`/attack-surface schemas by removing the `url` field, which can break existing tool callers or persisted records expecting it; behavior is otherwise documentation/schema-only.
> 
> **Overview**
> Consolidates application base URL handling by removing the separate `url` field from `document_app`/`DocumentAppSchema` and standardizing on a single `domain` field.
> 
> Updates `domain` descriptions and the whitebox attack-surface prompts to explicitly treat it as the base URL/domain mapping field, including guidance for cloud resources (notably enforcing canonical, virtual-hosted-style S3 URLs and discouraging alternative URL formats as separate documentation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2a1074936f950cfbe51e0e17dba636b44133223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->