### PR TITLE
Security: Arbitrary file read via absolute paths in `read_file` tool

### DIFF
--- a/src/core/agents/offSecAgent/tools/readFile.ts
+++ b/src/core/agents/offSecAgent/tools/readFile.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
-import { readFile as fsReadFile } from "fs/promises";
-import { resolve, isAbsolute } from "path";
+import { readFile as fsReadFile, realpath } from "fs/promises";
+import { resolve, sep } from "path";
 import type { ToolContext } from "./types";
 
 export const readFileInputSchema = z.object({
@@ -47,8 +47,15 @@ the end. If only endLine is given, reads from the beginning to that line.
 Output lines are prefixed with their line number for easy reference.`,
     inputSchema: readFileInputSchema,
     execute: async ({ path, startLine, endLine }): Promise<ReadFileResult> => {
-      const resolved = isAbsolute(path) ? path : resolve(ctx.agentCwd, path);
       try {
+        const allowedRoot = await realpath(ctx.agentCwd);
+        const requestedPath = resolve(allowedRoot, path);
+        const resolved = await realpath(requestedPath);
+
+        if (resolved !== allowedRoot && !resolved.startsWith(`${allowedRoot}${sep}`)) {
+          throw new Error("Access denied: path must be within the workspace");
+        }
+
         const raw = await fsReadFile(resolved, "utf-8");
         const allLines = raw.split("\n");
         const totalLines = allLines.length;


### PR DESCRIPTION
## Summary

Security: Arbitrary file read via absolute paths in `read_file` tool

## Problem

**Severity**: `High` | **File**: `src/core/agents/offSecAgent/tools/readFile.ts:L46`

The `read_file` tool allows absolute paths (`isAbsolute(path) ? path : resolve(...)`) and does not enforce that reads stay within a trusted workspace/session root. If an attacker can influence tool inputs (e.g., prompt injection or untrusted task data), they can read sensitive local files such as SSH keys, cloud credentials, or `/etc` secrets.

## Solution

Restrict file reads to an allowlisted root (e.g., `ctx.session.rootPath` or sandbox root). Canonicalize with `realpath`, then verify `resolvedPath.startsWith(allowedRoot + path.sep)`. Consider rejecting absolute paths entirely unless explicitly needed and approved.

## Changes

- `src/core/agents/offSecAgent/tools/readFile.ts` (modified)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens path resolution/validation for the `read_file` tool, which may break workflows that relied on reading files outside `ctx.agentCwd` or via symlinks. Change is security-sensitive but small and localized to a single tool.
> 
> **Overview**
> **Locks down the `read_file` tool to prevent arbitrary filesystem reads.** The tool now canonicalizes `ctx.agentCwd` and the requested path via `realpath`, resolves requests relative to the workspace root, and rejects any path that escapes that root (including via symlinks).
> 
> This removes support for reading arbitrary absolute paths and returns a clear "Access denied" error when the requested file is outside the workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b870408ca006cea40d27bac3c90836e1ded358. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->