### PR TITLE
fix: restore all subagents on session resume

### DIFF
--- a/src/core/session/persistence.test.ts
+++ b/src/core/session/persistence.test.ts
@@ -421,6 +421,123 @@ describe("loadSubagents manifest merge", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Directory-only subagent discovery
+// ---------------------------------------------------------------------------
+
+describe("loadSubagents directory-only discovery", () => {
+  it("discovers threat-model agents from messages.json directories", () => {
+    const subagentsDir = join(tmpDir, "subagents");
+    const tmDir = join(subagentsDir, "threat-model-myapp-_api_users");
+    mkdirSync(tmDir, { recursive: true });
+    writeFileSync(
+      join(tmDir, "messages.json"),
+      JSON.stringify([
+        { role: "user", content: "Analyze endpoint /api/users" },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Analyzing..." }],
+        },
+      ]),
+    );
+
+    const loaded = loadSubagents(tmpDir);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].id).toBe("threat-model-myapp-_api_users");
+    expect(loaded[0].type).toBe("pentest");
+    expect(loaded[0].name).toContain("Threat Model");
+    expect(loaded[0].status).toBe("completed");
+    expect(loaded[0].messages.length).toBeGreaterThan(0);
+  });
+
+  it("discovers whitebox discovery agents from messages.json directories", () => {
+    const subagentsDir = join(tmpDir, "subagents");
+    for (const dirName of [
+      "whitebox-apps-discovery",
+      "pages-myapp",
+      "apiEndpoints-myapp",
+    ]) {
+      const dir = join(subagentsDir, dirName);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "messages.json"),
+        JSON.stringify([
+          { role: "user", content: `Discover ${dirName}` },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Found endpoints" }],
+          },
+        ]),
+      );
+    }
+
+    const loaded = loadSubagents(tmpDir);
+    expect(loaded).toHaveLength(3);
+    const ids = loaded.map((s) => s.id);
+    expect(ids).toContain("whitebox-apps-discovery");
+    expect(ids).toContain("pages-myapp");
+    expect(ids).toContain("apiEndpoints-myapp");
+  });
+
+  it("does not duplicate agents that have both .json snapshot and directory", () => {
+    const session = makeSession();
+    saveSubagentData(session, {
+      agentName: "pentest-agent-1",
+      target: "http://localhost:8080",
+      status: "completed",
+      messages: [],
+    });
+
+    // Also create the messages.json directory (this happens at runtime)
+    const msgDir = join(tmpDir, "subagents", "pentest-agent-1");
+    mkdirSync(msgDir, { recursive: true });
+    writeFileSync(
+      join(msgDir, "messages.json"),
+      JSON.stringify([
+        { role: "user", content: "Test" },
+        { role: "assistant", content: [{ type: "text", text: "Testing" }] },
+      ]),
+    );
+
+    const loaded = loadSubagents(tmpDir);
+    expect(loaded).toHaveLength(1);
+  });
+
+  it("skips -tasks and -plan directories", () => {
+    const subagentsDir = join(tmpDir, "subagents");
+    for (const dirName of ["pentest-agent-1-tasks", "pentest-agent-1-plan"]) {
+      const dir = join(subagentsDir, dirName);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "messages.json"),
+        JSON.stringify([{ role: "user", content: "test" }]),
+      );
+    }
+
+    const loaded = loadSubagents(tmpDir);
+    expect(loaded).toHaveLength(0);
+  });
+
+  it("skips directories without messages.json", () => {
+    const subagentsDir = join(tmpDir, "subagents");
+    const dir = join(subagentsDir, "threat-model-empty");
+    mkdirSync(dir, { recursive: true });
+
+    const loaded = loadSubagents(tmpDir);
+    expect(loaded).toHaveLength(0);
+  });
+
+  it("skips directories with empty messages array", () => {
+    const subagentsDir = join(tmpDir, "subagents");
+    const dir = join(subagentsDir, "threat-model-empty");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "messages.json"), JSON.stringify([]));
+
+    const loaded = loadSubagents(tmpDir);
+    expect(loaded).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Operator state persistence (single messages field)
 // ---------------------------------------------------------------------------
 

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -12,6 +12,7 @@ import {
   writeFileSync,
   readFileSync,
   readdirSync,
+  statSync,
 } from "fs";
 import { join } from "path";
 import type { SessionInfo } from "./index";
@@ -316,21 +317,54 @@ export function getCompletedAgentIds(session: SessionInfo): Set<string> {
 // ---------------------------------------------------------------------------
 
 /**
- * Parse a subagent filename to extract agent type and display name.
+ * Parse a subagent filename (or directory name) to extract agent type and display name.
  *
  * Handles every naming convention the writer has ever used:
- *  - "attack-surface-agent-..."  → attack-surface
- *  - "pentest-agent-3-..."       → pentest, "Pentest Agent 3"
- *  - "vuln-test-sqli-..."        → pentest (back-compat)
- *  - "orchestrator-..."          → skipped upstream
- *  - fallback                    → pentest
+ *  - "attack-surface-agent-..."      → attack-surface
+ *  - "whitebox-apps-discovery"       → attack-surface
+ *  - "pages-<app>" / "apiEndpoints-<app>" / "cloudResourceEndpoints-<app>" → attack-surface (whitebox discovery)
+ *  - "threat-model-<app>-<endpoint>" → attack-surface (threat model)
+ *  - "pentest-agent-3-..."           → pentest, "Pentest Agent 3"
+ *  - "vuln-test-sqli-..."            → pentest (back-compat)
+ *  - "orchestrator-..."              → skipped upstream
+ *  - fallback                        → pentest
  */
 function parseSubagentFilename(filename: string): {
-  agentType: "attack-surface" | "pentest";
+  agentType: UISubagent["type"];
   name: string;
 } {
   if (filename.startsWith("attack-surface-agent")) {
     return { agentType: "attack-surface", name: "Attack Surface Discovery" };
+  }
+
+  if (filename === "whitebox-apps-discovery") {
+    return { agentType: "pentest", name: "Whitebox Apps Discovery" };
+  }
+
+  if (filename === "whitebox-incremental") {
+    return { agentType: "pentest", name: "Incremental Recon" };
+  }
+
+  if (filename.startsWith("pages-")) {
+    const appName = filename.replace("pages-", "");
+    return { agentType: "pentest", name: `Pages: ${appName}` };
+  }
+
+  if (filename.startsWith("apiEndpoints-")) {
+    const appName = filename.replace("apiEndpoints-", "");
+    return { agentType: "pentest", name: `API Endpoints: ${appName}` };
+  }
+
+  if (filename.startsWith("cloudResourceEndpoints-")) {
+    const appName = filename.replace("cloudResourceEndpoints-", "");
+    return { agentType: "pentest", name: `Cloud Resources: ${appName}` };
+  }
+
+  if (filename.startsWith("threat-model-")) {
+    const rest = filename.replace("threat-model-", "");
+    const parts = rest.split("-");
+    const label = parts.length > 1 ? parts.slice(1).join("-") : rest;
+    return { agentType: "pentest", name: `Threat Model: ${label}` };
   }
 
   const pentestMatch = filename.match(/^pentest-agent-(\d+)/);
@@ -475,10 +509,11 @@ export function convertModelMessagesToUI(
  *
  * This is the single reader for subagent state. It:
  *  1. Reads all .json files from {rootPath}/{SUBAGENTS_DIR}/
- *  2. Reads the agent manifest from {rootPath}/{MANIFEST_FILE}
- *  3. Matches manifest entries to loaded files by agentName === entry.id
- *  4. Marks matched "running" manifest entries as "paused"
- *  5. Creates paused stubs for unmatched "running" manifest entries
+ *  2. Discovers subdirectories with messages.json (no snapshot .json)
+ *  3. Reads the agent manifest from {rootPath}/{MANIFEST_FILE}
+ *  4. Matches manifest entries to loaded files by agentName === entry.id
+ *  5. Marks matched "running" manifest entries as "paused"
+ *  6. Creates paused stubs for unmatched "running" manifest entries
  */
 export function loadSubagents(rootPath: string): UISubagent[] {
   const subagentsPath = join(rootPath, SUBAGENTS_DIR);
@@ -558,6 +593,57 @@ export function loadSubagents(rootPath: string): UISubagent[] {
         });
       } catch (e) {
         console.error(`Failed to load subagent file ${file}:`, e);
+      }
+    }
+
+    // --- Discover directory-only subagents ---
+    // Some agents (threat model, whitebox discovery, coding agents) only
+    // persist messages.json via the base class but never call
+    // saveSubagentData(). Scan for subdirectories with messages.json
+    // that have no matching top-level snapshot .json file.
+    const entries = readdirSync(subagentsPath);
+    for (const entry of entries) {
+      if (agentNameIndex.has(entry)) continue;
+
+      const entryPath = join(subagentsPath, entry);
+      try {
+        if (!statSync(entryPath).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+
+      // Skip task directories (pentest plan phase output) and
+      // plan agent directories (plan agent messages are not standalone)
+      if (entry.endsWith("-tasks") || entry.endsWith("-plan")) continue;
+
+      const messagesPath = join(entryPath, "messages.json");
+      if (!existsSync(messagesPath)) continue;
+
+      try {
+        const raw = JSON.parse(
+          readFileSync(messagesPath, "utf-8"),
+        ) as ModelMessage[];
+        if (!Array.isArray(raw) || raw.length === 0) continue;
+
+        const { agentType, name } = parseSubagentFilename(entry);
+
+        const dirStat = statSync(messagesPath);
+        const timestamp = dirStat.mtime;
+
+        const messages = convertMessagesToUI(raw, timestamp);
+
+        agentNameIndex.set(entry, subagents.length);
+        subagents.push({
+          id: entry,
+          name,
+          type: agentType,
+          target: "Unknown",
+          messages,
+          createdAt: timestamp,
+          status: "completed",
+        });
+      } catch {
+        // Skip directories with unreadable messages.json
       }
     }
   }

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -375,6 +375,18 @@ function parseSubagentFilename(filename: string): {
     };
   }
 
+  const codingMatch = filename.match(/^coding-agent-(\d+)/);
+  if (codingMatch) {
+    return {
+      agentType: "pentest",
+      name: `Coding Agent ${codingMatch[1]}`,
+    };
+  }
+
+  if (filename === "auth-agent") {
+    return { agentType: "pentest", name: "Auth Agent" };
+  }
+
   // Legacy convention: vuln-test-{vulnClass}-...
   if (filename.startsWith("vuln-test-")) {
     const parts = filename.replace("vuln-test-", "").split("-");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

**Problem:** When running a pentest, threat model agents (and other ancillary subagents like whitebox discovery agents) show up correctly during the live session. However, when quitting and resuming the session, all threat model agents disappear — only the attack surface agent and pentest agents are restored.

**Root cause:** `loadSubagents()` only discovers agents that have a top-level `subagents/<name>.json` snapshot file, created by `saveSubagentData()`. However, threat model agents, whitebox discovery agents (`whitebox-apps-discovery`, `pages-*`, `apiEndpoints-*`, `cloudResourceEndpoints-*`), and other ancillary agents never call `saveSubagentData()`. They only persist `subagents/<id>/messages.json` via the `OffensiveSecurityAgent` base class. Since `loadSubagents()` only scanned for `.json` files in the `subagents/` directory (not subdirectories with `messages.json`), these agents were invisible on resume.

**Fix:**

1. **Augmented `loadSubagents()`** to also scan for subdirectories under `subagents/` that contain `messages.json` but have no matching top-level snapshot `.json` file. These directory-only agents are now discovered and restored.

2. **Extended `parseSubagentFilename()`** to recognize the naming conventions used by all subagent types:
   - `threat-model-<app>-<endpoint>` → classified as pentest type (matches live-run behavior where they appear in the agent card grid)
   - `whitebox-apps-discovery`, `whitebox-incremental` → classified as pentest type
   - `pages-<app>`, `apiEndpoints-<app>`, `cloudResourceEndpoints-<app>` → classified as pentest type
   - `coding-agent-<N>` → "Coding Agent N", pentest type
   - `auth-agent` → "Auth Agent", pentest type

3. **Excluded non-agent directories** that happen to have `messages.json` but aren't standalone agents: `-tasks` directories (plan phase output) and `-plan` directories (plan agent intermediate state).

### Known fragility

`parseSubagentFilename()` is a switch over hardcoded prefixes. Every spawn site in the codebase was audited and all 10 known prefixes are now covered, but any new subagent spawn site must remember to add its prefix here or it will fall through to a generic "first-token" display name. A cleaner long-term fix would be to move display name + type into the agent manifest (or a per-agent sidecar) so the loader doesn't have to parse filenames at all — left for a follow-up.

### How did you verify your code works?

- Added 6 new unit tests covering directory-only subagent discovery:
  - Discovers threat-model agents from `messages.json` directories
  - Discovers whitebox discovery agents from `messages.json` directories
  - Does not duplicate agents that have both `.json` snapshot and directory
  - Skips `-tasks` and `-plan` directories
  - Skips directories without `messages.json`
  - Skips directories with empty messages array
- All new tests pass; 2 pre-existing test failures are unrelated to this change
- Type check (`tsc --noEmit`), lint (`eslint`), and format check (`prettier`) all pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3e05c38-67d0-48f6-a81c-e2c1504a58e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3e05c38-67d0-48f6-a81c-e2c1504a58e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>