### PR TITLE
feat: default browser MCP to desktop Chrome UA and 1920x1080 viewport

### DIFF
--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -200,10 +200,29 @@ function withTimeout<T>(
 }
 
 // ---------------------------------------------------------------------------
-// Module-level default headless setting (used when not explicitly provided)
+// Module-level defaults (used when not explicitly provided)
 // ---------------------------------------------------------------------------
 
 let defaultHeadless = true;
+
+/**
+ * Default User-Agent string for new browser sessions.
+ *
+ * Playwright MCP's Chromium default advertises `HeadlessChrome/…`, which is
+ * the single most common trigger for nginx / Cloudflare / generic-WAF 403s
+ * on targets we're otherwise authorised to test. Override the default to a
+ * real desktop Chrome UA so the browser isn't immediately fingerprinted as
+ * a headless bot at the edge.
+ */
+let defaultUserAgent: string | undefined =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
+/**
+ * Default viewport size (format: `WIDTH,HEIGHT`) for new browser sessions.
+ * 1920x1080 matches a standard desktop resolution and avoids the small
+ * default viewport that some SPAs use as a mobile/bot signal.
+ */
+let defaultViewportSize: string | undefined = "1920,1080";
 
 /**
  * Configure the default headless mode for new browser sessions.
@@ -212,6 +231,23 @@ let defaultHeadless = true;
  */
 export function setHeadlessMode(headless: boolean): void {
   defaultHeadless = headless;
+}
+
+/**
+ * Configure the default User-Agent for new browser sessions.
+ * Pass `undefined` to fall back to Chromium's built-in UA.
+ */
+export function setUserAgent(userAgent: string | undefined): void {
+  defaultUserAgent = userAgent;
+}
+
+/**
+ * Configure the default viewport size for new browser sessions.
+ * Format is `"WIDTH,HEIGHT"`, e.g. `"1920,1080"`.
+ * Pass `undefined` to fall back to Chromium's default viewport.
+ */
+export function setViewportSize(viewportSize: string | undefined): void {
+  defaultViewportSize = viewportSize;
 }
 
 /**
@@ -232,9 +268,17 @@ export class PlaywrightMcpSession {
   private connectionPromise: Promise<Client> | null = null;
   private disconnecting = false;
   private readonly headless: boolean;
+  private readonly userAgent: string | undefined;
+  private readonly viewportSize: string | undefined;
 
-  constructor(headless = true) {
+  constructor(
+    headless = true,
+    userAgent?: string,
+    viewportSize?: string,
+  ) {
     this.headless = headless;
+    this.userAgent = userAgent;
+    this.viewportSize = viewportSize;
   }
 
   /** Immediately reset all instance state. Synchronous — no I/O. */
@@ -298,6 +342,14 @@ export class PlaywrightMcpSession {
         const args = [cliPath, "--isolated"];
         if (this.headless) {
           args.push("--headless");
+        }
+
+        if (this.userAgent) {
+          args.push("--user-agent", this.userAgent);
+        }
+
+        if (this.viewportSize) {
+          args.push(`--viewport-size=${this.viewportSize}`);
         }
 
         // Disable Chromium sandbox when running as root (e.g., in Docker/ECS containers).
@@ -688,6 +740,12 @@ Use this to check for:
  * @param abortSignal - Optional abort signal for cleanup
  * @param headless - Override headless mode for this session (defaults to the
  *   value set by {@link setHeadlessMode}, which itself defaults to `true`)
+ * @param userAgent - Override User-Agent for this session (defaults to the
+ *   value set by {@link setUserAgent}). Passing `null` forces Chromium's
+ *   built-in UA (useful if the default anti-bot UA is counter-productive).
+ * @param viewportSize - Override viewport size (format `"WIDTH,HEIGHT"`) for
+ *   this session (defaults to the value set by {@link setViewportSize}).
+ *   Passing `null` forces Chromium's default viewport.
  */
 export function createBrowserTools(
   targetUrl: string,
@@ -696,8 +754,19 @@ export function createBrowserTools(
   logger?: Logger,
   abortSignal?: AbortSignal,
   headless?: boolean,
+  userAgent?: string | null,
+  viewportSize?: string | null,
 ) {
-  const session = new PlaywrightMcpSession(headless ?? defaultHeadless);
+  const resolvedUserAgent =
+    userAgent === null ? undefined : (userAgent ?? defaultUserAgent);
+  const resolvedViewportSize =
+    viewportSize === null ? undefined : (viewportSize ?? defaultViewportSize);
+
+  const session = new PlaywrightMcpSession(
+    headless ?? defaultHeadless,
+    resolvedUserAgent,
+    resolvedViewportSize,
+  );
 
   if (abortSignal) {
     const onAbort = () => session.disconnect().catch(() => {});


### PR DESCRIPTION
## Summary

- Playwright MCP's default Chromium advertises `HeadlessChrome/...` and uses a small default viewport — the single most common trigger for nginx / Cloudflare / generic-WAF 403s on targets we're otherwise authorised to test (recent example: `web.dev.diracinc.com`, which 200s to `curl` but 403s to the auth subagent's headless Playwright).
- Set module-level defaults for User-Agent (desktop Chrome 131) and viewport size (`1920,1080`) and pipe them through as `--user-agent` and `--viewport-size` CLI flags when spawning the MCP child process.
- Expose `setUserAgent` / `setViewportSize` setters (mirroring existing `setHeadlessMode`) and per-call overrides on `createBrowserTools`. Passing `null` as the per-call override forces Chromium's built-in values as an escape hatch.
- No call-site changes required: auth, pentest, attack-surface, and operator agents inherit the new defaults automatically.

## Rationale

The auth subagent was hitting `403 Forbidden` on a legitimate test target at the nginx edge despite valid credentials, while `curl` to the same URL returned `200` with the SPA HTML. That pattern (browser 403, curl 200) is almost always the WAF fingerprinting the literal `HeadlessChrome` token in the default Playwright UA. Swapping to a real desktop Chrome UA + standard viewport clears the easy layer of these rules; if a 403 persists after this change, it's a deeper fingerprint (TLS/JA3, `sec-ch-ua`) or IP/geo block, and we'd escalate to `--device` emulation or a proxy.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Re-run auth subagent against a previously-403'd target and confirm the login page now loads
- [ ] Spot-check pentest mode: browser still navigates, fills, clicks, screenshots correctly
- [ ] Confirm existing `browserCookies.test.ts` still passes (no signature changes on the positional args it uses)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global/default browser fingerprinting (UA/viewport) for all MCP-driven agents, which can alter site behavior and potentially affect login/flow stability on some targets despite limited code surface area.
> 
> **Overview**
> Updates Playwright MCP browser sessions to default to a desktop Chrome User-Agent and a `1920,1080` viewport, and passes these through when spawning the MCP CLI (`--user-agent`, `--viewport-size`) to reduce WAF/bot fingerprint blocks.
> 
> Adds module-level setters `setUserAgent`/`setViewportSize` and extends `createBrowserTools` with per-session overrides (with `null` as an escape hatch to force Chromium defaults) while keeping existing call sites compatible via optional parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f9714e169bb7536f3efed55067af2eea34320b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->