### PR TITLE
fix: include auth session data in plan agent prompt

### DIFF
--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -528,6 +528,56 @@ export function buildPentestSystemPrompt(session: {
   return exfilMode ? PENTEST_SYSTEM_PROMPT_EXFIL : PENTEST_SYSTEM_PROMPT_BASE;
 }
 
+/**
+ * Build the "Existing Authentication Session" prompt section from auth-data.json.
+ * Returns an empty string when no authenticated session exists.
+ */
+export function buildAuthSection(sessionRootPath: string): string {
+  const authDataPath = join(sessionRootPath, "auth", "auth-data.json");
+
+  if (!existsSync(authDataPath)) return "";
+
+  try {
+    const raw = readFileSync(authDataPath, "utf-8");
+    const authData = JSON.parse(raw) as {
+      authenticated?: boolean;
+      cookies?: string;
+      headers?: Record<string, string>;
+      strategy?: string;
+    };
+
+    if (!authData.authenticated) return "";
+
+    const parts: string[] = [
+      `## Existing Authentication Session`,
+      `An authenticated session already exists — **do NOT re-authenticate**. Include these credentials in every request.\n`,
+    ];
+
+    if (authData.cookies) {
+      parts.push(`- **Cookie header:** \`${authData.cookies}\``);
+    }
+
+    if (authData.headers && Object.keys(authData.headers).length > 0) {
+      for (const [name, value] of Object.entries(authData.headers)) {
+        parts.push(`- **${name}:** \`${value}\``);
+      }
+    }
+
+    if (authData.strategy) {
+      parts.push(`- Auth strategy: ${authData.strategy}`);
+    }
+
+    parts.push(
+      `\nFor \`http_request\`, pass these as the \`headers\` parameter.`,
+      `For \`execute_command\` (curl), add the appropriate \`-H\` or \`-b\` flags.`,
+    );
+
+    return parts.join("\n");
+  } catch {
+    return "";
+  }
+}
+
 export function buildPentestPrompt(
   target: string,
   objectives: string[],
@@ -550,50 +600,7 @@ export function buildPentestPrompt(
   const outcomeGuidance = session.config?.outcomeGuidance;
   const objectiveList = objectives.map((o, i) => `${i + 1}. ${o}`).join("\n");
 
-  let authSection = "";
-  const authDataPath = join(sessionRootPath, "auth", "auth-data.json");
-
-  if (existsSync(authDataPath)) {
-    try {
-      const raw = readFileSync(authDataPath, "utf-8");
-      const authData = JSON.parse(raw) as {
-        authenticated?: boolean;
-        cookies?: string;
-        headers?: Record<string, string>;
-        strategy?: string;
-      };
-
-      if (authData.authenticated) {
-        const parts: string[] = [
-          `\n## Existing Authentication Session`,
-          `An authenticated session already exists — **do NOT re-authenticate**. Include these credentials in every request.\n`,
-        ];
-
-        if (authData.cookies) {
-          parts.push(`- **Cookie header:** \`${authData.cookies}\``);
-        }
-
-        if (authData.headers && Object.keys(authData.headers).length > 0) {
-          for (const [name, value] of Object.entries(authData.headers)) {
-            parts.push(`- **${name}:** \`${value}\``);
-          }
-        }
-
-        if (authData.strategy) {
-          parts.push(`- Auth strategy: ${authData.strategy}`);
-        }
-
-        parts.push(
-          `\nFor \`http_request\`, pass these as the \`headers\` parameter.`,
-          `For \`execute_command\` (curl), add the appropriate \`-H\` or \`-b\` flags.`,
-        );
-
-        authSection = parts.join("\n");
-      }
-    } catch {
-      // Malformed auth data — ignore silently
-    }
-  }
+  const authSection = buildAuthSection(sessionRootPath);
 
   let knownFindingsSection = "";
   if (findingsRegistry && findingsRegistry.size > 0) {

--- a/src/core/agents/specialized/pentest/planPrompt.ts
+++ b/src/core/agents/specialized/pentest/planPrompt.ts
@@ -6,6 +6,8 @@
  * a structured pentest plan before execution begins.
  */
 
+import { buildAuthSection } from "./agent";
+
 export const PLAN_PHASE_SYSTEM_PROMPT = `You are an expert penetration tester performing reconnaissance and planning.
 
 Your job is to analyze the target, understand its attack surface, and create a comprehensive testing plan. You have READ-ONLY tools available — you can probe the target but NOT exploit it.
@@ -34,14 +36,19 @@ Guidelines:
 /**
  * Build the user prompt for the plan phase.
  */
-export function buildPlanPrompt(target: string, objectives: string[]): string {
+export function buildPlanPrompt(
+  target: string,
+  objectives: string[],
+  sessionRootPath: string,
+): string {
   const objectiveList = objectives.map((o, i) => `${i + 1}. ${o}`).join("\n");
+  const authSection = buildAuthSection(sessionRootPath);
 
   return `# Planning Assignment
 
 ## Target
 - **URL:** ${target}
-
+${authSection ? `\n${authSection}\n` : ""}
 ## Objectives
 ${objectiveList}
 

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -233,7 +233,11 @@ export async function runPentestSwarm(
           );
           const planAgent = new OffensiveSecurityAgent({
             system: PLAN_PHASE_SYSTEM_PROMPT,
-            prompt: buildPlanPrompt(target.target, target.objectives),
+            prompt: buildPlanPrompt(
+              target.target,
+              target.objectives,
+              session.rootPath,
+            ),
             model,
             session,
             target: target.target,


### PR DESCRIPTION
## Summary

- Extract `buildAuthSection` as a shared helper from inline code in `buildPentestPrompt`
- Wire it into `buildPlanPrompt` so the plan agent receives authentication cookies/headers during reconnaissance
- Previously, the plan agent's HTTP probes hit 401/403 on authenticated endpoints, producing plans with incomplete attack surface mapping
- Also deduplicates the auth-data.json reading logic that was inlined in `buildPentestPrompt`

## Test plan

- [ ] Run a pentest with plan phase enabled against an authenticated target
- [ ] Verify the plan agent's prompt contains the "Existing Authentication Session" section after auth-data.json is written
- [ ] Verify plan agent recon requests succeed on authenticated endpoints (200 vs 401/403)
- [ ] Verify execution agent still receives auth data as before (regression check)