### PR TITLE
fix: slow down tool call shimmer animation, add inter-cycle pause, use theme-aware alpha

### DIFF
--- a/src/tui/components/loaders.tsx
+++ b/src/tui/components/loaders.tsx
@@ -686,22 +686,31 @@ export function LaserBar({
  * Renders `text` with a bright shimmer that sweeps left-to-right,
  * like light glinting off a surface. Base text stays dim, and a
  * bell-curve bright window slides across continuously.
+ *
+ * @param pauseMs - dead time between shimmer passes (ms). Default 600.
  */
 export function ShiningText({
   text,
   fg,
-  speed = 2,
+  speed = 1,
   shimmerWidth = 9,
-  baseAlpha = 0.35,
+  baseAlpha,
+  pauseMs = 600,
 }: {
   text: string;
   fg?: RGBA;
   speed?: number;
   shimmerWidth?: number;
   baseAlpha?: number;
+  /** Dead time between shimmer passes (ms). 0 = continuous. */
+  pauseMs?: number;
 }) {
-  const { colors } = useTheme();
+  const { colors, mode } = useTheme();
   const base = fg ?? colors.text;
+
+  const resolvedBaseAlpha =
+    baseAlpha ?? (mode === "light" ? 0.55 : 0.35);
+
   // Subscribe to the shared tick to drive re-renders, but derive the cycle
   // position from absolute wall-clock time so multiple ShiningText instances
   // (with different text lengths) start each shimmer pass in lockstep.
@@ -718,8 +727,12 @@ export function ShiningText({
 
   const len = displayText.length;
   const totalFrames = len + shimmerWidth;
-  const periodMs = 1250 / speed;
-  const cyclePos = (Date.now() % periodMs) / periodMs;
+  const sweepMs = 1250 / speed;
+  const cycleMs = sweepMs + pauseMs;
+  const elapsed = Date.now() % cycleMs;
+  const inPause = elapsed >= sweepMs;
+
+  const cyclePos = inPause ? 1 : elapsed / sweepMs;
   // Smoothstep easing per cycle so the highlight glides through the middle
   // and softens near the edges — gives a more natural "shine" sweep.
   const eased = cyclePos * cyclePos * (3 - 2 * cyclePos);
@@ -728,18 +741,28 @@ export function ShiningText({
   const chars = useMemo(() => {
     const out: { ch: string; color: RGBA }[] = [];
     for (let i = 0; i < len; i++) {
+      if (inPause) {
+        out.push({
+          ch: displayText[i],
+          color: withAlpha(base, resolvedBaseAlpha),
+        });
+        continue;
+      }
       const dist = head - i;
       if (dist >= 0 && dist < shimmerWidth) {
         const norm = dist / (shimmerWidth - 1);
         const bell = 1.0 - (2 * norm - 1) * (2 * norm - 1);
-        const alpha = baseAlpha + (1.0 - baseAlpha) * bell;
+        const alpha = resolvedBaseAlpha + (1.0 - resolvedBaseAlpha) * bell;
         out.push({ ch: displayText[i], color: withAlpha(base, alpha) });
       } else {
-        out.push({ ch: displayText[i], color: withAlpha(base, baseAlpha) });
+        out.push({
+          ch: displayText[i],
+          color: withAlpha(base, resolvedBaseAlpha),
+        });
       }
     }
     return out;
-  }, [head, displayText, base, shimmerWidth, baseAlpha, len]);
+  }, [head, displayText, base, shimmerWidth, resolvedBaseAlpha, len, inPause]);
 
   return (
     <box flexDirection="row">

--- a/src/tui/components/loaders.tsx
+++ b/src/tui/components/loaders.tsx
@@ -708,8 +708,7 @@ export function ShiningText({
   const { colors, mode } = useTheme();
   const base = fg ?? colors.text;
 
-  const resolvedBaseAlpha =
-    baseAlpha ?? (mode === "light" ? 0.55 : 0.35);
+  const resolvedBaseAlpha = baseAlpha ?? (mode === "light" ? 0.55 : 0.35);
 
   // Subscribe to the shared tick to drive re-renders, but derive the cycle
   // position from absolute wall-clock time so multiple ShiningText instances


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

The shimmer animation on pending tool calls (`ShiningText` component) was distracting — too fast, continuous with no breaks, and hard-coded for a single color mode. This PR addresses all three issues:

1. **Slower sweep** — Changed the default `speed` from `2` to `1`, making the shimmer sweep ~2x slower. The `sweepMs` at speed=1 is 1250ms per pass (previously 625ms at speed=2).

2. **Inter-cycle pause** — Added a new `pauseMs` parameter (default 600ms) that inserts dead time between shimmer passes. During the pause, all characters render at the base alpha with no highlight movement. The total cycle is now `sweepMs + pauseMs` (~1850ms), giving the eye a rest between sweeps.

3. **Theme-aware base alpha** — Instead of hard-coding `baseAlpha = 0.35`, the component now derives it from the active `ColorMode`: `0.55` for light mode (where dim text needs more opacity to be readable) and `0.35` for dark mode. Callers can still override via the `baseAlpha` prop.

All callers (`tool-renderer.tsx`, `tool-message.tsx`, `agent-display.tsx`) pass `fg={colors.warning}` which already comes from the theme, so the shimmer highlight color itself was already theme-aware. The fix targets the *base/dim* alpha that was the remaining hard-coded value.

### How did you verify your code works?

- `bun run tsc` — no type errors
- `bun run lint` — no lint errors  
- `bun run test` — all 832 tests pass (15 skipped)
- Ran `bun loader-demo.tsx` and visually confirmed the slower shimmer with visible pause between cycles

**Screen recording of the updated shimmer animation:**

<a href="https://cursor.com/agents/bc-394f47c3-3b41-4463-9be8-a42d121c5f13/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshimmer_animation_slow_with_pause.mp4"><img src="https://cursor.com/artifacts/c/art-4a21a943-6884-4c3a-9468-52f16cada022" alt="shimmer_animation_slow_with_pause.mp4" /></a>

The recording shows:
- The shimmer sweep moves slowly across the text (~1.25s per pass)
- There is a clear pause (~600ms) between sweeps where the text sits at base alpha
- The animation feels measured and non-distracting
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-394f47c3-3b41-4463-9be8-a42d121c5f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-394f47c3-3b41-4463-9be8-a42d121c5f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

