### PR TITLE
fix: bound per-endpoint threat-model concurrency

### DIFF
--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -287,6 +287,8 @@ export async function generateThreatModelForEndpoint(
   const model = ctx.model;
 
   return threatModelLimiter(async () => {
+    if (ctx.abortSignal?.aborted) return null;
+
     const { CodeAgent } = await import("../../specialized/codeAgent/agent");
 
     const subagentId = `threat-model-${sanitize(input.appName)}-${sanitize(input.routePath)}`;

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -1,7 +1,13 @@
+import pLimit from "p-limit";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 import type { RiskScore } from "../../specialized/whiteboxAttackSurface/types";
 import { AgentEventBus } from "../../../eventBus";
+
+// Process-wide cap — parents emit `document_endpoint` tool calls in parallel,
+// so without this gate each parent fans out unboundedly.
+const THREAT_MODEL_CONCURRENCY = 5;
+const threatModelLimiter = pLimit(THREAT_MODEL_CONCURRENCY);
 
 // ---------------------------------------------------------------------------
 // Response schema
@@ -278,78 +284,81 @@ export async function generateThreatModelForEndpoint(
   input: GenerateThreatModelInput,
 ): Promise<ThreatModelOutput | null> {
   if (!ctx.model) return null;
+  const model = ctx.model;
 
-  const { CodeAgent } = await import("../../specialized/codeAgent/agent");
+  return threatModelLimiter(async () => {
+    const { CodeAgent } = await import("../../specialized/codeAgent/agent");
 
-  const subagentId = `threat-model-${sanitize(input.appName)}-${sanitize(input.routePath)}`;
+    const subagentId = `threat-model-${sanitize(input.appName)}-${sanitize(input.routePath)}`;
 
-  ctx.eventBus?.emit("subagent-spawn", {
-    subagentId,
-    name: `Threat Model: ${input.routePath}`,
-    input: { app: input.appName, endpoint: input.routePath },
-  });
-
-  const localBus = new AgentEventBus();
-  AgentEventBus.attachChild(localBus, ctx.eventBus, subagentId);
-
-  const prompt = buildThreatModelPrompt(input, ctx.projectThreatModel);
-
-  const agent = new CodeAgent<ThreatModelResult>({
-    codebasePath: ctx.agentCwd,
-    objective: prompt,
-    system: THREAT_MODEL_SYSTEM_PROMPT,
-    model: ctx.model,
-    session: ctx.session,
-    authConfig: ctx.authConfig,
-    abortSignal: ctx.abortSignal,
-    eventBus: localBus,
-    subagentId,
-    responseSchema: ThreatModelResultSchema,
-    excludeTools: ["document_endpoint", "document_app"],
-  });
-
-  try {
-    const result = await agent.consume();
-    ctx.eventBus?.emit("subagent-complete", {
+    ctx.eventBus?.emit("subagent-spawn", {
       subagentId,
-      status: "completed",
+      name: `Threat Model: ${input.routePath}`,
+      input: { app: input.appName, endpoint: input.routePath },
     });
 
-    if (!result) return null;
+    const localBus = new AgentEventBus();
+    AgentEventBus.attachChild(localBus, ctx.eventBus, subagentId);
 
-    const totalScore =
-      result.exposure +
-      result.dataSensitivity +
-      result.functionCriticality +
-      result.securityIndicators;
+    const prompt = buildThreatModelPrompt(input, ctx.projectThreatModel);
 
-    return {
-      businessLogic: result.businessLogic,
-      threatModel: result.threatModel,
-      riskScore: {
-        score: totalScore,
-        explanation: result.riskScoreJustification,
-        breakdown: {
-          exposure: result.exposure,
-          dataSensitivity: result.dataSensitivity,
-          functionCriticality: result.functionCriticality,
-          securityIndicators: result.securityIndicators,
+    const agent = new CodeAgent<ThreatModelResult>({
+      codebasePath: ctx.agentCwd,
+      objective: prompt,
+      system: THREAT_MODEL_SYSTEM_PROMPT,
+      model,
+      session: ctx.session,
+      authConfig: ctx.authConfig,
+      abortSignal: ctx.abortSignal,
+      eventBus: localBus,
+      subagentId,
+      responseSchema: ThreatModelResultSchema,
+      excludeTools: ["document_endpoint", "document_app"],
+    });
+
+    try {
+      const result = await agent.consume();
+      ctx.eventBus?.emit("subagent-complete", {
+        subagentId,
+        status: "completed",
+      });
+
+      if (!result) return null;
+
+      const totalScore =
+        result.exposure +
+        result.dataSensitivity +
+        result.functionCriticality +
+        result.securityIndicators;
+
+      return {
+        businessLogic: result.businessLogic,
+        threatModel: result.threatModel,
+        riskScore: {
+          score: totalScore,
+          explanation: result.riskScoreJustification,
+          breakdown: {
+            exposure: result.exposure,
+            dataSensitivity: result.dataSensitivity,
+            functionCriticality: result.functionCriticality,
+            securityIndicators: result.securityIndicators,
+          },
         },
-      },
-      pentestObjectives: (result.pentestObjectives ?? []).map(
-        flattenPentestObjective,
-      ),
-    };
-  } catch (error) {
-    ctx.eventBus?.emit("subagent-complete", {
-      subagentId,
-      status: "failed",
-    });
-    console.error(
-      `Threat model generation failed for ${input.routePath}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return null;
-  }
+        pentestObjectives: (result.pentestObjectives ?? []).map(
+          flattenPentestObjective,
+        ),
+      };
+    } catch (error) {
+      ctx.eventBus?.emit("subagent-complete", {
+        subagentId,
+        status: "failed",
+      });
+      console.error(
+        `Threat model generation failed for ${input.routePath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return null;
+    }
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -6,7 +6,7 @@ import { AgentEventBus } from "../../../eventBus";
 
 // Process-wide cap — parents emit `document_endpoint` tool calls in parallel,
 // so without this gate each parent fans out unboundedly.
-const THREAT_MODEL_CONCURRENCY = 5;
+const THREAT_MODEL_CONCURRENCY = 10;
 const threatModelLimiter = pLimit(THREAT_MODEL_CONCURRENCY);
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #653.

`generateThreatModelForEndpoint` spawned a fresh `CodeAgent` per call with no semaphore. Anthropic emits parallel `tool_use` blocks per turn and the AI SDK runs each tool's `execute()` concurrently, so a single discovery agent's parallel `document_endpoint` calls could spawn ~13 threat-model subagents at once. Observed peak in a local recon: **68 concurrent** threat-model subagents (5 parent discovery agents × ~13 children each).

This adds a module-level `p-limit` semaphore (cap=10) inside `threatModelGenerator.ts`. The body of `generateThreatModelForEndpoint` is wrapped in the limiter so the `subagent-spawn` event fires only when a slot is available — keeping the UI in sync with actual concurrency. `p-limit` was already a dependency; no `package.json` change.

The cap is exposed as a single named constant (`THREAT_MODEL_CONCURRENCY`) so it's a one-line bump if we want to tune it later. 10 is conservative-but-not-restrictive given the recon service runs with `4 vCPU / 16 GB` Fargate headroom; the real binding constraint at scale is Bedrock TPM, not memory.

The `runWithBoundedConcurrency` utility in `src/core/utils/concurrency.ts` is batch-bounded and not suitable here (it requires knowing the full item list upfront). `spawnCodingAgent.ts` already has its own bounded fanout, so this is the only call site that needed gating.

## Regression history

A cap of 5 (via `runWithBoundedConcurrency`) existed in the original endpoint-threat-model PR #583 inside `src/core/workflows/endpointThreatModeling.ts`. It was inadvertently dropped in 16329997 ("spawn dedicated threat model sub-agent from document_endpoint") when generation moved into the tool — the batch-bounded primitive doesn't fit per-tool-call invocations. This PR restores the cap with the right primitive (a process-wide `p-limit` semaphore).

## Test plan

- [x] `bun run tsc` — clean
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun run test` — 754 passed, 18 skipped
- [x] Manual: trigger a fresh whitebox recon and confirm peak concurrent `threat-model-*` subagents ≤ 10 in agent_logs (vs 68 today)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces global concurrency limiting around threat-model subagent execution; incorrect tuning could slow recon throughput or cause unexpected queuing, but it does not change scoring/output shapes.
> 
> **Overview**
> Adds a **process-wide concurrency gate** to `generateThreatModelForEndpoint` using `p-limit` (constant `THREAT_MODEL_CONCURRENCY = 10`) to prevent unbounded parallel spawning of threat-model `CodeAgent` subagents when many `document_endpoint` tool calls run concurrently.
> 
> Wraps the subagent spawn/execute path in the limiter (and checks `abortSignal` inside the gated section), so `subagent-spawn`/`subagent-complete` events now reflect *actual* bounded execution while keeping the returned threat-model output shape unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f77c42bee35d0ead64926c7bb0661ee4cbdbd3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->