### PR TITLE
Rename /auth command to /login with toast notification for expired tokens

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -60,7 +60,7 @@ navigation:
             path: ./docs/commands/operator.mdx
           - page: /threat-model
             path: ./docs/commands/threat-model.mdx
-          - page: /auth
+          - page: /login
             path: ./docs/commands/auth.mdx
           - page: /models
             path: ./docs/commands/models.mdx
@@ -86,7 +86,7 @@ navigation:
             path: ./docs/cli/targeted-pentest.mdx
           - page: pensar threat-model
             path: ./docs/cli/threat-model.mdx
-          - page: pensar auth
+          - page: pensar login
             path: ./docs/cli/auth.mdx
           - page: pensar projects
             path: ./docs/cli/projects.mdx

--- a/fern/docs/cli/auth.mdx
+++ b/fern/docs/cli/auth.mdx
@@ -1,31 +1,36 @@
 ---
-title: "pensar auth"
+title: "pensar login"
 description: "Connect to Pensar Console from the command line"
 ---
 
 ## Overview
 
-The `pensar auth` command connects your CLI to [Pensar Console](https://console.pensar.dev) for managed inference. This is the headless equivalent of the TUI [`/auth`](/apex/commands/auth) command — it uses the same device authorization flow but runs entirely in the terminal without the TUI.
+The `pensar login` command connects your CLI to [Pensar Console](https://console.pensar.dev) for managed inference. This is the headless equivalent of the TUI [`/login`](/apex/commands/auth) command — it uses the same device authorization flow but runs entirely in the terminal without the TUI.
+
+<Note>
+  The `pensar auth` command still works as an alias for backward compatibility, but `pensar login` is now the primary command name.
+</Note>
 
 ## Usage
 
 ```bash
-pensar auth [subcommand]
+pensar login [subcommand]
 ```
 
 ## Subcommands
 
-| Subcommand           | Description                                              |
-| -------------------- | -------------------------------------------------------- |
-| `pensar auth`        | Start the login flow (or show status if already connected) |
-| `pensar auth login`  | Start the login flow                                     |
-| `pensar auth logout` | Disconnect from Pensar Console                           |
-| `pensar auth status` | Show current connection status                           |
+| Subcommand            | Description                                              |
+| --------------------- | -------------------------------------------------------- |
+| `pensar login`        | Start the login flow (or show status if already connected) |
+| `pensar login status` | Show current connection status                           |
+| `pensar login logout` | Disconnect from Pensar Console                           |
+
+The legacy `pensar auth` command and subcommands still work for backward compatibility.
 
 ## Login Flow
 
 ```bash
-pensar auth login
+pensar login
 ```
 
 1. Apex requests a device code from the Pensar authentication service
@@ -34,12 +39,12 @@ pensar auth login
 4. Select a workspace (if your account has multiple)
 5. Apex stores the auth tokens locally
 
-If you're already connected, `pensar auth` will show your current status and offer to reconnect.
+If you're already connected, `pensar login` will show your current status and offer to reconnect.
 
 ## Checking Status
 
 ```bash
-pensar auth status
+pensar login status
 ```
 
 Displays your auth type (WorkOS or API key) and current workspace. When using API key auth, the command resolves your workspace from the server if it isn't already stored locally.
@@ -53,18 +58,18 @@ Displays your auth type (WorkOS or API key) and current workspace. When using AP
 ## Logging Out
 
 ```bash
-pensar auth logout
+pensar login logout
 ```
 
-Clears stored authentication tokens from your local configuration. You can reconnect at any time by running `pensar auth login` again.
+Clears stored authentication tokens from your local configuration. You can reconnect at any time by running `pensar login` again.
 
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/auth" icon="shield-check" href="/apex/commands/auth">
+  <Card title="/login" icon="shield-check" href="/apex/commands/auth">
     Connect via the TUI with the same device flow
   </Card>
   <Card title="pensar projects" icon="folder" href="/apex/cli/projects">
-    List workspace projects (requires auth)
+    List workspace projects (requires login)
   </Card>
 </CardGroup>

--- a/fern/docs/cli/fixes.mdx
+++ b/fern/docs/cli/fixes.mdx
@@ -16,7 +16,7 @@ pensar fixes get <fixId>       # Get fix details (includes diff)
 
 ## Prerequisites
 
-You must be connected to Pensar Console via [`pensar auth login`](/apex/cli/auth) before using this command.
+You must be connected to Pensar Console via [`pensar login`](/apex/cli/auth) before using this command.
 
 ## Subcommands
 

--- a/fern/docs/cli/issues.mdx
+++ b/fern/docs/cli/issues.mdx
@@ -17,7 +17,7 @@ pensar issues update <issueId> [options]       # Update an issue
 
 ## Prerequisites
 
-You must be connected to Pensar Console via [`pensar auth login`](/apex/cli/auth) before using this command.
+You must be connected to Pensar Console via [`pensar login`](/apex/cli/auth) before using this command.
 
 ## Subcommands
 

--- a/fern/docs/cli/logs.mdx
+++ b/fern/docs/cli/logs.mdx
@@ -16,7 +16,7 @@ pensar logs search <issueId> <query> [options]  # Search agent logs
 
 ## Prerequisites
 
-You must be connected to Pensar Console via [`pensar auth login`](/apex/cli/auth) before using this command.
+You must be connected to Pensar Console via [`pensar login`](/apex/cli/auth) before using this command.
 
 ## Subcommands
 

--- a/fern/docs/cli/pentests.mdx
+++ b/fern/docs/cli/pentests.mdx
@@ -17,7 +17,7 @@ pensar pentests dispatch <projectId> [options]   # Dispatch a new pentest
 
 ## Prerequisites
 
-You must be connected to Pensar Console via [`pensar auth login`](/apex/cli/auth) before using this command.
+You must be connected to Pensar Console via [`pensar login`](/apex/cli/auth) before using this command.
 
 ## Subcommands
 

--- a/fern/docs/cli/projects.mdx
+++ b/fern/docs/cli/projects.mdx
@@ -15,7 +15,7 @@ pensar projects
 
 ## Prerequisites
 
-You must be connected to Pensar Console via [`pensar auth login`](/apex/cli/auth) before using this command.
+You must be connected to Pensar Console via [`pensar login`](/apex/cli/auth) before using this command.
 
 ## Output
 

--- a/fern/docs/commands/auth.mdx
+++ b/fern/docs/commands/auth.mdx
@@ -1,37 +1,43 @@
 ---
-title: "/auth"
+title: "/login"
 description: "Connect Apex to Pensar Console for managed inference and billing"
 ---
 
 ## Overview
 
-The `/auth` command connects your Apex CLI to [Pensar Console](https://console.pensar.dev) for **managed inference**. Once connected, Apex uses Pensar-hosted AI models — no API key configuration required. Inference costs are tracked and deducted from your workspace's credit balance.
+The `/login` command connects your Apex CLI to [Pensar Console](https://console.pensar.dev) for **managed inference**. Once connected, Apex uses Pensar-hosted AI models — no API key configuration required. Inference costs are tracked and deducted from your workspace's credit balance.
+
+<Note>
+  The `/auth` command still works as an alias for backward compatibility, but `/login` is now the primary command name.
+</Note>
 
 ## Usage
 
 Inside the TUI:
 
 ```bash
-/auth
+/login
 ```
 
 From the command line (headless):
 
 ```bash
-pensar auth login      # Start the login flow
-pensar auth status     # Show current connection status
-pensar auth logout     # Disconnect from Pensar Console
+pensar login           # Start the login flow
+pensar login status    # Show current connection status
+pensar login logout    # Disconnect from Pensar Console
 ```
 
-`pensar auth status` displays your auth type (WorkOS or API key) and current workspace. When using API key auth, the command resolves your workspace from the server if it isn't already stored locally.
+The legacy `pensar auth` command still works for backward compatibility.
+
+`pensar login status` displays your auth type (WorkOS or API key) and current workspace. When using API key auth, the command resolves your workspace from the server if it isn't already stored locally.
 
 ## How It Works
 
-Both the TUI `/auth` command and the CLI `pensar auth` command use a **device authorization flow** — similar to how you link a streaming device to your account. Apex displays a code, you verify it in your browser, and the CLI is automatically authenticated.
+Both the TUI `/login` command and the CLI `pensar login` command use a **device authorization flow** — similar to how you link a streaming device to your account. Apex displays a code, you verify it in your browser, and the CLI is automatically authenticated.
 
 <Steps>
   <Step title="Start Auth Flow">
-    Run `/auth` in Apex and press Enter to begin. Apex requests a device code from the Pensar authentication service.
+    Run `/login` in Apex and press Enter to begin. Apex requests a device code from the Pensar authentication service.
   </Step>
   <Step title="Verify in Browser">
     A browser window opens automatically to the verification URL. If it doesn't open, copy the URL displayed in the terminal and open it manually. Enter the **user code** shown in Apex to confirm the connection.
@@ -55,7 +61,7 @@ Both the TUI `/auth` command and the CLI `pensar auth` command use a **device au
 
 ## Pensar Console
 
-[Pensar Console](https://console.pensar.dev) is the web platform where you manage workspaces, projects, billing, and more. When you authenticate Apex with `/auth`, you're linking it to a Console workspace.
+[Pensar Console](https://console.pensar.dev) is the web platform where you manage workspaces, projects, billing, and more. When you authenticate Apex with `/login`, you're linking it to a Console workspace.
 
 If you don't have an account yet, the verification URL will guide you through sign-up and workspace creation.
 
@@ -94,7 +100,7 @@ Apex inference through the Pensar gateway uses a **pre-paid credits** model. Cre
 
 ### Setting Up Billing
 
-If Apex reports that billing isn't configured or your balance is low during `/auth`:
+If Apex reports that billing isn't configured or your balance is low during `/login`:
 
 <Steps>
   <Step title="Open Billing Page">
@@ -115,11 +121,11 @@ For detailed billing documentation including auto-reload, invoices, and usage tr
 
 ## Disconnecting
 
-When connected, press `[D]` on the `/auth` screen to disconnect. This clears the stored authentication tokens from your local Apex configuration. You can reconnect at any time by running `/auth` again.
+When connected, press `[D]` on the `/login` screen to disconnect. This clears the stored authentication tokens from your local Apex configuration. You can reconnect at any time by running `/login` again.
 
 ## Configuration
 
-Authentication state is stored in your local Apex configuration at `~/.pensar/`. The following values are managed by the `/auth` flow:
+Authentication state is stored in your local Apex configuration at `~/.pensar/`. The following values are managed by the `/login` flow:
 
 | Config Key | Description |
 |---|---|
@@ -130,7 +136,11 @@ Authentication state is stored in your local Apex configuration at `~/.pensar/`.
 | `signingKey` | HMAC signing key for authenticated gateway inference requests |
 | `gatewayUrl` | Inference gateway URL (defaults to gateway.pensar.dev) |
 
-Tokens are automatically refreshed when they expire. You do not need to re-run `/auth` unless you want to switch workspaces or have explicitly disconnected.
+Tokens are automatically refreshed when they expire. You do not need to re-run `/login` unless you want to switch workspaces or have explicitly disconnected.
+
+## Expired Session Notifications
+
+If your Pensar Console session has truly expired (access token expired and no valid refresh token), Apex will show a toast notification on startup prompting you to run `/login` to refresh. If you have a valid refresh token, your session will be silently restored on the next API call without any notification.
 
 ## Troubleshooting
 
@@ -148,11 +158,11 @@ Tokens are automatically refreshed when they expire. You do not need to re-run `
   </Accordion>
 
   <Accordion title="Want to switch workspaces">
-    Press `[D]` to disconnect, then run `/auth` again. You'll be prompted to select a workspace during the new auth flow.
+    Press `[D]` to disconnect, then run `/login` again. You'll be prompted to select a workspace during the new auth flow.
   </Accordion>
 
   <Accordion title="Auth flow times out">
-    Device codes expire after a few minutes. Run `/auth` again to restart the flow with a fresh code.
+    Device codes expire after a few minutes. Run `/login` again to restart the flow with a fresh code.
   </Accordion>
 </AccordionGroup>
 

--- a/fern/docs/commands/config.mdx
+++ b/fern/docs/commands/config.mdx
@@ -20,11 +20,11 @@ Apex stores all configuration at `~/.pensar/config.json`. This includes:
 - **AI provider API keys** — configured via `/providers`
 - **Selected model** — configured via `/models`
 - **Theme settings** — configured via `/themes`
-- **Auth tokens** — configured via `/auth`
+- **Auth tokens** — configured via `/login`
 - **Workspace info** — workspace ID and slug from Pensar Console
 
 <Callout intent="info">
-  Most configuration is managed through dedicated commands (`/providers`, `/models`, `/themes`, `/auth`). The `/config` dialog provides a unified view of your current settings.
+  Most configuration is managed through dedicated commands (`/providers`, `/models`, `/themes`, `/login`). The `/config` dialog provides a unified view of your current settings.
 </Callout>
 
 ## Related Commands
@@ -39,7 +39,7 @@ Apex stores all configuration at `~/.pensar/config.json`. This includes:
   <Card title="/themes" icon="palette" href="/apex/commands/themes">
     Customize visual appearance
   </Card>
-  <Card title="/auth" icon="shield-check" href="/apex/commands/auth">
+  <Card title="/login" icon="shield-check" href="/apex/commands/auth">
     Connect to Pensar Console
   </Card>
 </CardGroup>

--- a/fern/docs/commands/credits.mdx
+++ b/fern/docs/commands/credits.mdx
@@ -17,7 +17,7 @@ Alias: `/buy`
 
 ## Prerequisites
 
-You must be connected to Pensar Console via the [`/auth`](/apex/commands/auth) command before using `/credits`. If you're not authenticated, Apex will prompt you to connect first.
+You must be connected to Pensar Console via the [`/login`](/apex/commands/auth) command before using `/credits`. If you're not authenticated, Apex will prompt you to connect first.
 
 ## What You'll See
 
@@ -58,7 +58,7 @@ Credits are a **pre-paid balance** (denominated in USD) stored at the workspace 
 
 <AccordionGroup>
   <Accordion title="'Not authenticated' error">
-    Run [`/auth`](/apex/commands/auth) first to connect Apex to your Console workspace.
+    Run [`/login`](/apex/commands/auth) first to connect Apex to your Console workspace.
   </Accordion>
 
   <Accordion title="Balance shows $0.00">
@@ -73,7 +73,7 @@ Credits are a **pre-paid balance** (denominated in USD) stored at the workspace 
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/auth" icon="shield-check" href="/apex/commands/auth">
+  <Card title="/login" icon="shield-check" href="/apex/commands/auth">
     Connect to Pensar Console for managed inference.
   </Card>
   <Card title="/providers" icon="plug" href="/apex/commands/providers">

--- a/fern/docs/commands/help.mdx
+++ b/fern/docs/commands/help.mdx
@@ -53,7 +53,7 @@ When you run `/help`, you'll see a dialog showing:
   <Card title="/providers" icon="plug">
     Manage AI providers and configure API keys
   </Card>
-  <Card title="/auth" icon="shield-check" href="/apex/commands/auth">
+  <Card title="/login" icon="shield-check" href="/apex/commands/auth">
     Connect to Pensar Console for managed inference
   </Card>
   <Card title="/credits" icon="credit-card" href="/apex/commands/credits">
@@ -86,7 +86,7 @@ When you run `/help`, you'll see a dialog showing:
 | `/config`       |                    | Show config dialog                              |
 | `/models`       |                    | Show available AI models                        |
 | `/providers`    |                    | Manage AI providers and API keys                |
-| `/auth`         |                    | Connect to Pensar Console for managed inference |
+| `/login`        | `/auth`            | Connect to Pensar Console for managed inference |
 | `/credits`      | `/buy`             | Buy credits / check balance                     |
 | `/themes`       | `/theme`           | Manage application themes                       |
 | `/create-skill` |                    | Create a new operator skill                     |
@@ -99,7 +99,7 @@ For new users, here's the recommended order of commands:
 <Steps>
   <Step title="Configure Provider">
     Run `/providers` to set up your AI provider API key (Anthropic recommended),
-    or `/auth` to connect via Pensar Console
+    or `/login` to connect via Pensar Console
   </Step>
   <Step title="Select Model">
     Run `/models` to choose which AI model to use for testing
@@ -136,7 +136,7 @@ For new users, here's the recommended order of commands:
 
 ## Command Suggestions
 
-When typing a `/` command, Apex displays a windowed suggestions dropdown with up to 6 visible entries at a time. Commands are sorted by priority — `/pentest`, `/operator`, `/auth`, `/models`, `/sessions`, `/themes`, `/help` appear first, followed by the rest alphabetically. Scroll indicators (`↑`/`↓`) appear when more suggestions exist outside the visible window.
+When typing a `/` command, Apex displays a windowed suggestions dropdown with up to 6 visible entries at a time. Commands are sorted by priority — `/pentest`, `/operator`, `/login`, `/models`, `/sessions`, `/themes`, `/help` appear first, followed by the rest alphabetically. Scroll indicators (`↑`/`↓`) appear when more suggestions exist outside the visible window.
 
 ## CLI Commands
 
@@ -166,7 +166,7 @@ In addition to the TUI slash commands above, Apex provides headless CLI commands
   <Card title="/providers" icon="plug" href="/apex/commands/providers">
     Configure AI providers
   </Card>
-  <Card title="/auth" icon="shield-check" href="/apex/commands/auth">
+  <Card title="/login" icon="shield-check" href="/apex/commands/auth">
     Connect to Pensar Console
   </Card>
   <Card title="/credits" icon="credit-card" href="/apex/commands/credits">

--- a/fern/docs/commands/models.mdx
+++ b/fern/docs/commands/models.mdx
@@ -21,7 +21,7 @@ When no model is explicitly selected, Apex automatically picks a default based o
 
 <Callout intent="info">
   Only models from **configured providers** are shown. Use `/providers` to set
-  up additional AI providers, or `/auth` to connect via Pensar Console.
+  up additional AI providers, or `/login` to connect via Pensar Console.
 </Callout>
 
 <img
@@ -125,7 +125,7 @@ When you open `/models`, you'll see:
     - Claude Haiku 4.5
     - And more...
 
-    Connect via `/auth` in Apex.
+    Connect via `/login` in Apex.
 
   </Accordion>
 </AccordionGroup>

--- a/fern/docs/commands/providers.mdx
+++ b/fern/docs/commands/providers.mdx
@@ -36,7 +36,7 @@ Apex supports the following AI providers:
     Amazon Bedrock AI models for enterprise deployments.
   </Card>
   <Card title="Pensar Console" icon="shield-check">
-    Managed inference — connect via `/auth` instead, no API key needed.
+    Managed inference — connect via `/login` instead, no API key needed.
   </Card>
 </CardGroup>
 
@@ -58,7 +58,7 @@ Apex supports the following AI providers:
     Input your API key for the selected provider. Apex verifies your key against the provider's API before saving — if the key is invalid, you'll see an inline error and can try again.
 
     <Callout intent="info">
-      Selecting **Pensar Console** from the provider list routes you to the `/auth` device-flow login instead of the API key input screen.
+      Selecting **Pensar Console** from the provider list routes you to the `/login` device-flow login instead of the API key input screen.
     </Callout>
   </Step>
   <Step title="Select Model">
@@ -175,7 +175,7 @@ Apex supports the following AI providers:
     Pensar Console provides managed inference so you don't need to bring your own API key.
 
     ### Connect
-    1. Run `/auth` in Apex (not `/providers`)
+    1. Run `/login` in Apex (not `/providers`)
     2. Follow the authentication flow to link your Pensar Console account
     3. Your models will appear automatically in `/models`
 

--- a/fern/docs/getting-started.mdx
+++ b/fern/docs/getting-started.mdx
@@ -78,7 +78,7 @@ Before running Apex, you need to configure your AI provider API key. Apex suppor
   </Accordion>
 
   <Accordion title="Pensar Console (Managed)" icon="shield-check">
-    Use the `/auth` command inside Apex to connect to [Pensar Console](https://console.pensar.dev) for managed inference — no API key required.
+    Use the `/login` command inside Apex to connect to [Pensar Console](https://console.pensar.dev) for managed inference — no API key required.
 
   </Accordion>
 </AccordionGroup>
@@ -117,9 +117,9 @@ Apex also supports headless CLI commands for CI/CD and scripting:
 ```bash
 pensar pentest --target <url>               # Run a full pentest orchestration
 pensar targeted-pentest --target <url>      # Run a targeted pentest
-pensar auth login                           # Connect to Pensar Console from the CLI
-pensar auth status                          # Show current auth connection status
-pensar auth logout                          # Disconnect from Pensar Console
+pensar login                                # Connect to Pensar Console from the CLI
+pensar login status                         # Show current login connection status
+pensar login logout                         # Disconnect from Pensar Console
 pensar projects                             # List workspace projects
 pensar pentests <projectId>                 # List/get/dispatch pentests
 pensar issues <projectId>                   # List/get/update security issues
@@ -160,7 +160,7 @@ Now that Apex is installed, here's how to get started:
 
 <Steps>
   <Step title="Login to Pensar">
-    Run `/auth` to login to Pensar.
+    Run `/login` to login to Pensar.
   </Step>
   <Step title="Select Model">
     Run `/models` to choose which AI model to use

--- a/fern/docs/intro.mdx
+++ b/fern/docs/intro.mdx
@@ -44,7 +44,7 @@ description: "AI-powered penetration testing CLI tool for comprehensive security
     terminal.
   </Step>
   <Step title="Login to Pensar">
-    Use the `/auth` command to login to Pensar.
+    Use the `/login` command to login to Pensar.
   </Step>
   <Step title="Select Model">
     Use the `/models` command to select which AI model to use for testing.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,7 +88,7 @@ Usage:
   pensar pentest [options]            Run a full pentest orchestration
   pensar targeted-pentest [options]   Run a targeted pentest on a single target
   pensar threat-model [options]       Generate application-centric threat model
-  pensar auth                         Connect to Pensar Console
+  pensar login                        Connect to Pensar Console
   pensar uninstall                    Uninstall Pensar (keeps sessions, memories, skills)
   pensar projects                     List workspace projects
   pensar pentests                     List and manage pentests
@@ -349,7 +349,7 @@ if (command === "version" || command === "--version" || command === "-v") {
   await runPentest();
 } else if (command === "targeted-pentest") {
   await runTargetedPentest();
-} else if (command === "auth") {
+} else if (command === "login" || command === "auth") {
   process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
   await import("./cli/auth");
 } else if (command === "uninstall") {

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -1,16 +1,17 @@
 #!/usr/bin/env bun
 
 /**
- * Pensar Auth CLI
+ * Pensar Login CLI
  *
  * Connect to Pensar Console for managed inference, directly from the CLI.
- * Mirrors the TUI /auth flow using centralized auth logic from core/auth.
+ * Mirrors the TUI /login flow using centralized auth logic from core/auth.
  *
  * Subcommands:
- *   pensar auth            Start the login flow (or show status if already connected)
- *   pensar auth login      Start the login flow
- *   pensar auth logout     Disconnect from Pensar Console
- *   pensar auth status     Show current connection status
+ *   pensar login           Start the login flow (or show status if already connected)
+ *   pensar login status    Show current connection status
+ *   pensar login logout    Disconnect from Pensar Console
+ *
+ * Legacy alias: `pensar auth` still works for backward compatibility
  */
 
 import { config } from "../core/config";
@@ -247,7 +248,7 @@ async function status(): Promise<void> {
 
   if (!isConnected(appConfig)) {
     console.log(
-      "Not connected to Pensar Console.\n\nRun `pensar auth login` to connect.",
+      "Not connected to Pensar Console.\n\nRun `pensar login` to connect.",
     );
     return;
   }
@@ -288,13 +289,14 @@ async function status(): Promise<void> {
 }
 
 function showHelp(): void {
-  console.log(`Pensar Auth — Connect to Pensar Console
+  console.log(`Pensar Login — Connect to Pensar Console
 
 Usage:
-  pensar auth              Login to Pensar Console (or show status if connected)
-  pensar auth login        Login to Pensar Console
-  pensar auth logout       Disconnect from Pensar Console
-  pensar auth status       Show connection status
+  pensar login             Login to Pensar Console (or show status if connected)
+  pensar login status      Show connection status
+  pensar login logout      Disconnect from Pensar Console
+
+Legacy alias: 'pensar auth' still works for backward compatibility
 
 Options:
   -h, --help               Show this help message`);
@@ -322,7 +324,7 @@ async function main(): Promise<void> {
       await status();
     } else {
       console.error(`Unknown auth subcommand: ${subcommand}`);
-      console.error("Run 'pensar auth --help' for usage information");
+      console.error("Run 'pensar login --help' for usage information");
       process.exit(1);
     }
   } catch (err) {

--- a/src/core/agents/offSecAgent/tools/webSearch.ts
+++ b/src/core/agents/offSecAgent/tools/webSearch.ts
@@ -83,7 +83,7 @@ COMMON SEARCH PATTERNS:
             success: false,
             results: [],
             error:
-              "Web search requires a Pensar account. Please sign in to your Pensar account to use this feature. You can sign in via the TUI settings or by running 'pensar auth login'.",
+              "Web search requires a Pensar account. Please sign in to your Pensar account to use this feature. You can sign in via the TUI settings or by running 'pensar login'.",
           };
         }
 

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -78,7 +78,7 @@ export function createPensarModel(
       if (!result) {
         logError("buildHeaders: getToken() returned null — auth failed");
         throw new Error(
-          "Pensar authentication failed. Run /auth to reconnect.",
+          "Pensar authentication failed. Run /login to reconnect.",
         );
       }
       headers.Authorization = `Bearer ${result.token.slice(0, 12)}…`;

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -201,7 +201,7 @@ export function getProviderModel(
 
       if (!pensarApiKey && !hasWorkOSAuth) {
         throw new Error(
-          "Pensar not configured. Run /auth to connect to Pensar Console.",
+          "Pensar not configured. Run /login to connect to Pensar Console.",
         );
       }
 

--- a/src/core/api/issues.ts
+++ b/src/core/api/issues.ts
@@ -130,7 +130,7 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
 
   if (!validToken) {
     throw new Error(
-      "Not authenticated. Run `pensar auth login` to connect to Pensar Console.",
+      "Not authenticated. Run `pensar login` to connect to Pensar Console.",
     );
   }
 

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -321,7 +321,8 @@ export const commands: CommandConfig[] = [
 
   // — Configuration —
   {
-    name: "auth",
+    name: "login",
+    aliases: ["auth"],
     description: "Connect to Pensar Console for managed inference",
     category: "Configuration",
     handler: async (args, ctx) => {

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -194,7 +194,7 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
           {[
             { cmd: "/pentest", desc: "autonomous pentest" },
             { cmd: "/operator", desc: "interactive operator" },
-            { cmd: "/auth", desc: "login to Pensar" },
+            { cmd: "/login", desc: "login to Pensar" },
             { cmd: "/models", desc: "select AI model" },
             { cmd: "/providers", desc: "manage API keys" },
           ].map(({ cmd, desc }) => (

--- a/src/tui/components/commands/credits-flow.tsx
+++ b/src/tui/components/commands/credits-flow.tsx
@@ -116,7 +116,7 @@ export default function CreditsFlow({
   // Build dynamic footer actions per step
   let footerActions: FooterAction[] = [];
   if (step === "no-auth") {
-    footerActions = [{ key: "Enter", label: "run /auth", variant: "primary" }];
+    footerActions = [{ key: "Enter", label: "run /login", variant: "primary" }];
   } else if (step === "display") {
     footerActions = [
       { key: "Enter", label: "open in browser", variant: "primary" },
@@ -146,7 +146,7 @@ export default function CreditsFlow({
             </box>
             <box>
               <text fg={colors.textMuted}>
-                Run <span fg={colors.primary}>/auth</span> first to connect your
+                Run <span fg={colors.primary}>/login</span> first to connect your
                 account.
               </text>
             </box>

--- a/src/tui/components/commands/credits-flow.tsx
+++ b/src/tui/components/commands/credits-flow.tsx
@@ -146,8 +146,8 @@ export default function CreditsFlow({
             </box>
             <box>
               <text fg={colors.textMuted}>
-                Run <span fg={colors.primary}>/login</span> first to connect your
-                account.
+                Run <span fg={colors.primary}>/login</span> first to connect
+                your account.
               </text>
             </box>
           </box>

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -9,7 +9,6 @@ import { buildBaseSystemPrompt } from "../../../core/agents/offSecAgent/prompt";
 const OPERATOR_ALLOWED_COMMANDS = new Set([
   "/models",
   "/login",
-  "/auth",
   "/themes",
   "/new",
   "/operator",

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -8,6 +8,7 @@ import { buildBaseSystemPrompt } from "../../../core/agents/offSecAgent/prompt";
 
 const OPERATOR_ALLOWED_COMMANDS = new Set([
   "/models",
+  "/login",
   "/auth",
   "/themes",
   "/new",

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -259,6 +259,25 @@ function AppContent({
         );
       },
     );
+
+    // Check if auth token needs refresh
+    const checkAuthToken = async () => {
+      const { isTokenExpired, isConnected } = await import(
+        "../core/auth"
+      );
+      if (
+        isConnected(config.data) &&
+        config.data.accessToken &&
+        isTokenExpired(config.data.accessToken, 60)
+      ) {
+        toast(
+          "Your Pensar Console session has expired. Run /login to refresh.",
+          "warn",
+          8000,
+        );
+      }
+    };
+    checkAuthToken();
   }, []);
 
   useEffect(() => {

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -265,10 +265,14 @@ function AppContent({
       const { isTokenExpired, isConnected } = await import(
         "../core/auth"
       );
+      // Only show toast if access token is expired AND there's no refresh token
+      // to automatically recover the session. If a refresh token exists,
+      // ensureValidToken() will silently restore the session on next API call.
       if (
         isConnected(config.data) &&
         config.data.accessToken &&
-        isTokenExpired(config.data.accessToken, 60)
+        isTokenExpired(config.data.accessToken, 60) &&
+        !config.data.refreshToken
       ) {
         toast(
           "Your Pensar Console session has expired. Run /login to refresh.",

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -263,14 +263,15 @@ function AppContent({
     // Check if auth token needs refresh
     const checkAuthToken = async () => {
       const { isTokenExpired, isConnected } = await import("../core/auth");
-      // Only show toast if access token is expired AND there's no refresh token
-      // to automatically recover the session. If a refresh token exists,
-      // ensureValidToken() will silently restore the session on next API call.
+      // Only show toast if access token is expired AND there's no recovery path.
+      // ensureValidToken() can recover via refresh token OR fall back to pensarAPIKey,
+      // so we only warn when both are unavailable.
       if (
         isConnected(config.data) &&
         config.data.accessToken &&
         isTokenExpired(config.data.accessToken, 60) &&
-        !config.data.refreshToken
+        !config.data.refreshToken &&
+        !config.data.pensarAPIKey
       ) {
         toast(
           "Your Pensar Console session has expired. Run /login to refresh.",

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -262,9 +262,7 @@ function AppContent({
 
     // Check if auth token needs refresh
     const checkAuthToken = async () => {
-      const { isTokenExpired, isConnected } = await import(
-        "../core/auth"
-      );
+      const { isTokenExpired, isConnected } = await import("../core/auth");
       // Only show toast if access token is expired AND there's no refresh token
       // to automatically recover the session. If a refresh token exists,
       // ensureValidToken() will silently restore the session on next API call.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

This PR addresses the issue where the `/auth` command is not easily discoverable and users need to be notified when their authentication token expires.

**Changes made:**

1. **Renamed command from `/auth` to `/login`**
   - Primary command is now `/login` in the TUI
   - `/auth` is kept as an alias for backward compatibility
   - Updated CLI from `pensar auth` to `pensar login` (keeping `auth` as alias)

2. **Added toast notification for expired tokens**
   - On TUI startup, checks if the user has an expired WorkOS access token
   - Shows a warning toast: "Your Pensar Console session has expired. Run /login to refresh."
   - Toast appears for 8 seconds to give users time to read it
   - **Smart detection**: Toast only shows when session truly cannot auto-recover (no refresh token AND no legacy API key)

3. **Updated all references**
   - Updated help text, error messages, and documentation to reference `/login`
   - Updated home screen quick reference
   - Updated credits flow prompts
   - Updated error messages in AI providers and tools
   - Updated operator dashboard autocomplete to include `/login`

4. **Comprehensive documentation updates**
   - Updated all 15 Fern documentation files
   - Updated TUI command docs (`/login` command page)
   - Updated CLI command docs (`pensar login` command page)
   - Updated navigation in docs.yml
   - Updated all cross-references in getting started, intro, and other command docs
   - Added section on expired session notifications

5. **Code quality improvements**
   - Removed dead code from operator autocomplete (redundant `/auth` entry)
   - Fixed formatting issues across the codebase

**Why these changes work:**

- The `/login` command name is more intuitive—users naturally try `/login` first when attempting to authenticate
- The toast notification intelligently checks all recovery paths:
  - If a valid refresh token exists, `ensureValidToken()` will silently restore the session → no toast
  - If a legacy `pensarAPIKey` exists, it serves as fallback → no toast
  - Toast only appears when both recovery paths are unavailable
- The check runs once on startup alongside the update check, so there's no performance impact
- All backward compatibility is maintained through the `/auth` alias
- Rebased with latest canary to incorporate upstream PasteEvent fixes

### How did you verify your code works?

1. **Unit tests:** All 747 tests pass ✓
   ```
   Test Files  33 passed | 7 skipped (40)
        Tests  747 passed | 15 skipped (762)
   ```

2. **All CI Checks:** ✅ ALL PASSING
   - ✅ typecheck / typecheck
   - ✅ lint / lint
   - ✅ test / test
   - ✅ build / build
   - ✅ console-typecheck (Integration CI)
   - ✅ preview-docs
   - ✅ Cursor Bugbot

3. **TypeScript:** Type checking passes with no errors ✓

4. **Linter:** ESLint passes with no errors ✓

5. **Build:** Project builds successfully ✓

6. **Formatting:** Prettier checks pass ✓

7. **CLI verification:**
   - `./build/cli.js --help` shows `pensar login` command ✓
   - `./build/cli.js login --help` shows updated help text with backward compatibility note ✓
   - `./build/cli.js auth --help` works as alias and shows same help text ✓

8. **Toast notification logic verification:**
   Tested all scenarios with verification scripts:
   - Expired access token + valid refresh token → No toast (auto-recovers) ✓
   - Expired access token + no refresh token + legacy API key → No toast (fallback works) ✓
   - Expired access token + no refresh token + no API key → Toast shown ✓
   - Valid access token → No toast ✓
   - Not connected → No toast ✓

9. **Code changes verification:**
   - Command registry updated with `/login` as primary and `/auth` as alias ✓
   - Operator autocomplete includes `/login` (dead `/auth` removed) ✓
   - Toast notification check added to TUI startup `useEffect` ✓
   - Toast logic checks all recovery paths (refresh token AND pensarAPIKey) ✓
   - All error messages and help text consistently reference `/login` ✓
   - Backward compatibility maintained throughout ✓
   - All 15 documentation files updated consistently ✓

10. **Rebase:** Successfully rebased with latest canary ✓
    - Incorporated upstream PasteEvent fixes (commit was auto-dropped during rebase)
    - All tests still passing with canary's new tests

**Bugbot Fixes Applied:**
1. Toast notification only fires when session cannot auto-recover (checks for missing refresh token)
2. Toast notification also checks for missing pensarAPIKey fallback
3. Operator autocomplete includes `/login` command in allowed commands list
4. Removed redundant `/auth` dead code from operator allowed commands (aliases don't appear in autocomplete)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7531bb95-31d5-4e81-a223-6cf3482b2793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7531bb95-31d5-4e81-a223-6cf3482b2793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

