### PR TITLE
fix(offsec-agent): rename response tool input field to avoid name collision

### DIFF
--- a/src/core/agents/offSecAgent/tools/response.ts
+++ b/src/core/agents/offSecAgent/tools/response.ts
@@ -17,10 +17,10 @@ export function createResponseTool(
   return tool({
     description: `Submit your final structured response. Call this ONCE when you have completed your task and assembled all results. This ends your run — make sure all data is included.`,
     inputSchema: z.object({
-      response: responseSchema,
+      result: responseSchema,
     }),
-    execute: async ({ response }) => {
-      onResult(response);
+    execute: async ({ result }) => {
+      onResult(result);
       return { success: true, message: "Response submitted." };
     },
   });


### PR DESCRIPTION
Renames the `response` tool's inner input field from `response` → `result` so it no longer collides with the tool's own name. The collision was making Haiku 4.5 occasionally emit `{"response":{"response":{...}}}` instead of `{"response":{...}}`, which Zod rejected after the model had already streamed the full ~50KB tool input. Callers pass the schema, not the wrapper, so no other code changes.

Closes #666

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized API-shape change to a single tool input; main risk is breaking any external prompts/tests that still send `response` instead of `result`.
> 
> **Overview**
> Updates the offsec agent’s `response` tool contract so the tool input object uses `result` instead of `response`, and wires `execute` to pass `result` through to `onResult`.
> 
> This avoids occasional name-collision behavior where models emit an extra `response.response` wrapper that fails Zod validation, without changing how callers provide the response schema or how the captured result is consumed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c17ea23b6ffcb601fc5b630c91e8dc83848243e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->