### PR TITLE
test(ai): bump deprecated claude-3-haiku to claude-haiku-4-5

### DIFF
--- a/src/core/ai/ai.test.ts
+++ b/src/core/ai/ai.test.ts
@@ -12,7 +12,7 @@ describeOrSkip("AI Stream Response", () => {
     console.log("\n=== Testing Basic Stream Response ===\n");
 
     const stream = streamResponse({
-      model: "claude-3-haiku-20240307",
+      model: "claude-haiku-4-5",
       system: "You are a helpful assistant.",
       prompt: "Say hello and explain what you can do in one sentence.",
     });
@@ -245,7 +245,7 @@ describeOrSkip("AI Stream Response", () => {
     let toolExecuted = false;
 
     const stream = streamResponse({
-      model: "claude-3-haiku-20240307",
+      model: "claude-haiku-4-5",
       system:
         "You are a test assistant. You must use the test_tool with these EXACT parameters: {wrongField: 'test', invalidNumber: 'not a number', missingEmail: true}. Do NOT try to fix or validate the parameters yourself - just use them exactly as given.",
       prompt:


### PR DESCRIPTION
## Summary

- Two live-API tests in `src/core/ai/ai.test.ts` (`should stream a basic response`, `should repair tool calls with incorrect parameters`) pinned to `claude-3-haiku-20240307`, which Anthropic deprecated. Locally with `ANTHROPIC_API_KEY` set they failed; CI stayed green because the whole `describeOrSkip` block is gated on `hasApiKeys`.
- Bump both call sites to `claude-haiku-4-5`, matching the convention already used in `src/tests/auth.test.ts`, `src/tests/attackSurface.test.ts`, and `src/core/api/attackSurface.test.ts`.
- Two-line diff. Failures reproduced identically on plain `canary`/`main`, so this is unrelated to any in-flight PR.

## Test plan

- [x] `bun run lint`
- [x] `bun run tsc`
- [x] `bun run test src/core/ai/ai.test.ts` with no API keys set — both tests skipped (CI parity).
- [x] `ANTHROPIC_API_KEY=… bun run test src/core/ai/ai.test.ts` — both tests pass against the live API; tool-call repair path verified end-to-end (model emits the deliberately-broken args from the system prompt → repair fires → retry lands valid `{name, age, email}` → tool executes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only model identifier updates; no runtime behavior changes outside live API test execution.
> 
> **Overview**
> Updates `src/core/ai/ai.test.ts` to run the two live-stream Anthropic tests against `claude-haiku-4-5` instead of the deprecated `claude-3-haiku-20240307`.
> 
> This is a test-only change intended to restore local runs when API keys are present; no production AI logic is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14ed6ddc7dff51ae5a3285d13594a310cbfdf25d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->