### PR TITLE
fix: improve cloud resource domain/endpoint handling in attack surface recon

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentApp.ts
+++ b/src/core/agents/offSecAgent/tools/documentApp.ts
@@ -9,6 +9,57 @@ function sanitizeName(name: string): string {
 }
 
 /**
+ * Validates that a domain string is a well-formed URL with scheme + host.
+ * Returns a normalized origin string or null if invalid.
+ */
+function validateDomainUrl(value: string): {
+  valid: boolean;
+  origin: string | null;
+  error: string | null;
+} {
+  const trimmed = value.trim();
+
+  if (!trimmed.includes("://")) {
+    return {
+      valid: false,
+      origin: null,
+      error:
+        `Domain "${trimmed}" is missing a URL scheme. ` +
+        `Use a full URL with scheme (e.g., "https://${trimmed}" instead of "${trimmed}").`,
+    };
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return {
+        valid: false,
+        origin: null,
+        error:
+          `Domain "${trimmed}" has an unsupported scheme "${parsed.protocol}". ` +
+          `Use "https://" or "http://".`,
+      };
+    }
+    if (!parsed.hostname) {
+      return {
+        valid: false,
+        origin: null,
+        error: `Domain "${trimmed}" has no hostname.`,
+      };
+    }
+    return { valid: true, origin: parsed.origin, error: null };
+  } catch {
+    return {
+      valid: false,
+      origin: null,
+      error:
+        `Domain "${trimmed}" is not a valid URL. ` +
+        `Provide a full URL (e.g., "https://example.com", "https://bucket.s3.amazonaws.com").`,
+    };
+  }
+}
+
+/**
  * Factory for the `document_app` tool.
  *
  * Documents a discovered application during attack surface analysis —
@@ -47,8 +98,6 @@ Each application creates a JSON file in the apps directory for tracking and anal
           "web_application",
           "api",
           "full_stack",
-          "domain",
-          "subdomain",
           "database",
           "cloud_resource",
           "storage",
@@ -81,12 +130,16 @@ Each application creates a JSON file in the apps directory for tracking and anal
         .describe("Additional notes or observations about the application"),
       domain: z
         .string()
-        .optional()
         .describe(
-          "Base URL / domain this application is associated with (e.g., 'https://example.com'). " +
-            "Used to map applications to monitored domains. " +
-            "For cloud resources set this to the canonical resource URL " +
-            "(e.g., 'https://bucket-name.s3.amazonaws.com').",
+          "Base URL / domain this application is associated with. Must be a full URL with scheme. " +
+            "For web apps/APIs: the public URL (e.g., 'https://api.example.com'). " +
+            "For S3 buckets: 'https://{ACTUAL-BUCKET-NAME}.s3.amazonaws.com' — you MUST include the real bucket name from IaC, NOT 'https://s3.amazonaws.com'. " +
+            "For databases (RDS/Aurora): 'https://{cluster-endpoint}.rds.amazonaws.com'. " +
+            "For Redis/ElastiCache: 'https://{cluster-id}.cache.amazonaws.com'. " +
+            "For SQS queues: 'https://sqs.{region}.amazonaws.com/{account}/{queue-name}'. " +
+            "For Lambda functions: use the API Gateway or Function URL that routes to them, NOT a generic API domain. " +
+            "For CDN/CloudFront: 'https://{distribution-id}.cloudfront.net'. " +
+            "CRITICAL: each resource must have its OWN unique domain derived from its infrastructure definition — never reuse the console or API domain for unrelated resources.",
         ),
       toolCallDescription: z
         .string()
@@ -95,6 +148,18 @@ Each application creates a JSON file in the apps directory for tracking and anal
         ),
     }),
     execute: async (input) => {
+      if (input.domain) {
+        const domainCheck = validateDomainUrl(input.domain);
+        if (!domainCheck.valid) {
+          return {
+            success: false,
+            error: "invalid_domain",
+            message: domainCheck.error!,
+          };
+        }
+        input = { ...input, domain: domainCheck.origin! };
+      }
+
       if (!existsSync(baseAppsPath)) {
         mkdirSync(baseAppsPath, { recursive: true });
       }
@@ -117,6 +182,7 @@ Each application creates a JSON file in the apps directory for tracking and anal
         success: true,
         appName: input.appName,
         appType: input.appType,
+        domain: input.domain,
         filepath,
         message: `Application '${input.appName}' documented successfully`,
       };

--- a/src/core/agents/offSecAgent/tools/documentEndpoint.ts
+++ b/src/core/agents/offSecAgent/tools/documentEndpoint.ts
@@ -9,6 +9,7 @@ function sanitizeName(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9-_.]/g, "_");
 }
 
+
 /**
  * Factory for the `document_endpoint` tool.
  *
@@ -64,9 +65,12 @@ Each endpoint creates a JSON file in the assets directory for tracking and analy
         .string()
         .optional()
         .describe(
-          "The HTTP route served by this endpoint (e.g., '/api/users', '/dashboard'). " +
+          "The HTTP route or access path served by this endpoint (e.g., '/api/users', '/dashboard'). " +
             "This is the URL path a client requests — NOT a source-file path. " +
-            "Use the separate 'file' field for the source-code location.",
+            "Use the separate 'file' field for the source-code location. " +
+            "For cloud resource endpoints (endpointType 'asset'), use the specific access pattern " +
+            "or path — NOT the base domain URL, which is already stored on the parent application. " +
+            "Examples: '/{objectKey}?X-Amz-Signature=...', '/index.html', 'arn:aws:s3:::bucket-name'.",
         ),
       method: z
         .union([z.string(), z.array(z.string())])
@@ -149,6 +153,20 @@ Each endpoint creates a JSON file in the assets directory for tracking and analy
             message: `Duplicate endpoint (${check.matchType}): already documented as "${matchName}". Skipping.`,
           };
         }
+      }
+
+       if (
+        input.routePath &&
+        (input.routePath.startsWith("https://") ||
+          input.routePath.startsWith("http://"))
+      ) {
+        return {
+          success: false,
+          error: "routePath_is_url",
+          message:
+            `routePath "${input.routePath}" is a full URL. The domain is already stored on the parent application. ` +
+            `Use a path or access pattern instead (e.g. "/api/users", "/{objectKey}?X-Amz-Signature={sig}", "arn:aws:s3:::bucket-name").`,
+        };
       }
 
       const targetDir = join(baseAssetsPath, sanitizeName(input.appName));

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -732,13 +732,32 @@ A **cloud resource** qualifies if it is an **owned infrastructure resource** ref
    - Search for cache/database endpoints (ElastiCache, Redis, DynamoDB, etc.)
    - Check infrastructure-as-code files (Terraform, CloudFormation, CDK, Pulumi, SST, serverless.yml)
    - Document each cloud resource as an app with \`appType: "cloud_resource"\` or \`appType: "storage"\`
-   - For S3 buckets: set the \`url\` to the bucket endpoint (e.g. \`https://bucket-name.s3.amazonaws.com\`)
 7. For each app/resource, determine:
    - **name**: the application or service name
    - **framework**: the web framework or cloud service (e.g. "AWS S3", "CloudFront", "Express")
    - **description**: brief summary of what it does
    - **location**: path relative to the repository root (for code) or the resource identifier (for cloud resources)
    - **type**: classify as \`"web_application"\` for frontend-only apps, \`"api"\` for backend API services, \`"full_stack"\` for frameworks serving both UI and API (Next.js, Remix, Nuxt, SvelteKit, Django with templates, Rails), \`"database"\` for databases, \`"cloud_resource"\` for owned cloud infra (SQS, CDN, etc.), \`"storage"\` for S3/GCS/blob storage.
+
+### Setting the \`domain\` field on \`document_app\` — CRITICAL
+
+Every app and cloud resource MUST have a **unique, resource-specific** domain. This is used to map the resource to the attack surface. **Never reuse a generic domain or another application's domain.**
+
+**For web apps and API services:** Use the public-facing URL from the Known Domains list, route configuration, or infrastructure definition (e.g., \`https://console.pensar.dev\`, \`https://api.example.com\`).
+
+**For S3 / GCS / blob storage buckets:** You MUST derive the **actual bucket name** from the infrastructure-as-code. The bucket name is defined in the IaC resource definition (e.g., SST \`new sst.aws.Bucket("ProjectData")\` produces a bucket with a name like \`console-staging-projectdata-abc123\`). Set domain to \`https://{actual-bucket-name}.s3.amazonaws.com\`. If the exact runtime name includes a random suffix you can't determine, use the logical name pattern: \`https://{stage}-{logicalName}.s3.amazonaws.com\`. **NEVER use \`https://s3.amazonaws.com\`** — that is the S3 service, not a bucket.
+
+**For databases (RDS, Aurora, DynamoDB):** Use the cluster/instance endpoint from IaC (e.g., \`https://{cluster-name}.cluster-{id}.{region}.rds.amazonaws.com\`). If the exact endpoint isn't determinable, use the logical resource name pattern.
+
+**For Redis / ElastiCache:** Use the cache cluster endpoint (e.g., \`https://{cluster-id}.{region}.cache.amazonaws.com\`).
+
+**For SQS queues:** Use \`https://sqs.{region}.amazonaws.com/{account}/{queue-name}\`. If account/region aren't determinable, use the queue's logical name: \`https://sqs.amazonaws.com/{logical-queue-name}\`.
+
+**For Lambda functions:** Use the Lambda Function URL or the API Gateway route that invokes it — NOT the generic API domain shared by all functions. If the Lambda is only invoked by SQS/EventBridge (no HTTP endpoint), set domain to \`https://lambda.{region}.amazonaws.com/functions/{function-name}\`.
+
+**For CloudFront / CDN:** Use the distribution domain (e.g., \`https://{distribution-id}.cloudfront.net\`) or the custom domain alias.
+
+**For WebSocket APIs:** Use the WebSocket endpoint URL (e.g., \`wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}\`).
 
 When finished, call the \`response\` tool with your structured findings.`;
 }
@@ -866,21 +885,26 @@ function buildCloudResourceEndpointsObjective(
 - **Resource location:** ${appInfo.location}
 - **Service:** ${appInfo.framework}
 
+## Context — Application Domain
+The parent application for this cloud resource already has a domain/URL associated with it (set via \`document_app\`). **Do NOT create endpoints that simply repeat the base domain URL.** The domain is already stored on the application record — endpoints should document **distinct access patterns** that go beyond the base domain.
+
 ## Scope — CRITICAL
-You are documenting the **externally-accessible entry points of this cloud resource itself** — the URLs, ARNs, or endpoints where the resource can be reached from outside the application code.
+You are documenting the **distinct access patterns and resource identifiers** for this cloud resource — specific ways the resource can be accessed that are NOT just its base domain URL.
 
 Do NOT document:
-- Code locations where the app calls/uses this resource (e.g. "line 42 of api.ts calls S3.putObject" is NOT an endpoint — that's application code, not a resource entry point)
+- The base domain URL of the resource (e.g. \`https://bucket-name.s3.amazonaws.com\`) — this is already the application's domain
+- Code locations where the app calls/uses this resource (e.g. "line 42 of api.ts calls S3.putObject" is NOT an endpoint)
 - API routes from other apps that happen to interact with this resource
 - Internal SDK calls or client instantiations
 
 DO document:
-- The resource's own external URLs (e.g. \`https://bucket-name.s3.amazonaws.com\`)
-- Public access endpoints (e.g. static website hosting URL, CDN distribution URL)
-- Resource identifiers that represent direct access points (queue URLs, function URLs)
+- **Specific access patterns** beyond the base domain (e.g. pre-signed URL patterns, static website hosting paths, object key patterns)
+- **Resource ARNs** that represent programmatic access points (e.g. \`arn:aws:s3:::bucket-name\`, \`arn:aws:sqs:region:account:queue-name\`)
+- **Alternative access URLs** (e.g. CDN distribution URL, static website hosting URL, regional endpoint variants)
+- **Queue/topic URLs** for message-based resources
 
 ## Task
-Find the **externally-accessible entry points** for this cloud resource by reading infrastructure-as-code and configuration.
+Find the **distinct access patterns and resource identifiers** for this cloud resource by reading infrastructure-as-code and configuration.
 
 ### Where to find entry point information
 1. **Infrastructure-as-code** — Terraform (*.tf), CloudFormation (*.yaml/*.json), CDK constructs, SST components (sst.config.ts, infra/), Pulumi, serverless.yml — these define the resource and its access configuration
@@ -888,19 +912,19 @@ Find the **externally-accessible entry points** for this cloud resource by readi
 3. **Resource policies** — bucket policies, CORS configs, access control settings that reveal how the resource is exposed
 
 ### What qualifies as an entry point (by resource type)
-- **S3 / GCS / Blob Storage**: The bucket's HTTP endpoint (e.g. \`https://bucket.s3.amazonaws.com\`), static website hosting URL, pre-signed URL patterns. One entry point per distinct access pattern (e.g. public read vs authenticated upload are separate).
-- **CloudFront / CDN**: Distribution domain (e.g. \`https://d123.cloudfront.net\`), custom domain aliases
+- **S3 / GCS / Blob Storage**: Pre-signed URL patterns (e.g. \`/{objectKey}?X-Amz-Signature={sig}\`), static website hosting URL, ARN. Do NOT include the plain bucket HTTPS endpoint — that's the app domain.
+- **CloudFront / CDN**: Custom domain aliases, origin access patterns
 - **SQS / SNS / Message Queues**: Queue URL, topic ARN
 - **Lambda / Cloud Functions**: Function URL, API Gateway integration URL
-- **DynamoDB / ElastiCache / Redis**: Connection endpoint URL
+- **DynamoDB / ElastiCache / Redis**: Connection endpoint URL, ARN
 
 ### How to document each entry point
 For each entry point, call \`document_endpoint\` with:
 - **appName**: \`${appInfo.name}\`
-- **endpointName**: The resource's external URL or identifier (e.g., \`https://bucket.s3.amazonaws.com\`, \`arn:aws:sqs:...\`)
+- **endpointName**: A descriptive name for this access pattern (e.g., "Pre-signed URL access", "Bucket ARN", "Queue URL")
 - **endpointType**: \`"asset"\`
-- **description**: What this entry point exposes (e.g., "Public static asset hosting", "User upload pre-signed URL endpoint", "Event queue ingestion")
-- **routePath**: The external URL or ARN of the resource itself (e.g., \`https://bucket.s3.amazonaws.com\`)
+- **description**: What this entry point exposes (e.g., "Pre-signed HTTP URLs for temporary read access to objects", "AWS resource ARN for programmatic access through IAM policies")
+- **routePath**: The specific access pattern, path template, or ARN — NOT the base domain URL. Examples: \`/{objectKey}?X-Amz-Signature={signature}&X-Amz-Credential={credential}\`, \`arn:aws:s3:::bucket-name\`, \`https://sqs.region.amazonaws.com/account/queue-name\`
 - **method**: Access methods on the resource (e.g., \`["GET", "PUT"]\` for S3, \`["SendMessage", "ReceiveMessage"]\` for SQS, \`["READ", "WRITE"]\` for generic)
 - **file**: Infrastructure or config file where this resource is defined (e.g., \`infra/storage.ts\`). NOT application code that calls it.
 - **line**: Line number if determinable


### PR DESCRIPTION
## Summary
- Add domain format validation to `document_app` — rejects bare hostnames, non-HTTP schemes, and malformed URLs; normalizes to origin before persisting
- Add `routePath` validation to `document_endpoint` — rejects full `http(s)://` URLs since the domain is already stored on the parent application
- Rewrite `buildCloudResourceEndpointsObjective` prompt to instruct agents to document distinct access patterns (pre-signed URL templates, ARNs, queue URLs) instead of repeating the base domain URL as an endpoint
- Add detailed per-resource-type domain guidance to `buildAppsDiscoveryObjective` so agents derive correct bucket-specific, cluster-specific, etc. domains instead of using generic service URLs (`https://s3.amazonaws.com`) or reusing the console/API domain for unrelated cloud resources

## Context
Cloud resources (S3 buckets, databases, caches, queues) were getting generic or incorrect domains during attack surface recon:
- S3 buckets all got `https://s3.amazonaws.com` instead of `https://{bucket-name}.s3.amazonaws.com`
- Databases and caches got the console URL (`https://staging-console.pensar.dev`)
- Endpoints redundantly repeated the resource's base domain URL

## Test plan
- [ ] Run whitebox attack surface recon on a codebase with S3 buckets, databases, queues
- [ ] Verify each cloud resource gets a unique, resource-specific domain
- [ ] Verify `document_app` rejects bare hostnames (e.g., `bucket.s3.amazonaws.com`) and returns a corrective error
- [ ] Verify `document_endpoint` rejects `routePath` values starting with `http://` or `https://`
- [ ] Verify cloud resource endpoints document access patterns (ARNs, pre-signed URL templates) instead of base domain URLs

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the published package entrypoint/build output and adds runtime branching between Node and Bun, which can break installs or CLI behavior across environments. CI adds smoke tests, but edge cases around global installs/shell PATH and TUI launch still warrant manual validation.
> 
> **Overview**
> **CLI packaging/runtime change:** The npm `pensar` launcher (`bin/pensar.js`) now runs under Node, re-execs under Bun only for zero-arg TUI launches (with a clearer error when Bun is missing), and always dispatches subcommands through `build/cli.js` (with `package.json` `main` updated accordingly).
> 
> **New/expanded headless CLI + streaming:** Adds `pensar threat-model` (writes a threat model file) and extends `pensar pentest` with `--prompt`/`--threat-model` (`@file` supported) while moving agent output wiring from ad-hoc callbacks to a shared `AgentEventBus` (also adopted by various `scripts/*` runners and exported via `src/core/agents/offSecAgent`).
> 
> **Infra/docs alignment:** CI build workflow now smoke-tests the packed npm install under Node and Bun plus a compiled binary, the Kali container installs Node LTS and improves `.env` loading/mounting, and Fern/README/AGENTS docs are reorganized/expanded to cover the new CLI commands and conventions (along with dependency updates in `bun.lock`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3693009418d188730add6230fd1e070e2fd2e06f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->