### PR TITLE
feat: add Claude Opus 4.7 to Anthropic and Pensar/Bedrock providers

### DIFF
--- a/scripts/generate-models.ts
+++ b/scripts/generate-models.ts
@@ -48,6 +48,7 @@ const CONTEXT_LENGTHS: Record<string, number> = {
   "claude-haiku-4": 200000,
   "claude-sonnet-4": 200000,
   "claude-opus-4": 200000,
+  "claude-opus-4-7": 1000000,
   "claude-2": 100000,
   "claude-instant": 100000,
 
@@ -107,6 +108,7 @@ const CONTEXT_LENGTHS: Record<string, number> = {
   "anthropic.claude-haiku": 200000,
   "anthropic.claude-sonnet": 200000,
   "anthropic.claude-opus": 200000,
+  "anthropic.claude-opus-4-7": 1000000,
 };
 
 function getContextLength(modelId: string): number | undefined {
@@ -548,6 +550,16 @@ function main() {
     anthropicDts,
     "AnthropicMessagesModelId",
   );
+
+  // Models available on the Anthropic API but not yet in the AI SDK type definitions
+  const EXTRA_ANTHROPIC_IDS = ["claude-opus-4-7"];
+  const existingAnthropicIds = new Set(anthropicIds);
+  for (const id of EXTRA_ANTHROPIC_IDS) {
+    if (!existingAnthropicIds.has(id)) {
+      anthropicIds.push(id);
+    }
+  }
+
   const anthropicModels: ModelEntry[] = anthropicIds.map((id) => ({
     id,
     name: formatModelName(id, "anthropic"),
@@ -596,7 +608,10 @@ function main() {
   const bedrockBaseIds = [...new Set(bedrockRawIds)];
 
   // Models available on Bedrock but not yet in the AI SDK type definitions
-  const EXTRA_BEDROCK_IDS = ["moonshotai.kimi-k2.5"];
+  const EXTRA_BEDROCK_IDS = [
+    "moonshotai.kimi-k2.5",
+    "anthropic.claude-opus-4-7",
+  ];
 
   const existingIds = new Set(bedrockBaseIds);
   for (const id of EXTRA_BEDROCK_IDS) {

--- a/src/core/ai/models/anthropic.ts
+++ b/src/core/ai/models/anthropic.ts
@@ -118,4 +118,10 @@ export const ANTHROPIC_MODELS: ModelInfo[] = [
     provider: "anthropic",
     contextLength: 200000,
   },
+  {
+    id: "claude-opus-4-7",
+    name: "Claude Opus 4.7",
+    provider: "anthropic",
+    contextLength: 1000000,
+  },
 ];

--- a/src/core/ai/models/bedrock.ts
+++ b/src/core/ai/models/bedrock.ts
@@ -431,6 +431,12 @@ export const BEDROCK_MODELS: ModelInfo[] = [
     contextLength: 262000,
   },
   {
+    id: "anthropic.claude-opus-4-7",
+    name: "Claude Opus 4.7 (Bedrock)",
+    provider: "bedrock",
+    contextLength: 1000000,
+  },
+  {
     id: "global.anthropic.claude-v2",
     name: "Claude v2 (Global)",
     provider: "bedrock",
@@ -537,5 +543,11 @@ export const BEDROCK_MODELS: ModelInfo[] = [
     name: "Claude 3 Opus (2024-02-29) (Global)",
     provider: "bedrock",
     contextLength: 200000,
+  },
+  {
+    id: "global.anthropic.claude-opus-4-7",
+    name: "Claude Opus 4.7 (Global)",
+    provider: "bedrock",
+    contextLength: 1000000,
   },
 ];

--- a/src/core/ai/models/pensar.ts
+++ b/src/core/ai/models/pensar.ts
@@ -2,6 +2,12 @@ import type { ModelInfo } from "../ai";
 
 export const PENSAR_MODELS: ModelInfo[] = [
   {
+    id: "pensar:anthropic.claude-opus-4-7",
+    name: "Claude Opus 4.7",
+    provider: "pensar",
+    contextLength: 1000000,
+  },
+  {
     id: "pensar:anthropic.claude-opus-4-6-v1",
     name: "Claude Opus 4.6",
     provider: "pensar",


### PR DESCRIPTION
## Summary
- Register `anthropic.claude-opus-4-7` on the Pensar Bedrock-backed provider and `claude-opus-4-7` on the direct Anthropic provider (1M context)
- Extend `scripts/generate-models.ts` with an `EXTRA_ANTHROPIC_IDS` mechanism (mirroring the existing `EXTRA_BEDROCK_IDS`) so models not yet in the AI SDK type definitions can be included
- Regenerated `anthropic.ts` and `bedrock.ts` to include Opus 4.7 (plus the `global.anthropic.claude-opus-4-7` regional variant)

## Test plan
- [ ] `bun run generate:models` still produces a clean diff
- [ ] Opus 4.7 appears in the model picker under Anthropic and Pensar
- [ ] Sending a request through Pensar and Anthropic providers with the new model succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds new model metadata and generation plumbing; low blast radius, with the main risk being incorrect context-length/ID strings affecting model selection or token-limit UI.
> 
> **Overview**
> Adds the `claude-opus-4-7` model to the Anthropic model list with a **1,000,000** context length.
> 
> Extends the model generation script to allow injecting *extra* Anthropic and Bedrock model IDs not yet present in the AI SDK type definitions, and regenerates the Bedrock/Pensar lists to include `anthropic.claude-opus-4-7` plus its `global.` regional variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fc80d651cb22d222d8e47ea01ec6d0eb9190adf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->