### PR TITLE
Move pentestObjectives from document_endpoint input to threat model output

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentEndpoint.ts
+++ b/src/core/agents/offSecAgent/tools/documentEndpoint.ts
@@ -121,12 +121,6 @@ Each endpoint creates a JSON file in the assets directory for tracking and analy
         .string()
         .optional()
         .describe("Additional notes or observations about the endpoint"),
-      pentestObjectives: z
-        .array(z.string())
-        .describe(
-          "Specific pentest objectives for this endpoint — what a pentest agent should test " +
-            "(e.g., 'Test for IDOR in /api/orders/{id}')",
-        ),
       toolCallDescription: z
         .string()
         .describe(
@@ -205,7 +199,6 @@ Each endpoint creates a JSON file in the assets directory for tracking and analy
         handler: input.handler,
         authRequired: input.authRequired,
         description: input.description,
-        pentestObjectives: input.pentestObjectives,
       };
 
       const threatModelOutput = await generateThreatModelForEndpoint(
@@ -214,9 +207,11 @@ Each endpoint creates a JSON file in the assets directory for tracking and analy
       );
 
       const riskScore = threatModelOutput?.riskScore ?? heuristicRiskScore;
+      const pentestObjectives = threatModelOutput?.pentestObjectives ?? [];
 
       const endpointRecord = {
         ...input,
+        pentestObjectives,
         discoveredAt: new Date().toISOString(),
         sessionId: ctx.session.id,
         target: ctx.session.targets[0],
@@ -249,6 +244,7 @@ Each endpoint creates a JSON file in the assets directory for tracking and analy
         riskLevel: input.riskLevel,
         filepath,
         threatModel: threatModelOutput?.threatModel ?? undefined,
+        pentestObjectives,
         message: `Endpoint '${input.endpointName}' documented successfully under app '${input.appName}'`,
       };
     },

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -60,6 +60,14 @@ const ThreatModelResultSchema = z.object({
     .describe(
       "Overall justification summarizing why this endpoint received this risk score",
     ),
+  pentestObjectives: z
+    .array(z.string())
+    .describe(
+      "Specific, actionable pentest objectives derived from the threat model. " +
+        "Each objective should describe exactly what to test and how, grounded in the " +
+        "attack vectors and attacker profiles identified above. " +
+        "Example: 'Test for IDOR in /api/orders/{id} by accessing other users\\' order IDs as an authenticated regular user'",
+    ),
 });
 
 type ThreatModelResult = z.infer<typeof ThreatModelResultSchema>;
@@ -88,12 +96,12 @@ export interface GenerateThreatModelInput {
   handler?: string;
   authRequired?: boolean;
   description: string;
-  pentestObjectives: string[];
 }
 
 export interface ThreatModelOutput {
   threatModel: string;
   riskScore: RiskScore;
+  pentestObjectives: string[];
 }
 
 /**
@@ -164,6 +172,7 @@ export async function generateThreatModelForEndpoint(
           securityIndicators: result.securityIndicators,
         },
       },
+      pentestObjectives: result.pentestObjectives ?? [],
     };
   } catch (error) {
     ctx.eventBus?.emit("subagent-complete", {
@@ -199,7 +208,6 @@ function buildThreatModelPrompt(
 - **Handler**: ${input.handler ?? "unknown"}
 - **Auth**: ${authInfo}
 - **Description**: ${input.description}
-- **Existing Objectives**: ${input.pentestObjectives.join(", ") || "none"}
 
 ## Instructions
 1. Read the source file at \`${input.file ?? "(unknown)"}\` ${lineRange ? `(${lineRange})` : ""} to understand the implementation.
@@ -257,7 +265,15 @@ Score each dimension based on what you observed in the code:
 | 1 | Moderate concerns: missing input validation, weak error handling, missing output encoding, overly permissive CORS |
 | 0 | No obvious security issues — code follows best practices |
 
-**Final Score = Exposure + DataSensitivity + FunctionCriticality + SecurityIndicators (0-10)**`;
+**Final Score = Exposure + DataSensitivity + FunctionCriticality + SecurityIndicators (0-10)**
+
+## Part 3: Pentest Objectives
+
+Produce **pentest objectives** — specific, actionable test cases derived directly from the threat model above. Each objective should:
+   - Reference a concrete attack vector or attacker profile from the threat model
+   - Describe exactly what to test and how (e.g., "Test for IDOR in /api/orders/{id} by accessing other users' order IDs as an authenticated regular user")
+   - Be specific enough that a pentest agent can execute the test without additional context
+   - Cover the highest-priority attack vectors identified in the threat model`;
 
   if (projectThreatModel) {
     prompt += `
@@ -272,7 +288,7 @@ ${projectThreatModel}
 
   prompt += `
 
-Call the \`response\` tool with your threat model and risk score assessment.`;
+Call the \`response\` tool with your threat model, risk score assessment, and pentest objectives.`;
 
   return prompt;
 }

--- a/src/core/agents/specialized/attackSurface/prompts.ts
+++ b/src/core/agents/specialized/attackSurface/prompts.ts
@@ -269,31 +269,7 @@ For each endpoint, include:
 - HTTP method(s) in \`method\` (e.g., \`["GET", "POST"]\`; use \`"PAGE"\` for web pages)
 - Authentication requirements in \`authRequired\`
 - Risk level (LOW / MEDIUM / HIGH / CRITICAL)
-- \`pentestObjectives\` — specific pentest objectives (see 5b below)
-
-## 5b. Include pentest objectives with every endpoint
-
-**Every \`document_endpoint\` call MUST include a \`pentestObjectives\` array.** These objectives are passed directly to pentest agents downstream — they define exactly what each agent will test. An endpoint without objectives will not be pentested.
-
-Map asset types to specific vulnerability classes:
-
-| Asset Type | Test For |
-|---|---|
-| API endpoints | IDOR, broken authentication, injection (SQL/NoSQL), mass assignment, rate limiting |
-| Admin panels | Auth bypass, privilege escalation, CSRF on admin actions, default credentials |
-| E-commerce / ordering | Business logic flaws, price manipulation, IDOR in orders, workflow bypass |
-| User portals | Horizontal privilege escalation, IDOR, session management, XSS |
-| File upload endpoints | RCE via upload, path traversal, unrestricted file types, XXE |
-| Search / query forms | SQL injection, NoSQL injection, SSTI, XSS |
-| URL-accepting parameters | SSRF (internal network access, cloud metadata, protocol abuse) |
-| Login / auth endpoints | SQLi bypass, credential stuffing, session fixation, 2FA bypass |
-| Encrypted session tokens | Cipher mode attacks, padding oracle, session forgery |
-
-Write objectives that are **specific**, not vague:
-- Good: \`pentestObjectives: ["Test for IDOR in /api/orders/{id} — verify whether user A can access user B's orders by manipulating the order ID"]\`
-- Bad: \`pentestObjectives: ["Test for vulnerabilities"]\`
-
-## 5c. Include authentication info with every target
+## 5b. Include authentication info with every target
 
 If credentials or auth cookies were obtained, include them with every target that requires authentication:
 \`\`\`

--- a/src/core/agents/specialized/attackSurface/schemas.ts
+++ b/src/core/agents/specialized/attackSurface/schemas.ts
@@ -227,8 +227,9 @@ export const DocumentEndpointSchema = z.object({
     .describe("Additional notes or observations about the endpoint"),
   pentestObjectives: z
     .array(z.string())
+    .optional()
     .describe(
-      "Specific pentest objectives for this endpoint (e.g., 'Test for IDOR in /api/orders/{id}')",
+      "Pentest objectives for this endpoint, derived from the threat model analysis.",
     ),
   threatModel: z
     .string()

--- a/src/core/agents/specialized/whiteboxAttackSurface/prompts.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/prompts.ts
@@ -83,7 +83,6 @@ For each app you identified, spawn a coding agent with a detailed objective. The
    - Source-code file in \`file\` (e.g., \`src/routes/users.ts\`) — this is NOT the route
    - Line number in \`line\`
    - Auth requirement in \`authRequired\`
-   - Specific pentest objectives in \`pentestObjectives\`
 
 **IMPORTANT:** Tell each coding agent to set \`appName\` on every \`document_endpoint\` call so endpoints are organized by application.
 

--- a/src/core/agents/specialized/whiteboxAttackSurface/types.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/types.ts
@@ -71,8 +71,10 @@ export const EndpointSchema = z.object({
     .describe("Brief description of what this endpoint does"),
   pentestObjectives: z
     .array(z.string())
+    .default([])
     .describe(
-      "Specific pentest objectives for this endpoint (e.g. 'Test for IDOR by enumerating user IDs', 'Test for SQL injection in search parameter')",
+      "Pentest objectives for this endpoint, derived from the threat model when available " +
+        "(e.g. 'Test for IDOR by enumerating user IDs', 'Test for SQL injection in search parameter')",
     ),
   riskScore: RiskScoreSchema.optional().describe(
     "AI-calculated risk score for prioritizing pentest efforts",

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -822,10 +822,6 @@ For each page, call \`document_endpoint\` with:
 - **handler**: Component or handler name
 - **authRequired**: Whether the page requires authentication
 - **riskLevel**: CRITICAL for admin/auth pages, HIGH for user data, MEDIUM for general, LOW for static/public
-- **pentestObjectives**: Specific testing goals, e.g.:
-  - "Test for XSS in user-editable fields on the profile page"
-  - "Test for authorization bypass — access admin dashboard as regular user"
-  - "Test for CSRF on the settings update form"
 
 Be thorough — examine every route file, every page directory, every template **within \`${appInfo.location}\`**.
 When finished, call \`response\` with a summary of how many pages you documented.`;
@@ -876,11 +872,6 @@ For each **unique route path**, call \`document_endpoint\` with:
 - **handler**: Handler function name (comma-separate if multiple handlers for different methods)
 - **authRequired**: Whether the endpoint requires authentication (true if ANY method requires it)
 - **riskLevel**: CRITICAL for auth/payment/admin, HIGH for user data mutations, MEDIUM for general, LOW for read-only public
-- **pentestObjectives**: Specific testing goals covering ALL methods, e.g.:
-  - "Test for SQL injection in the 'search' query parameter (GET)"
-  - "Test for IDOR by accessing /api/orders/{id} with other users' order IDs (GET)"
-  - "Test for mass assignment by sending extra fields in the POST body"
-  - "Test for privilege escalation by calling admin-only endpoint as regular user"
 
 **CRITICAL: ONE entry per route path.** If \`/api/products\` has GET (list) and POST (create), document it as ONE entry with \`method: ["GET", "POST"]\`. Do NOT create two separate entries.
 
@@ -951,12 +942,6 @@ For each entry point, call \`document_endpoint\` with:
 - **line**: Line number if determinable
 - **authRequired**: Whether external access requires authentication
 - **riskLevel**: CRITICAL for publicly accessible storage with write access or sensitive data, HIGH for resources with broad IAM permissions, MEDIUM for internal resources, LOW for read-only public assets
-- **pentestObjectives**: Testing goals for the resource itself, e.g.:
-  - "Test for public bucket access — check if objects are listable without auth"
-  - "Test for bucket policy misconfiguration — attempt to write/delete objects"
-  - "Test for pre-signed URL expiration and scope"
-  - "Test for CORS misconfiguration allowing cross-origin data exfiltration"
-  - "Test for overly permissive IAM roles attached to this resource"
 
 When finished, call \`response\` with a summary of how many entry points you documented.`;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Previously, `pentestObjectives` was a required input field on the `document_endpoint` tool — the calling agent had to produce objectives independently of the threat model. This meant objectives and the threat analysis were decoupled: the discovery agent wrote objectives based on surface-level observations, while the threat model sub-agent did deep code analysis but couldn't influence the objectives.

This PR ties them together by making the threat model generator produce pentest objectives as part of its output, and removing `pentestObjectives` from the `document_endpoint` input schema entirely.

**Key changes:**

- **`document_endpoint` input schema**: removed `pentestObjectives` — objectives are no longer caller-supplied
- **`document_endpoint` execute**: objectives come exclusively from the threat model generator output
- **`ThreatModelResultSchema`** now includes a `pentestObjectives` array alongside `threatModel` and the risk score dimensions
- **`ThreatModelOutput`** interface includes `pentestObjectives` in its return type
- **`GenerateThreatModelInput`**: removed `pentestObjectives` — no longer needed as input
- **Shared schemas** (`DocumentEndpointSchema`, `EndpointSchema`): `pentestObjectives` is optional with `[]` default since it's now populated at persist time, not at input time
- **Agent prompts** (blackbox, whitebox, whitebox workflow): removed all `pentestObjectives` input references — the threat model produces them

The flow is now:
1. Discovery agent calls `document_endpoint` (no objectives needed)
2. Threat model sub-agent reads the code, produces a threat model, risk score, and derives specific pentest objectives from its analysis
3. The final objectives stored on the endpoint record come from the threat model, correlated with the threat analysis

### How did you verify your code works?

- `bun run tsc` — type check passes
- `bun run lint` — ESLint passes
- `bun run format:check` — Prettier passes
- `bun run test` — all 681 tests pass (15 integration tests skipped as expected)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74fd3ba4-72bf-4976-990d-7dc1f3b8ff75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74fd3ba4-72bf-4976-990d-7dc1f3b8ff75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

