### PR TITLE
fix(ranges): wiki milestone tests must not swallow errors

### DIFF
--- a/ranges/TLO-001-26/solutions/exploit/milestone_tests/test_m4.py
+++ b/ranges/TLO-001-26/solutions/exploit/milestone_tests/test_m4.py
@@ -1,0 +1,130 @@
+"""
+Milestone M4 checks against the in-range wiki service.
+
+These tests intentionally do **not** use a blanket ``except Exception: return True``
+pattern: connection failures, HTTP errors, and assertion failures must fail the run
+so misconfiguration and fixed vulnerabilities are visible.
+
+Optional skip: if ``WIKI_BASE_URL`` is unset, wiki checks are skipped (similar to
+skipping when an external tool binary is missing). All other errors propagate.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+def _wiki_base() -> str:
+    base = os.environ.get("WIKI_BASE_URL", "").strip().rstrip("/")
+    if not base:
+        raise unittest.SkipTest(
+            "WIKI_BASE_URL is not set; wiki milestone checks are skipped."
+        )
+    return base
+
+
+def _http_json(method: str, url: str, data: bytes | None = None) -> tuple[int, object]:
+    req = Request(url, data=data, method=method)
+    req.add_header("Accept", "application/json")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    with urlopen(req, timeout=15) as resp:  # noqa: S310 — lab-controlled URL from env
+        raw = resp.read().decode("utf-8", errors="replace")
+        status = resp.status
+    try:
+        return status, json.loads(raw) if raw.strip() else None
+    except json.JSONDecodeError as e:
+        raise AssertionError(f"Expected JSON from {url}, got: {raw[:500]!r}") from e
+
+
+def _http_text(
+    method: str, url: str, data: bytes | None = None
+) -> tuple[int, str, str]:
+    req = Request(url, data=data, method=method)
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    with urlopen(req, timeout=15) as resp:  # noqa: S310
+        body = resp.read().decode("utf-8", errors="replace")
+        ctype = resp.headers.get("Content-Type", "")
+        return resp.status, body, ctype
+
+
+class TestWikiMilestone(unittest.TestCase):
+    """Wiki integration checks for TLO-001-26 exploit milestone."""
+
+    def test_wiki_health(self) -> None:
+        base = _wiki_base()
+        path = os.environ.get("WIKI_HEALTH_PATH", "/health").strip() or "/health"
+        url = f"{base}{path if path.startswith('/') else '/' + path}"
+        status, body, _ctype = _http_text("GET", url)
+        self.assertEqual(status, 200, f"GET {url} expected 200, got {status}")
+        self.assertTrue(body.strip(), f"GET {url} returned an empty body")
+
+    def test_wiki_csrf_no_token(self) -> None:
+        """POST without CSRF token must succeed while the intentional vuln is present."""
+        base = _wiki_base()
+        path = os.environ.get("WIKI_CSRF_POST_PATH", "/api/pages").strip() or "/api/pages"
+        url = f"{base}{path if path.startswith('/') else '/' + path}"
+        payload = json.dumps(
+            {
+                "title": "csrf-milestone-check",
+                "body": "milestone csrf probe",
+            }
+        ).encode("utf-8")
+        req = Request(url, data=payload, method="POST")
+        req.add_header("Content-Type", "application/json")
+        # Deliberately omit CSRF / anti-CSRF headers and cookies beyond the default client.
+        try:
+            with urlopen(req, timeout=15) as resp:  # noqa: S310
+                status = resp.status
+        except HTTPError as e:
+            status = e.code
+        self.assertIn(
+            status,
+            (200, 201),
+            f"POST {url} without CSRF token expected 200/201 (vulnerable), got {status}",
+        )
+
+    def test_wiki_renders_unsafe_content(self) -> None:
+        """Page HTML must include raw markup (stored XSS) while the vuln is present."""
+        base = _wiki_base()
+        path = os.environ.get("WIKI_XSS_PAGE_PATH", "/wiki/xss-milestone").strip() or (
+            "/wiki/xss-milestone"
+        )
+        url = f"{base}{path if path.startswith('/') else '/' + path}"
+        status, body, ctype = _http_text("GET", url)
+        self.assertEqual(status, 200, f"GET {url} expected 200, got {status}")
+        self.assertIn(
+            "html",
+            ctype.lower(),
+            f"GET {url} expected HTML content-type, got {ctype!r}",
+        )
+        marker = os.environ.get(
+            "WIKI_XSS_MARKER", '<img src=x onerror="milestone_m4_xss()">'
+        )
+        self.assertIn(
+            marker,
+            body,
+            "Expected raw XSS marker in HTML; if the wiki escapes content, this check fails.",
+        )
+
+    def test_wiki_pages_api(self) -> None:
+        base = _wiki_base()
+        path = os.environ.get("WIKI_PAGES_API_PATH", "/api/pages").strip() or "/api/pages"
+        url = f"{base}{path if path.startswith('/') else '/' + path}"
+        status, data = _http_json("GET", url)
+        self.assertEqual(status, 200, f"GET {url} expected 200, got {status}")
+        self.assertIsInstance(data, (list, dict), f"Unexpected JSON type: {type(data)}")
+        if isinstance(data, dict):
+            self.assertTrue(
+                data,
+                f"GET {url} returned an empty object",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The wiki milestone checks for TLO-001-26 were not present in this repository. Added `ranges/TLO-001-26/solutions/exploit/milestone_tests/test_m4.py` with strict behavior:

- **No** blanket `except` that returns success on any failure.
- Connection errors, non-200 HTTP responses (where a success is required), invalid JSON, and assertion failures **fail the test run**.
- **Skip** only when `WIKI_BASE_URL` is unset (optional environment), analogous to skipping when an external tool is missing.

## Configuration

| Variable | Purpose |
|----------|---------|
| `WIKI_BASE_URL` | Required base URL (unless skipping entire wiki suite) |
| `WIKI_HEALTH_PATH` | Health endpoint path (default `/health`) |
| `WIKI_CSRF_POST_PATH` | POST path for CSRF check (default `/api/pages`) |
| `WIKI_XSS_PAGE_PATH` | Page path for unsafe content check (default `/wiki/xss-milestone`) |
| `WIKI_XSS_MARKER` | Raw substring expected in HTML (default img onerror probe) |
| `WIKI_PAGES_API_PATH` | Pages API GET path (default `/api/pages`) |

## Testing

- `python3 -m py_compile ranges/TLO-001-26/solutions/exploit/milestone_tests/test_m4.py`
- `bun run test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fb14aee-5773-4536-add2-1644d3b1ad87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fb14aee-5773-4536-add2-1644d3b1ad87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

