### PR TITLE
feat(operator): decision timeout for approval gate

### DIFF
--- a/src/core/operator/approvalGate.test.ts
+++ b/src/core/operator/approvalGate.test.ts
@@ -26,9 +26,8 @@ describe("ApprovalGate — operator decision timeout", () => {
     const pending = gate.check("http_request", "tc_1", { url: "https://t/" });
     // Attach the rejection assertion before advancing timers so the
     // eventual reject() lands on an already-handled promise.
-    const assertion = expect(pending).rejects.toBeInstanceOf(
-      ApprovalTimeoutError,
-    );
+    const assertion =
+      expect(pending).rejects.toBeInstanceOf(ApprovalTimeoutError);
 
     // Operator never responds — advance past the SLA.
     await vi.advanceTimersByTimeAsync(1_000);

--- a/src/core/operator/approvalGate.test.ts
+++ b/src/core/operator/approvalGate.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ApprovalGate,
+  ApprovalTimeoutError,
+  DEFAULT_DECISION_TIMEOUT_MS,
+} from "./approvalGate";
+
+describe("ApprovalGate — operator decision timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("denies the pending approval when the operator does not respond within the SLA", async () => {
+    const gate = new ApprovalGate({
+      requireApproval: true,
+      decisionTimeoutMs: 1_000,
+    });
+
+    const resolvedEvents: unknown[] = [];
+    gate.on("approval-resolved", (e) => resolvedEvents.push(e));
+
+    const pending = gate.check("http_request", "tc_1", { url: "https://t/" });
+    // Attach the rejection assertion before advancing timers so the
+    // eventual reject() lands on an already-handled promise.
+    const assertion = expect(pending).rejects.toBeInstanceOf(
+      ApprovalTimeoutError,
+    );
+
+    // Operator never responds — advance past the SLA.
+    await vi.advanceTimersByTimeAsync(1_000);
+    await assertion;
+
+    expect(gate.getPendingApprovals()).toHaveLength(0);
+    expect(resolvedEvents).toEqual([
+      expect.objectContaining({
+        type: "approval-resolved",
+        decision: "denied",
+      }),
+    ]);
+
+    const [historyEntry] = gate.getActionHistory();
+    expect(historyEntry.decision).toBe("denied");
+    expect(historyEntry.resultSummary).toBe("decision_timeout:1000ms");
+  });
+
+  it("does not fire the timeout when the operator approves in time", async () => {
+    const gate = new ApprovalGate({
+      requireApproval: true,
+      decisionTimeoutMs: 1_000,
+    });
+
+    let approvalId = "";
+    gate.once("approval-needed", (e) => {
+      approvalId = (e as { approval: { id: string } }).approval.id;
+    });
+
+    const pending = gate.check("http_request", "tc_2", { url: "https://t/" });
+    expect(approvalId).not.toBe("");
+
+    await vi.advanceTimersByTimeAsync(500);
+    gate.approve(approvalId);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(pending).resolves.toBe("approved");
+    expect(gate.getActionHistory().at(-1)?.resultSummary).toBeUndefined();
+  });
+
+  it("does not fire the timeout when the operator denies in time", async () => {
+    const gate = new ApprovalGate({
+      requireApproval: true,
+      decisionTimeoutMs: 1_000,
+    });
+
+    let approvalId = "";
+    gate.once("approval-needed", (e) => {
+      approvalId = (e as { approval: { id: string } }).approval.id;
+    });
+
+    const pending = gate.check("http_request", "tc_3", { url: "https://t/" });
+    const assertion = expect(pending).rejects.toThrow("Action denied by user");
+    await vi.advanceTimersByTimeAsync(500);
+    gate.deny(approvalId);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await assertion;
+    expect(gate.getActionHistory().at(-1)?.resultSummary).toBeUndefined();
+  });
+
+  it("defaults to a 15-minute SLA when none is supplied", () => {
+    expect(DEFAULT_DECISION_TIMEOUT_MS).toBe(15 * 60 * 1000);
+    const gate = new ApprovalGate({ requireApproval: true });
+    expect(gate.getConfig().decisionTimeoutMs).toBe(
+      DEFAULT_DECISION_TIMEOUT_MS,
+    );
+  });
+
+  it("disables the timeout when decisionTimeoutMs is explicitly undefined-like (0)", async () => {
+    const gate = new ApprovalGate({
+      requireApproval: true,
+      decisionTimeoutMs: 0,
+    });
+
+    let approvalId = "";
+    gate.once("approval-needed", (e) => {
+      approvalId = (e as { approval: { id: string } }).approval.id;
+    });
+
+    const pending = gate.check("http_request", "tc_4", { url: "https://t/" });
+
+    // Advance well beyond a "default" timeout — nothing should fire.
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(gate.getPendingApprovals()).toHaveLength(1);
+
+    gate.approve(approvalId);
+    await expect(pending).resolves.toBe("approved");
+  });
+
+  it("auto-approves without ever starting a timer when requireApproval is false", async () => {
+    const gate = new ApprovalGate({
+      requireApproval: false,
+      decisionTimeoutMs: 1_000,
+    });
+
+    const result = await gate.check("http_request", "tc_5", {});
+    expect(result).toBe("auto-approved");
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(gate.getPendingApprovals()).toHaveLength(0);
+  });
+});

--- a/src/core/operator/approvalGate.ts
+++ b/src/core/operator/approvalGate.ts
@@ -8,19 +8,26 @@ import type {
 } from "./types";
 
 /**
- * Approval gate configuration — simple boolean toggle.
+ * Approval gate configuration.
+ *
+ * `decisionTimeoutMs` sets the operator decision SLA: when the operator
+ * does not respond within this window, the pending approval is resolved
+ * by the default-safe action (currently `"deny"`). `undefined` disables
+ * the timeout (operator decides when to act).
  */
 export interface ApprovalGateConfig {
   requireApproval: boolean;
+  decisionTimeoutMs?: number;
 }
 
-/**
- * Deferred promise for pending approvals
- */
+/** Default operator decision SLA when `requireApproval` is true. */
+export const DEFAULT_DECISION_TIMEOUT_MS = 15 * 60 * 1000;
+
 interface DeferredApproval {
   approval: PendingApproval;
   resolve: (decision: ApprovalDecision) => void;
   reject: (error: Error) => void;
+  timeoutHandle?: ReturnType<typeof setTimeout>;
 }
 
 /**
@@ -37,7 +44,10 @@ export class ApprovalGate extends EventEmitter {
 
   constructor(config: ApprovalGateConfig) {
     super();
-    this.config = config;
+    this.config = {
+      decisionTimeoutMs: DEFAULT_DECISION_TIMEOUT_MS,
+      ...config,
+    };
   }
 
   updateConfig(config: Partial<ApprovalGateConfig>): void {
@@ -94,8 +104,44 @@ export class ApprovalGate extends EventEmitter {
     return new Promise((resolve, reject) => {
       const deferred: DeferredApproval = { approval, resolve, reject };
       this.pendingApprovals.set(approval.id, deferred);
+
+      // Enforce the operator decision SLA: on timeout, resolve to the
+      // default-safe action (deny) so the agent never hangs on an
+      // unresponsive operator.
+      const timeoutMs = this.config.decisionTimeoutMs;
+      if (timeoutMs !== undefined && timeoutMs > 0) {
+        deferred.timeoutHandle = setTimeout(() => {
+          this.timeoutApproval(approval.id, timeoutMs);
+        }, timeoutMs);
+      }
+
       this.emitEvent({ type: "approval-needed", approval });
     });
+  }
+
+  private timeoutApproval(approvalId: string, timeoutMs: number): void {
+    const deferred = this.pendingApprovals.get(approvalId);
+    if (!deferred) return;
+
+    this.pendingApprovals.delete(approvalId);
+    const entry = this.recordAction(
+      deferred.approval.toolName,
+      deferred.approval.toolCallId,
+      "denied",
+    );
+    entry.resultSummary = `decision_timeout:${timeoutMs}ms`;
+
+    this.emitEvent({
+      type: "approval-resolved",
+      id: approvalId,
+      decision: "denied",
+    });
+    this.emitEvent({ type: "action-completed", entry });
+    deferred.reject(
+      new ApprovalTimeoutError(
+        `Operator decision timeout after ${timeoutMs}ms for ${deferred.approval.toolName} — default-safe deny`,
+      ),
+    );
   }
 
   approve(approvalId: string): void {
@@ -104,6 +150,7 @@ export class ApprovalGate extends EventEmitter {
       throw new Error(`No pending approval with id: ${approvalId}`);
     }
 
+    if (deferred.timeoutHandle) clearTimeout(deferred.timeoutHandle);
     this.pendingApprovals.delete(approvalId);
     const entry = this.recordAction(
       deferred.approval.toolName,
@@ -124,6 +171,7 @@ export class ApprovalGate extends EventEmitter {
     const deferred = this.pendingApprovals.get(approvalId);
     if (!deferred) return;
 
+    if (deferred.timeoutHandle) clearTimeout(deferred.timeoutHandle);
     this.pendingApprovals.delete(approvalId);
     const entry = this.recordAction(
       deferred.approval.toolName,
@@ -193,6 +241,18 @@ export class ApprovalDeniedError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "ApprovalDeniedError";
+  }
+}
+
+/**
+ * Raised when an approval request exceeds the operator decision SLA.
+ * Extends `ApprovalDeniedError` so callers that already treat denial as
+ * fail-closed will treat a timeout the same way.
+ */
+export class ApprovalTimeoutError extends ApprovalDeniedError {
+  constructor(message: string) {
+    super(message);
+    this.name = "ApprovalTimeoutError";
   }
 }
 

--- a/src/core/operator/index.ts
+++ b/src/core/operator/index.ts
@@ -54,6 +54,8 @@ export {
   ApprovalGate,
   ApprovalBlockedError,
   ApprovalDeniedError,
+  ApprovalTimeoutError,
+  DEFAULT_DECISION_TIMEOUT_MS,
   wrapToolWithApproval,
   type ApprovalGateConfig,
 } from "./approvalGate";


### PR DESCRIPTION
Approval requests in manual mode previously had no timeout — an unresponsive operator would hang the agent indefinitely. Adds a configurable `decisionTimeoutMs` (15 min default) with a default-safe deny: on expiry the pending approval is removed, a denied action is recorded, the normal `approval-resolved` event fires, and the call rejects with a new `ApprovalTimeoutError` (subclass of `ApprovalDeniedError` so existing fail-closed catches keep working).

Addresses OWASP APTS **[APTS-HO-003 — Decision Timeout and Default-Safe Behavior](https://github.com/OWASP/APTS/blob/main/standard/3_Human_Oversight/README.md#apts-ho-003-decision-timeout-and-default-safe-behavior)**.

Closes #638.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes approval workflow timing and rejection behavior by auto-denying pending approvals after a configurable SLA, which could impact long-running/manual sessions if misconfigured. Logic is fail-closed and covered by new timer-based tests, reducing risk of unsafe behavior but still affecting core operator control flow.
> 
> **Overview**
> Adds an operator decision SLA to `ApprovalGate`: pending approvals now start a timer (default `DEFAULT_DECISION_TIMEOUT_MS` = 15 minutes) and, if the operator does not respond in time, the request is **auto-denied**, removed from the pending queue, and recorded with `resultSummary` `decision_timeout:<ms>`, while still emitting the normal `approval-resolved`/`action-completed` events.
> 
> Introduces `decisionTimeoutMs` config (disable with `0`) and a new `ApprovalTimeoutError` (extends `ApprovalDeniedError`) for timeout rejections; `approve()`/`deny()` now clear any pending timer. Exports the new error/constant from `src/core/operator/index.ts` and adds Vitest coverage for timeout, non-timeout, defaults, and disabled timeout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b99cbdbaab9efc1d0e8ef33dd56358059296bdac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->