### PR TITLE
feat: add per-environment app creation guidance and make document_app domain optional

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentApp.ts
+++ b/src/core/agents/offSecAgent/tools/documentApp.ts
@@ -130,8 +130,12 @@ Each application creates a JSON file in the apps directory for tracking and anal
         .describe("Additional notes or observations about the application"),
       domain: z
         .string()
+        .optional()
         .describe(
-          "Base URL / domain this application is associated with. Must be a full URL with scheme. " +
+          "Base URL / domain this application is associated with. Only provide this if you can deterministically derive it from evidence — source code, IaC, config, Known Domains list, or live discovery. " +
+            "Substituting a known environment/stage name into an IaC template IS deterministic (e.g. IaC defines '${stage}-bucket' and environments include 'production' → 'https://production-bucket.s3.amazonaws.com' is valid). " +
+            "Do NOT invent domains with no supporting evidence — if no domain can be derived, omit this field. " +
+            "Must be a full URL with scheme when provided. " +
             "For web apps/APIs: the public URL (e.g., 'https://api.example.com'). " +
             "For S3 buckets: 'https://{ACTUAL-BUCKET-NAME}.s3.amazonaws.com' — you MUST include the real bucket name from IaC, NOT 'https://s3.amazonaws.com'. " +
             "For databases (RDS/Aurora): 'https://{cluster-endpoint}.rds.amazonaws.com'. " +

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -675,7 +675,7 @@ function buildAppsDiscoveryObjective(
 
 **For each environment** (${environments.join(", ")}), create an app entry with:
 - **name**: \`<environment>-<resource-name>\` (e.g. \`${environments[0]}-data-bucket\`)
-- **domain**: The environment-specific URL/ARN (e.g. \`https://${environments[0]}-api.example.com\`, \`https://${environments[0]}-data.s3.amazonaws.com\`)
+- **domain**: Substitute the environment name into the IaC naming pattern to derive the environment-specific URL (e.g. IaC has \`\${stage}-data\` → \`https://${environments[0]}-data.s3.amazonaws.com\`). Omit if no naming pattern exists in the code.
 
 **Shared resources:** If a resource is clearly shared across all environments (e.g. a single CDN distribution, a shared auth service), document it once without an environment prefix.\n`
     : "";
@@ -726,23 +726,25 @@ A **cloud resource** qualifies if it is an **owned infrastructure resource** ref
 
 ### Setting the \`domain\` field on \`document_app\` — CRITICAL
 
-Every app and cloud resource MUST have a **unique, resource-specific** domain. This is used to map the resource to the attack surface. **Never reuse a generic domain or another application's domain.**
+**Only set \`domain\` when you can deterministically derive it from evidence** — Known Domains list, IaC resource definitions, configuration files, environment variables, or route definitions. Substituting a known environment/stage name into an IaC naming pattern IS deterministic (e.g. IaC defines \`\${stage}-bucket\` and the target environments include "production" → \`https://production-bucket.s3.amazonaws.com\` is valid). However, do NOT invent domains with no supporting evidence — if no domain can be derived from the source, **omit the \`domain\` field entirely**. A missing domain is far better than a hallucinated one.
+
+When you CAN determine the domain, each resource must have its OWN unique, resource-specific domain. Never reuse a generic domain or another application's domain.
 
 **For web apps and API services:** Use the public-facing URL from the Known Domains list, route configuration, or infrastructure definition (e.g., \`https://console.pensar.dev\`, \`https://api.example.com\`).
 
-**For S3 / GCS / blob storage buckets:** You MUST derive the **actual bucket name** from the infrastructure-as-code. The bucket name is defined in the IaC resource definition (e.g., SST \`new sst.aws.Bucket("ProjectData")\` produces a bucket with a name like \`console-staging-projectdata-abc123\`). Set domain to \`https://{actual-bucket-name}.s3.amazonaws.com\`. If the exact runtime name includes a random suffix you can't determine, use the logical name pattern: \`https://{stage}-{logicalName}.s3.amazonaws.com\`. **NEVER use \`https://s3.amazonaws.com\`** — that is the S3 service, not a bucket.
+**For S3 / GCS / blob storage buckets:** Derive the **actual bucket name** from the infrastructure-as-code. The bucket name is defined in the IaC resource definition (e.g., SST \`new sst.aws.Bucket("ProjectData")\` produces a bucket with a name like \`console-staging-projectdata-abc123\`). Set domain to \`https://{actual-bucket-name}.s3.amazonaws.com\`. If the IaC uses a stage/environment variable in the name, substitute the known environment name (e.g. \`\${stage}-projectdata\` with environment "production" → \`https://production-projectdata.s3.amazonaws.com\`). **NEVER use \`https://s3.amazonaws.com\`** — that is the S3 service, not a bucket. If you cannot determine the bucket name at all, omit the domain.
 
-**For databases (RDS, Aurora, DynamoDB):** Use the cluster/instance endpoint from IaC (e.g., \`https://{cluster-name}.cluster-{id}.{region}.rds.amazonaws.com\`). If the exact endpoint isn't determinable, use the logical resource name pattern.
+**For databases (RDS, Aurora, DynamoDB):** Use the cluster/instance endpoint from IaC. If the exact endpoint isn't determinable, omit the domain.
 
-**For Redis / ElastiCache:** Use the cache cluster endpoint (e.g., \`https://{cluster-id}.{region}.cache.amazonaws.com\`).
+**For Redis / ElastiCache:** Use the cache cluster endpoint if determinable, otherwise omit.
 
-**For SQS queues:** Use \`https://sqs.{region}.amazonaws.com/{account}/{queue-name}\`. If account/region aren't determinable, use the queue's logical name: \`https://sqs.amazonaws.com/{logical-queue-name}\`.
+**For SQS queues:** Use \`https://sqs.{region}.amazonaws.com/{account}/{queue-name}\` if determinable, otherwise omit.
 
-**For Lambda functions:** Use the Lambda Function URL or the API Gateway route that invokes it — NOT the generic API domain shared by all functions. If the Lambda is only invoked by SQS/EventBridge (no HTTP endpoint), set domain to \`https://lambda.{region}.amazonaws.com/functions/{function-name}\`.
+**For Lambda functions:** Use the Lambda Function URL or the API Gateway route — NOT a generic API domain shared by all functions. If no concrete URL is determinable, omit.
 
-**For CloudFront / CDN:** Use the distribution domain (e.g., \`https://{distribution-id}.cloudfront.net\`) or the custom domain alias.
+**For CloudFront / CDN:** Use the distribution domain or custom domain alias if determinable, otherwise omit.
 
-**For WebSocket APIs:** Use the WebSocket endpoint URL (e.g., \`wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}\`).
+**For WebSocket APIs:** Use the WebSocket endpoint URL if determinable, otherwise omit.
 
 When finished, call the \`response\` tool with your structured findings.`;
 }

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -176,6 +176,8 @@ export interface WhiteboxAttackSurfaceWorkflowInput {
   domains?: string[];
   /** Project-level threat model content (e.g. from .pensar/threat_model.md), if found */
   projectThreatModel?: string;
+  /** Deployment environment names (e.g. ["production", "staging"]) from project settings. */
+  environments?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -231,6 +233,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     onCacheMetrics,
     domains,
     projectThreatModel,
+    environments,
   } = input;
 
   // =========================================================================
@@ -239,7 +242,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
 
   const appsAgent = new CodeAgent<AppsDiscoveryResult>({
     codebasePath,
-    objective: buildAppsDiscoveryObjective(codebasePath, domains),
+    objective: buildAppsDiscoveryObjective(codebasePath, domains, environments),
     system: WHITEBOX_CODE_AGENT_SYSTEM_PROMPT,
     model,
     session,
@@ -251,6 +254,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     onStepFinish: (event) => onStepFinish?.(event),
     onCacheMetrics,
     responseSchema: AppsDiscoveryResultSchema,
+    projectThreatModel,
   });
 
   console.log(
@@ -376,7 +380,11 @@ export async function runWhiteboxAttackSurfaceWorkflow(
         task.type === "pages"
           ? buildPagesDiscoveryObjective(codebasePath, task.appInfo)
           : task.type === "cloudResourceEndpoints"
-            ? buildCloudResourceEndpointsObjective(codebasePath, task.appInfo)
+            ? buildCloudResourceEndpointsObjective(
+                codebasePath,
+                task.appInfo,
+                environments,
+              )
             : buildApiEndpointsDiscoveryObjective(codebasePath, task.appInfo);
 
       const agent = new CodeAgent<DiscoverySummary>({
@@ -650,16 +658,33 @@ function isPageEndpoint(record: DocumentedEndpointRecord): boolean {
 function buildAppsDiscoveryObjective(
   codebasePath: string,
   domains?: string[],
+  environments?: string[],
 ): string {
   const domainSection = domains?.length
     ? `\n## Known Domains\nThe following domains are associated with this project. When you document an application, set the \`domain\` field on \`document_app\` if you can determine which domain the app is served from:\n${domains.map((d) => `- ${d}`).join("\n")}\n`
+    : "";
+
+  const environmentsSection = environments?.length
+    ? `\n## Target Environments\nThis project is deployed to the following environments:\n${environments.map((e) => `- **${e}**`).join("\n")}\n
+**Per-environment app creation:** When infrastructure-as-code or configuration defines resources that are dynamically named per environment (e.g. environment-prefixed S3 buckets, stage-scoped databases, per-environment API endpoints), you MUST create a **separate app entry for each environment**. Use the environment name as a prefix in the app name (e.g. \`${environments[0]}-user-uploads-bucket\`, \`${environments.length > 1 ? environments[1] : "staging"}-api-gateway\`).
+
+**How to identify environment-scoped resources:**
+- IaC that interpolates a stage/environment variable into resource names (e.g. \`\${stage}-my-bucket\`, \`\${env}-api\`, \`$app.$stage.example.com\`)
+- Separate config blocks, Terraform workspaces, SST stages, or CDK stacks per environment
+- Environment variables or config files that change resource identifiers per stage
+
+**For each environment** (${environments.join(", ")}), create an app entry with:
+- **name**: \`<environment>-<resource-name>\` (e.g. \`${environments[0]}-data-bucket\`)
+- **domain**: The environment-specific URL/ARN (e.g. \`https://${environments[0]}-api.example.com\`, \`https://${environments[0]}-data.s3.amazonaws.com\`)
+
+**Shared resources:** If a resource is clearly shared across all environments (e.g. a single CDN distribution, a shared auth service), document it once without an environment prefix.\n`
     : "";
 
   return `# Identify All Applications in the Repository
 
 ## Codebase
 - **Path:** ${codebasePath}
-${domainSection}
+${domainSection}${environmentsSection}
 ## Task
 Analyze the repository structure and identify every **deployed application or service** (APIs, web apps, microservices) defined within it. Also discover **cloud resources and external services** referenced in the code that are owned by the target (e.g. S3 buckets, cloud storage, CDN origins, message queues).
 
@@ -837,14 +862,19 @@ When finished, call \`response\` with a summary of how many endpoints you docume
 function buildCloudResourceEndpointsObjective(
   codebasePath: string,
   appInfo: z.infer<typeof AppInfoSchema>,
+  environments?: string[],
 ): string {
+  const envNote = environments?.length
+    ? `\n## Target Environments\nThis resource may exist in the following environments: ${environments.join(", ")}. When documenting entry points, use the **environment-specific resource identifiers** (e.g. environment-prefixed bucket names, stage-scoped queue URLs, per-environment ARNs). If the app name already includes an environment prefix, use that environment's resource names in the endpoints.\n`
+    : "";
+
   return `# Document Entry Points for Cloud Resource: ${appInfo.name}
 
 ## Codebase
 - **Repository root:** ${codebasePath}
 - **Resource location:** ${appInfo.location}
 - **Service:** ${appInfo.framework}
-
+${envNote}
 ## Context — Application Domain
 The parent application for this cloud resource already has a domain/URL associated with it (set via \`document_app\`). **Do NOT create endpoints that simply repeat the base domain URL.** The domain is already stored on the application record — endpoints should document **distinct access patterns** that go beyond the base domain.
 
@@ -1052,6 +1082,7 @@ export async function runIncrementalWhiteboxAttackSurfaceWorkflow(
     assetsPath,
     existingResult,
     input.domains,
+    input.environments,
   );
 
   const agent = new CodeAgent<IncrementalResult>({
@@ -1147,6 +1178,7 @@ function buildIncrementalObjective(
   assetsPath: string,
   existingResult: WhiteboxAttackSurfaceResult,
   domains?: string[],
+  environments?: string[],
 ): string {
   const appsSummary = existingResult.apps
     .map((app) => {
@@ -1159,6 +1191,10 @@ function buildIncrementalObjective(
     ? `\n## Known Domains\nThe following domains are associated with this project. When documenting new apps, set the \`domain\` field on \`document_app\` if you can determine which domain serves the app:\n${domains.map((d) => `- ${d}`).join("\n")}\n`
     : "";
 
+  const environmentsSection = environments?.length
+    ? `\n## Target Environments\nThis project is deployed to: ${environments.join(", ")}. When the diff introduces new dynamically-named resources (e.g. environment-prefixed S3 buckets, stage-scoped databases), create a **separate app entry per environment** using the environment name as a prefix (e.g. \`${environments[0]}-<resource>\`). Use environment-specific identifiers in domains and endpoints.\n`
+    : "";
+
   return `# Incremental Attack Surface Update
 
 ## Context
@@ -1168,8 +1204,7 @@ You are updating the attack surface map for a repository after a new commit. Rat
 - **Path:** ${codebasePath}
 - **Diff file:** ${diffPath} (contains \`git diff\` output between the previous and current commit)
 - **Existing assets directory:** ${assetsPath}
-${domainSection}
-
+${domainSection}${environmentsSection}
 ## Directory Structure
 The assets directory uses app-scoped folders:
 \`\`\`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Two related improvements to the whitebox attack surface recon prompts:

1. **Make `document_app` domain optional** (`documentApp.ts`) — The `domain` field on `document_app` is now `z.string().optional()`. The description explicitly tells the agent to only set `domain` when it can be **deterministically derived from evidence** (Known Domains, IaC definitions, config files). Inventing/hallucinating domains when no evidence exists was causing noisy, inaccurate attack surface maps. A missing domain is far better than a fabricated one.

2. **Per-environment app creation guidance** (`whiteboxAttackSurface.ts`) — When the caller passes `environments` (e.g. `["production", "staging"]`), the discovery prompts now instruct the agent to:
   - Create **separate app entries for each environment** when IaC defines dynamically-named resources (e.g. `${stage}-data-bucket`)
   - Substitute the known environment name into IaC naming patterns to derive environment-specific domains
   - Document shared resources (e.g. a single CDN) only once, without an environment prefix
   - Use environment-specific identifiers in cloud resource endpoints

   This is threaded through the apps discovery, cloud resource endpoints, and incremental update objectives.

**Why:** Whitebox recon was producing a single generic app entry for resources that actually exist per-environment, and was hallucinating domains for resources where no URL evidence existed. These changes improve coverage and accuracy of the attack surface map.

### How did you verify your code works?

- `bun run tsc` — passes
- `bun run lint` — passes  
- `bun run test` — 681 passed, 15 skipped (integration tests), 0 failures
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1226b488-02fc-45ec-8417-98b14e583c53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1226b488-02fc-45ec-8417-98b14e583c53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

