### PR TITLE
refactor: extract shared patchToolResultOutput helper in operator-dashboard

### DIFF
--- a/src/core/agents/offSecAgent/tools/scopeGuard.test.ts
+++ b/src/core/agents/offSecAgent/tools/scopeGuard.test.ts
@@ -255,9 +255,9 @@ describe("assertUrlInScope", () => {
 
   it("blocks other registrable domains", () => {
     const ctx = makeCtx({ target: "https://web.dev.diracinc.com" });
-    expect(() =>
-      assertUrlInScope("https://notdiracinc.com", ctx),
-    ).toThrow(ScopeViolationError);
+    expect(() => assertUrlInScope("https://notdiracinc.com", ctx)).toThrow(
+      ScopeViolationError,
+    );
     expect(() =>
       assertUrlInScope("https://diracinc.com.evil.com", ctx),
     ).toThrow(ScopeViolationError);

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -86,6 +86,7 @@ import {
   buildOperatorSystemPrompt,
   resolveInputFocused,
   accumulateTokenUsage,
+  patchToolResultOutput,
 } from "./logic";
 import {
   createSubagentSessionHelpers,
@@ -1780,36 +1781,14 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
       const toolCallId = pendingToolCallIdRef.current;
       if (!toolCallId) return;
 
-      // Bedrock Converse / Anthropic requires { type: 'json', value: ... } wrapper.
-      const wrappedOutput = {
-        type: "json" as const,
-        value: result as unknown as Record<string, unknown>,
-      };
-
-      const updated: ModelMessage[] = conversationRef.current.map((msg) => {
-        if (msg.role !== "tool") return msg;
-        if (!Array.isArray(msg.content)) return msg;
-        let mutated = false;
-        const nextContent = msg.content.map((part) => {
-          if (
-            part &&
-            typeof part === "object" &&
-            "type" in part &&
-            (part as { type?: unknown }).type === "tool-result" &&
-            (part as { toolCallId?: unknown }).toolCallId === toolCallId
-          ) {
-            mutated = true;
-            return {
-              ...(part as Record<string, unknown>),
-              output: wrappedOutput,
-            };
-          }
-          return part;
-        });
-        return mutated
-          ? ({ ...msg, content: nextContent } as ModelMessage)
-          : msg;
-      });
+      const updated = patchToolResultOutput(
+        conversationRef.current,
+        toolCallId,
+        {
+          type: "json" as const,
+          value: result as unknown as Record<string, unknown>,
+        },
+      );
 
       conversationRef.current = updated;
 
@@ -1999,37 +1978,18 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
       key.preventDefault?.();
       const toolCallId = pendingToolCallIdRef.current;
       if (toolCallId) {
-        const abortedResult = {
-          type: "json" as const,
-          value: {
-            answers: [],
-            skipped: true,
-            aborted: true,
-          } as unknown as Record<string, unknown>,
-        };
-        conversationRef.current = conversationRef.current.map((msg) => {
-          if (msg.role !== "tool" || !Array.isArray(msg.content)) return msg;
-          let mutated = false;
-          const nextContent = msg.content.map((part) => {
-            if (
-              part &&
-              typeof part === "object" &&
-              "type" in part &&
-              (part as { type?: unknown }).type === "tool-result" &&
-              (part as { toolCallId?: unknown }).toolCallId === toolCallId
-            ) {
-              mutated = true;
-              return {
-                ...(part as Record<string, unknown>),
-                output: abortedResult,
-              };
-            }
-            return part;
-          });
-          return mutated
-            ? ({ ...msg, content: nextContent } as ModelMessage)
-            : msg;
-        });
+        conversationRef.current = patchToolResultOutput(
+          conversationRef.current,
+          toolCallId,
+          {
+            type: "json" as const,
+            value: {
+              answers: [],
+              skipped: true,
+              aborted: true,
+            } as unknown as Record<string, unknown>,
+          },
+        );
         const activeSession = sessionRef.current;
         if (activeSession) {
           try {

--- a/src/tui/components/operator-dashboard/logic.test.ts
+++ b/src/tui/components/operator-dashboard/logic.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ModelMessage } from "ai";
 import {
   filterOperatorAutocomplete,
   resolveSubmit,
@@ -8,6 +9,7 @@ import {
   buildOperatorSystemPrompt,
   resolveInputFocused,
   accumulateTokenUsage,
+  patchToolResultOutput,
   type DashboardStatus,
 } from "./logic";
 import type { AutocompleteOption } from "../shared/prompt-input";
@@ -665,5 +667,105 @@ describe("accumulateTokenUsage", () => {
       cachedTokens: 0,
       cacheWriteTokens: 0,
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patchToolResultOutput
+// ---------------------------------------------------------------------------
+
+describe("patchToolResultOutput", () => {
+  const toolCallId = "call_123";
+  const wrappedOutput = {
+    type: "json" as const,
+    value: { answers: [{ answer: "yes" }], skipped: false },
+  };
+
+  function makeToolMessage(id: string): ModelMessage {
+    return {
+      role: "tool" as const,
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: id,
+          toolName: "ask_user_questions",
+          output: { type: "text", value: "pending" },
+        },
+      ],
+    } as unknown as ModelMessage;
+  }
+
+  it("patches the matching tool-result output", () => {
+    const messages: ModelMessage[] = [
+      { role: "system", content: "hello" } as unknown as ModelMessage,
+      makeToolMessage(toolCallId),
+    ];
+    const result = patchToolResultOutput(messages, toolCallId, wrappedOutput);
+    expect(result).toHaveLength(2);
+    const toolMsg = result[1] as { content: Array<Record<string, unknown>> };
+    expect(toolMsg.content[0].output).toEqual(wrappedOutput);
+  });
+
+  it("does not mutate the original array", () => {
+    const messages: ModelMessage[] = [makeToolMessage(toolCallId)];
+    const result = patchToolResultOutput(messages, toolCallId, wrappedOutput);
+    expect(result).not.toBe(messages);
+    const original = messages[0] as {
+      content: Array<Record<string, unknown>>;
+    };
+    expect(original.content[0].output).toEqual({
+      type: "text",
+      value: "pending",
+    });
+  });
+
+  it("returns messages unchanged when no match", () => {
+    const messages: ModelMessage[] = [
+      { role: "system", content: "hello" } as unknown as ModelMessage,
+      makeToolMessage("other_id"),
+    ];
+    const result = patchToolResultOutput(messages, toolCallId, wrappedOutput);
+    expect(result[0]).toBe(messages[0]);
+    expect(result[1]).toBe(messages[1]);
+  });
+
+  it("handles empty messages array", () => {
+    const result = patchToolResultOutput([], toolCallId, wrappedOutput);
+    expect(result).toEqual([]);
+  });
+
+  it("skips tool messages with non-array content", () => {
+    const messages: ModelMessage[] = [
+      { role: "tool", content: "plain string" } as unknown as ModelMessage,
+    ];
+    const result = patchToolResultOutput(messages, toolCallId, wrappedOutput);
+    expect(result[0]).toBe(messages[0]);
+  });
+
+  it("only patches the part with the matching toolCallId", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "tool" as const,
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "other_id",
+            toolName: "other_tool",
+            output: { type: "text", value: "keep" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: toolCallId,
+            toolName: "ask_user_questions",
+            output: { type: "text", value: "replace" },
+          },
+        ],
+      } as unknown as ModelMessage,
+    ];
+    const result = patchToolResultOutput(messages, toolCallId, wrappedOutput);
+    const content = (result[0] as { content: Array<Record<string, unknown>> })
+      .content;
+    expect(content[0].output).toEqual({ type: "text", value: "keep" });
+    expect(content[1].output).toEqual(wrappedOutput);
   });
 });

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -356,11 +356,6 @@ export function accumulateTokenUsage(
 // Tool-result patching
 // ---------------------------------------------------------------------------
 
-/**
- * Find the tool-result part matching `toolCallId` in a conversation and
- * replace its `output` with `wrappedOutput`. Returns a new array (messages
- * without a matching part are shared by reference).
- */
 export function patchToolResultOutput(
   messages: ModelMessage[],
   toolCallId: string,

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -1,3 +1,4 @@
+import type { ModelMessage } from "ai";
 import type { AutocompleteOption } from "../shared/prompt-input";
 import type { OperatorSessionState } from "../../../core/operator";
 import { buildBaseSystemPrompt } from "../../../core/agents/offSecAgent/prompt";
@@ -349,4 +350,41 @@ export function accumulateTokenUsage(
     cachedTokens: current.cachedTokens,
     cacheWriteTokens: current.cacheWriteTokens,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Tool-result patching
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the tool-result part matching `toolCallId` in a conversation and
+ * replace its `output` with `wrappedOutput`. Returns a new array (messages
+ * without a matching part are shared by reference).
+ */
+export function patchToolResultOutput(
+  messages: ModelMessage[],
+  toolCallId: string,
+  wrappedOutput: { type: "json"; value: Record<string, unknown> },
+): ModelMessage[] {
+  return messages.map((msg) => {
+    if (msg.role !== "tool" || !Array.isArray(msg.content)) return msg;
+    let mutated = false;
+    const nextContent = msg.content.map((part) => {
+      if (
+        part &&
+        typeof part === "object" &&
+        "type" in part &&
+        (part as { type?: unknown }).type === "tool-result" &&
+        (part as { toolCallId?: unknown }).toolCallId === toolCallId
+      ) {
+        mutated = true;
+        return {
+          ...(part as Record<string, unknown>),
+          output: wrappedOutput,
+        };
+      }
+      return part;
+    });
+    return mutated ? ({ ...msg, content: nextContent } as ModelMessage) : msg;
+  });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

The `Ctrl+C` pending-questions handler and `resumeWithQuestionResult` in the operator dashboard both contained ~40 lines of near-identical logic for:

1. Finding a `tool-result` part by `toolCallId` in `conversationRef.current`
2. Patching its `output` with a new JSON-wrapped value
3. Returning the updated messages array

This duplication creates a maintenance risk — if one path is updated, the other can silently diverge.

**Changes:**

- **Extracted `patchToolResultOutput`** into `logic.ts` — a pure function that takes a `ModelMessage[]` array, a `toolCallId`, and a wrapped output value, and returns a new array with the matching tool-result patched. Messages without a match are shared by reference (no unnecessary copies).
- **Replaced both call sites** in `index.tsx` with calls to the shared helper, reducing the Ctrl+C handler by ~20 lines and `resumeWithQuestionResult` by ~15 lines.
- **Added 6 unit tests** covering: matching, immutability, no-match passthrough, empty arrays, non-array content skipping, and multi-part selective patching.

### How did you verify your code works?

- `bun run lint` — passes clean
- `bun run tsc` — no new errors (pre-existing `PasteEvent` type issues are unrelated)
- `bun run test` — all 738 tests pass (32 test files pass, 7 skipped as expected), including the 6 new `patchToolResultOutput` tests
- `bun run format:check` — no formatting issues in changed files (pre-existing issue in `scopeGuard.test.ts` is unrelated)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1913f227-c771-46d2-88e3-0e58abb55015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1913f227-c771-46d2-88e3-0e58abb55015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

