### PR TITLE
fix: dynamic dialog heights via overflow scroll on Dialog panel

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentEndpoint.ts
+++ b/src/core/agents/offSecAgent/tools/documentEndpoint.ts
@@ -9,7 +9,6 @@ function sanitizeName(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9-_.]/g, "_");
 }
 
-
 /**
  * Factory for the `document_endpoint` tool.
  *
@@ -155,7 +154,7 @@ Each endpoint creates a JSON file in the assets directory for tracking and analy
         }
       }
 
-       if (
+      if (
         input.routePath &&
         (input.routePath.startsWith("https://") ||
           input.routePath.startsWith("http://"))

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -519,10 +519,8 @@ export default function WebWizard({
           <box
             flexDirection="column"
             width="100%"
-            height="100%"
             alignItems="center"
             justifyContent="center"
-            flexGrow={1}
             gap={2}
           >
             <SpinnerDots label="Creating session..." fg={colors.primary} />

--- a/src/tui/context/dialog.tsx
+++ b/src/tui/context/dialog.tsx
@@ -60,7 +60,7 @@ export function Dialog({
         width={DIALOG_WIDTHS[size] ?? 60}
         maxWidth={dimensions.width - 2}
         maxHeight={dimensions.height - 4}
-        overflow="hidden"
+        overflow="scroll"
         backgroundColor={themeColors.backgroundElement}
         flexDirection="column"
         flexGrow={0}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

**Issue:** Some dialogs (help, pentest wizard, skills detail, report viewer) stretched to fill the entire terminal height despite having little content, while others (auth, credits, providers, shortcuts) correctly sized to their content. This happened even though all used the same `Dialog` component.

**Root cause:** The `Dialog` component's inner panel used `overflow="hidden"` combined with `maxHeight={dimensions.height - 4}`. The `ScrollBox` component (from `@opentui/core`) internally sets `minHeight: "100%"` on its content node when vertical scrolling is enabled. In yoga-layout, when a container has `overflow: hidden` and `maxHeight`, percentage-based `minHeight` values on descendants resolve against the `maxHeight`, causing the entire dialog to inflate to `maxHeight` (full terminal height minus padding).

**Fix:** Changed `overflow="hidden"` to `overflow="scroll"` on the Dialog panel. In yoga-layout, `overflow: scroll` tells the layout engine to treat the container as a scroll container, which prevents percentage-based child heights from expanding the container beyond its content size. Both `overflow: hidden` and `overflow: scroll` clip content identically in `@opentui`'s rendering layer — the only difference is in layout computation.

This is a one-line fix in the reusable `Dialog` component that automatically fixes all dialogs without requiring changes to each individual dialog.

Also removed `height="100%"` from the WebWizard's "creating session" spinner state, which relied on the old expansion behavior to center the spinner.

### How did you verify your code works?

1. **Yoga layout tests** — wrote isolated yoga-layout tests reproducing the exact node hierarchy (Dialog → DialogLayout → body → ScrollBox internals) confirming:
   - `overflow: hidden` + `minHeight: 100%` on content → panel expands to `maxHeight` (36 rows for 3-line content)
   - `overflow: scroll` + same structure → panel shrinks to content (9 rows for 3-line content)
   - Large content (50+ lines) still caps at `maxHeight` and scrolls correctly
   - Static content dialogs (no scrollbox) are unaffected

2. **Automated tests** — `bun run test` (608 tests pass), `bun run tsc`, `bun run lint` all pass

3. **Manual TUI testing** — opened help, shortcuts, and credits dialogs in the TUI, confirmed all have dynamic content-sized heights:

**Help dialog** — dynamic height, ~1/3 of terminal:
![Help dialog with dynamic height](https://cursor.com/artifacts/c/art-ff820f30-db1b-4c3f-934d-5e3cce461ff1)

**Shortcuts dialog** — even smaller, ~1/4 of terminal:
![Shortcuts dialog with dynamic height](https://cursor.com/artifacts/c/art-2d0abb0f-0597-4270-9366-47c969a5791a)

**Credits dialog** — compact content-sized height:
![Credits dialog with dynamic height](https://cursor.com/artifacts/c/art-5f9e1ad7-3e4f-482d-b9f0-18f0e44b12ea)

**Video walkthrough:**
<a href="https://cursor.com/agents/bc-fa6067a2-58e1-4a8f-a18a-07676ffaafed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_help_dialog_dynamic_height.mp4"><img src="https://cursor.com/artifacts/c/art-557ee14e-8bb6-466f-b84f-12355cb46721" alt="demo_help_dialog_dynamic_height.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa6067a2-58e1-4a8f-a18a-07676ffaafed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa6067a2-58e1-4a8f-a18a-07676ffaafed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

