### PR TITLE
fix(persistentShell): authoritative post-kill stdout capture

### DIFF
--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "child_process";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { PersistentShell } from "./persistentShell";
+import { extractFallbackStdout, PersistentShell } from "./persistentShell";
 
 const HAS_STDBUF =
   process.platform !== "win32" &&
@@ -289,6 +289,34 @@ describe("PersistentShell — long-running stability", () => {
   }, 10_000);
 
   /**
+   * Smoke test: shell's happy-path timeout doesn't leak markers either.
+   * Useful as a second line of defense against marker leaks even though
+   * the real-world trigger (busy event loop, setTimeout fires before
+   * onStdoutData processes the exit-marker chunk) is covered by the
+   * dedicated `extractFallbackStdout` unit tests below.
+   */
+  it("does not leak nonce markers on timeout", async () => {
+    const shell = make();
+    const r = await shell.execute(`printf 'hello\\n'; sleep 10`, 1);
+    expect(r.exitCode).toBe(124);
+    expect(r.stdout).not.toMatch(/__APEX_[0-9a-f]+__(CUTOVER|EXIT_)/);
+  }, 10_000);
+
+  it("does not leak nonce markers on abort", async () => {
+    const shell = make();
+    const ac = new AbortController();
+    setTimeout(() => ac.abort(), 200);
+    const r = await shell.execute(
+      `printf 'hi\\n'; sleep 10`,
+      30,
+      undefined,
+      ac.signal,
+    );
+    expect(r.exitCode).toBe(130);
+    expect(r.stdout).not.toMatch(/__APEX_[0-9a-f]+__(CUTOVER|EXIT_)/);
+  }, 10_000);
+
+  /**
    * Streaming callback fires as output arrives, where the platform's
    * `tail -f` actually flushes line-by-line. Requires effective
    * `stdbuf -oL` on `/usr/bin/tail` (or equivalent), which means:
@@ -369,4 +397,82 @@ describe("PersistentShell — long-running stability", () => {
     expect(final.stdout).toContain("final");
     expect(elapsed).toBeLessThan(3_000);
   }, 60_000);
+});
+
+/**
+ * Direct unit tests for the fallback stdout extractor.
+ *
+ * The real-world failure (timeout or abort timer firing while Node is
+ * too busy to have processed the shell's exit-marker chunk) is too
+ * non-deterministic to force in an integration test — the shell's
+ * post-kill wrapper finishes emitting markers in a couple hundred
+ * milliseconds and almost always loses the race to the 2-second
+ * fallback timer on an idle test runner. These tests exercise the
+ * stripping logic directly on synthetic `PendingCommand` buffers that
+ * match what Node would accumulate in the pathological cases actually
+ * observed in NOCTURNE traces.
+ */
+describe("extractFallbackStdout", () => {
+  const cut = "__APEX_deadbeef00112233__CUTOVER";
+  const exitPrefix = "__APEX_deadbeef00112233__EXIT_";
+
+  const mk = (stream: string, authoritative = "") => ({
+    authoritativeStdout: authoritative,
+    streamedStdout: stream,
+    cutoverMarker: cut,
+    exitMarkerPrefix: exitPrefix,
+  });
+
+  it("returns authoritativeStdout verbatim when populated", () => {
+    expect(extractFallbackStdout(mk("ignored", "real output\n"))).toBe(
+      "real output\n",
+    );
+  });
+
+  it("strips both cutover prefix and exit-marker suffix from streamed buffer", () => {
+    // Shape observed in NOCTURNE trace step 2: command in fact completed
+    // successfully, shell emitted everything, but the fallback resolver
+    // fired before onStdoutData processed the chunk.
+    const leaked =
+      cut +
+      "\n" +
+      "/console -> HTTP 404\n/debug -> HTTP 404\n" +
+      exitPrefix +
+      "0\n";
+    expect(extractFallbackStdout(mk(leaked))).toBe(
+      "/console -> HTTP 404\n/debug -> HTTP 404",
+    );
+  });
+
+  it("strips cutover when exit marker was never emitted (killed mid-cat)", () => {
+    const leaked = cut + "\n" + "[FOUND] /health -> HTTP 200\n";
+    expect(extractFallbackStdout(mk(leaked))).toBe(
+      "[FOUND] /health -> HTTP 200\n",
+    );
+  });
+
+  it("strips exit marker when cutover was never emitted (tail never flushed)", () => {
+    // Shape from NOCTURNE step 7: only the two markers came through,
+    // no actual stdout in between.
+    const leaked = exitPrefix + "143\n";
+    expect(extractFallbackStdout(mk(leaked))).toBe("(no output)");
+  });
+
+  it("returns '(no output)' when both markers absent and buffer empty", () => {
+    expect(extractFallbackStdout(mk(""))).toBe("(no output)");
+  });
+
+  it("returns raw buffer when neither marker present but bytes did stream", () => {
+    // Tail flushed some live bytes, then the shell/pipe died before
+    // either marker reached us. Caller still sees what tail managed.
+    expect(extractFallbackStdout(mk("partial probe output\n"))).toBe(
+      "partial probe output\n",
+    );
+  });
+
+  it("handles cutover immediately followed by exit marker (empty command output)", () => {
+    // `cat $OUT` emitted zero bytes because $OUT was empty.
+    const leaked = cut + "\n" + exitPrefix + "0\n";
+    expect(extractFallbackStdout(mk(leaked))).toBe("(no output)");
+  });
 });

--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -423,9 +423,20 @@ describe("extractFallbackStdout", () => {
     exitMarkerPrefix: exitPrefix,
   });
 
-  it("returns authoritativeStdout verbatim when populated", () => {
+  it("prefers authoritativeStdout over streamedStdout when populated", () => {
     expect(extractFallbackStdout(mk("ignored", "real output\n"))).toBe(
       "real output\n",
+    );
+  });
+
+  it("strips exit marker from authoritativeStdout when fallback fires mid-phase", () => {
+    const auth = "probe results\n" + exitPrefix + "0\n";
+    expect(extractFallbackStdout(mk("ignored", auth))).toBe("probe results");
+  });
+
+  it("returns '(no output)' when authoritativeStdout contains only the exit marker", () => {
+    expect(extractFallbackStdout(mk("ignored", exitPrefix + "137\n"))).toBe(
+      "(no output)",
     );
   });
 

--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -52,8 +52,10 @@ describe("PersistentShell — long-running stability", () => {
    * plain `tail -f` for streaming. Because `tail`'s stdout was a pipe it
    * block-buffered, so short outputs were killed with tail before ever
    * flushing — every `ls -la`-style command came back with empty stdout
-   * and the agent saw `(no output)`. We now skip `tail -f` in that case
-   * and `cat` the tempfile at the end, so output is always captured.
+   * and the agent saw `(no output)`. The current wrapper always runs an
+   * authoritative post-kill `cat` of the per-command tempfile through
+   * bash's real stdout pipe, so `tail` buffering can no longer cause
+   * stdout loss.
    */
   it("captures short stdout (no-stdbuf safe)", async () => {
     const shell = make();
@@ -61,6 +63,58 @@ describe("PersistentShell — long-running stability", () => {
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toContain("hello");
     expect(r.stdout).toContain("world");
+  });
+
+  /**
+   * Regression: on macOS with SIP, `stdbuf -oL` is a silent no-op on
+   * /usr/bin/tail (DYLD_INSERT_LIBRARIES is stripped from protected
+   * binaries). If the wrapper relies on tail alone to stream stdout,
+   * tail block-buffers (~8 KiB default) and the buffer is discarded
+   * when we kill tail 100 ms after the command finishes — every short
+   * command returns empty stdout. Executed by APEX TUI in operator mode,
+   * by the CLI pentest entrypoint, and by Evalgate-driven runs (e.g.
+   * NOCTURNE), producing `(no output)` for trivial commands and
+   * dominating eval signal with shell brokenness rather than agent
+   * capability.
+   *
+   * These assertions fail on macOS against the pre-patch wrapper and
+   * pass once the authoritative post-kill `cat` phase is in place.
+   */
+  it("captures trivial stdout even when tail block-buffers", async () => {
+    const shell = make();
+    const echo = await shell.execute("echo hello", 5);
+    expect(echo.exitCode).toBe(0);
+    expect(echo.stdout).toContain("hello");
+
+    const pwd = await shell.execute("pwd", 5);
+    expect(pwd.exitCode).toBe(0);
+    expect(pwd.stdout.trim().length).toBeGreaterThan(0);
+
+    const seq = await shell.execute("seq 1 5", 5);
+    expect(seq.exitCode).toBe(0);
+    expect(seq.stdout.trim()).toBe("1\n2\n3\n4\n5");
+  });
+
+  /**
+   * Regression: tail's default block-buffer is ~8 KiB. A command whose
+   * stdout is just under, at, and just over that boundary must come back
+   * fully intact, with no silent truncation regardless of whether tail
+   * ever flushed its buffer. Exercises the authoritative `cat` phase on
+   * a realistic recon-output size.
+   */
+  it("captures output across the 8 KiB block-buffer boundary", async () => {
+    const shell = make();
+    // Emit exactly 9000 'x' bytes followed by a newline. Uses /dev/zero
+    // to avoid bash/yes-pipeline byte-counting footguns (e.g.
+    // `yes x | head -c 9000` includes the newlines that `yes` emits, so
+    // stripping them halves the payload). 9000 > 8192 to ensure we
+    // exceed tail's default ~8 KiB block-buffer size.
+    const r = await shell.execute(
+      "head -c 9000 /dev/zero | tr '\\0' 'x'; echo",
+      5,
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.replace(/\n$/, "").length).toBe(9000);
   });
 
   /**
@@ -235,12 +289,24 @@ describe("PersistentShell — long-running stability", () => {
   }, 10_000);
 
   /**
-   * Streaming callback still fires as output arrives, even though stdout
-   * is now routed through a per-command tempfile + `tail -f` rather than
-   * bash's raw stdout pipe. Requires GNU `stdbuf` to line-buffer `tail -f`;
-   * without it the shell skips streaming and `cat`s the tempfile at the end.
+   * Streaming callback fires as output arrives, where the platform's
+   * `tail -f` actually flushes line-by-line. Requires effective
+   * `stdbuf -oL` on `/usr/bin/tail` (or equivalent), which means:
+   *
+   *   - Linux glibc + GNU coreutils: works.
+   *   - macOS under SIP: `DYLD_INSERT_LIBRARIES` is stripped from
+   *     `/usr/bin/tail`, so `stdbuf` is a silent no-op; `tail`
+   *     block-buffers its pipe and nothing flushes until we kill it.
+   *     Final stdout is still correct (guaranteed by the authoritative
+   *     post-kill `cat` phase), but live streaming is a known lossy UX
+   *     on darwin and agents do not rely on it. Skip there.
+   *   - Alpine / musl: BusyBox `tail` ignores `libstdbuf`; same result.
+   *
+   * The patch does not fix live streaming on these platforms — it only
+   * fixes final-stdout correctness. This test guards the live-streaming
+   * property on platforms that can deliver it.
    */
-  it.skipIf(!HAS_STDBUF)(
+  it.skipIf(!HAS_STDBUF || process.platform === "darwin")(
     "streams stdout to onData as output arrives",
     async () => {
       const shell = make();

--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -299,7 +299,7 @@ describe("PersistentShell — long-running stability", () => {
     const shell = make();
     const r = await shell.execute(`printf 'hello\\n'; sleep 10`, 1);
     expect(r.exitCode).toBe(124);
-    expect(r.stdout).not.toMatch(/__APEX_[0-9a-f]+__(CUTOVER|EXIT_)/);
+    expect(r.stdout).not.toMatch(/__APEX_[0-9a-f]+___(CUTOVER|EXIT_)/);
   }, 10_000);
 
   it("does not leak nonce markers on abort", async () => {
@@ -313,7 +313,7 @@ describe("PersistentShell — long-running stability", () => {
       ac.signal,
     );
     expect(r.exitCode).toBe(130);
-    expect(r.stdout).not.toMatch(/__APEX_[0-9a-f]+__(CUTOVER|EXIT_)/);
+    expect(r.stdout).not.toMatch(/__APEX_[0-9a-f]+___(CUTOVER|EXIT_)/);
   }, 10_000);
 
   /**

--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -431,7 +431,7 @@ describe("extractFallbackStdout", () => {
 
   it("strips exit marker from authoritativeStdout when fallback fires mid-phase", () => {
     const auth = "probe results\n" + exitPrefix + "0\n";
-    expect(extractFallbackStdout(mk("ignored", auth))).toBe("probe results");
+    expect(extractFallbackStdout(mk("ignored", auth))).toBe("probe results\n");
   });
 
   it("returns '(no output)' when authoritativeStdout contains only the exit marker", () => {
@@ -451,7 +451,7 @@ describe("extractFallbackStdout", () => {
       exitPrefix +
       "0\n";
     expect(extractFallbackStdout(mk(leaked))).toBe(
-      "/console -> HTTP 404\n/debug -> HTTP 404",
+      "/console -> HTTP 404\n/debug -> HTTP 404\n",
     );
   });
 

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -136,7 +136,6 @@ export function extractFallbackStdout(cmd: {
     const exitIdx = s.indexOf(cmd.exitMarkerPrefix);
     if (exitIdx !== -1) {
       s = s.substring(0, exitIdx);
-      if (s.endsWith("\n")) s = s.substring(0, s.length - 1);
     }
     return s || "(no output)";
   }
@@ -152,7 +151,6 @@ export function extractFallbackStdout(cmd: {
   const exitIdx = s.indexOf(cmd.exitMarkerPrefix);
   if (exitIdx !== -1) {
     s = s.substring(0, exitIdx);
-    if (s.endsWith("\n")) s = s.substring(0, s.length - 1);
   }
 
   return s || "(no output)";

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -11,7 +11,25 @@ export interface ShellExecuteResult {
 }
 
 interface PendingCommand {
-  stdout: string;
+  /**
+   * Bytes observed on bash's stdout pipe BEFORE the cutover marker. These
+   * come from the background `tail -f` of the per-command tempfile and
+   * are best-effort live UX only — on platforms where `tail`'s pipe
+   * block-buffers (macOS under SIP even with `stdbuf`), this buffer may
+   * be partial or empty. Used for `onData` streaming and as a fallback
+   * if the command is killed before the authoritative phase starts.
+   */
+  streamedStdout: string;
+  /**
+   * Bytes observed AFTER the cutover marker. Emitted by `cat "$OUT"`
+   * through bash's real stdout pipe with no tail/libc intermediary, so
+   * this is the authoritative capture of the user command's stdout.
+   */
+  authoritativeStdout: string;
+  /** True once we've seen the per-command cutover marker on the pipe. */
+  cutoverSeen: boolean;
+  /** The cutover marker string for this command (per-command random). */
+  cutoverMarker: string;
   stderr: string;
   stdoutTruncated: boolean;
   exitMarkerPrefix: string;
@@ -55,12 +73,15 @@ interface PendingCommand {
  */
 /**
  * Cached once: whether `stdbuf` is available. We use it to line-buffer
- * `tail -f` so command output streams to the caller in near-real-time.
- * When it isn't available we skip `tail -f` entirely and `cat` the
- * per-command output tempfile after the command finishes — correct final
- * output, but no real-time streaming. We can't use plain `tail -f` as a
- * fallback: when its stdout is a pipe it block-buffers, so short outputs
- * are lost when we kill the tail before it flushes.
+ * `tail -f` so command output streams to the caller in near-real-time
+ * on platforms where it's effective (Linux glibc).
+ *
+ * Final stdout correctness does NOT depend on `stdbuf` — the wrapper
+ * always emits a post-kill authoritative `cat` of the per-command
+ * output tempfile through bash's real stdout pipe, so even when
+ * `tail -f` block-buffers (macOS under SIP, Alpine, minimal containers)
+ * and its buffer is discarded when we kill it, the caller still gets
+ * the full output. `stdbuf` only affects live streaming UX quality.
  */
 let stdbufAvailable: boolean | null = null;
 function hasStdbuf(): boolean {
@@ -133,7 +154,8 @@ export class PersistentShell {
         this.current = null;
         this.pendingCancel = null;
         cmd.resolve({
-          stdout: cmd.stdout || "(no output)",
+          stdout:
+            cmd.authoritativeStdout || cmd.streamedStdout || "(no output)",
           stderr: cmd.stderr || "",
           exitCode: 1,
         });
@@ -157,22 +179,71 @@ export class PersistentShell {
    * incoming bytes are silently dropped so background-process output does
    * not fill the kernel pipe buffer and does not bleed into the next
    * command's captured output.
+   *
+   * Each wrapped command emits, in order on bash's stdout pipe:
+   *   1. Best-effort live bytes from the background `tail -f` (may be
+   *      empty if the platform's tail block-buffers).
+   *   2. A per-command cutover marker emitted by `printf` after tail is
+   *      killed.
+   *   3. Authoritative bytes from `cat "$OUT"` through bash's own pipe
+   *      (no tail, no libc buffering) — this is the source of truth for
+   *      `result.stdout`.
+   *   4. The exit marker.
+   *
+   * We split the incoming stream at the cutover marker:
+   *   - Pre-cutover → fed to `onData` for live UX, buffered in
+   *     `streamedStdout` as a fallback for kill-before-cutover paths.
+   *   - Post-cutover → accumulated in `authoritativeStdout`; exit-marker
+   *     detection runs on this buffer, so user command output cannot
+   *     accidentally match the exit marker before the authoritative
+   *     phase has been bracketed.
    */
   private onStdoutData(data: Buffer): void {
     const cmd = this.current;
     if (!cmd) return;
 
-    const chunk = data.toString();
-    if (cmd.onData) {
-      const mIdx = chunk.indexOf(cmd.exitMarkerPrefix);
-      const visible = mIdx === -1 ? chunk : chunk.substring(0, mIdx);
-      if (visible.length > 0) cmd.onData(visible);
-    }
-    cmd.stdout += chunk;
+    let chunk = data.toString();
 
-    const markerIdx = cmd.stdout.indexOf(cmd.exitMarkerPrefix);
+    if (!cmd.cutoverSeen) {
+      // Search the accumulated buffer, not just the new chunk, so a
+      // cutover marker that straddles two Buffer reads is still found.
+      const prevLen = cmd.streamedStdout.length;
+      cmd.streamedStdout += chunk;
+      const cutIdx = cmd.streamedStdout.indexOf(cmd.cutoverMarker);
+
+      if (cutIdx === -1) {
+        if (chunk.length > 0 && cmd.onData) cmd.onData(chunk);
+        if (cmd.streamedStdout.length > MAX_BUFFER) {
+          cmd.streamedStdout = cmd.streamedStdout.substring(
+            cmd.streamedStdout.length - MAX_BUFFER,
+          );
+        }
+        return;
+      }
+
+      // Feed only the pre-cutover bytes from THIS chunk to onData so we
+      // don't re-emit bytes that earlier chunks already delivered.
+      const chunkCutOffset = cutIdx - prevLen;
+      if (chunkCutOffset > 0 && cmd.onData) {
+        cmd.onData(chunk.substring(0, chunkCutOffset));
+      }
+
+      const postMarker = cmd.streamedStdout.substring(
+        cutIdx + cmd.cutoverMarker.length,
+      );
+      cmd.cutoverSeen = true;
+      cmd.streamedStdout = "";
+      chunk = postMarker.startsWith("\n")
+        ? postMarker.substring(1)
+        : postMarker;
+      if (chunk.length === 0) return;
+    }
+
+    cmd.authoritativeStdout += chunk;
+
+    const markerIdx = cmd.authoritativeStdout.indexOf(cmd.exitMarkerPrefix);
     if (markerIdx !== -1) {
-      const afterPrefix = cmd.stdout.substring(
+      const afterPrefix = cmd.authoritativeStdout.substring(
         markerIdx + cmd.exitMarkerPrefix.length,
       );
       const nlIdx = afterPrefix.indexOf("\n");
@@ -180,7 +251,7 @@ export class PersistentShell {
         nlIdx >= 0 ? afterPrefix.substring(0, nlIdx) : afterPrefix;
       const naturalExitCode = parseInt(exitStr, 10);
 
-      let commandOutput = cmd.stdout.substring(0, markerIdx);
+      let commandOutput = cmd.authoritativeStdout.substring(0, markerIdx);
       if (cmd.stdoutTruncated) {
         commandOutput = "(stdout truncated)...\n" + commandOutput;
       }
@@ -206,8 +277,10 @@ export class PersistentShell {
       return;
     }
 
-    if (cmd.stdout.length > MAX_BUFFER) {
-      cmd.stdout = cmd.stdout.substring(cmd.stdout.length - MAX_BUFFER);
+    if (cmd.authoritativeStdout.length > MAX_BUFFER) {
+      cmd.authoritativeStdout = cmd.authoritativeStdout.substring(
+        cmd.authoritativeStdout.length - MAX_BUFFER,
+      );
       cmd.stdoutTruncated = true;
     }
   }
@@ -250,6 +323,7 @@ export class PersistentShell {
 
     const marker = `__APEX_${randomBytes(8).toString("hex")}__`;
     const exitMarkerPrefix = `${marker}_EXIT_`;
+    const cutoverMarker = `${marker}_CUTOVER`;
 
     return new Promise<ShellExecuteResult>((resolve) => {
       let resolved = false;
@@ -257,7 +331,10 @@ export class PersistentShell {
       let killEscalationTimer: ReturnType<typeof setTimeout> | undefined;
 
       const pending: PendingCommand = {
-        stdout: "",
+        streamedStdout: "",
+        authoritativeStdout: "",
+        cutoverSeen: false,
+        cutoverMarker,
         stderr: "",
         stdoutTruncated: false,
         exitMarkerPrefix,
@@ -294,7 +371,10 @@ export class PersistentShell {
             setTimeout(() => {
               if (resolved) return;
               pending.resolve({
-                stdout: pending.stdout || "(no output)",
+                stdout:
+                  pending.authoritativeStdout ||
+                  pending.streamedStdout ||
+                  "(no output)",
                 stderr:
                   (pending.stderr || "") + (pending.forcedStderrSuffix ?? ""),
                 exitCode: 130,
@@ -322,7 +402,10 @@ export class PersistentShell {
             setTimeout(() => {
               if (resolved) return;
               pending.resolve({
-                stdout: pending.stdout || "(no output)",
+                stdout:
+                  pending.authoritativeStdout ||
+                  pending.streamedStdout ||
+                  "(no output)",
                 stderr: pending.stderr || "",
                 exitCode: 124,
               });
@@ -337,45 +420,52 @@ export class PersistentShell {
       //   - stdin redirected from `/dev/null` so children that read stdin
       //     cannot hijack our command pipe;
       //   - stdout captured to a per-command tempfile (NOT bash's stdout
-      //     pipe) and streamed back via a background `tail -f`. This
-      //     prevents backgrounded children whose fd 1 was never redirected
-      //     (`nmap -v &`) from bleeding their output into the next
-      //     command's captured stdout, because their inherited fd 1 is
-      //     the tempfile for the command that spawned them, not the
+      //     pipe) and streamed back via a background `tail -f` for live
+      //     UX. This prevents backgrounded children whose fd 1 was never
+      //     redirected (`nmap -v &`) from bleeding their output into the
+      //     next command's captured stdout, because their inherited fd 1
+      //     is the tempfile for the command that spawned them, not the
       //     shell's stdout pipe;
       //   - stderr captured to another tempfile and flushed after, so we
       //     can distinguish stdout from stderr without interleaving;
+      //   - after the user command finishes we kill the tail, then emit
+      //     a per-command cutover marker on bash's real stdout pipe, then
+      //     `cat` the stdout tempfile. The post-cutover `cat` bytes are
+      //     authoritative: they pass through bash's pipe with no tail /
+      //     libc block-buffering intermediary. The Node handler treats
+      //     pre-cutover bytes as live-UX streaming only and post-cutover
+      //     bytes as the authoritative capture returned in the result.
+      //     This is required because `tail`'s stdout is a pipe and
+      //     block-buffered by libc; on platforms where `stdbuf` is a
+      //     no-op (macOS under SIP, Alpine, minimal containers without
+      //     coreutils) the buffered bytes would be discarded when we
+      //     kill tail, silently losing all stdout for small commands;
       //   - the exit marker is echoed on bash's real stdout pipe, so the
       //     parent Node handler always sees it immediately regardless of
-      //     how much command output the tail has left to flush.
-      // When `stdbuf` is available (GNU coreutils), a fast-polling
-      // `stdbuf -oL tail -n +1 -f -s 0.05` is run in the background so
-      // stdout streams to the caller in near-real-time (well under 100 ms
-      // latency per chunk). Without `stdbuf` (e.g. default macOS), `tail`'s
-      // stdout is a pipe and block-buffered, so short outputs never flush
-      // before we kill it — we'd lose them entirely. In that case we skip
-      // streaming and just `cat` the tempfile after the command finishes;
-      // output is correct but no longer real-time.
-      const streaming = hasStdbuf();
+      //     how much command output the cat has left to flush.
+      // When `stdbuf` is available and effective (GNU coreutils on glibc
+      // Linux), a fast-polling `stdbuf -oL tail -n +1 -f -s 0.05` is run
+      // in the background so live streaming latency is well under 100 ms
+      // per chunk. Elsewhere the tail still runs (in case it happens to
+      // flush) but the authoritative cat guarantees correctness either
+      // way.
+      const tailCmd = hasStdbuf()
+        ? `stdbuf -oL tail -n +1 -f -s 0.05 "$__APEX_OUT"`
+        : `tail -n +1 -f -s 0.05 "$__APEX_OUT"`;
       const wrapped = [
         `__APEX_OUT=$(mktemp 2>/dev/null || echo /tmp/.apex_out_$$)`,
         `__APEX_ERR=$(mktemp 2>/dev/null || echo /tmp/.apex_err_$$)`,
-        ...(streaming
-          ? [
-              `stdbuf -oL tail -n +1 -f -s 0.05 "$__APEX_OUT" 2>/dev/null &`,
-              `__APEX_TAIL=$!`,
-            ]
-          : []),
+        `${tailCmd} 2>/dev/null &`,
+        `__APEX_TAIL=$!`,
         `{ ${command}\n} </dev/null >"$__APEX_OUT" 2>"$__APEX_ERR"`,
         `__APEX_EC=$?`,
-        ...(streaming
-          ? [
-              // Let tail drain any remaining bytes before we kill it.
-              `sleep 0.1`,
-              `kill "$__APEX_TAIL" 2>/dev/null`,
-              `wait "$__APEX_TAIL" 2>/dev/null`,
-            ]
-          : [`cat "$__APEX_OUT"`]),
+        `sleep 0.1`,
+        `kill "$__APEX_TAIL" 2>/dev/null`,
+        `wait "$__APEX_TAIL" 2>/dev/null`,
+        // Authoritative cutover: post-marker bytes come through bash's
+        // real stdout pipe via `cat`, bypassing any tail/libc buffering.
+        `printf '%s\\n' "${cutoverMarker}"`,
+        `cat "$__APEX_OUT"`,
         `cat "$__APEX_ERR" >&2`,
         `rm -f "$__APEX_OUT" "$__APEX_ERR"`,
         `echo "${exitMarkerPrefix}$__APEX_EC"`,
@@ -414,7 +504,8 @@ export class PersistentShell {
         // Fallback resolve if bash's wrapper never emits a marker.
         setTimeout(() => {
           cmd.resolve({
-            stdout: cmd.stdout || "(no output)",
+            stdout:
+              cmd.authoritativeStdout || cmd.streamedStdout || "(no output)",
             stderr: (cmd.stderr || "") + (cmd.forcedStderrSuffix ?? ""),
             exitCode: 130,
           });
@@ -422,7 +513,7 @@ export class PersistentShell {
       }, 500);
     } else {
       cmd.resolve({
-        stdout: cmd.stdout || "(no output)",
+        stdout: cmd.authoritativeStdout || cmd.streamedStdout || "(no output)",
         stderr: (cmd.stderr || "") + (cmd.forcedStderrSuffix ?? ""),
         exitCode: 130,
       });

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -131,7 +131,15 @@ export function extractFallbackStdout(cmd: {
   cutoverMarker: string;
   exitMarkerPrefix: string;
 }): string {
-  if (cmd.authoritativeStdout) return cmd.authoritativeStdout;
+  if (cmd.authoritativeStdout) {
+    let s = cmd.authoritativeStdout;
+    const exitIdx = s.indexOf(cmd.exitMarkerPrefix);
+    if (exitIdx !== -1) {
+      s = s.substring(0, exitIdx);
+      if (s.endsWith("\n")) s = s.substring(0, s.length - 1);
+    }
+    return s || "(no output)";
+  }
 
   let s = cmd.streamedStdout;
 

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -95,6 +95,61 @@ function hasStdbuf(): boolean {
   return stdbufAvailable;
 }
 
+/**
+ * Produce a clean stdout string for the timeout / abort / close / cancel
+ * fallback resolvers.
+ *
+ * The happy-path handler (`onStdoutData`) parses the cutover and exit
+ * markers as they arrive and only commits stripped bytes to
+ * `authoritativeStdout`. When a fallback resolver fires first — because
+ * the Node event loop was busy processing AI SDK streams / telemetry /
+ * other tool calls while the shell's output was queued on the pipe, so
+ * a timeout/abort timer got to run before `onStdoutData` processed the
+ * chunk containing the exit marker — the candidate stdout is
+ * `streamedStdout`, which is the raw bash pipe accumulator and may still
+ * contain the per-command markers verbatim.
+ *
+ * Observed before this helper (NOCTURNE traces): commands that had in
+ * fact completed successfully had their stdout leak as e.g.
+ *   `__APEX_7e680629f7b4a78b__CUTOVER\n/debug -> HTTP 404\n...\n__APEX_7e680629f7b4a78b__EXIT_0\n`
+ * to the agent as tool output, which the model interpreted as literal
+ * strings in the target application's response.
+ *
+ * This function performs the same stripping the happy-path parser does,
+ * so all four fallback paths produce the same shape of stdout a normal
+ * completion would.
+ *
+ * Prefers `authoritativeStdout` when populated (happy path partially
+ * ran) since those bytes are already stripped; otherwise parses the raw
+ * `streamedStdout`. Exported for direct unit testing — the real-world
+ * trigger requires a busy event loop which is hard to force in a
+ * deterministic integration test.
+ */
+export function extractFallbackStdout(cmd: {
+  authoritativeStdout: string;
+  streamedStdout: string;
+  cutoverMarker: string;
+  exitMarkerPrefix: string;
+}): string {
+  if (cmd.authoritativeStdout) return cmd.authoritativeStdout;
+
+  let s = cmd.streamedStdout;
+
+  const cutIdx = s.indexOf(cmd.cutoverMarker);
+  if (cutIdx !== -1) {
+    s = s.substring(cutIdx + cmd.cutoverMarker.length);
+    if (s.startsWith("\n")) s = s.substring(1);
+  }
+
+  const exitIdx = s.indexOf(cmd.exitMarkerPrefix);
+  if (exitIdx !== -1) {
+    s = s.substring(0, exitIdx);
+    if (s.endsWith("\n")) s = s.substring(0, s.length - 1);
+  }
+
+  return s || "(no output)";
+}
+
 export class PersistentShell {
   private proc: ChildProcess | null = null;
   private alive = false;
@@ -154,8 +209,7 @@ export class PersistentShell {
         this.current = null;
         this.pendingCancel = null;
         cmd.resolve({
-          stdout:
-            cmd.authoritativeStdout || cmd.streamedStdout || "(no output)",
+          stdout: extractFallbackStdout(cmd),
           stderr: cmd.stderr || "",
           exitCode: 1,
         });
@@ -371,10 +425,7 @@ export class PersistentShell {
             setTimeout(() => {
               if (resolved) return;
               pending.resolve({
-                stdout:
-                  pending.authoritativeStdout ||
-                  pending.streamedStdout ||
-                  "(no output)",
+                stdout: extractFallbackStdout(pending),
                 stderr:
                   (pending.stderr || "") + (pending.forcedStderrSuffix ?? ""),
                 exitCode: 130,
@@ -402,10 +453,7 @@ export class PersistentShell {
             setTimeout(() => {
               if (resolved) return;
               pending.resolve({
-                stdout:
-                  pending.authoritativeStdout ||
-                  pending.streamedStdout ||
-                  "(no output)",
+                stdout: extractFallbackStdout(pending),
                 stderr: pending.stderr || "",
                 exitCode: 124,
               });
@@ -504,8 +552,7 @@ export class PersistentShell {
         // Fallback resolve if bash's wrapper never emits a marker.
         setTimeout(() => {
           cmd.resolve({
-            stdout:
-              cmd.authoritativeStdout || cmd.streamedStdout || "(no output)",
+            stdout: extractFallbackStdout(cmd),
             stderr: (cmd.stderr || "") + (cmd.forcedStderrSuffix ?? ""),
             exitCode: 130,
           });
@@ -513,7 +560,7 @@ export class PersistentShell {
       }, 500);
     } else {
       cmd.resolve({
-        stdout: cmd.authoritativeStdout || cmd.streamedStdout || "(no output)",
+        stdout: extractFallbackStdout(cmd),
         stderr: (cmd.stderr || "") + (cmd.forcedStderrSuffix ?? ""),
         exitCode: 130,
       });


### PR DESCRIPTION
## Summary

Silent stdout loss in `PersistentShell` on macOS (and Alpine / minimal containers) is corrupting agent behavior across the APEX TUI, the `pentest` CLI, and every Evalgate-driven frontier eval that runs APEX on a Mac. Short commands (`echo`, `pwd`, `ls -la`, most recon probes) return empty stdout, which [`executeCommand.ts`](../blob/canary/src/core/agents/offSecAgent/tools/executeCommand.ts#L69) turns into `"(no output)"`. The agent believes its recon returned nothing, abandons real attack paths, and hallucinates findings from whatever did come through (browser tool, HTTP tool, stderr).

This PR makes final-stdout capture authoritative and platform-independent by adding a post-kill `cat` phase that bypasses `tail`/libc buffering entirely.

## The bug

The current wrapper streams per-command stdout to Node by running a background `tail -f` of a tempfile:

```bash
stdbuf -oL tail -n +1 -f -s 0.05 "$__APEX_OUT" 2>/dev/null &
__APEX_TAIL=\$!
{ <command> } </dev/null >\"\$__APEX_OUT\" 2>\"\$__APEX_ERR\"
__APEX_EC=\$?
sleep 0.1
kill \"\$__APEX_TAIL\" 2>/dev/null
wait \"\$__APEX_TAIL\" 2>/dev/null
```

Correctness depends on two assumptions:

1. `stdbuf -oL` actually line-buffers `tail`'s stdout pipe.
2. `tail` flushes everything before we kill it.

On macOS under SIP, **both fail**. SIP strips \`DYLD_INSERT_LIBRARIES\` from protected system binaries, including \`/usr/bin/tail\`, so \`stdbuf\`'s \`LD_PRELOAD\`/\`libstdbuf\` trick is a silent no-op. Tail block-buffers its stdout pipe (~8 KiB default), the \`kill\` fires ~100 ms later, tail's buffer is discarded with the process, and the parent Node handler sees only the exit marker. \`cmd.stdout\` ends up \`\"\"\`.

Stderr survives because it's \`cat\`'d synchronously after the command, bypassing tail.

### Platform scope

| Platform | Effective \`stdbuf\`? | \`tail\` stdout | Bug? | Why |
|---|---|---|---|---|
| macOS (Intel / Apple Silicon), SIP on | No | Block-buffered | **Yes, when \`stdbuf\` is on PATH** (brew coreutils) | SIP strips \`DYLD_INSERT_LIBRARIES\` from \`/usr/bin/tail\` |
| macOS with no \`stdbuf\` on PATH | N/A | N/A | No (today) | [#636](https://github.com/pensarai/apex/pull/636) added a \`cat\`-only fallback for this case |
| Linux glibc + coreutils (Debian/Ubuntu/Fedora/Arch, CI, Daytona) | Yes | Line-buffered | No | \`LD_PRELOAD\` works, libstdbuf forces line buffering |
| Linux (musl / Alpine) | Partial | Block-buffered | Often yes | BusyBox \`tail\` ignores libstdbuf; \`libstdbuf\` may not load on musl |
| Linux glibc without coreutils (minimal containers) | No | N/A | No (today, via #636) | \`cat\`-only fallback |
| Inside APEX Daytona sandbox | Yes | Line-buffered | No | glibc + coreutils |
| Windows | N/A | N/A | No | Separate \`cmd.exe\` code path |

Where the bug actually fires today: APEX TUI on a Mac, APEX CLI pentest on a Mac, Evalgate \`runApexFromSource\` spawning APEX on a Mac (the NOCTURNE path), APEX running inside Alpine/BusyBox targets. Never fires inside the Daytona sandbox, which is why benchmark runs don't trip it. Never caught by CI unit tests, which run on Ubuntu/glibc.

### Why [#636](https://github.com/pensarai/apex/pull/636) didn't close the bug

PR #636 made \`hasStdbuf()\` fall back to \`cat \"\$__APEX_OUT\"\` when \`stdbuf\` isn't installed at all. It fixed the \"vanilla macOS dev machine\" case. But users with brew coreutils installed, or any container with partial GNU tooling, still take the \`tail -f\` path — and on those setups \`stdbuf\` is present but **ineffective**, so the original failure still fires. \`hasStdbuf()\` doesn't distinguish \"\`stdbuf\` exists\" from \"\`stdbuf\` is effective against the dynamic linker on this platform\".

## The fix

**Keep \`tail -f\` for live UX; add an authoritative post-kill \`cat\` phase that Node treats as the source of truth.**

After killing the background tail, the wrapper emits:

1. A per-command random cutover marker (\`__APEX_<nonce>__CUTOVER\`) via \`printf\` on bash's real stdout pipe.
2. \`cat \"\$__APEX_OUT\"\` — also through bash's real stdout pipe, with no tail or libc buffering in between.

Node-side, \`onStdoutData\` splits the incoming stream at the cutover marker:

- **Pre-cutover** bytes → fed to \`onData\` for live UX streaming, buffered in \`streamedStdout\` as a fallback for kill-before-cutover paths (timeout, abort, cancel).
- **Post-cutover** bytes → accumulated into \`authoritativeStdout\`. Exit-marker detection runs against this buffer, so the user command's own stdout cannot accidentally trigger early resolution from the pre-cutover phase.

\`PendingCommand\` now has \`streamedStdout\`, \`authoritativeStdout\`, \`cutoverSeen\`, \`cutoverMarker\` in place of a single \`stdout\`. All four fallback-resolve sites (close handler, timeout fallback, abort fallback, \`cancelCurrentCommand\`) return \`authoritativeStdout || streamedStdout || \"(no output)\"\` — so a command killed before the cutover phase still returns whatever tail managed to flush, never worse than today.

The two old wrapper branches (\`hasStdbuf\` → tail-with-stdbuf vs \`!hasStdbuf\` → cat-only) collapse into one unified wrapper. \`stdbuf\` is still used as a hint for better streaming UX when it's effective, but final-stdout correctness no longer depends on it.

### Chunk-boundary safety

An early iteration of the handler had a bug where a cutover marker straddling two Node Buffer reads would be missed (\`chunk.indexOf(marker)\` returns -1 on each chunk alone). The committed handler searches the accumulated \`streamedStdout\` (not just the latest chunk), so markers that arrive split are matched correctly; \`onData\` only receives the new-chunk slice of the pre-cutover bytes, so streamed bytes are never emitted twice.

### Behavior preserved

- \`cd\`, \`export\`, shell functions, aliases still persist (brace-group wrapping unchanged).
- Stdin still redirected from \`/dev/null\` (stdin-hijack fix from #625 unchanged).
- Process-group cleanup on timeout/abort unchanged.
- Exit-code sentinels (124 on timeout, 130 on abort/cancel) unchanged.
- \`MAX_BUFFER\` truncation + \`(stdout truncated)...\` prefix unchanged, now applied to the authoritative buffer.
- Live-streaming UX on Linux glibc unchanged.
- Windows \`cmd.exe\` path completely untouched.

## Risks

| Risk | Likelihood | Mitigation |
|---|---|---|
| Exit-marker false positive inside user output | Negligible | 8 random hex bytes per command; same collision model as today |
| Cutover-marker collision with user output | Negligible | Same nonce; per-command |
| Doubled wire traffic (tail stream + authoritative \`cat\`) | Low | KB-scale for typical commands; Node drains the pipe continuously so nothing accumulates |
| \`cat\` fails mid-phase (tempfile vanishes) | Very low | Fallback returns \`streamedStdout\`; not worse than today |
| Kill before cutover (timeout/abort) | Handled | Forced exit codes unchanged; fallback resolvers return \`streamedStdout\` |

Risks of **not** fixing:

- Every macOS APEX run silently loses stdout for small commands. No user-visible error; \`success: true\` masks it.
- NOCTURNE and every Evalgate frontier eval produce signal dominated by shell brokenness, not agent capability. Current eval scores on Mac runners are contaminated.
- Any deployment on Alpine or minimal containers hits the same bug.
- CI unit tests on Ubuntu/glibc don't catch the failure — silent regression risk forever.

## Validation

### Added regression tests

[\`src/core/agents/offSecAgent/tools/persistentShell.test.ts\`](../blob/fix/persistent-shell-authoritative-stdout/src/core/agents/offSecAgent/tools/persistentShell.test.ts):

- **\"captures trivial stdout even when tail block-buffers\"** — runs \`echo hello\`, \`pwd\`, \`seq 1 5\` back-to-back. Fails on macOS with \`stdbuf\` on PATH against the pre-patch wrapper (every \`.stdout\` is \`\"(no output)\"\`); passes post-patch.
- **\"captures output across the 8 KiB block-buffer boundary\"** — uses \`head -c 9000 /dev/zero | tr '\\\\0' 'x'\` to emit exactly 9000 \`x\` bytes (well above tail's ~8 KiB default buffer); asserts the full payload survives.
- Existing **\"streams stdout to onData as output arrives\"** — gated on \`!HAS_STDBUF || process.platform === \"darwin\"\`. Comment documents the SIP/DYLD reason and notes that live streaming is a known best-effort UX on darwin; the patch only guarantees final-stdout correctness there. All other platforms continue to enforce the live-streaming property.

### Local verification

```
bun run lint        # clean
bun run format:check  # clean
bun run test src/core/agents/offSecAgent/tools/persistentShell.test.ts
# 10 passed, 1 skipped (streaming test on darwin, by design)
bun run test      # 756 passed, 2 failed
```

The 2 failures in \`src/core/ai/ai.test.ts\` are pre-existing (\`AI_APICallError\` against real Anthropic) — confirmed to reproduce on \`canary\` with the patch stashed, unrelated to this change. Similarly, the single \`src/tui/utils/paste.ts\` \`tsc\` error is pre-existing on \`canary\`.

### Suggested post-merge validation

- Run APEX TUI operator mode on a Mac (\`bun run dev\`) against a local target. Confirm recon commands no longer return \`\"(no output)\"\` by grepping the session trace:
  \`\`\`
  rg -c '\"\\\\(no output\\\\)\"' ~/.pensar/sessions/<id>/subagents/*.trace.jsonl
  \`\`\`
  Pre-patch on Mac: tens to hundreds within the first minute. Post-patch: single digits (only commands that legitimately produce no output).
- Re-run NOCTURNE via Evalgate on a Mac and compare \`(no output)\` counts against baseline. Expect > 90% reduction in \`(no output)\` and a corresponding increase in real shell-based recon reaching the target (e.g. \`/debug/\*\` hits on Meridian rising from 0 to dozens).

### CI matrix

Current CI (\`.github/workflows/ci.yml\`) runs on Linux glibc — the patched correctness tests pass there today. Suggested follow-up (not in this PR): add an Alpine job so \`docker run --rm -v \"\$PWD\":/a -w /a oven/bun:1-alpine bun test\` gets exercised — it would have caught this class of bug pre-emptively.

## Follow-up: fallback-path marker leak (commit 2)

After the initial authoritative-stdout fix landed, a NOCTURNE re-run surfaced a secondary issue on the Node-side fallback paths. The shell-side patch works for the happy path, but the timeout / abort / close / `cancelCurrentCommand` resolvers were returning the raw `streamedStdout` accumulator verbatim — which still contained the per-command `__APEX_<nonce>__CUTOVER` and `__APEX_<nonce>__EXIT_<code>` markers the shell had emitted but Node's chunk handler hadn't yet processed.

### Evidence: NOCTURNE pre-patch vs post-patch vs this follow-up

Comparing `weave_export_evalgate-apex-nocturne-002_2026-04-24.jsonl` (post-initial-patch) to pre-patch baseline `01KPXQXR5D7THJJV9EFRSBHF2E`:

| Metric | Pre-patch (run 001) | Post-patch (run 002) | Remaining |
|---|---|---|---|
| `execute_command` calls | 31 | 74 | — |
| Calls returning real stdout | 0 / 31 (0%) | 50 / 74 (68%) | fixed |
| Calls with clean stdout (no marker leak) | 0 | 47 / 50 (94%) | 3 leaks |
| Calls with marker leaked into stdout | 0 | 3 / 74 | this commit |
| `(no output)` responses | 31 (100%) | 24 (32%) | all genuine timeouts |
|  — of which are stdout-capture bug | 31 | 0 | fixed |
|  — of which are real timeouts | 0 | 24 | out of scope |
| Leaks on commands with `success: true` | 0 | 0 | — |
| Leaks on commands with `error: "Command timed out"` | 0 | 3 / 3 (100%) | this commit |
| Agent progression | stopped ~step 16, zero real recon | reached step 39, ran gobuster 5× + ffuf 10× | fixed |

Three representative leaked records (all from run 002):

| Step | `success` | `error` | Observed stdout (trimmed) |
|---|---|---|---|
| 2 | false | Command timed out | `__APEX_7e680629f7b4a78b__CUTOVER\n/console -> HTTP 404\n/debug -> HTTP 404\n…\n__APEX_7e680629f7b4a78b__EXIT_0\n` |
| 3 | false | Command timed out | `__APEX_da6cc953a56a8138__CUTOVER\n[FOUND] /health -> HTTP 200\n__APEX_da6cc953a56a8138__EXIT_0\n` |
| 7 | false | Command timed out | `__APEX_d4f9e531b2424497__CUTOVER\n__APEX_d4f9e531b2424497__EXIT_143\n` |

Step 2 is the smoking gun: the leaked buffer contains `EXIT_0`, meaning the command actually completed successfully, but Node's timeout timer fired before `onStdoutData` processed the chunk containing the marker — so the fallback resolver ran and returned the raw accumulator instead of the parsed result.

### Root cause

Classic event-loop race. The real trigger is a busy Node loop (AI SDK streaming, telemetry, multiple concurrent tool calls): chunks arrive on the shell's stdout pipe but the `onStdoutData` handler is queued behind other work. Meanwhile, `setTimeout`-driven timeout / abort fallbacks are scheduled at wall-clock deadlines and run when their slot comes up, independent of whether the chunk queue has drained. When the fallback wins the race, `cmd.streamedStdout` still contains the markers verbatim — and the pre-follow-up code returned that buffer untouched.

Hard to force deterministically on an idle test runner (the shell's post-kill wrapper finishes emitting markers within a few hundred ms, almost always beating the 2-second fallback timer in unit tests) — but unambiguous in real NOCTURNE traces, exactly where the event loop is under pressure.

### Fix

Extract a pure helper `extractFallbackStdout(cmd)` that performs the same stripping the happy-path parser does — prefers `authoritativeStdout` when populated, otherwise strips the cutover prefix and exit-marker suffix from `streamedStdout`. Route all five fallback resolve sites through it:

1. `this.proc.on("close", ...)` — shell-death path.
2. Abort path — inner `setTimeout` after SIGKILL escalation.
3. Timeout path — inner `setTimeout` after SIGKILL escalation.
4. `cancelCurrentCommand` SIGKILL-path (Unix).
5. `cancelCurrentCommand` else-branch (Windows).

Node-side only. No shell-script change. No API change. Five call sites, one helper.

### Added regression tests

Real-world race is hard to force deterministically, so the helper is exported for direct unit testing. Seven unit tests in `extractFallbackStdout` describe block exercise the exact leaked-buffer shapes from NOCTURNE traces (steps 2, 3, 7) plus boundary cases — authoritative preferred when populated, both markers absent, cutover-only, exit-only, both adjacent, empty buffer.

Verified as genuine regression guards: with the stripping logic removed, 4 of the 7 new tests fail with the exact shape of leaked buffers observed in production. With the fix, all pass.

Two integration tests (`does not leak nonce markers on timeout`, `does not leak nonce markers on abort`) ride along as a second line of defense — they assert the correct shape of stdout after a real timeout/abort. They pass both with and without the fix in a quiet test environment, because the happy-path parser typically wins the race on an idle runner, but will catch regressions if the helper is bypassed entirely.

### Suggested post-merge validation

After re-running NOCTURNE:

```
RUN=.evalgate/results/nocturne/<new-run>/NOCTURNE-001
rg -c '_CUTOVER|_EXIT_' "$RUN"/pensar-session/subagents/*.trace.jsonl
# Expect 0.
```

### Risks (follow-up only)

| Risk | Likelihood | Mitigation |
|---|---|---|
| Helper strips a marker-lookalike in genuine user output | Negligible | Nonces are 8 random hex bytes per command; zero collision risk. |
| Helper returns `authoritativeStdout` mid-authoritative-phase | Low | That's the right answer — partial authoritative > raw streamed. |
| Fallback fires before tail flushes any bytes | Expected | Returns `"(no output)"` — correct for a killed-early command. |
| Shell-side behavior changes | None | Follow-up is Node-side only. |
| Regresses Linux streaming | None | Helper runs only on fallback paths, identical across platforms. |

## Post-deploy validation: NOCTURNE 003 → 004

After landing both commits on this branch, the first NOCTURNE re-run (003) appeared to show that **leaks were unchanged** despite the fix. Investigation revealed the cause: Evalgate invokes APEX through the published bin (`bin/pensar.js → build/cli.js`), which is a static bundle produced by `bun run build`. That bundle had not been regenerated since March, so the fix was present in source but not in the running binary. There is no `postinstall` / pre-test rebuild hook, so any local change to `src/` is invisible to Evalgate until `bun run build` runs.

After `bun run build` (`build/cli-242p2y3r.js` now contains 6 references to `extractFallbackStdout` — 1 declaration + 5 fallback call sites — and all bundle chunks are timestamped post-fix), NOCTURNE 004 was run on the same target with the same prompt.

### NOCTURNE 003 vs 004

| Metric | NOCTURNE 003 (stale bundle, fix not deployed) | NOCTURNE 004 (rebuilt bundle, fix deployed) |
|---|---|---|
| `execute_command` observations | 63 | 71 |
| Steps containing `execute_command` | (similar) | 37 |
| Steps issuing 2+ parallel `execute_command` | (similar) | **31 / 37 (84%)** |
| Steps issuing 3 parallel | (similar) | 3 |
| Marker leaks in tool stdout | 2 | **1** |
| Leak shape | own-nonce + cross-nonce mixed | **cross-nonce only** |

The single residual leak in 004 is **not** the same bug as commit 2 of this PR. It surfaces a separate, lower-frequency bug in `PersistentShell` that the helper is structurally unable to fix.

## Known limitation: concurrent-call output bleed (separate bug, follow-up PR)

The one residual leak in NOCTURNE 004 is forensic proof of a distinct race condition in `PersistentShell.execute()` — concurrent commands sharing a single shell can cross-contaminate each other's stdout *and stderr* buffers.

### Evidence

Step 4 of `attack-surface-agent` issues two parallel `execute_command` calls:

| | Call A `toolu_013gEBbqhmGpnRSqMJo9kYCt` | Call B `toolu_011teCwm4UHUs9t4SV1G8E9o` |
|---|---|---|
| description | "Find available wordlists" | "Test Flask-specific paths and more endpoint patterns" |
| command | `find / -name "*.txt" -path "*/wordlist*" …; find …; find …; find …` | `for path in /meridian /auth … /playground; do curl … done` |
| timeout | **10 s** | **120 s** |
| `result.success` | false | false |
| `result.error` | `Command timed out` | `Command timed out` |
| `result.stdout` | `(no output)` ← clean ✓ | `__APEX_8b35a2965745ce81___CUTOVER\n__APEX_8b35a2965745ce81___EXIT_137\n` ← LEAK |
| `result.stderr` | `""` | `bash: line 126: 4264 Terminated: 15 find / -name "*.txt" -path "*/wordlist*" …\n4416 Killed: 9   find / -name "*.txt" -path "*/dirb*" …\n4421 Terminated: 15 find / -name "*.txt" -path "*/dirbuster*" …\n5878 Killed: 9   find / -name "*.txt" -path "*/SecLists*" …` |

Call B never spawned a `find`. Yet Call B's stderr contains the kernel-termination messages for **Call A's** four `find` processes, and Call B's stdout contains a full wrapper-output skeleton (`CUTOVER\nEXIT_137\n` with empty body) that exactly matches Call A's behavior — `find`'s stdout was empty because `2>/dev/null` redirected its only output (stderr) away, `__APEX_EC=$?` captured 137 from the `SIGKILL` escalation, and the cleanup phase emitted an empty `cat` between the markers.

### Root cause

`PersistentShell.execute()` has no per-shell command queue:

```ts
// src/core/agents/offSecAgent/tools/persistentShell.ts:408
this.current = pending;
this.pendingCancel = pending.resolve;
```

When the agent issues parallel tool calls in a single Claude turn, both `execute()` invocations land in the same JS tick. They run synchronously to the `return new Promise(…)`:

1. Each call writes its wrapper to `proc.stdin` immediately.
2. Each call assigns `this.current = pending` — last writer wins.

Bash drains stdin serially, executing wrapper A then wrapper B. **All bash output flows to whichever pending is currently `this.current`** — i.e. pending B for both wrappers. When wrapper A's cleanup phase emits its CUTOVER + cat + EXIT (under nonce A), those bytes accumulate in pending **B**'s `streamedStdout`. Pending A's `streamedStdout` stays empty for its entire lifetime, so its fallback returns `(no output)` (clean). Pending B's fallback finds A's markers in its buffer, can't match its own (B's) nonce, and — correctly per its contract — returns the buffer verbatim. The helper does not strip foreign nonces, by design: those bytes could be legitimate user output that happens to contain a marker-shaped string.

The same bleed silently corrupts **stderr**: pending B's stderr contains pending A's `find` kill messages, with no marker pattern to flag the contamination. The model cannot tell these messages aren't about its own curl loop. This is a correctness hazard for agent reasoning that the marker stripping cannot detect.

### Why so rare in 004 (only 1 leak in 31 parallel-call steps)

Most parallel batches resolve cleanly because:

- The shorter-timeout call's timer fires first, forces it to fall back to `(no output)` while bash is still working through the queue.
- Bash continues executing queued wrappers; the **last** pending (the one `this.current` points to) eventually sees its own CUTOVER/EXIT and the happy-path parser strips them clean.

The leak surfaces only when the first wrapper finishes (or is killed) after a different pending has been registered as `this.current`, **and** the holder of `this.current` also fails to complete its own happy path within the fallback window. Narrow window — but with 31 parallel-call steps in one trace, it hit at least once.

### Why this is a separate PR

The fix is **serialize `execute()` per shell with a FIFO promise chain** — small, mechanical change that makes each pending see only its own wrapper's bytes. The marker-stripping helper's correctness assumption (one command's nonces are in one command's buffer) becomes structurally guaranteed.

That is a behavioral change (parallel `execute_command` calls become serial through a shared shell) and deserves its own review and its own NOCTURNE pass. Holding it out of this PR keeps the wins isolated:

- This PR: silent stdout-loss eliminated; own-nonce marker leaks eliminated; one structural class of bug remains, fully diagnosed.
- Follow-up PR: cross-command output bleed eliminated.

Both ship before the next eval cycle. The follow-up is tracked in #645 so reviewers of this PR don't have to evaluate two semantically distinct fixes at once.

## Rollback

Touches exactly one file plus its test. No data-format change, no migration. Single \`git revert\`; zero blast radius.

## Test plan

- [x] CI passes (Lint / TypeCheck / Test / Build)
- [ ] Manual TUI smoke on a Mac: operator mode against a local target, confirm recon returns real output instead of \`\"(no output)\"\`
- [ ] Manual CLI smoke on a Mac: \`bun run src/cli.ts pentest --target ...\` inside a trivial challenge
- [x] Re-run NOCTURNE via Evalgate on a Mac (run 004) — silent-truncation incidents eliminated; see *Post-deploy validation* table above
- [x] Confirm marker leaks have collapsed to the single residual concurrent-call bleed case — diagnosed and tracked for a separate follow-up PR
- [ ] Optional: manual run inside Alpine container to confirm correctness on musl

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core command-execution plumbing used by the offsec agent; bugs could cause missing/duplicated output or incorrect exit handling across platforms, though changes are well-covered by targeted regression tests.
> 
> **Overview**
> Makes `PersistentShell` return **platform-independent, authoritative stdout** by always running a post-`tail` cutover marker plus `cat` phase, and splitting output into pre-cutover *best-effort streaming* vs post-cutover *authoritative capture*.
> 
> Adds `extractFallbackStdout` and routes timeout/abort/cancel/close fallback resolves through it to prevent `__APEX_*` cutover/exit markers leaking into tool stdout when fallback timers win event-loop races.
> 
> Expands `persistentShell.test.ts` with regressions for macOS/blocked-buffer `tail` (trivial commands, 8KiB boundary) and marker-leak guards, plus direct unit tests for `extractFallbackStdout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f14c3a524ccde8a04c8926b386a28cbfb72b2e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->