### PR TITLE
fix: forward step-finish events and return threatModel from document_endpoint

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentEndpoint.ts
+++ b/src/core/agents/offSecAgent/tools/documentEndpoint.ts
@@ -247,6 +247,7 @@ Each endpoint creates a JSON file in the assets directory for tracking and analy
         endpointType: input.endpointType,
         riskLevel: input.riskLevel,
         filepath,
+        threatModel: threatModel ?? undefined,
         message: `Endpoint '${input.endpointName}' documented successfully under app '${input.appName}'`,
       };
     },

--- a/src/core/agents/offSecAgent/tools/riskScoreGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/riskScoreGenerator.ts
@@ -225,6 +225,7 @@ const CHILD_BUS_EVENT_KEYS = [
   "subagent-complete",
   "command-output",
   "error",
+  "step-finish",
 ] as const satisfies readonly (keyof AgentEventMap)[];
 
 function attachChildEventBus(

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -16,6 +16,7 @@ const CHILD_BUS_EVENT_KEYS = [
   "subagent-complete",
   "command-output",
   "error",
+  "step-finish",
 ] as const satisfies readonly (keyof AgentEventMap)[];
 
 function attachChildEventBus(

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -176,6 +176,7 @@ const CHILD_BUS_EVENT_KEYS = [
   "subagent-complete",
   "command-output",
   "error",
+  "step-finish",
 ] as const satisfies readonly (keyof AgentEventMap)[];
 
 function attachChildEventBus(


### PR DESCRIPTION
## Summary

- Add `step-finish` to `CHILD_BUS_EVENT_KEYS` in `threatModelGenerator.ts`, `spawnCodingAgent.ts`, and `riskScoreGenerator.ts` so child event buses forward the full set of lifecycle events to the parent
- Include `threatModel` in the `document_endpoint` tool return value — the threat model was generated inside the tool and written to disk, but not returned to the caller

## Context

The `CHILD_BUS_EVENT_KEYS` allowlist was written to forward events needed for realtime streaming (`text-delta`, `tool-call-*`) and lifecycle tracking (`subagent-spawn/complete`). The `step-finish` event was missed — any parent bus listener that depends on `step-finish` from a child agent would never see it. This affects all three sub-agent spawning sites: threat model generation, risk score generation, and coding agent spawning.

Separately, `document_endpoint` generates a threat model via a sub-agent and writes it to the endpoint JSON file, but the tool's return value only included metadata (`success`, `appName`, `riskLevel`, etc.). Consumers of the tool result had no access to the `threatModel` field without reading the file from disk.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 679 tests pass
- [x] `npx prettier --check` on changed files