### PR TITLE
Add screenshot-safe obfuscation mode (`--obfuscate` / `/obfuscate`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensar/apex",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "module": "src/tui/index.tsx",
   "main": "build/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,18 @@ const args = process.argv.slice(2);
 const command = args[0];
 const version = packageJson.version;
 
+// Detect global --obfuscate flag and propagate to the TUI via env so the
+// flag works regardless of where it appears in argv. The flag is stripped
+// before any per-command parsing so it never collides with subcommand args.
+const OBFUSCATE_FLAGS = new Set(["--obfuscate", "--redact", "-O"]);
+const obfuscateRequested = args.some((a) => OBFUSCATE_FLAGS.has(a));
+if (obfuscateRequested) {
+  process.env.PENSAR_OBFUSCATE = "1";
+  for (let i = args.length - 1; i >= 0; i--) {
+    if (OBFUSCATE_FLAGS.has(args[i]!)) args.splice(i, 1);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -122,6 +134,9 @@ threat-model options:
 Global options:
   -h, --help         Show this help message
   -v, --version      Show version number
+  --obfuscate        Run the TUI in obfuscation mode — redacts hostnames,
+                     IPs, UUIDs, emails, paths, tokens, and apparent
+                     company names so screenshots are safe to share.
 `);
 }
 

--- a/src/core/obfuscation/engine.test.ts
+++ b/src/core/obfuscation/engine.test.ts
@@ -67,13 +67,17 @@ describe("obfuscation engine", () => {
 
   it("redacts every hostname including the operator's own infra", () => {
     // No allowlist: pensar.dev, github.com, subdomains thereof are all redacted.
+    // A bare host gets a HOST placeholder; a host followed by a slash-path is
+    // absorbed by the route pattern as a single PATH placeholder, which is
+    // strictly more conservative.
     const out = obfuscate(
       "See staging-console.pensar.dev and github.com/org/repo",
     );
     expect(out).toContain("[HOST_1]");
-    expect(out).toContain("[HOST_2]");
+    expect(out).toContain("[PATH_1]");
     expect(out).not.toContain("pensar.dev");
     expect(out).not.toContain("github.com");
+    expect(out).not.toContain("/org/repo");
   });
 
   it("redacts JWTs and bearer-style tokens", () => {
@@ -93,6 +97,128 @@ describe("obfuscation engine", () => {
     const out = obfuscate("/Users/alice/code/acme/src/index.ts");
     expect(out).toContain("[PATH_1]");
     expect(out).not.toContain("alice");
+  });
+
+  it("redacts API endpoint paths", () => {
+    const out = obfuscate(
+      "POST /v1/external/sendgrid/{tenant_id} returned 500",
+    );
+    expect(out).toContain("[PATH_1]");
+    expect(out).not.toContain("/v1/external/sendgrid");
+    expect(out).not.toContain("{tenant_id}");
+  });
+
+  it("redacts debug endpoint paths", () => {
+    const out = obfuscate("Hit /__debug/pprof/heap on staging");
+    expect(out).toContain("[PATH_1]");
+    expect(out).not.toContain("/__debug/pprof/heap");
+  });
+
+  it("redacts single-segment debug endpoints", () => {
+    const out = obfuscate("Health check at /__health returned 200");
+    expect(out).toContain("[PATH_1]");
+    expect(out).not.toContain("/__health");
+  });
+
+  it("redacts single-segment paths with trailing slash", () => {
+    const out = obfuscate("Found /docs/ exposing the OpenAPI spec");
+    expect(out).toContain("[PATH_1]");
+    expect(out).not.toContain("/docs/");
+  });
+
+  it("redacts non-home filesystem paths", () => {
+    const out = obfuscate(
+      "AI catalog path: /tmp/ai_search_trimmed_catalog_tenant123.json",
+    );
+    expect(out).toContain("[PATH_1]");
+    expect(out).not.toContain("tenant123");
+  });
+
+  it("absorbs nested placeholders into the surrounding route", () => {
+    const out = obfuscate(
+      "Internal document path: /core/documents/550e8400-e29b-41d4-a716-446655440000",
+    );
+    expect(out).toContain("[PATH_1]");
+    expect(out).not.toContain("/core/documents");
+    expect(out).not.toContain("550e8400");
+  });
+
+  it("redacts multi-segment paths without a leading slash", () => {
+    const out = obfuscate("see __debug/config and __debug/endpoints");
+    expect(out).not.toContain("__debug/config");
+    expect(out).not.toContain("__debug/endpoints");
+    expect(out).toMatch(/\[PATH_\d+\]/);
+  });
+
+  it("redacts template-style relative paths", () => {
+    const out = obfuscate("media/{tenant_id} and access/users/${userId}/tenants");
+    expect(out).not.toContain("media/{tenant_id}");
+    expect(out).not.toContain("access/users/${userId}/tenants");
+    expect(out).toMatch(/\[PATH_\d+\]/);
+  });
+
+  it("does not redact bare single-token slash commands", () => {
+    expect(obfuscate("/help")).toBe("/help");
+    expect(obfuscate("Run /obfuscate now")).toBe("Run /obfuscate now");
+  });
+
+  it("gives distinct route paths distinct placeholders", () => {
+    const out = obfuscate("Hit /v1/users then /v1/orders next.");
+    expect(out).toContain("[PATH_1]");
+    expect(out).toContain("[PATH_2]");
+  });
+
+  it("redacts AWS Cognito-style region-prefixed identifiers", () => {
+    const out = obfuscate("pool_id: us-east-1_X8rlYugE7");
+    expect(out).toContain("[TOKEN_1]");
+    expect(out).not.toContain("X8rlYugE7");
+  });
+
+  it("redacts opaque alphanumeric IDs with mixed letters and digits", () => {
+    const out = obfuscate("client_id: q0vuru56saramn8hbgljgmuva");
+    expect(out).toContain("[TOKEN_1]");
+    expect(out).not.toContain("q0vuru56saramn8hbgljgmuva");
+  });
+
+  it("does not redact long all-letter identifiers", () => {
+    const sentence = "function getUserTenantsFromCognitoPool() {}";
+    expect(obfuscate(sentence)).toBe(sentence);
+  });
+
+  it("aliases bare org references once the host has been seen", () => {
+    const first = obfuscate("Visited https://contoso.com for recon.");
+    expect(first).toContain("[URL_1]");
+    const second = obfuscate(
+      "Only the contoso subdomain returned full data, the Contoso corporate tenant.",
+    );
+    expect(second).not.toContain("contoso");
+    expect(second).not.toContain("Contoso");
+    expect(second).toMatch(/\[URL_1\]/);
+  });
+
+  it("aliases the leading word of a redacted org name", () => {
+    const first = obfuscate("Engagement scoped for Acme Corp.");
+    expect(first).toContain("[ORG_1]");
+    const second = obfuscate("Acme had three open S3 buckets.");
+    expect(second).not.toContain("Acme");
+    expect(second).toContain("[ORG_1]");
+  });
+
+  it("does not alias generic provider labels", () => {
+    obfuscate("Bucket lives on s3.amazonaws.com behind cloudfront.net.");
+    const out = obfuscate(
+      "AWS announced a new Amazon S3 feature today, also Cloudflare.",
+    );
+    expect(out).toContain("Amazon");
+    expect(out).toContain("Cloudflare");
+  });
+
+  it("alias replacement can be disabled per call (input round-trip)", () => {
+    obfuscate("Reviewed https://contoso.com");
+    const withAliases = obfuscate("Contoso is great");
+    expect(withAliases).not.toContain("Contoso");
+    const withoutAliases = obfuscate("Contoso is great", { aliases: false });
+    expect(withoutAliases).toBe("Contoso is great");
   });
 
   it("redacts apparent company names with corporate suffixes", () => {

--- a/src/core/obfuscation/engine.test.ts
+++ b/src/core/obfuscation/engine.test.ts
@@ -99,6 +99,13 @@ describe("obfuscation engine", () => {
     expect(out).toContain("<MAC_1>");
   });
 
+  it("redacts compressed IPv6 addresses", () => {
+    const out = obfuscate("Bound to fe80::1 and 2001:db8::8a2e:370:7334");
+    expect(out).toContain("<IPV6_1>");
+    expect(out).toContain("<IPV6_2>");
+    expect(out).not.toContain("fe80::1");
+  });
+
   it("redacts a credit card number that passes Luhn", () => {
     const out = obfuscate("Card 4111 1111 1111 1111 on file");
     expect(out).toContain("<CARD_1>");

--- a/src/core/obfuscation/engine.test.ts
+++ b/src/core/obfuscation/engine.test.ts
@@ -151,7 +151,9 @@ describe("obfuscation engine", () => {
   });
 
   it("redacts template-style relative paths", () => {
-    const out = obfuscate("media/{tenant_id} and access/users/${userId}/tenants");
+    const out = obfuscate(
+      "media/{tenant_id} and access/users/${userId}/tenants",
+    );
     expect(out).not.toContain("media/{tenant_id}");
     expect(out).not.toContain("access/users/${userId}/tenants");
     expect(out).toMatch(/\[PATH_\d+\]/);

--- a/src/core/obfuscation/engine.test.ts
+++ b/src/core/obfuscation/engine.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   obfuscate,
   obfuscateValue,
+  deobfuscate,
   resetObfuscation,
   setObfuscationEnabled,
   isObfuscationEnabled,
@@ -144,5 +145,37 @@ describe("obfuscation engine", () => {
     const out = obfuscate("Edit config.json then run app.py");
     expect(out).toContain("config.json");
     expect(out).toContain("app.py");
+  });
+
+  it("deobfuscate restores originals from placeholders", () => {
+    const original = "Scan staging-console.pensar.dev and 10.0.0.1";
+    const redacted = obfuscate(original);
+    expect(redacted).not.toContain("staging-console.pensar.dev");
+    expect(redacted).not.toContain("10.0.0.1");
+    expect(deobfuscate(redacted)).toBe(original);
+  });
+
+  it("deobfuscate handles two-digit indices without prefix collision", () => {
+    // Build 11 host entries so we have <HOST_10> and <HOST_1> coexisting.
+    for (let i = 1; i <= 11; i++) {
+      obfuscate(`host-${i}.example.com`);
+    }
+    const text = "see <HOST_1> and <HOST_10>";
+    const restored = deobfuscate(text);
+    expect(restored).toContain("host-1.example.com");
+    expect(restored).toContain("host-10.example.com");
+    expect(restored).not.toContain("<HOST_1>");
+    expect(restored).not.toContain("<HOST_10>");
+  });
+
+  it("deobfuscate is a no-op when nothing has been obfuscated", () => {
+    resetObfuscation();
+    expect(deobfuscate("plain text <HOST_1>")).toBe("plain text <HOST_1>");
+  });
+
+  it("deobfuscate works even when obfuscation is disabled", () => {
+    obfuscate("acme.example.com");
+    setObfuscationEnabled(false);
+    expect(deobfuscate("seen at <HOST_1>")).toBe("seen at acme.example.com");
   });
 });

--- a/src/core/obfuscation/engine.test.ts
+++ b/src/core/obfuscation/engine.test.ts
@@ -157,9 +157,26 @@ describe("obfuscation engine", () => {
     expect(out).toMatch(/\[PATH_\d+\]/);
   });
 
-  it("does not redact bare single-token slash commands", () => {
+  it("does not redact a bare slash command standing alone", () => {
+    // No char follows → command router still sees it intact. This
+    // matters in two places: (1) the engine being called on an input
+    // buffer that starts with `/` (PromptInput already bypasses, but
+    // the engine itself stays safe as a defence-in-depth), and (2)
+    // a slash command that ends a line in agent prose.
     expect(obfuscate("/help")).toBe("/help");
-    expect(obfuscate("Run /obfuscate now")).toBe("Run /obfuscate now");
+    expect(obfuscate("/obfuscate")).toBe("/obfuscate");
+    expect(obfuscate("see /obfuscate\nthen continue")).toBe(
+      "see /obfuscate\nthen continue",
+    );
+  });
+
+  it("redacts single-segment paths followed by char or space", () => {
+    // The screenshot case: "/login, /tenant-selector, /dashboard, ..."
+    const out = obfuscate("Routes: /login, /dashboard, /leads here.");
+    expect(out).not.toContain("/login");
+    expect(out).not.toContain("/dashboard");
+    expect(out).not.toContain("/leads");
+    expect(out).toMatch(/\[PATH_\d+\]/);
   });
 
   it("gives distinct route paths distinct placeholders", () => {

--- a/src/core/obfuscation/engine.test.ts
+++ b/src/core/obfuscation/engine.test.ts
@@ -47,19 +47,32 @@ describe("obfuscation engine", () => {
     expect(out).not.toContain("10.0.42.17");
   });
 
+  it("redacts IPv4 addresses written with hyphens (session-name style)", () => {
+    const out = obfuscate("session pentest-10-0-0-1 ready");
+    expect(out).toContain("pentest-<IPV4_1>");
+    expect(out).not.toContain("10-0-0-1");
+  });
+
+  it("does not redact non-octet hyphen sequences (dates, versions)", () => {
+    const out = obfuscate("Build 2026-04-28-12 shipped");
+    expect(out).toContain("2026-04-28-12");
+  });
+
   it("redacts URLs and underlying hosts consistently", () => {
     const out = obfuscate("GET https://api.acme-corp.internal/v1/users → 200");
     expect(out).toContain("<URL_1>");
     expect(out).not.toContain("acme-corp.internal");
   });
 
-  it("preserves allowlisted hosts (example.com, github.com)", () => {
+  it("redacts every hostname including the operator's own infra", () => {
+    // No allowlist: pensar.dev, github.com, subdomains thereof are all redacted.
     const out = obfuscate(
-      "See https://example.com/foo and github.com/org/repo",
+      "See staging-console.pensar.dev and github.com/org/repo",
     );
-    // example.com is allowlisted as host but the URL pattern wins, so we
-    // expect the URL to be redacted while the bare github.com mention is kept.
-    expect(out).toContain("github.com/org/repo");
+    expect(out).toContain("<HOST_1>");
+    expect(out).toContain("<HOST_2>");
+    expect(out).not.toContain("pensar.dev");
+    expect(out).not.toContain("github.com");
   });
 
   it("redacts JWTs and bearer-style tokens", () => {

--- a/src/core/obfuscation/engine.test.ts
+++ b/src/core/obfuscation/engine.test.ts
@@ -25,32 +25,32 @@ describe("obfuscation engine", () => {
   it("redacts emails with stable placeholders", () => {
     const out1 = obfuscate("Contact alice@acme.com for details");
     const out2 = obfuscate("Email alice@acme.com again");
-    expect(out1).toContain("<EMAIL_1>");
+    expect(out1).toContain("[EMAIL_1]");
     expect(out1).not.toContain("alice@acme.com");
-    expect(out2).toContain("<EMAIL_1>");
+    expect(out2).toContain("[EMAIL_1]");
   });
 
   it("issues a new placeholder for a different value of the same category", () => {
     obfuscate("alice@acme.com");
     const out = obfuscate("bob@globex.io");
-    expect(out).toContain("<EMAIL_2>");
+    expect(out).toContain("[EMAIL_2]");
   });
 
   it("redacts UUIDs", () => {
     const out = obfuscate("session 550e8400-e29b-41d4-a716-446655440000");
-    expect(out).toContain("<UUID_1>");
+    expect(out).toContain("[UUID_1]");
   });
 
   it("redacts IPv4 addresses", () => {
     const out = obfuscate("Connecting to 10.0.42.17 and 192.168.1.1");
-    expect(out).toMatch(/<IPV4_1>/);
-    expect(out).toMatch(/<IPV4_2>/);
+    expect(out).toContain("[IPV4_1]");
+    expect(out).toContain("[IPV4_2]");
     expect(out).not.toContain("10.0.42.17");
   });
 
   it("redacts IPv4 addresses written with hyphens (session-name style)", () => {
     const out = obfuscate("session pentest-10-0-0-1 ready");
-    expect(out).toContain("pentest-<IPV4_1>");
+    expect(out).toContain("pentest-[IPV4_1]");
     expect(out).not.toContain("10-0-0-1");
   });
 
@@ -61,7 +61,7 @@ describe("obfuscation engine", () => {
 
   it("redacts URLs and underlying hosts consistently", () => {
     const out = obfuscate("GET https://api.acme-corp.internal/v1/users → 200");
-    expect(out).toContain("<URL_1>");
+    expect(out).toContain("[URL_1]");
     expect(out).not.toContain("acme-corp.internal");
   });
 
@@ -70,8 +70,8 @@ describe("obfuscation engine", () => {
     const out = obfuscate(
       "See staging-console.pensar.dev and github.com/org/repo",
     );
-    expect(out).toContain("<HOST_1>");
-    expect(out).toContain("<HOST_2>");
+    expect(out).toContain("[HOST_1]");
+    expect(out).toContain("[HOST_2]");
     expect(out).not.toContain("pensar.dev");
     expect(out).not.toContain("github.com");
   });
@@ -80,25 +80,25 @@ describe("obfuscation engine", () => {
     const jwt =
       "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
     const out = obfuscate(`Authorization: Bearer ${jwt}`);
-    expect(out).toContain("<JWT_1>");
+    expect(out).toContain("[JWT_1]");
     expect(out).not.toContain(jwt);
   });
 
   it("redacts API keys", () => {
     const out = obfuscate("sk-abcdefghijklmnopqrstuvwxyz1234");
-    expect(out).toContain("<TOKEN_1>");
+    expect(out).toContain("[TOKEN_1]");
   });
 
   it("redacts user home paths", () => {
     const out = obfuscate("/Users/alice/code/acme/src/index.ts");
-    expect(out).toContain("<PATH_1>");
+    expect(out).toContain("[PATH_1]");
     expect(out).not.toContain("alice");
   });
 
   it("redacts apparent company names with corporate suffixes", () => {
     const out = obfuscate("Engagement scoped for Acme Corp and Globex LLC.");
-    expect(out).toContain("<ORG_1>");
-    expect(out).toContain("<ORG_2>");
+    expect(out).toContain("[ORG_1]");
+    expect(out).toContain("[ORG_2]");
     expect(out).not.toContain("Acme");
     expect(out).not.toContain("Globex");
   });
@@ -110,28 +110,28 @@ describe("obfuscation engine", () => {
 
   it("redacts MAC addresses", () => {
     const out = obfuscate("nic 00:1A:2B:3C:4D:5E");
-    expect(out).toContain("<MAC_1>");
+    expect(out).toContain("[MAC_1]");
   });
 
   it("redacts compressed IPv6 addresses", () => {
     const out = obfuscate("Bound to fe80::1 and 2001:db8::8a2e:370:7334");
-    expect(out).toContain("<IPV6_1>");
-    expect(out).toContain("<IPV6_2>");
+    expect(out).toContain("[IPV6_1]");
+    expect(out).toContain("[IPV6_2]");
     expect(out).not.toContain("fe80::1");
   });
 
   it("redacts a credit card number that passes Luhn", () => {
     const out = obfuscate("Card 4111 1111 1111 1111 on file");
-    expect(out).toContain("<CARD_1>");
+    expect(out).toContain("[CARD_1]");
   });
 
   it("redacts phone numbers", () => {
     const out = obfuscate("Call +1 415 555 0123 today");
-    expect(out).toContain("<PHONE_1>");
+    expect(out).toContain("[PHONE_1]");
   });
 
   it("obfuscateValue assigns category placeholder when enabled", () => {
-    expect(obfuscateValue("acme-internal-host", "HOST")).toBe("<HOST_1>");
+    expect(obfuscateValue("acme-internal-host", "HOST")).toBe("[HOST_1]");
   });
 
   it("returns original from obfuscateValue when disabled", () => {
@@ -156,26 +156,26 @@ describe("obfuscation engine", () => {
   });
 
   it("deobfuscate handles two-digit indices without prefix collision", () => {
-    // Build 11 host entries so we have <HOST_10> and <HOST_1> coexisting.
+    // Build 11 host entries so we have [HOST_10] and [HOST_1] coexisting.
     for (let i = 1; i <= 11; i++) {
       obfuscate(`host-${i}.example.com`);
     }
-    const text = "see <HOST_1> and <HOST_10>";
+    const text = "see [HOST_1] and [HOST_10]";
     const restored = deobfuscate(text);
     expect(restored).toContain("host-1.example.com");
     expect(restored).toContain("host-10.example.com");
-    expect(restored).not.toContain("<HOST_1>");
-    expect(restored).not.toContain("<HOST_10>");
+    expect(restored).not.toContain("[HOST_1]");
+    expect(restored).not.toContain("[HOST_10]");
   });
 
   it("deobfuscate is a no-op when nothing has been obfuscated", () => {
     resetObfuscation();
-    expect(deobfuscate("plain text <HOST_1>")).toBe("plain text <HOST_1>");
+    expect(deobfuscate("plain text [HOST_1]")).toBe("plain text [HOST_1]");
   });
 
   it("deobfuscate works even when obfuscation is disabled", () => {
     obfuscate("acme.example.com");
     setObfuscationEnabled(false);
-    expect(deobfuscate("seen at <HOST_1>")).toBe("seen at acme.example.com");
+    expect(deobfuscate("seen at [HOST_1]")).toBe("seen at acme.example.com");
   });
 });

--- a/src/core/obfuscation/engine.test.ts
+++ b/src/core/obfuscation/engine.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  obfuscate,
+  obfuscateValue,
+  resetObfuscation,
+  setObfuscationEnabled,
+  isObfuscationEnabled,
+} from "./engine";
+
+describe("obfuscation engine", () => {
+  beforeEach(() => {
+    resetObfuscation();
+    setObfuscationEnabled(true);
+  });
+
+  it("is a no-op when disabled", () => {
+    setObfuscationEnabled(false);
+    expect(obfuscate("alice@acme.com 192.168.1.1")).toBe(
+      "alice@acme.com 192.168.1.1",
+    );
+    expect(isObfuscationEnabled()).toBe(false);
+  });
+
+  it("redacts emails with stable placeholders", () => {
+    const out1 = obfuscate("Contact alice@acme.com for details");
+    const out2 = obfuscate("Email alice@acme.com again");
+    expect(out1).toContain("<EMAIL_1>");
+    expect(out1).not.toContain("alice@acme.com");
+    expect(out2).toContain("<EMAIL_1>");
+  });
+
+  it("issues a new placeholder for a different value of the same category", () => {
+    obfuscate("alice@acme.com");
+    const out = obfuscate("bob@globex.io");
+    expect(out).toContain("<EMAIL_2>");
+  });
+
+  it("redacts UUIDs", () => {
+    const out = obfuscate("session 550e8400-e29b-41d4-a716-446655440000");
+    expect(out).toContain("<UUID_1>");
+  });
+
+  it("redacts IPv4 addresses", () => {
+    const out = obfuscate("Connecting to 10.0.42.17 and 192.168.1.1");
+    expect(out).toMatch(/<IPV4_1>/);
+    expect(out).toMatch(/<IPV4_2>/);
+    expect(out).not.toContain("10.0.42.17");
+  });
+
+  it("redacts URLs and underlying hosts consistently", () => {
+    const out = obfuscate("GET https://api.acme-corp.internal/v1/users → 200");
+    expect(out).toContain("<URL_1>");
+    expect(out).not.toContain("acme-corp.internal");
+  });
+
+  it("preserves allowlisted hosts (example.com, github.com)", () => {
+    const out = obfuscate(
+      "See https://example.com/foo and github.com/org/repo",
+    );
+    // example.com is allowlisted as host but the URL pattern wins, so we
+    // expect the URL to be redacted while the bare github.com mention is kept.
+    expect(out).toContain("github.com/org/repo");
+  });
+
+  it("redacts JWTs and bearer-style tokens", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    const out = obfuscate(`Authorization: Bearer ${jwt}`);
+    expect(out).toContain("<JWT_1>");
+    expect(out).not.toContain(jwt);
+  });
+
+  it("redacts API keys", () => {
+    const out = obfuscate("sk-abcdefghijklmnopqrstuvwxyz1234");
+    expect(out).toContain("<TOKEN_1>");
+  });
+
+  it("redacts user home paths", () => {
+    const out = obfuscate("/Users/alice/code/acme/src/index.ts");
+    expect(out).toContain("<PATH_1>");
+    expect(out).not.toContain("alice");
+  });
+
+  it("redacts apparent company names with corporate suffixes", () => {
+    const out = obfuscate("Engagement scoped for Acme Corp and Globex LLC.");
+    expect(out).toContain("<ORG_1>");
+    expect(out).toContain("<ORG_2>");
+    expect(out).not.toContain("Acme");
+    expect(out).not.toContain("Globex");
+  });
+
+  it("does not redact short capitalised English sentences without org cues", () => {
+    const sentence = "The Quick Brown Fox jumped.";
+    expect(obfuscate(sentence)).toBe(sentence);
+  });
+
+  it("redacts MAC addresses", () => {
+    const out = obfuscate("nic 00:1A:2B:3C:4D:5E");
+    expect(out).toContain("<MAC_1>");
+  });
+
+  it("redacts a credit card number that passes Luhn", () => {
+    const out = obfuscate("Card 4111 1111 1111 1111 on file");
+    expect(out).toContain("<CARD_1>");
+  });
+
+  it("redacts phone numbers", () => {
+    const out = obfuscate("Call +1 415 555 0123 today");
+    expect(out).toContain("<PHONE_1>");
+  });
+
+  it("obfuscateValue assigns category placeholder when enabled", () => {
+    expect(obfuscateValue("acme-internal-host", "HOST")).toBe("<HOST_1>");
+  });
+
+  it("returns original from obfuscateValue when disabled", () => {
+    setObfuscationEnabled(false);
+    expect(obfuscateValue("acme-internal-host", "HOST")).toBe(
+      "acme-internal-host",
+    );
+  });
+
+  it("ignores common file extensions when redacting hostnames", () => {
+    const out = obfuscate("Edit config.json then run app.py");
+    expect(out).toContain("config.json");
+    expect(out).toContain("app.py");
+  });
+});

--- a/src/core/obfuscation/engine.ts
+++ b/src/core/obfuscation/engine.ts
@@ -3,8 +3,10 @@
  *
  * The engine maintains a process-lifetime map of `original → placeholder`
  * so the same value produces the same placeholder every time. Placeholders
- * use angle brackets (`<EMAIL_1>`) so they are obviously not real data and
- * cannot collide with any of the regexes below.
+ * use square brackets (`[EMAIL_1]`) — angle brackets would be parsed as
+ * inline HTML by the markdown renderer and disappear from the rendered
+ * message, so brackets keep the placeholder visible across every render
+ * path.
  *
  * Hosts have **no allowlist**: every detected hostname is redacted, even
  * apparently public ones (e.g. `pensar.dev`, `github.com`). The point of
@@ -119,7 +121,7 @@ const ORG_STOPWORDS = new Set<string>([
 
 /**
  * Patterns are run in this order. Order matters because once a substring
- * is replaced with `<CATEGORY_N>`, it can no longer match later patterns.
+ * is replaced with `[CATEGORY_N]`, it can no longer match later patterns.
  *
  * Each pattern receives the full match and returns the substring that
  * should be tracked / replaced. The optional `pick` filter exists so a
@@ -287,12 +289,12 @@ function luhn(digits: string): boolean {
 function placeholderFor(value: string, category: ObfuscationCategory): string {
   const existing = STATE.mapping.get(value);
   if (existing) {
-    return `<${existing.category}_${existing.index}>`;
+    return `[${existing.category}_${existing.index}]`;
   }
   const next = (STATE.counters.get(category) ?? 0) + 1;
   STATE.counters.set(category, next);
   STATE.mapping.set(value, { category, index: next });
-  return `<${category}_${next}>`;
+  return `[${category}_${next}]`;
 }
 
 /** Globally enable/disable obfuscation. */
@@ -350,7 +352,7 @@ export function obfuscateValue(
 
 /**
  * Reverse `obfuscate()`/`obfuscateValue()` — replace every known
- * `<CATEGORY_N>` placeholder with the original value it was generated
+ * `[CATEGORY_N]` placeholder with the original value it was generated
  * from. Unknown placeholders are left intact.
  *
  * Used by inputs that redact text in-place while the user types: the
@@ -364,7 +366,7 @@ export function obfuscateValue(
 export function deobfuscate(input: string): string {
   if (!input || STATE.mapping.size === 0) return input;
   // Sort by descending index per category so longer placeholders
-  // (`<HOST_10>`) are tried before their prefixes (`<HOST_1>`). Both are
+  // (`[HOST_10]`) are tried before their prefixes (`[HOST_1]`). Both are
   // unique strings, but ordering keeps the regex shape simple if we
   // ever switch to a single combined pass.
   const entries = Array.from(STATE.mapping.entries()).sort(
@@ -372,7 +374,7 @@ export function deobfuscate(input: string): string {
   );
   let output = input;
   for (const [original, { category, index }] of entries) {
-    const placeholder = `<${category}_${index}>`;
+    const placeholder = `[${category}_${index}]`;
     if (!output.includes(placeholder)) continue;
     output = output.split(placeholder).join(original);
   }

--- a/src/core/obfuscation/engine.ts
+++ b/src/core/obfuscation/engine.ts
@@ -167,7 +167,10 @@ const UUID_REGEX =
 const IPV4_REGEX =
   /\b(?:25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])(?:\.(?:25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])){3}\b/g;
 
-const IPV6_REGEX = /\b(?:[0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}\b/g;
+// Match both full and compressed (`fe80::1`, `2001:db8::8a2e`) IPv6 forms.
+// Compressed: contains `::`. Full: has 7 colons separating 8 hex groups.
+const IPV6_REGEX =
+  /\b(?:(?:[0-9a-fA-F]{1,4}:){1,7}:[0-9a-fA-F]{0,4}|(?:[0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}|::(?:[0-9a-fA-F]{1,4})|[0-9a-fA-F]{1,4}::(?:[0-9a-fA-F]{1,4}(?::[0-9a-fA-F]{1,4})*)?)\b/g;
 
 const MAC_REGEX = /\b(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}\b/g;
 

--- a/src/core/obfuscation/engine.ts
+++ b/src/core/obfuscation/engine.ts
@@ -40,7 +40,102 @@ const STATE = {
   enabled: false,
   counters: new Map<ObfuscationCategory, number>(),
   mapping: new Map<string, Mapping>(),
+  /**
+   * Lowercase `label → Mapping` aliases derived from previously-redacted
+   * values: when we redact `acme.com → [HOST_42]` we also register
+   * `acme → [HOST_42]` so bare references to the same org get the
+   * same placeholder. Same idea for `Acme Corp → [ORG_3]` registering
+   * `acme → [ORG_3]`.
+   *
+   * Aliases share placeholders with their parent value, so deobfuscation
+   * resolves `[HOST_42]` to the canonical hostname regardless of which
+   * surface (full host vs. bare label) produced the placeholder.
+   */
+  aliases: new Map<string, Mapping>(),
 };
+
+/**
+ * Generic SaaS / cloud / infra labels that should never be aliased even
+ * when they appear inside a redacted hostname. Without this filter,
+ * `s3.amazonaws.com` would teach the engine that `amazonaws` is a
+ * sensitive label and start redacting every mention of "Amazon" or
+ * "AWS" in agent prose.
+ */
+const PROVIDER_LABELS = new Set<string>([
+  "amazon",
+  "amazonaws",
+  "amazonses",
+  "amazonsns",
+  "amazoncognito",
+  "google",
+  "googleapis",
+  "googleusercontent",
+  "gstatic",
+  "github",
+  "githubusercontent",
+  "gitlab",
+  "bitbucket",
+  "cloudflare",
+  "cloudflareinsights",
+  "cloudfront",
+  "azure",
+  "azurewebsites",
+  "microsoft",
+  "microsoftonline",
+  "office",
+  "windows",
+  "outlook",
+  "slack",
+  "atlassian",
+  "jira",
+  "heroku",
+  "vercel",
+  "netlify",
+  "digitalocean",
+  "linode",
+  "fastly",
+  "akamai",
+  "edgekey",
+  "edgesuite",
+  "stripe",
+  "paypal",
+  "shopify",
+  "wordpress",
+  "blogspot",
+  "twitter",
+  "facebook",
+  "instagram",
+  "linkedin",
+  "youtube",
+  "discord",
+  "twitch",
+  "zoom",
+  "dropbox",
+  "okta",
+  "auth0",
+  "duo",
+  "cognito",
+  "salesforce",
+  "hubspot",
+  "intercom",
+  "zendesk",
+  "sendgrid",
+  "twilio",
+  "mailgun",
+  "datadog",
+  "sentry",
+  "newrelic",
+  "rollbar",
+  "segment",
+  "mixpanel",
+  "amplitude",
+  "stackoverflow",
+  "medium",
+  "reddit",
+  "wikipedia",
+  "localhost",
+  "example",
+]);
 
 /** Words used as `org` placeholder bait — these are not redacted. */
 const ORG_STOPWORDS = new Set<string>([
@@ -187,6 +282,64 @@ const PATH_WIN_REGEX =
   /[A-Za-z]:\\Users\\[A-Za-z0-9._-]+(?:\\[A-Za-z0-9._\- \\+]*)?/g;
 
 /**
+ * URL-style filesystem and HTTP route paths with a leading slash, e.g.
+ * `/v1/external/sendgrid/{tenant_id}`, `/__debug/pprof/heap`,
+ * `/tmp/cache.json`, `/docs/`, `/__health`.
+ *
+ * Three alternatives, ordered greediest-first so multi-segment matches
+ * absorb `__`-prefixed first segments:
+ *   1. multi-segment path: `/foo/bar`, `/v1/users/{id}`
+ *   2. `__`-prefixed single segment: `/__debug`, `/__health`
+ *   3. single segment with trailing slash: `/docs/`
+ *
+ * This deliberately leaves bare single-token slash commands (`/help`,
+ * `/obfuscate`, `/threat-model`) untouched so the command router still
+ * sees them. The PromptInput layer additionally skips real-time
+ * obfuscation when the buffer begins with `/`, so even multi-segment
+ * commands like `/threat-model --output foo/bar` aren't mangled.
+ *
+ * Inner segment chars accept `{}`, `[]`, and `$` so existing
+ * placeholder values (`{tenant_id}`, `${userId}`, `[UUID_3]`) and
+ * earlier obfuscation results get folded into the surrounding path.
+ */
+const ROUTE_PATH_REGEX =
+  /(?<![A-Za-z0-9_./-])\/(?:[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.{}$[\]-]*)+\/?|__[A-Za-z0-9_.-]+\/?|[A-Za-z0-9_.-]+\/)/g;
+
+/**
+ * Multi-segment path WITHOUT a leading slash: `__debug/config`,
+ * `docs/media/`, `v2/access/users/type`, `media/{tenant_id}`,
+ * `access/users/${userId}/tenants`.
+ *
+ * Aggressive on purpose — operators would rather over-redact paths
+ * than leak endpoint surface. Side effect: trivially matches phrases
+ * like `and/or`, `key/value`, dates such as `04/28/2026`, and
+ * `12/30/2025`. We accept those false positives.
+ */
+const RELATIVE_PATH_REGEX =
+  /(?<![A-Za-z0-9_./\\-])[A-Za-z0-9_.-]+\/(?:[A-Za-z0-9_.{}$[\]-]*\/)*[A-Za-z0-9_.{}$[\]-]*/g;
+
+/**
+ * Region-prefixed AWS identifiers such as Cognito user-pool IDs
+ * (`us-east-1_X8rlYugE7`) and similar `<region>_<base62>` blobs.
+ * Region alone (`us-east-1`) is left intact — only the suffixed form
+ * is sensitive.
+ */
+const AWS_REGION_ID_REGEX =
+  /\b(?:us|eu|ap|sa|ca|me|af|cn)-(?:north|south|east|west|central|southeast|northeast|southwest|northwest)-\d_[A-Za-z0-9]{6,}\b/g;
+
+/**
+ * Opaque alphanumeric blob 20+ chars containing both letters and at
+ * least one digit. Catches AWS/GCP client IDs, Cognito identity blobs,
+ * session tokens, and other long mixed-case identifiers that don't
+ * match a vendor-specific prefix. The double lookahead requires both
+ * a digit and a letter so we don't redact long all-letter strings
+ * (concatenated identifiers like `getUserTenants`) or all-digit
+ * strings (handled by phone/card patterns).
+ */
+const OPAQUE_ID_REGEX =
+  /\b(?=[A-Za-z0-9]{20,}\b)(?=[A-Za-z0-9]*\d)(?=[A-Za-z0-9]*[A-Za-z])[A-Za-z0-9]{20,}\b/g;
+
+/**
  * Bare hostnames such as `acme-corp.internal`, `target.example.com`,
  * `s3-bucket.eu-west-1.amazonaws.com`. Caught after URLs so the URL
  * pass takes precedence.
@@ -239,8 +392,12 @@ const PATTERNS: Pattern[] = [
       return m[0];
     },
   },
+  { category: "TOKEN", regex: AWS_REGION_ID_REGEX },
   { category: "PATH", regex: PATH_UNIX_REGEX },
   { category: "PATH", regex: PATH_WIN_REGEX },
+  { category: "PATH", regex: ROUTE_PATH_REGEX },
+  { category: "PATH", regex: RELATIVE_PATH_REGEX },
+  { category: "TOKEN", regex: OPAQUE_ID_REGEX },
   {
     category: "HOST",
     regex: HOST_REGEX,
@@ -289,12 +446,110 @@ function luhn(digits: string): boolean {
 function placeholderFor(value: string, category: ObfuscationCategory): string {
   const existing = STATE.mapping.get(value);
   if (existing) {
+    learnAliases(value, category, existing);
     return `[${existing.category}_${existing.index}]`;
   }
   const next = (STATE.counters.get(category) ?? 0) + 1;
   STATE.counters.set(category, next);
-  STATE.mapping.set(value, { category, index: next });
+  const mapping: Mapping = { category, index: next };
+  STATE.mapping.set(value, mapping);
+  learnAliases(value, category, mapping);
   return `[${category}_${next}]`;
+}
+
+/**
+ * Pull a "registrable" label out of a hostname, e.g. `acme` from
+ * `acme.com` or `staging-console.acme.dev`. Returns null when the
+ * label is too short, looks like a TLD, has no letters, or is in the
+ * global provider blocklist.
+ */
+function extractHostLabel(host: string): string | null {
+  const cleaned = host.toLowerCase().replace(/^\[|\]$/g, "");
+  const parts = cleaned.split(".").filter(Boolean);
+  if (parts.length < 2) return null;
+  const label = parts[parts.length - 2];
+  if (!label) return null;
+  if (label.length < 4) return null;
+  if (!/[a-z]/.test(label)) return null;
+  if (PROVIDER_LABELS.has(label)) return null;
+  return label;
+}
+
+/** Pull the host out of an `https://host[:port]/path...` URL match. */
+function extractHostFromUrl(url: string): string | null {
+  const m = /^https?:\/\/([^\/?#:]+)/i.exec(url);
+  return m && m[1] ? m[1] : null;
+}
+
+/**
+ * Pull the leading capitalised word out of an org match, e.g. `Acme`
+ * from `Acme Corp` or `Globex Industries`. Skips the corporate suffix
+ * itself (`Corp`, `LLC`, ...) and any token already in the stopword
+ * list so well-known platforms don't get aliased.
+ */
+function extractOrgLabel(text: string): string | null {
+  const first = text.trim().split(/\s+/)[0];
+  if (!first) return null;
+  if (first.length < 4) return null;
+  if (ORG_STOPWORDS.has(first)) return null;
+  const lower = first.toLowerCase();
+  if (PROVIDER_LABELS.has(lower)) return null;
+  return lower;
+}
+
+function recordAlias(label: string | null, mapping: Mapping): void {
+  if (!label) return;
+  if (STATE.aliases.has(label)) return;
+  STATE.aliases.set(label, mapping);
+}
+
+function learnAliases(
+  value: string,
+  category: ObfuscationCategory,
+  mapping: Mapping,
+): void {
+  switch (category) {
+    case "HOST":
+      recordAlias(extractHostLabel(value), mapping);
+      break;
+    case "URL": {
+      const host = extractHostFromUrl(value);
+      if (host) recordAlias(extractHostLabel(host), mapping);
+      break;
+    }
+    case "ORG":
+      recordAlias(extractOrgLabel(value), mapping);
+      break;
+    default:
+      break;
+  }
+}
+
+/** Escape regex metacharacters in a literal string. */
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Replace every learned alias with its placeholder, case-insensitive,
+ * whole-word. Run as a final pass after the regex patterns so the
+ * aliases mostly act on agent prose ("the Acme corporate tenant")
+ * rather than the structured values the patterns already handled.
+ */
+function applyAliases(input: string): string {
+  if (STATE.aliases.size === 0) return input;
+  const labels = Array.from(STATE.aliases.keys()).sort(
+    (a, b) => b.length - a.length,
+  );
+  const regex = new RegExp(
+    `\\b(?:${labels.map(escapeRegex).join("|")})\\b`,
+    "gi",
+  );
+  return input.replace(regex, (match) => {
+    const mapping = STATE.aliases.get(match.toLowerCase());
+    if (!mapping) return match;
+    return `[${mapping.category}_${mapping.index}]`;
+  });
 }
 
 /** Globally enable/disable obfuscation. */
@@ -311,14 +566,25 @@ export function isObfuscationEnabled(): boolean {
 export function resetObfuscation(): void {
   STATE.counters.clear();
   STATE.mapping.clear();
+  STATE.aliases.clear();
 }
 
 /**
  * Redact a string. When obfuscation is disabled, the input is returned
  * unchanged. When enabled, every recognised pattern is replaced with a
  * stable placeholder.
+ *
+ * `options.aliases` (default `true`) controls the final org-label
+ * replacement pass. The PromptInput layer disables it because aliases
+ * are lossy to round-trip: typing the bare label `Acme` would
+ * obfuscate to `[HOST_42]` and deobfuscate back to the canonical host
+ * (`acme.com`), corrupting the user's input. Display surfaces
+ * (renderer, tool output) keep aliasing on since they never round-trip.
  */
-export function obfuscate(input: string): string {
+export function obfuscate(
+  input: string,
+  options?: { aliases?: boolean },
+): string {
   if (!STATE.enabled) return input;
   if (!input) return input;
 
@@ -333,6 +599,13 @@ export function obfuscate(input: string): string {
       if (tracked === null) return match;
       return placeholderFor(tracked, pattern.category);
     });
+  }
+  // Final pass: case-insensitive whole-word replacement of any org
+  // labels we learned from previously-redacted hosts/URLs/orgs. This
+  // is what catches bare references like "the Acme subdomain"
+  // once the engine has seen `acme.com` or `Acme Inc.`.
+  if (options?.aliases !== false) {
+    output = applyAliases(output);
   }
   return output;
 }

--- a/src/core/obfuscation/engine.ts
+++ b/src/core/obfuscation/engine.ts
@@ -1,0 +1,355 @@
+/**
+ * Pattern-based obfuscation engine.
+ *
+ * The engine maintains a process-lifetime map of `original → placeholder`
+ * so the same value produces the same placeholder every time. Placeholders
+ * use angle brackets (`<EMAIL_1>`) so they are obviously not real data and
+ * cannot collide with any of the regexes below.
+ */
+
+export type ObfuscationCategory =
+  | "EMAIL"
+  | "UUID"
+  | "URL"
+  | "HOST"
+  | "IPV4"
+  | "IPV6"
+  | "MAC"
+  | "PATH"
+  | "JWT"
+  | "TOKEN"
+  | "HEX"
+  | "PHONE"
+  | "CARD"
+  | "ORG"
+  | "USER";
+
+interface Mapping {
+  category: ObfuscationCategory;
+  index: number;
+}
+
+const STATE = {
+  enabled: false,
+  counters: new Map<ObfuscationCategory, number>(),
+  mapping: new Map<string, Mapping>(),
+};
+
+/** Allowlisted hosts/domains we never redact (well-known public infra). */
+const HOST_ALLOWLIST = new Set<string>([
+  "localhost",
+  "localhost.localdomain",
+  "example.com",
+  "example.org",
+  "example.net",
+  "example",
+  "pensar.dev",
+  "pensar.com",
+  "pensar.io",
+  "github.com",
+  "githubusercontent.com",
+  "gitlab.com",
+  "bun.sh",
+  "nodejs.org",
+  "npmjs.com",
+  "anthropic.com",
+  "openai.com",
+  "google.com",
+  "googleapis.com",
+  "amazonaws.com",
+  "cloudflare.com",
+]);
+
+/** Words used as `org` placeholder bait — these are not redacted. */
+const ORG_STOPWORDS = new Set<string>([
+  "Pensar",
+  "Apex",
+  "Linux",
+  "Windows",
+  "MacOS",
+  "Ubuntu",
+  "Debian",
+  "Fedora",
+  "Bun",
+  "Node",
+  "TypeScript",
+  "JavaScript",
+  "Python",
+  "Java",
+  "Go",
+  "Rust",
+  "Docker",
+  "Kubernetes",
+  "GitHub",
+  "Anthropic",
+  "OpenAI",
+  "Google",
+  "AWS",
+  "Azure",
+  "Claude",
+  "GPT",
+  "Sonnet",
+  "Opus",
+  "Haiku",
+  "User",
+  "Admin",
+  "Test",
+  "Dev",
+  "Prod",
+  "Staging",
+  "TODO",
+  "README",
+  "API",
+  "URL",
+  "HTTP",
+  "HTTPS",
+  "JSON",
+  "XML",
+  "YAML",
+  "CSV",
+  "PDF",
+  "HTML",
+  "CSS",
+  "SQL",
+  "TLS",
+  "SSL",
+  "JWT",
+  "UUID",
+  "CWE",
+  "CVE",
+  "OS",
+  "PII",
+  "URI",
+  "IDE",
+  "CLI",
+  "TUI",
+  "SDK",
+  "MCP",
+  "REST",
+  "GraphQL",
+  "OAuth",
+  "SSO",
+  "IAM",
+  "VPN",
+  "DNS",
+  "ICMP",
+  "TCP",
+  "UDP",
+]);
+
+/**
+ * Patterns are run in this order. Order matters because once a substring
+ * is replaced with `<CATEGORY_N>`, it can no longer match later patterns.
+ *
+ * Each pattern receives the full match and returns the substring that
+ * should be tracked / replaced. This lets us, for example, skip
+ * allowlisted hosts but still match every other host.
+ */
+interface Pattern {
+  category: ObfuscationCategory;
+  /** Regex with the global flag set. */
+  regex: RegExp;
+  /**
+   * Optional filter: return null to keep the original substring,
+   * otherwise return the substring to track + replace.
+   */
+  pick?: (match: RegExpExecArray) => string | null;
+}
+
+const URL_REGEX =
+  /\bhttps?:\/\/(?:[A-Za-z0-9._~%!$&'()*+,;=:@-]+\/?)+(?:\?[^\s<>"]*)?(?:#[^\s<>"]*)?/g;
+
+const EMAIL_REGEX = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+\b/g;
+
+const UUID_REGEX =
+  /\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b/g;
+
+const IPV4_REGEX =
+  /\b(?:25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])(?:\.(?:25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])){3}\b/g;
+
+const IPV6_REGEX = /\b(?:[0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}\b/g;
+
+const MAC_REGEX = /\b(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}\b/g;
+
+const JWT_REGEX =
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
+
+const TOKEN_REGEX =
+  /\b(?:sk-[A-Za-z0-9_-]{20,}|sk_(?:live|test)_[A-Za-z0-9]{20,}|pk_(?:live|test)_[A-Za-z0-9]{20,}|xox[abprs]-[A-Za-z0-9-]{10,}|ghp_[A-Za-z0-9]{20,}|gho_[A-Za-z0-9]{20,}|ghs_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[0-9A-Z]{16})\b/g;
+
+const HEX_REGEX = /\b[0-9a-fA-F]{32,128}\b/g;
+
+const CARD_REGEX = /\b(?:\d[ -]?){13,19}\b/g;
+
+const PHONE_REGEX = /\+?\d{1,3}[ -]?\(?\d{2,4}\)?[ -]?\d{3,4}[ -]?\d{3,4}\b/g;
+
+const PATH_UNIX_REGEX =
+  /\/(?:Users|home)\/[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._\- /+]*)?/g;
+const PATH_WIN_REGEX =
+  /[A-Za-z]:\\Users\\[A-Za-z0-9._-]+(?:\\[A-Za-z0-9._\- \\+]*)?/g;
+
+/**
+ * Bare hostnames such as `acme-corp.internal`, `target.example.com`,
+ * `s3-bucket.eu-west-1.amazonaws.com`. Caught after URLs so the URL
+ * pass takes precedence.
+ */
+const HOST_REGEX =
+  /\b(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,24}\b/g;
+
+/**
+ * Capitalised compound nouns that look like company / product names,
+ * e.g. `Acme Corp`, `Globex Industries`, `Initech LLC`.
+ *
+ * Uses a sliding window of capitalised tokens. Single capitalised words
+ * are too noisy (every sentence start would match), so we require either
+ * a corporate suffix (`Inc`, `LLC`, ...) or two consecutive capitalised
+ * words.
+ */
+const ORG_SUFFIXES =
+  "(?:Inc|LLC|Ltd|Limited|Corp|Corporation|Co|Holdings|Group|GmbH|S\\.?A\\.?|Industries|Solutions|Systems|Technologies|Labs|Networks|Bank|Capital|Partners|Pty)";
+
+const ORG_REGEX = new RegExp(
+  `\\b(?:[A-Z][a-zA-Z0-9&'-]+(?:\\s+[A-Z][a-zA-Z0-9&'-]+){0,3})\\s+${ORG_SUFFIXES}\\.?\\b`,
+  "g",
+);
+
+const PATTERNS: Pattern[] = [
+  { category: "URL", regex: URL_REGEX },
+  { category: "EMAIL", regex: EMAIL_REGEX },
+  { category: "JWT", regex: JWT_REGEX },
+  { category: "TOKEN", regex: TOKEN_REGEX },
+  { category: "UUID", regex: UUID_REGEX },
+  { category: "MAC", regex: MAC_REGEX },
+  { category: "IPV6", regex: IPV6_REGEX },
+  { category: "IPV4", regex: IPV4_REGEX },
+  {
+    category: "CARD",
+    regex: CARD_REGEX,
+    pick: (m) => {
+      const digits = m[0].replace(/[ -]/g, "");
+      if (digits.length < 13 || digits.length > 19) return null;
+      return luhn(digits) ? m[0] : null;
+    },
+  },
+  {
+    category: "PHONE",
+    regex: PHONE_REGEX,
+    pick: (m) => {
+      const digits = m[0].replace(/\D/g, "");
+      if (digits.length < 10 || digits.length > 15) return null;
+      return m[0];
+    },
+  },
+  { category: "PATH", regex: PATH_UNIX_REGEX },
+  { category: "PATH", regex: PATH_WIN_REGEX },
+  {
+    category: "HOST",
+    regex: HOST_REGEX,
+    pick: (m) => {
+      const host = m[0].toLowerCase();
+      if (HOST_ALLOWLIST.has(host)) return null;
+      const labels = host.split(".");
+      const apex = labels.slice(-2).join(".");
+      if (HOST_ALLOWLIST.has(apex)) return null;
+      // Skip anything that looks like a filename (`config.json`, `app.py`).
+      if (
+        /^[a-z]+\.(?:json|js|ts|tsx|jsx|md|txt|csv|xml|yaml|yml|toml|sh|py|rb|go|rs|java|css|html|log|lock|env)$/.test(
+          host,
+        )
+      ) {
+        return null;
+      }
+      return m[0];
+    },
+  },
+  { category: "HEX", regex: HEX_REGEX },
+  {
+    category: "ORG",
+    regex: ORG_REGEX,
+    pick: (m) => {
+      const text = m[0].trim();
+      if (ORG_STOPWORDS.has(text.split(/\s+/)[0]!)) return null;
+      return text;
+    },
+  },
+];
+
+function luhn(digits: string): boolean {
+  let sum = 0;
+  let alt = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let n = digits.charCodeAt(i) - 48;
+    if (n < 0 || n > 9) return false;
+    if (alt) {
+      n *= 2;
+      if (n > 9) n -= 9;
+    }
+    sum += n;
+    alt = !alt;
+  }
+  return sum % 10 === 0;
+}
+
+function placeholderFor(value: string, category: ObfuscationCategory): string {
+  const existing = STATE.mapping.get(value);
+  if (existing) {
+    return `<${existing.category}_${existing.index}>`;
+  }
+  const next = (STATE.counters.get(category) ?? 0) + 1;
+  STATE.counters.set(category, next);
+  STATE.mapping.set(value, { category, index: next });
+  return `<${category}_${next}>`;
+}
+
+/** Globally enable/disable obfuscation. */
+export function setObfuscationEnabled(enabled: boolean): void {
+  STATE.enabled = enabled;
+}
+
+/** Whether obfuscation is currently active. */
+export function isObfuscationEnabled(): boolean {
+  return STATE.enabled;
+}
+
+/** Reset the placeholder mapping. Mostly useful in tests. */
+export function resetObfuscation(): void {
+  STATE.counters.clear();
+  STATE.mapping.clear();
+}
+
+/**
+ * Redact a string. When obfuscation is disabled, the input is returned
+ * unchanged. When enabled, every recognised pattern is replaced with a
+ * stable placeholder.
+ */
+export function obfuscate(input: string): string {
+  if (!STATE.enabled) return input;
+  if (!input) return input;
+
+  let output = input;
+  for (const pattern of PATTERNS) {
+    const regex = new RegExp(pattern.regex.source, pattern.regex.flags);
+    output = output.replace(regex, (match, ..._rest) => {
+      const arr = [match] as unknown as RegExpExecArray;
+      arr.index = 0;
+      arr.input = output;
+      const tracked = pattern.pick ? pattern.pick(arr) : match;
+      if (tracked === null) return match;
+      return placeholderFor(tracked, pattern.category);
+    });
+  }
+  return output;
+}
+
+/**
+ * Generate a stable placeholder for a known sensitive value.
+ * Use when the value is already isolated (e.g. a credential field) and
+ * you don't need pattern detection.
+ */
+export function obfuscateValue(
+  value: string,
+  category: ObfuscationCategory = "USER",
+): string {
+  if (!STATE.enabled || !value) return value;
+  return placeholderFor(value, category);
+}

--- a/src/core/obfuscation/engine.ts
+++ b/src/core/obfuscation/engine.ts
@@ -284,26 +284,31 @@ const PATH_WIN_REGEX =
 /**
  * URL-style filesystem and HTTP route paths with a leading slash, e.g.
  * `/v1/external/sendgrid/{tenant_id}`, `/__debug/pprof/heap`,
- * `/tmp/cache.json`, `/docs/`, `/__health`.
+ * `/tmp/cache.json`, `/docs/`, `/__health`, `/login,`.
  *
- * Three alternatives, ordered greediest-first so multi-segment matches
+ * Four alternatives, ordered greediest-first so multi-segment matches
  * absorb `__`-prefixed first segments:
  *   1. multi-segment path: `/foo/bar`, `/v1/users/{id}`
  *   2. `__`-prefixed single segment: `/__debug`, `/__health`
  *   3. single segment with trailing slash: `/docs/`
+ *   4. single segment followed by some character or whitespace
+ *      (anything but newline/EOS): `/login,`, `/dashboard `, `/leads.`
  *
- * This deliberately leaves bare single-token slash commands (`/help`,
- * `/obfuscate`, `/threat-model`) untouched so the command router still
- * sees them. The PromptInput layer additionally skips real-time
- * obfuscation when the buffer begins with `/`, so even multi-segment
- * commands like `/threat-model --output foo/bar` aren't mangled.
+ * Alternative 4 deliberately requires SOMETHING after the segment so
+ * a bare standalone slash command (`/help`, `/obfuscate` at end of
+ * input or end of line) stays intact for the command router. The
+ * PromptInput layer additionally skips real-time obfuscation when the
+ * buffer begins with `/`, so user-typed commands with arguments
+ * (`/threat-model --output foo/bar`) aren't mangled either; the
+ * remaining false positives are agent prose like "run /obfuscate now",
+ * which we accept.
  *
  * Inner segment chars accept `{}`, `[]`, and `$` so existing
  * placeholder values (`{tenant_id}`, `${userId}`, `[UUID_3]`) and
  * earlier obfuscation results get folded into the surrounding path.
  */
 const ROUTE_PATH_REGEX =
-  /(?<![A-Za-z0-9_./-])\/(?:[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.{}$[\]-]*)+\/?|__[A-Za-z0-9_.-]+\/?|[A-Za-z0-9_.-]+\/)/g;
+  /(?<![A-Za-z0-9_./-])\/(?:[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.{}$[\]-]*)+\/?|__[A-Za-z0-9_.-]+\/?|[A-Za-z0-9_.-]+\/|[A-Za-z0-9_.-]+(?=[^A-Za-z0-9_.\-\n\r]))/g;
 
 /**
  * Multi-segment path WITHOUT a leading slash: `__debug/config`,

--- a/src/core/obfuscation/engine.ts
+++ b/src/core/obfuscation/engine.ts
@@ -347,3 +347,34 @@ export function obfuscateValue(
   if (!STATE.enabled || !value) return value;
   return placeholderFor(value, category);
 }
+
+/**
+ * Reverse `obfuscate()`/`obfuscateValue()` — replace every known
+ * `<CATEGORY_N>` placeholder with the original value it was generated
+ * from. Unknown placeholders are left intact.
+ *
+ * Used by inputs that redact text in-place while the user types: the
+ * textarea displays placeholders, but the agent must receive the
+ * original values on submit.
+ *
+ * Reversal is unconditional — it works even when obfuscation is
+ * disabled, so a value that was redacted before obfuscation was toggled
+ * off still resolves cleanly.
+ */
+export function deobfuscate(input: string): string {
+  if (!input || STATE.mapping.size === 0) return input;
+  // Sort by descending index per category so longer placeholders
+  // (`<HOST_10>`) are tried before their prefixes (`<HOST_1>`). Both are
+  // unique strings, but ordering keeps the regex shape simple if we
+  // ever switch to a single combined pass.
+  const entries = Array.from(STATE.mapping.entries()).sort(
+    ([, a], [, b]) => b.index - a.index,
+  );
+  let output = input;
+  for (const [original, { category, index }] of entries) {
+    const placeholder = `<${category}_${index}>`;
+    if (!output.includes(placeholder)) continue;
+    output = output.split(placeholder).join(original);
+  }
+  return output;
+}

--- a/src/core/obfuscation/engine.ts
+++ b/src/core/obfuscation/engine.ts
@@ -5,6 +5,11 @@
  * so the same value produces the same placeholder every time. Placeholders
  * use angle brackets (`<EMAIL_1>`) so they are obviously not real data and
  * cannot collide with any of the regexes below.
+ *
+ * Hosts have **no allowlist**: every detected hostname is redacted, even
+ * apparently public ones (e.g. `pensar.dev`, `github.com`). The point of
+ * obfuscate-mode is screenshot safety, and any host in the transcript is
+ * potential signal — including the operator's own infrastructure.
  */
 
 export type ObfuscationCategory =
@@ -34,31 +39,6 @@ const STATE = {
   counters: new Map<ObfuscationCategory, number>(),
   mapping: new Map<string, Mapping>(),
 };
-
-/** Allowlisted hosts/domains we never redact (well-known public infra). */
-const HOST_ALLOWLIST = new Set<string>([
-  "localhost",
-  "localhost.localdomain",
-  "example.com",
-  "example.org",
-  "example.net",
-  "example",
-  "pensar.dev",
-  "pensar.com",
-  "pensar.io",
-  "github.com",
-  "githubusercontent.com",
-  "gitlab.com",
-  "bun.sh",
-  "nodejs.org",
-  "npmjs.com",
-  "anthropic.com",
-  "openai.com",
-  "google.com",
-  "googleapis.com",
-  "amazonaws.com",
-  "cloudflare.com",
-]);
 
 /** Words used as `org` placeholder bait — these are not redacted. */
 const ORG_STOPWORDS = new Set<string>([
@@ -142,8 +122,9 @@ const ORG_STOPWORDS = new Set<string>([
  * is replaced with `<CATEGORY_N>`, it can no longer match later patterns.
  *
  * Each pattern receives the full match and returns the substring that
- * should be tracked / replaced. This lets us, for example, skip
- * allowlisted hosts but still match every other host.
+ * should be tracked / replaced. The optional `pick` filter exists so a
+ * pattern can opt out of redacting specific matches (e.g. anything that
+ * looks like a source-code filename).
  */
 interface Pattern {
   category: ObfuscationCategory;
@@ -166,6 +147,18 @@ const UUID_REGEX =
 
 const IPV4_REGEX =
   /\b(?:25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])(?:\.(?:25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])){3}\b/g;
+
+/**
+ * IPv4 written with hyphens instead of dots (e.g. `10-0-0-1`). Common in
+ * filesystem-safe session names and reverse-DNS labels like
+ * `pentest-10-0-0-1` or `ec2-54-12-34-56.compute.amazonaws.com`.
+ *
+ * Lookbehind/lookahead reject continuation of a longer hyphenated number
+ * sequence (so `1-2-3-4-5` does not match `2-3-4-5` once `1-2-3-4` is
+ * rejected by the trailing lookahead).
+ */
+const IPV4_DASHED_REGEX =
+  /(?<![0-9])(?<!\d-)(?:25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])(?:-(?:25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])){3}(?![0-9])(?!-\d)/g;
 
 // Match both full and compressed (`fe80::1`, `2001:db8::8a2e`) IPv6 forms.
 // Compressed: contains `::`. Full: has 7 colons separating 8 hex groups.
@@ -225,6 +218,7 @@ const PATTERNS: Pattern[] = [
   { category: "MAC", regex: MAC_REGEX },
   { category: "IPV6", regex: IPV6_REGEX },
   { category: "IPV4", regex: IPV4_REGEX },
+  { category: "IPV4", regex: IPV4_DASHED_REGEX },
   {
     category: "CARD",
     regex: CARD_REGEX,
@@ -250,11 +244,8 @@ const PATTERNS: Pattern[] = [
     regex: HOST_REGEX,
     pick: (m) => {
       const host = m[0].toLowerCase();
-      if (HOST_ALLOWLIST.has(host)) return null;
-      const labels = host.split(".");
-      const apex = labels.slice(-2).join(".");
-      if (HOST_ALLOWLIST.has(apex)) return null;
-      // Skip anything that looks like a filename (`config.json`, `app.py`).
+      // Skip anything that looks like a filename (`config.json`, `app.py`)
+      // so source-code references don't get redacted as fake hostnames.
       if (
         /^[a-z]+\.(?:json|js|ts|tsx|jsx|md|txt|csv|xml|yaml|yml|toml|sh|py|rb|go|rs|java|css|html|log|lock|env)$/.test(
           host,

--- a/src/core/obfuscation/index.ts
+++ b/src/core/obfuscation/index.ts
@@ -19,6 +19,7 @@
 export {
   obfuscate,
   obfuscateValue,
+  deobfuscate,
   resetObfuscation,
   isObfuscationEnabled,
   setObfuscationEnabled,

--- a/src/core/obfuscation/index.ts
+++ b/src/core/obfuscation/index.ts
@@ -8,12 +8,13 @@
  * Design goals:
  *  - **Stable mapping**: the same input value always produces the same
  *    placeholder within a process lifetime, so redacted output stays
- *    legible (the same email becomes `<EMAIL_1>` everywhere).
+ *    legible (the same email becomes `[EMAIL_1]` everywhere).
  *  - **Pattern-based**: no LLM call is required — every detection is a
  *    regex over the text. This keeps redaction synchronous, deterministic
  *    and cheap enough to run on every render.
- *  - **Allowlist**: well-known public hostnames and reserved/example
- *    domains are not redacted, since they don't leak engagement detail.
+ *  - **No allowlist**: every recognised value is redacted. Any hostname
+ *    or identifier in the transcript is potential signal, including the
+ *    operator's own infra.
  */
 
 export {

--- a/src/core/obfuscation/index.ts
+++ b/src/core/obfuscation/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Obfuscation Engine
+ *
+ * Detects and redacts sensitive content (PII, company names, identifiers,
+ * URLs, IPs, hostnames, file paths, emails, credentials, UUIDs, tokens, etc.)
+ * for screenshot-safe display in the TUI when `--obfuscate` is active.
+ *
+ * Design goals:
+ *  - **Stable mapping**: the same input value always produces the same
+ *    placeholder within a process lifetime, so redacted output stays
+ *    legible (the same email becomes `<EMAIL_1>` everywhere).
+ *  - **Pattern-based**: no LLM call is required — every detection is a
+ *    regex over the text. This keeps redaction synchronous, deterministic
+ *    and cheap enough to run on every render.
+ *  - **Allowlist**: well-known public hostnames and reserved/example
+ *    domains are not redacted, since they don't leak engagement detail.
+ */
+
+export {
+  obfuscate,
+  obfuscateValue,
+  resetObfuscation,
+  isObfuscationEnabled,
+  setObfuscationEnabled,
+} from "./engine";
+export type { ObfuscationCategory } from "./engine";

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -22,6 +22,19 @@ export interface AppCommandContext {
   openAuthDialog?: () => void;
   openPentestDialog?: (flags?: WebCommandOptions) => void;
   openSkillsDialog?: (slug?: string) => void;
+  /**
+   * Toggle obfuscation mode (when called without an argument) or set it to
+   * an explicit value. Returns the new state.
+   */
+  setObfuscation?: (enabled?: boolean) => boolean;
+  /** Whether obfuscation mode is currently active. */
+  getObfuscation?: () => boolean;
+  /** Show a transient toast notification. */
+  toast?: (
+    message: string,
+    variant?: "default" | "warn" | "error",
+    duration?: number,
+  ) => void;
 }
 
 /**
@@ -352,6 +365,48 @@ export const commands: CommandConfig[] = [
     category: "Configuration",
     handler: async (args, ctx) => {
       ctx.openProvidersDialog?.();
+    },
+  },
+  {
+    name: "obfuscate",
+    aliases: ["redact"],
+    description: "Toggle screenshot-safe obfuscation mode (redact PII)",
+    category: "Configuration",
+    options: [
+      {
+        name: "on",
+        description: "Enable obfuscation",
+      },
+      {
+        name: "off",
+        description: "Disable obfuscation",
+      },
+      {
+        name: "toggle",
+        description: "Toggle obfuscation (default if no argument)",
+      },
+    ],
+    handler: async (args, ctx) => {
+      if (!ctx.setObfuscation || !ctx.getObfuscation) return;
+      const subcommand = (args[0] || "").toLowerCase();
+      let target: boolean | undefined;
+      if (subcommand === "on" || subcommand === "enable") target = true;
+      else if (subcommand === "off" || subcommand === "disable") target = false;
+      else if (subcommand === "toggle" || subcommand === "") target = undefined;
+      else {
+        ctx.toast?.(
+          `Unknown /obfuscate argument "${subcommand}". Use on, off, or toggle.`,
+          "error",
+        );
+        return;
+      }
+      const next = ctx.setObfuscation(target);
+      ctx.toast?.(
+        next
+          ? "Obfuscation mode enabled — sensitive values will be redacted."
+          : "Obfuscation mode disabled.",
+        next ? "warn" : "default",
+      );
     },
   },
   {

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -7,6 +7,7 @@ import {
 } from "./utils/command-flags";
 import { getAllThemeNames } from "./theme";
 import { config } from "../core/config";
+import { isObfuscationEnabled } from "../core/obfuscation";
 /**
  * Define your application's CommandContext type with specific methods
  */
@@ -389,11 +390,12 @@ export const commands: CommandConfig[] = [
     handler: async (args, ctx) => {
       if (!ctx.setObfuscation || !ctx.getObfuscation) return;
       const subcommand = (args[0] || "").toLowerCase();
-      let target: boolean | undefined;
+      let target: boolean;
       if (subcommand === "on" || subcommand === "enable") target = true;
       else if (subcommand === "off" || subcommand === "disable") target = false;
-      else if (subcommand === "toggle" || subcommand === "") target = undefined;
-      else {
+      else if (subcommand === "toggle" || subcommand === "") {
+        target = !isObfuscationEnabled();
+      } else {
         ctx.toast?.(
           `Unknown /obfuscate argument "${subcommand}". Use on, off, or toggle.`,
           "error",

--- a/src/tui/command-router.ts
+++ b/src/tui/command-router.ts
@@ -32,13 +32,23 @@ export class CommandRouter<TContext = AppCommandContext> {
   }
 
   /**
-   * Register a command definition that will be bound to a context
+   * Register a command definition that will be bound to a context.
+   *
+   * Metadata (name, aliases, description) is captured once at
+   * registration. The handler, however, is re-bound on every
+   * `execute()` call using the ctx passed at that time. This is
+   * critical for handlers that read live React state (e.g. obfuscation
+   * toggle) — otherwise we'd freeze the ctx from the first render and
+   * subsequent toggles would short-circuit on stale closures.
    */
   registerWithContext(definition: CommandDefinition<TContext>, ctx: TContext) {
-    const { handler, ...metadata } = definition(ctx);
+    const { handler: _frozen, ...metadata } = definition(ctx);
     this.register({
       ...metadata,
-      handler: (args) => handler(args),
+      handler: async (args, runtimeCtx) => {
+        const { handler } = definition(runtimeCtx);
+        await handler(args);
+      },
     });
   }
 

--- a/src/tui/components/agent-display.tsx
+++ b/src/tui/components/agent-display.tsx
@@ -9,6 +9,7 @@ import {
 import { useTheme } from "../theme";
 import { useDimensions } from "../context/dimensions";
 import { obfuscate } from "../../core/obfuscation";
+import { useObfuscation } from "../context/obfuscation";
 
 export type Subagent = {
   id: string;
@@ -212,6 +213,8 @@ const SubAgentDisplay = memo(function SubAgentDisplay({
   subagent: Subagent;
 }) {
   const { colors } = useTheme();
+  // Subscribe so memoised render bypasses cached output on /obfuscate toggle.
+  useObfuscation();
   const [open, setOpen] = useState(false);
 
   return (
@@ -258,6 +261,8 @@ const AgentMessage = memo(function AgentMessage({
 }) {
   const { colors } = useTheme();
   const dimensions = useDimensions();
+  // Subscribe so memoised render bypasses cached output on /obfuscate toggle.
+  useObfuscation();
   let content = "";
 
   if (typeof message.content === "string") {

--- a/src/tui/components/agent-display.tsx
+++ b/src/tui/components/agent-display.tsx
@@ -8,6 +8,7 @@ import {
 } from "./shared";
 import { useTheme } from "../theme";
 import { useDimensions } from "../context/dimensions";
+import { obfuscate } from "../../core/obfuscation";
 
 export type Subagent = {
   id: string;
@@ -224,16 +225,16 @@ const SubAgentDisplay = memo(function SubAgentDisplay({
     >
       <box flexDirection="row" alignItems="center" gap={1}>
         {subagent.status === "pending" && (
-          <SpinningDots label={subagent.name} fg={colors.primary} />
+          <SpinningDots label={obfuscate(subagent.name)} fg={colors.primary} />
         )}
         {subagent.status === "completed" && (
-          <text fg={colors.primary}> ✓ {subagent.name}</text>
+          <text fg={colors.primary}> ✓ {obfuscate(subagent.name)}</text>
         )}
         {subagent.status === "failed" && (
-          <text fg={colors.error}>✗ {subagent.name}</text>
+          <text fg={colors.error}>✗ {obfuscate(subagent.name)}</text>
         )}
         {subagent.status === "paused" && (
-          <text fg={colors.tierRisky}>⏸ {subagent.name}</text>
+          <text fg={colors.tierRisky}>⏸ {obfuscate(subagent.name)}</text>
         )}
         <text fg={colors.textMuted}>{open ? "▼" : "▶"}</text>
       </box>
@@ -280,11 +281,12 @@ const AgentMessage = memo(function AgentMessage({
     content = JSON.stringify(message.content, null, 2);
   }
 
-  // Render markdown for assistant messages
+  // Render markdown for assistant messages (markdown pipeline obfuscates internally).
+  // Plain-text branches (user/system/tool labels) are obfuscated here.
   const displayContent =
     message.role === "assistant"
       ? markdownToStyledText(content, colors)
-      : content;
+      : obfuscate(content);
 
   const isPendingTool =
     message.role === "tool" &&
@@ -336,13 +338,17 @@ const AgentMessage = memo(function AgentMessage({
               {/* Streaming logs for pending tools */}
               {streamingLogs.length > 0 && (
                 <box flexDirection="column" marginTop={0} paddingLeft={2}>
-                  {streamingLogs.slice(-3).map((log, idx) => (
-                    <text
-                      key={idx}
-                      fg={colors.textMuted}
-                      content={log.length > 100 ? log.slice(0, 100) + "…" : log}
-                    />
-                  ))}
+                  {streamingLogs.slice(-3).map((log, idx) => {
+                    const trimmed =
+                      log.length > 100 ? log.slice(0, 100) + "…" : log;
+                    return (
+                      <text
+                        key={idx}
+                        fg={colors.textMuted}
+                        content={obfuscate(trimmed)}
+                      />
+                    );
+                  })}
                 </box>
               )}
             </>
@@ -397,18 +403,17 @@ function ToolDetails({ message }: { message: DisplayMessage }) {
     return null;
   }
 
-  // Format result for display (truncate if too long)
+  // Format result for display (truncate if too long, redact PII when active).
   const formatResult = (result: unknown): string => {
+    let str: string;
     try {
-      const str = JSON.stringify(result, null, 2);
-      // Truncate very long results
-      if (str.length > 2000) {
-        return str.substring(0, 2000) + "\n... (truncated)";
-      }
-      return str;
+      str = JSON.stringify(result, null, 2);
     } catch {
-      return String(result);
+      str = String(result);
     }
+    const truncated =
+      str.length > 2000 ? str.substring(0, 2000) + "\n... (truncated)" : str;
+    return obfuscate(truncated);
   };
 
   return (
@@ -427,7 +432,7 @@ function ToolDetails({ message }: { message: DisplayMessage }) {
           </box>
           {showArgs && (
             <text fg={colors.text}>
-              {JSON.stringify(message.args, null, 2)}
+              {obfuscate(JSON.stringify(message.args, null, 2))}
             </text>
           )}
         </box>

--- a/src/tui/components/agent-display.tsx
+++ b/src/tui/components/agent-display.tsx
@@ -8,7 +8,6 @@ import {
 } from "./shared";
 import { useTheme } from "../theme";
 import { useDimensions } from "../context/dimensions";
-import { obfuscate } from "../../core/obfuscation";
 import { useObfuscation } from "../context/obfuscation";
 
 export type Subagent = {
@@ -228,16 +227,16 @@ const SubAgentDisplay = memo(function SubAgentDisplay({
     >
       <box flexDirection="row" alignItems="center" gap={1}>
         {subagent.status === "pending" && (
-          <SpinningDots label={obfuscate(subagent.name)} fg={colors.primary} />
+          <SpinningDots label={subagent.name} fg={colors.primary} />
         )}
         {subagent.status === "completed" && (
-          <text fg={colors.primary}> ✓ {obfuscate(subagent.name)}</text>
+          <text fg={colors.primary}> ✓ {subagent.name}</text>
         )}
         {subagent.status === "failed" && (
-          <text fg={colors.error}>✗ {obfuscate(subagent.name)}</text>
+          <text fg={colors.error}>✗ {subagent.name}</text>
         )}
         {subagent.status === "paused" && (
-          <text fg={colors.tierRisky}>⏸ {obfuscate(subagent.name)}</text>
+          <text fg={colors.tierRisky}>⏸ {subagent.name}</text>
         )}
         <text fg={colors.textMuted}>{open ? "▼" : "▶"}</text>
       </box>
@@ -286,12 +285,13 @@ const AgentMessage = memo(function AgentMessage({
     content = JSON.stringify(message.content, null, 2);
   }
 
-  // Render markdown for assistant messages (markdown pipeline obfuscates internally).
-  // Plain-text branches (user/system/tool labels) are obfuscated here.
+  // Render markdown for assistant messages (markdown pipeline obfuscates
+  // internally). Plain-text branches flow into `<text>` children, where
+  // the central TextNodeRenderable patch handles redaction.
   const displayContent =
     message.role === "assistant"
       ? markdownToStyledText(content, colors)
-      : obfuscate(content);
+      : content;
 
   const isPendingTool =
     message.role === "tool" &&
@@ -347,11 +347,9 @@ const AgentMessage = memo(function AgentMessage({
                     const trimmed =
                       log.length > 100 ? log.slice(0, 100) + "…" : log;
                     return (
-                      <text
-                        key={idx}
-                        fg={colors.textMuted}
-                        content={obfuscate(trimmed)}
-                      />
+                      <text key={idx} fg={colors.textMuted}>
+                        {trimmed}
+                      </text>
                     );
                   })}
                 </box>
@@ -408,7 +406,9 @@ function ToolDetails({ message }: { message: DisplayMessage }) {
     return null;
   }
 
-  // Format result for display (truncate if too long, redact PII when active).
+  // Format result for display (truncate if too long). Redaction is
+  // handled by the central TextNodeRenderable patch when this string
+  // hits a `<text>` child.
   const formatResult = (result: unknown): string => {
     let str: string;
     try {
@@ -418,7 +418,7 @@ function ToolDetails({ message }: { message: DisplayMessage }) {
     }
     const truncated =
       str.length > 2000 ? str.substring(0, 2000) + "\n... (truncated)" : str;
-    return obfuscate(truncated);
+    return truncated;
   };
 
   return (
@@ -437,7 +437,7 @@ function ToolDetails({ message }: { message: DisplayMessage }) {
           </box>
           {showArgs && (
             <text fg={colors.text}>
-              {obfuscate(JSON.stringify(message.args, null, 2))}
+              {JSON.stringify(message.args, null, 2)}
             </text>
           )}
         </box>

--- a/src/tui/components/chat/header.tsx
+++ b/src/tui/components/chat/header.tsx
@@ -7,6 +7,7 @@
 
 import { useTheme } from "../../theme";
 import type { OperatorMode, OperatorStage } from "../../../core/operator";
+import { obfuscate } from "../../../core/obfuscation";
 
 export interface HeaderProps {
   /** Session mode */
@@ -92,7 +93,7 @@ export function Header({
         {target && (
           <>
             <text fg={colors.textMuted}>│</text>
-            <text fg={colors.text}>{target}</text>
+            <text fg={colors.text}>{obfuscate(target)}</text>
           </>
         )}
 

--- a/src/tui/components/chat/header.tsx
+++ b/src/tui/components/chat/header.tsx
@@ -7,8 +7,6 @@
 
 import { useTheme } from "../../theme";
 import type { OperatorMode, OperatorStage } from "../../../core/operator";
-import { obfuscate } from "../../../core/obfuscation";
-import { useObfuscation } from "../../context/obfuscation";
 
 export interface HeaderProps {
   /** Session mode */
@@ -56,9 +54,8 @@ export function Header({
   toolCallsCount = 0,
 }: HeaderProps) {
   const { colors } = useTheme();
-  // Subscribe so the header re-renders when /obfuscate is toggled,
-  // restoring or redacting the target string in real time.
-  useObfuscation();
+  // Target & session strings flow through `<text>`, so the central
+  // TextNodeRenderable patch handles redaction transparently.
   // Get mode display
   const getModeDisplay = () => {
     if (mode === "chat") {
@@ -97,7 +94,7 @@ export function Header({
         {target && (
           <>
             <text fg={colors.textMuted}>│</text>
-            <text fg={colors.text}>{obfuscate(target)}</text>
+            <text fg={colors.text}>{target}</text>
           </>
         )}
 

--- a/src/tui/components/chat/header.tsx
+++ b/src/tui/components/chat/header.tsx
@@ -8,6 +8,7 @@
 import { useTheme } from "../../theme";
 import type { OperatorMode, OperatorStage } from "../../../core/operator";
 import { obfuscate } from "../../../core/obfuscation";
+import { useObfuscation } from "../../context/obfuscation";
 
 export interface HeaderProps {
   /** Session mode */
@@ -55,6 +56,9 @@ export function Header({
   toolCallsCount = 0,
 }: HeaderProps) {
   const { colors } = useTheme();
+  // Subscribe so the header re-renders when /obfuscate is toggled,
+  // restoring or redacting the target string in real time.
+  useObfuscation();
   // Get mode display
   const getModeDisplay = () => {
     if (mode === "chat") {

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -9,7 +9,6 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useDimensions } from "../../context/dimensions";
-import { PetriAnimation } from "./petri-animation";
 import { useCommand } from "../../context/command";
 import { useInput } from "../../context/input";
 import { useFocus } from "../../context/focus";
@@ -21,6 +20,7 @@ import { OperatorModeBar, providerDisplayName } from "./input-area";
 import { useTheme } from "../../theme";
 import { useAgent } from "../../context/agent";
 import * as History from "../../../core/history";
+import PetriAnimation from "./petri-animation";
 
 type ViewType = "home" | "config" | "chat";
 
@@ -167,104 +167,121 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
       alignItems="center"
       overflow="hidden"
     >
-      {/* Petri Animation */}
+      {/* Petri Animation - absolutely positioned so it doesn't push the
+          centered content block off-center. Sits behind/above the column flow
+          starting at the top of the home view. */}
       {animationHeight > 0 && (
-        <box height={animationHeight} width="100%">
+        <box
+          position="absolute"
+          top={0}
+          left={0}
+          height={animationHeight}
+          width="100%"
+        >
           <PetriAnimation height={animationHeight} />
         </box>
       )}
 
-      {/* Title - centered */}
       <box
         flexDirection="column"
         alignItems="center"
-        marginTop={titleMarginTop}
-        flexShrink={0}
+        justifyContent="center"
+        height="100%"
       >
-        <text fg={colors.text}>
-          Apex{" "}
-          <span fg={colors.textMuted}>({config.data.version || "local"})</span>
-        </text>
-        <text fg={colors.textMuted}>Automated offensive security</text>
-      </box>
-
-      {/* Command Quick Reference */}
-      {showCommands && (
-        <box flexDirection="column" marginTop={menuMarginTop} flexShrink={0}>
-          {[
-            { cmd: "/pentest", desc: "autonomous pentest" },
-            { cmd: "/operator", desc: "interactive operator" },
-            { cmd: "/login", desc: "login to Pensar" },
-            { cmd: "/models", desc: "select AI model" },
-            { cmd: "/providers", desc: "manage API keys" },
-          ].map(({ cmd, desc }) => (
-            <box key={cmd} flexDirection="row">
-              <box width={24} justifyContent="flex-end">
-                <text fg={colors.primary}>{cmd}</text>
-              </box>
-              <box width={4} />
-              <box>
-                <text fg={colors.textMuted}>{desc}</text>
-              </box>
-            </box>
-          ))}
+        {/* Title - centered */}
+        <box
+          flexDirection="column"
+          alignItems="center"
+          marginTop={titleMarginTop}
+          flexShrink={0}
+        >
+          <text fg={colors.text}>
+            Apex{" "}
+            <span fg={colors.textMuted}>
+              ({config.data.version || "local"})
+            </span>
+          </text>
+          <text fg={colors.textMuted}>Automated offensive security</text>
         </box>
-      )}
 
-      {/* Centered Input Area */}
-      <box
-        flexDirection="column"
-        width={inputWidth}
-        marginTop={inputMarginTop}
-        padding={inputPadding}
-        border={["left", "right"]}
-        borderColor={colors.primary}
-        flexShrink={0}
-      >
-        {/* Input with built-in autocomplete */}
-        <PromptInput
-          ref={promptRef}
-          focused={!externalDialogOpen && stack.length === 0}
-          width={inputWidth - 2 - inputPadding * 2}
-          minHeight={1}
-          maxHeight={4}
-          onSubmit={handleSubmit}
-          placeholder="Type a message to start operator, or / for commands..."
-          textColor={colors.text}
-          focusedTextColor={colors.text}
-          backgroundColor="transparent"
-          focusedBackgroundColor="transparent"
-          enableAutocomplete={true}
-          autocompleteOptions={autocompleteOptions}
-          commandOptionMap={commandOptionMap}
-          commandNames={commandNames}
-          maxVisibleSuggestions={maxSuggestions}
-          enableCommands={true}
-          onCommandExecute={handleCommandExecute}
-          commandHistory={commandHistory}
-          showPromptIndicator={true}
-        />
-
-        {/* Hint message */}
-        {hintMessage && (
-          <box marginTop={1}>
-            <text fg={colors.text}>{hintMessage}</text>
+        {/* Command Quick Reference */}
+        {showCommands && (
+          <box flexDirection="column" marginTop={menuMarginTop} flexShrink={0}>
+            {[
+              { cmd: "/pentest", desc: "autonomous pentest" },
+              { cmd: "/operator", desc: "interactive operator" },
+              { cmd: "/login", desc: "login to Pensar" },
+              { cmd: "/models", desc: "select AI model" },
+              { cmd: "/providers", desc: "manage API keys" },
+            ].map(({ cmd, desc }) => (
+              <box key={cmd} flexDirection="row">
+                <box width={24} justifyContent="flex-end">
+                  <text fg={colors.primary}>{cmd}</text>
+                </box>
+                <box width={4} />
+                <box>
+                  <text fg={colors.textMuted}>{desc}</text>
+                </box>
+              </box>
+            ))}
           </box>
         )}
 
-        <OperatorModeBar
-          operatorMode="manual"
-          modelName={model.name}
-          providerName={providerDisplayName(model.provider)}
-          showMode={false}
-          maxWidth={inputWidth - 2 - inputPadding * 2}
-          rightContent={
-            <text fg={colors.textMuted}>
-              <span fg={colors.text}>[/]</span> commands
-            </text>
-          }
-          rightContentWidth={"[/] commands".length}
-        />
+        {/* Centered Input Area */}
+        <box
+          flexDirection="column"
+          width={inputWidth}
+          marginTop={inputMarginTop}
+          padding={inputPadding}
+          border={["left", "right"]}
+          borderColor={colors.primary}
+          flexShrink={0}
+        >
+          {/* Input with built-in autocomplete */}
+          <PromptInput
+            ref={promptRef}
+            focused={!externalDialogOpen && stack.length === 0}
+            width={inputWidth - 2 - inputPadding * 2}
+            minHeight={1}
+            maxHeight={4}
+            onSubmit={handleSubmit}
+            placeholder="Type a message to start operator, or / for commands..."
+            textColor={colors.text}
+            focusedTextColor={colors.text}
+            backgroundColor="transparent"
+            focusedBackgroundColor="transparent"
+            enableAutocomplete={true}
+            autocompleteOptions={autocompleteOptions}
+            commandOptionMap={commandOptionMap}
+            commandNames={commandNames}
+            maxVisibleSuggestions={maxSuggestions}
+            enableCommands={true}
+            onCommandExecute={handleCommandExecute}
+            commandHistory={commandHistory}
+            showPromptIndicator={true}
+          />
+
+          {/* Hint message */}
+          {hintMessage && (
+            <box marginTop={1}>
+              <text fg={colors.text}>{hintMessage}</text>
+            </box>
+          )}
+
+          <OperatorModeBar
+            operatorMode="manual"
+            modelName={model.name}
+            providerName={providerDisplayName(model.provider)}
+            showMode={false}
+            maxWidth={inputWidth - 2 - inputPadding * 2}
+            rightContent={
+              <text fg={colors.textMuted}>
+                <span fg={colors.text}>[/]</span> commands
+              </text>
+            }
+            rightContentWidth={"[/] commands".length}
+          />
+        </box>
       </box>
     </box>
   );

--- a/src/tui/components/chat/sidebar.tsx
+++ b/src/tui/components/chat/sidebar.tsx
@@ -15,6 +15,7 @@ import type {
   VerifiedVuln,
   Credential,
 } from "../operator-dashboard/types";
+import { obfuscate } from "../../../core/obfuscation";
 
 // ============================================
 // Sidebar State Types
@@ -96,7 +97,9 @@ function TargetPanel({ host, ports }: TargetPanelProps) {
   return (
     <box flexDirection="column" gap={1}>
       <text fg={colors.text}>Target</text>
-      <text fg={colors.primary}>{host || "Not configured"}</text>
+      <text fg={colors.primary}>
+        {host ? obfuscate(host) : "Not configured"}
+      </text>
       <box flexDirection="row" gap={1}>
         <text fg={colors.textMuted}>Ports:</text>
         <text fg={colors.textMuted}>{portsStr}</text>
@@ -155,7 +158,7 @@ function AttackSurfacePanel({
               <box key={ep.id || idx} flexDirection="row" gap={1}>
                 <text fg={color}>{icon}</text>
                 <text fg={colors.textMuted}>{ep.method}</text>
-                <text fg={colors.text}>{ep.path}</text>
+                <text fg={colors.text}>{obfuscate(ep.path)}</text>
                 {ep.vulnType && <text fg={colors.error}>({ep.vulnType})</text>}
               </box>
             );
@@ -216,7 +219,7 @@ function CredentialsPanel({
             <box key={cred.id || idx} flexDirection="column">
               <box flexDirection="row" gap={1}>
                 {cred.isActive && <text fg={colors.warning}>★</text>}
-                <text fg={colors.text}>{cred.username}</text>
+                <text fg={colors.text}>{obfuscate(cred.username)}</text>
                 <text fg={colors.textMuted}>:</text>
                 <text fg={colors.textMuted}>{redactSecret(cred.secret)}</text>
               </box>
@@ -293,7 +296,7 @@ function VulnsPanel({ vulns, maxVisible = 3 }: VulnsPanelProps) {
                 <text fg={colors.text}>{vuln.type}</text>
               </box>
               <box marginLeft={2}>
-                <text fg={colors.textMuted}>{vuln.endpoint}</text>
+                <text fg={colors.textMuted}>{obfuscate(vuln.endpoint)}</text>
               </box>
             </box>
           ))}

--- a/src/tui/components/chat/sidebar.tsx
+++ b/src/tui/components/chat/sidebar.tsx
@@ -16,6 +16,7 @@ import type {
   Credential,
 } from "../operator-dashboard/types";
 import { obfuscate } from "../../../core/obfuscation";
+import { useObfuscation } from "../../context/obfuscation";
 
 // ============================================
 // Sidebar State Types
@@ -52,6 +53,9 @@ interface SidebarProps {
  */
 export function Sidebar({ collapsed, state, width = "30%" }: SidebarProps) {
   const { colors } = useTheme();
+  // Subscribe so all child panels re-render their obfuscate(...) calls
+  // when /obfuscate toggles.
+  useObfuscation();
   if (collapsed) {
     return null;
   }

--- a/src/tui/components/chat/sidebar.tsx
+++ b/src/tui/components/chat/sidebar.tsx
@@ -15,8 +15,6 @@ import type {
   VerifiedVuln,
   Credential,
 } from "../operator-dashboard/types";
-import { obfuscate } from "../../../core/obfuscation";
-import { useObfuscation } from "../../context/obfuscation";
 
 // ============================================
 // Sidebar State Types
@@ -53,9 +51,8 @@ interface SidebarProps {
  */
 export function Sidebar({ collapsed, state, width = "30%" }: SidebarProps) {
   const { colors } = useTheme();
-  // Subscribe so all child panels re-render their obfuscate(...) calls
-  // when /obfuscate toggles.
-  useObfuscation();
+  // Sensitive strings flow into `<text>`, so the central
+  // TextNodeRenderable patch redacts them transparently.
   if (collapsed) {
     return null;
   }
@@ -101,9 +98,7 @@ function TargetPanel({ host, ports }: TargetPanelProps) {
   return (
     <box flexDirection="column" gap={1}>
       <text fg={colors.text}>Target</text>
-      <text fg={colors.primary}>
-        {host ? obfuscate(host) : "Not configured"}
-      </text>
+      <text fg={colors.primary}>{host || "Not configured"}</text>
       <box flexDirection="row" gap={1}>
         <text fg={colors.textMuted}>Ports:</text>
         <text fg={colors.textMuted}>{portsStr}</text>
@@ -162,7 +157,7 @@ function AttackSurfacePanel({
               <box key={ep.id || idx} flexDirection="row" gap={1}>
                 <text fg={color}>{icon}</text>
                 <text fg={colors.textMuted}>{ep.method}</text>
-                <text fg={colors.text}>{obfuscate(ep.path)}</text>
+                <text fg={colors.text}>{ep.path}</text>
                 {ep.vulnType && <text fg={colors.error}>({ep.vulnType})</text>}
               </box>
             );
@@ -223,7 +218,7 @@ function CredentialsPanel({
             <box key={cred.id || idx} flexDirection="column">
               <box flexDirection="row" gap={1}>
                 {cred.isActive && <text fg={colors.warning}>★</text>}
-                <text fg={colors.text}>{obfuscate(cred.username)}</text>
+                <text fg={colors.text}>{cred.username}</text>
                 <text fg={colors.textMuted}>:</text>
                 <text fg={colors.textMuted}>{redactSecret(cred.secret)}</text>
               </box>
@@ -300,7 +295,7 @@ function VulnsPanel({ vulns, maxVisible = 3 }: VulnsPanelProps) {
                 <text fg={colors.text}>{vuln.type}</text>
               </box>
               <box marginLeft={2}>
-                <text fg={colors.textMuted}>{obfuscate(vuln.endpoint)}</text>
+                <text fg={colors.textMuted}>{vuln.endpoint}</text>
               </box>
             </box>
           ))}

--- a/src/tui/components/chat/tool-message.tsx
+++ b/src/tui/components/chat/tool-message.tsx
@@ -19,6 +19,7 @@ import {
 import { isToolMessage } from "../shared/type-guards";
 import type { DisplayMessage } from "../agent-display";
 import { useObfuscation } from "../../context/obfuscation";
+import { obfuscate } from "../../../core/obfuscation";
 
 // Tool category icons
 const TOOL_ICONS: Record<string, string> = {
@@ -68,21 +69,24 @@ export const ToolMessage = memo(function ToolMessage({
     preferDescription: isPending,
   });
 
-  // For execute_command, extract both description and command so we can show both
+  // For execute_command, extract both description and command. Both flow
+  // through obfuscate() so /obfuscate redacts them dynamically.
   const execDescription =
     toolName === "execute_command" &&
     typeof args.toolCallDescription === "string" &&
     args.toolCallDescription.trim().length > 0
-      ? args.toolCallDescription.trim()
+      ? obfuscate(args.toolCallDescription.trim())
       : null;
   const execCommand =
     toolName === "execute_command" && typeof args.command === "string"
       ? args.command.split("\n")[0]
       : null;
   const execCommandDisplay = execCommand
-    ? execCommand.length > 80
-      ? `$ ${execCommand.slice(0, 80)}…`
-      : `$ ${execCommand}`
+    ? obfuscate(
+        execCommand.length > 80
+          ? `$ ${execCommand.slice(0, 80)}…`
+          : `$ ${execCommand}`,
+      )
     : null;
 
   // Get result summary for completed tools
@@ -120,7 +124,9 @@ export const ToolMessage = memo(function ToolMessage({
       {isPending && logs && logs.length > 0 && (
         <box marginLeft={2}>
           <text fg={colors.textMuted}>
-            {expandedLogs ? logs.join("\n") : logs.slice(-2).join("\n")}
+            {obfuscate(
+              expandedLogs ? logs.join("\n") : logs.slice(-2).join("\n"),
+            )}
           </text>
         </box>
       )}
@@ -140,7 +146,7 @@ export const ToolMessage = memo(function ToolMessage({
           </box>
           {showArgs && (
             <box marginLeft={2}>
-              <text fg={colors.textMuted}>{formatArgs(args)}</text>
+              <text fg={colors.textMuted}>{obfuscate(formatArgs(args))}</text>
             </box>
           )}
         </box>

--- a/src/tui/components/chat/tool-message.tsx
+++ b/src/tui/components/chat/tool-message.tsx
@@ -19,7 +19,6 @@ import {
 import { isToolMessage } from "../shared/type-guards";
 import type { DisplayMessage } from "../agent-display";
 import { useObfuscation } from "../../context/obfuscation";
-import { obfuscate } from "../../../core/obfuscation";
 
 // Tool category icons
 const TOOL_ICONS: Record<string, string> = {
@@ -49,7 +48,10 @@ export const ToolMessage = memo(function ToolMessage({
   expandedLogs = false,
 }: ToolMessageProps) {
   const { colors, mode } = useTheme();
-  // Subscribe so memoised tool messages re-render on /obfuscate toggle.
+  // Subscribe so the result summary's `content`-prop StyledText
+  // (precomputed in `result-registry.ts`) re-runs on /obfuscate
+  // toggle. String children are redacted centrally by the
+  // TextNodeRenderable patch.
   useObfuscation();
   const [showArgs, setShowArgs] = useState(false);
   const [showOutput, setShowOutput] = useState(false);
@@ -69,24 +71,23 @@ export const ToolMessage = memo(function ToolMessage({
     preferDescription: isPending,
   });
 
-  // For execute_command, extract both description and command. Both flow
-  // through obfuscate() so /obfuscate redacts them dynamically.
+  // For execute_command, extract both description and command. Strings
+  // flow into `<text>` children, so the central TextNodeRenderable patch
+  // handles obfuscation transparently.
   const execDescription =
     toolName === "execute_command" &&
     typeof args.toolCallDescription === "string" &&
     args.toolCallDescription.trim().length > 0
-      ? obfuscate(args.toolCallDescription.trim())
+      ? args.toolCallDescription.trim()
       : null;
   const execCommand =
     toolName === "execute_command" && typeof args.command === "string"
       ? args.command.split("\n")[0]
       : null;
   const execCommandDisplay = execCommand
-    ? obfuscate(
-        execCommand.length > 80
-          ? `$ ${execCommand.slice(0, 80)}…`
-          : `$ ${execCommand}`,
-      )
+    ? execCommand.length > 80
+      ? `$ ${execCommand.slice(0, 80)}…`
+      : `$ ${execCommand}`
     : null;
 
   // Get result summary for completed tools
@@ -124,9 +125,7 @@ export const ToolMessage = memo(function ToolMessage({
       {isPending && logs && logs.length > 0 && (
         <box marginLeft={2}>
           <text fg={colors.textMuted}>
-            {obfuscate(
-              expandedLogs ? logs.join("\n") : logs.slice(-2).join("\n"),
-            )}
+            {expandedLogs ? logs.join("\n") : logs.slice(-2).join("\n")}
           </text>
         </box>
       )}
@@ -146,7 +145,7 @@ export const ToolMessage = memo(function ToolMessage({
           </box>
           {showArgs && (
             <box marginLeft={2}>
-              <text fg={colors.textMuted}>{obfuscate(formatArgs(args))}</text>
+              <text fg={colors.textMuted}>{formatArgs(args)}</text>
             </box>
           )}
         </box>

--- a/src/tui/components/chat/tool-message.tsx
+++ b/src/tui/components/chat/tool-message.tsx
@@ -18,6 +18,7 @@ import {
 } from "../shared/result-registry";
 import { isToolMessage } from "../shared/type-guards";
 import type { DisplayMessage } from "../agent-display";
+import { useObfuscation } from "../../context/obfuscation";
 
 // Tool category icons
 const TOOL_ICONS: Record<string, string> = {
@@ -47,6 +48,8 @@ export const ToolMessage = memo(function ToolMessage({
   expandedLogs = false,
 }: ToolMessageProps) {
   const { colors, mode } = useTheme();
+  // Subscribe so memoised tool messages re-render on /obfuscate toggle.
+  useObfuscation();
   const [showArgs, setShowArgs] = useState(false);
   const [showOutput, setShowOutput] = useState(false);
 

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -13,6 +13,7 @@ import { useTheme } from "../../theme";
 import { useSessionsList } from "../../hooks/use-sessions-list";
 import { useToast } from "../../context/toast";
 import DialogLayout from "../dialog-layout";
+import { obfuscate } from "../../../core/obfuscation";
 
 interface SessionsDisplayProps {
   onClose: () => void;
@@ -304,7 +305,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
                           <text
                             fg={isSelected ? colors.text : colors.textMuted}
                           >
-                            {session.name}
+                            {obfuscate(session.name ?? "")}
                           </text>
                           <text
                             fg={

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -13,8 +13,6 @@ import { useTheme } from "../../theme";
 import { useSessionsList } from "../../hooks/use-sessions-list";
 import { useToast } from "../../context/toast";
 import DialogLayout from "../dialog-layout";
-import { obfuscate } from "../../../core/obfuscation";
-import { useObfuscation } from "../../context/obfuscation";
 
 interface SessionsDisplayProps {
   onClose: () => void;
@@ -22,8 +20,6 @@ interface SessionsDisplayProps {
 
 export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
   const { colors } = useTheme();
-  // Subscribe so the list re-renders session names when /obfuscate toggles.
-  useObfuscation();
   const { refocusPrompt } = useFocus();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const { toast } = useToast();
@@ -308,7 +304,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
                           <text
                             fg={isSelected ? colors.text : colors.textMuted}
                           >
-                            {obfuscate(session.name ?? "")}
+                            {session.name ?? ""}
                           </text>
                           <text
                             fg={

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -14,6 +14,7 @@ import { useSessionsList } from "../../hooks/use-sessions-list";
 import { useToast } from "../../context/toast";
 import DialogLayout from "../dialog-layout";
 import { obfuscate } from "../../../core/obfuscation";
+import { useObfuscation } from "../../context/obfuscation";
 
 interface SessionsDisplayProps {
   onClose: () => void;
@@ -21,6 +22,8 @@ interface SessionsDisplayProps {
 
 export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
   const { colors } = useTheme();
+  // Subscribe so the list re-renders session names when /obfuscate toggles.
+  useObfuscation();
   const { refocusPrompt } = useFocus();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const { toast } = useToast();

--- a/src/tui/components/footer.tsx
+++ b/src/tui/components/footer.tsx
@@ -6,6 +6,7 @@ import { useSession } from "../context/session";
 import { useInput } from "../context/input";
 import { useTheme } from "../theme";
 import { useDimensions } from "../context/dimensions";
+import { useObfuscation } from "../context/obfuscation";
 
 interface FooterProps {
   cwd?: string;
@@ -34,13 +35,17 @@ export default function Footer({
   const { colors } = useTheme();
   const { isExecuting, sessionCwd } = useAgent();
   const { width: termWidth } = useDimensions();
+  const { enabled: obfuscateEnabled } = useObfuscation();
   const effectiveCwd = sessionCwd || cwd;
   const relativeCwd = effectiveCwd.split(os.homedir()).pop() || "";
   const segments = relativeCwd.split("/").filter(Boolean);
-  const displayCwd =
+  const rawDisplayCwd =
     segments.length <= 2
       ? "~/" + segments.join("/")
       : "…/" + segments.slice(-2).join("/");
+  // When obfuscation is on, show a generic placeholder rather than leaking
+  // the operator's local working directory in screenshots.
+  const displayCwd = obfuscateEnabled ? "~/[workdir]" : rawDisplayCwd;
   const showCwd = termWidth >= 100;
   const session = useSession();
   const { isInputEmpty } = useInput();

--- a/src/tui/components/footer.tsx
+++ b/src/tui/components/footer.tsx
@@ -91,14 +91,20 @@ export default function Footer({
 export function AgentStatus() {
   const { colors } = useTheme();
   const { tokenUsage } = useAgent();
+  const { width: termWidth } = useDimensions();
+  const showTokenCount = termWidth > 85;
 
   const tokenLabel = `↓${formatTokenCount(tokenUsage.inputTokens)} ↑${formatTokenCount(tokenUsage.outputTokens)}${tokenUsage.cachedTokens > 0 ? ` ⚡${formatTokenCount(tokenUsage.cachedTokens)}` : ""} Σ${formatTokenCount(tokenUsage.totalTokens)}`;
 
   return (
     <box flexDirection="row" gap={1}>
-      <box border={["right"]} borderColor={colors.primary} />
-      <text fg={colors.text}>{tokenLabel}</text>
-      <box border={["right"]} borderColor={colors.primary} />
+      {showTokenCount && (
+        <>
+          <box border={["right"]} borderColor={colors.primary} />
+          <text fg={colors.text}>{tokenLabel}</text>
+          <box border={["right"]} borderColor={colors.primary} />
+        </>
+      )}
       <ContextProgress width={16} showPercent={true} />
     </box>
   );

--- a/src/tui/components/loaders.tsx
+++ b/src/tui/components/loaders.tsx
@@ -7,6 +7,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { RGBA } from "@opentui/core";
 import { useTheme } from "../theme";
+import { useObfuscation } from "../context/obfuscation";
 
 // ---------------------------------------------------------------------------
 // Shared tick system — all loaders share one interval to avoid timer bloat
@@ -706,7 +707,16 @@ export function ShiningText({
   // (with different text lengths) start each shimmer pass in lockstep.
   useTick();
 
-  const len = text.length;
+  // Each character gets its own `<text content={ch} />`. The content setter
+  // sits on TextRenderable, not TextNodeRenderable, so it bypasses the
+  // central obfuscation patch in `tui/obfuscation/patch.ts`. Apply
+  // obfuscation here at the component boundary so the per-char split
+  // operates on the already-redacted string. Subscribing via
+  // `useObfuscation()` also forces a re-render on toggle.
+  const { redact } = useObfuscation();
+  const displayText = redact(text);
+
+  const len = displayText.length;
   const totalFrames = len + shimmerWidth;
   const periodMs = 1250 / speed;
   const cyclePos = (Date.now() % periodMs) / periodMs;
@@ -723,13 +733,13 @@ export function ShiningText({
         const norm = dist / (shimmerWidth - 1);
         const bell = 1.0 - (2 * norm - 1) * (2 * norm - 1);
         const alpha = baseAlpha + (1.0 - baseAlpha) * bell;
-        out.push({ ch: text[i], color: withAlpha(base, alpha) });
+        out.push({ ch: displayText[i], color: withAlpha(base, alpha) });
       } else {
-        out.push({ ch: text[i], color: withAlpha(base, baseAlpha) });
+        out.push({ ch: displayText[i], color: withAlpha(base, baseAlpha) });
       }
     }
     return out;
-  }, [head, text, base, shimmerWidth, baseAlpha, len]);
+  }, [head, displayText, base, shimmerWidth, baseAlpha, len]);
 
   return (
     <box flexDirection="row">

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -102,6 +102,7 @@ import { isAbsolute, join, resolve } from "path";
 
 import { buildThreatModelPrompt } from "../../../core/skills/builtins/threatModel";
 import { buildPentestPrompt } from "../../../core/skills/builtins/pentest";
+import { obfuscate } from "../../../core/obfuscation";
 
 function markInFlightToolsErrored(
   messages: DisplayMessage[],
@@ -2208,12 +2209,14 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
         flexShrink={0}
       >
         <box flexDirection="row" gap={2}>
-          <text fg={colors.text}>{session?.name ?? "New Session"}</text>
+          <text fg={colors.text}>
+            {obfuscate(session?.name ?? "New Session")}
+          </text>
           {(session?.targets[0] || initialConfig?.target) && (
             <>
               <text fg={colors.textMuted}>•</text>
               <text fg={colors.textMuted}>
-                {session?.targets[0] || initialConfig?.target}
+                {obfuscate(session?.targets[0] || initialConfig?.target || "")}
               </text>
             </>
           )}

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -103,6 +103,7 @@ import { isAbsolute, join, resolve } from "path";
 import { buildThreatModelPrompt } from "../../../core/skills/builtins/threatModel";
 import { buildPentestPrompt } from "../../../core/skills/builtins/pentest";
 import { obfuscate } from "../../../core/obfuscation";
+import { useObfuscation } from "../../context/obfuscation";
 
 function markInFlightToolsErrored(
   messages: DisplayMessage[],
@@ -134,6 +135,9 @@ export default function OperatorDashboard({
   };
 }) {
   const { colors } = useTheme();
+  // Subscribe so the dashboard header (session name + target) re-renders
+  // when /obfuscate is toggled at runtime.
+  useObfuscation();
   const route = useRoute();
   const config = useConfig();
   const {

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -102,8 +102,6 @@ import { isAbsolute, join, resolve } from "path";
 
 import { buildThreatModelPrompt } from "../../../core/skills/builtins/threatModel";
 import { buildPentestPrompt } from "../../../core/skills/builtins/pentest";
-import { obfuscate } from "../../../core/obfuscation";
-import { useObfuscation } from "../../context/obfuscation";
 
 function markInFlightToolsErrored(
   messages: DisplayMessage[],
@@ -135,9 +133,6 @@ export default function OperatorDashboard({
   };
 }) {
   const { colors } = useTheme();
-  // Subscribe so the dashboard header (session name + target) re-renders
-  // when /obfuscate is toggled at runtime.
-  useObfuscation();
   const route = useRoute();
   const config = useConfig();
   const {
@@ -2213,14 +2208,12 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
         flexShrink={0}
       >
         <box flexDirection="row" gap={2}>
-          <text fg={colors.text}>
-            {obfuscate(session?.name ?? "New Session")}
-          </text>
+          <text fg={colors.text}>{session?.name ?? "New Session"}</text>
           {(session?.targets[0] || initialConfig?.target) && (
             <>
               <text fg={colors.textMuted}>•</text>
               <text fg={colors.textMuted}>
-                {obfuscate(session?.targets[0] || initialConfig?.target || "")}
+                {session?.targets[0] || initialConfig?.target || ""}
               </text>
             </>
           )}

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -16,6 +16,7 @@ const OPERATOR_ALLOWED_COMMANDS = new Set([
   "/pentest",
   "/skills",
   "/plan",
+  "/obfuscate",
   "/help",
 ]);
 

--- a/src/tui/components/shared/markdown.ts
+++ b/src/tui/components/shared/markdown.ts
@@ -13,6 +13,7 @@ import {
 } from "@opentui/core";
 import { marked } from "marked";
 import type { ThemeColors } from "../../theme";
+import { obfuscate } from "../../../core/obfuscation";
 
 /**
  * Convert markdown content to StyledText for terminal rendering.
@@ -29,9 +30,12 @@ import type { ThemeColors } from "../../theme";
  * - Paragraphs
  */
 export function markdownToStyledText(
-  content: string,
+  rawContent: string,
   colors?: ThemeColors,
 ): StyledText {
+  // Apply obfuscation before any tokenisation so emails/URLs/hostnames are
+  // redacted before they get coloured as links/codespans.
+  const content = obfuscate(rawContent);
   // Resolve colors with fallbacks for backwards compatibility
   const codeColor = colors?.markdownCode ?? RGBA.fromInts(100, 255, 100, 255);
   const linkColor = colors?.markdownLink ?? RGBA.fromInts(100, 200, 255, 255);

--- a/src/tui/components/shared/markdown.ts
+++ b/src/tui/components/shared/markdown.ts
@@ -54,6 +54,7 @@ export function markdownToStyledText(
     type InlineToken = {
       type?: string;
       text?: string;
+      raw?: string;
       tokens?: InlineToken[];
       [key: string]: unknown;
     };
@@ -97,6 +98,15 @@ export function markdownToStyledText(
           chunks.push({
             __isChunk: true,
             text: "\n",
+            attributes: defaultAttrs,
+          });
+        } else if (token.type === "html") {
+          // Inline HTML — emit as literal text so any angle-bracketed
+          // content the assistant produces appears on screen instead of
+          // being silently consumed by the markdown lexer.
+          chunks.push({
+            __isChunk: true,
+            text: token.raw || token.text || "",
             attributes: defaultAttrs,
           });
         } else if (token.tokens) {
@@ -147,6 +157,16 @@ export function markdownToStyledText(
         chunks.push({ __isChunk: true, text: "\n", attributes: 0 });
       } else if (token.type === "space") {
         chunks.push({ __isChunk: true, text: "\n", attributes: 0 });
+      } else if (token.type === "html") {
+        // Block-level HTML — pass through as literal text. Mirrors the
+        // inline `html` handler so angle-bracketed obfuscation
+        // placeholders survive a full-line emission.
+        const tk = token as { raw?: string; text?: string };
+        chunks.push({
+          __isChunk: true,
+          text: tk.raw || tk.text || "",
+          attributes: 0,
+        });
       }
     }
 

--- a/src/tui/components/shared/message-renderer.tsx
+++ b/src/tui/components/shared/message-renderer.tsx
@@ -13,6 +13,7 @@ import { isToolMessage } from "./type-guards";
 import type { DisplayMessage } from "../agent-display";
 import { PlanReviewMessage } from "../chat/plan-review-message";
 import { obfuscate } from "../../../core/obfuscation";
+import { useObfuscation } from "../../context/obfuscation";
 
 interface MessageRendererProps {
   message: DisplayMessage;
@@ -50,6 +51,10 @@ export const MessageRenderer = memo(function MessageRenderer({
   username = "user",
 }: MessageRendererProps) {
   const { colors } = useTheme();
+  // Subscribe to obfuscation toggles so this component re-renders (and
+  // re-runs `obfuscate()` / `markdownToStyledText()` with the new engine
+  // state) when the operator toggles `/obfuscate` on or off.
+  const { enabled: obfuscateEnabled } = useObfuscation();
   // Get string content
   const rawContent =
     typeof message.content === "string"
@@ -60,13 +65,15 @@ export const MessageRenderer = memo(function MessageRenderer({
   const content =
     message.role === "assistant" ? rawContent : obfuscate(rawContent);
 
-  // Memoize markdown conversion for assistant messages
+  // Memoize markdown conversion for assistant messages.
+  // `obfuscateEnabled` is included in deps so toggling /obfuscate busts
+  // the cache: the same rawContent must re-render with the new state.
   const displayContent = useMemo(
     () =>
       message.role === "assistant"
         ? markdownToStyledText(content, colors)
         : content,
-    [content, message.role, colors],
+    [content, message.role, colors, obfuscateEnabled],
   );
 
   // Tool messages

--- a/src/tui/components/shared/message-renderer.tsx
+++ b/src/tui/components/shared/message-renderer.tsx
@@ -88,7 +88,7 @@ export const MessageRenderer = memo(function MessageRenderer({
   }
 
   // User messages — detect <skill name="..." target="..."> wrapper and display as /command.
-  // Parse from the raw content because obfuscation turns the target into <URL_1>
+  // Parse from the raw content because obfuscation turns the target into [URL_1]
   // which still satisfies the regex but we want to redact the target after the fact.
   if (message.role === "user") {
     const rawSkill = parseSkillTag(rawContent);

--- a/src/tui/components/shared/message-renderer.tsx
+++ b/src/tui/components/shared/message-renderer.tsx
@@ -12,7 +12,6 @@ import { ToolRenderer } from "./tool-renderer";
 import { isToolMessage } from "./type-guards";
 import type { DisplayMessage } from "../agent-display";
 import { PlanReviewMessage } from "../chat/plan-review-message";
-import { obfuscate } from "../../../core/obfuscation";
 import { useObfuscation } from "../../context/obfuscation";
 
 interface MessageRendererProps {
@@ -51,19 +50,17 @@ export const MessageRenderer = memo(function MessageRenderer({
   username = "user",
 }: MessageRendererProps) {
   const { colors } = useTheme();
-  // Subscribe to obfuscation toggles so this component re-renders (and
-  // re-runs `obfuscate()` / `markdownToStyledText()` with the new engine
-  // state) when the operator toggles `/obfuscate` on or off.
+  // Subscribe to obfuscation toggles so the assistant-message branch
+  // re-runs `markdownToStyledText()` with the new engine state. The
+  // `<text>` children paths (user/system/tool labels) are handled by
+  // the central TextNodeRenderable patch and don't need this hook —
+  // we keep it for the markdown branch only.
   const { enabled: obfuscateEnabled } = useObfuscation();
-  // Get string content
   const rawContent =
     typeof message.content === "string"
       ? message.content
       : JSON.stringify(message.content);
-  // Assistant content gets obfuscated downstream by markdownToStyledText.
-  // For all other roles we redact here so the same EMAIL_1 mapping is reused.
-  const content =
-    message.role === "assistant" ? rawContent : obfuscate(rawContent);
+  const content = rawContent;
 
   // Memoize markdown conversion for assistant messages.
   // `obfuscateEnabled` is included in deps so toggling /obfuscate busts
@@ -91,13 +88,7 @@ export const MessageRenderer = memo(function MessageRenderer({
   // Parse from the raw content because obfuscation turns the target into [URL_1]
   // which still satisfies the regex but we want to redact the target after the fact.
   if (message.role === "user") {
-    const rawSkill = parseSkillTag(rawContent);
-    const skill = rawSkill
-      ? {
-          name: rawSkill.name,
-          target: rawSkill.target ? obfuscate(rawSkill.target) : undefined,
-        }
-      : null;
+    const skill = parseSkillTag(rawContent);
 
     if (variant === "chat") {
       return (

--- a/src/tui/components/shared/message-renderer.tsx
+++ b/src/tui/components/shared/message-renderer.tsx
@@ -12,6 +12,7 @@ import { ToolRenderer } from "./tool-renderer";
 import { isToolMessage } from "./type-guards";
 import type { DisplayMessage } from "../agent-display";
 import { PlanReviewMessage } from "../chat/plan-review-message";
+import { obfuscate } from "../../../core/obfuscation";
 
 interface MessageRendererProps {
   message: DisplayMessage;
@@ -50,10 +51,14 @@ export const MessageRenderer = memo(function MessageRenderer({
 }: MessageRendererProps) {
   const { colors } = useTheme();
   // Get string content
-  const content =
+  const rawContent =
     typeof message.content === "string"
       ? message.content
       : JSON.stringify(message.content);
+  // Assistant content gets obfuscated downstream by markdownToStyledText.
+  // For all other roles we redact here so the same EMAIL_1 mapping is reused.
+  const content =
+    message.role === "assistant" ? rawContent : obfuscate(rawContent);
 
   // Memoize markdown conversion for assistant messages
   const displayContent = useMemo(
@@ -75,9 +80,17 @@ export const MessageRenderer = memo(function MessageRenderer({
     );
   }
 
-  // User messages — detect <skill name="..." target="..."> wrapper and display as /command
+  // User messages — detect <skill name="..." target="..."> wrapper and display as /command.
+  // Parse from the raw content because obfuscation turns the target into <URL_1>
+  // which still satisfies the regex but we want to redact the target after the fact.
   if (message.role === "user") {
-    const skill = parseSkillTag(content);
+    const rawSkill = parseSkillTag(rawContent);
+    const skill = rawSkill
+      ? {
+          name: rawSkill.name,
+          target: rawSkill.target ? obfuscate(rawSkill.target) : undefined,
+        }
+      : null;
 
     if (variant === "chat") {
       return (

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -31,6 +31,12 @@ import {
   type InlineOptionContext,
 } from "./prompt-input-logic";
 import { usePasteExtmarks } from "./use-paste-extmarks";
+import {
+  obfuscate as engineObfuscate,
+  deobfuscate as engineDeobfuscate,
+  isObfuscationEnabled,
+} from "../../../core/obfuscation";
+import { useObfuscation } from "../../context/obfuscation";
 /** Word-wrap text and return at most `maxLines` lines, adding ellipsis if truncated. */
 function truncateToLines(
   text: string,
@@ -215,6 +221,33 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
 
     const { handlePaste, resolveText, clearPaste } =
       usePasteExtmarks(textareaRef);
+
+    // Guard for our own obfuscation-driven setText calls so the
+    // re-entrant onContentChange doesn't try to obfuscate again.
+    const isObfuscatingRef = useRef(false);
+
+    // Subscribe to obfuscation toggles so we can re-process the buffer
+    // when the operator flips `/obfuscate` mid-edit.
+    const { enabled: obfuscateEnabled } = useObfuscation();
+    useEffect(() => {
+      const ta = textareaRef.current;
+      if (!ta) return;
+      // Skip while a large paste is active — its extmark offsets must
+      // not shift under us.
+      if (ta.extmarks.getAll().length > 0) return;
+      const current = ta.plainText;
+      if (!current) return;
+      const next = obfuscateEnabled
+        ? engineObfuscate(current)
+        : engineDeobfuscate(current);
+      if (next === current) return;
+      isObfuscatingRef.current = true;
+      ta.setText(next);
+      ta.cursorOffset = next.length;
+      isObfuscatingRef.current = false;
+      setInputValue(next);
+      fullTextRef.current = next;
+    }, [obfuscateEnabled, setInputValue]);
 
     // Inline slash detection state — drives autocomplete filtering
     const [inlineSlashToken, setInlineSlashToken] = useState<string | null>(
@@ -527,8 +560,11 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
         }
       }
 
-      // Resolve paste placeholders to full text before submit
-      const rawText = resolveText(textareaRef.current?.plainText ?? "");
+      // Resolve paste placeholders → full text, then expand any
+      // obfuscation placeholders the user-typed text may contain back to
+      // their original values so the agent receives real input.
+      const pasteResolved = resolveText(textareaRef.current?.plainText ?? "");
+      const rawText = engineDeobfuscate(pasteResolved);
       const valueToSubmit = rawText.trim();
 
       if (!valueToSubmit) return;
@@ -550,8 +586,38 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
 
     // Content change syncs to context and resets history browsing
     const handleContentChange = () => {
-      const text = textareaRef.current?.plainText ?? "";
-      const cursorOffset = textareaRef.current?.cursorOffset ?? text.length;
+      const ta = textareaRef.current;
+      let text = ta?.plainText ?? "";
+      let cursorOffset = ta?.cursorOffset ?? text.length;
+
+      // Real-time redaction: when obfuscation is on, replace recognised
+      // patterns (URLs, hosts, IPs, emails, …) with stable placeholders
+      // as the user types. The originals are recovered on submit via
+      // `deobfuscate` so the agent still receives real values.
+      //
+      // Skipped while paste-extmarks are present: the paste mechanism
+      // already shows its own atomic placeholder and the offsets that
+      // its `resolveText` walks would shift if we mutated the buffer.
+      if (
+        ta &&
+        !isObfuscatingRef.current &&
+        isObfuscationEnabled() &&
+        ta.extmarks.getAll().length === 0
+      ) {
+        const redacted = engineObfuscate(text);
+        if (redacted !== text) {
+          isObfuscatingRef.current = true;
+          ta.setText(redacted);
+          // Replacement may shorten the buffer; the user just typed a
+          // value at the end of a token, so end-of-text is the natural
+          // cursor home.
+          ta.cursorOffset = redacted.length;
+          isObfuscatingRef.current = false;
+          text = redacted;
+          cursorOffset = redacted.length;
+        }
+      }
+
       setInputValue(text);
       fullTextRef.current = text;
 

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -237,8 +237,13 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       if (ta.extmarks.getAll().length > 0) return;
       const current = ta.plainText;
       if (!current) return;
+      // Slash-commands (`/threat-model --output foo/bar`) must reach the
+      // command router intact. The path patterns are aggressive enough
+      // that they would otherwise rewrite the command itself or its
+      // file-path arguments.
+      if (current.startsWith("/")) return;
       const next = obfuscateEnabled
-        ? engineObfuscate(current)
+        ? engineObfuscate(current, { aliases: false })
         : engineDeobfuscate(current);
       if (next === current) return;
       isObfuscatingRef.current = true;
@@ -602,9 +607,10 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
         ta &&
         !isObfuscatingRef.current &&
         isObfuscationEnabled() &&
-        ta.extmarks.getAll().length === 0
+        ta.extmarks.getAll().length === 0 &&
+        !text.startsWith("/")
       ) {
-        const redacted = engineObfuscate(text);
+        const redacted = engineObfuscate(text, { aliases: false });
         if (redacted !== text) {
           isObfuscatingRef.current = true;
           ta.setText(redacted);

--- a/src/tui/components/shared/result-registry.ts
+++ b/src/tui/components/shared/result-registry.ts
@@ -38,16 +38,17 @@ export function getResultSummary(
 ): ResultSummary | null {
   const summary = getResultSummaryRaw(result, toolName, args, mode);
   if (!summary) return summary;
+  // `text`, `fullText`, and `label` are rendered as string children of
+  // `<text>` by tool-message / tool-renderer, so the central
+  // TextNodeRenderable patch in `tui/obfuscation/patch.ts` redacts them
+  // automatically. `styledText` is the exception: it goes through
+  // `<text content={...}>`, which routes through TextRenderable's
+  // content setter and bypasses the patch. We obfuscate that one
+  // upstream so the redacted chunks bake into the StyledText before it
+  // reaches the renderer.
   if (!isObfuscationEnabled()) return summary;
-  return {
-    ...summary,
-    text: obfuscate(summary.text),
-    fullText: summary.fullText ? obfuscate(summary.fullText) : summary.fullText,
-    label: summary.label ? obfuscate(summary.label) : summary.label,
-    styledText: summary.styledText
-      ? obfuscateStyledText(summary.styledText)
-      : summary.styledText,
-  };
+  if (!summary.styledText) return summary;
+  return { ...summary, styledText: obfuscateStyledText(summary.styledText) };
 }
 
 function obfuscateStyledText(styled: StyledText): StyledText {
@@ -892,5 +893,7 @@ export function formatResultDetail(
     str.length > maxLength
       ? str.substring(0, maxLength) + "\n... (truncated)"
       : str;
-  return obfuscate(truncated);
+  // No obfuscation here — callers render this through `<text>` string
+  // children, which the central TextNodeRenderable patch redacts.
+  return truncated;
 }

--- a/src/tui/components/shared/result-registry.ts
+++ b/src/tui/components/shared/result-registry.ts
@@ -8,6 +8,7 @@
 import { RGBA, StyledText, type TextChunk } from "@opentui/core";
 import { highlightCode } from "./syntax-highlight";
 import type { ColorMode } from "../../theme/types";
+import { obfuscate, isObfuscationEnabled } from "../../../core/obfuscation";
 
 export interface ResultSummary {
   text: string;
@@ -30,6 +31,34 @@ export interface ResultSummary {
  * @returns Summary object with text and error flag, or null if no summary available
  */
 export function getResultSummary(
+  result: unknown,
+  toolName?: string,
+  args?: Record<string, unknown>,
+  mode: ColorMode = "dark",
+): ResultSummary | null {
+  const summary = getResultSummaryRaw(result, toolName, args, mode);
+  if (!summary) return summary;
+  if (!isObfuscationEnabled()) return summary;
+  return {
+    ...summary,
+    text: obfuscate(summary.text),
+    fullText: summary.fullText ? obfuscate(summary.fullText) : summary.fullText,
+    label: summary.label ? obfuscate(summary.label) : summary.label,
+    styledText: summary.styledText
+      ? obfuscateStyledText(summary.styledText)
+      : summary.styledText,
+  };
+}
+
+function obfuscateStyledText(styled: StyledText): StyledText {
+  const next: TextChunk[] = styled.chunks.map((c) => ({
+    ...c,
+    text: typeof c.text === "string" ? obfuscate(c.text) : c.text,
+  }));
+  return new StyledText(next);
+}
+
+function getResultSummaryRaw(
   result: unknown,
   toolName?: string,
   args?: Record<string, unknown>,
@@ -853,13 +882,15 @@ export function formatResultDetail(
   result: unknown,
   maxLength: number = 2000,
 ): string {
+  let str: string;
   try {
-    const str = JSON.stringify(result, null, 2);
-    if (str.length > maxLength) {
-      return str.substring(0, maxLength) + "\n... (truncated)";
-    }
-    return str;
+    str = JSON.stringify(result, null, 2);
   } catch {
-    return String(result);
+    str = String(result);
   }
+  const truncated =
+    str.length > maxLength
+      ? str.substring(0, maxLength) + "\n... (truncated)"
+      : str;
+  return obfuscate(truncated);
 }

--- a/src/tui/components/shared/tool-registry.ts
+++ b/src/tui/components/shared/tool-registry.ts
@@ -7,8 +7,6 @@
  * Inspired by OpenCode's extensible tool display pattern.
  */
 
-import { obfuscate } from "../../../core/obfuscation";
-
 type ToolSummaryFn = (args: Record<string, unknown>) => string;
 
 /**
@@ -145,7 +143,7 @@ export function getToolSummary(
       ? `${toolName} ${String(firstArg).slice(0, 50)}`
       : toolName;
   }
-  return obfuscate(summary);
+  return summary;
 }
 
 /**
@@ -162,7 +160,7 @@ export function getToolDisplayLabel(
   if (options.preferDescription && toolName === "execute_command") {
     const description = args.toolCallDescription;
     if (typeof description === "string" && description.trim().length > 0) {
-      return obfuscate(description.trim());
+      return description.trim();
     }
   }
 
@@ -214,7 +212,7 @@ export function getArgsPreview(
     const str = typeof value === "string" ? value : JSON.stringify(value);
     const truncated =
       str.length > maxLength ? str.slice(0, maxLength) + "…" : str;
-    return obfuscate(truncated);
+    return truncated;
   }
 
   // For multi-arg tools, show key:value pairs
@@ -241,5 +239,5 @@ export function getArgsPreview(
   const preview = parts.join(" ");
   const truncated =
     preview.length > maxLength ? preview.slice(0, maxLength) + "…" : preview;
-  return obfuscate(truncated);
+  return truncated;
 }

--- a/src/tui/components/shared/tool-registry.ts
+++ b/src/tui/components/shared/tool-registry.ts
@@ -7,6 +7,8 @@
  * Inspired by OpenCode's extensible tool display pattern.
  */
 
+import { obfuscate } from "../../../core/obfuscation";
+
 type ToolSummaryFn = (args: Record<string, unknown>) => string;
 
 /**
@@ -129,17 +131,21 @@ export function getToolSummary(
 ): string {
   // Check registry first
   const summaryFn = TOOL_SUMMARY_MAP[toolName];
+  let summary: string;
   if (summaryFn) {
-    return summaryFn(args);
+    summary = summaryFn(args);
+  } else {
+    // Fallback: use first non-description arg value
+    const firstArg = Object.entries(args)
+      .filter(([k]) => k !== "toolCallDescription")
+      .map(([, v]) => (typeof v === "string" ? v : JSON.stringify(v)))
+      .find((v) => v && v.length > 0);
+
+    summary = firstArg
+      ? `${toolName} ${String(firstArg).slice(0, 50)}`
+      : toolName;
   }
-
-  // Fallback: use first non-description arg value
-  const firstArg = Object.entries(args)
-    .filter(([k]) => k !== "toolCallDescription")
-    .map(([, v]) => (typeof v === "string" ? v : JSON.stringify(v)))
-    .find((v) => v && v.length > 0);
-
-  return firstArg ? `${toolName} ${String(firstArg).slice(0, 50)}` : toolName;
+  return obfuscate(summary);
 }
 
 /**
@@ -156,7 +162,7 @@ export function getToolDisplayLabel(
   if (options.preferDescription && toolName === "execute_command") {
     const description = args.toolCallDescription;
     if (typeof description === "string" && description.trim().length > 0) {
-      return description.trim();
+      return obfuscate(description.trim());
     }
   }
 
@@ -206,7 +212,9 @@ export function getArgsPreview(
   if (filteredArgs.length === 1) {
     const [, value] = filteredArgs[0];
     const str = typeof value === "string" ? value : JSON.stringify(value);
-    return str.length > maxLength ? str.slice(0, maxLength) + "…" : str;
+    const truncated =
+      str.length > maxLength ? str.slice(0, maxLength) + "…" : str;
+    return obfuscate(truncated);
   }
 
   // For multi-arg tools, show key:value pairs
@@ -231,7 +239,7 @@ export function getArgsPreview(
   });
 
   const preview = parts.join(" ");
-  return preview.length > maxLength
-    ? preview.slice(0, maxLength) + "…"
-    : preview;
+  const truncated =
+    preview.length > maxLength ? preview.slice(0, maxLength) + "…" : preview;
+  return obfuscate(truncated);
 }

--- a/src/tui/components/shared/tool-renderer.tsx
+++ b/src/tui/components/shared/tool-renderer.tsx
@@ -13,6 +13,7 @@ import { getResultSummary, type ResultSummary } from "./result-registry";
 import { isToolMessage } from "./type-guards";
 import type { DisplayMessage } from "../agent-display";
 import { PentestWorkflowDisplay } from "./pentest-workflow-display";
+import { useObfuscation } from "../../context/obfuscation";
 
 const TOOLS_WITH_LOG_WINDOW = new Set([
   "execute_command",
@@ -41,6 +42,10 @@ export const ToolRenderer = memo(function ToolRenderer({
   expandedLogs = false,
 }: ToolRendererProps) {
   const { colors, mode } = useTheme();
+  // Subscribe so tool labels and result summaries (both flow through
+  // `obfuscate()` in tool-registry / result-registry) re-render when
+  // /obfuscate is toggled.
+  useObfuscation();
   const [showOutput, setShowOutput] = useState(false);
 
   // Type guard ensures we have a tool message

--- a/src/tui/components/shared/tool-renderer.tsx
+++ b/src/tui/components/shared/tool-renderer.tsx
@@ -14,7 +14,6 @@ import { isToolMessage } from "./type-guards";
 import type { DisplayMessage } from "../agent-display";
 import { PentestWorkflowDisplay } from "./pentest-workflow-display";
 import { useObfuscation } from "../../context/obfuscation";
-import { obfuscate } from "../../../core/obfuscation";
 
 const TOOLS_WITH_LOG_WINDOW = new Set([
   "execute_command",
@@ -43,9 +42,10 @@ export const ToolRenderer = memo(function ToolRenderer({
   expandedLogs = false,
 }: ToolRendererProps) {
   const { colors, mode } = useTheme();
-  // Subscribe so tool labels and result summaries (both flow through
-  // `obfuscate()` in tool-registry / result-registry) re-render when
-  // /obfuscate is toggled.
+  // Subscribe so the result summary's `content`-prop StyledText
+  // (precomputed in `result-registry.ts`) re-runs when `/obfuscate`
+  // toggles. Plain string children are handled centrally by the
+  // TextNodeRenderable patch and don't require this subscription.
   useObfuscation();
   const [showOutput, setShowOutput] = useState(false);
 
@@ -78,25 +78,23 @@ export const ToolRenderer = memo(function ToolRenderer({
   });
 
   // For execute_command, extract both description and command so we can show
-  // both. Both flow through obfuscate() so a toggled `/obfuscate` mid-stream
-  // immediately redacts the command preview and human description (which can
-  // freely include hosts, paths, emails, etc.).
+  // both. Strings flow into `<text>` children, so the centralised
+  // `TextNodeRenderable` patch (src/tui/obfuscation/patch.ts) handles
+  // redaction transparently.
   const execDescription =
     toolName === "execute_command" &&
     typeof args.toolCallDescription === "string" &&
     args.toolCallDescription.trim().length > 0
-      ? obfuscate(args.toolCallDescription.trim())
+      ? args.toolCallDescription.trim()
       : null;
   const execCommand =
     toolName === "execute_command" && typeof args.command === "string"
       ? args.command.split("\n")[0]
       : null;
   const execCommandDisplay = execCommand
-    ? obfuscate(
-        execCommand.length > 80
-          ? `$ ${execCommand.slice(0, 80)}…`
-          : `$ ${execCommand}`,
-      )
+    ? execCommand.length > 80
+      ? `$ ${execCommand.slice(0, 80)}…`
+      : `$ ${execCommand}`
     : null;
 
   // Get result summary for completed tools
@@ -148,9 +146,7 @@ export const ToolRenderer = memo(function ToolRenderer({
               <box marginLeft={0}>
                 <text fg={colors.textMuted}>
                   {"  │ "}
-                  {obfuscate(
-                    (expandedLogs ? logs : logs.slice(-15)).join("\n  │ "),
-                  )}
+                  {(expandedLogs ? logs : logs.slice(-15)).join("\n  │ ")}
                 </text>
               </box>
               <text fg={colors.textMuted}>{"  └─"}</text>
@@ -164,9 +160,7 @@ export const ToolRenderer = memo(function ToolRenderer({
           logs.length > 0 && (
             <box marginLeft={2}>
               <text fg={colors.textMuted}>
-                {obfuscate(
-                  expandedLogs ? logs.join("\n") : logs.slice(-2).join("\n"),
-                )}
+                {expandedLogs ? logs.join("\n") : logs.slice(-2).join("\n")}
               </text>
             </box>
           )}

--- a/src/tui/components/shared/tool-renderer.tsx
+++ b/src/tui/components/shared/tool-renderer.tsx
@@ -14,6 +14,7 @@ import { isToolMessage } from "./type-guards";
 import type { DisplayMessage } from "../agent-display";
 import { PentestWorkflowDisplay } from "./pentest-workflow-display";
 import { useObfuscation } from "../../context/obfuscation";
+import { obfuscate } from "../../../core/obfuscation";
 
 const TOOLS_WITH_LOG_WINDOW = new Set([
   "execute_command",
@@ -76,21 +77,26 @@ export const ToolRenderer = memo(function ToolRenderer({
     preferDescription: isPending,
   });
 
-  // For execute_command, extract both description and command so we can show both
+  // For execute_command, extract both description and command so we can show
+  // both. Both flow through obfuscate() so a toggled `/obfuscate` mid-stream
+  // immediately redacts the command preview and human description (which can
+  // freely include hosts, paths, emails, etc.).
   const execDescription =
     toolName === "execute_command" &&
     typeof args.toolCallDescription === "string" &&
     args.toolCallDescription.trim().length > 0
-      ? args.toolCallDescription.trim()
+      ? obfuscate(args.toolCallDescription.trim())
       : null;
   const execCommand =
     toolName === "execute_command" && typeof args.command === "string"
       ? args.command.split("\n")[0]
       : null;
   const execCommandDisplay = execCommand
-    ? execCommand.length > 80
-      ? `$ ${execCommand.slice(0, 80)}…`
-      : `$ ${execCommand}`
+    ? obfuscate(
+        execCommand.length > 80
+          ? `$ ${execCommand.slice(0, 80)}…`
+          : `$ ${execCommand}`,
+      )
     : null;
 
   // Get result summary for completed tools
@@ -142,7 +148,9 @@ export const ToolRenderer = memo(function ToolRenderer({
               <box marginLeft={0}>
                 <text fg={colors.textMuted}>
                   {"  │ "}
-                  {(expandedLogs ? logs : logs.slice(-15)).join("\n  │ ")}
+                  {obfuscate(
+                    (expandedLogs ? logs : logs.slice(-15)).join("\n  │ "),
+                  )}
                 </text>
               </box>
               <text fg={colors.textMuted}>{"  └─"}</text>
@@ -156,7 +164,9 @@ export const ToolRenderer = memo(function ToolRenderer({
           logs.length > 0 && (
             <box marginLeft={2}>
               <text fg={colors.textMuted}>
-                {expandedLogs ? logs.join("\n") : logs.slice(-2).join("\n")}
+                {obfuscate(
+                  expandedLogs ? logs.join("\n") : logs.slice(-2).join("\n"),
+                )}
               </text>
             </box>
           )}

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -17,6 +17,7 @@ import type { AutocompleteOption } from "../components/shared/prompt-input";
 import { useRoute, type WebCommandOptions } from "./route";
 import { createSkillsRegistry, type SkillsRegistry } from "../../core/skills";
 import { useObfuscation } from "./obfuscation";
+import { isObfuscationEnabled } from "../../core/obfuscation";
 import { useToast } from "./toast";
 
 interface CommandContextValue {
@@ -96,15 +97,15 @@ export function CommandProvider({
       openPentestDialog: onOpenPentestDialog,
       openSkillsDialog: onOpenSkillsDialog,
       setObfuscation: (enabled) => {
-        // The React state update is async, so compute the resulting value
-        // up-front (matching the toggle semantics inside the provider) and
-        // return it for command handlers that want to display feedback.
-        const next =
-          typeof enabled === "boolean" ? enabled : !obfuscation.enabled;
+        // Read live engine state so toast feedback is accurate even if
+        // this closure was captured on an earlier render. The provider's
+        // `setEnabled` is itself idempotent against stale closures.
+        const current = isObfuscationEnabled();
+        const next = typeof enabled === "boolean" ? enabled : !current;
         obfuscation.setEnabled(next);
         return next;
       },
-      getObfuscation: () => obfuscation.enabled,
+      getObfuscation: () => isObfuscationEnabled(),
       toast,
     };
     return ctx;

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -16,6 +16,8 @@ import {
 import type { AutocompleteOption } from "../components/shared/prompt-input";
 import { useRoute, type WebCommandOptions } from "./route";
 import { createSkillsRegistry, type SkillsRegistry } from "../../core/skills";
+import { useObfuscation } from "./obfuscation";
+import { useToast } from "./toast";
 
 interface CommandContextValue {
   router: CommandRouter<AppCommandContext>;
@@ -75,6 +77,8 @@ export function CommandProvider({
   onOpenSkillsDialog,
 }: CommandProviderProps) {
   const route = useRoute();
+  const obfuscation = useObfuscation();
+  const { toast } = useToast();
   const [registry] = useState(() => createSkillsRegistry());
   const [registryVersion, setRegistryVersion] = useState(0);
 
@@ -91,6 +95,17 @@ export function CommandProvider({
       openAuthDialog: onOpenAuthDialog,
       openPentestDialog: onOpenPentestDialog,
       openSkillsDialog: onOpenSkillsDialog,
+      setObfuscation: (enabled) => {
+        // The React state update is async, so compute the resulting value
+        // up-front (matching the toggle semantics inside the provider) and
+        // return it for command handlers that want to display feedback.
+        const next =
+          typeof enabled === "boolean" ? enabled : !obfuscation.enabled;
+        obfuscation.setEnabled(next);
+        return next;
+      },
+      getObfuscation: () => obfuscation.enabled,
+      toast,
     };
     return ctx;
   }, [
@@ -104,6 +119,8 @@ export function CommandProvider({
     onOpenAuthDialog,
     onOpenPentestDialog,
     onOpenSkillsDialog,
+    obfuscation,
+    toast,
   ]);
 
   const refreshSkills = useCallback(async () => {

--- a/src/tui/context/obfuscation.tsx
+++ b/src/tui/context/obfuscation.tsx
@@ -1,0 +1,60 @@
+/**
+ * Obfuscation context for the TUI.
+ *
+ * Activates when the CLI was started with `--obfuscate` (which sets
+ * `PENSAR_OBFUSCATE=1`). When active, the engine inside
+ * `core/obfuscation` is enabled globally so any module that imports
+ * `obfuscate()` will redact text consistently across the UI.
+ */
+
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import {
+  isObfuscationEnabled,
+  setObfuscationEnabled,
+  obfuscate as engineObfuscate,
+} from "../../core/obfuscation";
+
+interface ObfuscationContextValue {
+  enabled: boolean;
+  redact: (input: string) => string;
+}
+
+const ObfuscationContext = createContext<ObfuscationContextValue>({
+  enabled: false,
+  redact: (s) => s,
+});
+
+interface ObfuscationProviderProps {
+  enabled: boolean;
+  children: ReactNode;
+}
+
+export function ObfuscationProvider({
+  enabled,
+  children,
+}: ObfuscationProviderProps) {
+  // Enabling is a global side-effect on the engine because many code paths
+  // (markdown rendering, syntax highlighting, footer status text) are not
+  // React components and need a synchronous gate without prop drilling.
+  if (isObfuscationEnabled() !== enabled) {
+    setObfuscationEnabled(enabled);
+  }
+
+  const value = useMemo<ObfuscationContextValue>(
+    () => ({
+      enabled,
+      redact: (input: string) => (enabled ? engineObfuscate(input) : input),
+    }),
+    [enabled],
+  );
+
+  return (
+    <ObfuscationContext.Provider value={value}>
+      {children}
+    </ObfuscationContext.Provider>
+  );
+}
+
+export function useObfuscation(): ObfuscationContextValue {
+  return useContext(ObfuscationContext);
+}

--- a/src/tui/context/obfuscation.tsx
+++ b/src/tui/context/obfuscation.tsx
@@ -2,51 +2,79 @@
  * Obfuscation context for the TUI.
  *
  * Activates when the CLI was started with `--obfuscate` (which sets
- * `PENSAR_OBFUSCATE=1`). When active, the engine inside
+ * `PENSAR_OBFUSCATE=1`) or when the user toggles it at runtime via the
+ * `/obfuscate` slash command. When active, the engine inside
  * `core/obfuscation` is enabled globally so any module that imports
  * `obfuscate()` will redact text consistently across the UI.
  */
 
-import { createContext, useContext, useMemo, type ReactNode } from "react";
 import {
-  isObfuscationEnabled,
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  resetObfuscation,
   setObfuscationEnabled,
   obfuscate as engineObfuscate,
 } from "../../core/obfuscation";
 
 interface ObfuscationContextValue {
   enabled: boolean;
+  /** Enable, disable, or toggle obfuscation. Toggle when no value is passed. */
+  setEnabled: (enabled?: boolean) => void;
+  toggle: () => void;
   redact: (input: string) => string;
 }
 
 const ObfuscationContext = createContext<ObfuscationContextValue>({
   enabled: false,
+  setEnabled: () => {},
+  toggle: () => {},
   redact: (s) => s,
 });
 
 interface ObfuscationProviderProps {
-  enabled: boolean;
+  initialEnabled: boolean;
   children: ReactNode;
 }
 
 export function ObfuscationProvider({
-  enabled,
+  initialEnabled,
   children,
 }: ObfuscationProviderProps) {
-  // Enabling is a global side-effect on the engine because many code paths
-  // (markdown rendering, syntax highlighting, footer status text) are not
-  // React components and need a synchronous gate without prop drilling.
-  if (isObfuscationEnabled() !== enabled) {
-    setObfuscationEnabled(enabled);
-  }
+  const [enabled, setEnabledState] = useState<boolean>(initialEnabled);
 
-  const value = useMemo<ObfuscationContextValue>(
-    () => ({
+  // Keep the global engine state in sync with React state. The engine is a
+  // module-level singleton because many code paths (markdown rendering,
+  // syntax highlighting, footer status text) are not React components and
+  // need a synchronous gate without prop drilling.
+  useEffect(() => {
+    setObfuscationEnabled(enabled);
+  }, [enabled]);
+
+  const value = useMemo<ObfuscationContextValue>(() => {
+    const setEnabled = (next?: boolean) => {
+      setEnabledState((prev) => {
+        const target = typeof next === "boolean" ? next : !prev;
+        if (target === prev) return prev;
+        // Reset placeholder counters when turning obfuscation on so a fresh
+        // mapping starts at <CATEGORY_1>. Leave the mapping alone on disable
+        // so re-enabling within the same session reuses prior placeholders.
+        if (target && !prev) resetObfuscation();
+        return target;
+      });
+    };
+    return {
       enabled,
+      setEnabled,
+      toggle: () => setEnabled(),
       redact: (input: string) => (enabled ? engineObfuscate(input) : input),
-    }),
-    [enabled],
-  );
+    };
+  }, [enabled]);
 
   return (
     <ObfuscationContext.Provider value={value}>

--- a/src/tui/context/obfuscation.tsx
+++ b/src/tui/context/obfuscation.tsx
@@ -4,8 +4,15 @@
  * Activates when the CLI was started with `--obfuscate` (which sets
  * `PENSAR_OBFUSCATE=1`) or when the user toggles it at runtime via the
  * `/obfuscate` slash command. When active, the engine inside
- * `core/obfuscation` is enabled globally so any module that imports
- * `obfuscate()` will redact text consistently across the UI.
+ * `core/obfuscation` is enabled globally; the actual redaction at
+ * render time is handled by the central `TextNodeRenderable` patch in
+ * `src/tui/obfuscation/patch.ts`, which intercepts every JSX `<text>`
+ * leaf the @opentui/react reconciler creates or updates. Components
+ * therefore don't need to call `obfuscate()` on their own strings.
+ *
+ * On toggle this provider walks the renderer's tree and re-emits each
+ * text node from its stored original so already-rendered prose
+ * retroactively reflects the new state.
  */
 
 import {
@@ -16,12 +23,14 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { useRenderer } from "@opentui/react";
 import {
   resetObfuscation,
   setObfuscationEnabled,
   isObfuscationEnabled,
   obfuscate as engineObfuscate,
 } from "../../core/obfuscation";
+import { refreshObfuscatedText } from "../obfuscation/patch";
 
 interface ObfuscationContextValue {
   enabled: boolean;
@@ -59,6 +68,7 @@ export function ObfuscationProvider({
     setObfuscationEnabled(initialEnabled);
   }
   const [enabled, setEnabledState] = useState<boolean>(initialEnabled);
+  const renderer = useRenderer();
 
   const value = useMemo<ObfuscationContextValue>(() => {
     const setEnabled = (next?: boolean) => {
@@ -78,6 +88,11 @@ export function ObfuscationProvider({
       // by the state setter below already sees the new state.
       setObfuscationEnabled(target);
       setEnabledState(target);
+      // Walk the renderable tree and re-emit every text node from its
+      // stored original. Without this, React's reconciler would skip
+      // `commitTextUpdate` on existing text whose string value hasn't
+      // changed, so already-rendered prose would lag behind the toggle.
+      if (renderer) refreshObfuscatedText(renderer);
     };
     return {
       enabled,
@@ -85,7 +100,7 @@ export function ObfuscationProvider({
       toggle: () => setEnabled(),
       redact: (input: string) => (enabled ? engineObfuscate(input) : input),
     };
-  }, [enabled]);
+  }, [enabled, renderer]);
 
   return (
     <ObfuscationContext.Provider value={value}>

--- a/src/tui/context/obfuscation.tsx
+++ b/src/tui/context/obfuscation.tsx
@@ -70,7 +70,7 @@ export function ObfuscationProvider({
       const target = typeof next === "boolean" ? next : !current;
       if (target === current) return;
       // Reset placeholder counters when turning obfuscation on so a fresh
-      // mapping starts at <CATEGORY_1>. Leave the mapping alone on disable
+      // mapping starts at [CATEGORY_1]. Leave the mapping alone on disable
       // so re-enabling within the same session reuses prior placeholders
       // and `deobfuscate()` can still expand them back to originals.
       if (target && !current) resetObfuscation();

--- a/src/tui/context/obfuscation.tsx
+++ b/src/tui/context/obfuscation.tsx
@@ -58,13 +58,18 @@ export function ObfuscationProvider({
 
   const value = useMemo<ObfuscationContextValue>(() => {
     const setEnabled = (next?: boolean) => {
-      const target = typeof next === "boolean" ? next : !enabled;
-      if (target === enabled) return;
+      // Read live engine state rather than the captured `enabled` from
+      // closure. This makes the function safe against stale references
+      // — a caller that grabbed `setEnabled` on an early render still
+      // toggles correctly after subsequent flips.
+      const current = isObfuscationEnabled();
+      const target = typeof next === "boolean" ? next : !current;
+      if (target === current) return;
       // Reset placeholder counters when turning obfuscation on so a fresh
       // mapping starts at <CATEGORY_1>. Leave the mapping alone on disable
       // so re-enabling within the same session reuses prior placeholders
       // and `deobfuscate()` can still expand them back to originals.
-      if (target && !enabled) resetObfuscation();
+      if (target && !current) resetObfuscation();
       // Update the engine FIRST, synchronously, so any render kicked off
       // by the state setter below already sees the new state.
       setObfuscationEnabled(target);

--- a/src/tui/context/obfuscation.tsx
+++ b/src/tui/context/obfuscation.tsx
@@ -12,6 +12,7 @@ import {
   createContext,
   useContext,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -46,12 +47,15 @@ export function ObfuscationProvider({
   initialEnabled,
   children,
 }: ObfuscationProviderProps) {
-  // Initialise the engine eagerly, before any consumer renders, so the
-  // first frame sees the right state. Done at module-call time rather
-  // than via useEffect because effects run AFTER render — any component
-  // that calls `obfuscate()` during the first render would otherwise see
-  // stale engine state.
-  if (isObfuscationEnabled() !== initialEnabled) {
+  // Initialise the engine ONCE on first mount, before any consumer
+  // renders, so the first frame sees the right state. Critically this
+  // must NOT run on every render — otherwise the next render after a
+  // toggle would overwrite the just-flipped engine state with the
+  // (forever-`false`) `initialEnabled` prop and the toggle would be
+  // silently undone.
+  const initializedRef = useRef(false);
+  if (!initializedRef.current) {
+    initializedRef.current = true;
     setObfuscationEnabled(initialEnabled);
   }
   const [enabled, setEnabledState] = useState<boolean>(initialEnabled);

--- a/src/tui/context/obfuscation.tsx
+++ b/src/tui/context/obfuscation.tsx
@@ -11,7 +11,6 @@
 import {
   createContext,
   useContext,
-  useEffect,
   useMemo,
   useState,
   type ReactNode,
@@ -19,6 +18,7 @@ import {
 import {
   resetObfuscation,
   setObfuscationEnabled,
+  isObfuscationEnabled,
   obfuscate as engineObfuscate,
 } from "../../core/obfuscation";
 
@@ -46,27 +46,29 @@ export function ObfuscationProvider({
   initialEnabled,
   children,
 }: ObfuscationProviderProps) {
+  // Initialise the engine eagerly, before any consumer renders, so the
+  // first frame sees the right state. Done at module-call time rather
+  // than via useEffect because effects run AFTER render — any component
+  // that calls `obfuscate()` during the first render would otherwise see
+  // stale engine state.
+  if (isObfuscationEnabled() !== initialEnabled) {
+    setObfuscationEnabled(initialEnabled);
+  }
   const [enabled, setEnabledState] = useState<boolean>(initialEnabled);
-
-  // Keep the global engine state in sync with React state. The engine is a
-  // module-level singleton because many code paths (markdown rendering,
-  // syntax highlighting, footer status text) are not React components and
-  // need a synchronous gate without prop drilling.
-  useEffect(() => {
-    setObfuscationEnabled(enabled);
-  }, [enabled]);
 
   const value = useMemo<ObfuscationContextValue>(() => {
     const setEnabled = (next?: boolean) => {
-      setEnabledState((prev) => {
-        const target = typeof next === "boolean" ? next : !prev;
-        if (target === prev) return prev;
-        // Reset placeholder counters when turning obfuscation on so a fresh
-        // mapping starts at <CATEGORY_1>. Leave the mapping alone on disable
-        // so re-enabling within the same session reuses prior placeholders.
-        if (target && !prev) resetObfuscation();
-        return target;
-      });
+      const target = typeof next === "boolean" ? next : !enabled;
+      if (target === enabled) return;
+      // Reset placeholder counters when turning obfuscation on so a fresh
+      // mapping starts at <CATEGORY_1>. Leave the mapping alone on disable
+      // so re-enabling within the same session reuses prior placeholders
+      // and `deobfuscate()` can still expand them back to originals.
+      if (target && !enabled) resetObfuscation();
+      // Update the engine FIRST, synchronously, so any render kicked off
+      // by the state setter below already sees the new state.
+      setObfuscationEnabled(target);
+      setEnabledState(target);
     };
     return {
       enabled,

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -61,6 +61,7 @@ import { setupAutoCopy } from "./auto-copy";
 import { TerminalDimensionsProvider } from "./context/dimensions";
 import { TerminalFocusHandler } from "./components/terminal-focus-handler";
 import { cleanupTerminalFocusMode } from "./terminal-focus";
+import { ObfuscationProvider } from "./context/obfuscation";
 
 interface AppProps {
   appConfig: Config;
@@ -698,18 +699,22 @@ async function main() {
     process.exit(1);
   });
 
+  const obfuscateEnabled = process.env.PENSAR_OBFUSCATE === "1";
+
   createRoot(renderer).render(
-    <ThemeProvider initialTheme={themeName} initialMode={mode}>
-      <ConsoleThemeSync />
-      <TerminalDimensionsProvider>
-        <ToastProvider>
-          <ErrorBoundary>
-            <App appConfig={appConfig} />
-          </ErrorBoundary>
-          <ToastContainer />
-        </ToastProvider>
-      </TerminalDimensionsProvider>
-    </ThemeProvider>,
+    <ObfuscationProvider enabled={obfuscateEnabled}>
+      <ThemeProvider initialTheme={themeName} initialMode={mode}>
+        <ConsoleThemeSync />
+        <TerminalDimensionsProvider>
+          <ToastProvider>
+            <ErrorBoundary>
+              <App appConfig={appConfig} />
+            </ErrorBoundary>
+            <ToastContainer />
+          </ToastProvider>
+        </TerminalDimensionsProvider>
+      </ThemeProvider>
+    </ObfuscationProvider>,
   );
 }
 

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -702,7 +702,7 @@ async function main() {
   const obfuscateEnabled = process.env.PENSAR_OBFUSCATE === "1";
 
   createRoot(renderer).render(
-    <ObfuscationProvider enabled={obfuscateEnabled}>
+    <ObfuscationProvider initialEnabled={obfuscateEnabled}>
       <ThemeProvider initialTheme={themeName} initialMode={mode}>
         <ConsoleThemeSync />
         <TerminalDimensionsProvider>

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -62,6 +62,9 @@ import { TerminalDimensionsProvider } from "./context/dimensions";
 import { TerminalFocusHandler } from "./components/terminal-focus-handler";
 import { cleanupTerminalFocusMode } from "./terminal-focus";
 import { ObfuscationProvider } from "./context/obfuscation";
+import { installObfuscationTextPatch } from "./obfuscation/patch";
+
+installObfuscationTextPatch();
 
 interface AppProps {
   appConfig: Config;

--- a/src/tui/obfuscation/patch.ts
+++ b/src/tui/obfuscation/patch.ts
@@ -1,0 +1,134 @@
+/**
+ * Centralised obfuscation interception for the TUI's text-rendering layer.
+ *
+ * Instead of every component calling `obfuscate(...)` on the strings it
+ * passes to `<text>`, we monkey-patch the two `TextNodeRenderable` entry
+ * points that the @opentui/react reconciler funnels every JSX text leaf
+ * through:
+ *
+ *   - `TextNodeRenderable.fromString(text)` — invoked by the host config's
+ *     `createTextInstance`, i.e. every time a string child is mounted.
+ *   - `TextNodeRenderable.prototype.children` setter — invoked by
+ *     `commitTextUpdate`, i.e. every time a string child changes.
+ *
+ * Each patched node remembers its original (unobfuscated) text in a
+ * symbol-keyed slot. On `/obfuscate` toggle, `refreshObfuscatedText`
+ * walks the renderer's tree and re-feeds those originals through the
+ * setter, which re-evaluates them against the new engine state. Without
+ * the walker, only newly-committed text would honour the toggle —
+ * existing rendered prose would lag because React's reconciler skips
+ * `commitTextUpdate` when the string value hasn't changed.
+ *
+ * Notes:
+ *   - `<textarea>` / `<input>` use a different renderable path that
+ *     bypasses `TextNodeRenderable`, so the operator's own typing is
+ *     never auto-obfuscated by this patch. PromptInput keeps its
+ *     explicit obfuscation flow.
+ *   - `<text content={styledText} />` flows through TextRenderable's
+ *     content setter, not through here. Tool/result rendering already
+ *     obfuscates StyledText upstream in `result-registry.ts`.
+ */
+
+import {
+  TextNodeRenderable,
+  type CliRenderer,
+  type BaseRenderable,
+} from "@opentui/core";
+import { obfuscate, isObfuscationEnabled } from "../../core/obfuscation";
+
+const ORIGINAL = Symbol.for("pensar.obfuscation.originalChildren");
+
+type Carrier = TextNodeRenderable & {
+  [ORIGINAL]?: ReadonlyArray<string | TextNodeRenderable>;
+};
+
+let installed = false;
+
+/**
+ * Install the prototype patches. Idempotent — safe to call from both
+ * test setup and the production entrypoint. Must run before any TUI
+ * component renders so the very first frame goes through the patched
+ * setter.
+ */
+export function installObfuscationTextPatch(): void {
+  if (installed) return;
+  installed = true;
+
+  patchFromString();
+  patchChildrenSetter();
+}
+
+function patchFromString(): void {
+  const original = TextNodeRenderable.fromString.bind(TextNodeRenderable);
+  TextNodeRenderable.fromString = function patchedFromString(
+    text: string,
+    options?: Parameters<typeof TextNodeRenderable.fromString>[1],
+  ): TextNodeRenderable {
+    const node = original(transform(text), options) as Carrier;
+    node[ORIGINAL] = [text];
+    return node;
+  };
+}
+
+function patchChildrenSetter(): void {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    TextNodeRenderable.prototype,
+    "children",
+  );
+  if (!descriptor || !descriptor.set) {
+    throw new Error(
+      "Obfuscation patch: TextNodeRenderable.prototype.children setter not found.",
+    );
+  }
+  const originalSetter = descriptor.set;
+  Object.defineProperty(TextNodeRenderable.prototype, "children", {
+    ...descriptor,
+    set(
+      this: Carrier,
+      next: ReadonlyArray<string | TextNodeRenderable>,
+    ) {
+      this[ORIGINAL] = Array.isArray(next) ? [...next] : next;
+      const transformed = next.map((child) =>
+        typeof child === "string" ? transform(child) : child,
+      );
+      originalSetter.call(this, transformed);
+    },
+  });
+}
+
+function transform(text: string): string {
+  if (!isObfuscationEnabled()) return text;
+  return obfuscate(text);
+}
+
+/**
+ * Walk the renderer's tree and re-emit every `TextNodeRenderable`'s
+ * children from its stored originals. Each re-emit goes through the
+ * patched `children` setter, which re-evaluates the strings against
+ * the current obfuscation state.
+ *
+ * Call this whenever the engine's `enabled` flag flips so existing
+ * text on screen retroactively reflects the new state.
+ */
+export function refreshObfuscatedText(renderer: CliRenderer): void {
+  if (!installed) return;
+  walk(renderer.root as unknown as BaseRenderable, (node) => {
+    if (!(node instanceof TextNodeRenderable)) return;
+    const carrier = node as Carrier;
+    const original = carrier[ORIGINAL];
+    if (!original || original.length === 0) return;
+    // Going through the setter is intentional: it re-records originals
+    // (idempotent — same array) and re-applies `transform`.
+    node.children = [...original];
+  });
+}
+
+function walk(
+  node: BaseRenderable,
+  fn: (node: BaseRenderable) => void,
+): void {
+  fn(node);
+  const children = node.getChildren?.();
+  if (!children) return;
+  for (const child of children) walk(child, fn);
+}

--- a/src/tui/obfuscation/patch.ts
+++ b/src/tui/obfuscation/patch.ts
@@ -31,6 +31,7 @@
 
 import {
   TextNodeRenderable,
+  TextRenderable,
   type CliRenderer,
   type BaseRenderable,
 } from "@opentui/core";
@@ -128,6 +129,16 @@ function walk(
   fn: (node: BaseRenderable) => void,
 ): void {
   fn(node);
+
+  // `<text>` keeps its TextNodeRenderable subtree on a side-channel
+  // (`textNode`) because TextNodeRenderable extends BaseRenderable but
+  // not Renderable, so it's invisible to Renderable.getChildren(). Cross
+  // the boundary explicitly or we never visit the leaves where the
+  // [ORIGINAL] markers live.
+  if (node instanceof TextRenderable) {
+    walk(node.textNode as unknown as BaseRenderable, fn);
+  }
+
   const children = node.getChildren?.();
   if (!children) return;
   for (const child of children) walk(child, fn);

--- a/src/tui/obfuscation/patch.ts
+++ b/src/tui/obfuscation/patch.ts
@@ -84,10 +84,7 @@ function patchChildrenSetter(): void {
   const originalSetter = descriptor.set;
   Object.defineProperty(TextNodeRenderable.prototype, "children", {
     ...descriptor,
-    set(
-      this: Carrier,
-      next: ReadonlyArray<string | TextNodeRenderable>,
-    ) {
+    set(this: Carrier, next: ReadonlyArray<string | TextNodeRenderable>) {
       this[ORIGINAL] = Array.isArray(next) ? [...next] : next;
       const transformed = next.map((child) =>
         typeof child === "string" ? transform(child) : child,
@@ -124,10 +121,7 @@ export function refreshObfuscatedText(renderer: CliRenderer): void {
   });
 }
 
-function walk(
-  node: BaseRenderable,
-  fn: (node: BaseRenderable) => void,
-): void {
+function walk(node: BaseRenderable, fn: (node: BaseRenderable) => void): void {
   fn(node);
 
   // `<text>` keeps its TextNodeRenderable subtree on a side-channel


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Adds a global `--obfuscate` flag (alias `--redact`, `-O`) **and** a runtime `/obfuscate` slash command that put the Pensar TUI into **obfuscation mode**. When active, every layer of the UI passes its text through a pattern-based redaction engine before rendering, so engagement screenshots can be shared without leaking sensitive information.

### Engine — `src/core/obfuscation/`

A pattern-based redactor with a stable, process-lifetime mapping (the same input always produces the same placeholder, so `[EMAIL_1]` is always Alice's email).

| Category | Examples redacted |
| --- | --- |
| `URL`, `HOST` | `https://api.acme-corp.internal/v1/users`, `staging-console.acme.dev` |
| `EMAIL`, `PHONE` | `alice@acme.com`, `+1 415 555 0123` |
| `IPV4`, `IPV6`, `MAC` | `10.0.42.17`, `pentest-10-0-0-1`, `fe80::1`, `00:1A:2B:3C:4D:5E` |
| `UUID` | `550e8400-e29b-41d4-a716-446655440000` |
| `JWT`, `TOKEN` | bearer tokens, `sk-…`, GitHub PATs, AWS access keys, Cognito region IDs (`us-east-1_X8rlYugE7`), opaque 20+ char client IDs |
| `HEX` | long hex blobs |
| `PATH` | `/Users/alice/...`, `C:\Users\alice\...`, `/v1/external/sendgrid/{tenant_id}`, `/__debug/pprof/heap`, `/docs/`, single-segment routes (`/login,`, `/dashboard `, `/leads.`), and template-style relatives (`media/{tenant_id}`) |
| `CARD` | Luhn-validated card numbers |
| `ORG` | `Acme Corp`, `Globex LLC`, `Initech Industries`, plus bare org references via the alias system (see below) |

Notes on detection:

- **No host allowlist.** Every detected hostname is redacted, even apparently public ones (`pensar.dev`, `github.com`, …). The only filter on `HOST` is a source-code filename heuristic so `config.json` and `app.py` aren't mis-redacted.
- **Dashed IPv4** in session names / reverse-DNS labels (`pentest-10-0-0-1`, `ec2-54-12-34-56`) is caught with lookbehind/lookahead guards so longer hyphenated number sequences and date-shaped strings (`2026-04-28-12`) don't false-match.
- **Single-segment slash paths** like `/login,`, `/dashboard ` are redacted only when a non-segment, non-newline character follows, so bare slash commands (`/help` at end-of-line / EOS) stay intact for the command router.
- **Org alias system.** When the engine redacts a host or URL, it learns the registrable label (`acme` from `acme.com`) and stores it as an alias for the same placeholder. A final case-insensitive whole-word pass replaces bare references to the org (`the Acme corporate tenant`, `acme-login-recon`) with the same placeholder, so the org name is consistent across surfaces. A blocklist of generic provider labels (AWS, Cloudflare, GitHub, …) prevents the alias system from ever redacting third-party brand names. An `aliases: false` opt-out is exposed for input round-trip flows that need the literal string back.
- Stop-words (`Pensar`, `OpenAI`, `JSON`, …) prevent ORG false positives on common technical terms.

### Placeholder format

Square brackets: `[EMAIL_1]`, `[HOST_1]`, …. Angle brackets get parsed as inline HTML by `marked` and silently dropped from rendered messages, so brackets are the only form that survives every render path.

### TUI integration — centralized rendering patch

Rather than every component calling `obfuscate(...)` on its own strings, the TUI installs a one-time monkey-patch on the OpenTUI text primitives:

- **`TextNodeRenderable.fromString`** (used by the React reconciler's `createTextInstance` on every JSX text leaf) — redacts on creation.
- **`TextNodeRenderable.prototype.children` setter** (used by `commitTextUpdate` on every text update) — redacts on every change.

Each patched node remembers its original (unobfuscated) text in a symbol-keyed slot. On `/obfuscate` toggle, a tree-walker re-emits every node's children from its stored original through the same patched setter, so already-rendered prose retroactively reflects the new state — without it, React's reconciler would skip `commitTextUpdate` on existing text whose string value hasn't changed and the toggle would only affect newly-committed text.

The walker descends into `TextRenderable.textNode` explicitly because OpenTUI keeps each `<text>`'s text-node subtree on a side-channel — `TextNodeRenderable extends BaseRenderable` (not `Renderable`), so it's invisible to the standard `Renderable.getChildren()` traversal.

### Carve-outs (text that bypasses the patch)

A handful of paths route through `TextRenderable`'s `content` setter or a different primitive entirely, and are obfuscated upstream at the boundary:

- **`markdownToStyledText`** — bakes obfuscation into chunks before they become `StyledText`, since assistant messages render via `<text content={styledText}>`.
- **`result-registry.obfuscateStyledText`** — applied to tool result `styledText` (syntax-highlighted previews) for the same reason.
- **`PromptInput`** — runs `obfuscate()` against the textarea buffer on every content change, replacing recognised values with placeholders as the user types. On submit, paste-extmark expansion runs first, then `deobfuscate()` expands every placeholder back to its original — so the agent always receives real values while screenshots of the prompt show only placeholders. The textarea reacts to live `/obfuscate` toggles, redacting or expanding the current buffer in place. Slash commands are bypassed at this layer so `/help` etc. aren't mangled.
- **`ShiningText`** (pending tool-call shimmer) — obfuscates the input string once at the component boundary because the shimmer renders character-by-character via `<text content={ch}>`.

The markdown renderer also passes through inline and block `html` tokens as literal text, so any future angle-bracketed content the assistant emits stays visible instead of being silently consumed by the lexer.

### `/obfuscate` slash command

`ObfuscationProvider` is stateful, seeded by `--obfuscate` (env `PENSAR_OBFUSCATE=1`) and exposes `setEnabled` / `toggle` / `enabled` / `redact` to the React tree. Engine state and React state are kept in lock-step synchronously so toggling never leaves a frame in an inconsistent state. The `CommandRouter` re-binds handler context on every `execute()` so toggles read live engine state instead of a stale closure from the first render. Subcommands: `on`, `off`, `toggle` (default). A toast confirms the new state.

Help text in `pensar --help` documents the flag; the in-TUI help dialog auto-picks up the new `/obfuscate` command from the registry.

### How did you verify your code works?

- `bun run tsc` ✅
- `bun run lint` ✅
- `bun run format:check` ✅
- `bun run test src/core/obfuscation` ✅ — 43 cases covering the no-allowlist behaviour, dashed-IP detection, route + relative + template-style path patterns, opaque/AWS-region IDs, ORG/alias logic with provider-blocklist and round-trip opt-out, and `deobfuscate` round-trips.
- `bun run test` ⚠️ — only failures are pre-existing `src/core/ai/ai.test.ts` cases unrelated to this change (retired `claude-3-haiku-20240307` model; identical to `canary`).
- Branch rebased onto latest `canary`. Rebase resolved three conflicts cleanly: footer (kept the new dimensions-aware `showCwd`, dropped the `● obfuscated` indicator), agent-display (`SpinnerDots` → `SpinningDots`), and operator-dashboard header (kept canary's simplified header).
- Manual TUI verification on a real terminal:

https://github.com/user-attachments/assets/d62f9687-d0e8-4570-82e1-5c6eced6fc34

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4a58872-ea32-49fb-bf90-5bfbb4183fbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4a58872-ea32-49fb-bf90-5bfbb4183fbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>