### PR TITLE
feat(pentest): screenshot liberally during browser interaction

### DIFF
--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -308,10 +308,14 @@ const SECTION_POC_PORTABILITY = `POC Script Portability Requirements:
 const SECTION_BROWSER_INTERACTION = `Browser Interaction:
 - Use browser_navigate to load pages, browser_snapshot to inspect the DOM, and browser_screenshot for visual evidence
 - Use browser_click and browser_fill to interact with forms, buttons, and input fields — essential for testing login flows, search fields, and other interactive elements
-- Take screenshots of: successful XSS execution, error pages revealing sensitive info, authentication bypass results, anomalous server responses
-- Take a screenshot when you encounter unexpected errors to document the failure state
-- Use descriptive filenames that indicate what the screenshot captures (e.g. "xss-alert-fired", "sql-error-disclosure", "auth-bypass-admin-panel")
-- Screenshots are automatically stored and displayed alongside your tool call logs`;
+- Screenshot liberally so the user can follow along. Whenever you are driving a browser, treat screenshots as the primary way the user watches your work. Err heavily on the side of more screenshots rather than fewer.
+  - Take a screenshot after EVERY meaningful browser action: after navigating to a new page, after filling a form, after clicking a button, after a page finishes loading a new state, and after any action whose outcome isn't obvious from the tool call alone.
+  - Capture both the "before" and "after" states for interactions that change the page (e.g. pre-submit form, post-submit response; unauthenticated view, authenticated view).
+  - Always screenshot: successful payload execution (XSS alerts, rendered injections), error pages revealing sensitive info, authentication bypass results, unexpected redirects, anomalous server responses, and any state that materially changes what the user would see.
+  - Take a screenshot when you encounter unexpected errors or dead ends to document the failure state before pivoting.
+- Use descriptive filenames that indicate what the screenshot captures (e.g. "login-page-initial", "login-form-filled", "post-login-dashboard", "xss-alert-fired", "sql-error-disclosure", "auth-bypass-admin-panel"). Filenames should read like a narrative of the session.
+- Screenshots are cheap — prefer taking one and not needing it over skipping one and losing visibility. Do NOT attempt to conserve tokens by skipping screenshots during browser-driven testing.
+- Screenshots are automatically stored and displayed alongside your tool call logs, so each one directly improves the user's ability to follow the test in real time.`;
 
 const SECTION_AUTHENTICATION = `Authentication:
 - If the prompt includes an "Existing Authentication Session" section, USE those cookies/headers on every request. Do NOT attempt to re-authenticate.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Updates the pentest agent's `SECTION_BROWSER_INTERACTION` prompt guidance to instruct the agent to **screenshot liberally** whenever it is driving a browser, so users can follow along in real time.

Previously, the prompt only mentioned screenshotting at specific "interesting" moments (successful XSS, error pages, etc.) and when documenting failure states. In practice, this leaves long gaps during browser-driven testing where the user cannot see what the agent is doing.

The new guidance:

- Frames screenshots as the **primary way the user watches the agent work** during browser interaction
- Requires a screenshot after every meaningful browser action (navigate, fill, click, state change)
- Asks for before/after pairs for state-changing interactions (pre/post login, pre/post submit)
- Keeps the existing list of "always screenshot" states (XSS, error pages, auth bypass, redirects, anomalous responses)
- Encourages descriptive, narrative filenames (e.g. `login-page-initial`, `login-form-filled`, `post-login-dashboard`) so the screenshot series reads like a story
- Explicitly tells the agent **not** to skip screenshots to conserve tokens — screenshots are cheap and directly improve visibility

This guidance flows through to all four pentest prompt variants (base, exfil, task-driven, task-driven-exfil) because they all embed `SECTION_BROWSER_INTERACTION`.

### How did you verify your code works?

This is a prompt-text-only change in `src/core/agents/specialized/pentest/agent.ts`. The guidance is string content that is embedded into the system prompt the model reads at runtime — there is no new logic, no new tool, and no schema change.

- ✅ `bun run lint`
- ✅ `bun run test` (732 passed, 15 skipped — all pre-existing)
- ✅ `bunx prettier --check src/core/agents/specialized/pentest/agent.ts`
- ⚠️ `bun run tsc` — fails only on pre-existing, unrelated `PasteEvent.text` type errors in `src/tui/components/**` that exist on `canary` and are untouched by this change
- ⚠️ `bun run format:check` — warns only on pre-existing format issues in `src/core/agents/offSecAgent/tools/playwrightMcp.ts` and `scopeGuard.test.ts` that exist on `canary` and are untouched by this change

No manual TUI testing was performed because this change is a model prompt update — its effect is only observable during a live pentest run against a real target with an AI provider key, which is not reproducible in this environment. The existing unit tests cover that the prompt assembly functions still produce valid strings.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ef7d2c4-ca14-496e-ae99-5b6a1d95f40a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ef7d2c4-ca14-496e-ae99-5b6a1d95f40a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

