### PR TITLE
fix: correct pensar provider cache token counting

### DIFF
--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -467,13 +467,12 @@ export function streamResponse(
             let cacheRead = (meta?.cacheReadInputTokens as number) ?? 0;
             let cacheCreation = (meta?.cacheCreationInputTokens as number) ?? 0;
 
-            // Fallback: extract from V3 usage fields (pensar provider)
+            // Pensar provider doesn't populate providerMetadata.anthropic;
+            // fall back to the SDK's normalized usage.inputTokenDetails.
             if (cacheRead === 0 && cacheCreation === 0) {
-              const usage = stepResult.usage as
-                | { inputTokens?: { cacheRead?: number; cacheWrite?: number } }
-                | undefined;
-              cacheRead = usage?.inputTokens?.cacheRead ?? 0;
-              cacheCreation = usage?.inputTokens?.cacheWrite ?? 0;
+              const { inputTokenDetails } = stepResult.usage;
+              cacheRead = inputTokenDetails?.cacheReadTokens ?? 0;
+              cacheCreation = inputTokenDetails?.cacheWriteTokens ?? 0;
             }
 
             if (cacheRead > 0 || cacheCreation > 0) {

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -557,7 +557,10 @@ export function createPensarModel(
               },
               usage: {
                 inputTokens: {
-                  total: inputTokens + (cacheReadTokens || 0) + (cacheCreationTokens || 0),
+                  total:
+                    inputTokens +
+                    (cacheReadTokens || 0) +
+                    (cacheCreationTokens || 0),
                   noCache: inputTokens,
                   cacheRead: cacheReadTokens || undefined,
                   cacheWrite: cacheCreationTokens || undefined,

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -557,8 +557,8 @@ export function createPensarModel(
               },
               usage: {
                 inputTokens: {
-                  total: inputTokens,
-                  noCache: undefined,
+                  total: inputTokens + (cacheReadTokens || 0) + (cacheCreationTokens || 0),
+                  noCache: inputTokens,
                   cacheRead: cacheReadTokens || undefined,
                   cacheWrite: cacheCreationTokens || undefined,
                 },


### PR DESCRIPTION
## Summary
- Pensar provider's `inputTokens.total` now includes cache tokens, matching the `@ai-sdk/anthropic` and `@ai-sdk/amazon-bedrock` convention
- Cache extraction fallback in `ai.ts` uses AI SDK v6 `inputTokenDetails` instead of broken pre-normalization field access

## Context
The Anthropic API returns three **additive** token fields: `input_tokens` (non-cached), `cache_read_input_tokens`, and `cache_creation_input_tokens`. The AI SDK v6 provider contract expects `inputTokens.total` = sum of all three.

The pensar provider was only setting `total = input_tokens`, causing:
- TUI cache indicator (`⚡`) never appearing (fallback extraction silently returned 0)
- Benchmark `noCacheInputTokens` clamped to 0 (base input cost zeroed)
- All downstream token totals excluding cached tokens

## Test plan
- [ ] Run a cached pentest via TUI with Pensar provider — verify `⚡` cache indicator appears
- [ ] Check benchmark `computeTokenMetrics` produces non-zero `noCacheInputTokens`
- [ ] Cross-provider: compare token totals between Pensar and direct Anthropic paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to token accounting and metrics extraction; main risk is altered token totals affecting billing/benchmarks and UI indicators.
> 
> **Overview**
> Ensures the Pensar provider reports input token usage in the AI SDK v6 convention: `usage.inputTokens.total` now includes cache-read and cache-write tokens, while `usage.inputTokens.noCache` preserves the non-cached `input_tokens` value.
> 
> Updates cache-metric extraction in `ai.ts` to stop reading legacy Pensar-specific usage fields and instead fall back to the SDK-normalized `usage.inputTokenDetails` when `providerMetadata.anthropic` is missing, enabling downstream cache indicators/metrics to work for Pensar streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7f40b88870f07c158140db69db6c76d2931a623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->