### PR TITLE
fix: prevent subagent logs from duplicating in operator mode main view

### DIFF
--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -5,6 +5,7 @@ import { writeFileSync } from "fs";
 import type { ToolContext } from "./types";
 import { type AuthCredentials } from "../../specialized/authenticationAgent/types";
 import { CredentialManager } from "../../../credentials";
+import { AgentEventBus } from "../../../eventBus";
 // runAuthenticationAgent is dynamically imported inside execute() to break
 // the circular dependency: authAgent → offensiveSecurityAgent → tools → delegateAuth → authAgent
 
@@ -297,6 +298,9 @@ When to use delegate_to_auth_subagent vs authenticate_session:
         const { runAuthenticationAgent } =
           await import("../../../api/authentication");
 
+        const localBus = new AgentEventBus();
+        AgentEventBus.attachChild(localBus, ctx.eventBus, subagentId);
+
         const result = await runAuthenticationAgent({
           target,
           session: ctx.session,
@@ -304,7 +308,7 @@ When to use delegate_to_auth_subagent vs authenticate_session:
           model: ctx.model,
           authConfig: ctx.authConfig,
           abortSignal: ctx.abortSignal,
-          eventBus: ctx.eventBus,
+          eventBus: localBus,
           subagentId,
         });
 

--- a/src/core/agents/offSecAgent/tools/runAttackSurface.ts
+++ b/src/core/agents/offSecAgent/tools/runAttackSurface.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { ToolContext } from "./types";
 import type { AttackSurfaceResult } from "../../specialized/attackSurface/blackboxAgent";
 import type { WhiteboxAttackSurfaceResult } from "../../specialized/whiteboxAttackSurface/types";
+import { AgentEventBus } from "../../../eventBus";
 
 /**
  * Factory for the `run_attack_surface` tool.
@@ -66,6 +67,9 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
           const { WhiteboxAttackSurfaceAgent } =
             await import("../../specialized/whiteboxAttackSurface/agent");
 
+          const localBus = new AgentEventBus();
+          AgentEventBus.attachChild(localBus, ctx.eventBus, subagentId);
+
           const agent = new WhiteboxAttackSurfaceAgent({
             codebasePath: cwd,
             model: ctx.model,
@@ -73,7 +77,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
             authConfig: ctx.authConfig,
             abortSignal: ctx.abortSignal,
             attackSurfaceRegistry: ctx.attackSurfaceRegistry,
-            eventBus: ctx.eventBus,
+            eventBus: localBus,
             subagentId,
           });
 
@@ -131,6 +135,9 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
         const { BlackboxAttackSurfaceAgent } =
           await import("../../specialized/attackSurface/blackboxAgent");
 
+        const localBus = new AgentEventBus();
+        AgentEventBus.attachChild(localBus, ctx.eventBus, subagentId);
+
         const agent = new BlackboxAttackSurfaceAgent({
           target: target!,
           model: ctx.model,
@@ -138,7 +145,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
           authConfig: ctx.authConfig,
           abortSignal: ctx.abortSignal,
           attackSurfaceRegistry: ctx.attackSurfaceRegistry,
-          eventBus: ctx.eventBus,
+          eventBus: localBus,
           subagentId,
         });
 

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -1,38 +1,10 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { ToolContext } from "./types";
-import { AgentEventBus, type AgentEventMap } from "../../../eventBus";
+import { AgentEventBus } from "../../../eventBus";
 
 /** Default max concurrent coding agents */
 const DEFAULT_CONCURRENCY = 5;
-
-const CHILD_BUS_EVENT_KEYS = [
-  "text-delta",
-  "tool-call-start",
-  "tool-call-delta",
-  "tool-call-complete",
-  "tool-result",
-  "subagent-spawn",
-  "subagent-complete",
-  "command-output",
-  "error",
-  "step-finish",
-] as const satisfies readonly (keyof AgentEventMap)[];
-
-function attachChildEventBus(
-  localBus: AgentEventBus,
-  parentBus: AgentEventBus | undefined,
-  accumulateText: (chunk: string) => void,
-): void {
-  for (const key of CHILD_BUS_EVENT_KEYS) {
-    localBus.on(key, (payload: AgentEventMap[typeof key]) => {
-      if (key === "text-delta") {
-        accumulateText((payload as AgentEventMap["text-delta"]).text);
-      }
-      parentBus?.emit(key, payload);
-    });
-  }
-}
 
 /**
  * Factory for the `spawn_coding_agent` tool.
@@ -194,8 +166,9 @@ async function runSingleCodingAgent(
 
   const localBus = new AgentEventBus();
   let textOutput = "";
-  attachChildEventBus(localBus, ctx.eventBus, (t) => {
-    textOutput += t;
+  AgentEventBus.attachChild(localBus, ctx.eventBus, subagentId);
+  localBus.on("text-delta", (d) => {
+    textOutput += d.text;
   });
 
   const agent = new CodeAgent({

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { ToolContext } from "./types";
 import type { RiskScore } from "../../specialized/whiteboxAttackSurface/types";
-import { AgentEventBus, type AgentEventMap } from "../../../eventBus";
+import { AgentEventBus } from "../../../eventBus";
 
 const ThreatModelResultSchema = z.object({
   threatModel: z
@@ -127,7 +127,7 @@ export async function generateThreatModelForEndpoint(
   });
 
   const localBus = new AgentEventBus();
-  attachChildEventBus(localBus, ctx.eventBus);
+  AgentEventBus.attachChild(localBus, ctx.eventBus, subagentId);
 
   const prompt = buildThreatModelPrompt(input, ctx.projectThreatModel);
 
@@ -295,28 +295,4 @@ Call the \`response\` tool with your threat model, risk score assessment, and pe
 
 function sanitize(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9-_.]/g, "_");
-}
-
-const CHILD_BUS_EVENT_KEYS = [
-  "text-delta",
-  "tool-call-start",
-  "tool-call-delta",
-  "tool-call-complete",
-  "tool-result",
-  "subagent-spawn",
-  "subagent-complete",
-  "command-output",
-  "error",
-  "step-finish",
-] as const satisfies readonly (keyof AgentEventMap)[];
-
-function attachChildEventBus(
-  local: AgentEventBus,
-  parent: AgentEventBus | undefined,
-): void {
-  for (const key of CHILD_BUS_EVENT_KEYS) {
-    local.on(key, (payload: AgentEventMap[typeof key]) => {
-      parent?.emit(key, payload);
-    });
-  }
 }

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -69,6 +69,23 @@ export type AgentEventMap = {
 };
 
 /**
+ * Events forwarded from a child event bus to its parent via
+ * {@link AgentEventBus.attachChild}.
+ */
+const CHILD_BUS_FORWARDED_EVENTS = [
+  "text-delta",
+  "tool-call-start",
+  "tool-call-delta",
+  "tool-call-complete",
+  "tool-result",
+  "subagent-spawn",
+  "subagent-complete",
+  "command-output",
+  "error",
+  "step-finish",
+] as const satisfies readonly (keyof AgentEventMap)[];
+
+/**
  * Centralized, typed event bus for agent streaming output.
  *
  * Replaces the callback-based `ConsumeCallbacks` / `SubagentConsumeCallbacks`
@@ -128,6 +145,33 @@ export class AgentEventBus {
       this.emitter.removeAllListeners();
     }
     return this;
+  }
+
+  /**
+   * Forward selected events from a child bus to a parent bus, ensuring
+   * all forwarded payloads carry the given `subagentId`.
+   *
+   * Tools running inside a subagent emit side-channel events (e.g.
+   * `command-output`) without `subagentId`. This method injects the
+   * ID so the parent's routing logic (subagent store vs main view)
+   * works correctly.
+   */
+  static attachChild(
+    child: AgentEventBus,
+    parent: AgentEventBus | undefined,
+    subagentId: string,
+  ): void {
+    for (const key of CHILD_BUS_FORWARDED_EVENTS) {
+      child.on(key, (payload: AgentEventMap[typeof key]) => {
+        if (!parent) return;
+        const p = payload as Record<string, unknown>;
+        if (!p.subagentId) {
+          parent.emit(key, { ...p, subagentId } as AgentEventMap[typeof key]);
+        } else {
+          parent.emit(key, payload);
+        }
+      });
+    }
   }
 
   /**

--- a/src/tui/components/chat/message-list.tsx
+++ b/src/tui/components/chat/message-list.tsx
@@ -17,6 +17,8 @@ const SUBAGENT_TOOLS = new Set([
   "run_pentest_workflow",
   "spawn_pentest_swarm",
   "run_attack_surface",
+  "spawn_coding_agent",
+  "delegate_to_auth_subagent",
 ]);
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes the issue where subagent logs (e.g. from coding agents spawned during the threat model skill) were being duplicated in the operator mode main message view instead of being isolated to the subagent dialog (Ctrl+A).

**Root cause:** Tools running inside subagents (e.g. `execute_command`) emit side-channel events like `command-output` on their local event bus **without** `subagentId`. When these events are forwarded from the child bus to the parent via `attachChildEventBus`, they arrive at the operator dashboard untagged. The dashboard's routing logic (`if (d.subagentId) { subagentHelpers... return; }`) then treats them as main-agent output and renders them in the main view.

**Fix:** Introduce `AgentEventBus.attachChild()` — a shared static method that forwards events from a child bus to a parent bus while injecting the subagent's ID into any payload that lacks one. This ensures all events originating from a subagent's bus are properly tagged for the dashboard's routing logic.

**Changes:**

1. **`src/core/eventBus.ts`** — Added `AgentEventBus.attachChild()` with the forwarded event key list and subagentId injection logic.

2. **`src/core/agents/offSecAgent/tools/threatModelGenerator.ts`** — Replaced the local `attachChildEventBus` + `CHILD_BUS_EVENT_KEYS` with `AgentEventBus.attachChild()`. This was the primary source of the reported duplication when the threat model skill called `document_endpoint` → `generateThreatModelForEndpoint`.

3. **`src/core/agents/offSecAgent/tools/spawnCodingAgent.ts`** — Same deduplication: replaced the local `attachChildEventBus` + `CHILD_BUS_EVENT_KEYS` with `AgentEventBus.attachChild()`. Text accumulation moved to a separate `localBus.on("text-delta", ...)` listener.

4. **`src/core/agents/offSecAgent/tools/runAttackSurface.ts`** — Previously passed `ctx.eventBus` directly to whitebox/blackbox agents (sharing the parent bus). Now creates a local bus with `attachChild` so tool-emitted events from these agents get tagged.

5. **`src/core/agents/offSecAgent/tools/delegateAuth.ts`** — Same fix: auth subagent now uses a local bus with `attachChild` instead of sharing the parent's bus.

6. **`src/tui/components/chat/message-list.tsx`** — Added `spawn_coding_agent` and `delegate_to_auth_subagent` to `SUBAGENT_TOOLS` so the main view shows "Waiting for agents..." instead of "Executing" when these tools are active.

### How did you verify your code works?

- All CI checks pass: TypeScript type check (`tsc --noEmit`), ESLint, Prettier, unit tests (710 passed, 15 skipped), and build.
- Code review of the event flow confirms that `AgentEventBus.attachChild()` correctly injects `subagentId` for events that lack it (tool side-channel events like `command-output`) while preserving existing `subagentId` values (stream events from `consume()` and nested subagent lifecycle events).
- The fix is minimal and focused: the forwarded event key list is identical to the previous per-file implementations, and the only behavioral change is the subagentId injection for untagged events.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03025be8-a614-460d-9551-5e6a34a7e141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03025be8-a614-460d-9551-5e6a34a7e141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

