### PR TITLE
WIP: feat: add ask_user_questions tool and ExplorationAgent

### DIFF
--- a/src/core/agents/explorationAgent/agent.test.ts
+++ b/src/core/agents/explorationAgent/agent.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for {@link ExplorationAgent}.
+ *
+ * Approach: we mock `getProviderModel` from `../../ai/utils` so that the
+ * base harness's `streamResponse` call is served by a
+ * `MockLanguageModelV3` instead of hitting a real provider. The mock
+ * emits a single `ask_user_questions` tool-call, which both exercises
+ * the `hasToolCall('ask_user_questions')` stop condition and lets us
+ * verify that the messages surfaced via `streamResult.response` contain
+ * the expected tool-call payload.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+
+// Mock the provider model factory BEFORE importing the agent/base class
+// so the base harness's `streamResponse` resolves to the mock model.
+vi.mock("../../ai/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../ai/utils")>();
+
+  const stringifiedInput = JSON.stringify({
+    questions: [
+      {
+        id: "deployment-runtime",
+        question: "Where does this application actually run?",
+        multiSelect: false,
+        allowFreeform: true,
+        options: [
+          {
+            id: "ecs-fargate",
+            label: "AWS ECS Fargate (inferred from infra/ecs.ts)",
+          },
+          {
+            id: "k8s",
+            label: "Self-hosted Kubernetes (inferred from kubernetes/)",
+          },
+        ],
+      },
+    ],
+  });
+
+  const mockChunks: LanguageModelV3StreamPart[] = [
+    { type: "stream-start", warnings: [] },
+    {
+      type: "response-metadata",
+      id: "mock-response-1",
+      timestamp: new Date(0),
+      modelId: "mock-model",
+    },
+    {
+      type: "tool-call",
+      toolCallId: "tc_mock_1",
+      toolName: "ask_user_questions",
+      input: stringifiedInput,
+    },
+    {
+      type: "finish",
+      usage: {
+        inputTokens: {
+          total: 10,
+          noCache: 10,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+        outputTokens: {
+          total: 20,
+          text: 20,
+          reasoning: 0,
+        },
+      },
+      finishReason: { unified: "tool-calls", raw: "tool_use" },
+    },
+  ];
+
+  const mockModel = new MockLanguageModelV3({
+    provider: "mock-provider",
+    modelId: "mock-model",
+    doStream: async () => ({
+      stream: simulateReadableStream({ chunks: mockChunks }),
+    }),
+  });
+
+  return {
+    ...actual,
+    getProviderModel: () => mockModel,
+  };
+});
+
+// Now safe to import — the mock is hoisted to the top of the file by
+// vitest's `vi.mock`.
+const { ExplorationAgent } = await import("./agent");
+const { sessions } = await import("../../session");
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "exploration-agent-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("ExplorationAgent", () => {
+  it(
+    "stops on ask_user_questions tool call and surfaces the tool-call in messages",
+    async () => {
+      // Construct a minimal session via the real factory — this gives
+      // us all the paths and config defaults the base harness expects.
+      const session = await sessions.create({
+        name: "test-exploration",
+        targets: [],
+        config: { agentCwd: tmpDir },
+      });
+
+      const agent = new ExplorationAgent({
+        prompt:
+          "Explore the cloned repo and ask the operator for grounding context.",
+        model: "claude-opus-4-6",
+        session,
+      });
+
+      // consume() drains the stream, runs resolveResult (void here), and
+      // returns. Under the mocked model, the single tool-call triggers
+      // the hasToolCall('ask_user_questions') stop condition.
+      await agent.consume();
+
+      const response = await agent.streamResult.response;
+      const messages = response.messages ?? [];
+
+      // Find the assistant message that contains the ask_user_questions
+      // tool-call. The base harness stores tool-calls inside an
+      // assistant message's content array.
+      let foundToolCall: {
+        toolName: string;
+        input: unknown;
+      } | null = null;
+
+      for (const msg of messages) {
+        if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+        for (const part of msg.content) {
+          if (
+            part.type === "tool-call" &&
+            part.toolName === "ask_user_questions"
+          ) {
+            foundToolCall = {
+              toolName: part.toolName,
+              input: part.input,
+            };
+          }
+        }
+      }
+
+      expect(
+        foundToolCall,
+        "expected messages to contain an ask_user_questions tool-call",
+      ).not.toBeNull();
+      expect(foundToolCall!.toolName).toBe("ask_user_questions");
+      const input = foundToolCall!.input as {
+        questions: Array<{ id: string; options: Array<{ label: string }> }>;
+      };
+      expect(Array.isArray(input.questions)).toBe(true);
+      expect(input.questions.length).toBeGreaterThanOrEqual(1);
+      // Grounding discipline: the mock emits a label with a filename
+      // reference. Assert at least one option label contains a backtick
+      // or filename-like token to guard against regressions where the
+      // test fixture is accidentally stripped of grounding.
+      const allLabels = input.questions.flatMap((q) =>
+        q.options.map((o) => o.label),
+      );
+      expect(
+        allLabels.some((l) => /\.(ts|yml|toml|json)\b|\//.test(l)),
+        `expected at least one grounded option label, got: ${JSON.stringify(allLabels)}`,
+      ).toBe(true);
+    },
+    15_000,
+  );
+});

--- a/src/core/agents/explorationAgent/agent.ts
+++ b/src/core/agents/explorationAgent/agent.ts
@@ -1,0 +1,56 @@
+import { hasToolCall, stepCountIs } from "ai";
+import { OffensiveSecurityAgent } from "../offSecAgent/offensiveSecurityAgent";
+import { buildExplorationSystemPrompt } from "./prompts";
+import type { ExplorationAgentInput } from "./types";
+
+/**
+ * Guided-onboarding exploration agent.
+ *
+ * A light, single-turn specialization of {@link OffensiveSecurityAgent}
+ * that browses a cloned source repository with a small read-only toolset
+ * and issues ONE batched `ask_user_questions` tool call before stopping.
+ * Consumers collect the answers and feed them into downstream workflows
+ * (e.g. whitebox recon) as user-provided context.
+ *
+ * Stop conditions:
+ *   - `hasToolCall('ask_user_questions')` — the primary handshake.
+ *   - `stepCountIs(40)` — hard cap in case the model never asks.
+ *
+ * The `askUserQuestionsEnabled: true` flag is the gate that causes the
+ * base harness's `createAllTools` to actually include the
+ * `ask_user_questions` tool factory in this agent's toolset. Without
+ * the flag, listing the tool in `activeTools` would be a no-op.
+ *
+ * @example
+ * ```ts
+ * const agent = new ExplorationAgent({
+ *   prompt: "Explore the repo at /workspace/acme-app and ask operator for context.",
+ *   model: "claude-opus-4-6",
+ *   session,
+ * });
+ * await agent.consume();
+ * ```
+ */
+export class ExplorationAgent extends OffensiveSecurityAgent<void> {
+  constructor(opts: ExplorationAgentInput) {
+    super({
+      system: buildExplorationSystemPrompt(),
+      prompt: opts.prompt,
+      model: opts.model,
+      session: opts.session,
+      authConfig: opts.authConfig,
+      abortSignal: opts.abortSignal,
+      onStepFinish: opts.onStepFinish,
+      messages: opts.priorMessages,
+
+      // Gate that causes createAllTools to include ask_user_questions for
+      // this agent. Without this, the tool is not in the toolset even if
+      // it is listed in activeTools.
+      askUserQuestionsEnabled: true,
+
+      activeTools: ["read_file", "list_files", "grep", "ask_user_questions"],
+
+      stopWhen: [hasToolCall("ask_user_questions"), stepCountIs(40)],
+    });
+  }
+}

--- a/src/core/agents/explorationAgent/index.ts
+++ b/src/core/agents/explorationAgent/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Barrel for the guided-onboarding {@link ExplorationAgent}.
+ *
+ * Re-exports the agent class, its input type, and the shared
+ * `ask_user_questions` types so consumers can deserialize tool-call
+ * inputs and tool-result outputs without reaching into Apex internals.
+ */
+export { ExplorationAgent } from "./agent";
+export type { ExplorationAgentInput } from "./types";
+export type {
+  AskUserQuestion,
+  AskUserQuestionAnswer,
+  AskUserQuestionsResult,
+} from "../offSecAgent/tools/askUserQuestions";

--- a/src/core/agents/explorationAgent/prompts.ts
+++ b/src/core/agents/explorationAgent/prompts.ts
@@ -1,0 +1,147 @@
+/**
+ * System prompt for the {@link ExplorationAgent}.
+ *
+ * Encodes the five requirements from the guided-onboarding design doc,
+ * §"Prompt strategy (abbreviated)":
+ *
+ *   1. Explore first — skim manifests, infra, auth modules, API routes.
+ *      Budget roughly 15–25 tool calls before asking questions.
+ *   2. Ground the options — every option label must reference something
+ *      observed in the repo (e.g. "AWS ECS Fargate (inferred from
+ *      `infra/ecs.ts`)"), not a generic template.
+ *   3. Ask categories — deployment/runtime, user types, data sensitivity,
+ *      trust boundaries, known concerns. Pick the top 3–5 that matter.
+ *   4. One batch, then stop — V1 is strictly single-turn.
+ *   5. Respect size — truncate `read_file` per call and favor `grep` for
+ *      locating things.
+ *
+ * The prompt is intentionally self-contained — the base harness will
+ * append its usual session-workspace section. Exported as a builder so
+ * consumers can evolve it (e.g. inject per-session context) without a
+ * breaking-change to the module shape.
+ */
+export function buildExplorationSystemPrompt(): string {
+  return `You are the Pensar Exploration Agent.
+
+Your job is to do a LIGHT, single-turn reconnaissance of a cloned source
+repository and then ask the operator a small, well-grounded batch of
+multiple-choice questions that will seed a deeper security review. You
+are NOT pentesting. You are NOT writing a threat model. You are
+orienting — just enough to make the questions you ask materially better
+than generic security-onboarding templates.
+
+## Available tools
+
+- \`list_files\` — list files/directories in the cloned repo.
+- \`read_file\` — read a single file (size-capped per call).
+- \`grep\` — search across the repo for a regex.
+- \`ask_user_questions\` — stop and ask the operator 2–5 grounded
+  questions. Calling this tool ENDS your turn. You get ONE call.
+
+You have no other tools. Do not attempt to execute shell commands, make
+HTTP requests, or browse. This is a read-only codebase pass.
+
+## The five rules
+
+### 1. Explore first — do not ask before you understand
+
+Before calling \`ask_user_questions\`, orient yourself on the codebase.
+A reasonable plan:
+
+- List the repo root. Identify the language(s) and package manager by
+  looking for \`package.json\`, \`go.mod\`, \`Cargo.toml\`,
+  \`requirements.txt\`, \`pyproject.toml\`, \`pom.xml\`, \`Gemfile\`,
+  \`composer.json\`, etc.
+- Skim deployment signal: \`Dockerfile\`, \`docker-compose.yml\`,
+  \`infra/\`, \`terraform/\`, \`cdk/\`, \`serverless.yml\`, \`.github/\`,
+  \`fly.toml\`, \`vercel.json\`, \`netlify.toml\`, \`kubernetes/\`,
+  \`helm/\`.
+- Locate auth modules: grep for terms like \`session\`, \`login\`,
+  \`auth\`, \`jwt\`, \`oauth\`, \`passport\`, \`clerk\`, \`workos\`,
+  \`cognito\`, \`firebase-auth\`.
+- Locate API routes: \`routes/\`, \`api/\`, \`app/api/\`, \`controllers/\`,
+  framework-specific route registrations (Express, Fastify, Flask,
+  FastAPI, Rails, Gin, Chi, etc.).
+
+Budget roughly **15–25 tool calls** for this exploration. Fewer than 10
+is usually too shallow; more than 30 is wasted effort for a V1 pass.
+
+### 2. Ground every option in observed code
+
+This is the rule that makes or breaks the agent. Every option label you
+emit in \`ask_user_questions\` MUST cite something concrete you observed:
+a filename, a package, a config value, a route pattern, an env var name,
+an infra artifact. Examples:
+
+- Good: \`"AWS ECS Fargate (inferred from \`infra/ecs.ts\`)"\`
+- Good: \`"Clerk for end-user auth (inferred from \`@clerk/nextjs\` in package.json)"\`
+- Good: \`"Postgres via Drizzle (inferred from \`drizzle.config.ts\`)"\`
+- Bad: \`"AWS"\` — no grounding.
+- Bad: \`"Some form of authentication"\` — no grounding.
+- Bad: \`"Cloud-hosted"\` — generic template.
+
+If you cannot ground an option in an observation, do not include it.
+It is strictly better to ask fewer, sharper questions than to pad with
+generic ones.
+
+### 3. Ask from these categories — pick the top 3–5 that matter
+
+Do not ask all five. Pick the categories where the repo signal is
+strongest AND where the answer would meaningfully change how a deeper
+review proceeds.
+
+- **Deployment / runtime** — where and how does this actually run?
+  (ECS / Lambda / Kubernetes / Vercel / bare-metal / on-prem …)
+- **User types** — who is authenticated by this system? (end users,
+  partner integrations, internal admins, service-to-service, …)
+- **Data sensitivity** — what categories of data does the system hold?
+  (PII, payment, health, auth secrets, business telemetry, …)
+- **Trust boundaries** — what external systems does this talk to, and
+  what does it trust from them? (third-party webhooks, partner APIs,
+  unauthenticated endpoints, shared databases, …)
+- **Known concerns** — is there an area the operator already suspects
+  is risky or wants prioritized? (recently shipped feature, a specific
+  endpoint class, a compliance ask, …)
+
+### 4. One batch — then stop
+
+V1 is single-turn. You get ONE call to \`ask_user_questions\`. Make it
+count: 2–5 questions, each grounded, each actionable. Do not plan for
+follow-ups. Calling \`ask_user_questions\` stops your turn; the consumer
+will collect answers and use them downstream.
+
+### 5. Respect size
+
+- Prefer \`grep\` for locating things over \`read_file\` — it returns
+  many hits in one call.
+- When you do \`read_file\`, it is automatically truncated per call.
+  Do not read giant lockfiles or generated bundles; they waste the
+  budget and teach you nothing.
+- Skim, do not exhaustively read. You are looking for signal, not
+  completeness.
+
+## Question object shape
+
+Each question passed to \`ask_user_questions\` is:
+
+\`\`\`
+{
+  id: string          // stable id, e.g. "deployment-runtime"
+  question: string    // the human-readable question
+  multiSelect: bool   // true if the operator can pick multiple options
+  allowFreeform: bool // true if a write-in answer is accepted
+  options: [{
+    id: string,
+    label: string,       // MUST reference observed code per Rule 2
+    description?: string // optional 1-sentence elaboration
+  }, ...]  // 2–6 options
+}
+\`\`\`
+
+You may include up to 5 such questions in a single call. Aim for 3.
+
+## Output discipline
+
+Keep your chain-of-thought output terse. The operator sees your tool
+calls live — long deliberation text is noise. Think, act, ask, stop.`;
+}

--- a/src/core/agents/explorationAgent/types.ts
+++ b/src/core/agents/explorationAgent/types.ts
@@ -1,0 +1,49 @@
+import type {
+  ModelMessage,
+  StreamTextOnStepFinishCallback,
+  ToolSet,
+} from "ai";
+import type { AIModel } from "../../ai";
+import type { AIAuthConfig } from "../../ai/utils";
+import type { SessionInfo } from "../../session";
+
+/**
+ * Input for {@link ExplorationAgent}.
+ *
+ * The exploration agent is a light, single-turn specialization of
+ * {@link OffensiveSecurityAgent} whose only job is to browse a cloned
+ * repository, issue one batched `ask_user_questions` tool call, and stop.
+ *
+ * This input type intentionally omits most of the harness-level knobs
+ * (findings registry, sandbox, skills, approval gate, etc.) because V1
+ * never exercises them. Add fields here as real exploration consumers
+ * need them.
+ */
+export interface ExplorationAgentInput {
+  /** Initial user prompt — typically a short directive describing the repo to explore. */
+  prompt: string;
+
+  /** AI model identifier (defaults selected by the consumer; Opus 4.6 is the reference default). */
+  model: AIModel;
+
+  /** Session providing paths for trace/message persistence and the agent's working directory. */
+  session: SessionInfo;
+
+  /** Per-provider API key overrides. */
+  authConfig?: AIAuthConfig;
+
+  /** AbortSignal to cancel the agent mid-run. */
+  abortSignal?: AbortSignal;
+
+  /** Callback fired after each agent step completes. */
+  onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
+
+  /**
+   * Existing conversation history to seed the agent with.
+   *
+   * When present, these messages replace the synthetic user-prompt message
+   * the base class would otherwise construct from `prompt`. Used by the
+   * Console consumer to resume an `agent_chat_sessions` thread on each turn.
+   */
+  priorMessages?: ModelMessage[];
+}

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -187,6 +187,7 @@ export class OffensiveSecurityAgent<TResult = void> {
       credentialManager,
       persistentShell: this.persistentShell,
       skillsRegistry: input.skillsRegistry,
+      askUserQuestionsEnabled: input.askUserQuestionsEnabled,
       traceWriter,
       tasksDir,
       enableThinking: input.enableThinking,

--- a/src/core/agents/offSecAgent/tools/askUserQuestions.ts
+++ b/src/core/agents/offSecAgent/tools/askUserQuestions.ts
@@ -1,0 +1,95 @@
+import { tool } from "ai";
+import { z } from "zod";
+import type { ToolContext } from "./types";
+
+/**
+ * Zod schema for a single question in an `ask_user_questions` tool call.
+ *
+ * Each question has 2–6 grounded multi-choice options, an optional
+ * freeform escape hatch, and an optional `multiSelect` flag. The `id`
+ * is a stable identifier used to correlate the answer back to the
+ * question when the consumer resumes the agent with a tool-result.
+ */
+export const AskUserQuestionSchema = z.object({
+  id: z
+    .string()
+    .describe(
+      'Stable identifier for the question (e.g. "deployment-model"). Used to correlate the answer.',
+    ),
+  question: z.string(),
+  multiSelect: z.boolean().default(false),
+  allowFreeform: z.boolean().default(true),
+  options: z
+    .array(
+      z.object({
+        id: z.string(),
+        label: z.string(),
+        description: z.string().optional(),
+      }),
+    )
+    .min(2)
+    .max(6),
+});
+
+/**
+ * Shape of the `ask_user_questions` tool INPUT (one question).
+ * Persisted on the assistant message as part of the tool-call input.
+ */
+export type AskUserQuestion = z.infer<typeof AskUserQuestionSchema>;
+
+/**
+ * A single answer submitted by the user for one question.
+ *
+ * - `questionId` matches `AskUserQuestion.id`.
+ * - `selectedOptionIds` is empty if the user only provided freeform text.
+ * - `freeformText` is `null` when the user did not use the freeform field.
+ */
+export interface AskUserQuestionAnswer {
+  questionId: string;
+  selectedOptionIds: string[];
+  freeformText: string | null;
+}
+
+/**
+ * Shape of the `ask_user_questions` tool RESULT output.
+ * Persisted on the tool message when the consumer resumes the agent.
+ *
+ * `skipped: true` means the user chose to skip rather than answer; the
+ * recon adapter (and any other downstream consumer) uses this flag to
+ * decide whether to emit a User-Provided Context block.
+ */
+export interface AskUserQuestionsResult {
+  answers: AskUserQuestionAnswer[];
+  skipped: boolean;
+}
+
+/**
+ * Factory for the `ask_user_questions` Apex tool.
+ *
+ * Takes `ToolContext` for consistency with other tool factories and to
+ * leave room for a future transport hook if operator mode needs it.
+ *
+ * The consuming agent MUST configure `stopWhen(hasToolCall('ask_user_questions'))`
+ * — the agent is stopped when the model emits this tool call. The `execute`
+ * body below is a sentinel that exists so the tool is well-formed and
+ * survives in-process unit testing of the agent; in production the real
+ * stopping/transport/resume is handled by the consumer (Console).
+ */
+export function askUserQuestions(_ctx: ToolContext) {
+  return tool({
+    description:
+      "Stop the agent and ask the user a batch of 2–5 grounded, multi-choice questions. " +
+      "Option labels MUST reference something observed in the codebase — not generic templates. " +
+      "The consumer of this agent is responsible for collecting answers and, if applicable, " +
+      "resuming with a tool-result in the message history.",
+    inputSchema: z.object({
+      questions: z.array(AskUserQuestionSchema).min(1).max(5),
+    }),
+    // The agent is STOPPED by hasToolCall('ask_user_questions') — this body
+    // will never run in production. It exists so the tool is well-formed and
+    // survives in-process unit testing of the agent with a mocked transport.
+    execute: async ({ questions }) => {
+      return { ok: true as const, pendingQuestionCount: questions.length };
+    },
+  });
+}

--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -145,6 +145,7 @@ import { updateTask } from "./updateTask";
 import { listTasksTool } from "./listTasks";
 import { writePlan } from "./writePlan";
 import { submitPlan } from "./submitPlan";
+import { askUserQuestions } from "./askUserQuestions";
 
 /**
  * Create the full toolset for the OffensiveSecurityAgent.
@@ -214,6 +215,11 @@ export function createAllTools(ctx: ToolContext & { subagentId?: string }) {
 
     // Skill tools (conditional — only when registry is provided)
     ...(ctx.skillsRegistry ? { read_skill: readSkill(ctx) } : {}),
+
+    // Guided onboarding tools (conditional — only when ask-user-questions is enabled)
+    ...(ctx.askUserQuestionsEnabled
+      ? { ask_user_questions: askUserQuestions(ctx) }
+      : {}),
 
     // Observability tools (conditional — only when trace writer is provided)
     ...(ctx.traceWriter ? { checkpoint_state: checkpointState(ctx) } : {}),
@@ -292,6 +298,8 @@ export const ALL_TOOL_NAMES: ToolName[] = [
   // Plan mode
   "write_plan",
   "submit_plan",
+  // Guided onboarding
+  "ask_user_questions",
 ];
 
 /**

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -108,4 +108,13 @@ export type ToolContext = {
    * plan agents to write plans scoped to their corresponding execution agent.
    */
   planSubagentId?: string;
+
+  /**
+   * Opt-in flag to include the `ask_user_questions` tool in this agent's
+   * toolset. When set (and `'ask_user_questions'` is listed in `activeTools`),
+   * `createAllTools` exposes the tool. Consuming agents MUST pair this with
+   * `stopWhen(hasToolCall('ask_user_questions'))` — the real transport and
+   * resume logic is handled by the consumer (e.g. Console).
+   */
+  askUserQuestionsEnabled?: boolean;
 };

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -227,6 +227,13 @@ export type OffensiveSecurityAgentInput<TResult = void> = {
   skillsRegistry?: SkillsRegistry;
 
   /**
+   * Gates availability of the `ask_user_questions` tool. When `true`, the
+   * base class forwards the flag via {@link ToolContext} so specialized
+   * agents (e.g. the exploration agent) can opt into interactive clarification.
+   */
+  askUserQuestionsEnabled?: boolean;
+
+  /**
    * When provided, each tool call is gated through the approval gate.
    * The gate will pause execution until the operator approves or denies
    * the call (when `requireApproval` is enabled on the gate).


### PR DESCRIPTION
Adds a new `ask_user_questions` tool and an `ExplorationAgent` that uses it
to pause agent execution and surface structured multi-choice + freeform
questions to a human. Shape follows Claude Code's AskUserQuestion.

First consumer is Pensar Console's guided-onboarding-exploration flow, which
does a light codebase pass and asks 2–5 grounded questions to inform
downstream recon. Apex owns the tool schema + stop semantics; consumers own
transport (persist the stop, surface to a human, resume via
`streamText({ messages })` — AI SDK replay is native).

Enablement mirrors `read_skill` / `skillsRegistry`: the tool is added to
`createAllTools` conditionally on `ctx.askUserQuestionsEnabled`. Only
`ExplorationAgent` sets the flag in V1; every other agent is unchanged and
does not receive the tool. Not added to `PLAN_MODE_TOOL_NAMES` — defer until
operator-mode integration lands.

Tests: 680 passed / 17 skipped (+1 new, mocks the model with
`MockLanguageModelV3` emitting a canned `ask_user_questions` tool-call to
exercise the stop condition).

Console-side PR will point the submodule at this commit once merged.