### PR TITLE
fix(persistentShell): serialize execute() with FIFO mutex (#645)

### DIFF
--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -7,17 +7,6 @@ const HAS_STDBUF =
   process.platform !== "win32" &&
   spawnSync("stdbuf", ["--version"], { stdio: "ignore" }).status === 0;
 
-/**
- * These tests document and reproduce the "shell eventually stops responding"
- * class of bugs in PersistentShell. They are written as hang-repros: each test
- * exercises a scenario a long-running pentest agent realistically hits, and
- * asserts the contract the tool advertises.
- *
- * Several of these are EXPECTED TO FAIL against the current implementation.
- * They are intentionally left failing so the bugs cannot be silently
- * re-introduced once fixed. They use `it.fails(...)` so the suite stays green
- * while clearly flagging the known-broken behavior.
- */
 describe("PersistentShell — long-running stability", () => {
   const shells: PersistentShell[] = [];
   const make = () => {
@@ -47,16 +36,6 @@ describe("PersistentShell — long-running stability", () => {
     expect(r2.stdout).toContain("two");
   });
 
-  /**
-   * Regression: on macOS without GNU `stdbuf`, the old wrapper relied on
-   * plain `tail -f` for streaming. Because `tail`'s stdout was a pipe it
-   * block-buffered, so short outputs were killed with tail before ever
-   * flushing — every `ls -la`-style command came back with empty stdout
-   * and the agent saw `(no output)`. The current wrapper always runs an
-   * authoritative post-kill `cat` of the per-command tempfile through
-   * bash's real stdout pipe, so `tail` buffering can no longer cause
-   * stdout loss.
-   */
   it("captures short stdout (no-stdbuf safe)", async () => {
     const shell = make();
     const r = await shell.execute("printf 'hello\\nworld\\n'", 5);
@@ -65,21 +44,6 @@ describe("PersistentShell — long-running stability", () => {
     expect(r.stdout).toContain("world");
   });
 
-  /**
-   * Regression: on macOS with SIP, `stdbuf -oL` is a silent no-op on
-   * /usr/bin/tail (DYLD_INSERT_LIBRARIES is stripped from protected
-   * binaries). If the wrapper relies on tail alone to stream stdout,
-   * tail block-buffers (~8 KiB default) and the buffer is discarded
-   * when we kill tail 100 ms after the command finishes — every short
-   * command returns empty stdout. Executed by APEX TUI in operator mode,
-   * by the CLI pentest entrypoint, and by Evalgate-driven runs (e.g.
-   * NOCTURNE), producing `(no output)` for trivial commands and
-   * dominating eval signal with shell brokenness rather than agent
-   * capability.
-   *
-   * These assertions fail on macOS against the pre-patch wrapper and
-   * pass once the authoritative post-kill `cat` phase is in place.
-   */
   it("captures trivial stdout even when tail block-buffers", async () => {
     const shell = make();
     const echo = await shell.execute("echo hello", 5);
@@ -95,20 +59,9 @@ describe("PersistentShell — long-running stability", () => {
     expect(seq.stdout.trim()).toBe("1\n2\n3\n4\n5");
   });
 
-  /**
-   * Regression: tail's default block-buffer is ~8 KiB. A command whose
-   * stdout is just under, at, and just over that boundary must come back
-   * fully intact, with no silent truncation regardless of whether tail
-   * ever flushed its buffer. Exercises the authoritative `cat` phase on
-   * a realistic recon-output size.
-   */
   it("captures output across the 8 KiB block-buffer boundary", async () => {
     const shell = make();
-    // Emit exactly 9000 'x' bytes followed by a newline. Uses /dev/zero
-    // to avoid bash/yes-pipeline byte-counting footguns (e.g.
-    // `yes x | head -c 9000` includes the newlines that `yes` emits, so
-    // stripping them halves the payload). 9000 > 8192 to ensure we
-    // exceed tail's default ~8 KiB block-buffer size.
+    // 9000 > 8192 to exceed tail's default block-buffer.
     const r = await shell.execute(
       "head -c 9000 /dev/zero | tr '\\0' 'x'; echo",
       5,
@@ -117,58 +70,26 @@ describe("PersistentShell — long-running stability", () => {
     expect(r.stdout.replace(/\n$/, "").length).toBe(9000);
   });
 
-  /**
-   * Repro #1 — Stdin hijack by a child process.
-   *
-   * The shell's stdin pipe is shared with every child bash spawns. A command
-   * that reads from stdin (cat/ssh/sudo/python/mysql/read/...) used to
-   * consume bytes meant for bash's own command parsing, wedging the shell
-   * for every subsequent call.
-   *
-   * The fix redirects each user command's stdin from /dev/null, so stdin
-   * readers see EOF immediately and cannot hijack our command pipe. We
-   * verify:
-   *   1. `cat` does NOT hang — it EOFs cleanly (exit 0) in well under the
-   *      timeout, proving stdin isolation works.
-   *   2. The next command still runs immediately afterward.
-   *
-   * Agents hit this constantly in practice because models run things like
-   * `sudo ...` or `ssh ...` mid-pentest.
-   */
   it("stays responsive after a command that normally reads stdin", async () => {
     const shell = make();
 
     const warm = await shell.execute("echo warm", 5);
     expect(warm.exitCode).toBe(0);
 
-    // `cat` with no args normally blocks on stdin. With /dev/null
-    // redirection it EOFs instantly.
+    // `cat` with no args normally blocks on stdin. With /dev/null it EOFs.
     const start = Date.now();
     const hung = await shell.execute("cat", 2);
     const elapsed = Date.now() - start;
     expect(hung.exitCode).toBe(0);
     expect(elapsed).toBeLessThan(1_500);
 
-    // Subsequent command should return within a normal timeout.
     const after = await shell.execute("echo after-cat", 5);
     expect(after.exitCode).toBe(0);
     expect(after.stdout).toContain("after-cat");
   }, 20_000);
 
-  /**
-   * Repro #2 — Process-group leak after timeout.
-   *
-   * `pkill -TERM -P <bashpid>` only reaps direct children of bash. For a
-   * pipeline (`a | b | c`) the workers are grandchildren of bash (children
-   * of the subshell), so they survive the timeout, become orphans, and keep
-   * their inherited fd 1 — feeding Repro #3 below.
-   *
-   * After the timeout, we should see no descendant processes still holding
-   * the shell's stdout pipe.
-   */
   it("cleans up pipeline grandchildren when a command times out", async () => {
     const shell = make();
-    // Prime the shell so we have a stable pid to probe.
     await shell.execute("echo prime", 5);
     const bashPid = (shell as unknown as { proc: { pid: number } }).proc.pid;
     expect(bashPid).toBeGreaterThan(0);
@@ -177,7 +98,6 @@ describe("PersistentShell — long-running stability", () => {
     const timed = await shell.execute("sleep 30 | cat", 2);
     expect(timed.exitCode).toBe(124);
 
-    // Give pkill + the 1s drain window a moment.
     await new Promise((r) => setTimeout(r, 1_500));
 
     const { spawnSync } = await import("child_process");
@@ -190,63 +110,32 @@ describe("PersistentShell — long-running stability", () => {
       .split("\n")
       .map((l) => l.trim())
       .filter(Boolean);
-    // No direct bash children should remain; none of them should be sleep.
     expect(remaining.find((l) => l.includes("sleep"))).toBeUndefined();
   }, 20_000);
 
-  /**
-   * Repro #3 — Output from a backgrounded command bleeds into the next
-   * command's captured stdout.
-   *
-   * Background producers whose fd 1 wasn't redirected keep writing to bash's
-   * stdout pipe. Between `execute()` calls the `data` listener is removed,
-   * so buffered bytes land on the *next* command's `stdout` accumulator.
-   * The caller sees output they never asked for, and sufficiently chatty
-   * producers eventually push past the 5MB MAX_BUFFER and trip the
-   * "stdout = stdout.substring(stdout.length - MAX_BUFFER)" truncation —
-   * which, if a marker ever lands near the start, silently drops it and
-   * we wait for a marker that will never appear.
-   */
   it("does not leak background-process output into the next command's stdout", async () => {
     const shell = make();
 
-    // Background a generator whose fd 1 is NOT redirected. This is the
-    // realistic footgun (`nmap -v &` without `>out.log 2>&1 &`).
+    // Background a generator whose fd 1 is NOT redirected (`nmap -v &`).
     const bg = await shell.execute(
       "( while :; do echo spam-$RANDOM; done ) &",
       3,
     );
     expect(bg.exitCode).toBe(0);
 
-    // Give the spammer a moment to write into the pipe.
     await new Promise((r) => setTimeout(r, 500));
 
     const quick = await shell.execute("echo fast", 3);
 
-    // Clean up the spammer before asserting so the shell is reusable.
     await shell.execute(
       "kill $(jobs -p) 2>/dev/null; wait 2>/dev/null; true",
       3,
     );
 
     expect(quick.exitCode).toBe(0);
-    // The next command should see ONLY its own output, not a mountain of
-    // spam from the orphaned background loop.
     expect(quick.stdout.includes("spam-")).toBe(false);
   }, 20_000);
 
-  /**
-   * Repro #4 — `cd` persists across commands.
-   *
-   * Previously the wrapper ran every command inside `( ... )`, a subshell,
-   * which hid `cd`, `export`, shell functions, and option changes from the
-   * outer shell. The tool's own description told the model these would
-   * persist, so agents ran workflows that silently broke.
-   *
-   * The fix uses a brace group `{ ...; }` instead, which runs the command
-   * in the current shell. Same scoping rules as a normal bash script, so
-   * `cd`/`export`/etc. persist as advertised.
-   */
   it("persists cd and export across commands (documented contract)", async () => {
     const shell = make();
     const mk = await shell.execute(
@@ -272,29 +161,16 @@ describe("PersistentShell — long-running stability", () => {
     expect(echo.stdout).toContain("hello");
   });
 
-  /**
-   * Timeout still reports the documented sentinel (124) and kills the
-   * command's descendants, even though the shell's wrapper completes
-   * cleanly after the kill.
-   */
   it("reports exit code 124 on timeout and kills descendants", async () => {
     const shell = make();
     const r = await shell.execute("sleep 30", 1);
     expect(r.exitCode).toBe(124);
 
-    // Shell must still be responsive.
     const after = await shell.execute("echo ok", 5);
     expect(after.exitCode).toBe(0);
     expect(after.stdout).toContain("ok");
   }, 10_000);
 
-  /**
-   * Smoke test: shell's happy-path timeout doesn't leak markers either.
-   * Useful as a second line of defense against marker leaks even though
-   * the real-world trigger (busy event loop, setTimeout fires before
-   * onStdoutData processes the exit-marker chunk) is covered by the
-   * dedicated `extractFallbackStdout` unit tests below.
-   */
   it("does not leak nonce markers on timeout", async () => {
     const shell = make();
     const r = await shell.execute(`printf 'hello\\n'; sleep 10`, 1);
@@ -316,24 +192,10 @@ describe("PersistentShell — long-running stability", () => {
     expect(r.stdout).not.toMatch(/__APEX_[0-9a-f]+___(CUTOVER|EXIT_)/);
   }, 10_000);
 
-  /**
-   * Streaming callback fires as output arrives, where the platform's
-   * `tail -f` actually flushes line-by-line. Requires effective
-   * `stdbuf -oL` on `/usr/bin/tail` (or equivalent), which means:
-   *
-   *   - Linux glibc + GNU coreutils: works.
-   *   - macOS under SIP: `DYLD_INSERT_LIBRARIES` is stripped from
-   *     `/usr/bin/tail`, so `stdbuf` is a silent no-op; `tail`
-   *     block-buffers its pipe and nothing flushes until we kill it.
-   *     Final stdout is still correct (guaranteed by the authoritative
-   *     post-kill `cat` phase), but live streaming is a known lossy UX
-   *     on darwin and agents do not rely on it. Skip there.
-   *   - Alpine / musl: BusyBox `tail` ignores `libstdbuf`; same result.
-   *
-   * The patch does not fix live streaming on these platforms — it only
-   * fixes final-stdout correctness. This test guards the live-streaming
-   * property on platforms that can deliver it.
-   */
+  // Live-streaming UX requires effective `stdbuf -oL` on tail. macOS/SIP
+  // strips DYLD_INSERT_LIBRARIES from /usr/bin/tail, and BusyBox tail ignores
+  // libstdbuf — final stdout is still correct (authoritative cat) but live
+  // streaming is lossy on those platforms, so skip there.
   it.skipIf(!HAS_STDBUF || process.platform === "darwin")(
     "streams stdout to onData as output arrives",
     async () => {
@@ -350,8 +212,6 @@ describe("PersistentShell — long-running stability", () => {
       expect(joined).toContain("line-a");
       expect(joined).toContain("line-b");
       expect(joined).toContain("line-c");
-      // The first chunk must arrive well before the last. If everything
-      // came in one block at the end, streaming is broken.
       const firstA = events.find((e) => e.text.includes("line-a"));
       const firstC = events.find((e) => e.text.includes("line-c"));
       expect(firstA).toBeDefined();
@@ -360,20 +220,6 @@ describe("PersistentShell — long-running stability", () => {
     },
   );
 
-  /**
-   * Repro #6 — Concurrent execute() calls cross-contaminate stdout.
-   *
-   * Two `execute()` calls fired in the same JS tick used to share
-   * `this.current` (last writer wins). Bash drained both wrappers serially
-   * but every byte on the stdout/stderr pipes routed to whichever pending
-   * was assigned last, so call A's wrapper output (including its CUTOVER
-   * and EXIT markers under A's nonce) ended up on call B's `streamedStdout`
-   * accumulator. The fallback extractor correctly refused to strip a
-   * foreign nonce and the markers leaked verbatim to the agent.
-   *
-   * Post-fix: each call takes a turn in the FIFO queue, so each pending
-   * receives only its own wrapper's bytes. See issue #645.
-   */
   it("does not cross-contaminate stdout across parallel execute() calls", async () => {
     const shell = make();
     const [a, b] = await Promise.all([
@@ -391,17 +237,6 @@ describe("PersistentShell — long-running stability", () => {
     expect(b.stdout).not.toMatch(/__APEX_[0-9a-f]+___(CUTOVER|EXIT_)/);
   }, 15_000);
 
-  /**
-   * Repro #7 — Concurrent execute() calls cross-contaminate stderr.
-   *
-   * Same race as the stdout test, but on the stderr pipe. The wrapper
-   * redirects user-command stderr to a tempfile and only flushes it after
-   * the cutover, but bash's own job-control messages (e.g. SIGTERM
-   * notifications, syntax errors) emit on bash's real stderr pipe — those
-   * route through `onStderrData`, which reads `this.current`. With two
-   * concurrent calls, those bytes bled onto whichever pending was last
-   * assigned. There's no marker on stderr at all, so the leak was silent.
-   */
   it("does not cross-contaminate stderr across parallel execute() calls", async () => {
     const shell = make();
     const [a, b] = await Promise.all([
@@ -416,16 +251,6 @@ describe("PersistentShell — long-running stability", () => {
     expect(b.stdout).toContain("apex-call-b-stdout");
   }, 15_000);
 
-  /**
-   * Repro #8 — Concurrent execute() with a timing-out sibling.
-   *
-   * The forensic case from NOCTURNE 004 step 4: a long-running command
-   * fired alongside a shorter one. Pre-fix, the timed-out command's
-   * SIGTERM/SIGKILL bash messages, CUTOVER marker, and EXIT_137 marker
-   * all leaked onto the sibling's buffers. Post-fix, the second call
-   * queues behind the first, so by the time it runs the timed-out
-   * command's wrapper has fully drained.
-   */
   it("isolates parallel-call timeouts (no marker or kill-message leakage)", async () => {
     const shell = make();
     const [timedOut, ok] = await Promise.all([
@@ -440,19 +265,11 @@ describe("PersistentShell — long-running stability", () => {
     expect(ok.stdout).toContain("apex-after-timeout");
     expect(ok.stdout).not.toMatch(/__APEX_[0-9a-f]+___(CUTOVER|EXIT_)/);
     expect(ok.stderr).not.toMatch(/__APEX_[0-9a-f]+___(CUTOVER|EXIT_)/);
-    // Bash's own job-control kill messages from the timed-out sibling must
-    // not show up on the surviving call's stderr.
+    // Bash's job-control kill messages from the timed-out sibling must not
+    // appear on the surviving call's stderr.
     expect(ok.stderr).not.toMatch(/Terminated|Killed/);
   }, 15_000);
 
-  /**
-   * Repro #9 — Queue preserves FIFO ordering.
-   *
-   * Pins against any regression to "queue exists but runs out of order"
-   * (e.g. switching to a Set-based ready set, awaiting the wrong promise,
-   * etc.). Each call resolves with its own command's output indexed in
-   * call order.
-   */
   it("preserves FIFO ordering for parallel execute() calls", async () => {
     const shell = make();
     const results = await Promise.all([
@@ -467,28 +284,13 @@ describe("PersistentShell — long-running stability", () => {
     for (const r of results) expect(r.exitCode).toBe(0);
   }, 15_000);
 
-  /**
-   * Repro #10 — Aborted-while-queued bails without running its own command.
-   *
-   * A queued call must wait its turn (single-shell FIFO is the design),
-   * but if the agent aborts before the turn arrives, the queued call
-   * should bail WITHOUT running its wrapped command in bash. Validates
-   * the post-await disposal/abort short-circuit.
-   *
-   * Setup: first command takes ~1s. Queued command, if it ran, would
-   * take ~5s. After abort the queued call must resolve close to the
-   * first call's completion time (waited for queue, then bailed) — not
-   * 5s+ later (waited for queue, then ran its own sleep) and not 0s
-   * (which would mean we jumped the queue, a design we explicitly
-   * rejected to preserve single-shell FIFO ordering).
-   */
   it("aborts a queued execute() without running its bash command", async () => {
     const shell = make();
     const ac = new AbortController();
 
     const first = shell.execute("sleep 1", 10);
-    // Fire the second call synchronously so it's queued behind the first,
-    // then abort before it gets a turn.
+    // Fire the second call synchronously so it queues, then abort before
+    // its turn arrives.
     const queued = shell.execute("sleep 5", 10, undefined, ac.signal);
     ac.abort();
 
@@ -498,25 +300,13 @@ describe("PersistentShell — long-running stability", () => {
 
     expect(queuedResult.exitCode).toBe(130);
     expect(queuedResult.stderr).toContain("aborted");
-    // Must not have run its own 5s sleep — aborted calls bail on turn
-    // arrival without writing to bash.
+    // Must not have run its own 5s sleep — aborted calls bail on turn arrival.
     expect(elapsed).toBeLessThan(3_000);
 
-    // First call should still complete normally, proving the queue
-    // didn't deadlock.
     const firstResult = await first;
     expect(firstResult.exitCode).toBe(0);
   }, 15_000);
 
-  /**
-   * Repro #5 — The cumulative "agent ran for a while" simulation.
-   *
-   * After many commands — some of which read stdin, some of which
-   * background processes without redirecting fd 1, some of which use
-   * pipelines that time out — a trivial `echo` should still come back
-   * within its timeout. This is the end-state the user described:
-   * "after some time commands will just hang and timeout".
-   */
   it("stays responsive after a mixed workload of 30 commands", async () => {
     const shell = make();
 
@@ -525,18 +315,14 @@ describe("PersistentShell — long-running stability", () => {
       expect(r.exitCode).toBe(0);
     }
 
-    // A couple of stdin-reading commands (get killed by timeout).
     for (let i = 0; i < 2; i++) {
       await shell.execute("cat", 2);
     }
 
-    // A background spammer.
     await shell.execute("while :; do echo s-$RANDOM; done &", 3);
 
-    // A timing-out pipeline.
     await shell.execute("sleep 10 | cat", 2);
 
-    // Final probe: trivial echo must succeed quickly.
     const start = Date.now();
     const final = await shell.execute("echo final", 5);
     const elapsed = Date.now() - start;
@@ -547,19 +333,6 @@ describe("PersistentShell — long-running stability", () => {
   }, 60_000);
 });
 
-/**
- * Direct unit tests for the fallback stdout extractor.
- *
- * The real-world failure (timeout or abort timer firing while Node is
- * too busy to have processed the shell's exit-marker chunk) is too
- * non-deterministic to force in an integration test — the shell's
- * post-kill wrapper finishes emitting markers in a couple hundred
- * milliseconds and almost always loses the race to the 2-second
- * fallback timer on an idle test runner. These tests exercise the
- * stripping logic directly on synthetic `PendingCommand` buffers that
- * match what Node would accumulate in the pathological cases actually
- * observed in NOCTURNE traces.
- */
 describe("extractFallbackStdout", () => {
   const cut = "__APEX_deadbeef00112233__CUTOVER";
   const exitPrefix = "__APEX_deadbeef00112233__EXIT_";
@@ -589,9 +362,6 @@ describe("extractFallbackStdout", () => {
   });
 
   it("strips both cutover prefix and exit-marker suffix from streamed buffer", () => {
-    // Shape observed in NOCTURNE trace step 2: command in fact completed
-    // successfully, shell emitted everything, but the fallback resolver
-    // fired before onStdoutData processed the chunk.
     const leaked =
       cut +
       "\n" +
@@ -611,8 +381,6 @@ describe("extractFallbackStdout", () => {
   });
 
   it("strips exit marker when cutover was never emitted (tail never flushed)", () => {
-    // Shape from NOCTURNE step 7: only the two markers came through,
-    // no actual stdout in between.
     const leaked = exitPrefix + "143\n";
     expect(extractFallbackStdout(mk(leaked))).toBe("(no output)");
   });
@@ -622,15 +390,12 @@ describe("extractFallbackStdout", () => {
   });
 
   it("returns raw buffer when neither marker present but bytes did stream", () => {
-    // Tail flushed some live bytes, then the shell/pipe died before
-    // either marker reached us. Caller still sees what tail managed.
     expect(extractFallbackStdout(mk("partial probe output\n"))).toBe(
       "partial probe output\n",
     );
   });
 
   it("handles cutover immediately followed by exit marker (empty command output)", () => {
-    // `cat $OUT` emitted zero bytes because $OUT was empty.
     const leaked = cut + "\n" + exitPrefix + "0\n";
     expect(extractFallbackStdout(mk(leaked))).toBe("(no output)");
   });

--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -361,6 +361,154 @@ describe("PersistentShell — long-running stability", () => {
   );
 
   /**
+   * Repro #6 — Concurrent execute() calls cross-contaminate stdout.
+   *
+   * Two `execute()` calls fired in the same JS tick used to share
+   * `this.current` (last writer wins). Bash drained both wrappers serially
+   * but every byte on the stdout/stderr pipes routed to whichever pending
+   * was assigned last, so call A's wrapper output (including its CUTOVER
+   * and EXIT markers under A's nonce) ended up on call B's `streamedStdout`
+   * accumulator. The fallback extractor correctly refused to strip a
+   * foreign nonce and the markers leaked verbatim to the agent.
+   *
+   * Post-fix: each call takes a turn in the FIFO queue, so each pending
+   * receives only its own wrapper's bytes. See issue #645.
+   */
+  it("does not cross-contaminate stdout across parallel execute() calls", async () => {
+    const shell = make();
+    const [a, b] = await Promise.all([
+      shell.execute("echo apex-call-a-output", 5),
+      shell.execute("echo apex-call-b-output", 5),
+    ]);
+
+    expect(a.exitCode).toBe(0);
+    expect(b.exitCode).toBe(0);
+    expect(a.stdout).toContain("apex-call-a-output");
+    expect(a.stdout).not.toContain("apex-call-b-output");
+    expect(b.stdout).toContain("apex-call-b-output");
+    expect(b.stdout).not.toContain("apex-call-a-output");
+    expect(a.stdout).not.toMatch(/__APEX_[0-9a-f]+___(CUTOVER|EXIT_)/);
+    expect(b.stdout).not.toMatch(/__APEX_[0-9a-f]+___(CUTOVER|EXIT_)/);
+  }, 15_000);
+
+  /**
+   * Repro #7 — Concurrent execute() calls cross-contaminate stderr.
+   *
+   * Same race as the stdout test, but on the stderr pipe. The wrapper
+   * redirects user-command stderr to a tempfile and only flushes it after
+   * the cutover, but bash's own job-control messages (e.g. SIGTERM
+   * notifications, syntax errors) emit on bash's real stderr pipe — those
+   * route through `onStderrData`, which reads `this.current`. With two
+   * concurrent calls, those bytes bled onto whichever pending was last
+   * assigned. There's no marker on stderr at all, so the leak was silent.
+   */
+  it("does not cross-contaminate stderr across parallel execute() calls", async () => {
+    const shell = make();
+    const [a, b] = await Promise.all([
+      shell.execute(">&2 echo apex-call-a-stderr", 5),
+      shell.execute("echo apex-call-b-stdout", 5),
+    ]);
+
+    expect(a.exitCode).toBe(0);
+    expect(b.exitCode).toBe(0);
+    expect(a.stderr).toContain("apex-call-a-stderr");
+    expect(b.stderr).not.toContain("apex-call-a-stderr");
+    expect(b.stdout).toContain("apex-call-b-stdout");
+  }, 15_000);
+
+  /**
+   * Repro #8 — Concurrent execute() with a timing-out sibling.
+   *
+   * The forensic case from NOCTURNE 004 step 4: a long-running command
+   * fired alongside a shorter one. Pre-fix, the timed-out command's
+   * SIGTERM/SIGKILL bash messages, CUTOVER marker, and EXIT_137 marker
+   * all leaked onto the sibling's buffers. Post-fix, the second call
+   * queues behind the first, so by the time it runs the timed-out
+   * command's wrapper has fully drained.
+   */
+  it("isolates parallel-call timeouts (no marker or kill-message leakage)", async () => {
+    const shell = make();
+    const [timedOut, ok] = await Promise.all([
+      shell.execute("sleep 30", 1),
+      shell.execute("echo apex-after-timeout", 5),
+    ]);
+
+    expect(timedOut.exitCode).toBe(124);
+    expect(timedOut.stdout).not.toMatch(/__APEX_[0-9a-f]+___(CUTOVER|EXIT_)/);
+
+    expect(ok.exitCode).toBe(0);
+    expect(ok.stdout).toContain("apex-after-timeout");
+    expect(ok.stdout).not.toMatch(/__APEX_[0-9a-f]+___(CUTOVER|EXIT_)/);
+    expect(ok.stderr).not.toMatch(/__APEX_[0-9a-f]+___(CUTOVER|EXIT_)/);
+    // Bash's own job-control kill messages from the timed-out sibling must
+    // not show up on the surviving call's stderr.
+    expect(ok.stderr).not.toMatch(/Terminated|Killed/);
+  }, 15_000);
+
+  /**
+   * Repro #9 — Queue preserves FIFO ordering.
+   *
+   * Pins against any regression to "queue exists but runs out of order"
+   * (e.g. switching to a Set-based ready set, awaiting the wrong promise,
+   * etc.). Each call resolves with its own command's output indexed in
+   * call order.
+   */
+  it("preserves FIFO ordering for parallel execute() calls", async () => {
+    const shell = make();
+    const results = await Promise.all([
+      shell.execute("echo 1", 5),
+      shell.execute("echo 2", 5),
+      shell.execute("echo 3", 5),
+    ]);
+
+    expect(results[0].stdout.trim()).toBe("1");
+    expect(results[1].stdout.trim()).toBe("2");
+    expect(results[2].stdout.trim()).toBe("3");
+    for (const r of results) expect(r.exitCode).toBe(0);
+  }, 15_000);
+
+  /**
+   * Repro #10 — Aborted-while-queued bails without running its own command.
+   *
+   * A queued call must wait its turn (single-shell FIFO is the design),
+   * but if the agent aborts before the turn arrives, the queued call
+   * should bail WITHOUT running its wrapped command in bash. Validates
+   * the post-await disposal/abort short-circuit.
+   *
+   * Setup: first command takes ~1s. Queued command, if it ran, would
+   * take ~5s. After abort the queued call must resolve close to the
+   * first call's completion time (waited for queue, then bailed) — not
+   * 5s+ later (waited for queue, then ran its own sleep) and not 0s
+   * (which would mean we jumped the queue, a design we explicitly
+   * rejected to preserve single-shell FIFO ordering).
+   */
+  it("aborts a queued execute() without running its bash command", async () => {
+    const shell = make();
+    const ac = new AbortController();
+
+    const first = shell.execute("sleep 1", 10);
+    // Fire the second call synchronously so it's queued behind the first,
+    // then abort before it gets a turn.
+    const queued = shell.execute("sleep 5", 10, undefined, ac.signal);
+    ac.abort();
+
+    const start = Date.now();
+    const queuedResult = await queued;
+    const elapsed = Date.now() - start;
+
+    expect(queuedResult.exitCode).toBe(130);
+    expect(queuedResult.stderr).toContain("aborted");
+    // Must not have run its own 5s sleep — aborted calls bail on turn
+    // arrival without writing to bash.
+    expect(elapsed).toBeLessThan(3_000);
+
+    // First call should still complete normally, proving the queue
+    // didn't deadlock.
+    const firstResult = await first;
+    expect(firstResult.exitCode).toBe(0);
+  }, 15_000);
+
+  /**
    * Repro #5 — The cumulative "agent ran for a while" simulation.
    *
    * After many commands — some of which read stdin, some of which

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -1,7 +1,6 @@
 import { spawn, spawnSync, type ChildProcess } from "child_process";
 import { randomBytes } from "crypto";
 
-/** Hard memory safety cap — prevents OOM on pathological output (5 MB). */
 const MAX_BUFFER = 5_000_000;
 
 export interface ShellExecuteResult {
@@ -11,78 +10,24 @@ export interface ShellExecuteResult {
 }
 
 interface PendingCommand {
-  /**
-   * Bytes observed on bash's stdout pipe BEFORE the cutover marker. These
-   * come from the background `tail -f` of the per-command tempfile and
-   * are best-effort live UX only — on platforms where `tail`'s pipe
-   * block-buffers (macOS under SIP even with `stdbuf`), this buffer may
-   * be partial or empty. Used for `onData` streaming and as a fallback
-   * if the command is killed before the authoritative phase starts.
-   */
+  // Raw bytes from `tail -f` of the per-command tempfile. Best-effort live UX
+  // only — may be partial/empty on platforms where tail block-buffers.
   streamedStdout: string;
-  /**
-   * Bytes observed AFTER the cutover marker. Emitted by `cat "$OUT"`
-   * through bash's real stdout pipe with no tail/libc intermediary, so
-   * this is the authoritative capture of the user command's stdout.
-   */
+  // Bytes from the post-cutover `cat`, the authoritative capture.
   authoritativeStdout: string;
-  /** True once we've seen the per-command cutover marker on the pipe. */
   cutoverSeen: boolean;
-  /** The cutover marker string for this command (per-command random). */
   cutoverMarker: string;
   stderr: string;
   stdoutTruncated: boolean;
   exitMarkerPrefix: string;
   onData?: (chunk: string) => void;
   resolve: (result: ShellExecuteResult) => void;
-  /**
-   * When non-null, overrides whatever exit code bash reports via the
-   * marker. Set by the timeout / abort paths so the caller always sees
-   * the documented sentinel (124 for timeout, 130 for abort) even when
-   * bash's wrapper ran to completion after our kill.
-   */
+  // When set, overrides bash's reported exit code with a sentinel
+  // (124 timeout, 130 abort) so callers see the documented value.
   forcedExitCode: number | null;
-  /** Extra stderr appended by abort/timeout paths. */
   forcedStderrSuffix: string | null;
 }
 
-/**
- * A long-lived bash process that persists across execute_command calls.
- *
- * Commands are sent to stdin and delimited with unique markers so the
- * caller can extract per-command stdout, stderr, and the exit code.
- * Background processes (`&`) survive between calls because the parent
- * shell never exits.
- *
- * Stability design notes:
- *
- *  - User commands are wrapped in a brace group `{ ...; }` (NOT a subshell)
- *    so that `cd`, `export`, shell functions, and aliases persist across
- *    calls as advertised.
- *  - The user command block has its stdin redirected from `/dev/null` so
- *    that children that read stdin (cat/ssh/sudo/python/mysql/read/…)
- *    cannot hijack the shared pipe that we use to send commands to bash.
- *  - A single persistent `data` listener is attached to the shell's
- *    stdout/stderr at spawn time. Between commands, incoming bytes (e.g.
- *    from backgrounded processes whose fd1 was not redirected) are
- *    actively drained into a discard buffer so the kernel pipe buffer
- *    never fills and blocks the shell.
- *  - On timeout / cancel we walk the process tree under the shell and
- *    SIGTERM → SIGKILL every descendant (not just direct children), so
- *    pipelines and grandchildren cannot be orphaned holding our pipe.
- */
-/**
- * Cached once: whether `stdbuf` is available. We use it to line-buffer
- * `tail -f` so command output streams to the caller in near-real-time
- * on platforms where it's effective (Linux glibc).
- *
- * Final stdout correctness does NOT depend on `stdbuf` — the wrapper
- * always emits a post-kill authoritative `cat` of the per-command
- * output tempfile through bash's real stdout pipe, so even when
- * `tail -f` block-buffers (macOS under SIP, Alpine, minimal containers)
- * and its buffer is discarded when we kill it, the caller still gets
- * the full output. `stdbuf` only affects live streaming UX quality.
- */
 let stdbufAvailable: boolean | null = null;
 function hasStdbuf(): boolean {
   if (stdbufAvailable !== null) return stdbufAvailable;
@@ -96,34 +41,13 @@ function hasStdbuf(): boolean {
 }
 
 /**
- * Produce a clean stdout string for the timeout / abort / close / cancel
- * fallback resolvers.
+ * Strip cutover/exit markers from a buffer for the timeout/abort/close/cancel
+ * fallback paths. The happy-path parser strips inline; if a fallback resolver
+ * fires before the parser saw the exit-marker chunk (busy event loop), the raw
+ * buffer can still contain markers that would otherwise leak to the agent.
  *
- * The happy-path handler (`onStdoutData`) parses the cutover and exit
- * markers as they arrive and only commits stripped bytes to
- * `authoritativeStdout`. When a fallback resolver fires first — because
- * the Node event loop was busy processing AI SDK streams / telemetry /
- * other tool calls while the shell's output was queued on the pipe, so
- * a timeout/abort timer got to run before `onStdoutData` processed the
- * chunk containing the exit marker — the candidate stdout is
- * `streamedStdout`, which is the raw bash pipe accumulator and may still
- * contain the per-command markers verbatim.
- *
- * Observed before this helper (NOCTURNE traces): commands that had in
- * fact completed successfully had their stdout leak as e.g.
- *   `__APEX_7e680629f7b4a78b__CUTOVER\n/debug -> HTTP 404\n...\n__APEX_7e680629f7b4a78b__EXIT_0\n`
- * to the agent as tool output, which the model interpreted as literal
- * strings in the target application's response.
- *
- * This function performs the same stripping the happy-path parser does,
- * so all four fallback paths produce the same shape of stdout a normal
- * completion would.
- *
- * Prefers `authoritativeStdout` when populated (happy path partially
- * ran) since those bytes are already stripped; otherwise parses the raw
- * `streamedStdout`. Exported for direct unit testing — the real-world
- * trigger requires a busy event loop which is hard to force in a
- * deterministic integration test.
+ * Prefers `authoritativeStdout` when populated (already partially stripped);
+ * otherwise parses `streamedStdout`. Exported for unit testing.
  */
 export function extractFallbackStdout(cmd: {
   authoritativeStdout: string;
@@ -156,6 +80,11 @@ export function extractFallbackStdout(cmd: {
   return s || "(no output)";
 }
 
+/**
+ * Long-lived bash process. Commands are sent to stdin and bracketed with
+ * unique markers so per-command stdout/stderr/exit can be extracted.
+ * Background processes (`&`) survive between calls.
+ */
 export class PersistentShell {
   private proc: ChildProcess | null = null;
   private alive = false;
@@ -163,19 +92,12 @@ export class PersistentShell {
   private readonly cwd?: string;
   private readonly extraEnv?: Record<string, string>;
 
-  /** Single pending command; null between `execute()` calls. */
   private current: PendingCommand | null = null;
-
-  /** Allows cancelCurrentCommand() to force-resolve the running execute(). */
   private pendingCancel: ((result: ShellExecuteResult) => void) | null = null;
 
-  /**
-   * Tail of the FIFO mutex chain used by `acquireTurn()`. Each `execute()`
-   * call snapshots this, installs a new tail, and awaits its snapshot —
-   * serializing all calls so concurrent ones in the same JS tick can no
-   * longer race on `this.current` and cross-contaminate stdout/stderr.
-   * See issue #645 for the forensic trace of the underlying bug.
-   */
+  // FIFO mutex tail. Each execute() call snapshots, installs a new tail, and
+  // awaits its snapshot — serializing concurrent calls so they can't race on
+  // `this.current` and cross-contaminate output.
   private writeChain: Promise<void> = Promise.resolve();
 
   constructor(opts?: { cwd?: string; env?: Record<string, string> }) {
@@ -192,8 +114,8 @@ export class PersistentShell {
     this.proc = spawn(shell, args, {
       stdio: ["pipe", "pipe", "pipe"],
       cwd: this.cwd,
-      // New session so child has no controlling terminal — prevents
-      // interactive programs from writing prompts to the TUI's TTY.
+      // New session so children have no controlling terminal — keeps
+      // interactive prompts off the TUI's TTY.
       detached: process.platform !== "win32",
       env: {
         PATH: process.env.PATH ?? "",
@@ -217,8 +139,6 @@ export class PersistentShell {
     this.proc.on("close", () => {
       this.alive = false;
       this.proc = null;
-      // If a command was pending, fail it fast rather than letting it
-      // wait out its timeout.
       const cmd = this.current;
       if (cmd) {
         this.current = null;
@@ -243,30 +163,6 @@ export class PersistentShell {
     }
   }
 
-  /**
-   * Single persistent stdout handler. Between commands (`current === null`)
-   * incoming bytes are silently dropped so background-process output does
-   * not fill the kernel pipe buffer and does not bleed into the next
-   * command's captured output.
-   *
-   * Each wrapped command emits, in order on bash's stdout pipe:
-   *   1. Best-effort live bytes from the background `tail -f` (may be
-   *      empty if the platform's tail block-buffers).
-   *   2. A per-command cutover marker emitted by `printf` after tail is
-   *      killed.
-   *   3. Authoritative bytes from `cat "$OUT"` through bash's own pipe
-   *      (no tail, no libc buffering) — this is the source of truth for
-   *      `result.stdout`.
-   *   4. The exit marker.
-   *
-   * We split the incoming stream at the cutover marker:
-   *   - Pre-cutover → fed to `onData` for live UX, buffered in
-   *     `streamedStdout` as a fallback for kill-before-cutover paths.
-   *   - Post-cutover → accumulated in `authoritativeStdout`; exit-marker
-   *     detection runs on this buffer, so user command output cannot
-   *     accidentally match the exit marker before the authoritative
-   *     phase has been bracketed.
-   */
   private onStdoutData(data: Buffer): void {
     const cmd = this.current;
     if (!cmd) return;
@@ -274,8 +170,7 @@ export class PersistentShell {
     let chunk = data.toString();
 
     if (!cmd.cutoverSeen) {
-      // Search the accumulated buffer, not just the new chunk, so a
-      // cutover marker that straddles two Buffer reads is still found.
+      // Search the accumulated buffer so a marker straddling two chunks is found.
       const prevLen = cmd.streamedStdout.length;
       cmd.streamedStdout += chunk;
       const cutIdx = cmd.streamedStdout.indexOf(cmd.cutoverMarker);
@@ -290,8 +185,8 @@ export class PersistentShell {
         return;
       }
 
-      // Feed only the pre-cutover bytes from THIS chunk to onData so we
-      // don't re-emit bytes that earlier chunks already delivered.
+      // Only feed pre-cutover bytes from THIS chunk to onData; earlier chunks
+      // already delivered their pre-cutover portion.
       const chunkCutOffset = cutIdx - prevLen;
       if (chunkCutOffset > 0 && cmd.onData) {
         cmd.onData(chunk.substring(0, chunkCutOffset));
@@ -380,8 +275,8 @@ export class PersistentShell {
 
     const release = await this.acquireTurn();
     try {
-      // A queued call can wait minutes; re-validate runtime state after the
-      // wait so disposal or abort during the queue doesn't consume bash time.
+      // Re-validate after the queue wait — disposal/abort may have happened
+      // while we were queued.
       if (this.disposed) {
         return { stdout: "", stderr: "Shell has been disposed", exitCode: 1 };
       }
@@ -441,8 +336,6 @@ export class PersistentShell {
             killEscalationTimer = setTimeout(() => {
               if (resolved) return;
               killDescendants(proc.pid, "SIGKILL");
-              // Fallback: if bash didn't emit a marker within another
-              // 2 seconds (shell wedged), resolve with whatever we have.
               setTimeout(() => {
                 if (resolved) return;
                 pending.resolve({
@@ -463,15 +356,10 @@ export class PersistentShell {
           timeoutTimer = setTimeout(() => {
             if (resolved) return;
             pending.forcedExitCode = 124;
-            // Kill every descendant of the shell, not just direct children:
-            // pipelines and nested subshells are grandchildren and `pkill -P`
-            // would leak them.
             killDescendants(proc.pid, "SIGTERM");
             killEscalationTimer = setTimeout(() => {
               if (resolved) return;
               killDescendants(proc.pid, "SIGKILL");
-              // Fallback: if bash didn't emit a marker within another
-              // 2 seconds (shell wedged), resolve with whatever we have.
               setTimeout(() => {
                 if (resolved) return;
                 pending.resolve({
@@ -485,40 +373,13 @@ export class PersistentShell {
         }
 
         // Wrap command:
-        //   - brace group `{ ...; }` (NOT a subshell) so `cd`, `export`,
-        //     shell functions, aliases, and option changes persist;
-        //   - stdin redirected from `/dev/null` so children that read stdin
-        //     cannot hijack our command pipe;
-        //   - stdout captured to a per-command tempfile (NOT bash's stdout
-        //     pipe) and streamed back via a background `tail -f` for live
-        //     UX. This prevents backgrounded children whose fd 1 was never
-        //     redirected (`nmap -v &`) from bleeding their output into the
-        //     next command's captured stdout, because their inherited fd 1
-        //     is the tempfile for the command that spawned them, not the
-        //     shell's stdout pipe;
-        //   - stderr captured to another tempfile and flushed after, so we
-        //     can distinguish stdout from stderr without interleaving;
-        //   - after the user command finishes we kill the tail, then emit
-        //     a per-command cutover marker on bash's real stdout pipe, then
-        //     `cat` the stdout tempfile. The post-cutover `cat` bytes are
-        //     authoritative: they pass through bash's pipe with no tail /
-        //     libc block-buffering intermediary. The Node handler treats
-        //     pre-cutover bytes as live-UX streaming only and post-cutover
-        //     bytes as the authoritative capture returned in the result.
-        //     This is required because `tail`'s stdout is a pipe and
-        //     block-buffered by libc; on platforms where `stdbuf` is a
-        //     no-op (macOS under SIP, Alpine, minimal containers without
-        //     coreutils) the buffered bytes would be discarded when we
-        //     kill tail, silently losing all stdout for small commands;
-        //   - the exit marker is echoed on bash's real stdout pipe, so the
-        //     parent Node handler always sees it immediately regardless of
-        //     how much command output the cat has left to flush.
-        // When `stdbuf` is available and effective (GNU coreutils on glibc
-        // Linux), a fast-polling `stdbuf -oL tail -n +1 -f -s 0.05` is run
-        // in the background so live streaming latency is well under 100 ms
-        // per chunk. Elsewhere the tail still runs (in case it happens to
-        // flush) but the authoritative cat guarantees correctness either
-        // way.
+        //   - brace group `{ ...; }` (NOT a subshell) so cd/export/aliases persist;
+        //   - stdin from /dev/null so children can't hijack our command pipe;
+        //   - stdout/stderr to per-command tempfiles, streamed live via `tail -f`;
+        //   - after the command, kill tail, emit a cutover marker on bash's real
+        //     stdout, then `cat` the tempfile. Post-cutover bytes are
+        //     authoritative — they bypass tail's libc block-buffering, which is
+        //     a no-op `stdbuf` can't fix on macOS/SIP, Alpine, etc.
         const tailCmd = hasStdbuf()
           ? `stdbuf -oL tail -n +1 -f -s 0.05 "$__APEX_OUT"`
           : `tail -n +1 -f -s 0.05 "$__APEX_OUT"`;
@@ -532,8 +393,6 @@ export class PersistentShell {
           `sleep 0.1`,
           `kill "$__APEX_TAIL" 2>/dev/null`,
           `wait "$__APEX_TAIL" 2>/dev/null`,
-          // Authoritative cutover: post-marker bytes come through bash's
-          // real stdout pipe via `cat`, bypassing any tail/libc buffering.
           `printf '%s\\n' "${cutoverMarker}"`,
           `cat "$__APEX_OUT"`,
           `cat "$__APEX_ERR" >&2`,
@@ -553,10 +412,6 @@ export class PersistentShell {
         }
       });
     } catch (e) {
-      // Synchronous throws between `acquireTurn()` and resolver installation
-      // (e.g. `child_process.spawn` rejecting bad args, `randomBytes`
-      // exhausting entropy) land here so `finally` still releases the turn
-      // and the queue can't deadlock.
       return {
         stdout: "",
         stderr: e instanceof Error ? e.message : String(e),
@@ -567,12 +422,6 @@ export class PersistentShell {
     }
   }
 
-  /**
-   * Take the next slot in the FIFO mutex chain. Returns a release function
-   * that the caller must invoke (typically in `finally`) to free the next
-   * queued caller. Promise resolution is idempotent, so double-release is a
-   * no-op.
-   */
   private async acquireTurn(): Promise<() => void> {
     const myTurn = this.writeChain;
     let release!: () => void;
@@ -583,10 +432,6 @@ export class PersistentShell {
     return release;
   }
 
-  /**
-   * Cancel the currently running command without killing the shell.
-   * Returns true if a command was running and was cancelled.
-   */
   cancelCurrentCommand(): boolean {
     const cmd = this.current;
     if (!cmd || !this.proc) return false;
@@ -600,7 +445,6 @@ export class PersistentShell {
       killDescendants(this.proc.pid, "SIGTERM");
       setTimeout(() => {
         if (this.proc?.pid) killDescendants(this.proc.pid, "SIGKILL");
-        // Fallback resolve if bash's wrapper never emits a marker.
         setTimeout(() => {
           cmd.resolve({
             stdout: extractFallbackStdout(cmd),
@@ -634,13 +478,12 @@ export class PersistentShell {
       const p = this.proc;
       const pid = p.pid;
       setTimeout(() => {
-        // Kill the entire process group (detached session) so all
-        // child processes are cleaned up, not just the shell itself.
+        // Kill the whole process group so detached children die too.
         if (pid && process.platform !== "win32") {
           try {
             process.kill(-pid, "SIGTERM");
           } catch {
-            // group may already be gone
+            // already gone
           }
         }
         try {
@@ -653,7 +496,7 @@ export class PersistentShell {
             try {
               process.kill(-pid, "SIGKILL");
             } catch {
-              // group may already be gone
+              // already gone
             }
           }
           try {
@@ -671,11 +514,10 @@ export class PersistentShell {
 }
 
 /**
- * Walk the process tree under `rootPid` and send `signal` to every
- * descendant (deepest first). Does NOT signal `rootPid` itself — that's
- * the persistent shell we want to keep alive. Used instead of
- * `pkill -P <pid>`, which only hits direct children and so leaks
- * pipeline stages / grandchildren of timed-out commands.
+ * Walk the process tree under `rootPid` and signal every descendant
+ * (deepest first). Does NOT signal `rootPid` — that's the persistent shell.
+ * Used instead of `pkill -P` which only hits direct children and leaks
+ * pipeline grandchildren.
  */
 function killDescendants(
   rootPid: number | undefined,
@@ -700,12 +542,11 @@ function killDescendants(
         }
       }
     } catch {
-      // pgrep not available; nothing we can do
+      // pgrep not available
     }
   }
 
-  // Signal leaves first so intermediate processes don't see a dead child
-  // and exit before we get to their siblings.
+  // Leaves first so intermediates don't exit before we reach their siblings.
   for (let i = toKill.length - 1; i >= 0; i--) {
     try {
       process.kill(toKill[i], signal);

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -170,18 +170,11 @@ export class PersistentShell {
   private pendingCancel: ((result: ShellExecuteResult) => void) | null = null;
 
   /**
-   * FIFO queue for `execute()` calls. Each call awaits the previous tail of
-   * the chain before assigning `this.current`, so concurrent calls in the
-   * same JS tick can no longer race on a shared pending pointer and
-   * cross-contaminate stdout/stderr.
-   *
-   * Without this, two `execute()` calls in the same microtask both reach
-   * `this.current = pending` synchronously — last writer wins — and bash's
-   * stdout/stderr handlers (which read `this.current` per chunk) pin both
-   * wrappers' bytes onto the second pending. The first pending returns
-   * `(no output)`; the second leaks the first's wrapper markers and bash
-   * job-control stderr (e.g. SIGTERM messages for processes it didn't
-   * spawn). See issue #645 for the full forensic trace.
+   * Tail of the FIFO mutex chain used by `acquireTurn()`. Each `execute()`
+   * call snapshots this, installs a new tail, and awaits its snapshot —
+   * serializing all calls so concurrent ones in the same JS tick can no
+   * longer race on `this.current` and cross-contaminate stdout/stderr.
+   * See issue #645 for the forensic trace of the underlying bug.
    */
   private writeChain: Promise<void> = Promise.resolve();
 
@@ -381,71 +374,39 @@ export class PersistentShell {
     if (this.disposed) {
       return { stdout: "", stderr: "Shell has been disposed", exitCode: 1 };
     }
-
     if (abortSignal?.aborted) {
-      return {
-        stdout: "",
-        stderr: "Command aborted",
-        exitCode: 130,
-      };
-    }
-
-    // Take a turn in the FIFO queue. Concurrent calls in the same JS tick
-    // would otherwise both reach `this.current = pending` synchronously
-    // and cross-contaminate stdout/stderr (issue #645). Each call snapshots
-    // the current chain tail, installs a new tail, and waits for the
-    // previous tail to resolve. `releaseTurn` is called from
-    // `pending.resolve` (wrapped below) so every completion path — happy,
-    // timeout, abort, close, cancel, write-error — frees the next caller.
-    const myTurn = this.writeChain;
-    let releaseTurn!: () => void;
-    let turnReleased = false;
-    this.writeChain = new Promise<void>((res) => {
-      releaseTurn = () => {
-        if (turnReleased) return;
-        turnReleased = true;
-        res();
-      };
-    });
-    await myTurn;
-
-    // A queued call can wait minutes; re-validate runtime state after the
-    // wait so disposal or abort during the queue doesn't consume bash time.
-    if (this.disposed) {
-      releaseTurn();
-      return { stdout: "", stderr: "Shell has been disposed", exitCode: 1 };
-    }
-    if (abortSignal?.aborted) {
-      releaseTurn();
       return { stdout: "", stderr: "Command aborted", exitCode: 130 };
     }
 
-    this.ensureAlive();
+    const release = await this.acquireTurn();
+    try {
+      // A queued call can wait minutes; re-validate runtime state after the
+      // wait so disposal or abort during the queue doesn't consume bash time.
+      if (this.disposed) {
+        return { stdout: "", stderr: "Shell has been disposed", exitCode: 1 };
+      }
+      if (abortSignal?.aborted) {
+        return { stdout: "", stderr: "Command aborted", exitCode: 130 };
+      }
 
-    const proc = this.proc;
-    if (!proc || !proc.stdin || !proc.stdout || !proc.stderr) {
-      releaseTurn();
-      return { stdout: "", stderr: "Failed to spawn shell", exitCode: 1 };
-    }
+      this.ensureAlive();
 
-    return new Promise<ShellExecuteResult>((resolve) => {
-      let resolved = false;
-      let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
-      let killEscalationTimer: ReturnType<typeof setTimeout> | undefined;
-      let abortCleanup: (() => void) | undefined;
-      // Allocate the per-command markers inside the Promise body so any
-      // throw during construction (e.g. exhausted entropy on `randomBytes`)
-      // is caught by the outer try/catch below and the queue turn is
-      // released — without this, a throw between `await myTurn` and the
-      // installation of `pending.resolve` would deadlock the shell.
-      let pending: PendingCommand | null = null;
+      const proc = this.proc;
+      if (!proc || !proc.stdin || !proc.stdout || !proc.stderr) {
+        return { stdout: "", stderr: "Failed to spawn shell", exitCode: 1 };
+      }
 
-      try {
+      return await new Promise<ShellExecuteResult>((resolve) => {
+        let resolved = false;
+        let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+        let killEscalationTimer: ReturnType<typeof setTimeout> | undefined;
+        let abortCleanup: (() => void) | undefined;
+
         const marker = `__APEX_${randomBytes(8).toString("hex")}__`;
         const exitMarkerPrefix = `${marker}_EXIT_`;
         const cutoverMarker = `${marker}_CUTOVER`;
 
-        pending = {
+        const pending: PendingCommand = {
           streamedStdout: "",
           authoritativeStdout: "",
           cutoverSeen: false,
@@ -462,10 +423,6 @@ export class PersistentShell {
             if (timeoutTimer) clearTimeout(timeoutTimer);
             if (killEscalationTimer) clearTimeout(killEscalationTimer);
             if (abortCleanup) abortCleanup();
-            // Release the queue turn before resolving so the next queued
-            // execute() can assign `this.current` in the same tick the
-            // caller observes the result.
-            releaseTurn();
             resolve(result);
           },
         };
@@ -474,11 +431,12 @@ export class PersistentShell {
         this.pendingCancel = pending.resolve;
 
         if (abortSignal) {
-          const p = pending;
           const onAbort = () => {
             if (resolved) return;
-            p.forcedExitCode = 130;
-            p.forcedStderrSuffix = p.stderr ? "\n(aborted)" : "(aborted)";
+            pending.forcedExitCode = 130;
+            pending.forcedStderrSuffix = pending.stderr
+              ? "\n(aborted)"
+              : "(aborted)";
             killDescendants(proc.pid, "SIGTERM");
             killEscalationTimer = setTimeout(() => {
               if (resolved) return;
@@ -487,9 +445,10 @@ export class PersistentShell {
               // 2 seconds (shell wedged), resolve with whatever we have.
               setTimeout(() => {
                 if (resolved) return;
-                p.resolve({
-                  stdout: extractFallbackStdout(p),
-                  stderr: (p.stderr || "") + (p.forcedStderrSuffix ?? ""),
+                pending.resolve({
+                  stdout: extractFallbackStdout(pending),
+                  stderr:
+                    (pending.stderr || "") + (pending.forcedStderrSuffix ?? ""),
                   exitCode: 130,
                 });
               }, 2_000);
@@ -501,10 +460,9 @@ export class PersistentShell {
         }
 
         if (timeoutSeconds != null && timeoutSeconds > 0) {
-          const p = pending;
           timeoutTimer = setTimeout(() => {
             if (resolved) return;
-            p.forcedExitCode = 124;
+            pending.forcedExitCode = 124;
             // Kill every descendant of the shell, not just direct children:
             // pipelines and nested subshells are grandchildren and `pkill -P`
             // would leak them.
@@ -516,9 +474,9 @@ export class PersistentShell {
               // 2 seconds (shell wedged), resolve with whatever we have.
               setTimeout(() => {
                 if (resolved) return;
-                p.resolve({
-                  stdout: extractFallbackStdout(p),
-                  stderr: p.stderr || "",
+                pending.resolve({
+                  stdout: extractFallbackStdout(pending),
+                  stderr: pending.stderr || "",
                   exitCode: 124,
                 });
               }, 2_000);
@@ -593,28 +551,36 @@ export class PersistentShell {
             exitCode: 1,
           });
         }
-      } catch (e) {
-        // Defense in depth: if anything between `await myTurn` and
-        // installation of `pending.resolve` threw, the wrapped resolver
-        // never ran and the queue turn would leak, deadlocking subsequent
-        // execute() calls. Catch, release the turn directly, and surface
-        // the error to the caller.
-        if (pending) {
-          pending.resolve({
-            stdout: "",
-            stderr: e instanceof Error ? e.message : String(e),
-            exitCode: 1,
-          });
-        } else {
-          releaseTurn();
-          resolve({
-            stdout: "",
-            stderr: e instanceof Error ? e.message : String(e),
-            exitCode: 1,
-          });
-        }
-      }
+      });
+    } catch (e) {
+      // Synchronous throws between `acquireTurn()` and resolver installation
+      // (e.g. `child_process.spawn` rejecting bad args, `randomBytes`
+      // exhausting entropy) land here so `finally` still releases the turn
+      // and the queue can't deadlock.
+      return {
+        stdout: "",
+        stderr: e instanceof Error ? e.message : String(e),
+        exitCode: 1,
+      };
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Take the next slot in the FIFO mutex chain. Returns a release function
+   * that the caller must invoke (typically in `finally`) to free the next
+   * queued caller. Promise resolution is idempotent, so double-release is a
+   * no-op.
+   */
+  private async acquireTurn(): Promise<() => void> {
+    const myTurn = this.writeChain;
+    let release!: () => void;
+    this.writeChain = new Promise<void>((res) => {
+      release = res;
     });
+    await myTurn;
+    return release;
   }
 
   /**

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -169,6 +169,22 @@ export class PersistentShell {
   /** Allows cancelCurrentCommand() to force-resolve the running execute(). */
   private pendingCancel: ((result: ShellExecuteResult) => void) | null = null;
 
+  /**
+   * FIFO queue for `execute()` calls. Each call awaits the previous tail of
+   * the chain before assigning `this.current`, so concurrent calls in the
+   * same JS tick can no longer race on a shared pending pointer and
+   * cross-contaminate stdout/stderr.
+   *
+   * Without this, two `execute()` calls in the same microtask both reach
+   * `this.current = pending` synchronously — last writer wins — and bash's
+   * stdout/stderr handlers (which read `this.current` per chunk) pin both
+   * wrappers' bytes onto the second pending. The first pending returns
+   * `(no output)`; the second leaks the first's wrapper markers and bash
+   * job-control stderr (e.g. SIGTERM messages for processes it didn't
+   * spawn). See issue #645 for the full forensic trace.
+   */
+  private writeChain: Promise<void> = Promise.resolve();
+
   constructor(opts?: { cwd?: string; env?: Record<string, string> }) {
     this.cwd = opts?.cwd;
     this.extraEnv = opts?.env;
@@ -374,166 +390,229 @@ export class PersistentShell {
       };
     }
 
+    // Take a turn in the FIFO queue. Concurrent calls in the same JS tick
+    // would otherwise both reach `this.current = pending` synchronously
+    // and cross-contaminate stdout/stderr (issue #645). Each call snapshots
+    // the current chain tail, installs a new tail, and waits for the
+    // previous tail to resolve. `releaseTurn` is called from
+    // `pending.resolve` (wrapped below) so every completion path — happy,
+    // timeout, abort, close, cancel, write-error — frees the next caller.
+    const myTurn = this.writeChain;
+    let releaseTurn!: () => void;
+    let turnReleased = false;
+    this.writeChain = new Promise<void>((res) => {
+      releaseTurn = () => {
+        if (turnReleased) return;
+        turnReleased = true;
+        res();
+      };
+    });
+    await myTurn;
+
+    // A queued call can wait minutes; re-validate runtime state after the
+    // wait so disposal or abort during the queue doesn't consume bash time.
+    if (this.disposed) {
+      releaseTurn();
+      return { stdout: "", stderr: "Shell has been disposed", exitCode: 1 };
+    }
+    if (abortSignal?.aborted) {
+      releaseTurn();
+      return { stdout: "", stderr: "Command aborted", exitCode: 130 };
+    }
+
     this.ensureAlive();
 
     const proc = this.proc;
     if (!proc || !proc.stdin || !proc.stdout || !proc.stderr) {
+      releaseTurn();
       return { stdout: "", stderr: "Failed to spawn shell", exitCode: 1 };
     }
-
-    const marker = `__APEX_${randomBytes(8).toString("hex")}__`;
-    const exitMarkerPrefix = `${marker}_EXIT_`;
-    const cutoverMarker = `${marker}_CUTOVER`;
 
     return new Promise<ShellExecuteResult>((resolve) => {
       let resolved = false;
       let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
       let killEscalationTimer: ReturnType<typeof setTimeout> | undefined;
-
-      const pending: PendingCommand = {
-        streamedStdout: "",
-        authoritativeStdout: "",
-        cutoverSeen: false,
-        cutoverMarker,
-        stderr: "",
-        stdoutTruncated: false,
-        exitMarkerPrefix,
-        onData,
-        forcedExitCode: null,
-        forcedStderrSuffix: null,
-        resolve: (result) => {
-          if (resolved) return;
-          resolved = true;
-          if (timeoutTimer) clearTimeout(timeoutTimer);
-          if (killEscalationTimer) clearTimeout(killEscalationTimer);
-          if (abortCleanup) abortCleanup();
-          resolve(result);
-        },
-      };
-
-      this.current = pending;
-      this.pendingCancel = pending.resolve;
-
       let abortCleanup: (() => void) | undefined;
-      if (abortSignal) {
-        const onAbort = () => {
-          if (resolved) return;
-          pending.forcedExitCode = 130;
-          pending.forcedStderrSuffix = pending.stderr
-            ? "\n(aborted)"
-            : "(aborted)";
-          killDescendants(proc.pid, "SIGTERM");
-          killEscalationTimer = setTimeout(() => {
-            if (resolved) return;
-            killDescendants(proc.pid, "SIGKILL");
-            // Fallback: if bash didn't emit a marker within another
-            // 2 seconds (shell wedged), resolve with whatever we have.
-            setTimeout(() => {
-              if (resolved) return;
-              pending.resolve({
-                stdout: extractFallbackStdout(pending),
-                stderr:
-                  (pending.stderr || "") + (pending.forcedStderrSuffix ?? ""),
-                exitCode: 130,
-              });
-            }, 2_000);
-          }, 500);
-        };
-        abortSignal.addEventListener("abort", onAbort, { once: true });
-        abortCleanup = () => abortSignal.removeEventListener("abort", onAbort);
-      }
-
-      if (timeoutSeconds != null && timeoutSeconds > 0) {
-        timeoutTimer = setTimeout(() => {
-          if (resolved) return;
-          pending.forcedExitCode = 124;
-          // Kill every descendant of the shell, not just direct children:
-          // pipelines and nested subshells are grandchildren and `pkill -P`
-          // would leak them.
-          killDescendants(proc.pid, "SIGTERM");
-          killEscalationTimer = setTimeout(() => {
-            if (resolved) return;
-            killDescendants(proc.pid, "SIGKILL");
-            // Fallback: if bash didn't emit a marker within another
-            // 2 seconds (shell wedged), resolve with whatever we have.
-            setTimeout(() => {
-              if (resolved) return;
-              pending.resolve({
-                stdout: extractFallbackStdout(pending),
-                stderr: pending.stderr || "",
-                exitCode: 124,
-              });
-            }, 2_000);
-          }, 500);
-        }, timeoutSeconds * 1_000);
-      }
-
-      // Wrap command:
-      //   - brace group `{ ...; }` (NOT a subshell) so `cd`, `export`,
-      //     shell functions, aliases, and option changes persist;
-      //   - stdin redirected from `/dev/null` so children that read stdin
-      //     cannot hijack our command pipe;
-      //   - stdout captured to a per-command tempfile (NOT bash's stdout
-      //     pipe) and streamed back via a background `tail -f` for live
-      //     UX. This prevents backgrounded children whose fd 1 was never
-      //     redirected (`nmap -v &`) from bleeding their output into the
-      //     next command's captured stdout, because their inherited fd 1
-      //     is the tempfile for the command that spawned them, not the
-      //     shell's stdout pipe;
-      //   - stderr captured to another tempfile and flushed after, so we
-      //     can distinguish stdout from stderr without interleaving;
-      //   - after the user command finishes we kill the tail, then emit
-      //     a per-command cutover marker on bash's real stdout pipe, then
-      //     `cat` the stdout tempfile. The post-cutover `cat` bytes are
-      //     authoritative: they pass through bash's pipe with no tail /
-      //     libc block-buffering intermediary. The Node handler treats
-      //     pre-cutover bytes as live-UX streaming only and post-cutover
-      //     bytes as the authoritative capture returned in the result.
-      //     This is required because `tail`'s stdout is a pipe and
-      //     block-buffered by libc; on platforms where `stdbuf` is a
-      //     no-op (macOS under SIP, Alpine, minimal containers without
-      //     coreutils) the buffered bytes would be discarded when we
-      //     kill tail, silently losing all stdout for small commands;
-      //   - the exit marker is echoed on bash's real stdout pipe, so the
-      //     parent Node handler always sees it immediately regardless of
-      //     how much command output the cat has left to flush.
-      // When `stdbuf` is available and effective (GNU coreutils on glibc
-      // Linux), a fast-polling `stdbuf -oL tail -n +1 -f -s 0.05` is run
-      // in the background so live streaming latency is well under 100 ms
-      // per chunk. Elsewhere the tail still runs (in case it happens to
-      // flush) but the authoritative cat guarantees correctness either
-      // way.
-      const tailCmd = hasStdbuf()
-        ? `stdbuf -oL tail -n +1 -f -s 0.05 "$__APEX_OUT"`
-        : `tail -n +1 -f -s 0.05 "$__APEX_OUT"`;
-      const wrapped = [
-        `__APEX_OUT=$(mktemp 2>/dev/null || echo /tmp/.apex_out_$$)`,
-        `__APEX_ERR=$(mktemp 2>/dev/null || echo /tmp/.apex_err_$$)`,
-        `${tailCmd} 2>/dev/null &`,
-        `__APEX_TAIL=$!`,
-        `{ ${command}\n} </dev/null >"$__APEX_OUT" 2>"$__APEX_ERR"`,
-        `__APEX_EC=$?`,
-        `sleep 0.1`,
-        `kill "$__APEX_TAIL" 2>/dev/null`,
-        `wait "$__APEX_TAIL" 2>/dev/null`,
-        // Authoritative cutover: post-marker bytes come through bash's
-        // real stdout pipe via `cat`, bypassing any tail/libc buffering.
-        `printf '%s\\n' "${cutoverMarker}"`,
-        `cat "$__APEX_OUT"`,
-        `cat "$__APEX_ERR" >&2`,
-        `rm -f "$__APEX_OUT" "$__APEX_ERR"`,
-        `echo "${exitMarkerPrefix}$__APEX_EC"`,
-        ``,
-      ].join("\n");
+      // Allocate the per-command markers inside the Promise body so any
+      // throw during construction (e.g. exhausted entropy on `randomBytes`)
+      // is caught by the outer try/catch below and the queue turn is
+      // released — without this, a throw between `await myTurn` and the
+      // installation of `pending.resolve` would deadlock the shell.
+      let pending: PendingCommand | null = null;
 
       try {
-        proc.stdin!.write(wrapped);
-      } catch {
-        pending.resolve({
-          stdout: "",
-          stderr: "Failed to write to shell stdin",
-          exitCode: 1,
-        });
+        const marker = `__APEX_${randomBytes(8).toString("hex")}__`;
+        const exitMarkerPrefix = `${marker}_EXIT_`;
+        const cutoverMarker = `${marker}_CUTOVER`;
+
+        pending = {
+          streamedStdout: "",
+          authoritativeStdout: "",
+          cutoverSeen: false,
+          cutoverMarker,
+          stderr: "",
+          stdoutTruncated: false,
+          exitMarkerPrefix,
+          onData,
+          forcedExitCode: null,
+          forcedStderrSuffix: null,
+          resolve: (result) => {
+            if (resolved) return;
+            resolved = true;
+            if (timeoutTimer) clearTimeout(timeoutTimer);
+            if (killEscalationTimer) clearTimeout(killEscalationTimer);
+            if (abortCleanup) abortCleanup();
+            // Release the queue turn before resolving so the next queued
+            // execute() can assign `this.current` in the same tick the
+            // caller observes the result.
+            releaseTurn();
+            resolve(result);
+          },
+        };
+
+        this.current = pending;
+        this.pendingCancel = pending.resolve;
+
+        if (abortSignal) {
+          const p = pending;
+          const onAbort = () => {
+            if (resolved) return;
+            p.forcedExitCode = 130;
+            p.forcedStderrSuffix = p.stderr ? "\n(aborted)" : "(aborted)";
+            killDescendants(proc.pid, "SIGTERM");
+            killEscalationTimer = setTimeout(() => {
+              if (resolved) return;
+              killDescendants(proc.pid, "SIGKILL");
+              // Fallback: if bash didn't emit a marker within another
+              // 2 seconds (shell wedged), resolve with whatever we have.
+              setTimeout(() => {
+                if (resolved) return;
+                p.resolve({
+                  stdout: extractFallbackStdout(p),
+                  stderr: (p.stderr || "") + (p.forcedStderrSuffix ?? ""),
+                  exitCode: 130,
+                });
+              }, 2_000);
+            }, 500);
+          };
+          abortSignal.addEventListener("abort", onAbort, { once: true });
+          abortCleanup = () =>
+            abortSignal.removeEventListener("abort", onAbort);
+        }
+
+        if (timeoutSeconds != null && timeoutSeconds > 0) {
+          const p = pending;
+          timeoutTimer = setTimeout(() => {
+            if (resolved) return;
+            p.forcedExitCode = 124;
+            // Kill every descendant of the shell, not just direct children:
+            // pipelines and nested subshells are grandchildren and `pkill -P`
+            // would leak them.
+            killDescendants(proc.pid, "SIGTERM");
+            killEscalationTimer = setTimeout(() => {
+              if (resolved) return;
+              killDescendants(proc.pid, "SIGKILL");
+              // Fallback: if bash didn't emit a marker within another
+              // 2 seconds (shell wedged), resolve with whatever we have.
+              setTimeout(() => {
+                if (resolved) return;
+                p.resolve({
+                  stdout: extractFallbackStdout(p),
+                  stderr: p.stderr || "",
+                  exitCode: 124,
+                });
+              }, 2_000);
+            }, 500);
+          }, timeoutSeconds * 1_000);
+        }
+
+        // Wrap command:
+        //   - brace group `{ ...; }` (NOT a subshell) so `cd`, `export`,
+        //     shell functions, aliases, and option changes persist;
+        //   - stdin redirected from `/dev/null` so children that read stdin
+        //     cannot hijack our command pipe;
+        //   - stdout captured to a per-command tempfile (NOT bash's stdout
+        //     pipe) and streamed back via a background `tail -f` for live
+        //     UX. This prevents backgrounded children whose fd 1 was never
+        //     redirected (`nmap -v &`) from bleeding their output into the
+        //     next command's captured stdout, because their inherited fd 1
+        //     is the tempfile for the command that spawned them, not the
+        //     shell's stdout pipe;
+        //   - stderr captured to another tempfile and flushed after, so we
+        //     can distinguish stdout from stderr without interleaving;
+        //   - after the user command finishes we kill the tail, then emit
+        //     a per-command cutover marker on bash's real stdout pipe, then
+        //     `cat` the stdout tempfile. The post-cutover `cat` bytes are
+        //     authoritative: they pass through bash's pipe with no tail /
+        //     libc block-buffering intermediary. The Node handler treats
+        //     pre-cutover bytes as live-UX streaming only and post-cutover
+        //     bytes as the authoritative capture returned in the result.
+        //     This is required because `tail`'s stdout is a pipe and
+        //     block-buffered by libc; on platforms where `stdbuf` is a
+        //     no-op (macOS under SIP, Alpine, minimal containers without
+        //     coreutils) the buffered bytes would be discarded when we
+        //     kill tail, silently losing all stdout for small commands;
+        //   - the exit marker is echoed on bash's real stdout pipe, so the
+        //     parent Node handler always sees it immediately regardless of
+        //     how much command output the cat has left to flush.
+        // When `stdbuf` is available and effective (GNU coreutils on glibc
+        // Linux), a fast-polling `stdbuf -oL tail -n +1 -f -s 0.05` is run
+        // in the background so live streaming latency is well under 100 ms
+        // per chunk. Elsewhere the tail still runs (in case it happens to
+        // flush) but the authoritative cat guarantees correctness either
+        // way.
+        const tailCmd = hasStdbuf()
+          ? `stdbuf -oL tail -n +1 -f -s 0.05 "$__APEX_OUT"`
+          : `tail -n +1 -f -s 0.05 "$__APEX_OUT"`;
+        const wrapped = [
+          `__APEX_OUT=$(mktemp 2>/dev/null || echo /tmp/.apex_out_$$)`,
+          `__APEX_ERR=$(mktemp 2>/dev/null || echo /tmp/.apex_err_$$)`,
+          `${tailCmd} 2>/dev/null &`,
+          `__APEX_TAIL=$!`,
+          `{ ${command}\n} </dev/null >"$__APEX_OUT" 2>"$__APEX_ERR"`,
+          `__APEX_EC=$?`,
+          `sleep 0.1`,
+          `kill "$__APEX_TAIL" 2>/dev/null`,
+          `wait "$__APEX_TAIL" 2>/dev/null`,
+          // Authoritative cutover: post-marker bytes come through bash's
+          // real stdout pipe via `cat`, bypassing any tail/libc buffering.
+          `printf '%s\\n' "${cutoverMarker}"`,
+          `cat "$__APEX_OUT"`,
+          `cat "$__APEX_ERR" >&2`,
+          `rm -f "$__APEX_OUT" "$__APEX_ERR"`,
+          `echo "${exitMarkerPrefix}$__APEX_EC"`,
+          ``,
+        ].join("\n");
+
+        try {
+          proc.stdin!.write(wrapped);
+        } catch {
+          pending.resolve({
+            stdout: "",
+            stderr: "Failed to write to shell stdin",
+            exitCode: 1,
+          });
+        }
+      } catch (e) {
+        // Defense in depth: if anything between `await myTurn` and
+        // installation of `pending.resolve` threw, the wrapped resolver
+        // never ran and the queue turn would leak, deadlocking subsequent
+        // execute() calls. Catch, release the turn directly, and surface
+        // the error to the caller.
+        if (pending) {
+          pending.resolve({
+            stdout: "",
+            stderr: e instanceof Error ? e.message : String(e),
+            exitCode: 1,
+          });
+        } else {
+          releaseTurn();
+          resolve({
+            stdout: "",
+            stderr: e instanceof Error ? e.message : String(e),
+            exitCode: 1,
+          });
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary

Fixes #645. Adds a per-shell FIFO promise-chain mutex around `PersistentShell.execute()` so concurrent calls in the same JS tick can no longer race on `this.current` and cross-contaminate stdout/stderr.

## Root cause

`execute()` runs synchronously up to `return new Promise(...)` and inside that body assigns `this.current = pending` and writes its wrapper to bash's stdin. Two concurrent calls both reach the assignment in the same microtask — last writer wins. Bash drains stdin serially (wrapper A then B) but bytes on both pipes route to whichever pending is currently `this.current`, i.e. pendingB for *both* wrappers' output. PendingA returns ` (no output)`; pendingB leaks A's CUTOVER/EXIT markers (under A's nonce, so the marker-stripper from #640 correctly refuses to touch it) and A's bash job-control stderr.

NOCTURNE 004 step 4 (attack-surface-agent) confirmed the cross-contamination forensically. 84% of ` execute_command` steps in that trace issued 2+ parallel calls — every one a roll of the dice. The marker leak was visible (~1.4% of calls); the stderr leak is silent because there's no marker token on stderr at all.

## Fix

A `writeChain: Promise<void>` field threads a FIFO queue through `execute()`. Each call snapshots the chain tail, installs a new tail, awaits the previous, runs its body, and releases the tail from `pending.resolve` (which already covers all 6 completion paths: happy, timeout, abort, close, cancel, write-error).

Three refinements over the issue's sketch:

- **Re-validate disposal/abort after the queue wait.** A queued call can wait minutes; if the agent aborts mid-queue, it bails when its turn comes without consuming bash time.
- **Defensive try/catch around the post-await body.** If anything throws between `await myTurn` and `pending.resolve` being installed (e.g. `randomBytes` entropy exhaustion), `releaseTurn()` still runs and the queue doesn't deadlock.
- **Timer setup happens after `await myTurn`.** A user-supplied timeout now bounds *execution* time, not *queue time + execution time*.

The `extractFallbackStdout` helper from #640 stays — it's still useful as a safety net for the event-loop-starvation case it was originally designed for, even though cross-nonce contamination is now structurally impossible.

## Behavioral change

Parallel ` execute_command` calls from the agent become **serial** through a shared shell. Invisible to the model (each tool callback still resolves independently). Multi-shell parallelism was considered and rejected because it breaks the `cd`/`export`/alias persistence semantics that motivate `PersistentShell` in the first place.

## Tests

5 new regression tests in `persistentShell.test.ts`:

1. Parallel echoes do not cross-contaminate stdout (no foreign-nonce markers, no foreign output).
2. Parallel calls do not cross-contaminate stderr.
3. Parallel-call timeout isolation — timed-out call's SIGTERM/SIGKILL bash messages and CUTOVER/EXIT_137 markers do not leak to the surviving call.
4. FIFO queue ordering preserved across `Promise.all([echo 1, echo 2, echo 3])`.
5. Aborted-while-queued bails when its turn comes without running its bash command (validates refinement (a)).

All 14 pre-existing tests in the file still pass (26 passed, 1 skipped — the macOS-skipped streaming test).

## Verification

- `bun run test src/core/agents/offSecAgent/tools/persistentShell.test.ts` — 26 passed, 1 skipped.
- `bun run lint` — clean.
- `bun run format:check` — clean.
- `bun run tsc` — clean.
- Full `bun run test` — 791 passed, 16 skipped, 2 pre-existing AI-API-key-required failures unrelated to this change (also failing on canary).

## Test plan (post-merge / pre-merge human-driven)

- [ ] Manual TUI smoke: run a few ` execute_command` calls including a forced parallel batch, confirm normal behavior.
- [ ] NOCTURNE re-run: verify zero `__APEX_<nonce>__` strings in any tool result across all parallel-call steps. This is the durable acceptance criterion that a future regression would trip on.
- [ ] Spot-check stderr on a parallel-timeout step: confirm the surviving call's stderr does not contain ` Terminated` / `Killed` messages from the sibling.

## Related

- #640 — silent stdout-loss + own-nonce marker leak fix (lands first; covers the single-command event-loop-starvation case). #645 covers cross-command leaks. Both layers are needed.
- #636 — earlier `cat`-only fallback for missing `stdbuf` (predecessor work).
- #625 — stdin-hijack fix (sibling `PersistentShell` correctness work).

## Forensic citation

NOCTURNE 004, attack-surface-agent step 4: call A `toolu_013gEBbqhmGpnRSqMJo9kYCt` (find wordlists, 10s timeout), call B `toolu_011teCwm4UHUs9t4SV1G8E9o` (curl Flask paths, 120s timeout). B's stdout contained A's CUTOVER + EXIT_137 markers under A's nonce; B's stderr contained the SIGTERM/SIGKILL messages for A's four `find` processes (B never spawned a `find`).


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new queuing/mutex mechanism in `PersistentShell.execute()` that changes concurrency behavior and affects command timing/abort/timeout semantics, so regressions could impact agent command execution under load.
> 
> **Overview**
> Fixes a race in `PersistentShell.execute()` where concurrent calls could overwrite `this.current` and cause **stdout/stderr/marker leakage between commands**.
> 
> Adds a per-shell **FIFO promise-chain mutex** (`writeChain` + `acquireTurn`) so parallel `execute()` calls are serialized; queued calls re-check `disposed`/`abortSignal` after waiting, and timeouts now measure *execution time* rather than queue+execution.
> 
> Expands `persistentShell.test.ts` with new parallelism regression coverage (stdout/stderr isolation, timeout isolation, FIFO ordering, and abort-while-queued), while keeping existing long-running stability tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05ed022d9451a5ecfb607373bf6ee8dc6e0d2df9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Post-fix verification: NOCTURNE 005

Re-ran NOCTURNE on `fix/645-persistent-shell-serialize-execute`. The race condition was actually exercised by real agent traffic, and the durable acceptance criteria all hold.

### Acceptance criteria

| Criterion                                                                         | Result                                                  |
| --------------------------------------------------------------------------------- | ------------------------------------------------------- |
| Zero `__APEX_<nonce>__` strings in any tool result                                | **0 hits** across all 54 `execute_command` observations |
| Zero `EXIT_137` / `EXIT_143` markers (the specific shapes leaked in NOCTURNE 004) | **0 hits**                                              |
| Zero cross-stderr contamination from sibling kill messages                        | **0 hits** (1 self-kill, correctly attributed — below)  |

### Was the race actually exercised?

Yes. Concurrent calls were issued 16 times, including 3 triple-parallel steps:

```
total step records            = 70
steps containing exec_cmd     = 35
total exec_cmd observations   = 54
parallel-call distribution    = [(0, 35), (1, 19), (2, 13), (3, 3)]
steps with 2+ parallel exec   = 16  (46% of exec-steps)
max parallelism observed      = 3
```

Compared to the NOCTURNE 004 baseline cited in the issue (84% parallel, 1.4% visible marker-leak rate, plus systemic silent stderr contamination), this run is lower-density on parallelism but still exercised the contended code path 16 times. Zero leaks across all 16.

### The one bash kill-message in the trace is self-attribution

Step 14, `attack-surface-agent`, n=2 parallel:

- **Call A** (`toolu_01FRVhH2JAfZFR6EMpU3faZm`, curl method matrix on `/artifacts`): success, 4023 chars of clean stdout, **empty stderr**, no markers.
- **Call B** (`toolu_01TfKCE9t5yAMaJSV3dpyMLN`, `gobuster dir`): timed out at the 180s wrapper timeout. Its stderr contains:
  ```
  bash: line 537: 90229 Terminated: 15  gobuster dir -u "https://..." ...
  ```
  PID 90229 is running the same `gobuster` command whose text is in Call B's own `command` field — bash's job-control notice for **Call B's own process being killed because Call B itself timed out**. Pre-fix, this message would have race-routed to whichever pending was `this.current` when bash printed it; post-fix it's structurally pinned to the call that owns the killed process. Call A correctly received nothing.

  (Self-stderr-on-self-timeout is a separate, much smaller cosmetic issue — bash job-control prints to its real stderr pipe, bypassing the wrapper's `2>"$__APEX_ERR"` redirection. Not what #645 was about; out of scope for this PR.)

### Other failures are all explainable

5 non-success `execute_command` results across 54 calls (9.3%):

- 3 **scope violations** — agent tried to access disallowed targets; the policy layer rejected the command before it ran. Empty stdout is by design.
- 1 **self-timeout** (the gobuster above).
- 1 **exit code 1** — generic non-zero exit, no contamination signature.

None are shell-level bugs.

### Analysis caveats

- Trace observations store a 2000-char `outputPreview` (16 of 54 results were longer and got truncated). Marker leaks always appear at the *start* of the result (the wrapper emits CUTOVER first, and `extractFallbackStdout` returns them at the beginning when it can't strip), so the preview catches every known leak shape.
- Lower parallelism density than NOCTURNE 004 (46% vs 84%). Worth re-checking on any higher-density trace from a follow-up run, but this run is a strong positive signal on its own.
- No `extractFallbackStdout` fallback paths fired in this trace — agent saw clean output across the board.

**Net:** zero markers, zero EXIT_137/143, zero cross-stderr contamination across 16 parallel-call steps. Acceptance criteria met. Marking ready for review.
