### PR TITLE
feat: headless Weave tracing + extended thinking/task-driven CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,49 @@ Open the Apex TUI:
 pensar
 ```
 
+### Headless CLI
+
+Run pentests without the TUI for scripting, CI, or evalgate integration:
+
+```bash
+# Basic pentest
+pensar pentest --target https://example.com
+
+# With extended thinking and task-driven mode
+pensar pentest --target https://example.com --extended-thinking --task-driven
+
+# Whitebox (with source code access)
+pensar pentest --target https://example.com --cwd ./my-app
+
+# Targeted pentest with specific objectives
+pensar targeted-pentest --target https://example.com --objective "Test authentication bypass"
+```
+
+| Flag                           | Command                   | Description                                    |
+| ------------------------------ | ------------------------- | ---------------------------------------------- |
+| `--target <url>`               | pentest, targeted-pentest | Target URL (required)                          |
+| `--cwd <path>`                 | pentest                   | Source code path for whitebox mode             |
+| `--mode <mode>`                | pentest                   | `exfil` for pivoting and flag extraction       |
+| `--model <model>`              | pentest, targeted-pentest | AI model (default: auto-selected)              |
+| `--extended-thinking`          | pentest                   | Enable extended thinking for supported models  |
+| `--task-driven`                | pentest                   | Enable task-driven architecture (experimental) |
+| `--prompt <text\|@file>`       | pentest                   | Custom guidance for the agent                  |
+| `--threat-model <text\|@file>` | pentest                   | Threat model to guide testing                  |
+| `--objective <text>`           | targeted-pentest          | Testing objective (repeatable)                 |
+
+### W&B Weave Tracing
+
+Stream step-level agent traces to Weights & Biases Weave for analysis and fine-tuning:
+
+```bash
+export WANDB_API_KEY=your-key
+export WANDB_ENTITY=your-entity
+# WANDB_PROJECT defaults to "apex-traces"
+pensar pentest --target https://example.com
+```
+
+Traces include reasoning steps, tool calls, token usage, and state checkpoints. When credentials are not set, tracing is silently disabled.
+
 ## Kali Linux Container (Optional)
 
 For **best performance**, run Apex in the included Kali Linux container with preconfigured pentest tools:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { getCurrentVersion, upgrade } from "./core/installation";
 import { buildAuthConfig } from "./core/ai/utils";
 import { resolvePentestMode } from "./core/cli/pentestMode";
 import { AgentEventBus } from "./core/eventBus";
+import type { SessionInfo } from "./core/session";
 import {
   resolveFlagValue,
   resolveThreatModelPrompt,
@@ -40,6 +41,10 @@ function getArgRequired(flag: string, argv = args): string {
   return val;
 }
 
+function hasFlag(flag: string, argv = args): boolean {
+  return argv.includes(flag);
+}
+
 function getAllArgs(flag: string, argv = args): string[] {
   const values: string[] = [];
   for (let i = 0; i < argv.length; i++) {
@@ -55,6 +60,20 @@ function attachCliAgentStreamListeners(bus: AgentEventBus): void {
   bus.on("tool-call-complete", (d) => console.log(`\n→ ${d.toolName}`));
   bus.on("tool-result", (d) => console.log(`✓ ${d.toolName} completed`));
   bus.on("error", (d) => console.error("Error:", d.error));
+}
+
+async function createInstrumentedBus(
+  session: SessionInfo,
+): Promise<{ bus: AgentEventBus; cleanup: () => Promise<void> }> {
+  const bus = new AgentEventBus();
+  attachCliAgentStreamListeners(bus);
+  const { attachWandbToEventBus } =
+    await import("./core/integrations/wandb/upload");
+  const wandbCleanup = await attachWandbToEventBus(session, bus).catch((e) => {
+    console.warn("[wandb] Tracing disabled:", (e as Error).message);
+    return null;
+  });
+  return { bus, cleanup: async () => wandbCleanup?.() };
 }
 
 // ---------------------------------------------------------------------------
@@ -86,6 +105,8 @@ pentest options:
   --cwd <path>             Source code path — enables whitebox attack surface
   --mode <mode>            Pentest mode: exfil (pivoting & flag extraction)
   --model <model>          AI model (default: claude-sonnet-4-5)
+  --extended-thinking       Enable extended thinking for supported models
+  --task-driven             Enable task-driven architecture (experimental)
   --prompt <text|@file>    Guidance for the pentest agent (inline text or @filepath)
   --threat-model <text|@file>  Threat model to guide the pentest (inline or @filepath)
 
@@ -123,6 +144,8 @@ async function runPentest() {
   const mode = getArg("--mode");
   const promptRaw = getArg("--prompt");
   const threatModelRaw = getArg("--threat-model");
+  const enableThinking = hasFlag("--extended-thinking");
+  const taskDriven = hasFlag("--task-driven");
 
   // Resolve and combine threat model + prompt
   const resolvedTm = threatModelRaw
@@ -146,7 +169,7 @@ async function runPentest() {
 PENTEST ORCHESTRATION
 ${sep}
 Target:  ${target}${cwd ? `\nCwd:     ${cwd} (whitebox)` : ""}${exfilMode ? "\nMode:    exfil" : ""}
-Model:   ${model}
+Model:   ${model}${enableThinking ? "\nThinking: enabled" : ""}${taskDriven ? "\nTask-driven: enabled" : ""}
 `);
 
   const session = await sessions.create({
@@ -156,29 +179,35 @@ Model:   ${model}
       ...(cwd ? { cwd } : {}),
       ...(exfilMode ? { exfilMode: true } : {}),
       ...(prompt ? { prompt } : {}),
+      ...(taskDriven ? { taskDriven: true } : {}),
     },
   });
 
-  const pentestBus = new AgentEventBus();
-  attachCliAgentStreamListeners(pentestBus);
+  const { bus: pentestBus, cleanup: wandbCleanup } =
+    await createInstrumentedBus(session);
 
-  const { findings, findingsPath, pocsPath, reportPath } =
-    await runPentestAgent({
-      target,
-      ...(cwd ? { cwd } : {}),
-      session,
-      model,
-      authConfig: buildAuthConfig(pensarConfig),
-      eventBus: pentestBus,
-    });
+  try {
+    const { findings, findingsPath, pocsPath, reportPath } =
+      await runPentestAgent({
+        target,
+        ...(cwd ? { cwd } : {}),
+        session,
+        model,
+        enableThinking,
+        authConfig: buildAuthConfig(pensarConfig),
+        eventBus: pentestBus,
+      });
 
-  console.log(`
+    console.log(`
 ${sep}
 RESULTS
 ${sep}
 Findings:  ${findings.length}
 Path:      ${findingsPath}
 POCs:      ${pocsPath}${reportPath ? `\nReport:    ${reportPath}` : ""}`);
+  } finally {
+    await wandbCleanup();
+  }
 }
 
 async function runTargetedPentest() {
@@ -223,21 +252,29 @@ ${objectivesList}
     targets: [target],
   });
 
-  const { findings, findingsPath, pocsPath } = await runTargetedPentestAgent({
-    target,
-    objectives,
-    session,
-    model,
-    authConfig: buildAuthConfig(pensarConfig),
-  });
+  const { bus: targetedBus, cleanup: wandbCleanup } =
+    await createInstrumentedBus(session);
 
-  console.log(`
+  try {
+    const { findings, findingsPath, pocsPath } = await runTargetedPentestAgent({
+      target,
+      objectives,
+      session,
+      model,
+      authConfig: buildAuthConfig(pensarConfig),
+      eventBus: targetedBus,
+    });
+
+    console.log(`
 ${sep}
 RESULTS
 ${sep}
 Findings:  ${findings.length}
 Path:      ${findingsPath}
 POCs:      ${pocsPath}`);
+  } finally {
+    await wandbCleanup();
+  }
 }
 
 async function runThreatModel() {

--- a/src/core/api/blackboxPentest.ts
+++ b/src/core/api/blackboxPentest.ts
@@ -22,18 +22,7 @@ export async function runPentestAgent(
   input: PentestWorkflowInput,
 ): Promise<PentestWorkflowResult> {
   const { findings, findingsPath, pocsPath, reportPath } =
-    await runPentestWorkflow({
-      target: input.target,
-      cwd: input.cwd,
-      model: input.model,
-      session: input.session,
-      authConfig: input.authConfig,
-      abortSignal: input.abortSignal,
-      eventBus: input.eventBus,
-      enableThinking: input.enableThinking,
-      prompt: input.prompt,
-      threatModel: input.threatModel,
-    });
+    await runPentestWorkflow(input);
 
   console.log(`\nFound ${findings.length} vulnerabilities`);
   console.log(`Findings: ${findingsPath}`);

--- a/src/core/api/blackboxPentest.ts
+++ b/src/core/api/blackboxPentest.ts
@@ -30,6 +30,7 @@ export async function runPentestAgent(
       authConfig: input.authConfig,
       abortSignal: input.abortSignal,
       eventBus: input.eventBus,
+      enableThinking: input.enableThinking,
       prompt: input.prompt,
       threatModel: input.threatModel,
     });


### PR DESCRIPTION
## Summary

- Wire up W&B Weave tracing in headless CLI paths (`pensar pentest`, `pensar targeted-pentest`) so step-level traces stream to Weave when `WANDB_API_KEY` + `WANDB_ENTITY` are set
- Add `--extended-thinking` and `--task-driven` flags to `pensar pentest` command
- Forward `enableThinking` through `runPentestAgent` → `runPentestWorkflow` (was previously dropped at the API boundary)
- Simplify `blackboxPentest.ts` to spread input directly instead of manual field copying
- `try/finally` ensures Weave flush on both success and agent failure
- `createInstrumentedBus()` helper deduplicates eventbus + wandb setup across CLI commands

## Test plan

- [x] Run `pensar pentest --target <url> --extended-thinking --task-driven` and verify banner shows both flags enabled
- [x] Set `WANDB_API_KEY` + `WANDB_ENTITY` and verify traces appear in Weave (`apex-traces` project)
- [ ] Run without wandb env vars and verify graceful degradation (warning logged, no crash)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the CLI entrypoint and workflow wiring for pentest execution, so flag parsing and event-bus/tracing integration could change runtime behavior or introduce new failure modes if cleanup/attachment is incorrect.
> 
> **Overview**
> Adds a **headless CLI** section to the README documenting `pensar pentest`/`pensar targeted-pentest`, including new `--extended-thinking` and `--task-driven` flags plus optional **W&B Weave tracing** via `WANDB_*` env vars.
> 
> Updates `src/cli.ts` to (1) parse and display the new flags, (2) persist `taskDriven` into the created session config, (3) pass `enableThinking` into `runPentestAgent`, and (4) instrument headless `pentest` and `targeted-pentest` runs with a shared `createInstrumentedBus()` that attaches Weave tracing to the `AgentEventBus` and always flushes via `try/finally` (falling back gracefully when W&B isn’t configured).
> 
> Simplifies `runPentestAgent` in `blackboxPentest.ts` to forward the full workflow input directly to `runPentestWorkflow`, ensuring newly-added fields aren’t dropped at the API boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afb6af0e3509f02eec4e439fab54f86799481e84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->