### PR TITLE
fix(persistentShell): capture stdout when stdbuf is unavailable

### DIFF
--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -1,6 +1,11 @@
+import { spawnSync } from "child_process";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { PersistentShell } from "./persistentShell";
+
+const HAS_STDBUF =
+  process.platform !== "win32" &&
+  spawnSync("stdbuf", ["--version"], { stdio: "ignore" }).status === 0;
 
 /**
  * These tests document and reproduce the "shell eventually stops responding"
@@ -40,6 +45,22 @@ describe("PersistentShell — long-running stability", () => {
     const r2 = await shell.execute("echo two", 5);
     expect(r2.exitCode).toBe(0);
     expect(r2.stdout).toContain("two");
+  });
+
+  /**
+   * Regression: on macOS without GNU `stdbuf`, the old wrapper relied on
+   * plain `tail -f` for streaming. Because `tail`'s stdout was a pipe it
+   * block-buffered, so short outputs were killed with tail before ever
+   * flushing — every `ls -la`-style command came back with empty stdout
+   * and the agent saw `(no output)`. We now skip `tail -f` in that case
+   * and `cat` the tempfile at the end, so output is always captured.
+   */
+  it("captures short stdout (no-stdbuf safe)", async () => {
+    const shell = make();
+    const r = await shell.execute("printf 'hello\\nworld\\n'", 5);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("hello");
+    expect(r.stdout).toContain("world");
   });
 
   /**
@@ -216,9 +237,10 @@ describe("PersistentShell — long-running stability", () => {
   /**
    * Streaming callback still fires as output arrives, even though stdout
    * is now routed through a per-command tempfile + `tail -f` rather than
-   * bash's raw stdout pipe.
+   * bash's raw stdout pipe. Requires GNU `stdbuf` to line-buffer `tail -f`;
+   * without it the shell skips streaming and `cat`s the tempfile at the end.
    */
-  it("streams stdout to onData as output arrives", async () => {
+  it.skipIf(!HAS_STDBUF)("streams stdout to onData as output arrives", async () => {
     const shell = make();
     const events: Array<{ t: number; text: string }> = [];
     const t0 = Date.now();

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -56,8 +56,11 @@ interface PendingCommand {
 /**
  * Cached once: whether `stdbuf` is available. We use it to line-buffer
  * `tail -f` so command output streams to the caller in near-real-time.
- * When it isn't available we fall back to raw `tail -f`, which still
- * produces correct final output but in larger chunks.
+ * When it isn't available we skip `tail -f` entirely and `cat` the
+ * per-command output tempfile after the command finishes — correct final
+ * output, but no real-time streaming. We can't use plain `tail -f` as a
+ * fallback: when its stdout is a pipe it block-buffers, so short outputs
+ * are lost when we kill the tail before it flushes.
  */
 let stdbufAvailable: boolean | null = null;
 function hasStdbuf(): boolean {
@@ -345,24 +348,34 @@ export class PersistentShell {
       //   - the exit marker is echoed on bash's real stdout pipe, so the
       //     parent Node handler always sees it immediately regardless of
       //     how much command output the tail has left to flush.
-      // Fast-polling `tail -f -s 0.05` line-buffered via `stdbuf -oL`
-      // streams output as it is produced (well under 100 ms latency per
-      // chunk) while keeping the per-command tempfile isolation that
-      // prevents background-process output bleeding across commands.
-      const tailCmd = hasStdbuf()
-        ? `stdbuf -oL tail -n +1 -f -s 0.05 "$__APEX_OUT"`
-        : `tail -n +1 -f -s 0.05 "$__APEX_OUT"`;
+      // When `stdbuf` is available (GNU coreutils), a fast-polling
+      // `stdbuf -oL tail -n +1 -f -s 0.05` is run in the background so
+      // stdout streams to the caller in near-real-time (well under 100 ms
+      // latency per chunk). Without `stdbuf` (e.g. default macOS), `tail`'s
+      // stdout is a pipe and block-buffered, so short outputs never flush
+      // before we kill it — we'd lose them entirely. In that case we skip
+      // streaming and just `cat` the tempfile after the command finishes;
+      // output is correct but no longer real-time.
+      const streaming = hasStdbuf();
       const wrapped = [
         `__APEX_OUT=$(mktemp 2>/dev/null || echo /tmp/.apex_out_$$)`,
         `__APEX_ERR=$(mktemp 2>/dev/null || echo /tmp/.apex_err_$$)`,
-        `${tailCmd} 2>/dev/null &`,
-        `__APEX_TAIL=$!`,
+        ...(streaming
+          ? [
+              `stdbuf -oL tail -n +1 -f -s 0.05 "$__APEX_OUT" 2>/dev/null &`,
+              `__APEX_TAIL=$!`,
+            ]
+          : []),
         `{ ${command}\n} </dev/null >"$__APEX_OUT" 2>"$__APEX_ERR"`,
         `__APEX_EC=$?`,
-        // Let tail drain any remaining bytes before we kill it.
-        `sleep 0.1`,
-        `kill "$__APEX_TAIL" 2>/dev/null`,
-        `wait "$__APEX_TAIL" 2>/dev/null`,
+        ...(streaming
+          ? [
+              // Let tail drain any remaining bytes before we kill it.
+              `sleep 0.1`,
+              `kill "$__APEX_TAIL" 2>/dev/null`,
+              `wait "$__APEX_TAIL" 2>/dev/null`,
+            ]
+          : [`cat "$__APEX_OUT"`]),
         `cat "$__APEX_ERR" >&2`,
         `rm -f "$__APEX_OUT" "$__APEX_ERR"`,
         `echo "${exitMarkerPrefix}$__APEX_EC"`,


### PR DESCRIPTION
On systems without GNU `stdbuf` (default macOS, Alpine) the streaming `tail -f`
wrapper introduced in #625 block-buffers its output — short command results
never flushed before the wrapper killed `tail`, and `execute_command` returned
empty stdout / `(no output)` for every short command.

Skip the `tail -f` streaming on those systems and `cat` the per-command
tempfile after the command finishes. Real-time streaming is preserved when
`stdbuf` is available; otherwise output arrives at the end but is always
captured. Keeps the tempfile isolation that #625 added for background-process
bleed and stdin hijacking.

Added a regression test for the no-stdbuf path; the existing streaming test is
gated on `stdbuf` availability.

Closes #635

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `PersistentShell.execute()` captures and streams stdout on non-GNU environments (e.g. macOS), which could affect timing/streaming semantics and command output handling across platforms. The change is localized but touches a core execution wrapper used by the agent.
> 
> **Overview**
> Fixes a regression where short command output could be lost on systems without GNU `stdbuf` by **disabling `tail -f`-based streaming** in that environment and instead `cat`ing the per-command stdout tempfile after the command completes.
> 
> Adds a regression test to ensure short stdout is captured in the no-`stdbuf` path, and gates the existing streaming `onData` test behind `stdbuf` availability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7bb8706cae5b2ced6dfac0e5d7b11ba890d4178. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->