### PR TITLE
fix: abort stalled Pensar SSE streams on idle timeout

### DIFF
--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -259,12 +259,21 @@ export function createPensarModel(
 
       log(`  headers: ${Object.keys(headers).join(", ")}`);
 
+      // Bun's fetch has a 300-second default timeout that can't be disabled
+      // via AbortSignal. Wrap with an explicit 1-hour timeout so long-running
+      // streaming responses aren't killed by the runtime before the model
+      // finishes. Mirrors the Bedrock provider in `utils.ts`.
+      const longTimeout = AbortSignal.timeout(60 * 60 * 1000);
+      const fetchSignal = options.abortSignal
+        ? AbortSignal.any([options.abortSignal, longTimeout])
+        : longTimeout;
+
       let response: Response;
       try {
         response = await fetch(url, {
           method: "POST",
           headers,
-          signal: options.abortSignal,
+          signal: fetchSignal,
           body: serializedBody,
         });
       } catch (err) {
@@ -347,8 +356,11 @@ export function createPensarModel(
 
           let eventCount = 0;
           let lastEventTime = Date.now();
+          const idleTimeoutMs = Number(
+            process.env.PENSAR_SSE_IDLE_TIMEOUT_MS ?? 90_000,
+          );
           try {
-            for await (const sse of parseSSE(sseStream)) {
+            for await (const sse of parseSSE(sseStream, { idleTimeoutMs })) {
               const now = Date.now();
               const gap = now - lastEventTime;
               if (gap > 5000) {

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -10,6 +10,7 @@ import type {
 import { convertToBedrockFormat } from "./pensarFormatters";
 import { parseSSE } from "./pensarSSE";
 import { signGatewayRequest } from "./pensarSigning";
+import { buildStreamingFetchSignal } from "../utils";
 
 const DEBUG =
   process.env.PENSAR_DEBUG === "1" || process.env.PENSAR_DEBUG === "true";
@@ -259,14 +260,7 @@ export function createPensarModel(
 
       log(`  headers: ${Object.keys(headers).join(", ")}`);
 
-      // Bun's fetch has a 300-second default timeout that can't be disabled
-      // via AbortSignal. Wrap with an explicit 15-minute timeout so
-      // long-running streaming responses aren't killed by the runtime before
-      // the model finishes. Mirrors the Bedrock provider in `utils.ts`.
-      const longTimeout = AbortSignal.timeout(15 * 60 * 1000);
-      const fetchSignal = options.abortSignal
-        ? AbortSignal.any([options.abortSignal, longTimeout])
-        : longTimeout;
+      const fetchSignal = buildStreamingFetchSignal(options.abortSignal);
 
       let response: Response;
       try {

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -350,9 +350,11 @@ export function createPensarModel(
 
           let eventCount = 0;
           let lastEventTime = Date.now();
-          const idleTimeoutMs = Number(
-            process.env.PENSAR_SSE_IDLE_TIMEOUT_MS ?? 90_000,
-          );
+          const rawIdleTimeout = Number(process.env.PENSAR_SSE_IDLE_TIMEOUT_MS);
+          const idleTimeoutMs =
+            Number.isFinite(rawIdleTimeout) && rawIdleTimeout > 0
+              ? rawIdleTimeout
+              : 90_000;
           try {
             for await (const sse of parseSSE(sseStream, { idleTimeoutMs })) {
               const now = Date.now();

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -260,10 +260,10 @@ export function createPensarModel(
       log(`  headers: ${Object.keys(headers).join(", ")}`);
 
       // Bun's fetch has a 300-second default timeout that can't be disabled
-      // via AbortSignal. Wrap with an explicit 1-hour timeout so long-running
-      // streaming responses aren't killed by the runtime before the model
-      // finishes. Mirrors the Bedrock provider in `utils.ts`.
-      const longTimeout = AbortSignal.timeout(60 * 60 * 1000);
+      // via AbortSignal. Wrap with an explicit 15-minute timeout so
+      // long-running streaming responses aren't killed by the runtime before
+      // the model finishes. Mirrors the Bedrock provider in `utils.ts`.
+      const longTimeout = AbortSignal.timeout(15 * 60 * 1000);
       const fetchSignal = options.abortSignal
         ? AbortSignal.any([options.abortSignal, longTimeout])
         : longTimeout;

--- a/src/core/ai/providers/pensarSSE.test.ts
+++ b/src/core/ai/providers/pensarSSE.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { parseSSE } from "./pensarSSE";
+
+describe("parseSSE", () => {
+  it("yields events from a well-formed stream", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode('event: message\ndata: {"type":"a"}\n\n'),
+        );
+        controller.enqueue(
+          encoder.encode('event: message\ndata: {"type":"b"}\n\n'),
+        );
+        controller.close();
+      },
+    });
+
+    const events = [];
+    for await (const evt of parseSSE(stream)) {
+      events.push(evt);
+    }
+
+    expect(events).toEqual([
+      { event: "message", data: '{"type":"a"}' },
+      { event: "message", data: '{"type":"b"}' },
+    ]);
+  });
+
+  it("aborts with a descriptive error if the reader stalls past idleTimeoutMs", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start() {
+        // Never enqueues or closes — simulates a stalled upstream.
+      },
+    });
+
+    const start = Date.now();
+    let caught: unknown;
+    try {
+      for await (const _ of parseSSE(stream, { idleTimeoutMs: 100 })) {
+        // unreachable
+      }
+    } catch (err) {
+      caught = err;
+    }
+    const elapsed = Date.now() - start;
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/idle for 100ms/);
+    expect(elapsed).toBeGreaterThanOrEqual(90);
+    expect(elapsed).toBeLessThan(2_000);
+  });
+
+  it("resets the idle timer on each chunk", async () => {
+    const encoder = new TextEncoder();
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        controller = c;
+      },
+    });
+
+    const consume = (async () => {
+      const events = [];
+      for await (const evt of parseSSE(stream, { idleTimeoutMs: 150 })) {
+        events.push(evt);
+      }
+      return events;
+    })();
+
+    // Emit a chunk every 75ms — below the 150ms idle threshold, so no timeout should fire.
+    for (let i = 0; i < 4; i++) {
+      await new Promise((r) => setTimeout(r, 75));
+      controller.enqueue(
+        encoder.encode(`event: message\ndata: {"i":${i}}\n\n`),
+      );
+    }
+    controller.close();
+
+    const events = await consume;
+    expect(events).toHaveLength(4);
+  });
+});

--- a/src/core/ai/providers/pensarSSE.ts
+++ b/src/core/ai/providers/pensarSSE.ts
@@ -11,9 +11,20 @@ export interface SSEEvent {
   data: string;
 }
 
+export interface ParseSSEOptions {
+  /**
+   * Abort if no bytes arrive from the underlying reader for this many ms.
+   * Prevents indefinite hangs when the upstream gateway stalls mid-stream.
+   * Default: 90_000.
+   */
+  idleTimeoutMs?: number;
+}
+
 export async function* parseSSE(
   stream: ReadableStream<Uint8Array>,
+  options: ParseSSEOptions = {},
 ): AsyncGenerator<SSEEvent> {
+  const idleTimeoutMs = options.idleTimeoutMs ?? 90_000;
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
@@ -25,8 +36,27 @@ export async function* parseSSE(
 
   try {
     while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const idlePromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(
+            new Error(
+              `SSE stream idle for ${idleTimeoutMs}ms (${chunkCount} chunks, ${eventCount} events received so far)`,
+            ),
+          );
+        }, idleTimeoutMs);
+      });
+
+      let result: Awaited<ReturnType<typeof reader.read>>;
+      try {
+        result = await Promise.race([reader.read(), idlePromise]);
+      } catch (err) {
+        await reader.cancel(err).catch(() => {});
+        throw err;
+      } finally {
+        if (timeoutId) clearTimeout(timeoutId);
+      }
+      if (result.done) {
         console.error(
           `[parseSSE] stream done: ${chunkCount} chunks, ${totalBytes} bytes, ${eventCount} events yielded, remaining buffer=${buffer.length} chars`,
         );
@@ -36,6 +66,7 @@ export async function* parseSSE(
         break;
       }
 
+      const value = result.value;
       chunkCount++;
       totalBytes += value.byteLength;
       const decoded = decoder.decode(value, { stream: true });

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -31,6 +31,20 @@ export function isAnthropicProvider(model: AIModel): boolean {
   );
 }
 
+/**
+ * Bun's fetch has a 300-second default timeout that can't be disabled via
+ * AbortSignal. Providers streaming long model responses need a wider ceiling;
+ * this helper composes a 15-minute timeout with any caller-provided signal.
+ */
+const STREAMING_FETCH_TIMEOUT_MS = 15 * 60 * 1000;
+
+export function buildStreamingFetchSignal(
+  callerSignal?: AbortSignal | null,
+): AbortSignal {
+  const timeout = AbortSignal.timeout(STREAMING_FETCH_TIMEOUT_MS);
+  return callerSignal ? AbortSignal.any([callerSignal, timeout]) : timeout;
+}
+
 export type AIAuthConfig = {
   openAiAPIKey?: string;
   anthropicAPIKey?: string;
@@ -154,16 +168,11 @@ export function getProviderModel(
     }
 
     case "bedrock": {
-      // Bun's fetch has a 300-second default timeout that can't be disabled
-      // via AbortSignal. Pass a custom fetch that explicitly sets a 15-minute
-      // timeout to support long-running streaming requests at large context sizes.
-      const bedrockFetch = (input: RequestInfo | URL, init?: RequestInit) => {
-        const longTimeout = AbortSignal.timeout(15 * 60 * 1000);
-        const signal = init?.signal
-          ? AbortSignal.any([init.signal, longTimeout])
-          : longTimeout;
-        return globalThis.fetch(input, { ...init, signal });
-      };
+      const bedrockFetch = (input: RequestInfo | URL, init?: RequestInit) =>
+        globalThis.fetch(input, {
+          ...init,
+          signal: buildStreamingFetchSignal(init?.signal),
+        });
       const bedrock = createAmazonBedrock({
         apiKey: bedrockApiKey,
         region: bedrockRegion,

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -34,9 +34,9 @@ export function isAnthropicProvider(model: AIModel): boolean {
 /**
  * Bun's fetch has a 300-second default timeout that can't be disabled via
  * AbortSignal. Providers streaming long model responses need a wider ceiling;
- * this helper composes a 15-minute timeout with any caller-provided signal.
+ * this helper composes a 1-hour timeout with any caller-provided signal.
  */
-const STREAMING_FETCH_TIMEOUT_MS = 15 * 60 * 1000;
+const STREAMING_FETCH_TIMEOUT_MS = 60 * 60 * 1000;
 
 export function buildStreamingFetchSignal(
   callerSignal?: AbortSignal | null,

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -31,15 +31,7 @@ export function isAnthropicProvider(model: AIModel): boolean {
   );
 }
 
-/**
- * Bun's fetch has a 300-second default timeout that can't be disabled via
- * AbortSignal. Providers streaming long model responses need a wider ceiling;
- * this helper composes a 15-minute timeout with any caller-provided signal.
- * 15 minutes is tight enough to signal infrastructure failure (Lambda Function
- * URL's hard cap is also 15m) while comfortably covering any single streaming
- * response. The 90s SSE idle timeout is the primary guard against stalls;
- * this outer fetch timeout is a last-resort backstop.
- */
+// Last-resort backstop above Bun's 300s fetch default; SSE idle timeout is the primary stall guard.
 const STREAMING_FETCH_TIMEOUT_MS = 15 * 60 * 1000;
 
 export function buildStreamingFetchSignal(

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -34,9 +34,13 @@ export function isAnthropicProvider(model: AIModel): boolean {
 /**
  * Bun's fetch has a 300-second default timeout that can't be disabled via
  * AbortSignal. Providers streaming long model responses need a wider ceiling;
- * this helper composes a 1-hour timeout with any caller-provided signal.
+ * this helper composes a 15-minute timeout with any caller-provided signal.
+ * 15 minutes is tight enough to signal infrastructure failure (Lambda Function
+ * URL's hard cap is also 15m) while comfortably covering any single streaming
+ * response. The 90s SSE idle timeout is the primary guard against stalls;
+ * this outer fetch timeout is a last-resort backstop.
  */
-const STREAMING_FETCH_TIMEOUT_MS = 60 * 60 * 1000;
+const STREAMING_FETCH_TIMEOUT_MS = 15 * 60 * 1000;
 
 export function buildStreamingFetchSignal(
   callerSignal?: AbortSignal | null,

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -155,10 +155,10 @@ export function getProviderModel(
 
     case "bedrock": {
       // Bun's fetch has a 300-second default timeout that can't be disabled
-      // via AbortSignal. Pass a custom fetch that explicitly sets a 1-hour
+      // via AbortSignal. Pass a custom fetch that explicitly sets a 15-minute
       // timeout to support long-running streaming requests at large context sizes.
       const bedrockFetch = (input: RequestInfo | URL, init?: RequestInit) => {
-        const longTimeout = AbortSignal.timeout(60 * 60 * 1000);
+        const longTimeout = AbortSignal.timeout(15 * 60 * 1000);
         const signal = init?.signal
           ? AbortSignal.any([init.signal, longTimeout])
           : longTimeout;


### PR DESCRIPTION
Large tool calls (like the threat-model skill emitting thousands of lines in a single create_file) could hang indefinitely — the Pensar gateway stops emitting SSE chunks mid-stream and parseSSE had no idle timeout, so reader.read() blocked until Bun's TCP timeout eventually closed the socket ~2 min later with stop_reason=other and zero output tokens.

parseSSE now races each reader.read() against a 90s idle timer (PENSAR_SSE_IDLE_TIMEOUT_MS overrides), cancels the reader on stall, and surfaces a descriptive error. The fetch also gets a 1h AbortSignal mirroring the Bedrock provider in utils.ts.

The underlying cause is server-side — Lambda Function URLs drop idle streaming connections and Bedrock pauses emitting bytes during long generations. The correct long-term fix is SSE keepalive frames from the gateway; tracking that separately. This PR is the client-side safety net so users see an actionable error in ~90s instead of a silent 2-minute hang.

Refs #622

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes streaming control flow for Pensar/Bedrock by adding idle timeouts and new fetch abort signals; misconfiguration or edge cases could cause premature stream termination.
> 
> **Overview**
> Prevents Pensar streaming requests from hanging indefinitely by adding an *idle read timeout* to `parseSSE` (default 90s, configurable via `PENSAR_SSE_IDLE_TIMEOUT_MS`) that cancels the reader and throws a descriptive error when no bytes arrive.
> 
> Unifies streaming fetch timeouts via new `buildStreamingFetchSignal()` (15-minute backstop) and applies it to both the Pensar gateway fetch and the Bedrock provider’s custom fetch wrapper.
> 
> Adds focused `vitest` coverage for `parseSSE` event parsing and the new idle-timeout/reset behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dc46a75e52f37bf0056d81694f49937b3704cf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->