### PR TITLE
Fix PoC script portability: prohibit grep -P and bc in agent prompts

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentFinding.test.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.test.ts
@@ -27,6 +27,26 @@ grep -P 'pattern' file.txt`;
       expect(warnings[0]).toContain("grep -P or grep -oP");
     });
 
+    it("detects grep -Po (flag ordering variant)", () => {
+      const script = `#!/bin/bash
+curl -s http://target.com | grep -Po '(?<=id":)[0-9]+'`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("grep -P or grep -oP");
+    });
+
+    it("detects grep -Poi (multiple flags with P)", () => {
+      const script = `#!/bin/bash
+grep -Poi 'pattern' file.txt`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("grep -P or grep -oP");
+    });
+
     it("detects bc usage", () => {
       const script = `#!/bin/bash
 result=$(echo "scale=2; 10 / 3" | bc)
@@ -132,6 +152,36 @@ done
 
 echo "Success: exploited endpoint with ID $id"
 exit 0`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("does not flag netstat -c (not the same as stat -c)", () => {
+      const script = `#!/bin/bash
+# Monitor network connections continuously
+netstat -c`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("does not flag vmstat or other *stat commands", () => {
+      const script = `#!/bin/bash
+vmstat -c 5
+iostat -c 10`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("does not flag update --fix-broken or similar date substrings", () => {
+      const script = `#!/bin/bash
+apt-get update --fix-broken
+candidate --list`;
 
       const warnings = validatePocPortability(script, "bash");
 

--- a/src/core/agents/offSecAgent/tools/documentFinding.test.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.test.ts
@@ -47,7 +47,7 @@ grep -Poi 'pattern' file.txt`;
       expect(warnings[0]).toContain("grep -P or grep -oP");
     });
 
-    it("detects bc usage", () => {
+    it("detects bc usage (piped)", () => {
       const script = `#!/bin/bash
 result=$(echo "scale=2; 10 / 3" | bc)
 echo "Result: $result"`;
@@ -57,6 +57,17 @@ echo "Result: $result"`;
       expect(warnings).toHaveLength(1);
       expect(warnings[0]).toContain("bc command detected");
       expect(warnings[0]).toContain("$(( ))");
+    });
+
+    it("detects standalone bc usage on any line", () => {
+      const script = `#!/bin/bash
+echo "1+1" > calc.txt
+bc < calc.txt`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("bc command detected");
     });
 
     it("does not warn about bc if it's checked first", () => {

--- a/src/core/agents/offSecAgent/tools/documentFinding.test.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import { validatePocPortability } from "./documentFinding";
+
+describe("validatePocPortability", () => {
+  describe("bash scripts", () => {
+    it("detects grep -oP (Perl regex)", () => {
+      const script = `#!/bin/bash
+response=$(curl -s http://target.com/api/test)
+id=$(echo "$response" | grep -oP '(?<=id":)[0-9]+')
+echo "ID: $id"`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("grep -P or grep -oP");
+      expect(warnings[0]).toContain("grep -E");
+    });
+
+    it("detects grep -P (Perl regex)", () => {
+      const script = `#!/bin/bash
+grep -P 'pattern' file.txt`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("grep -P or grep -oP");
+    });
+
+    it("detects bc usage", () => {
+      const script = `#!/bin/bash
+result=$(echo "scale=2; 10 / 3" | bc)
+echo "Result: $result"`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("bc command detected");
+      expect(warnings[0]).toContain("$(( ))");
+    });
+
+    it("does not warn about bc if it's checked first", () => {
+      const script = `#!/bin/bash
+if command -v bc >/dev/null 2>&1; then
+  result=$(echo "scale=2; 10 / 3" | bc)
+else
+  result=$(python3 -c "print(10/3)")
+fi`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("detects GNU stat -c flag", () => {
+      const script = `#!/bin/bash
+stat -c '%s' /path/to/file`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("stat -c");
+      expect(warnings[0]).toContain("GNU-specific");
+    });
+
+    it("detects GNU date long options", () => {
+      const script = `#!/bin/bash
+date --rfc-3339=seconds`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("GNU date long options");
+    });
+
+    it("detects seq usage", () => {
+      const script = `#!/bin/bash
+for i in $(seq 1 10); do
+  echo $i
+done`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("seq");
+      expect(warnings[0]).toContain("brace expansion");
+    });
+
+    it("does not warn about seq if it's checked first", () => {
+      const script = `#!/bin/bash
+if which seq >/dev/null 2>&1; then
+  for i in $(seq 1 10); do echo $i; done
+else
+  for i in {1..10}; do echo $i; done
+fi`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("detects multiple portability issues", () => {
+      const script = `#!/bin/bash
+id=$(curl -s http://target.com | grep -oP '(?<=id":)[0-9]+')
+result=$(echo "scale=2; $id / 3" | bc)
+stat -c '%s' /tmp/output
+date --rfc-3339=seconds`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings.length).toBeGreaterThanOrEqual(4);
+      expect(warnings.some((w) => w.includes("grep -P"))).toBe(true);
+      expect(warnings.some((w) => w.includes("bc"))).toBe(true);
+      expect(warnings.some((w) => w.includes("stat -c"))).toBe(true);
+      expect(warnings.some((w) => w.includes("date"))).toBe(true);
+    });
+
+    it("returns empty array for portable bash script", () => {
+      const script = `#!/bin/bash
+set -e
+
+response=$(curl -s http://target.com/api/test)
+id=$(echo "$response" | grep -oE '"id":[0-9]+' | grep -oE '[0-9]+')
+
+# Use shell arithmetic instead of bc
+count=$((id * 2))
+
+for i in {1..10}; do
+  echo "Test iteration $i"
+  curl -X POST "http://target.com/api/item/$id"
+done
+
+echo "Success: exploited endpoint with ID $id"
+exit 0`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(0);
+    });
+  });
+
+  describe("python scripts", () => {
+    it("returns empty array for python scripts", () => {
+      const script = `#!/usr/bin/env python3
+import requests
+response = requests.get('http://target.com')
+print(response.text)`;
+
+      const warnings = validatePocPortability(script, "python");
+
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("does not validate portability for python", () => {
+      // Even with bash-style commands in comments or strings,
+      // we don't validate Python scripts
+      const script = `#!/usr/bin/env python3
+# This grep -oP would fail on macOS
+import subprocess
+subprocess.run(['grep', '-E', 'pattern'])`;
+
+      const warnings = validatePocPortability(script, "python");
+
+      expect(warnings).toHaveLength(0);
+    });
+  });
+
+  describe("javascript scripts", () => {
+    it("returns empty array for javascript scripts", () => {
+      const script = `#!/usr/bin/env node
+const axios = require('axios');
+axios.get('http://target.com')
+  .then(response => console.log(response.data));`;
+
+      const warnings = validatePocPortability(script, "javascript");
+
+      expect(warnings).toHaveLength(0);
+    });
+  });
+});

--- a/src/core/agents/offSecAgent/tools/documentFinding.test.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.test.ts
@@ -47,6 +47,26 @@ grep -Poi 'pattern' file.txt`;
       expect(warnings[0]).toContain("grep -P or grep -oP");
     });
 
+    it("detects grep with separate flag groups (grep -i -P)", () => {
+      const script = `#!/bin/bash
+curl -s http://target.com | grep -i -P '(?<=id":)[0-9]+'`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("grep -P or grep -oP");
+    });
+
+    it("detects grep with multiple separate flags (grep -o -P)", () => {
+      const script = `#!/bin/bash
+grep -o -P 'pattern' file.txt`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("grep -P or grep -oP");
+    });
+
     it("detects bc usage (piped)", () => {
       const script = `#!/bin/bash
 result=$(echo "scale=2; 10 / 3" | bc)
@@ -63,6 +83,28 @@ echo "Result: $result"`;
       const script = `#!/bin/bash
 echo "1+1" > calc.txt
 bc < calc.txt`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("bc command detected");
+    });
+
+    it("detects bc in command substitution $(bc ...)", () => {
+      const script = `#!/bin/bash
+result=$(bc <<< "scale=2; 10/3")
+echo "$result"`;
+
+      const warnings = validatePocPortability(script, "bash");
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("bc command detected");
+    });
+
+    it("detects bc in backtick command substitution", () => {
+      const script = `#!/bin/bash
+result=\`bc -l <<< "sqrt(2)"\`
+echo "$result"`;
 
       const warnings = validatePocPortability(script, "bash");
 

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -654,6 +654,68 @@ function sanitizeFilename(str: string): string {
     .substring(0, 50);
 }
 
+/**
+ * Validates PoC script for POSIX portability issues.
+ * Returns array of warning messages for non-portable patterns.
+ */
+export function validatePocPortability(
+  content: string,
+  pocType: PocType,
+): string[] {
+  const warnings: string[] = [];
+
+  // Only validate shell scripts (bash) for now
+  // Python and JavaScript have their own portable runtimes
+  if (pocType !== "bash") {
+    return warnings;
+  }
+
+  // Check for grep -P or grep -oP (Perl regex - not portable)
+  // Match -P as standalone or in combination with other flags, but NOT when followed by a letter
+  if (/grep\s+(-[a-zA-Z]*P(?![a-zA-Z])|--perl-regexp)\b/.test(content)) {
+    warnings.push(
+      "Non-portable: grep -P or grep -oP (Perl regex) detected. Use grep -E (extended regex) or grep -o instead for macOS/BusyBox compatibility.",
+    );
+  }
+
+  // Check for bare bc usage (not installed in sandbox)
+  // Match bc as a standalone command, typically piped to (e.g., "| bc")
+  if (
+    /(\|\s*bc\b|^\s*bc\b|\becho\s+.*\|\s*bc\b)/.test(content) &&
+    !/which\s+bc|command\s+-v\s+bc/.test(content)
+  ) {
+    warnings.push(
+      "Non-portable: bc command detected but not installed in sandbox. Use $(( )) shell arithmetic, awk, or python3 -c instead.",
+    );
+  }
+
+  // Check for GNU stat with -c flag
+  if (/stat\s+-c/.test(content)) {
+    warnings.push(
+      "Non-portable: stat -c is GNU-specific. Use stat -f on BSD/macOS or portable alternatives.",
+    );
+  }
+
+  // Check for GNU date with --rfc-3339 or similar
+  if (/date\s+--[a-z]/.test(content)) {
+    warnings.push(
+      "Non-portable: GNU date long options (--rfc-3339, etc.) may not work on BSD/macOS. Use date with standard format strings instead.",
+    );
+  }
+
+  // Check for seq without command check
+  if (
+    /\bseq\b/.test(content) &&
+    !/which\s+seq|command\s+-v\s+seq/.test(content)
+  ) {
+    warnings.push(
+      "Potentially non-portable: seq may not be available. Consider using for i in $(seq ...) with a fallback or brace expansion {1..N}.",
+    );
+  }
+
+  return warnings;
+}
+
 function preparePoc(input: {
   pocName: string;
   pocType: PocType;
@@ -664,6 +726,14 @@ function preparePoc(input: {
   const filename = `poc_${sanitizedName}${POC_EXTENSIONS[input.pocType]}`;
 
   let pocContent = input.pocContent.trim();
+
+  // Validate portability before preparing the script
+  const portabilityWarnings = validatePocPortability(pocContent, input.pocType);
+  if (portabilityWarnings.length > 0) {
+    console.warn(
+      `[PoC Portability] Warnings for ${filename}:\n  ${portabilityWarnings.join("\n  ")}`,
+    );
+  }
 
   if (!pocContent.startsWith("#!")) {
     const shebangs: Record<string, string> = {

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -671,17 +671,20 @@ export function validatePocPortability(
   }
 
   // Check for grep -P or grep -oP (Perl regex - not portable)
-  // Match -P anywhere in the flag group (e.g., -P, -oP, -Po, -Poi, etc.)
-  if (/grep\s+(-[a-zA-Z]*P[a-zA-Z]*|--perl-regexp)\b/.test(content)) {
+  // Match -P anywhere after grep (e.g., -P, -oP, -Po, grep -i -P, etc.)
+  if (
+    /grep\s+.*?-[a-zA-Z]*P[a-zA-Z]*\b/.test(content) ||
+    /grep\s+.*?--perl-regexp\b/.test(content)
+  ) {
     warnings.push(
       "Non-portable: grep -P or grep -oP (Perl regex) detected. Use grep -E (extended regex) or grep -o instead for macOS/BusyBox compatibility.",
     );
   }
 
   // Check for bare bc usage (not installed in sandbox)
-  // Match bc as a standalone command (piped or standalone)
+  // Match bc as a standalone command (piped, standalone, or in command substitution)
   if (
-    /(\|\s*bc\b|^\s*bc\b)/m.test(content) &&
+    /(\|\s*bc\b|^\s*bc\b|\$\(\s*bc\b|`\s*bc\b)/m.test(content) &&
     !/which\s+bc|command\s+-v\s+bc/.test(content)
   ) {
     warnings.push(

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -679,9 +679,9 @@ export function validatePocPortability(
   }
 
   // Check for bare bc usage (not installed in sandbox)
-  // Match bc as a standalone command, typically piped to (e.g., "| bc")
+  // Match bc as a standalone command (piped or standalone)
   if (
-    /(\|\s*bc\b|^\s*bc\b|\becho\s+.*\|\s*bc\b)/.test(content) &&
+    /(\|\s*bc\b|^\s*bc\b)/m.test(content) &&
     !/which\s+bc|command\s+-v\s+bc/.test(content)
   ) {
     warnings.push(

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -671,8 +671,8 @@ export function validatePocPortability(
   }
 
   // Check for grep -P or grep -oP (Perl regex - not portable)
-  // Match -P as standalone or in combination with other flags, but NOT when followed by a letter
-  if (/grep\s+(-[a-zA-Z]*P(?![a-zA-Z])|--perl-regexp)\b/.test(content)) {
+  // Match -P anywhere in the flag group (e.g., -P, -oP, -Po, -Poi, etc.)
+  if (/grep\s+(-[a-zA-Z]*P[a-zA-Z]*|--perl-regexp)\b/.test(content)) {
     warnings.push(
       "Non-portable: grep -P or grep -oP (Perl regex) detected. Use grep -E (extended regex) or grep -o instead for macOS/BusyBox compatibility.",
     );
@@ -689,15 +689,15 @@ export function validatePocPortability(
     );
   }
 
-  // Check for GNU stat with -c flag
-  if (/stat\s+-c/.test(content)) {
+  // Check for GNU stat with -c flag (with word boundary to avoid matching netstat, vmstat, etc.)
+  if (/\bstat\s+-c/.test(content)) {
     warnings.push(
       "Non-portable: stat -c is GNU-specific. Use stat -f on BSD/macOS or portable alternatives.",
     );
   }
 
-  // Check for GNU date with --rfc-3339 or similar
-  if (/date\s+--[a-z]/.test(content)) {
+  // Check for GNU date with --rfc-3339 or similar (with word boundary to avoid matching update, etc.)
+  if (/\bdate\s+--[a-z]/.test(content)) {
     warnings.push(
       "Non-portable: GNU date long options (--rfc-3339, etc.) may not work on BSD/macOS. Use date with standard format strings instead.",
     );

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -314,7 +314,7 @@ CRITICAL — document_vulnerability usage rules:
 
 POC Script Portability Requirements:
 - POC scripts MUST be POSIX-compatible to ensure they work across different environments (macOS, Linux, Alpine, BusyBox)
-- Use grep -E (extended regex) or grep -o NEVER use grep -P or grep -oP (Perl regex is not portable and will fail on macOS and BusyBox)
+- Use grep -E (extended regex) or grep -o. NEVER use grep -P or grep -oP (Perl regex is not portable and will fail on macOS and BusyBox)
 - Do NOT rely on bc for arithmetic — use $(( )) shell arithmetic, awk, or Python/Node instead (bc is not installed in sandbox environments)
 - Avoid GNU-specific flags that may not be available in BusyBox/Alpine (e.g., stat -c, date --rfc-3339)
 - When using seq, prefer $(seq ...) or brace expansion {1..N} for simple ranges

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -312,6 +312,16 @@ CRITICAL — document_vulnerability usage rules:
 - If you were unable to confirm or exploit a vulnerability, do NOT document it — instead describe it in your final response summary
 - It is completely acceptable to finish a test with zero documented vulnerabilities if none were found
 
+POC Script Portability Requirements:
+- POC scripts MUST be POSIX-compatible to ensure they work across different environments (macOS, Linux, Alpine, BusyBox)
+- Use grep -E (extended regex) or grep -o NEVER use grep -P or grep -oP (Perl regex is not portable and will fail on macOS and BusyBox)
+- Do NOT rely on bc for arithmetic — use $(( )) shell arithmetic, awk, or Python/Node instead (bc is not installed in sandbox environments)
+- Avoid GNU-specific flags that may not be available in BusyBox/Alpine (e.g., stat -c, date --rfc-3339)
+- When using seq, prefer $(seq ...) or brace expansion {1..N} for simple ranges
+- Test tools with which or command -v before using non-standard utilities
+- Prefer built-in shell features over external commands when possible
+- If a PoC requires a specific non-standard tool, check for it at the start and exit with a clear error message if missing
+
 Browser Interaction:
 - Use browser_navigate to load pages, browser_snapshot to inspect the DOM, and browser_screenshot for visual evidence
 - Use browser_click and browser_fill to interact with forms, buttons, and input fields — essential for testing login flows, search fields, and other interactive elements


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR fixes the issue where agent-generated PoC scripts used non-portable commands that fail on macOS and in Alpine/BusyBox sandbox environments. Specifically:

**Problem**: 
- `grep -oP` (Perl regex) was used in PoCs, which fails on macOS and BusyBox with "grep: invalid option -- P"
- `bc` was used for arithmetic but is not installed in the sandbox Alpine image
- Both issues appeared verbatim in customer-facing pentest reports

**Solution**:

1. **Agent Prompt Guidance** (`src/core/agents/specialized/pentest/agent.ts`)
   - Added "POC Script Portability Requirements" section to `PENTEST_SYSTEM_PROMPT_BASE`
   - Explicitly prohibits `grep -P`/`grep -oP` and recommends `grep -E` (extended regex)
   - Prohibits `bc` and recommends `$(( ))` shell arithmetic, `awk`, or `python3 -c`
   - Warns against other GNU-specific flags (`stat -c`, `date --long-options`)
   - Encourages checking for tools with `command -v` before using non-standard utilities

2. **Runtime Validation** (`src/core/agents/offSecAgent/tools/documentFinding.ts`)
   - Implemented `validatePocPortability(content, pocType)` function
   - Detects non-portable patterns in bash scripts:
     - `grep -P` / `grep -oP` → suggests `grep -E` or `grep -o`
     - `bc` usage (without availability check) → suggests `$(( ))`, `awk`, or `python3 -c`
     - `stat -c` (GNU-specific) → warns about BSD incompatibility
     - `date --long-opts` (GNU-specific) → suggests standard format strings
     - `seq` (without fallback) → suggests brace expansion `{1..N}`
   - Logs warnings to console when issues are detected (does not block execution)
   - Python and JavaScript scripts are not validated (they have portable runtimes)

3. **Comprehensive Tests** (`src/core/agents/offSecAgent/tools/documentFinding.test.ts`)
   - 13 unit tests covering all non-portable patterns
   - Tests that portable alternatives (grep -E, shell arithmetic) don't trigger warnings
   - Tests that Python/JS scripts are correctly skipped
   - Tests that multiple issues are detected in the same script

**Why this works**:
- The prompt guidance will prevent the agent from generating non-portable commands in new PoCs
- The validation function provides a safety net that logs warnings if non-portable patterns slip through
- The validation is informative (warns but doesn't block), allowing PoCs that may still succeed to execute
- All tests (unit, lint, type-check) pass with no regressions

### How did you verify your code works?

1. **Unit Tests**: Created 13 test cases covering all validation patterns. All pass.
   ```bash
   bun run test src/core/agents/offSecAgent/tools/documentFinding.test.ts
   # ✓ 13 tests passed
   ```

2. **Full Test Suite**: Ran entire test suite to ensure no regressions
   ```bash
   bun run test
   # ✓ 621 passed | 15 skipped (636 total)
   ```

3. **CI Checks**: Verified all CI checks pass
   - ✅ Lint: `bun run lint`
   - ✅ TypeCheck: `bun run tsc`
   - ✅ Format: `bun run format:check`
   - ✅ Tests: `bun run test`

4. **Code Review**: Validated that:
   - The regex patterns correctly identify non-portable commands
   - Portable alternatives (grep -E, shell arithmetic) don't trigger false positives
   - Warning messages are actionable and suggest specific alternatives
   - The validation function is exported for testing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffbfd742-8479-4029-89ff-ff57c7288c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffbfd742-8479-4029-89ff-ff57c7288c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

