### PR TITLE
fix: show all commands in dropdown (help, exit were missing)

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentEndpoint.ts
+++ b/src/core/agents/offSecAgent/tools/documentEndpoint.ts
@@ -9,7 +9,6 @@ function sanitizeName(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9-_.]/g, "_");
 }
 
-
 /**
  * Factory for the `document_endpoint` tool.
  *
@@ -155,7 +154,7 @@ Each endpoint creates a JSON file in the assets directory for tracking and analy
         }
       }
 
-       if (
+      if (
         input.routePath &&
         (input.routePath.startsWith("https://") ||
           input.routePath.startsWith("http://"))

--- a/src/tui/components/operator-dashboard/logic.test.ts
+++ b/src/tui/components/operator-dashboard/logic.test.ts
@@ -41,12 +41,11 @@ describe("filterOperatorAutocomplete", () => {
     const result = filterOperatorAutocomplete(allOptions);
     const values = result.map((o) => o.value);
     expect(values).not.toContain("/scan");
-    expect(values).not.toContain("/help");
   });
 
   it("returns only allowed commands", () => {
     const result = filterOperatorAutocomplete(allOptions);
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(4);
   });
 
   it("preserves description on allowed commands", () => {

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -15,6 +15,7 @@ const OPERATOR_ALLOWED_COMMANDS = new Set([
   "/pentest",
   "/skills",
   "/plan",
+  "/help",
 ]);
 
 export function filterOperatorAutocomplete(

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -175,7 +175,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       onSubmit,
       enableAutocomplete = false,
       autocompleteOptions = [],
-      maxSuggestions = 10,
+      maxSuggestions = 50,
       maxVisibleSuggestions = 6,
       enableCommands = false,
       onCommandExecute,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes the issue where `/help` and `/exit` (and potentially other commands added in the future) were missing from the command dropdown on both the home page and within operator mode.

**Root cause:** Two separate issues were causing the `/help` command to be missing:

1. **Home page — `maxSuggestions` cap too low:** The `PromptInput` component defaults `maxSuggestions` to 10, which caps the total number of filtered results returned by `filterInlineSuggestions`. However, there are currently 14 non-hidden commands in the registry. Since the `commands` array in `command-registry.ts` determines display order, commands at the end of the array (including `/help` at position 13 and `/exit` at position 14) were sliced off by `.slice(0, maxSuggestions)`. When typing `/h`, the filter narrowed results enough for `/help` to appear — but typing just `/` showed only the first 10.

2. **Operator mode — `/help` not in allowlist:** The operator dashboard uses `OPERATOR_ALLOWED_COMMANDS` to filter which commands appear in the dropdown. `/help` was not in this set.

**Changes:**

- **`src/tui/components/shared/prompt-input.tsx`** — Raised default `maxSuggestions` from 10 to 50. This is the total pool of filtered suggestions (before the visible window applies scroll). The visible viewport is still controlled by `maxVisibleSuggestions` (default 6) with scroll indicators, so the UI behavior is unchanged — users just see all matching commands when scrolling.

- **`src/tui/components/operator-dashboard/logic.ts`** — Added `/help` to `OPERATOR_ALLOWED_COMMANDS`.

- **`src/tui/components/operator-dashboard/logic.test.ts`** — Updated tests to reflect `/help` being an allowed operator command.

### How did you verify your code works?

1. All CI checks pass: lint, type check, and unit tests (608 passed, 15 skipped).
2. Manual testing in the TUI confirmed:
   - Typing `/` on the home screen shows all commands with scroll indicators
   - `/help` and `/exit` are visible when scrolling through the dropdown
   - Typing `/h` correctly filters to show `/help`

**Dropdown showing all commands with scroll indicator:**
![Command dropdown showing commands with scroll](https://cursor.com/artifacts/c/art-5362fd2d-9646-4505-b5cb-47c1dcee7c77)

**Scrolled to bottom showing /help and /exit:**
![Dropdown scrolled to show help and exit](https://cursor.com/artifacts/c/art-6d5ed9c2-3d9f-4640-ba61-f1703bd4780b)

**Filtering with /h shows /help:**
![Filtered dropdown showing help command](https://cursor.com/artifacts/c/art-74b06675-45ed-4fe5-ae52-e7f36912815f)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb478ba6-2454-4ce5-a8af-1843b3c5bfd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb478ba6-2454-4ce5-a8af-1843b3c5bfd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

