### PR TITLE
feat: add /open-session slash command in operator mode

### DIFF
--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -431,6 +431,15 @@ export const commands: CommandConfig[] = [
 
   // — Hidden (functional but not shown in autocomplete/help) —
   {
+    name: "open-session",
+    description: "Open session folder in Finder",
+    category: "General",
+    hidden: true,
+    handler: async () => {
+      // Handled by the operator dashboard
+    },
+  },
+  {
     name: "tools",
     aliases: ["t"],
     description: "View and manage active tools (session only)",

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -1582,7 +1582,25 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
         case "open-session": {
           const rootPath = sessionRef.current?.rootPath;
           if (rootPath) {
-            spawn("open", [rootPath], { detached: true, stdio: "ignore" });
+            try {
+              const platform = process.platform;
+              const command =
+                platform === "darwin"
+                  ? "open"
+                  : platform === "win32"
+                    ? "explorer"
+                    : "xdg-open";
+              const child = spawn(command, [rootPath], {
+                detached: true,
+                stdio: "ignore",
+              });
+              child.on("error", () => {
+                addSystemMessage(`Failed to open session at ${rootPath}.`);
+              });
+              child.unref();
+            } catch {
+              addSystemMessage(`Failed to open session at ${rootPath}.`);
+            }
           } else {
             addSystemMessage("No active session to open.");
           }

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -96,7 +96,7 @@ import { QueuedMessages } from "./queued-messages";
 import { SubagentStatusBar } from "./subagent-status-bar";
 import SubagentDialog from "./subagent-dialog";
 import { navigateUp, navigateDown, selectionAfterRemove } from "./queue";
-import { spawn } from "child_process";
+import { openFileInDefaultApp } from "../../utils/open-file.js";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { isAbsolute, join, resolve } from "path";
 
@@ -1582,25 +1582,7 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
         case "open-session": {
           const rootPath = sessionRef.current?.rootPath;
           if (rootPath) {
-            try {
-              const platform = process.platform;
-              const command =
-                platform === "darwin"
-                  ? "open"
-                  : platform === "win32"
-                    ? "explorer"
-                    : "xdg-open";
-              const child = spawn(command, [rootPath], {
-                detached: true,
-                stdio: "ignore",
-              });
-              child.on("error", () => {
-                addSystemMessage(`Failed to open session at ${rootPath}.`);
-              });
-              child.unref();
-            } catch {
-              addSystemMessage(`Failed to open session at ${rootPath}.`);
-            }
+            openFileInDefaultApp(rootPath);
           } else {
             addSystemMessage("No active session to open.");
           }

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -96,6 +96,7 @@ import { QueuedMessages } from "./queued-messages";
 import { SubagentStatusBar } from "./subagent-status-bar";
 import SubagentDialog from "./subagent-dialog";
 import { navigateUp, navigateDown, selectionAfterRemove } from "./queue";
+import { spawn } from "child_process";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { isAbsolute, join, resolve } from "path";
 
@@ -169,7 +170,14 @@ export default function OperatorDashboard({
         description: s.manifest.description || "Skill",
       };
     });
-    return [...commandOptions, ...skillOptions];
+    const operatorOnlyOptions = [
+      {
+        value: "/open-session",
+        label: "/open-session",
+        description: "Open session folder in Finder",
+      },
+    ];
+    return [...commandOptions, ...operatorOnlyOptions, ...skillOptions];
   }, [allAutocompleteOptions, skillsRegistry, skillsVersion]);
 
   // Session state
@@ -1568,6 +1576,15 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
             handleSubmit(
               `Use the read_skill tool to load the "${action.slug}" skill and follow its instructions.`,
             );
+          }
+          return;
+        }
+        case "open-session": {
+          const rootPath = sessionRef.current?.rootPath;
+          if (rootPath) {
+            spawn("open", [rootPath], { detached: true, stdio: "ignore" });
+          } else {
+            addSystemMessage("No active session to open.");
           }
           return;
         }

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -55,6 +55,7 @@ export function resolveSubmit(
 export type CommandAction =
   | { type: "show-models" }
   | { type: "show-plan" }
+  | { type: "open-session" }
   | { type: "run-skill"; slug: string; autopilot: boolean }
   | { type: "execute-command"; command: string };
 
@@ -70,6 +71,10 @@ export function routeCommand(
 
   if (commandLower === "plan" || commandLower.startsWith("plan ")) {
     return { type: "show-plan" };
+  }
+
+  if (commandLower === "open-session") {
+    return { type: "open-session" };
   }
 
   if (commandLower === "skills") {


### PR DESCRIPTION
## Summary
- Adds a `/open-session` command available only in operator mode that opens the current session's artifact folder (`~/.pensar/sessions/{id}/`) in Finder
- Command is hidden from the home screen and help dialog — it's injected directly into operator mode autocomplete
- Shows a system message if no session is active yet

## Test plan
- [ ] Start an operator session, type `/open-session`, verify Finder opens to the correct session directory
- [ ] Verify `/open-session` appears in operator mode autocomplete when typing `/open`
- [ ] Verify `/open-session` does **not** appear on the home screen autocomplete or help dialog


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new operator-only slash command that triggers an OS-level “open folder” action and a simple fallback message when no session is active.
> 
> **Overview**
> Adds a hidden `/open-session` slash command that’s only surfaced in operator-mode autocomplete and routed within the operator dashboard.
> 
> When executed, it opens the active session’s `rootPath` in the OS default file browser (Finder on macOS), or prints a system message if no session is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9c80a518c2ebe110def59142cc7b45a0767fbaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->