### PR TITLE
fix: correct all broken internal links in docs

### DIFF
--- a/fern/docs/cli/auth.mdx
+++ b/fern/docs/cli/auth.mdx
@@ -5,7 +5,7 @@ description: "Connect to Pensar Console from the command line"
 
 ## Overview
 
-The `pensar login` command connects your CLI to [Pensar Console](https://console.pensar.dev) for managed inference. This is the headless equivalent of the TUI [`/login`](/apex/commands/auth) command — it uses the same device authorization flow but runs entirely in the terminal without the TUI.
+The `pensar login` command connects your CLI to [Pensar Console](https://console.pensar.dev) for managed inference. This is the headless equivalent of the TUI [`/login`](/apex/tui-slash-commands/login) command — it uses the same device authorization flow but runs entirely in the terminal without the TUI.
 
 <Note>
   The `pensar auth` command still works as an alias for backward compatibility, but `pensar login` is now the primary command name.
@@ -66,10 +66,10 @@ Clears stored authentication tokens from your local configuration. You can recon
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/login" icon="shield-check" href="/apex/commands/auth">
+  <Card title="/login" icon="shield-check" href="/apex/tui-slash-commands/login">
     Connect via the TUI with the same device flow
   </Card>
-  <Card title="pensar projects" icon="folder" href="/apex/cli/projects">
+  <Card title="pensar projects" icon="folder" href="/apex/cli-commands/pensar-projects">
     List workspace projects (requires login)
   </Card>
 </CardGroup>

--- a/fern/docs/cli/doctor.mdx
+++ b/fern/docs/cli/doctor.mdx
@@ -61,10 +61,10 @@ AI Providers
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="pensar upgrade" icon="arrow-up" href="/apex/cli/upgrade">
+  <Card title="pensar upgrade" icon="arrow-up" href="/apex/cli-commands/pensar-upgrade">
     Update to the latest version
   </Card>
-  <Card title="/providers" icon="plug" href="/apex/commands/providers">
+  <Card title="/providers" icon="plug" href="/apex/tui-slash-commands/providers">
     Configure AI providers in the TUI
   </Card>
 </CardGroup>

--- a/fern/docs/cli/fixes.mdx
+++ b/fern/docs/cli/fixes.mdx
@@ -16,7 +16,7 @@ pensar fixes get <fixId>       # Get fix details (includes diff)
 
 ## Prerequisites
 
-You must be connected to Pensar Console via [`pensar login`](/apex/cli/auth) before using this command.
+You must be connected to Pensar Console via [`pensar login`](/apex/cli-commands/pensar-login) before using this command.
 
 ## Subcommands
 
@@ -49,10 +49,10 @@ pensar fixes get fix_jkl012
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="pensar issues" icon="bug" href="/apex/cli/issues">
+  <Card title="pensar issues" icon="bug" href="/apex/cli-commands/pensar-issues">
     List and manage the issues that fixes address
   </Card>
-  <Card title="pensar logs" icon="scroll" href="/apex/cli/logs">
+  <Card title="pensar logs" icon="scroll" href="/apex/cli-commands/pensar-logs">
     View agent execution logs for debugging
   </Card>
 </CardGroup>

--- a/fern/docs/cli/issues.mdx
+++ b/fern/docs/cli/issues.mdx
@@ -17,7 +17,7 @@ pensar issues update <issueId> [options]       # Update an issue
 
 ## Prerequisites
 
-You must be connected to Pensar Console via [`pensar login`](/apex/cli/auth) before using this command.
+You must be connected to Pensar Console via [`pensar login`](/apex/cli-commands/pensar-login) before using this command.
 
 ## Subcommands
 
@@ -77,10 +77,10 @@ pensar issues update issue_ghi789 --false-positive --fp-reason "Test environment
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="pensar fixes" icon="wrench" href="/apex/cli/fixes">
+  <Card title="pensar fixes" icon="wrench" href="/apex/cli-commands/pensar-fixes">
     View suggested fixes for an issue
   </Card>
-  <Card title="pensar logs" icon="scroll" href="/apex/cli/logs">
+  <Card title="pensar logs" icon="scroll" href="/apex/cli-commands/pensar-logs">
     View agent execution logs for an issue
   </Card>
 </CardGroup>

--- a/fern/docs/cli/logs.mdx
+++ b/fern/docs/cli/logs.mdx
@@ -16,7 +16,7 @@ pensar logs search <issueId> <query> [options]  # Search agent logs
 
 ## Prerequisites
 
-You must be connected to Pensar Console via [`pensar login`](/apex/cli/auth) before using this command.
+You must be connected to Pensar Console via [`pensar login`](/apex/cli-commands/pensar-login) before using this command.
 
 ## Subcommands
 
@@ -70,10 +70,10 @@ pensar logs search issue_ghi789 "timeout" --level warn --context 5
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="pensar issues" icon="bug" href="/apex/cli/issues">
+  <Card title="pensar issues" icon="bug" href="/apex/cli-commands/pensar-issues">
     View the issues these logs relate to
   </Card>
-  <Card title="pensar fixes" icon="wrench" href="/apex/cli/fixes">
+  <Card title="pensar fixes" icon="wrench" href="/apex/cli-commands/pensar-fixes">
     View suggested fixes for issues
   </Card>
 </CardGroup>

--- a/fern/docs/cli/pentest.mdx
+++ b/fern/docs/cli/pentest.mdx
@@ -93,7 +93,7 @@ Report:    /home/user/.pensar/sessions/.../report.md
 
 ## Default Model
 
-When `--model` is not provided, Apex uses the default model for your highest-priority configured provider. See [`pensar models`](/apex/commands/models#default-model-per-provider) for the priority order.
+When `--model` is not provided, Apex uses the default model for your highest-priority configured provider. See [`pensar models`](/apex/tui-slash-commands/models#default-model-per-provider) for the priority order.
 
 <Callout intent="warning">
   **Authorization Required**: Only test systems you own or have explicit authorization to test.
@@ -102,10 +102,10 @@ When `--model` is not provided, Apex uses the default model for your highest-pri
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="pensar targeted-pentest" icon="crosshairs" href="/apex/cli/targeted-pentest">
+  <Card title="pensar targeted-pentest" icon="crosshairs" href="/apex/cli-commands/pensar-targeted-pentest">
     Run a focused pentest with specific objectives
   </Card>
-  <Card title="/pentest" icon="play" href="/apex/commands/pentest">
+  <Card title="/pentest" icon="play" href="/apex/tui-slash-commands/pentest">
     Launch a pentest from the TUI with an interactive wizard
   </Card>
 </CardGroup>

--- a/fern/docs/cli/pentests.mdx
+++ b/fern/docs/cli/pentests.mdx
@@ -17,7 +17,7 @@ pensar pentests dispatch <projectId> [options]   # Dispatch a new pentest
 
 ## Prerequisites
 
-You must be connected to Pensar Console via [`pensar login`](/apex/cli/auth) before using this command.
+You must be connected to Pensar Console via [`pensar login`](/apex/cli-commands/pensar-login) before using this command.
 
 ## Subcommands
 
@@ -69,10 +69,10 @@ pensar pentests dispatch proj_abc123 --branch main --level full
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="pensar projects" icon="folder" href="/apex/cli/projects">
+  <Card title="pensar projects" icon="folder" href="/apex/cli-commands/pensar-projects">
     List workspace projects to find project IDs
   </Card>
-  <Card title="pensar issues" icon="bug" href="/apex/cli/issues">
+  <Card title="pensar issues" icon="bug" href="/apex/cli-commands/pensar-issues">
     View security issues found by pentests
   </Card>
 </CardGroup>

--- a/fern/docs/cli/projects.mdx
+++ b/fern/docs/cli/projects.mdx
@@ -15,7 +15,7 @@ pensar projects
 
 ## Prerequisites
 
-You must be connected to Pensar Console via [`pensar login`](/apex/cli/auth) before using this command.
+You must be connected to Pensar Console via [`pensar login`](/apex/cli-commands/pensar-login) before using this command.
 
 ## Output
 
@@ -41,10 +41,10 @@ Returns a JSON array of project objects:
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="pensar pentests" icon="shield-check" href="/apex/cli/pentests">
+  <Card title="pensar pentests" icon="shield-check" href="/apex/cli-commands/pensar-pentests">
     List and manage pentests for a project
   </Card>
-  <Card title="pensar issues" icon="bug" href="/apex/cli/issues">
+  <Card title="pensar issues" icon="bug" href="/apex/cli-commands/pensar-issues">
     List and manage security issues for a project
   </Card>
 </CardGroup>

--- a/fern/docs/cli/targeted-pentest.mdx
+++ b/fern/docs/cli/targeted-pentest.mdx
@@ -74,10 +74,10 @@ Use `pensar targeted-pentest` when you:
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="pensar pentest" icon="play" href="/apex/cli/pentest">
+  <Card title="pensar pentest" icon="play" href="/apex/cli-commands/pensar-pentest">
     Run a broad autonomous pentest
   </Card>
-  <Card title="/operator" icon="terminal" href="/apex/commands/operator">
+  <Card title="/operator" icon="terminal" href="/apex/tui-slash-commands/operator">
     Interactive testing with step-by-step control
   </Card>
 </CardGroup>

--- a/fern/docs/cli/threat-model.mdx
+++ b/fern/docs/cli/threat-model.mdx
@@ -67,15 +67,15 @@ Threat model written to: ./threat-model.md
 
 ## Default Model
 
-When `--model` is not provided, Apex uses the default model for your highest-priority configured provider. See [`pensar models`](/apex/commands/models#default-model-per-provider) for the priority order.
+When `--model` is not provided, Apex uses the default model for your highest-priority configured provider. See [`pensar models`](/apex/tui-slash-commands/models#default-model-per-provider) for the priority order.
 
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/threat-model" icon="shield-halved" href="/apex/commands/threat-model">
+  <Card title="/threat-model" icon="shield-halved" href="/apex/tui-slash-commands/threat-model">
     Generate a threat model from the TUI
   </Card>
-  <Card title="pensar pentest" icon="play" href="/apex/cli/pentest">
+  <Card title="pensar pentest" icon="play" href="/apex/cli-commands/pensar-pentest">
     Run a full autonomous pentest from the CLI
   </Card>
 </CardGroup>

--- a/fern/docs/cli/uninstall.mdx
+++ b/fern/docs/cli/uninstall.mdx
@@ -83,10 +83,10 @@ Removing pensar...
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="pensar upgrade" icon="arrow-up" href="/apex/cli/upgrade">
+  <Card title="pensar upgrade" icon="arrow-up" href="/apex/cli-commands/pensar-upgrade">
     Update instead of uninstalling
   </Card>
-  <Card title="pensar doctor" icon="stethoscope" href="/apex/cli/doctor">
+  <Card title="pensar doctor" icon="stethoscope" href="/apex/cli-commands/pensar-doctor">
     Diagnose issues before deciding to uninstall
   </Card>
 </CardGroup>

--- a/fern/docs/cli/upgrade.mdx
+++ b/fern/docs/cli/upgrade.mdx
@@ -35,10 +35,10 @@ Updated to v0.0.113
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="pensar doctor" icon="stethoscope" href="/apex/cli/doctor">
+  <Card title="pensar doctor" icon="stethoscope" href="/apex/cli-commands/pensar-doctor">
     Check dependencies and system health
   </Card>
-  <Card title="pensar version" icon="tag" href="/apex/cli/version">
+  <Card title="pensar version" icon="tag" href="/apex/cli-commands/pensar-version">
     Show your current version
   </Card>
 </CardGroup>

--- a/fern/docs/cli/version.mdx
+++ b/fern/docs/cli/version.mdx
@@ -25,10 +25,10 @@ v0.0.112
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="pensar upgrade" icon="arrow-up" href="/apex/cli/upgrade">
+  <Card title="pensar upgrade" icon="arrow-up" href="/apex/cli-commands/pensar-upgrade">
     Update to the latest version
   </Card>
-  <Card title="pensar doctor" icon="stethoscope" href="/apex/cli/doctor">
+  <Card title="pensar doctor" icon="stethoscope" href="/apex/cli-commands/pensar-doctor">
     Check system health and dependencies
   </Card>
 </CardGroup>

--- a/fern/docs/commands/auth.mdx
+++ b/fern/docs/commands/auth.mdx
@@ -169,16 +169,16 @@ If your Pensar Console session has truly expired (access token expired and no va
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/credits" icon="credit-card" href="/apex/commands/credits">
+  <Card title="/credits" icon="credit-card" href="/apex/tui-slash-commands/credits">
     Check your credit balance or open the purchase page.
   </Card>
-  <Card title="/providers" icon="plug" href="/apex/commands/providers">
+  <Card title="/providers" icon="plug" href="/apex/tui-slash-commands/providers">
     Configure API keys for direct provider access (alternative to managed inference).
   </Card>
-  <Card title="/models" icon="microchip" href="/apex/commands/models">
+  <Card title="/models" icon="microchip" href="/apex/tui-slash-commands/models">
     Select which AI model to use for testing.
   </Card>
-  <Card title="/pentest" icon="play" href="/apex/commands/pentest">
+  <Card title="/pentest" icon="play" href="/apex/tui-slash-commands/pentest">
     Launch a penetration test after connecting.
   </Card>
 </CardGroup>

--- a/fern/docs/commands/config.mdx
+++ b/fern/docs/commands/config.mdx
@@ -30,16 +30,16 @@ Apex stores all configuration at `~/.pensar/config.json`. This includes:
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/providers" icon="plug" href="/apex/commands/providers">
+  <Card title="/providers" icon="plug" href="/apex/tui-slash-commands/providers">
     Configure AI provider API keys
   </Card>
-  <Card title="/models" icon="microchip" href="/apex/commands/models">
+  <Card title="/models" icon="microchip" href="/apex/tui-slash-commands/models">
     Select AI model
   </Card>
-  <Card title="/themes" icon="palette" href="/apex/commands/themes">
+  <Card title="/themes" icon="palette" href="/apex/tui-slash-commands/themes">
     Customize visual appearance
   </Card>
-  <Card title="/login" icon="shield-check" href="/apex/commands/auth">
+  <Card title="/login" icon="shield-check" href="/apex/tui-slash-commands/login">
     Connect to Pensar Console
   </Card>
 </CardGroup>

--- a/fern/docs/commands/create-skill.mdx
+++ b/fern/docs/commands/create-skill.mdx
@@ -54,10 +54,10 @@ The AI agent will follow the instructions defined in the skill, applying them to
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/operator" icon="terminal" href="/apex/commands/operator">
+  <Card title="/operator" icon="terminal" href="/apex/tui-slash-commands/operator">
     Start an operator session to use skills
   </Card>
-  <Card title="/help" icon="circle-question" href="/apex/commands/help">
+  <Card title="/help" icon="circle-question" href="/apex/tui-slash-commands/help">
     View all available commands including dynamic skills
   </Card>
 </CardGroup>

--- a/fern/docs/commands/credits.mdx
+++ b/fern/docs/commands/credits.mdx
@@ -17,7 +17,7 @@ Alias: `/buy`
 
 ## Prerequisites
 
-You must be connected to Pensar Console via the [`/login`](/apex/commands/auth) command before using `/credits`. If you're not authenticated, Apex will prompt you to connect first.
+You must be connected to Pensar Console via the [`/login`](/apex/tui-slash-commands/login) command before using `/credits`. If you're not authenticated, Apex will prompt you to connect first.
 
 ## What You'll See
 
@@ -58,7 +58,7 @@ Credits are a **pre-paid balance** (denominated in USD) stored at the workspace 
 
 <AccordionGroup>
   <Accordion title="'Not authenticated' error">
-    Run [`/login`](/apex/commands/auth) first to connect Apex to your Console workspace.
+    Run [`/login`](/apex/tui-slash-commands/login) first to connect Apex to your Console workspace.
   </Accordion>
 
   <Accordion title="Balance shows $0.00">
@@ -73,13 +73,13 @@ Credits are a **pre-paid balance** (denominated in USD) stored at the workspace 
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/login" icon="shield-check" href="/apex/commands/auth">
+  <Card title="/login" icon="shield-check" href="/apex/tui-slash-commands/login">
     Connect to Pensar Console for managed inference.
   </Card>
-  <Card title="/providers" icon="plug" href="/apex/commands/providers">
+  <Card title="/providers" icon="plug" href="/apex/tui-slash-commands/providers">
     Configure direct API key access as an alternative to managed inference.
   </Card>
-  <Card title="/pentest" icon="play" href="/apex/commands/pentest">
+  <Card title="/pentest" icon="play" href="/apex/tui-slash-commands/pentest">
     Launch a penetration test.
   </Card>
 </CardGroup>

--- a/fern/docs/commands/help.mdx
+++ b/fern/docs/commands/help.mdx
@@ -53,10 +53,10 @@ When you run `/help`, you'll see a dialog showing:
   <Card title="/providers" icon="plug">
     Manage AI providers and configure API keys
   </Card>
-  <Card title="/login" icon="shield-check" href="/apex/commands/auth">
+  <Card title="/login" icon="shield-check" href="/apex/tui-slash-commands/login">
     Connect to Pensar Console for managed inference
   </Card>
-  <Card title="/credits" icon="credit-card" href="/apex/commands/credits">
+  <Card title="/credits" icon="credit-card" href="/apex/tui-slash-commands/credits">
     Buy credits or check your balance
   </Card>
   <Card title="/themes" icon="palette">
@@ -140,7 +140,7 @@ When typing a `/` command, Apex displays a windowed suggestions dropdown with up
 
 ## CLI Commands
 
-In addition to the TUI slash commands above, Apex provides headless CLI commands for pentesting, Console API access, and system management. See the [CLI Commands](/apex/cli/pentest) section in the sidebar for full documentation.
+In addition to the TUI slash commands above, Apex provides headless CLI commands for pentesting, Console API access, and system management. See the [CLI Commands](/apex/cli-commands/pensar-pentest) section in the sidebar for full documentation.
 
 ## Tips
 
@@ -157,19 +157,19 @@ In addition to the TUI slash commands above, Apex provides headless CLI commands
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/pentest" icon="play" href="/apex/commands/pentest">
+  <Card title="/pentest" icon="play" href="/apex/tui-slash-commands/pentest">
     Start a penetration test
   </Card>
-  <Card title="/models" icon="microchip" href="/apex/commands/models">
+  <Card title="/models" icon="microchip" href="/apex/tui-slash-commands/models">
     Select AI model
   </Card>
-  <Card title="/providers" icon="plug" href="/apex/commands/providers">
+  <Card title="/providers" icon="plug" href="/apex/tui-slash-commands/providers">
     Configure AI providers
   </Card>
-  <Card title="/login" icon="shield-check" href="/apex/commands/auth">
+  <Card title="/login" icon="shield-check" href="/apex/tui-slash-commands/login">
     Connect to Pensar Console
   </Card>
-  <Card title="/credits" icon="credit-card" href="/apex/commands/credits">
+  <Card title="/credits" icon="credit-card" href="/apex/tui-slash-commands/credits">
     Check balance or buy credits
   </Card>
 </CardGroup>

--- a/fern/docs/commands/models.mdx
+++ b/fern/docs/commands/models.mdx
@@ -243,13 +243,13 @@ Click "Connect provider" or press `Ctrl+P` to open the provider management inter
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/providers" icon="plug" href="/apex/commands/providers">
+  <Card title="/providers" icon="plug" href="/apex/tui-slash-commands/providers">
     Configure AI provider API keys
   </Card>
-  <Card title="/pentest" icon="play" href="/apex/commands/pentest">
+  <Card title="/pentest" icon="play" href="/apex/tui-slash-commands/pentest">
     Start testing with your selected model
   </Card>
-  <Card title="/help" icon="circle-question" href="/apex/commands/help">
+  <Card title="/help" icon="circle-question" href="/apex/tui-slash-commands/help">
     View all available commands
   </Card>
 </CardGroup>

--- a/fern/docs/commands/operator.mdx
+++ b/fern/docs/commands/operator.mdx
@@ -175,16 +175,16 @@ Once you start an operator session:
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/pentest" icon="play" href="/apex/commands/pentest">
+  <Card title="/pentest" icon="play" href="/apex/tui-slash-commands/pentest">
     Run an autonomous pentest instead
   </Card>
-  <Card title="/sessions" icon="clock-rotate-left" href="/apex/commands/help">
+  <Card title="/sessions" icon="clock-rotate-left" href="/apex/tui-slash-commands/sessions">
     Browse and resume previous sessions
   </Card>
-  <Card title="/models" icon="microchip" href="/apex/commands/models">
+  <Card title="/models" icon="microchip" href="/apex/tui-slash-commands/models">
     Select AI model before starting
   </Card>
-  <Card title="/providers" icon="plug" href="/apex/commands/providers">
+  <Card title="/providers" icon="plug" href="/apex/tui-slash-commands/providers">
     Configure AI provider API keys
   </Card>
 </CardGroup>

--- a/fern/docs/commands/pentest.mdx
+++ b/fern/docs/commands/pentest.mdx
@@ -221,13 +221,13 @@ For more hands-on control, use `/operator` to start an interactive session where
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/models" icon="microchip" href="/apex/commands/models">
+  <Card title="/models" icon="microchip" href="/apex/tui-slash-commands/models">
     Select AI model before starting a test
   </Card>
-  <Card title="/providers" icon="plug" href="/apex/commands/providers">
+  <Card title="/providers" icon="plug" href="/apex/tui-slash-commands/providers">
     Configure AI provider API keys
   </Card>
-  <Card title="/help" icon="circle-question" href="/apex/commands/help">
+  <Card title="/help" icon="circle-question" href="/apex/tui-slash-commands/help">
     View all available commands
   </Card>
 </CardGroup>

--- a/fern/docs/commands/providers.mdx
+++ b/fern/docs/commands/providers.mdx
@@ -258,13 +258,13 @@ You can also access providers from the models screen:
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/models" icon="microchip" href="/apex/commands/models">
+  <Card title="/models" icon="microchip" href="/apex/tui-slash-commands/models">
     Select AI model after configuring provider
   </Card>
-  <Card title="/pentest" icon="play" href="/apex/commands/pentest">
+  <Card title="/pentest" icon="play" href="/apex/tui-slash-commands/pentest">
     Start a penetration test
   </Card>
-  <Card title="/help" icon="circle-question" href="/apex/commands/help">
+  <Card title="/help" icon="circle-question" href="/apex/tui-slash-commands/help">
     View all available commands
   </Card>
 </CardGroup>

--- a/fern/docs/commands/sessions.mdx
+++ b/fern/docs/commands/sessions.mdx
@@ -43,10 +43,10 @@ Sessions are stored locally in `~/.pensar/sessions/`. Each session includes the 
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/pentest" icon="play" href="/apex/commands/pentest">
+  <Card title="/pentest" icon="play" href="/apex/tui-slash-commands/pentest">
     Start a new autonomous pentest session
   </Card>
-  <Card title="/operator" icon="terminal" href="/apex/commands/operator">
+  <Card title="/operator" icon="terminal" href="/apex/tui-slash-commands/operator">
     Start a new interactive operator session
   </Card>
 </CardGroup>

--- a/fern/docs/commands/themes.mdx
+++ b/fern/docs/commands/themes.mdx
@@ -54,10 +54,10 @@ Theme settings are stored in `~/.pensar/config.json` and persist across sessions
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/config" icon="gear" href="/apex/commands/config">
+  <Card title="/config" icon="gear" href="/apex/tui-slash-commands/config">
     View all configuration options
   </Card>
-  <Card title="/help" icon="circle-question" href="/apex/commands/help">
+  <Card title="/help" icon="circle-question" href="/apex/tui-slash-commands/help">
     View all available commands
   </Card>
 </CardGroup>

--- a/fern/docs/commands/threat-model.mdx
+++ b/fern/docs/commands/threat-model.mdx
@@ -87,10 +87,10 @@ This guides the pentest agent to prioritize testing based on the identified atta
 ## Related Commands
 
 <CardGroup cols={2}>
-  <Card title="/operator" icon="terminal" href="/apex/commands/operator">
+  <Card title="/operator" icon="terminal" href="/apex/tui-slash-commands/operator">
     Start an interactive operator session
   </Card>
-  <Card title="/pentest" icon="play" href="/apex/commands/pentest">
+  <Card title="/pentest" icon="play" href="/apex/tui-slash-commands/pentest">
     Run an autonomous pentest
   </Card>
 </CardGroup>

--- a/fern/docs/getting-started.mdx
+++ b/fern/docs/getting-started.mdx
@@ -189,16 +189,16 @@ Now that Apex is installed, here's how to get started:
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Commands Reference" icon="terminal" href="/apex/commands/help">
+  <Card title="Commands Reference" icon="terminal" href="/apex/tui-slash-commands/help">
     Learn about all available commands in Apex.
   </Card>
-  <Card title="AI Providers" icon="plug" href="/apex/commands/providers">
+  <Card title="AI Providers" icon="plug" href="/apex/tui-slash-commands/providers">
     Configure your AI provider for testing.
   </Card>
-  <Card title="Model Selection" icon="microchip" href="/apex/commands/models">
+  <Card title="Model Selection" icon="microchip" href="/apex/tui-slash-commands/models">
     Choose the right AI model for your needs.
   </Card>
-  <Card title="Start Testing" icon="play" href="/apex/commands/pentest">
+  <Card title="Start Testing" icon="play" href="/apex/tui-slash-commands/pentest">
     Launch your first penetration test.
   </Card>
 </CardGroup>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes all broken internal links across the Fern documentation (26 MDX files). The links broke when docs were reorganized into separate sections for TUI slash commands and CLI commands, but the internal `href` values and markdown link paths were never updated to match the new URL structure.

**Two categories of broken links were fixed:**

1. **TUI Slash Command pages** (`/apex/commands/*` → `/apex/tui-slash-commands/*`):
   - All `<Card>` component `href` attributes and inline markdown links referencing `/apex/commands/pentest`, `/apex/commands/models`, `/apex/commands/providers`, `/apex/commands/help`, etc. were updated.
   - The special case of `/apex/commands/auth` → `/apex/tui-slash-commands/login` was handled (the page is named `/login` but the file is `auth.mdx`).

2. **CLI Command pages** (`/apex/cli/*` → `/apex/cli-commands/pensar-*`):
   - All `<Card>` component `href` attributes and inline markdown links referencing `/apex/cli/pentest`, `/apex/cli/auth`, `/apex/cli/issues`, etc. were updated.
   - The slug format changed from just the command name to `pensar-<command>` (e.g., `/apex/cli/pentest` → `/apex/cli-commands/pensar-pentest`).

**Additional fix:** In `operator.mdx`, the `/sessions` card's `href` incorrectly pointed to `/apex/commands/help` instead of `/apex/commands/sessions` — this was also corrected to `/apex/tui-slash-commands/sessions`.

**Files modified:** All 26 MDX files under `fern/docs/commands/` and `fern/docs/cli/`, plus `fern/docs/getting-started.mdx`.

### How did you verify your code works?

1. **Automated verification:** Wrote and ran a TypeScript verification script that:
   - Parsed `docs.yml` to build a complete map of all valid page slugs
   - Scanned every MDX file for `href="/apex/..."` and `[text](/apex/...)` patterns
   - Validated each link against the slug map
   - Result: all internal `/apex/` links passed validation

2. **Live site verification:** Spot-checked several corrected URLs against the live docs site (`docs.pensar.dev`) to confirm they return 200:
   - `/apex/tui-slash-commands/models` ✅
   - `/apex/tui-slash-commands/login` ✅
   - `/apex/cli-commands/pensar-doctor` ✅
   - `/apex/tui-slash-commands/pentest` ✅
   - `/apex/cli-commands/pensar-pentest` ✅

3. **Grep verification:** Confirmed zero remaining instances of the old `/apex/commands/` and `/apex/cli/` patterns in the docs directory.

4. **CI checks:** Lint, type check, and all unit tests pass (832 passed, 15 skipped).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e31aa31a-f567-4224-9e4a-f0284464817c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e31aa31a-f567-4224-9e4a-f0284464817c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

