### PR TITLE
fix: theme-aware selected-item indicator in subagent hub

### DIFF
--- a/src/tui/components/operator-dashboard/subagent-hub.tsx
+++ b/src/tui/components/operator-dashboard/subagent-hub.tsx
@@ -137,7 +137,7 @@ const SubagentHubCard = memo(function SubagentHubCard({
     <box flexDirection="column">
       {/* Line 1: prefix + status icon + name */}
       <box flexDirection="row">
-        <text content={prefix} />
+        <text fg={focused ? colors.primary : colors.text} content={prefix} />
         {statusIcon}
         <text fg={nameColor} content={session.name} />
       </box>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

The triangle indicator (`▸`) next to the selected item in the subagent hub list was rendered without an explicit `fg` color prop. This caused it to inherit the terminal's default text color (typically white), making it invisible on light mode backgrounds.

**Root cause:** In `SubagentHubCard` (`src/tui/components/operator-dashboard/subagent-hub.tsx`), the prefix `<text>` element had no `fg` prop:
```tsx
<text content={prefix} />
```

**Fix:** Added a theme-aware `fg` prop that uses `colors.primary` when the item is focused (matching the name accent color) and `colors.text` when unfocused:
```tsx
<text fg={focused ? colors.primary : colors.text} content={prefix} />
```

This follows the same pattern already used by adjacent elements in the same component (e.g. `nameColor`, `statusIcon`) and is consistent with how the pentest view handles its `▸` indicator in `pentest.tsx`.

**Audit of related views:**
- `pentest.tsx` — The `▸` indicator for the "Pentest Completed" row already wraps the triangle inside a `<text fg={...}>` tag. No fix needed.
- `swarm-dashboard/index.tsx` — Uses border color for card selection, no triangle indicators. No fix needed.
- `agent-display.tsx` — Disclosure triangles (`▶`/`▼`) already use `colors.textMuted`. No fix needed.
- All other `<text content=...>` elements in the operator-dashboard have explicit `fg` props. No fix needed.

### How did you verify your code works?

- All CI checks pass: lint (ESLint + Prettier), type check (`tsc --noEmit`), and unit tests (832 passed, 15 skipped).
- Code review confirmed the fix matches the established theme-aware pattern used throughout the codebase.

**Screenshot of the fix (diff):**

![Git diff showing the theme-aware color fix](https://cursor.com/artifacts/c/art-38bd387b-314e-456e-b7ef-b3d2da51d37d)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-888363f4-d86d-4ad4-ae18-704fc0987434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-888363f4-d86d-4ad4-ae18-704fc0987434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

