### PR TITLE
fix: remove hardcoded height cap from sessions dialog

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentEndpoint.ts
+++ b/src/core/agents/offSecAgent/tools/documentEndpoint.ts
@@ -9,7 +9,6 @@ function sanitizeName(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9-_.]/g, "_");
 }
 
-
 /**
  * Factory for the `document_endpoint` tool.
  *
@@ -155,7 +154,7 @@ Each endpoint creates a JSON file in the assets directory for tracking and analy
         }
       }
 
-       if (
+      if (
         input.routePath &&
         (input.routePath.startsWith("https://") ||
           input.routePath.startsWith("http://"))

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -236,7 +236,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
             flexDirection="column"
             gap={2}
             flexGrow={1}
-            maxHeight={10}
+            flexShrink={1}
             overflow="hidden"
             marginTop={1}
           >
@@ -245,7 +245,6 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
               scrollbarOptions={{ visible: true }}
               style={{
                 rootOptions: {
-                  maxHeight: 10,
                   width: "100%",
                   flexGrow: 1,
                   flexShrink: 1,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

The sessions/resume dialog had a hardcoded `maxHeight={10}` on both the wrapping `<box>` element and the `scrollbox` `rootOptions`, which artificially capped the session list to approximately 10 terminal rows — regardless of how much vertical space was available in the terminal.

This was inconsistent with other scrollable dialogs in the codebase (e.g. `help-dialog`, `report-viewer-dialog`) that use `flexGrow: 1` without a fixed `maxHeight`, allowing them to fill the available space within the `Dialog` component's natural `maxHeight` constraint (`dimensions.height - 4`).

**Changes:**
- Removed `maxHeight={10}` from the wrapping `<box>` container around the sessions list
- Removed `maxHeight: 10` from the `scrollbox` `rootOptions`
- Added `flexShrink={1}` to the wrapping `<box>` for proper flex behavior
- The list now grows dynamically to fill available dialog space, consistent with other dialogs

**Why this works:** The parent `Dialog` component already provides a `maxHeight={dimensions.height - 4}` constraint on the dialog panel, so the sessions list will naturally be bounded by the terminal height while using all available space.

### How did you verify your code works?

1. TypeScript type check (`bun run tsc`) — passes
2. ESLint (`bun run lint`) — passes
3. Unit tests (`bun run test`) — all 608 tests pass (15 skipped)
4. Manual TUI testing — created 15 test sessions and verified the sessions dialog now shows many more sessions at once instead of being capped at ~10 rows

**Windowed mode:**
![Sessions dialog in windowed mode](https://cursor.com/artifacts/c/art-4d0335cb-80dd-4c54-a972-cbc386e90040)

**Fullscreen mode (showing more sessions using available space):**
![Sessions dialog in fullscreen showing expanded list](https://cursor.com/artifacts/c/art-24e170c9-3848-4cf1-ba2e-e7086ac2f2f9)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37a92dbf-cf24-4446-ab13-3b9ae632ea78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37a92dbf-cf24-4446-ab13-3b9ae632ea78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

