### PR TITLE
fix(persistentShell): stop long-running shell from wedging + add hang reproductions

### DIFF
--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -46,38 +46,39 @@ describe("PersistentShell — long-running stability", () => {
    * Repro #1 — Stdin hijack by a child process.
    *
    * The shell's stdin pipe is shared with every child bash spawns. A command
-   * that reads from stdin (cat/ssh/sudo/python/mysql/read/...) will consume
-   * bytes that were meant for bash's own command parsing.
+   * that reads from stdin (cat/ssh/sudo/python/mysql/read/...) used to
+   * consume bytes meant for bash's own command parsing, wedging the shell
+   * for every subsequent call.
    *
-   * After this command is killed by the timeout path, subsequent
-   * `execute()` calls should still work — but in practice they hang until
-   * their own timeout because:
-   *   - cat consumed part of bash's command buffer, or
-   *   - bash is still mid-way through the previous wrapped block.
+   * The fix redirects each user command's stdin from /dev/null, so stdin
+   * readers see EOF immediately and cannot hijack our command pipe. We
+   * verify:
+   *   1. `cat` does NOT hang — it EOFs cleanly (exit 0) in well under the
+   *      timeout, proving stdin isolation works.
+   *   2. The next command still runs immediately afterward.
    *
-   * Agents hit this constantly after many commands because the model is
-   * prone to running things like `sudo ...` or `ssh ...` mid-pentest.
+   * Agents hit this constantly in practice because models run things like
+   * `sudo ...` or `ssh ...` mid-pentest.
    */
-  it.fails(
-    "stays responsive after a command that reads from stdin is killed",
-    async () => {
-      const shell = make();
+  it("stays responsive after a command that normally reads stdin", async () => {
+    const shell = make();
 
-      const warm = await shell.execute("echo warm", 5);
-      expect(warm.exitCode).toBe(0);
+    const warm = await shell.execute("echo warm", 5);
+    expect(warm.exitCode).toBe(0);
 
-      // `cat` with no args blocks reading stdin. It inherits fd 0 from bash,
-      // which is the same pipe PersistentShell writes commands into.
-      const hung = await shell.execute("cat", 2);
-      expect(hung.exitCode).toBe(124);
+    // `cat` with no args normally blocks on stdin. With /dev/null
+    // redirection it EOFs instantly.
+    const start = Date.now();
+    const hung = await shell.execute("cat", 2);
+    const elapsed = Date.now() - start;
+    expect(hung.exitCode).toBe(0);
+    expect(elapsed).toBeLessThan(1_500);
 
-      // Subsequent command should return within a normal timeout.
-      const after = await shell.execute("echo after-cat", 5);
-      expect(after.exitCode).toBe(0);
-      expect(after.stdout).toContain("after-cat");
-    },
-    20_000,
-  );
+    // Subsequent command should return within a normal timeout.
+    const after = await shell.execute("echo after-cat", 5);
+    expect(after.exitCode).toBe(0);
+    expect(after.stdout).toContain("after-cat");
+  }, 20_000);
 
   /**
    * Repro #2 — Process-group leak after timeout.
@@ -90,37 +91,33 @@ describe("PersistentShell — long-running stability", () => {
    * After the timeout, we should see no descendant processes still holding
    * the shell's stdout pipe.
    */
-  it.fails(
-    "cleans up pipeline grandchildren when a command times out",
-    async () => {
-      const shell = make();
-      // Prime the shell so we have a stable pid to probe.
-      await shell.execute("echo prime", 5);
-      const bashPid = (shell as unknown as { proc: { pid: number } }).proc.pid;
-      expect(bashPid).toBeGreaterThan(0);
+  it("cleans up pipeline grandchildren when a command times out", async () => {
+    const shell = make();
+    // Prime the shell so we have a stable pid to probe.
+    await shell.execute("echo prime", 5);
+    const bashPid = (shell as unknown as { proc: { pid: number } }).proc.pid;
+    expect(bashPid).toBeGreaterThan(0);
 
-      // Pipeline: sleep is a grandchild of bash (child of the subshell).
-      const timed = await shell.execute("sleep 30 | cat", 2);
-      expect(timed.exitCode).toBe(124);
+    // Pipeline: sleep is a grandchild of bash (child of the subshell).
+    const timed = await shell.execute("sleep 30 | cat", 2);
+    expect(timed.exitCode).toBe(124);
 
-      // Give pkill + the 1s drain window a moment.
-      await new Promise((r) => setTimeout(r, 1_500));
+    // Give pkill + the 1s drain window a moment.
+    await new Promise((r) => setTimeout(r, 1_500));
 
-      const { spawnSync } = await import("child_process");
-      const out = spawnSync(
-        "ps",
-        ["--ppid", String(bashPid), "-o", "pid=,comm="],
-        { encoding: "utf8" },
-      );
-      const remaining = (out.stdout || "")
-        .split("\n")
-        .map((l) => l.trim())
-        .filter(Boolean);
-      // No direct bash children should remain; none of them should be sleep.
-      expect(remaining.find((l) => l.includes("sleep"))).toBeUndefined();
-    },
-    20_000,
-  );
+    const { spawnSync } = await import("child_process");
+    const out = spawnSync(
+      "ps",
+      ["--ppid", String(bashPid), "-o", "pid=,comm="],
+      { encoding: "utf8" },
+    );
+    const remaining = (out.stdout || "")
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    // No direct bash children should remain; none of them should be sleep.
+    expect(remaining.find((l) => l.includes("sleep"))).toBeUndefined();
+  }, 20_000);
 
   /**
    * Repro #3 — Output from a backgrounded command bleeds into the next
@@ -135,49 +132,47 @@ describe("PersistentShell — long-running stability", () => {
    * which, if a marker ever lands near the start, silently drops it and
    * we wait for a marker that will never appear.
    */
-  it.fails(
-    "does not leak background-process output into the next command's stdout",
-    async () => {
-      const shell = make();
+  it("does not leak background-process output into the next command's stdout", async () => {
+    const shell = make();
 
-      // Background a generator whose fd 1 is NOT redirected. This is the
-      // realistic footgun (`nmap -v &` without `>out.log 2>&1 &`).
-      const bg = await shell.execute(
-        "( while :; do echo spam-$RANDOM; done ) &",
-        3,
-      );
-      expect(bg.exitCode).toBe(0);
+    // Background a generator whose fd 1 is NOT redirected. This is the
+    // realistic footgun (`nmap -v &` without `>out.log 2>&1 &`).
+    const bg = await shell.execute(
+      "( while :; do echo spam-$RANDOM; done ) &",
+      3,
+    );
+    expect(bg.exitCode).toBe(0);
 
-      // Give the spammer a moment to write into the pipe.
-      await new Promise((r) => setTimeout(r, 500));
+    // Give the spammer a moment to write into the pipe.
+    await new Promise((r) => setTimeout(r, 500));
 
-      const quick = await shell.execute("echo fast", 3);
+    const quick = await shell.execute("echo fast", 3);
 
-      // Clean up the spammer before asserting so the shell is reusable.
-      await shell.execute(
-        "kill $(jobs -p) 2>/dev/null; wait 2>/dev/null; true",
-        3,
-      );
+    // Clean up the spammer before asserting so the shell is reusable.
+    await shell.execute(
+      "kill $(jobs -p) 2>/dev/null; wait 2>/dev/null; true",
+      3,
+    );
 
-      expect(quick.exitCode).toBe(0);
-      // The next command should see ONLY its own output, not a mountain of
-      // spam from the orphaned background loop.
-      expect(quick.stdout.includes("spam-")).toBe(false);
-    },
-    20_000,
-  );
+    expect(quick.exitCode).toBe(0);
+    // The next command should see ONLY its own output, not a mountain of
+    // spam from the orphaned background loop.
+    expect(quick.stdout.includes("spam-")).toBe(false);
+  }, 20_000);
 
   /**
-   * Repro #4 — `cd` does not persist across commands, contradicting the
-   * tool description that claims "environment variables, working directory
-   * (cd), and background processes survive across calls". Each command is
-   * wrapped in `( ... )` which runs in a subshell, so `cd` only affects the
-   * subshell.
+   * Repro #4 — `cd` persists across commands.
    *
-   * Not directly a "hang" cause, but it's the same root as the stability
-   * problems — the subshell wrapper hides state from the outer shell.
+   * Previously the wrapper ran every command inside `( ... )`, a subshell,
+   * which hid `cd`, `export`, shell functions, and option changes from the
+   * outer shell. The tool's own description told the model these would
+   * persist, so agents ran workflows that silently broke.
+   *
+   * The fix uses a brace group `{ ...; }` instead, which runs the command
+   * in the current shell. Same scoping rules as a normal bash script, so
+   * `cd`/`export`/etc. persist as advertised.
    */
-  it.fails("persists cd across commands (documented contract)", async () => {
+  it("persists cd and export across commands (documented contract)", async () => {
     const shell = make();
     const mk = await shell.execute(
       "mkdir -p /tmp/apex-persistent-shell-test-2ef1",
@@ -194,6 +189,56 @@ describe("PersistentShell — long-running stability", () => {
     const pwd = await shell.execute("pwd", 5);
     expect(pwd.exitCode).toBe(0);
     expect(pwd.stdout).toContain("/tmp/apex-persistent-shell-test-2ef1");
+
+    const exp = await shell.execute("export APEX_TEST_VAR=hello", 5);
+    expect(exp.exitCode).toBe(0);
+    const echo = await shell.execute('echo "$APEX_TEST_VAR"', 5);
+    expect(echo.exitCode).toBe(0);
+    expect(echo.stdout).toContain("hello");
+  });
+
+  /**
+   * Timeout still reports the documented sentinel (124) and kills the
+   * command's descendants, even though the shell's wrapper completes
+   * cleanly after the kill.
+   */
+  it("reports exit code 124 on timeout and kills descendants", async () => {
+    const shell = make();
+    const r = await shell.execute("sleep 30", 1);
+    expect(r.exitCode).toBe(124);
+
+    // Shell must still be responsive.
+    const after = await shell.execute("echo ok", 5);
+    expect(after.exitCode).toBe(0);
+    expect(after.stdout).toContain("ok");
+  }, 10_000);
+
+  /**
+   * Streaming callback still fires as output arrives, even though stdout
+   * is now routed through a per-command tempfile + `tail -f` rather than
+   * bash's raw stdout pipe.
+   */
+  it("streams stdout to onData as output arrives", async () => {
+    const shell = make();
+    const events: Array<{ t: number; text: string }> = [];
+    const t0 = Date.now();
+    const r = await shell.execute(
+      "echo line-a; sleep 0.3; echo line-b; sleep 0.3; echo line-c",
+      5,
+      (c) => events.push({ t: Date.now() - t0, text: c }),
+    );
+    expect(r.exitCode).toBe(0);
+    const joined = events.map((e) => e.text).join("");
+    expect(joined).toContain("line-a");
+    expect(joined).toContain("line-b");
+    expect(joined).toContain("line-c");
+    // The first chunk must arrive well before the last. If everything
+    // came in one block at the end, streaming is broken.
+    const firstA = events.find((e) => e.text.includes("line-a"));
+    const firstC = events.find((e) => e.text.includes("line-c"));
+    expect(firstA).toBeDefined();
+    expect(firstC).toBeDefined();
+    expect(firstC!.t - firstA!.t).toBeGreaterThan(200);
   });
 
   /**
@@ -205,36 +250,32 @@ describe("PersistentShell — long-running stability", () => {
    * within its timeout. This is the end-state the user described:
    * "after some time commands will just hang and timeout".
    */
-  it.fails(
-    "stays responsive after a mixed workload of 30 commands",
-    async () => {
-      const shell = make();
+  it("stays responsive after a mixed workload of 30 commands", async () => {
+    const shell = make();
 
-      for (let i = 0; i < 10; i++) {
-        const r = await shell.execute(`echo iter-${i}`, 5);
-        expect(r.exitCode).toBe(0);
-      }
+    for (let i = 0; i < 10; i++) {
+      const r = await shell.execute(`echo iter-${i}`, 5);
+      expect(r.exitCode).toBe(0);
+    }
 
-      // A couple of stdin-reading commands (get killed by timeout).
-      for (let i = 0; i < 2; i++) {
-        await shell.execute("cat", 2);
-      }
+    // A couple of stdin-reading commands (get killed by timeout).
+    for (let i = 0; i < 2; i++) {
+      await shell.execute("cat", 2);
+    }
 
-      // A background spammer.
-      await shell.execute("while :; do echo s-$RANDOM; done &", 3);
+    // A background spammer.
+    await shell.execute("while :; do echo s-$RANDOM; done &", 3);
 
-      // A timing-out pipeline.
-      await shell.execute("sleep 10 | cat", 2);
+    // A timing-out pipeline.
+    await shell.execute("sleep 10 | cat", 2);
 
-      // Final probe: trivial echo must succeed quickly.
-      const start = Date.now();
-      const final = await shell.execute("echo final", 5);
-      const elapsed = Date.now() - start;
+    // Final probe: trivial echo must succeed quickly.
+    const start = Date.now();
+    const final = await shell.execute("echo final", 5);
+    const elapsed = Date.now() - start;
 
-      expect(final.exitCode).toBe(0);
-      expect(final.stdout).toContain("final");
-      expect(elapsed).toBeLessThan(3_000);
-    },
-    60_000,
-  );
+    expect(final.exitCode).toBe(0);
+    expect(final.stdout).toContain("final");
+    expect(elapsed).toBeLessThan(3_000);
+  }, 60_000);
 });

--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { PersistentShell } from "./persistentShell";
+
+/**
+ * These tests document and reproduce the "shell eventually stops responding"
+ * class of bugs in PersistentShell. They are written as hang-repros: each test
+ * exercises a scenario a long-running pentest agent realistically hits, and
+ * asserts the contract the tool advertises.
+ *
+ * Several of these are EXPECTED TO FAIL against the current implementation.
+ * They are intentionally left failing so the bugs cannot be silently
+ * re-introduced once fixed. They use `it.fails(...)` so the suite stays green
+ * while clearly flagging the known-broken behavior.
+ */
+describe("PersistentShell — long-running stability", () => {
+  const shells: PersistentShell[] = [];
+  const make = () => {
+    const s = new PersistentShell();
+    shells.push(s);
+    return s;
+  };
+
+  afterEach(() => {
+    while (shells.length) {
+      try {
+        shells.pop()?.dispose();
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  it("basic smoke: sequential commands return quickly", async () => {
+    const shell = make();
+    const r1 = await shell.execute("echo one", 5);
+    expect(r1.exitCode).toBe(0);
+    expect(r1.stdout).toContain("one");
+
+    const r2 = await shell.execute("echo two", 5);
+    expect(r2.exitCode).toBe(0);
+    expect(r2.stdout).toContain("two");
+  });
+
+  /**
+   * Repro #1 — Stdin hijack by a child process.
+   *
+   * The shell's stdin pipe is shared with every child bash spawns. A command
+   * that reads from stdin (cat/ssh/sudo/python/mysql/read/...) will consume
+   * bytes that were meant for bash's own command parsing.
+   *
+   * After this command is killed by the timeout path, subsequent
+   * `execute()` calls should still work — but in practice they hang until
+   * their own timeout because:
+   *   - cat consumed part of bash's command buffer, or
+   *   - bash is still mid-way through the previous wrapped block.
+   *
+   * Agents hit this constantly after many commands because the model is
+   * prone to running things like `sudo ...` or `ssh ...` mid-pentest.
+   */
+  it.fails(
+    "stays responsive after a command that reads from stdin is killed",
+    async () => {
+      const shell = make();
+
+      const warm = await shell.execute("echo warm", 5);
+      expect(warm.exitCode).toBe(0);
+
+      // `cat` with no args blocks reading stdin. It inherits fd 0 from bash,
+      // which is the same pipe PersistentShell writes commands into.
+      const hung = await shell.execute("cat", 2);
+      expect(hung.exitCode).toBe(124);
+
+      // Subsequent command should return within a normal timeout.
+      const after = await shell.execute("echo after-cat", 5);
+      expect(after.exitCode).toBe(0);
+      expect(after.stdout).toContain("after-cat");
+    },
+    20_000,
+  );
+
+  /**
+   * Repro #2 — Process-group leak after timeout.
+   *
+   * `pkill -TERM -P <bashpid>` only reaps direct children of bash. For a
+   * pipeline (`a | b | c`) the workers are grandchildren of bash (children
+   * of the subshell), so they survive the timeout, become orphans, and keep
+   * their inherited fd 1 — feeding Repro #3 below.
+   *
+   * After the timeout, we should see no descendant processes still holding
+   * the shell's stdout pipe.
+   */
+  it.fails(
+    "cleans up pipeline grandchildren when a command times out",
+    async () => {
+      const shell = make();
+      // Prime the shell so we have a stable pid to probe.
+      await shell.execute("echo prime", 5);
+      const bashPid = (shell as unknown as { proc: { pid: number } }).proc.pid;
+      expect(bashPid).toBeGreaterThan(0);
+
+      // Pipeline: sleep is a grandchild of bash (child of the subshell).
+      const timed = await shell.execute("sleep 30 | cat", 2);
+      expect(timed.exitCode).toBe(124);
+
+      // Give pkill + the 1s drain window a moment.
+      await new Promise((r) => setTimeout(r, 1_500));
+
+      const { spawnSync } = await import("child_process");
+      const out = spawnSync(
+        "ps",
+        ["--ppid", String(bashPid), "-o", "pid=,comm="],
+        { encoding: "utf8" },
+      );
+      const remaining = (out.stdout || "")
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+      // No direct bash children should remain; none of them should be sleep.
+      expect(remaining.find((l) => l.includes("sleep"))).toBeUndefined();
+    },
+    20_000,
+  );
+
+  /**
+   * Repro #3 — Output from a backgrounded command bleeds into the next
+   * command's captured stdout.
+   *
+   * Background producers whose fd 1 wasn't redirected keep writing to bash's
+   * stdout pipe. Between `execute()` calls the `data` listener is removed,
+   * so buffered bytes land on the *next* command's `stdout` accumulator.
+   * The caller sees output they never asked for, and sufficiently chatty
+   * producers eventually push past the 5MB MAX_BUFFER and trip the
+   * "stdout = stdout.substring(stdout.length - MAX_BUFFER)" truncation —
+   * which, if a marker ever lands near the start, silently drops it and
+   * we wait for a marker that will never appear.
+   */
+  it.fails(
+    "does not leak background-process output into the next command's stdout",
+    async () => {
+      const shell = make();
+
+      // Background a generator whose fd 1 is NOT redirected. This is the
+      // realistic footgun (`nmap -v &` without `>out.log 2>&1 &`).
+      const bg = await shell.execute(
+        "( while :; do echo spam-$RANDOM; done ) &",
+        3,
+      );
+      expect(bg.exitCode).toBe(0);
+
+      // Give the spammer a moment to write into the pipe.
+      await new Promise((r) => setTimeout(r, 500));
+
+      const quick = await shell.execute("echo fast", 3);
+
+      // Clean up the spammer before asserting so the shell is reusable.
+      await shell.execute(
+        "kill $(jobs -p) 2>/dev/null; wait 2>/dev/null; true",
+        3,
+      );
+
+      expect(quick.exitCode).toBe(0);
+      // The next command should see ONLY its own output, not a mountain of
+      // spam from the orphaned background loop.
+      expect(quick.stdout.includes("spam-")).toBe(false);
+    },
+    20_000,
+  );
+
+  /**
+   * Repro #4 — `cd` does not persist across commands, contradicting the
+   * tool description that claims "environment variables, working directory
+   * (cd), and background processes survive across calls". Each command is
+   * wrapped in `( ... )` which runs in a subshell, so `cd` only affects the
+   * subshell.
+   *
+   * Not directly a "hang" cause, but it's the same root as the stability
+   * problems — the subshell wrapper hides state from the outer shell.
+   */
+  it.fails("persists cd across commands (documented contract)", async () => {
+    const shell = make();
+    const mk = await shell.execute(
+      "mkdir -p /tmp/apex-persistent-shell-test-2ef1",
+      5,
+    );
+    expect(mk.exitCode).toBe(0);
+
+    const cd = await shell.execute(
+      "cd /tmp/apex-persistent-shell-test-2ef1",
+      5,
+    );
+    expect(cd.exitCode).toBe(0);
+
+    const pwd = await shell.execute("pwd", 5);
+    expect(pwd.exitCode).toBe(0);
+    expect(pwd.stdout).toContain("/tmp/apex-persistent-shell-test-2ef1");
+  });
+
+  /**
+   * Repro #5 — The cumulative "agent ran for a while" simulation.
+   *
+   * After many commands — some of which read stdin, some of which
+   * background processes without redirecting fd 1, some of which use
+   * pipelines that time out — a trivial `echo` should still come back
+   * within its timeout. This is the end-state the user described:
+   * "after some time commands will just hang and timeout".
+   */
+  it.fails(
+    "stays responsive after a mixed workload of 30 commands",
+    async () => {
+      const shell = make();
+
+      for (let i = 0; i < 10; i++) {
+        const r = await shell.execute(`echo iter-${i}`, 5);
+        expect(r.exitCode).toBe(0);
+      }
+
+      // A couple of stdin-reading commands (get killed by timeout).
+      for (let i = 0; i < 2; i++) {
+        await shell.execute("cat", 2);
+      }
+
+      // A background spammer.
+      await shell.execute("while :; do echo s-$RANDOM; done &", 3);
+
+      // A timing-out pipeline.
+      await shell.execute("sleep 10 | cat", 2);
+
+      // Final probe: trivial echo must succeed quickly.
+      const start = Date.now();
+      const final = await shell.execute("echo final", 5);
+      const elapsed = Date.now() - start;
+
+      expect(final.exitCode).toBe(0);
+      expect(final.stdout).toContain("final");
+      expect(elapsed).toBeLessThan(3_000);
+    },
+    60_000,
+  );
+});

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -10,6 +10,24 @@ export interface ShellExecuteResult {
   exitCode: number;
 }
 
+interface PendingCommand {
+  stdout: string;
+  stderr: string;
+  stdoutTruncated: boolean;
+  exitMarkerPrefix: string;
+  onData?: (chunk: string) => void;
+  resolve: (result: ShellExecuteResult) => void;
+  /**
+   * When non-null, overrides whatever exit code bash reports via the
+   * marker. Set by the timeout / abort paths so the caller always sees
+   * the documented sentinel (124 for timeout, 130 for abort) even when
+   * bash's wrapper ran to completion after our kill.
+   */
+  forcedExitCode: number | null;
+  /** Extra stderr appended by abort/timeout paths. */
+  forcedStderrSuffix: string | null;
+}
+
 /**
  * A long-lived bash process that persists across execute_command calls.
  *
@@ -17,7 +35,42 @@ export interface ShellExecuteResult {
  * caller can extract per-command stdout, stderr, and the exit code.
  * Background processes (`&`) survive between calls because the parent
  * shell never exits.
+ *
+ * Stability design notes:
+ *
+ *  - User commands are wrapped in a brace group `{ ...; }` (NOT a subshell)
+ *    so that `cd`, `export`, shell functions, and aliases persist across
+ *    calls as advertised.
+ *  - The user command block has its stdin redirected from `/dev/null` so
+ *    that children that read stdin (cat/ssh/sudo/python/mysql/read/…)
+ *    cannot hijack the shared pipe that we use to send commands to bash.
+ *  - A single persistent `data` listener is attached to the shell's
+ *    stdout/stderr at spawn time. Between commands, incoming bytes (e.g.
+ *    from backgrounded processes whose fd1 was not redirected) are
+ *    actively drained into a discard buffer so the kernel pipe buffer
+ *    never fills and blocks the shell.
+ *  - On timeout / cancel we walk the process tree under the shell and
+ *    SIGTERM → SIGKILL every descendant (not just direct children), so
+ *    pipelines and grandchildren cannot be orphaned holding our pipe.
  */
+/**
+ * Cached once: whether `stdbuf` is available. We use it to line-buffer
+ * `tail -f` so command output streams to the caller in near-real-time.
+ * When it isn't available we fall back to raw `tail -f`, which still
+ * produces correct final output but in larger chunks.
+ */
+let stdbufAvailable: boolean | null = null;
+function hasStdbuf(): boolean {
+  if (stdbufAvailable !== null) return stdbufAvailable;
+  if (process.platform === "win32") {
+    stdbufAvailable = false;
+    return false;
+  }
+  const res = spawnSync("stdbuf", ["--version"], { stdio: "ignore" });
+  stdbufAvailable = res.status === 0;
+  return stdbufAvailable;
+}
+
 export class PersistentShell {
   private proc: ChildProcess | null = null;
   private alive = false;
@@ -25,11 +78,11 @@ export class PersistentShell {
   private readonly cwd?: string;
   private readonly extraEnv?: Record<string, string>;
 
+  /** Single pending command; null between `execute()` calls. */
+  private current: PendingCommand | null = null;
+
   /** Allows cancelCurrentCommand() to force-resolve the running execute(). */
   private pendingCancel: ((result: ShellExecuteResult) => void) | null = null;
-  /** Snapshot accessors set by execute(), read by cancelCurrentCommand(). */
-  private pendingStdout: (() => string) | null = null;
-  private pendingStderr: (() => string) | null = null;
 
   constructor(opts?: { cwd?: string; env?: Record<string, string> }) {
     this.cwd = opts?.cwd;
@@ -64,9 +117,24 @@ export class PersistentShell {
 
     this.alive = true;
 
+    this.proc.stdout?.on("data", (data: Buffer) => this.onStdoutData(data));
+    this.proc.stderr?.on("data", (data: Buffer) => this.onStderrData(data));
+
     this.proc.on("close", () => {
       this.alive = false;
       this.proc = null;
+      // If a command was pending, fail it fast rather than letting it
+      // wait out its timeout.
+      const cmd = this.current;
+      if (cmd) {
+        this.current = null;
+        this.pendingCancel = null;
+        cmd.resolve({
+          stdout: cmd.stdout || "(no output)",
+          stderr: cmd.stderr || "",
+          exitCode: 1,
+        });
+      }
     });
 
     this.proc.on("error", () => {
@@ -78,6 +146,77 @@ export class PersistentShell {
   private ensureAlive(): void {
     if (!this.alive || !this.proc) {
       this.spawn();
+    }
+  }
+
+  /**
+   * Single persistent stdout handler. Between commands (`current === null`)
+   * incoming bytes are silently dropped so background-process output does
+   * not fill the kernel pipe buffer and does not bleed into the next
+   * command's captured output.
+   */
+  private onStdoutData(data: Buffer): void {
+    const cmd = this.current;
+    if (!cmd) return;
+
+    const chunk = data.toString();
+    if (cmd.onData) {
+      const mIdx = chunk.indexOf(cmd.exitMarkerPrefix);
+      const visible = mIdx === -1 ? chunk : chunk.substring(0, mIdx);
+      if (visible.length > 0) cmd.onData(visible);
+    }
+    cmd.stdout += chunk;
+
+    const markerIdx = cmd.stdout.indexOf(cmd.exitMarkerPrefix);
+    if (markerIdx !== -1) {
+      const afterPrefix = cmd.stdout.substring(
+        markerIdx + cmd.exitMarkerPrefix.length,
+      );
+      const nlIdx = afterPrefix.indexOf("\n");
+      const exitStr =
+        nlIdx >= 0 ? afterPrefix.substring(0, nlIdx) : afterPrefix;
+      const naturalExitCode = parseInt(exitStr, 10);
+
+      let commandOutput = cmd.stdout.substring(0, markerIdx);
+      if (cmd.stdoutTruncated) {
+        commandOutput = "(stdout truncated)...\n" + commandOutput;
+      }
+
+      const effectiveExit =
+        cmd.forcedExitCode != null
+          ? cmd.forcedExitCode
+          : isNaN(naturalExitCode)
+            ? 1
+            : naturalExitCode;
+      const effectiveStderr = cmd.forcedStderrSuffix
+        ? (cmd.stderr || "") + cmd.forcedStderrSuffix
+        : cmd.stderr || "";
+
+      const resolve = cmd.resolve;
+      this.current = null;
+      this.pendingCancel = null;
+      resolve({
+        stdout: commandOutput || "(no output)",
+        stderr: effectiveStderr,
+        exitCode: effectiveExit,
+      });
+      return;
+    }
+
+    if (cmd.stdout.length > MAX_BUFFER) {
+      cmd.stdout = cmd.stdout.substring(cmd.stdout.length - MAX_BUFFER);
+      cmd.stdoutTruncated = true;
+    }
+  }
+
+  private onStderrData(data: Buffer): void {
+    const cmd = this.current;
+    if (!cmd) return;
+
+    cmd.stderr += data.toString();
+    if (cmd.stderr.length > MAX_BUFFER) {
+      cmd.stderr =
+        cmd.stderr.substring(0, MAX_BUFFER) + "...\n(stderr truncated)";
     }
   }
 
@@ -110,148 +249,122 @@ export class PersistentShell {
     const exitMarkerPrefix = `${marker}_EXIT_`;
 
     return new Promise<ShellExecuteResult>((resolve) => {
-      let stdout = "";
-      let stderr = "";
-      let stdoutTruncated = false;
       let resolved = false;
       let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+      let killEscalationTimer: ReturnType<typeof setTimeout> | undefined;
 
-      this.pendingStdout = () => stdout;
-      this.pendingStderr = () => stderr;
-
-      const safeResolve = (result: ShellExecuteResult) => {
-        if (resolved) return;
-        resolved = true;
-        this.pendingCancel = null;
-        this.pendingStdout = null;
-        this.pendingStderr = null;
-        if (timeoutTimer) clearTimeout(timeoutTimer);
-        if (abortCleanup) abortCleanup();
-        proc.stdout!.removeListener("data", onStdout);
-        proc.stderr!.removeListener("data", onStderr);
-        proc.removeListener("close", onClose);
-        resolve(result);
+      const pending: PendingCommand = {
+        stdout: "",
+        stderr: "",
+        stdoutTruncated: false,
+        exitMarkerPrefix,
+        onData,
+        forcedExitCode: null,
+        forcedStderrSuffix: null,
+        resolve: (result) => {
+          if (resolved) return;
+          resolved = true;
+          if (timeoutTimer) clearTimeout(timeoutTimer);
+          if (killEscalationTimer) clearTimeout(killEscalationTimer);
+          if (abortCleanup) abortCleanup();
+          resolve(result);
+        },
       };
 
-      this.pendingCancel = safeResolve;
+      this.current = pending;
+      this.pendingCancel = pending.resolve;
 
-      // Wire abort signal to cancel running command
       let abortCleanup: (() => void) | undefined;
       if (abortSignal) {
         const onAbort = () => {
           if (resolved) return;
-          const pid = proc.pid;
-          if (pid && process.platform !== "win32") {
-            try {
-              spawnSync("pkill", ["-TERM", "-P", pid.toString()], {
-                stdio: "ignore",
+          pending.forcedExitCode = 130;
+          pending.forcedStderrSuffix = pending.stderr
+            ? "\n(aborted)"
+            : "(aborted)";
+          killDescendants(proc.pid, "SIGTERM");
+          killEscalationTimer = setTimeout(() => {
+            if (resolved) return;
+            killDescendants(proc.pid, "SIGKILL");
+            // Fallback: if bash didn't emit a marker within another
+            // 2 seconds (shell wedged), resolve with whatever we have.
+            setTimeout(() => {
+              if (resolved) return;
+              pending.resolve({
+                stdout: pending.stdout || "(no output)",
+                stderr:
+                  (pending.stderr || "") + (pending.forcedStderrSuffix ?? ""),
+                exitCode: 130,
               });
-            } catch {
-              // pkill may not be available or no processes matched
-            }
-          }
-          setTimeout(() => {
-            safeResolve({
-              stdout: stdout || "(no output)",
-              stderr: stderr ? stderr + "\n(aborted)" : "(aborted)",
-              exitCode: 130,
-            });
+            }, 2_000);
           }, 500);
         };
         abortSignal.addEventListener("abort", onAbort, { once: true });
         abortCleanup = () => abortSignal.removeEventListener("abort", onAbort);
       }
 
-      const onStdout = (data: Buffer) => {
-        const chunk = data.toString();
-        if (onData && !chunk.includes(exitMarkerPrefix)) {
-          onData(chunk);
-        }
-        stdout += chunk;
-
-        const markerIdx = stdout.indexOf(exitMarkerPrefix);
-        if (markerIdx !== -1) {
-          const afterPrefix = stdout.substring(
-            markerIdx + exitMarkerPrefix.length,
-          );
-          const nlIdx = afterPrefix.indexOf("\n");
-          const exitStr =
-            nlIdx >= 0 ? afterPrefix.substring(0, nlIdx) : afterPrefix;
-          const exitCode = parseInt(exitStr, 10);
-
-          let commandOutput = stdout.substring(0, markerIdx);
-          if (stdoutTruncated) {
-            commandOutput = "(stdout truncated)...\n" + commandOutput;
-          }
-
-          safeResolve({
-            stdout: commandOutput || "(no output)",
-            stderr: stderr || "",
-            exitCode: isNaN(exitCode) ? 1 : exitCode,
-          });
-          return;
-        }
-
-        if (stdout.length > MAX_BUFFER) {
-          stdout = stdout.substring(stdout.length - MAX_BUFFER);
-          stdoutTruncated = true;
-        }
-      };
-
-      const onStderr = (data: Buffer) => {
-        stderr += data.toString();
-        if (stderr.length > MAX_BUFFER) {
-          stderr = stderr.substring(0, MAX_BUFFER) + "...\n(stderr truncated)";
-        }
-      };
-
-      proc.stdout!.on("data", onStdout);
-      proc.stderr!.on("data", onStderr);
-
-      const onClose = () => {
-        safeResolve({
-          stdout: stdout || "(no output)",
-          stderr: stderr || "",
-          exitCode: 1,
-        });
-      };
-      proc.once("close", onClose);
-
       if (timeoutSeconds != null && timeoutSeconds > 0) {
         timeoutTimer = setTimeout(() => {
           if (resolved) return;
-          // Kill child processes of the bash shell using signals.
-          // Writing to stdin doesn't work because bash is blocked on the
-          // foreground command and won't read stdin until it completes.
-          const pid = proc.pid;
-          if (pid && process.platform !== "win32") {
-            try {
-              spawnSync("pkill", ["-TERM", "-P", pid.toString()], {
-                stdio: "ignore",
+          pending.forcedExitCode = 124;
+          // Kill every descendant of the shell, not just direct children:
+          // pipelines and nested subshells are grandchildren and `pkill -P`
+          // would leak them.
+          killDescendants(proc.pid, "SIGTERM");
+          killEscalationTimer = setTimeout(() => {
+            if (resolved) return;
+            killDescendants(proc.pid, "SIGKILL");
+            // Fallback: if bash didn't emit a marker within another
+            // 2 seconds (shell wedged), resolve with whatever we have.
+            setTimeout(() => {
+              if (resolved) return;
+              pending.resolve({
+                stdout: pending.stdout || "(no output)",
+                stderr: pending.stderr || "",
+                exitCode: 124,
               });
-            } catch {
-              // pkill may not be available or no processes matched
-            }
-          }
-          setTimeout(() => {
-            safeResolve({
-              stdout: stdout || "(no output)",
-              stderr: stderr || "",
-              exitCode: 124,
-            });
-          }, 1_000);
+            }, 2_000);
+          }, 500);
         }, timeoutSeconds * 1_000);
       }
 
-      // Wrap command: capture stderr to temp file, echo exit marker on stdout.
-      // The subshell (...) isolates the command so `set -e` etc. don't kill
-      // our marker echo, and stderr redirection is clean.
+      // Wrap command:
+      //   - brace group `{ ...; }` (NOT a subshell) so `cd`, `export`,
+      //     shell functions, aliases, and option changes persist;
+      //   - stdin redirected from `/dev/null` so children that read stdin
+      //     cannot hijack our command pipe;
+      //   - stdout captured to a per-command tempfile (NOT bash's stdout
+      //     pipe) and streamed back via a background `tail -f`. This
+      //     prevents backgrounded children whose fd 1 was never redirected
+      //     (`nmap -v &`) from bleeding their output into the next
+      //     command's captured stdout, because their inherited fd 1 is
+      //     the tempfile for the command that spawned them, not the
+      //     shell's stdout pipe;
+      //   - stderr captured to another tempfile and flushed after, so we
+      //     can distinguish stdout from stderr without interleaving;
+      //   - the exit marker is echoed on bash's real stdout pipe, so the
+      //     parent Node handler always sees it immediately regardless of
+      //     how much command output the tail has left to flush.
+      // Fast-polling `tail -f -s 0.05` line-buffered via `stdbuf -oL`
+      // streams output as it is produced (well under 100 ms latency per
+      // chunk) while keeping the per-command tempfile isolation that
+      // prevents background-process output bleeding across commands.
+      const tailCmd = hasStdbuf()
+        ? `stdbuf -oL tail -n +1 -f -s 0.05 "$__APEX_OUT"`
+        : `tail -n +1 -f -s 0.05 "$__APEX_OUT"`;
       const wrapped = [
+        `__APEX_OUT=$(mktemp 2>/dev/null || echo /tmp/.apex_out_$$)`,
         `__APEX_ERR=$(mktemp 2>/dev/null || echo /tmp/.apex_err_$$)`,
-        `( ${command} ) 2>"$__APEX_ERR"`,
+        `${tailCmd} 2>/dev/null &`,
+        `__APEX_TAIL=$!`,
+        `{ ${command}\n} </dev/null >"$__APEX_OUT" 2>"$__APEX_ERR"`,
         `__APEX_EC=$?`,
+        // Let tail drain any remaining bytes before we kill it.
+        `sleep 0.1`,
+        `kill "$__APEX_TAIL" 2>/dev/null`,
+        `wait "$__APEX_TAIL" 2>/dev/null`,
         `cat "$__APEX_ERR" >&2`,
-        `rm -f "$__APEX_ERR"`,
+        `rm -f "$__APEX_OUT" "$__APEX_ERR"`,
         `echo "${exitMarkerPrefix}$__APEX_EC"`,
         ``,
       ].join("\n");
@@ -259,7 +372,7 @@ export class PersistentShell {
       try {
         proc.stdin!.write(wrapped);
       } catch {
-        safeResolve({
+        pending.resolve({
           stdout: "",
           stderr: "Failed to write to shell stdin",
           exitCode: 1,
@@ -273,36 +386,34 @@ export class PersistentShell {
    * Returns true if a command was running and was cancelled.
    */
   cancelCurrentCommand(): boolean {
-    if (!this.pendingCancel || !this.proc) return false;
+    const cmd = this.current;
+    if (!cmd || !this.proc) return false;
 
-    const cancel = this.pendingCancel;
-    const stdout = this.pendingStdout?.() ?? "";
-    const stderr = this.pendingStderr?.() ?? "";
+    cmd.forcedExitCode = 130;
+    cmd.forcedStderrSuffix = cmd.stderr
+      ? "\n(cancelled by user)"
+      : "(cancelled by user)";
 
-    // Kill child processes of the bash shell using signals.
-    // Writing to stdin doesn't work because bash is blocked on the
-    // foreground command and won't read stdin until it completes.
-    const pid = this.proc.pid;
-    if (pid && process.platform !== "win32") {
-      try {
-        spawnSync("pkill", ["-TERM", "-P", pid.toString()], {
-          stdio: "ignore",
-        });
-      } catch {
-        // pkill may not be available or no processes matched
-      }
-    }
-
-    // Give the process a moment to die, then force-resolve with partial output
-    setTimeout(() => {
-      cancel({
-        stdout: stdout || "(no output)",
-        stderr: stderr
-          ? stderr + "\n(cancelled by user)"
-          : "(cancelled by user)",
+    if (this.proc.pid && process.platform !== "win32") {
+      killDescendants(this.proc.pid, "SIGTERM");
+      setTimeout(() => {
+        if (this.proc?.pid) killDescendants(this.proc.pid, "SIGKILL");
+        // Fallback resolve if bash's wrapper never emits a marker.
+        setTimeout(() => {
+          cmd.resolve({
+            stdout: cmd.stdout || "(no output)",
+            stderr: (cmd.stderr || "") + (cmd.forcedStderrSuffix ?? ""),
+            exitCode: 130,
+          });
+        }, 2_000);
+      }, 500);
+    } else {
+      cmd.resolve({
+        stdout: cmd.stdout || "(no output)",
+        stderr: (cmd.stderr || "") + (cmd.forcedStderrSuffix ?? ""),
         exitCode: 130,
       });
-    }, 500);
+    }
 
     return true;
   }
@@ -354,5 +465,50 @@ export class PersistentShell {
 
     this.alive = false;
     this.proc = null;
+  }
+}
+
+/**
+ * Walk the process tree under `rootPid` and send `signal` to every
+ * descendant (deepest first). Does NOT signal `rootPid` itself — that's
+ * the persistent shell we want to keep alive. Used instead of
+ * `pkill -P <pid>`, which only hits direct children and so leaks
+ * pipeline stages / grandchildren of timed-out commands.
+ */
+function killDescendants(
+  rootPid: number | undefined,
+  signal: NodeJS.Signals,
+): void {
+  if (!rootPid || process.platform === "win32") return;
+
+  const toKill: number[] = [];
+  const queue = [rootPid];
+
+  while (queue.length > 0) {
+    const pid = queue.shift()!;
+    try {
+      const res = spawnSync("pgrep", ["-P", String(pid)], { encoding: "utf8" });
+      if (res.status === 0 && res.stdout) {
+        for (const line of res.stdout.split("\n")) {
+          const child = parseInt(line, 10);
+          if (Number.isFinite(child) && child > 0) {
+            toKill.push(child);
+            queue.push(child);
+          }
+        }
+      }
+    } catch {
+      // pgrep not available; nothing we can do
+    }
+  }
+
+  // Signal leaves first so intermediate processes don't see a dead child
+  // and exit before we get to their siblings.
+  for (let i = toKill.length - 1; i >= 0; i--) {
+    try {
+      process.kill(toKill[i], signal);
+    } catch {
+      // already dead / permission denied
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes the "commands eventually hang and timeout" behavior in the persistent bash used by `execute_command`, and lands the regression suite that reproduces each root cause.

#### Root causes addressed

1. **Stdin hijack.** Commands that read stdin (`cat`/`ssh`/`sudo`/`mysql`/`read`/…) used to consume bytes meant for bash's own command parsing, wedging the shell for every subsequent call. Each user command now has its stdin redirected from `/dev/null`, so stdin readers see EOF instantly and cannot hijack our command pipe.
2. **`cd` / `export` did not persist.** The wrapper ran commands in a `( … )` subshell, dropping `cd`, `export`, shell functions, and aliases — directly contradicting the tool description. Replaced with a brace group `{ …; }` so the command runs in the outer shell with normal bash scoping.
3. **Pipeline grandchildren leaked on timeout.** `pkill -TERM -P <bash>` only reaps direct children, so `a | b | c` or `timeout … foo` orphaned grandchildren that kept holding fd 1. Replaced with a recursive descendant walk (`pgrep -P` tree, deepest-first) plus a TERM→KILL escalation on every timeout / abort / cancel.
4. **Background output bled into the next command's captured stdout.** Backgrounded children whose fd 1 wasn't redirected kept writing to bash's stdout pipe; the prior code removed its `data` listener between calls so bytes piled up and were attributed to the next command. Each command now has its own per-invocation tempfile for stdout (and stderr), streamed in near-real-time via `stdbuf -oL tail -n +1 -f -s 0.05`. Orphaned writers from a prior command target the prior command's (since-removed) tempfile and cannot pollute later commands.
5. **Documented timeout sentinel is preserved.** `124` on timeout / `130` on abort+cancel are now always surfaced via a `forcedExitCode` + `forcedStderrSuffix` override on the marker-based resolution path, even when bash's wrapper runs to completion after our kill. A 2 s fallback still fires in case bash wedges entirely.
6. **Deterministic listener lifecycle.** A single persistent stdout/stderr listener is attached at spawn time; bytes are dropped when no command is pending. This prevents `MaxListenersExceededWarning` and ensures the shell's `close` event fails any in-flight command immediately instead of waiting out its timeout.

#### Tests

- `src/core/agents/offSecAgent/tools/persistentShell.test.ts` — originally landed with `it.fails(...)` to document the bugs; now flipped to plain `it(...)` and locks in the fixed contract. Two cases added: (a) `124` on timeout and (b) real-time `onData` streaming (chunks must arrive with measurable time between `line-a` and `line-c`, not in one end-of-command blob).

### How did you verify your code works?

- ✅ `bun run test src/core/agents/offSecAgent/tools/persistentShell.test.ts` — 8/8 green.
- ✅ `bun run test` — 740 passed, 15 skipped, 0 failed.
- ✅ `bun run lint`.
- ✅ `bunx prettier --check` on the two changed files.
- ✅ `bun run tsc` on the two changed files (no errors on these files; the pre-existing `PasteEvent.text` errors in `src/tui/**` also reproduce on plain `canary` and are unrelated).

Process-driven testing is the right evidence here because every root cause is directly observable from the tool surface: stdin-reading commands no longer hang, `cd`/`export` persist, pipelines leave no orphans, and background spam no longer bleeds between calls. All are asserted end-to-end by the vitest suite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10c11b9e-1072-48b4-b6c8-1345fbff2ef1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10c11b9e-1072-48b4-b6c8-1345fbff2ef1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

