### PR TITLE
fix: prevent read_file tool from being used on directories

### DIFF
--- a/src/core/agents/offSecAgent/prompt.ts
+++ b/src/core/agents/offSecAgent/prompt.ts
@@ -91,8 +91,8 @@ You can perform the full lifecycle of a penetration test and support a wide rang
 - **browser_get_cookies** — Extract all cookies (including httpOnly) from the browser context.
 
 ## Filesystem & Search
-- **read_file** — Read file contents (whole file or line range).
-- **list_files** — List directory contents (optionally recursive).
+- **read_file** — Read file contents (whole file or line range). Only works on files, not directories.
+- **list_files** — List directory contents (optionally recursive). Use this instead of read_file when you want to see what's inside a directory.
 - **grep** — Search file contents by pattern with full grep flag support.
 
 ## Authentication

--- a/src/core/agents/offSecAgent/prompt.ts
+++ b/src/core/agents/offSecAgent/prompt.ts
@@ -91,8 +91,8 @@ You can perform the full lifecycle of a penetration test and support a wide rang
 - **browser_get_cookies** — Extract all cookies (including httpOnly) from the browser context.
 
 ## Filesystem & Search
-- **read_file** — Read file contents (whole file or line range). Only works on files, not directories.
-- **list_files** — List directory contents (optionally recursive). Use this instead of read_file when you want to see what's inside a directory.
+- **read_file** — Read file contents (whole file or line range).
+- **list_files** — List directory contents (optionally recursive).
 - **grep** — Search file contents by pattern with full grep flag support.
 
 ## Authentication

--- a/src/core/agents/offSecAgent/tools/readFile.ts
+++ b/src/core/agents/offSecAgent/tools/readFile.ts
@@ -1,11 +1,15 @@
 import { tool } from "ai";
 import { z } from "zod";
-import { readFile as fsReadFile } from "fs/promises";
+import { readFile as fsReadFile, stat } from "fs/promises";
 import { resolve, isAbsolute } from "path";
 import type { ToolContext } from "./types";
 
 export const readFileInputSchema = z.object({
-  path: z.string().describe("Absolute or relative path to the file to read"),
+  path: z
+    .string()
+    .describe(
+      "Absolute or relative path to the file to read. Must be a file, not a directory.",
+    ),
   startLine: z
     .number()
     .optional()
@@ -34,7 +38,7 @@ export type ReadFileResult = {
 
 export function readFile(ctx: ToolContext) {
   return tool({
-    description: `Read the contents of a file from the filesystem.
+    description: `Read the contents of a file from the filesystem. This tool only works on files, NOT directories. To list directory contents, use the list_files tool instead.
 
 You can read the entire file or specify a line range using startLine / endLine
 (both 1-based, inclusive). If only startLine is given, reads from that line to
@@ -45,6 +49,15 @@ Output lines are prefixed with their line number for easy reference.`,
     execute: async ({ path, startLine, endLine }): Promise<ReadFileResult> => {
       const resolved = isAbsolute(path) ? path : resolve(ctx.agentCwd, path);
       try {
+        const info = await stat(resolved);
+        if (info.isDirectory()) {
+          return {
+            success: false,
+            error: `${path} is a directory, not a file. Use the list_files tool to list directory contents.`,
+            content: "",
+            path,
+          };
+        }
         const raw = await fsReadFile(resolved, "utf-8");
         const allLines = raw.split("\n");
         const totalLines = allLines.length;

--- a/src/core/agents/offSecAgent/tools/readFile.ts
+++ b/src/core/agents/offSecAgent/tools/readFile.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
-import { readFile as fsReadFile, stat } from "fs/promises";
+import { readFile as fsReadFile } from "fs/promises";
 import { resolve, isAbsolute } from "path";
 import type { ToolContext } from "./types";
 
@@ -49,15 +49,6 @@ Output lines are prefixed with their line number for easy reference.`,
     execute: async ({ path, startLine, endLine }): Promise<ReadFileResult> => {
       const resolved = isAbsolute(path) ? path : resolve(ctx.agentCwd, path);
       try {
-        const info = await stat(resolved);
-        if (info.isDirectory()) {
-          return {
-            success: false,
-            error: `${path} is a directory, not a file. Use the list_files tool to list directory contents.`,
-            content: "",
-            path,
-          };
-        }
         const raw = await fsReadFile(resolved, "utf-8");
         const allLines = raw.split("\n");
         const totalLines = allLines.length;


### PR DESCRIPTION
Slightly modify prompting to discourage agent from using `read_file` tool on directories.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only prompt/schema wording changes; no behavioral changes to filesystem access or data handling.
> 
> **Overview**
> Updates the OffSec agent’s `read_file` tool schema and description to explicitly state that the `path` must be a *file* (not a directory) and to direct directory browsing to `list_files` instead.
> 
> No execution logic changes; this is a prompt/schema clarification to reduce incorrect tool calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea11a6f9d14c941f48253d05fab55599bfb020d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->