### PR TITLE
feat(whitebox-recon): add coverage double-check phase for app discovery

### DIFF
--- a/src/core/agents/specialized/whiteboxAttackSurface/agent.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/agent.ts
@@ -144,7 +144,18 @@ function buildPrompt(
   operatorPrompt?: string,
 ): string {
   const domainSection = domains?.length
-    ? `\n## Known Domains\nThe following domains are associated with this project. When documenting apps, set the \`domain\` field on \`document_app\` if you can determine which domain serves the app:\n${domains.map((d) => `- ${d}`).join("\n")}\n`
+    ? `\n## Known Domains
+The following domains are **hints for association only** — they are known to be operated by the target and should be set on the \`domain\` field of \`document_app\` when you can determine which domain serves a given app.
+
+**IMPORTANT — these domains DO NOT define the scope of discovery:**
+- Discover and document **every** app/service/cloud resource defined in the codebase, regardless of whether it maps to one of these domains.
+- Apps with no known public domain (internal services, background workers, staging-only apps, functions, admin tools, etc.) MUST still be documented. Leave \`domain\` unset or use the canonical resource URL for cloud resources.
+- Do NOT filter out apps, endpoints, subdomains, or cloud resources because they don't appear to belong to one of these domains.
+- Do NOT skip directories, packages, or services because they "look unrelated" to the listed domains.
+
+Known domains:
+${domains.map((d) => `- ${d}`).join("\n")}
+`
     : "";
   const operatorGuidanceBlock = operatorPrompt
     ? `\n## Operator Guidance\n${operatorPrompt}\n`

--- a/src/core/agents/specialized/whiteboxAttackSurface/agent.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/agent.ts
@@ -162,10 +162,11 @@ Analyze this codebase and produce a complete attack surface map:
 3. Discover cloud resources and external infrastructure referenced in the code (S3 buckets, cloud storage, CDN origins, etc.) — document these as apps with the appropriate type
 4. For each app, find all web pages and API endpoints
 5. For each endpoint, generate pentest objectives
+6. **Before submitting**, perform the Phase 3 coverage double-check from the system prompt — re-scan workspace roots, framework configs, Dockerfiles, IaC, and CI/deploy configs for apps you may have missed on the first pass, and document any that were missed.
 
 Use \`spawn_coding_agent\` to delegate app-level analysis for higher fidelity.
 
-When finished, call \`submit_results\` with the complete structured output.
+When finished, call \`submit_results\` with the complete structured output. Do NOT call \`submit_results\` until you have explicitly completed the coverage double-check.
 
 Begin now.`;
 }

--- a/src/core/agents/specialized/whiteboxAttackSurface/prompts.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/prompts.ts
@@ -29,7 +29,7 @@ Your primary search tool. Use it to find route definitions, middleware, controll
 - Cloud resources like S3 buckets, cloud storage, CDN origins (appType: "cloud_resource" or "storage")
   - For S3 buckets: set \`domain\` to the **canonical virtual-hosted-style** endpoint (e.g. "https://bucket-name.s3.amazonaws.com") and use appType "storage". Do NOT use path-style URLs (e.g. "https://s3.amazonaws.com/bucket-name").
   - For other cloud resources: set \`domain\` to the primary/canonical resource endpoint and use appType "cloud_resource"
-- If known domains are provided, set the \`domain\` field to associate the app with the correct domain
+- If known domains are provided, set the \`domain\` field to associate the app with the correct domain. **Known domains are association hints only — they do NOT scope or limit discovery.** Document every app you find, even if it has no public domain or doesn't match any known domain.
 
 ## document_endpoint
 **This is your primary output tool for endpoints.** Each call persists a JSON record to the session's endpoints directory, organized by app. Document:
@@ -120,7 +120,7 @@ Before calling \`submit_results\`, verify the final coverage checklist:
 - [ ] Every workspace package / service directory is represented by a documented app
 - [ ] Every framework entry point discovered in Phase 3 maps to a documented app
 - [ ] Every Dockerfile / compose service / IaC resource maps to a documented app or cloud resource
-- [ ] Every known domain (if provided) is associated with at least one app where applicable
+- [ ] Every known domain (if provided) that maps to an app in the repo has been associated via the \`domain\` field — but apps that don't map to a known domain are still documented (known domains are hints, not a scope filter)
 - [ ] Each documented app has its endpoints/pages enumerated (or an explicit note in \`pentestObjectives\` if it is a non-HTTP service)
 
 Then:
@@ -135,4 +135,5 @@ Then:
 - Don't duplicate work — let the coding agents do the deep file-by-file analysis.
 - When in doubt about repo structure, read more config files before deciding.
 - **Never skip the Phase 3 coverage double-check** — initial discovery routinely misses apps, and a second pass is the cheapest way to catch them.
+- **Known domains are association hints, not a scope filter.** If the task includes a list of known domains, use them to populate the \`domain\` field on \`document_app\` when you can match an app to one. Do NOT use them to decide which apps, packages, services, endpoints, or cloud resources are worth documenting — document everything found in the codebase.
 `;

--- a/src/core/agents/specialized/whiteboxAttackSurface/prompts.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/prompts.ts
@@ -9,6 +9,7 @@ Given a codebase path, you must:
 2. Discover every application/service defined in the repo
 3. For each app, enumerate ALL web pages and ALL API endpoints defined in the source code
 4. For each endpoint, generate specific pentest objectives
+5. **Double-check app coverage before submitting** — initial discovery commonly misses apps (hidden monorepo packages, IaC-defined services, Docker compose services, serverless functions, mobile/desktop apps, etc.). A dedicated verification pass is mandatory before you submit results.
 
 # Tools at Your Disposal
 
@@ -86,7 +87,43 @@ For each app you identified, spawn a coding agent with a detailed objective. The
 
 **IMPORTANT:** Tell each coding agent to set \`appName\` on every \`document_endpoint\` call so endpoints are organized by application.
 
-## Phase 3: COLLECT AND SUBMIT (do this yourself)
+## Phase 3: COVERAGE DOUBLE-CHECK (do this yourself — DO NOT SKIP)
+
+**Initial app discovery almost always misses something.** Before submitting, you MUST verify that every app/service in the codebase has been documented. This phase is mandatory — do not skip it even if you believe you found everything.
+
+1. **Re-list the repo root and any workspace/package roots** to confirm you didn't miss a directory.
+2. **Check monorepo workspace declarations** against your documented apps:
+   - \`package.json\` \`workspaces\` field, \`pnpm-workspace.yaml\`, \`lerna.json\`, \`nx.json\`, \`turbo.json\`, \`rush.json\`
+   - \`Cargo.toml\` \`[workspace]\` members, \`go.work\` use directives
+   - Any top-level \`apps/\`, \`packages/\`, \`services/\`, \`cmd/\`, \`functions/\`, \`lambdas/\`, \`workers/\` directories
+3. **Search for additional entry points** you may have missed. Run targeted greps such as:
+   - Framework manifests: \`next.config.*\`, \`vite.config.*\`, \`remix.config.*\`, \`nuxt.config.*\`, \`astro.config.*\`, \`svelte.config.*\`, \`angular.json\`, \`gatsby-config.*\`, \`expo.json\`, \`app.json\`
+   - Backend entry points: \`main.py\`, \`app.py\`, \`manage.py\`, \`wsgi.py\`, \`asgi.py\`, \`server.{ts,js,go,rs}\`, \`main.{go,rs}\`, \`Program.cs\`, \`Startup.cs\`
+   - Dockerfiles and \`docker-compose.y*ml\` services — each service may be a separate app
+   - IaC definitions: \`serverless.y*ml\`, \`sam.y*ml\`, \`template.y*ml\`, \`*.tf\`, \`cdk.json\`, \`sst.config.*\`, \`pulumi.yaml\`
+   - CI/CD deployment configs: \`.github/workflows/\`, \`vercel.json\`, \`netlify.toml\`, \`fly.toml\`, \`railway.toml\`, \`app.yaml\`, \`Procfile\`
+   - Mobile apps: \`ios/\`, \`android/\`, \`*.xcodeproj\`, \`AndroidManifest.xml\`
+   - Browser extensions / desktop apps: \`manifest.json\` (MV2/MV3), \`electron\`, \`tauri.conf.*\`
+   - Background jobs / workers: search for \`worker\`, \`queue\`, \`cron\`, \`scheduler\`, \`BullMQ\`, \`Celery\`, \`Sidekiq\`
+4. **Check for hidden apps in unusual locations:** admin panels, internal tools, documentation sites, storybook, marketing sites, landing pages, \`docs/\`, \`www/\`, \`admin/\`, \`internal/\`, \`tools/\`.
+5. **Compare discovered cloud resources against IaC files** — every S3 bucket, Lambda, CloudFront distribution, storage bucket, or CDN origin referenced in infra code should be documented as an app.
+
+For every candidate you identify in this phase:
+- If it's **already documented** — good, move on.
+- If it's **NOT documented** — spawn another coding agent to analyze it, or document it yourself with \`document_app\` / \`document_endpoint\`. Do not simply note it in the final summary; it must be in the apps list.
+
+Only proceed to Phase 4 once you have explicitly walked through the checks above and confirmed coverage is complete.
+
+## Phase 4: COLLECT AND SUBMIT (do this yourself)
+
+Before calling \`submit_results\`, verify the final coverage checklist:
+- [ ] Every workspace package / service directory is represented by a documented app
+- [ ] Every framework entry point discovered in Phase 3 maps to a documented app
+- [ ] Every Dockerfile / compose service / IaC resource maps to a documented app or cloud resource
+- [ ] Every known domain (if provided) is associated with at least one app where applicable
+- [ ] Each documented app has its endpoints/pages enumerated (or an explicit note in \`pentestObjectives\` if it is a non-HTTP service)
+
+Then:
 1. Parse the output from all coding agents
 2. Assemble the complete structured result
 3. Call \`submit_results\` with the full data
@@ -97,4 +134,5 @@ For each app you identified, spawn a coding agent with a detailed objective. The
 - Give coding agents VERY detailed objectives — they work best with specific instructions about what to search for and how to report it.
 - Don't duplicate work — let the coding agents do the deep file-by-file analysis.
 - When in doubt about repo structure, read more config files before deciding.
+- **Never skip the Phase 3 coverage double-check** — initial discovery routinely misses apps, and a second pass is the cheapest way to catch them.
 `;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Adds prompt guidance to the whitebox attack surface recon agent to fix two related coverage problems:

1. **Initial app/service discovery often misses apps** — hidden monorepo packages, IaC-defined services (Lambdas, Cloud Run services, etc.), Docker compose services, serverless functions, mobile/desktop apps, admin panels, internal tools, etc.
2. **Passing known domains was implicitly limiting scope** — the agent was treating the provided `domains` list as a scope filter rather than association hints, so apps that didn't appear to map to a known domain were being dropped.

#### 1. Coverage double-check phase (`prompts.ts`)

Adds a new mandatory **Phase 3: COVERAGE DOUBLE-CHECK** that the orchestrator must perform itself after the coding-agent fan-out, before calling `submit_results`. It enumerates concrete things to re-scan:

- Repo roots and workspace/package roots
- Monorepo workspace declarations (`package.json` `workspaces`, `pnpm-workspace.yaml`, `lerna.json`, `nx.json`, `turbo.json`, `rush.json`, `Cargo.toml` `[workspace]`, `go.work`, conventional `apps/`/`packages/`/`services/`/`cmd/`/`functions/`/`lambdas/`/`workers/` dirs)
- Framework manifests (Next/Vite/Remix/Nuxt/Astro/Svelte/Angular/Gatsby/Expo)
- Backend entry points (`main.py`, `app.py`, `manage.py`, `wsgi.py`, `asgi.py`, `server.{ts,js,go,rs}`, `Program.cs`, etc.)
- Dockerfiles and `docker-compose` services
- IaC (`serverless.yml`, `sam.yml`, Terraform, CDK, SST, Pulumi)
- CI/CD deploy configs (`.github/workflows/`, Vercel, Netlify, Fly, Railway, `app.yaml`, `Procfile`)
- Mobile (`ios/`, `android/`, `*.xcodeproj`, `AndroidManifest.xml`)
- Browser extensions / Electron / Tauri
- Background jobs / workers
- Unusual locations (admin panels, internal tools, docs, storybook, marketing, `docs/`, `www/`, `admin/`, `internal/`, `tools/`)
- IaC-defined cloud resources

If a candidate is not already documented, the orchestrator must spawn another coding agent or call `document_app` / `document_endpoint` itself — not just mention it in the final summary. Phase 4 (renamed from Phase 3) adds a final checklist for workspace coverage, entry-point coverage, Docker/IaC coverage, domain association, and per-app endpoint enumeration.

Mirrored the coverage-check requirement in the top-level goal list and added a "never skip" guideline.

#### 2. Known-domains guidance (`prompts.ts` + `agent.ts`)

- `buildPrompt` in `agent.ts` now emits a `## Known Domains` section that explicitly labels domains as **association hints only** and includes rules reinforcing that they do NOT scope discovery: document every app/service/cloud resource regardless of domain match, don't filter out apps/endpoints/subdomains that don't belong to a known domain, don't skip directories or packages that "look unrelated."
- `prompts.ts` `document_app` section gains an inline note stating that known domains are association hints and do not scope or limit discovery.
- The Phase 4 submit checklist item for known domains is reworded so it only gates on "known domains that actually map to a repo app have their `domain` field set" — it no longer implies that unmatched apps are a problem.
- A new top-level guideline explicitly states: "Known domains are association hints, not a scope filter."

`spawn_coding_agent` does not receive the domains list, so no changes needed on the sub-agent side.

This is a prompt-only change — no behavioral/runtime code changes, no new dependencies, no type or schema changes.

### How did you verify your code works?

- ✅ `bun run test` — all existing tests pass (732 passed, 15 skipped on the initial run; 152 passed, 6 skipped on the focused agent suite after the second commit)
- ✅ `bun run lint` — clean
- ✅ `bunx prettier --check src/core/agents/specialized/whiteboxAttackSurface/` — formatted
- ⚠️ `bun run tsc` — pre-existing unrelated errors in `src/tui/components/**` (verified they exist on `canary` without this change)
- Manual/runtime testing of the agent against a live codebase was not performed because this is a prompt-only guidance change with no runtime code paths to exercise; correctness is about what the LLM reads. Reviewed both updated files end-to-end to confirm phase numbering, checklist items, the new domain-scope guidance, and the task-prompt wording are internally consistent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83dcdeb2-ab00-4744-b24c-ba1e3ce63cb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83dcdeb2-ab00-4744-b24c-ba1e3ce63cb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

