### PR TITLE
fix: auto-execute plan after operator approval

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -230,6 +230,7 @@ export default function OperatorDashboard({
   const [showPlanReview, setShowPlanReview] = useState(false);
   const planSubmittedRef = useRef(false);
   const planRejectedRef = useRef(false);
+  const planApprovedPendingRunRef = useRef(false);
   const operatorModeRef = useRef(operatorMode);
   useEffect(() => {
     operatorModeRef.current = operatorMode;
@@ -1537,6 +1538,14 @@ export default function OperatorDashboard({
     runAgentRef.current(next);
   }, [status]);
 
+  // Auto-run agent after plan approval (waits for mode transition to render)
+  useEffect(() => {
+    if (!planApprovedPendingRunRef.current) return;
+    if (operatorMode === "plan") return;
+    planApprovedPendingRunRef.current = false;
+    runAgentRef.current("Proceed with the approved plan.");
+  }, [operatorMode]);
+
   const addSystemMessage = useCallback((content: string) => {
     setMessages((prev) => [
       ...prev,
@@ -1891,12 +1900,12 @@ export default function OperatorDashboard({
           addSystemMessage("Plan file is missing or empty. Cannot approve.");
           return;
         }
+        approvedPlanRef.current = planContent;
+        planApprovedPendingRunRef.current = true;
         setApprovedPlanContent(planContent);
         setShowPlanReview(false);
         transitionToMode("manual");
-        addSystemMessage(
-          "Plan approved. Switching to manual mode for execution.",
-        );
+        addSystemMessage("Plan approved. Executing plan.");
         return;
       }
       if (key.name === "n" || key.raw === "N") {


### PR DESCRIPTION
## Summary
- Auto-run agent after operator approves plan (no manual nudge needed)
- Uses ref flag + useEffect to defer execution until mode transition renders

## Test plan
- [x] Enter plan mode, trigger pentest, wait for plan submission
- [x] Press Y to approve — agent should immediately start executing
- [x] Verify agent has full tool set (not plan-only tools)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes execution flow in the operator dashboard by triggering an automatic agent run immediately after plan approval; risk is mainly unintended or duplicate execution if the mode/approval transition logic misfires.
> 
> **Overview**
> After an operator approves a submitted plan (pressing `Y` in the plan review prompt), the dashboard now **automatically starts execution** by scheduling a follow-up `runAgent` call once the UI has transitioned out of `plan` mode.
> 
> This introduces a `planApprovedPendingRunRef` flag plus a `useEffect` keyed on `operatorMode` to defer the run until after the mode change renders, and updates the approval messaging to reflect immediate execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f2cfbb5698f4206731b622a6ba8adece5759044. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->