### PR TITLE
fix: make syntax highlighting theme-aware with per-theme IDE palettes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ On first launch, the TUI shows a "Responsible Use Disclosure" screen that must b
 
 **No state toggling in streaming callbacks.** Avoid calling `setState` to toggle visual indicators (like "Thinking...") directly in high-frequency streaming callbacks (`onTextDelta`, `onToolCallStreaming`). This causes per-frame flicker. Instead, derive display state from the underlying data model (e.g., check if the last message is a tool result rather than toggling a boolean).
 
-**Scrollbar visibility.** Scrollable content (lists, logs, long text) must have `scrollbarOptions={{ visible: true }}` so users can see their scroll position. Never hide scrollbars in scrollable regions.
+**Scrollbars.** Don't pass `scrollbarOptions={{ visible: true }}` — opentui auto-shows the bar when content overflows the viewport and hides it otherwise. Forcing `visible: true` paints a full-track thumb when content fits, which reads as a stray colored block. Style with `trackOptions: { foregroundColor: colors.textMuted, backgroundColor: colors.backgroundElement }` so the thumb stays subtle and theme-aware (don't use `colors.primary` — too loud). Never explicitly hide scrollbars in scrollable regions.
 
 ### Code hygiene
 

--- a/src/tui/components/agent-display.tsx
+++ b/src/tui/components/agent-display.tsx
@@ -159,7 +159,7 @@ export default function AgentDisplay({
         },
         scrollbarOptions: {
           trackOptions: {
-            foregroundColor: colors.primary,
+            foregroundColor: colors.textMuted,
             backgroundColor: colors.backgroundElement,
           },
         },

--- a/src/tui/components/chat/message-list.tsx
+++ b/src/tui/components/chat/message-list.tsx
@@ -124,9 +124,8 @@ export function MessageList({
           flexDirection: "column",
         },
         scrollbarOptions: {
-          visible: true,
           trackOptions: {
-            foregroundColor: colors.primary,
+            foregroundColor: colors.textMuted,
             backgroundColor: colors.backgroundElement,
           },
         },

--- a/src/tui/components/chat/tool-message.tsx
+++ b/src/tui/components/chat/tool-message.tsx
@@ -47,7 +47,7 @@ export const ToolMessage = memo(function ToolMessage({
   verbose = false,
   expandedLogs = false,
 }: ToolMessageProps) {
-  const { colors, mode } = useTheme();
+  const { colors } = useTheme();
   // Subscribe so the result summary's `content`-prop StyledText
   // (precomputed in `result-registry.ts`) re-runs on /obfuscate
   // toggle. String children are redacted centrally by the
@@ -93,7 +93,7 @@ export const ToolMessage = memo(function ToolMessage({
   // Get result summary for completed tools
   const resultDisplay: ResultSummary | null =
     isCompleted || isError
-      ? getResultSummary(result, toolName, args, mode)
+      ? getResultSummary(result, toolName, args, colors)
       : null;
 
   // Get tool icon

--- a/src/tui/components/commands/help-dialog.tsx
+++ b/src/tui/components/commands/help-dialog.tsx
@@ -184,9 +184,8 @@ export default function HelpDialog({ onClose }: HelpDialogProps) {
             rootOptions: { flexGrow: 1, width: "100%" },
             contentOptions: { flexDirection: "column" },
             scrollbarOptions: {
-              visible: true,
               trackOptions: {
-                foregroundColor: colors.primary,
+                foregroundColor: colors.textMuted,
                 backgroundColor: colors.backgroundElement,
               },
             },

--- a/src/tui/components/commands/provider-selection.tsx
+++ b/src/tui/components/commands/provider-selection.tsx
@@ -83,7 +83,7 @@ export default function ProviderSelection({
             },
             scrollbarOptions: {
               trackOptions: {
-                foregroundColor: colors.primary,
+                foregroundColor: colors.textMuted,
                 backgroundColor: colors.backgroundElement,
               },
             },

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -282,9 +282,8 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
                   flexDirection: "column",
                 },
                 scrollbarOptions: {
-                  visible: true,
                   trackOptions: {
-                    foregroundColor: colors.primary,
+                    foregroundColor: colors.textMuted,
                     backgroundColor: colors.backgroundElement,
                   },
                 },

--- a/src/tui/components/commands/skills-dialog.tsx
+++ b/src/tui/components/commands/skills-dialog.tsx
@@ -225,7 +225,7 @@ export default function SkillsDialog({
               },
               scrollbarOptions: {
                 trackOptions: {
-                  foregroundColor: colors.primary,
+                  foregroundColor: colors.textMuted,
                   backgroundColor: colors.backgroundElement,
                 },
               },

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -574,7 +574,7 @@ export default function WebWizard({
             },
             scrollbarOptions: {
               trackOptions: {
-                foregroundColor: colors.primary,
+                foregroundColor: colors.textMuted,
                 backgroundColor: colors.backgroundElement,
               },
             },

--- a/src/tui/components/operator-dashboard/subagent-hub.tsx
+++ b/src/tui/components/operator-dashboard/subagent-hub.tsx
@@ -233,9 +233,8 @@ export const SubagentHub = memo(function SubagentHub({
               paddingBottom: 1,
             },
             scrollbarOptions: {
-              visible: true,
               trackOptions: {
-                foregroundColor: colors.primary,
+                foregroundColor: colors.textMuted,
                 backgroundColor: colors.backgroundElement,
               },
             },

--- a/src/tui/components/pentest/pentest.tsx
+++ b/src/tui/components/pentest/pentest.tsx
@@ -1461,7 +1461,7 @@ function OrchestratorPanel({
             contentOptions: { flexDirection: "column", gap: 0 },
             scrollbarOptions: {
               trackOptions: {
-                foregroundColor: colors.primary,
+                foregroundColor: colors.textMuted,
                 backgroundColor: colors.backgroundElement,
               },
             },
@@ -1560,7 +1560,7 @@ function AgentCardGrid({
         },
         scrollbarOptions: {
           trackOptions: {
-            foregroundColor: colors.primary,
+            foregroundColor: colors.textMuted,
             backgroundColor: colors.backgroundElement,
           },
         },

--- a/src/tui/components/report-viewer-dialog.tsx
+++ b/src/tui/components/report-viewer-dialog.tsx
@@ -80,7 +80,7 @@ export default function ReportViewerDialog({
             },
             scrollbarOptions: {
               trackOptions: {
-                foregroundColor: colors.primary,
+                foregroundColor: colors.textMuted,
                 backgroundColor: colors.backgroundElement,
               },
             },

--- a/src/tui/components/shared/markdown-viewer.tsx
+++ b/src/tui/components/shared/markdown-viewer.tsx
@@ -148,7 +148,7 @@ export function MarkdownViewer({
           },
           scrollbarOptions: {
             trackOptions: {
-              foregroundColor: colors.primary,
+              foregroundColor: colors.textMuted,
               backgroundColor: colors.backgroundElement,
             },
           },

--- a/src/tui/components/shared/markdown.ts
+++ b/src/tui/components/shared/markdown.ts
@@ -36,14 +36,19 @@ export function markdownToStyledText(
   // Apply obfuscation before any tokenisation so emails/URLs/hostnames are
   // redacted before they get coloured as links/codespans.
   const content = obfuscate(rawContent);
-  // Resolve colors with fallbacks for backwards compatibility
+  // Resolve colors with fallbacks for backwards compatibility.
+  // textColor must be set on every plain-text chunk: StyledText chunks
+  // without an explicit fg fall back to opentui's default (white), which
+  // is invisible on light themes regardless of the parent <text fg=…>.
+  const textColor = colors?.text ?? RGBA.fromInts(220, 220, 220, 255);
+  const mutedColor = colors?.textMuted ?? RGBA.fromInts(150, 150, 150, 255);
   const codeColor = colors?.markdownCode ?? RGBA.fromInts(100, 255, 100, 255);
   const linkColor = colors?.markdownLink ?? RGBA.fromInts(100, 200, 255, 255);
 
   // Handle empty or whitespace-only content
   if (!content || !content.trim()) {
     return new StyledText([
-      { __isChunk: true, text: content || "", attributes: 0 },
+      { __isChunk: true, text: content || "", fg: textColor, attributes: 0 },
     ]);
   }
 
@@ -68,6 +73,7 @@ export function markdownToStyledText(
           chunks.push({
             __isChunk: true,
             text: token.text || "",
+            fg: textColor,
             attributes: defaultAttrs,
           });
         } else if (token.type === "strong") {
@@ -98,6 +104,7 @@ export function markdownToStyledText(
           chunks.push({
             __isChunk: true,
             text: "\n",
+            fg: textColor,
             attributes: defaultAttrs,
           });
         } else if (token.type === "html") {
@@ -107,6 +114,7 @@ export function markdownToStyledText(
           chunks.push({
             __isChunk: true,
             text: token.raw || token.text || "",
+            fg: textColor,
             attributes: defaultAttrs,
           });
         } else if (token.tokens) {
@@ -119,23 +127,39 @@ export function markdownToStyledText(
       if (token.type === "paragraph") {
         if (token.tokens)
           processInlineTokens(token.tokens as unknown as InlineToken[]);
-        chunks.push({ __isChunk: true, text: "\n", attributes: 0 });
+        chunks.push({
+          __isChunk: true,
+          text: "\n",
+          fg: textColor,
+          attributes: 0,
+        });
       } else if (token.type === "heading") {
         if (token.tokens)
           processInlineTokens(
             token.tokens as unknown as InlineToken[],
             TextAttributes.BOLD,
           );
-        chunks.push({ __isChunk: true, text: "\n", attributes: 0 });
+        chunks.push({
+          __isChunk: true,
+          text: "\n",
+          fg: textColor,
+          attributes: 0,
+        });
       } else if (token.type === "list") {
         for (const item of token.items) {
           chunks.push({
             __isChunk: true,
             text: token.ordered ? `${item.task ? "☐ " : "• "}` : "• ",
+            fg: textColor,
             attributes: 0,
           });
           processInlineTokens(item.tokens[0]?.tokens || []);
-          chunks.push({ __isChunk: true, text: "\n", attributes: 0 });
+          chunks.push({
+            __isChunk: true,
+            text: "\n",
+            fg: textColor,
+            attributes: 0,
+          });
         }
       } else if (token.type === "code") {
         chunks.push({
@@ -149,14 +173,24 @@ export function markdownToStyledText(
         chunks.push({
           __isChunk: true,
           text: "│ ",
-          fg: colors?.textMuted ?? RGBA.fromInts(150, 150, 150, 255),
+          fg: mutedColor,
           attributes: 0,
         });
         if (token.tokens)
           processInlineTokens(token.tokens as unknown as InlineToken[]);
-        chunks.push({ __isChunk: true, text: "\n", attributes: 0 });
+        chunks.push({
+          __isChunk: true,
+          text: "\n",
+          fg: textColor,
+          attributes: 0,
+        });
       } else if (token.type === "space") {
-        chunks.push({ __isChunk: true, text: "\n", attributes: 0 });
+        chunks.push({
+          __isChunk: true,
+          text: "\n",
+          fg: textColor,
+          attributes: 0,
+        });
       } else if (token.type === "html") {
         // Block-level HTML — pass through as literal text. Mirrors the
         // inline `html` handler so angle-bracketed obfuscation
@@ -165,6 +199,7 @@ export function markdownToStyledText(
         chunks.push({
           __isChunk: true,
           text: tk.raw || tk.text || "",
+          fg: textColor,
           attributes: 0,
         });
       }
@@ -196,6 +231,7 @@ export function markdownToStyledText(
       {
         __isChunk: true,
         text: content,
+        fg: textColor,
         attributes: 0,
       },
     ]);

--- a/src/tui/components/shared/result-registry.ts
+++ b/src/tui/components/shared/result-registry.ts
@@ -826,16 +826,16 @@ const WS_COLORS: Record<
   { globe: RGBA; domain: RGBA; title: RGBA; snippet: RGBA }
 > = {
   dark: {
-    globe: RGBA.fromInts(106, 115, 125, 255), // gray
-    domain: RGBA.fromInts(86, 182, 194, 255), // cyan
-    title: RGBA.fromInts(97, 175, 239, 255), // blue
+    globe: RGBA.fromInts(110, 118, 129, 255), // gray
+    domain: RGBA.fromInts(130, 170, 175, 255), // muted teal
+    title: RGBA.fromInts(140, 170, 200, 255), // muted steel blue
     snippet: RGBA.fromInts(140, 148, 160, 255), // muted
   },
   light: {
-    globe: RGBA.fromInts(106, 115, 125, 255), // gray
-    domain: RGBA.fromInts(28, 120, 134, 255), // darker cyan
-    title: RGBA.fromInts(30, 100, 200, 255), // darker blue
-    snippet: RGBA.fromInts(100, 108, 120, 255), // darker muted
+    globe: RGBA.fromInts(120, 125, 132, 255), // mid gray
+    domain: RGBA.fromInts(40, 100, 110, 255), // muted teal
+    title: RGBA.fromInts(50, 90, 150, 255), // muted navy
+    snippet: RGBA.fromInts(100, 108, 120, 255), // muted
   },
 };
 

--- a/src/tui/components/shared/result-registry.ts
+++ b/src/tui/components/shared/result-registry.ts
@@ -7,7 +7,7 @@
 
 import { RGBA, StyledText, type TextChunk } from "@opentui/core";
 import { highlightCode } from "./syntax-highlight";
-import type { ColorMode } from "../../theme/types";
+import type { ThemeColors } from "../../theme/types";
 import { obfuscate, isObfuscationEnabled } from "../../../core/obfuscation";
 
 export interface ResultSummary {
@@ -27,16 +27,16 @@ export interface ResultSummary {
  * @param result - The raw tool result
  * @param toolName - Optional tool name for tool-specific summaries
  * @param args - Optional tool args (used by file tools to show content previews)
- * @param mode - Color mode for syntax highlighting ("dark" or "light")
+ * @param colors - Resolved theme colors for syntax highlighting
  * @returns Summary object with text and error flag, or null if no summary available
  */
 export function getResultSummary(
   result: unknown,
   toolName?: string,
   args?: Record<string, unknown>,
-  mode: ColorMode = "dark",
+  colors?: ThemeColors,
 ): ResultSummary | null {
-  const summary = getResultSummaryRaw(result, toolName, args, mode);
+  const summary = getResultSummaryRaw(result, toolName, args, colors);
   if (!summary) return summary;
   // `text`, `fullText`, and `label` are rendered as string children of
   // `<text>` by tool-message / tool-renderer, so the central
@@ -63,7 +63,7 @@ function getResultSummaryRaw(
   result: unknown,
   toolName?: string,
   args?: Record<string, unknown>,
-  mode: ColorMode = "dark",
+  colors?: ThemeColors,
 ): ResultSummary | null {
   if (result === null || result === undefined) {
     return null;
@@ -98,7 +98,7 @@ function getResultSummaryRaw(
               isError: false,
               label: `${totalLines} lines`,
               styledText:
-                highlightCode(preview + suffix, filePath, mode) ?? undefined,
+                highlightCode(preview + suffix, filePath, colors) ?? undefined,
               fullText:
                 content.length > 400 ? content.slice(0, 2000) : undefined,
             };
@@ -173,7 +173,7 @@ function getResultSummaryRaw(
           const styledChunks = buildWebSearchStyledText(
             shown,
             results.length > 5 ? results.length : undefined,
-            mode,
+            colors,
           );
           return {
             text: `${results.length} result${results.length !== 1 ? "s" : ""}`,
@@ -228,7 +228,7 @@ function getResultSummaryRaw(
               text: preview + suffix,
               isError: false,
               styledText:
-                highlightCode(preview + suffix, filePath, mode) ?? undefined,
+                highlightCode(preview + suffix, filePath, colors) ?? undefined,
               fullText:
                 content.length > 400 ? content.slice(0, 2000) : undefined,
             };
@@ -261,7 +261,7 @@ function getResultSummaryRaw(
               isError: false,
               label: `${n} replacement${n !== 1 ? "s" : ""}`,
               styledText:
-                highlightCode(codePreview, filePath, mode) ?? undefined,
+                highlightCode(codePreview, filePath, colors) ?? undefined,
               fullText:
                 newContent.length > 400 ? newContent.slice(0, 2000) : undefined,
             };
@@ -821,24 +821,6 @@ function getResultSummaryRaw(
 // Web search styled text helpers
 // ---------------------------------------------------------------------------
 
-const WS_COLORS: Record<
-  ColorMode,
-  { globe: RGBA; domain: RGBA; title: RGBA; snippet: RGBA }
-> = {
-  dark: {
-    globe: RGBA.fromInts(110, 118, 129, 255), // gray
-    domain: RGBA.fromInts(130, 170, 175, 255), // muted teal
-    title: RGBA.fromInts(140, 170, 200, 255), // muted steel blue
-    snippet: RGBA.fromInts(140, 148, 160, 255), // muted
-  },
-  light: {
-    globe: RGBA.fromInts(120, 125, 132, 255), // mid gray
-    domain: RGBA.fromInts(40, 100, 110, 255), // muted teal
-    title: RGBA.fromInts(50, 90, 150, 255), // muted navy
-    snippet: RGBA.fromInts(100, 108, 120, 255), // muted
-  },
-};
-
 function chunk(text: string, fg?: RGBA): TextChunk {
   return { __isChunk: true, text, fg, attributes: 0 };
 }
@@ -855,9 +837,8 @@ function extractDomain(url: string): string {
 function buildWebSearchStyledText(
   results: Array<Record<string, unknown>>,
   totalCount?: number,
-  mode: ColorMode = "dark",
+  colors?: ThemeColors,
 ): StyledText {
-  const wsColors = WS_COLORS[mode];
   const chunks: TextChunk[] = [];
   for (let i = 0; i < results.length; i++) {
     const r = results[i];
@@ -865,13 +846,13 @@ function buildWebSearchStyledText(
     const title = String(r.title || "").slice(0, 70);
 
     if (i > 0) chunks.push(chunk("\n"));
-    chunks.push(chunk("🌐 ", wsColors.globe));
-    chunks.push(chunk(domain, wsColors.domain));
-    chunks.push(chunk(" — ", wsColors.globe));
-    chunks.push(chunk(title, wsColors.title));
+    chunks.push(chunk("🌐 ", colors?.syntaxComment));
+    chunks.push(chunk(domain, colors?.syntaxType));
+    chunks.push(chunk(" — ", colors?.syntaxComment));
+    chunks.push(chunk(title, colors?.syntaxFunction));
   }
   if (totalCount && totalCount > results.length) {
-    chunks.push(chunk(`\n… (${totalCount} total)`, wsColors.snippet));
+    chunks.push(chunk(`\n… (${totalCount} total)`, colors?.textMuted));
   }
   return new StyledText(chunks);
 }

--- a/src/tui/components/shared/syntax-highlight.ts
+++ b/src/tui/components/shared/syntax-highlight.ts
@@ -3,103 +3,53 @@
  *
  * Tokenizes code via highlight.js and maps the output to StyledText
  * chunks with per-token foreground colors for rich terminal rendering.
+ *
+ * Colors are theme-aware: each theme defines its own syntax palette
+ * with dark/light variants via ThemeColors tokens.
  */
 
 import { RGBA, StyledText, type TextChunk } from "@opentui/core";
 import hljs from "highlight.js";
 import { extname } from "path";
-import type { ColorMode } from "../../theme/types";
+import type { ThemeColors } from "../../theme/types";
 
 // ---------------------------------------------------------------------------
-// Color palettes — dark and light mode variants
+// Build hljs class → RGBA map from resolved theme colors
 // ---------------------------------------------------------------------------
 
-interface SyntaxPalette {
-  keyword: RGBA;
-  string: RGBA;
-  comment: RGBA;
-  number: RGBA;
-  function: RGBA;
-  title: RGBA;
-  attr: RGBA;
-  tag: RGBA;
-  type: RGBA;
-  literal: RGBA;
-  regexp: RGBA;
-  meta: RGBA;
-  punctuation: RGBA;
-}
-
-const DARK_PALETTE: SyntaxPalette = {
-  keyword: RGBA.fromInts(170, 140, 190, 255), // muted lavender
-  string: RGBA.fromInts(140, 170, 130, 255), // muted sage
-  comment: RGBA.fromInts(110, 118, 129, 255), // gray
-  number: RGBA.fromInts(180, 150, 120, 255), // muted tan
-  function: RGBA.fromInts(140, 170, 200, 255), // muted steel blue
-  title: RGBA.fromInts(140, 170, 200, 255), // muted steel blue
-  attr: RGBA.fromInts(180, 170, 140, 255), // muted sand
-  tag: RGBA.fromInts(180, 130, 130, 255), // muted rose
-  type: RGBA.fromInts(130, 170, 175, 255), // muted teal
-  literal: RGBA.fromInts(180, 150, 120, 255), // muted tan
-  regexp: RGBA.fromInts(140, 170, 130, 255), // muted sage
-  meta: RGBA.fromInts(110, 118, 129, 255), // gray
-  punctuation: RGBA.fromInts(155, 162, 172, 255), // light gray
-};
-
-const LIGHT_PALETTE: SyntaxPalette = {
-  keyword: RGBA.fromInts(100, 70, 120, 255), // muted plum
-  string: RGBA.fromInts(60, 100, 60, 255), // muted forest
-  comment: RGBA.fromInts(120, 125, 132, 255), // mid gray
-  number: RGBA.fromInts(130, 95, 50, 255), // muted brown
-  function: RGBA.fromInts(50, 90, 150, 255), // muted navy
-  title: RGBA.fromInts(50, 90, 150, 255), // muted navy
-  attr: RGBA.fromInts(110, 95, 50, 255), // muted olive
-  tag: RGBA.fromInts(140, 60, 65, 255), // muted burgundy
-  type: RGBA.fromInts(40, 100, 110, 255), // muted teal
-  literal: RGBA.fromInts(130, 95, 50, 255), // muted brown
-  regexp: RGBA.fromInts(60, 100, 60, 255), // muted forest
-  meta: RGBA.fromInts(120, 125, 132, 255), // mid gray
-  punctuation: RGBA.fromInts(90, 95, 105, 255), // dark gray
-};
-
-function buildClassColorMap(p: SyntaxPalette): Record<string, RGBA> {
+function buildClassColorMap(colors: ThemeColors): Record<string, RGBA> {
   return {
-    "hljs-keyword": p.keyword,
-    "hljs-built_in": p.keyword,
-    "hljs-type": p.type,
-    "hljs-literal": p.literal,
-    "hljs-number": p.number,
-    "hljs-string": p.string,
-    "hljs-regexp": p.regexp,
-    "hljs-template-variable": p.string,
-    "hljs-subst": p.string,
-    "hljs-comment": p.comment,
-    "hljs-doctag": p.comment,
-    "hljs-function": p.function,
-    "hljs-title": p.title,
-    "hljs-title.class_": p.type,
-    "hljs-title.function_": p.function,
-    "hljs-params": p.attr,
-    "hljs-attr": p.attr,
-    "hljs-attribute": p.attr,
-    "hljs-property": p.attr,
-    "hljs-variable": p.tag,
-    "hljs-tag": p.tag,
-    "hljs-name": p.tag,
-    "hljs-selector-tag": p.tag,
-    "hljs-selector-class": p.attr,
-    "hljs-selector-id": p.attr,
-    "hljs-meta": p.meta,
-    "hljs-meta keyword": p.keyword,
-    "hljs-symbol": p.literal,
-    "hljs-punctuation": p.punctuation,
+    "hljs-keyword": colors.syntaxKeyword,
+    "hljs-built_in": colors.syntaxKeyword,
+    "hljs-type": colors.syntaxType,
+    "hljs-literal": colors.syntaxNumber,
+    "hljs-number": colors.syntaxNumber,
+    "hljs-string": colors.syntaxString,
+    "hljs-regexp": colors.syntaxString,
+    "hljs-template-variable": colors.syntaxString,
+    "hljs-subst": colors.syntaxString,
+    "hljs-comment": colors.syntaxComment,
+    "hljs-doctag": colors.syntaxComment,
+    "hljs-function": colors.syntaxFunction,
+    "hljs-title": colors.syntaxFunction,
+    "hljs-title.class_": colors.syntaxType,
+    "hljs-title.function_": colors.syntaxFunction,
+    "hljs-params": colors.syntaxAttr,
+    "hljs-attr": colors.syntaxAttr,
+    "hljs-attribute": colors.syntaxAttr,
+    "hljs-property": colors.syntaxAttr,
+    "hljs-variable": colors.syntaxTag,
+    "hljs-tag": colors.syntaxTag,
+    "hljs-name": colors.syntaxTag,
+    "hljs-selector-tag": colors.syntaxTag,
+    "hljs-selector-class": colors.syntaxAttr,
+    "hljs-selector-id": colors.syntaxAttr,
+    "hljs-meta": colors.syntaxComment,
+    "hljs-meta keyword": colors.syntaxKeyword,
+    "hljs-symbol": colors.syntaxNumber,
+    "hljs-punctuation": colors.syntaxPunctuation,
   };
 }
-
-const CLASS_COLOR_MAPS: Record<ColorMode, Record<string, RGBA>> = {
-  dark: buildClassColorMap(DARK_PALETTE),
-  light: buildClassColorMap(LIGHT_PALETTE),
-};
 
 // ---------------------------------------------------------------------------
 // Extension → highlight.js language mapping
@@ -254,15 +204,16 @@ function parseHljsHtml(
  *
  * @param code - Source code to highlight
  * @param filePath - Optional file path to infer language from extension
- * @param mode - Color mode ("dark" or "light"), defaults to "dark"
+ * @param colors - Resolved ThemeColors for the current theme + mode
  * @returns StyledText with per-token colors, or null if highlighting fails
  */
 export function highlightCode(
   code: string,
   filePath?: string,
-  mode: ColorMode = "dark",
+  colors?: ThemeColors,
 ): StyledText | null {
   if (!code.trim()) return null;
+  if (!colors) return null;
 
   try {
     const lang = filePath ? inferLanguage(filePath) : undefined;
@@ -274,7 +225,8 @@ export function highlightCode(
 
     if (!result.value) return null;
 
-    const chunks = parseHljsHtml(result.value, CLASS_COLOR_MAPS[mode]);
+    const classColorMap = buildClassColorMap(colors);
+    const chunks = parseHljsHtml(result.value, classColorMap);
     if (chunks.length === 0) return null;
 
     return new StyledText(chunks);

--- a/src/tui/components/shared/syntax-highlight.ts
+++ b/src/tui/components/shared/syntax-highlight.ts
@@ -31,35 +31,35 @@ interface SyntaxPalette {
 }
 
 const DARK_PALETTE: SyntaxPalette = {
-  keyword: RGBA.fromInts(198, 120, 221, 255), // purple
-  string: RGBA.fromInts(152, 195, 121, 255), // green
-  comment: RGBA.fromInts(106, 115, 125, 255), // gray
-  number: RGBA.fromInts(209, 154, 102, 255), // orange
-  function: RGBA.fromInts(97, 175, 239, 255), // blue
-  title: RGBA.fromInts(97, 175, 239, 255), // blue
-  attr: RGBA.fromInts(229, 192, 123, 255), // yellow
-  tag: RGBA.fromInts(224, 108, 117, 255), // red
-  type: RGBA.fromInts(86, 182, 194, 255), // cyan
-  literal: RGBA.fromInts(209, 154, 102, 255), // orange
-  regexp: RGBA.fromInts(152, 195, 121, 255), // green
-  meta: RGBA.fromInts(106, 115, 125, 255), // gray
-  punctuation: RGBA.fromInts(171, 178, 191, 255), // light gray
+  keyword: RGBA.fromInts(170, 140, 190, 255), // muted lavender
+  string: RGBA.fromInts(140, 170, 130, 255), // muted sage
+  comment: RGBA.fromInts(110, 118, 129, 255), // gray
+  number: RGBA.fromInts(180, 150, 120, 255), // muted tan
+  function: RGBA.fromInts(140, 170, 200, 255), // muted steel blue
+  title: RGBA.fromInts(140, 170, 200, 255), // muted steel blue
+  attr: RGBA.fromInts(180, 170, 140, 255), // muted sand
+  tag: RGBA.fromInts(180, 130, 130, 255), // muted rose
+  type: RGBA.fromInts(130, 170, 175, 255), // muted teal
+  literal: RGBA.fromInts(180, 150, 120, 255), // muted tan
+  regexp: RGBA.fromInts(140, 170, 130, 255), // muted sage
+  meta: RGBA.fromInts(110, 118, 129, 255), // gray
+  punctuation: RGBA.fromInts(155, 162, 172, 255), // light gray
 };
 
 const LIGHT_PALETTE: SyntaxPalette = {
-  keyword: RGBA.fromInts(137, 63, 168, 255), // darker purple
-  string: RGBA.fromInts(56, 124, 56, 255), // darker green
-  comment: RGBA.fromInts(106, 115, 125, 255), // gray (works on both)
-  number: RGBA.fromInts(152, 104, 40, 255), // darker orange
-  function: RGBA.fromInts(30, 100, 200, 255), // darker blue
-  title: RGBA.fromInts(30, 100, 200, 255), // darker blue
-  attr: RGBA.fromInts(150, 120, 30, 255), // darker yellow
-  tag: RGBA.fromInts(180, 50, 55, 255), // darker red
-  type: RGBA.fromInts(28, 120, 134, 255), // darker cyan
-  literal: RGBA.fromInts(152, 104, 40, 255), // darker orange
-  regexp: RGBA.fromInts(56, 124, 56, 255), // darker green
-  meta: RGBA.fromInts(106, 115, 125, 255), // gray
-  punctuation: RGBA.fromInts(80, 85, 95, 255), // dark gray
+  keyword: RGBA.fromInts(100, 70, 120, 255), // muted plum
+  string: RGBA.fromInts(60, 100, 60, 255), // muted forest
+  comment: RGBA.fromInts(120, 125, 132, 255), // mid gray
+  number: RGBA.fromInts(130, 95, 50, 255), // muted brown
+  function: RGBA.fromInts(50, 90, 150, 255), // muted navy
+  title: RGBA.fromInts(50, 90, 150, 255), // muted navy
+  attr: RGBA.fromInts(110, 95, 50, 255), // muted olive
+  tag: RGBA.fromInts(140, 60, 65, 255), // muted burgundy
+  type: RGBA.fromInts(40, 100, 110, 255), // muted teal
+  literal: RGBA.fromInts(130, 95, 50, 255), // muted brown
+  regexp: RGBA.fromInts(60, 100, 60, 255), // muted forest
+  meta: RGBA.fromInts(120, 125, 132, 255), // mid gray
+  punctuation: RGBA.fromInts(90, 95, 105, 255), // dark gray
 };
 
 function buildClassColorMap(p: SyntaxPalette): Record<string, RGBA> {

--- a/src/tui/components/shared/syntax-highlight.ts
+++ b/src/tui/components/shared/syntax-highlight.ts
@@ -148,13 +148,20 @@ function decodeEntities(s: string): string {
  *
  * The HTML is simple: flat or shallowly nested `<span class="hljs-*">` tags.
  * We track a color stack so nested spans inherit/override correctly.
+ *
+ * `defaultColor` is used for any text outside an hljs span (whitespace,
+ * punctuation like `{`, `}`, `|`, `;`, plain identifiers). Chunks with no
+ * explicit `fg` fall back to opentui's white default rather than the parent
+ * `<text fg=…>`, so unclassed tokens render as invisible white in light
+ * themes unless we set this explicitly.
  */
 function parseHljsHtml(
   html: string,
   classColorMap: Record<string, RGBA>,
+  defaultColor: RGBA,
 ): TextChunk[] {
   const chunks: TextChunk[] = [];
-  const colorStack: (RGBA | undefined)[] = [undefined];
+  const colorStack: RGBA[] = [defaultColor];
 
   const TAG_RE = /<span\s+class="([^"]*)"[^>]*>|<\/span>|([^<]+)|(<[^>]*>)/g;
   let m: RegExpExecArray | null;
@@ -226,7 +233,7 @@ export function highlightCode(
     if (!result.value) return null;
 
     const classColorMap = buildClassColorMap(colors);
-    const chunks = parseHljsHtml(result.value, classColorMap);
+    const chunks = parseHljsHtml(result.value, classColorMap, colors.text);
     if (chunks.length === 0) return null;
 
     return new StyledText(chunks);

--- a/src/tui/components/shared/tool-renderer.tsx
+++ b/src/tui/components/shared/tool-renderer.tsx
@@ -41,7 +41,7 @@ export const ToolRenderer = memo(function ToolRenderer({
   verbose = false,
   expandedLogs = false,
 }: ToolRendererProps) {
-  const { colors, mode } = useTheme();
+  const { colors } = useTheme();
   // Subscribe so the result summary's `content`-prop StyledText
   // (precomputed in `result-registry.ts`) re-runs when `/obfuscate`
   // toggles. Plain string children are handled centrally by the
@@ -100,7 +100,7 @@ export const ToolRenderer = memo(function ToolRenderer({
   // Get result summary for completed tools
   const resultDisplay: ResultSummary | null =
     isCompleted || isError
-      ? getResultSummary(result, toolName, args, mode)
+      ? getResultSummary(result, toolName, args, colors)
       : null;
 
   // Determine border color based on status

--- a/src/tui/theme/themes/apex.ts
+++ b/src/tui/theme/themes/apex.ts
@@ -133,40 +133,40 @@ export const apex: ThemeDefinition = {
 
     // ── Syntax Highlighting ──────────────────────────────────
     syntaxKeyword: {
-      dark: RGBA.fromInts(170, 140, 190, 255), // muted lavender
-      light: RGBA.fromInts(100, 70, 120, 255), // muted plum
+      dark: RGBA.fromInts(180, 126, 206, 255), // muted lavender
+      light: RGBA.fromInts(98, 37, 126, 255), // muted plum
     },
     syntaxString: {
-      dark: RGBA.fromInts(140, 170, 130, 255), // muted sage
-      light: RGBA.fromInts(60, 100, 60, 255), // muted forest
+      dark: RGBA.fromInts(113, 186, 94, 255), // muted sage
+      light: RGBA.fromInts(48, 111, 32, 255), // muted forest
     },
     syntaxComment: {
-      dark: RGBA.fromInts(110, 118, 129, 255), // gray
-      light: RGBA.fromInts(120, 125, 132, 255), // mid gray
+      dark: RGBA.fromInts(103, 115, 126, 255), // gray
+      light: RGBA.fromInts(92, 102, 112, 255), // mid gray
     },
     syntaxNumber: {
-      dark: RGBA.fromInts(180, 150, 120, 255), // muted tan
-      light: RGBA.fromInts(130, 95, 50, 255), // muted brown
+      dark: RGBA.fromInts(192, 138, 89, 255), // muted tan
+      light: RGBA.fromInts(135, 79, 29, 255), // muted brown
     },
     syntaxFunction: {
-      dark: RGBA.fromInts(140, 170, 200, 255), // muted steel blue
-      light: RGBA.fromInts(50, 90, 150, 255), // muted navy
+      dark: RGBA.fromInts(114, 160, 202, 255), // muted steel blue
+      light: RGBA.fromInts(30, 89, 143, 255), // muted navy
     },
     syntaxType: {
-      dark: RGBA.fromInts(130, 170, 175, 255), // muted teal
-      light: RGBA.fromInts(40, 100, 110, 255), // muted teal
+      dark: RGBA.fromInts(114, 182, 182, 255), // muted teal
+      light: RGBA.fromInts(37, 126, 126, 255), // muted teal
     },
     syntaxTag: {
-      dark: RGBA.fromInts(180, 130, 130, 255), // muted rose
-      light: RGBA.fromInts(140, 60, 65, 255), // muted burgundy
+      dark: RGBA.fromInts(194, 112, 112, 255), // muted rose
+      light: RGBA.fromInts(142, 41, 41, 255), // muted burgundy
     },
     syntaxAttr: {
-      dark: RGBA.fromInts(180, 170, 140, 255), // muted sand
-      light: RGBA.fromInts(110, 95, 50, 255), // muted olive
+      dark: RGBA.fromInts(194, 176, 112, 255), // muted sand
+      light: RGBA.fromInts(135, 111, 29, 255), // muted olive
     },
     syntaxPunctuation: {
-      dark: RGBA.fromInts(155, 162, 172, 255), // light gray
-      light: RGBA.fromInts(90, 95, 105, 255), // dark gray
+      dark: RGBA.fromInts(148, 156, 168, 255), // light gray
+      light: RGBA.fromInts(87, 95, 107, 255), // dark gray
     },
 
     // ── Diff ─────────────────────────────────────────────────

--- a/src/tui/theme/themes/apex.ts
+++ b/src/tui/theme/themes/apex.ts
@@ -131,6 +131,44 @@ export const apex: ThemeDefinition = {
       light: RGBA.fromInts(175, 160, 0, 255),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromInts(170, 140, 190, 255), // muted lavender
+      light: RGBA.fromInts(100, 70, 120, 255), // muted plum
+    },
+    syntaxString: {
+      dark: RGBA.fromInts(140, 170, 130, 255), // muted sage
+      light: RGBA.fromInts(60, 100, 60, 255), // muted forest
+    },
+    syntaxComment: {
+      dark: RGBA.fromInts(110, 118, 129, 255), // gray
+      light: RGBA.fromInts(120, 125, 132, 255), // mid gray
+    },
+    syntaxNumber: {
+      dark: RGBA.fromInts(180, 150, 120, 255), // muted tan
+      light: RGBA.fromInts(130, 95, 50, 255), // muted brown
+    },
+    syntaxFunction: {
+      dark: RGBA.fromInts(140, 170, 200, 255), // muted steel blue
+      light: RGBA.fromInts(50, 90, 150, 255), // muted navy
+    },
+    syntaxType: {
+      dark: RGBA.fromInts(130, 170, 175, 255), // muted teal
+      light: RGBA.fromInts(40, 100, 110, 255), // muted teal
+    },
+    syntaxTag: {
+      dark: RGBA.fromInts(180, 130, 130, 255), // muted rose
+      light: RGBA.fromInts(140, 60, 65, 255), // muted burgundy
+    },
+    syntaxAttr: {
+      dark: RGBA.fromInts(180, 170, 140, 255), // muted sand
+      light: RGBA.fromInts(110, 95, 50, 255), // muted olive
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromInts(155, 162, 172, 255), // light gray
+      light: RGBA.fromInts(90, 95, 105, 255), // dark gray
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromInts(76, 175, 80, 255),

--- a/src/tui/theme/themes/ayu.ts
+++ b/src/tui/theme/themes/ayu.ts
@@ -130,6 +130,44 @@ export const ayu: ThemeDefinition = {
       light: RGBA.fromHex("#a37acc"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#ff8f40"), // orange (keyword)
+      light: RGBA.fromHex("#fa8d3e"),
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#aad94c"), // green
+      light: RGBA.fromHex("#86b300"),
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#636a72"), // comment
+      light: RGBA.fromHex("#8a9199"),
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#e6b450"), // yellow/accent
+      light: RGBA.fromHex("#a37acc"), // purple in light
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#ffb454"), // amber (function)
+      light: RGBA.fromHex("#f2ae49"),
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#39bae6"), // blue (type)
+      light: RGBA.fromHex("#399ee6"),
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#39bae6"), // blue (tag)
+      light: RGBA.fromHex("#399ee6"),
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#f29668"), // orange (attr)
+      light: RGBA.fromHex("#e6ba7e"),
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#bfbdb6"), // fg
+      light: RGBA.fromHex("#5c6166"),
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#7fd962"),

--- a/src/tui/theme/themes/ayu.ts
+++ b/src/tui/theme/themes/ayu.ts
@@ -133,11 +133,11 @@ export const ayu: ThemeDefinition = {
     // ── Syntax Highlighting ──────────────────────────────────
     syntaxKeyword: {
       dark: RGBA.fromHex("#ff8f40"), // orange (keyword)
-      light: RGBA.fromHex("#fa8d3e"),
+      light: RGBA.fromHex("#d75d06"),
     },
     syntaxString: {
       dark: RGBA.fromHex("#aad94c"), // green
-      light: RGBA.fromHex("#86b300"),
+      light: RGBA.fromHex("#678a00"),
     },
     syntaxComment: {
       dark: RGBA.fromHex("#636a72"), // comment
@@ -145,23 +145,23 @@ export const ayu: ThemeDefinition = {
     },
     syntaxNumber: {
       dark: RGBA.fromHex("#e6b450"), // yellow/accent
-      light: RGBA.fromHex("#a37acc"), // purple in light
+      light: RGBA.fromHex("#996bc6"), // purple in light
     },
     syntaxFunction: {
       dark: RGBA.fromHex("#ffb454"), // amber (function)
-      light: RGBA.fromHex("#f2ae49"),
+      light: RGBA.fromHex("#b4710d"),
     },
     syntaxType: {
       dark: RGBA.fromHex("#39bae6"), // blue (type)
-      light: RGBA.fromHex("#399ee6"),
+      light: RGBA.fromHex("#1a85d2"),
     },
     syntaxTag: {
       dark: RGBA.fromHex("#39bae6"), // blue (tag)
-      light: RGBA.fromHex("#399ee6"),
+      light: RGBA.fromHex("#1a85d2"),
     },
     syntaxAttr: {
       dark: RGBA.fromHex("#f29668"), // orange (attr)
-      light: RGBA.fromHex("#e6ba7e"),
+      light: RGBA.fromHex("#b37623"),
     },
     syntaxPunctuation: {
       dark: RGBA.fromHex("#bfbdb6"), // fg

--- a/src/tui/theme/themes/catppuccin.ts
+++ b/src/tui/theme/themes/catppuccin.ts
@@ -130,6 +130,44 @@ export const catppuccin: ThemeDefinition = {
       light: RGBA.fromHex("#df8e1d"), // yellow (latte)
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#cba6f7"), // mauve (mocha)
+      light: RGBA.fromHex("#8839ef"), // mauve (latte)
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#a6e3a1"), // green (mocha)
+      light: RGBA.fromHex("#40a02b"), // green (latte)
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#6c7086"), // overlay0 (mocha)
+      light: RGBA.fromHex("#9ca0b0"), // overlay0 (latte)
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#fab387"), // peach (mocha)
+      light: RGBA.fromHex("#fe640b"), // peach (latte)
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#89b4fa"), // blue (mocha)
+      light: RGBA.fromHex("#1e66f5"), // blue (latte)
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#f9e2af"), // yellow (mocha)
+      light: RGBA.fromHex("#df8e1d"), // yellow (latte)
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#f38ba8"), // red (mocha)
+      light: RGBA.fromHex("#d20f39"), // red (latte)
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#94e2d5"), // teal (mocha)
+      light: RGBA.fromHex("#179299"), // teal (latte)
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#a6adc8"), // subtext0 (mocha)
+      light: RGBA.fromHex("#6c6f85"), // subtext0 (latte)
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#a6e3a1"), // green (mocha)

--- a/src/tui/theme/themes/catppuccin.ts
+++ b/src/tui/theme/themes/catppuccin.ts
@@ -137,15 +137,15 @@ export const catppuccin: ThemeDefinition = {
     },
     syntaxString: {
       dark: RGBA.fromHex("#a6e3a1"), // green (mocha)
-      light: RGBA.fromHex("#40a02b"), // green (latte)
+      light: RGBA.fromHex("#338022"), // green (latte)
     },
     syntaxComment: {
       dark: RGBA.fromHex("#6c7086"), // overlay0 (mocha)
-      light: RGBA.fromHex("#9ca0b0"), // overlay0 (latte)
+      light: RGBA.fromHex("#7a7f95"), // overlay0 (latte)
     },
     syntaxNumber: {
       dark: RGBA.fromHex("#fab387"), // peach (mocha)
-      light: RGBA.fromHex("#fe640b"), // peach (latte)
+      light: RGBA.fromHex("#c14701"), // peach (latte)
     },
     syntaxFunction: {
       dark: RGBA.fromHex("#89b4fa"), // blue (mocha)
@@ -153,7 +153,7 @@ export const catppuccin: ThemeDefinition = {
     },
     syntaxType: {
       dark: RGBA.fromHex("#f9e2af"), // yellow (mocha)
-      light: RGBA.fromHex("#df8e1d"), // yellow (latte)
+      light: RGBA.fromHex("#a06615"), // yellow (latte)
     },
     syntaxTag: {
       dark: RGBA.fromHex("#f38ba8"), // red (mocha)
@@ -161,7 +161,7 @@ export const catppuccin: ThemeDefinition = {
     },
     syntaxAttr: {
       dark: RGBA.fromHex("#94e2d5"), // teal (mocha)
-      light: RGBA.fromHex("#179299"), // teal (latte)
+      light: RGBA.fromHex("#148187"), // teal (latte)
     },
     syntaxPunctuation: {
       dark: RGBA.fromHex("#a6adc8"), // subtext0 (mocha)

--- a/src/tui/theme/themes/dracula.ts
+++ b/src/tui/theme/themes/dracula.ts
@@ -131,6 +131,44 @@ export const dracula: ThemeDefinition = {
       light: RGBA.fromHex("#9a7b00"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#ff79c6"), // pink
+      light: RGBA.fromHex("#d6336c"),
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#f1fa8c"), // yellow
+      light: RGBA.fromHex("#9a7b00"),
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#6272a4"), // comment
+      light: RGBA.fromHex("#8b95b8"),
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#bd93f9"), // purple
+      light: RGBA.fromHex("#7c3aed"),
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#50fa7b"), // green
+      light: RGBA.fromHex("#1b8332"),
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#8be9fd"), // cyan
+      light: RGBA.fromHex("#0e7490"),
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#ff5555"), // red
+      light: RGBA.fromHex("#c62828"),
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#ffb86c"), // orange
+      light: RGBA.fromHex("#c2410c"),
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#f8f8f2"), // fg
+      light: RGBA.fromHex("#4e5173"),
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#50fa7b"),

--- a/src/tui/theme/themes/dracula.ts
+++ b/src/tui/theme/themes/dracula.ts
@@ -138,11 +138,11 @@ export const dracula: ThemeDefinition = {
     },
     syntaxString: {
       dark: RGBA.fromHex("#f1fa8c"), // yellow
-      light: RGBA.fromHex("#9a7b00"),
+      light: RGBA.fromHex("#907300"),
     },
     syntaxComment: {
-      dark: RGBA.fromHex("#6272a4"), // comment
-      light: RGBA.fromHex("#8b95b8"),
+      dark: RGBA.fromHex("#7c89b3"), // comment
+      light: RGBA.fromHex("#7884ac"),
     },
     syntaxNumber: {
       dark: RGBA.fromHex("#bd93f9"), // purple
@@ -157,7 +157,7 @@ export const dracula: ThemeDefinition = {
       light: RGBA.fromHex("#0e7490"),
     },
     syntaxTag: {
-      dark: RGBA.fromHex("#ff5555"), // red
+      dark: RGBA.fromHex("#ff5f5f"), // red
       light: RGBA.fromHex("#c62828"),
     },
     syntaxAttr: {

--- a/src/tui/theme/themes/everforest.ts
+++ b/src/tui/theme/themes/everforest.ts
@@ -133,35 +133,35 @@ export const everforest: ThemeDefinition = {
     // ── Syntax Highlighting ──────────────────────────────────
     syntaxKeyword: {
       dark: RGBA.fromHex("#e67e80"), // red
-      light: RGBA.fromHex("#f85552"),
+      light: RGBA.fromHex("#f7423e"),
     },
     syntaxString: {
       dark: RGBA.fromHex("#a7c080"), // green
-      light: RGBA.fromHex("#8da101"),
+      light: RGBA.fromHex("#7b8d01"),
     },
     syntaxComment: {
       dark: RGBA.fromHex("#859289"), // grey1
-      light: RGBA.fromHex("#939f91"), // grey0
+      light: RGBA.fromHex("#889586"), // grey0
     },
     syntaxNumber: {
       dark: RGBA.fromHex("#d699b6"), // purple
-      light: RGBA.fromHex("#df69ba"),
+      light: RGBA.fromHex("#da50ae"),
     },
     syntaxFunction: {
       dark: RGBA.fromHex("#a7c080"), // green
-      light: RGBA.fromHex("#8da101"),
+      light: RGBA.fromHex("#7b8d01"),
     },
     syntaxType: {
       dark: RGBA.fromHex("#dbbc7f"), // yellow
-      light: RGBA.fromHex("#dfa000"),
+      light: RGBA.fromHex("#ac7b00"),
     },
     syntaxTag: {
       dark: RGBA.fromHex("#e69875"), // orange
-      light: RGBA.fromHex("#f57d26"),
+      light: RGBA.fromHex("#d45f0a"),
     },
     syntaxAttr: {
       dark: RGBA.fromHex("#7fbbb3"), // aqua
-      light: RGBA.fromHex("#35a77c"),
+      light: RGBA.fromHex("#2e906b"),
     },
     syntaxPunctuation: {
       dark: RGBA.fromHex("#d3c6aa"), // fg

--- a/src/tui/theme/themes/everforest.ts
+++ b/src/tui/theme/themes/everforest.ts
@@ -130,6 +130,44 @@ export const everforest: ThemeDefinition = {
       light: RGBA.fromHex("#df69ba"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#e67e80"), // red
+      light: RGBA.fromHex("#f85552"),
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#a7c080"), // green
+      light: RGBA.fromHex("#8da101"),
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#859289"), // grey1
+      light: RGBA.fromHex("#939f91"), // grey0
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#d699b6"), // purple
+      light: RGBA.fromHex("#df69ba"),
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#a7c080"), // green
+      light: RGBA.fromHex("#8da101"),
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#dbbc7f"), // yellow
+      light: RGBA.fromHex("#dfa000"),
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#e69875"), // orange
+      light: RGBA.fromHex("#f57d26"),
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#7fbbb3"), // aqua
+      light: RGBA.fromHex("#35a77c"),
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#d3c6aa"), // fg
+      light: RGBA.fromHex("#5c6a72"),
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#a7c080"),

--- a/src/tui/theme/themes/flexoki.ts
+++ b/src/tui/theme/themes/flexoki.ts
@@ -146,7 +146,7 @@ export const flexoki: ThemeDefinition = {
     },
     syntaxNumber: {
       dark: RGBA.fromHex("#a580e2"), // purple
-      light: RGBA.fromHex("#8b7ec8"),
+      light: RGBA.fromHex("#8577c5"),
     },
     syntaxFunction: {
       dark: RGBA.fromHex("#da702c"), // orange
@@ -154,7 +154,7 @@ export const flexoki: ThemeDefinition = {
     },
     syntaxType: {
       dark: RGBA.fromHex("#d0a215"), // yellow
-      light: RGBA.fromHex("#ad8301"),
+      light: RGBA.fromHex("#a37b01"),
     },
     syntaxTag: {
       dark: RGBA.fromHex("#4385be"), // blue

--- a/src/tui/theme/themes/flexoki.ts
+++ b/src/tui/theme/themes/flexoki.ts
@@ -131,6 +131,44 @@ export const flexoki: ThemeDefinition = {
       light: RGBA.fromHex("#8b7ec8"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#d14d41"), // red
+      light: RGBA.fromHex("#af3029"),
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#879a39"), // green
+      light: RGBA.fromHex("#66800b"),
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#878580"), // tx-2
+      light: RGBA.fromHex("#6f6e69"),
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#a580e2"), // purple
+      light: RGBA.fromHex("#8b7ec8"),
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#da702c"), // orange
+      light: RGBA.fromHex("#bc5215"),
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#d0a215"), // yellow
+      light: RGBA.fromHex("#ad8301"),
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#4385be"), // blue
+      light: RGBA.fromHex("#205ea6"),
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#3aa99f"), // cyan
+      light: RGBA.fromHex("#24837b"),
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#878580"), // tx-2
+      light: RGBA.fromHex("#6f6e69"),
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#879a39"),

--- a/src/tui/theme/themes/github.ts
+++ b/src/tui/theme/themes/github.ts
@@ -130,6 +130,44 @@ export const github: ThemeDefinition = {
       light: RGBA.fromHex("#9a6700"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#ff7b72"), // red
+      light: RGBA.fromHex("#cf222e"),
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#a5d6ff"), // light blue (string)
+      light: RGBA.fromHex("#0a3069"),
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#8b949e"), // muted
+      light: RGBA.fromHex("#57606a"),
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#79c0ff"), // blue
+      light: RGBA.fromHex("#0550ae"),
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#d2a8ff"), // purple
+      light: RGBA.fromHex("#8250df"),
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#ffa657"), // orange (type)
+      light: RGBA.fromHex("#953800"),
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#7ee787"), // green (tag)
+      light: RGBA.fromHex("#116329"),
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#79c0ff"), // blue
+      light: RGBA.fromHex("#0550ae"),
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#c9d1d9"), // fg
+      light: RGBA.fromHex("#24292f"),
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#3fb950"),

--- a/src/tui/theme/themes/gruvbox.ts
+++ b/src/tui/theme/themes/gruvbox.ts
@@ -149,7 +149,7 @@ export const gruvbox: ThemeDefinition = {
     },
     syntaxFunction: {
       dark: RGBA.fromHex("#fabd2f"), // yellow (bright)
-      light: RGBA.fromHex("#b57614"), // yellow (faded)
+      light: RGBA.fromHex("#ac7013"), // yellow (faded)
     },
     syntaxType: {
       dark: RGBA.fromHex("#83a598"), // aqua (bright)

--- a/src/tui/theme/themes/gruvbox.ts
+++ b/src/tui/theme/themes/gruvbox.ts
@@ -130,6 +130,44 @@ export const gruvbox: ThemeDefinition = {
       light: RGBA.fromHex("#8f3f71"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#fb4934"), // red (bright)
+      light: RGBA.fromHex("#9d0006"), // red (faded)
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#b8bb26"), // green (bright)
+      light: RGBA.fromHex("#79740e"), // green (faded)
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#928374"), // gray
+      light: RGBA.fromHex("#928374"),
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#d3869b"), // purple
+      light: RGBA.fromHex("#8f3f71"), // purple (faded)
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#fabd2f"), // yellow (bright)
+      light: RGBA.fromHex("#b57614"), // yellow (faded)
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#83a598"), // aqua (bright)
+      light: RGBA.fromHex("#427b58"), // aqua (faded)
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#fe8019"), // orange (bright)
+      light: RGBA.fromHex("#af3a03"), // orange (faded)
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#8ec07c"), // aqua (bright)
+      light: RGBA.fromHex("#427b58"), // aqua (faded)
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#a89984"), // fg4
+      light: RGBA.fromHex("#665c54"), // fg4
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#b8bb26"),

--- a/src/tui/theme/themes/kanagawa.ts
+++ b/src/tui/theme/themes/kanagawa.ts
@@ -137,7 +137,7 @@ export const kanagawa: ThemeDefinition = {
     },
     syntaxString: {
       dark: RGBA.fromHex("#98bb6c"), // springGreen (wave)
-      light: RGBA.fromHex("#6f894e"), // lotusGreen
+      light: RGBA.fromHex("#6a834a"), // lotusGreen
     },
     syntaxComment: {
       dark: RGBA.fromHex("#727169"), // fujiGray (wave)

--- a/src/tui/theme/themes/kanagawa.ts
+++ b/src/tui/theme/themes/kanagawa.ts
@@ -130,6 +130,44 @@ export const kanagawa: ThemeDefinition = {
       light: RGBA.fromHex("#836930"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#957fb8"), // oniViolet (wave)
+      light: RGBA.fromHex("#624c83"), // oniViolet (lotus)
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#98bb6c"), // springGreen (wave)
+      light: RGBA.fromHex("#6f894e"), // lotusGreen
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#727169"), // fujiGray (wave)
+      light: RGBA.fromHex("#8a8980"), // fujiGray (lotus)
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#d27e99"), // sakuraPink (wave)
+      light: RGBA.fromHex("#b35b79"), // lotusPink
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#7e9cd8"), // crystalBlue (wave)
+      light: RGBA.fromHex("#4d699b"), // crystalBlue (lotus)
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#7fb4ca"), // springBlue (wave)
+      light: RGBA.fromHex("#4d699b"),
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#e6c384"), // carpYellow (wave)
+      light: RGBA.fromHex("#836930"),
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#6a9589"), // waveAqua2 (wave)
+      light: RGBA.fromHex("#5a7a68"),
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#9cabca"), // oldWhite (wave)
+      light: RGBA.fromHex("#68687a"),
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#76946a"),

--- a/src/tui/theme/themes/material.ts
+++ b/src/tui/theme/themes/material.ts
@@ -138,15 +138,15 @@ export const material: ThemeDefinition = {
     },
     syntaxString: {
       dark: RGBA.fromHex("#c3e88d"), // green
-      light: RGBA.fromHex("#91b859"),
+      light: RGBA.fromHex("#6c8d3c"),
     },
     syntaxComment: {
-      dark: RGBA.fromHex("#546e7a"), // comment
-      light: RGBA.fromHex("#90a4ae"),
+      dark: RGBA.fromHex("#607e8c"), // comment
+      light: RGBA.fromHex("#7e95a1"),
     },
     syntaxNumber: {
       dark: RGBA.fromHex("#f78c6c"), // orange
-      light: RGBA.fromHex("#f76d47"),
+      light: RGBA.fromHex("#f54616"),
     },
     syntaxFunction: {
       dark: RGBA.fromHex("#82aaff"), // blue
@@ -154,7 +154,7 @@ export const material: ThemeDefinition = {
     },
     syntaxType: {
       dark: RGBA.fromHex("#ffcb6b"), // yellow
-      light: RGBA.fromHex("#e2931d"),
+      light: RGBA.fromHex("#b57617"),
     },
     syntaxTag: {
       dark: RGBA.fromHex("#f07178"), // red
@@ -162,11 +162,11 @@ export const material: ThemeDefinition = {
     },
     syntaxAttr: {
       dark: RGBA.fromHex("#89ddff"), // cyan
-      light: RGBA.fromHex("#39adb5"),
+      light: RGBA.fromHex("#2f8f96"),
     },
     syntaxPunctuation: {
       dark: RGBA.fromHex("#89ddff"), // cyan (operators)
-      light: RGBA.fromHex("#39adb5"),
+      light: RGBA.fromHex("#2f8f96"),
     },
 
     // ── Diff ─────────────────────────────────────────────────

--- a/src/tui/theme/themes/material.ts
+++ b/src/tui/theme/themes/material.ts
@@ -131,6 +131,44 @@ export const material: ThemeDefinition = {
       light: RGBA.fromHex("#e2931d"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#c792ea"), // purple
+      light: RGBA.fromHex("#7c4dff"),
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#c3e88d"), // green
+      light: RGBA.fromHex("#91b859"),
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#546e7a"), // comment
+      light: RGBA.fromHex("#90a4ae"),
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#f78c6c"), // orange
+      light: RGBA.fromHex("#f76d47"),
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#82aaff"), // blue
+      light: RGBA.fromHex("#6182b8"),
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#ffcb6b"), // yellow
+      light: RGBA.fromHex("#e2931d"),
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#f07178"), // red
+      light: RGBA.fromHex("#e53935"),
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#89ddff"), // cyan
+      light: RGBA.fromHex("#39adb5"),
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#89ddff"), // cyan (operators)
+      light: RGBA.fromHex("#39adb5"),
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#c3e88d"),

--- a/src/tui/theme/themes/monokai.ts
+++ b/src/tui/theme/themes/monokai.ts
@@ -131,6 +131,44 @@ export const monokai: ThemeDefinition = {
       light: RGBA.fromHex("#a67f00"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#ff6188"), // red/pink
+      light: RGBA.fromHex("#cc2944"),
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#ffd866"), // yellow
+      light: RGBA.fromHex("#a67f00"),
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#727072"), // comment
+      light: RGBA.fromHex("#9e9b9f"),
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#ab9df2"), // purple
+      light: RGBA.fromHex("#6e56cf"),
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#a9dc76"), // green
+      light: RGBA.fromHex("#4d7a27"),
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#78dce8"), // cyan
+      light: RGBA.fromHex("#0b7e8b"),
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#ff6188"), // red/pink
+      light: RGBA.fromHex("#cc2944"),
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#fc9867"), // orange
+      light: RGBA.fromHex("#c25d00"),
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#939293"), // muted fg
+      light: RGBA.fromHex("#6e6c6e"),
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#a9dc76"),

--- a/src/tui/theme/themes/monokai.ts
+++ b/src/tui/theme/themes/monokai.ts
@@ -141,8 +141,8 @@ export const monokai: ThemeDefinition = {
       light: RGBA.fromHex("#a67f00"),
     },
     syntaxComment: {
-      dark: RGBA.fromHex("#727072"), // comment
-      light: RGBA.fromHex("#9e9b9f"),
+      dark: RGBA.fromHex("#817f81"), // comment
+      light: RGBA.fromHex("#949195"),
     },
     syntaxNumber: {
       dark: RGBA.fromHex("#ab9df2"), // purple

--- a/src/tui/theme/themes/nightfox.ts
+++ b/src/tui/theme/themes/nightfox.ts
@@ -130,6 +130,44 @@ export const nightfox: ThemeDefinition = {
       light: RGBA.fromHex("#AC5402"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#9d79d6"), // magenta
+      light: RGBA.fromHex("#6e33ce"),
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#81b29a"), // green
+      light: RGBA.fromHex("#396847"),
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#738091"), // comment
+      light: RGBA.fromHex("#837a72"),
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#f4a261"), // orange
+      light: RGBA.fromHex("#955f61"),
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#719cd6"), // blue
+      light: RGBA.fromHex("#2848a9"),
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#dbc074"), // yellow
+      light: RGBA.fromHex("#AC5402"),
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#c94f6d"), // red
+      light: RGBA.fromHex("#a5222f"),
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#63cdcf"), // cyan
+      light: RGBA.fromHex("#287980"),
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#aeafb0"), // muted fg
+      light: RGBA.fromHex("#5a5565"),
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#81b29a"),

--- a/src/tui/theme/themes/nord.ts
+++ b/src/tui/theme/themes/nord.ts
@@ -131,6 +131,44 @@ export const nord: ThemeDefinition = {
       light: RGBA.fromHex("#c08b30"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#81a1c1"), // nord9 (frost blue)
+      light: RGBA.fromHex("#5e81ac"), // nord10
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#a3be8c"), // nord14 (aurora green)
+      light: RGBA.fromHex("#6d8a54"),
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#4c566a"), // nord3 (polar night)
+      light: RGBA.fromHex("#7b88a1"),
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#b48ead"), // nord15 (aurora purple)
+      light: RGBA.fromHex("#8c6aa8"),
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#88c0d0"), // nord8 (frost cyan)
+      light: RGBA.fromHex("#5e81ac"), // nord10
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#ebcb8b"), // nord13 (aurora yellow)
+      light: RGBA.fromHex("#c08b30"),
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#bf616a"), // nord11 (aurora red)
+      light: RGBA.fromHex("#bf616a"),
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#d08770"), // nord12 (aurora orange)
+      light: RGBA.fromHex("#c46840"),
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#d8dee9"), // nord4 (snow storm)
+      light: RGBA.fromHex("#4c566a"), // nord3
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#a3be8c"), // nord14

--- a/src/tui/theme/themes/nord.ts
+++ b/src/tui/theme/themes/nord.ts
@@ -134,14 +134,14 @@ export const nord: ThemeDefinition = {
     // ── Syntax Highlighting ──────────────────────────────────
     syntaxKeyword: {
       dark: RGBA.fromHex("#81a1c1"), // nord9 (frost blue)
-      light: RGBA.fromHex("#5e81ac"), // nord10
+      light: RGBA.fromHex("#577ca9"), // nord10
     },
     syntaxString: {
       dark: RGBA.fromHex("#a3be8c"), // nord14 (aurora green)
-      light: RGBA.fromHex("#6d8a54"),
+      light: RGBA.fromHex("#688450"),
     },
     syntaxComment: {
-      dark: RGBA.fromHex("#4c566a"), // nord3 (polar night)
+      dark: RGBA.fromHex("#75829c"), // nord3 (polar night)
       light: RGBA.fromHex("#7b88a1"),
     },
     syntaxNumber: {
@@ -150,19 +150,19 @@ export const nord: ThemeDefinition = {
     },
     syntaxFunction: {
       dark: RGBA.fromHex("#88c0d0"), // nord8 (frost cyan)
-      light: RGBA.fromHex("#5e81ac"), // nord10
+      light: RGBA.fromHex("#577ca9"), // nord10
     },
     syntaxType: {
       dark: RGBA.fromHex("#ebcb8b"), // nord13 (aurora yellow)
-      light: RGBA.fromHex("#c08b30"),
+      light: RGBA.fromHex("#9f7328"),
     },
     syntaxTag: {
-      dark: RGBA.fromHex("#bf616a"), // nord11 (aurora red)
+      dark: RGBA.fromHex("#c8777f"), // nord11 (aurora red)
       light: RGBA.fromHex("#bf616a"),
     },
     syntaxAttr: {
       dark: RGBA.fromHex("#d08770"), // nord12 (aurora orange)
-      light: RGBA.fromHex("#c46840"),
+      light: RGBA.fromHex("#bf633b"),
     },
     syntaxPunctuation: {
       dark: RGBA.fromHex("#d8dee9"), // nord4 (snow storm)

--- a/src/tui/theme/themes/onedark.ts
+++ b/src/tui/theme/themes/onedark.ts
@@ -131,6 +131,44 @@ export const oneDark: ThemeDefinition = {
       light: RGBA.fromHex("#c18401"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#c678dd"), // purple
+      light: RGBA.fromHex("#a626a4"),
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#98c379"), // green
+      light: RGBA.fromHex("#50a14f"),
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#5c6370"), // comment
+      light: RGBA.fromHex("#a0a1a7"),
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#d19a66"), // orange
+      light: RGBA.fromHex("#986801"),
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#61afef"), // blue
+      light: RGBA.fromHex("#4078f2"),
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#56b6c2"), // cyan
+      light: RGBA.fromHex("#0184bc"),
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#e06c75"), // red
+      light: RGBA.fromHex("#e45649"),
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#e5c07b"), // yellow
+      light: RGBA.fromHex("#c18401"),
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#abb2bf"), // fg
+      light: RGBA.fromHex("#383a42"),
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#98c379"),

--- a/src/tui/theme/themes/onedark.ts
+++ b/src/tui/theme/themes/onedark.ts
@@ -138,11 +138,11 @@ export const oneDark: ThemeDefinition = {
     },
     syntaxString: {
       dark: RGBA.fromHex("#98c379"), // green
-      light: RGBA.fromHex("#50a14f"),
+      light: RGBA.fromHex("#499348"),
     },
     syntaxComment: {
-      dark: RGBA.fromHex("#5c6370"), // comment
-      light: RGBA.fromHex("#a0a1a7"),
+      dark: RGBA.fromHex("#656d7b"), // comment
+      light: RGBA.fromHex("#909198"),
     },
     syntaxNumber: {
       dark: RGBA.fromHex("#d19a66"), // orange
@@ -162,7 +162,7 @@ export const oneDark: ThemeDefinition = {
     },
     syntaxAttr: {
       dark: RGBA.fromHex("#e5c07b"), // yellow
-      light: RGBA.fromHex("#c18401"),
+      light: RGBA.fromHex("#ad7601"),
     },
     syntaxPunctuation: {
       dark: RGBA.fromHex("#abb2bf"), // fg

--- a/src/tui/theme/themes/rose-pine.ts
+++ b/src/tui/theme/themes/rose-pine.ts
@@ -132,16 +132,16 @@ export const rosePine: ThemeDefinition = {
 
     // ── Syntax Highlighting ──────────────────────────────────
     syntaxKeyword: {
-      dark: RGBA.fromHex("#31748f"), // pine (main)
+      dark: RGBA.fromHex("#347a97"), // pine (main)
       light: RGBA.fromHex("#286983"), // pine (dawn)
     },
     syntaxString: {
       dark: RGBA.fromHex("#f6c177"), // gold (main)
-      light: RGBA.fromHex("#ea9d34"), // gold (dawn)
+      light: RGBA.fromHex("#b97313"), // gold (dawn)
     },
     syntaxComment: {
       dark: RGBA.fromHex("#6e6a86"), // muted (main)
-      light: RGBA.fromHex("#9893a5"), // muted (dawn)
+      light: RGBA.fromHex("#938da0"), // muted (dawn)
     },
     syntaxNumber: {
       dark: RGBA.fromHex("#c4a7e7"), // iris (main)
@@ -149,11 +149,11 @@ export const rosePine: ThemeDefinition = {
     },
     syntaxFunction: {
       dark: RGBA.fromHex("#ebbcba"), // rose (main)
-      light: RGBA.fromHex("#d7827e"), // rose (dawn)
+      light: RGBA.fromHex("#cd645f"), // rose (dawn)
     },
     syntaxType: {
       dark: RGBA.fromHex("#9ccfd8"), // foam (main)
-      light: RGBA.fromHex("#56949f"), // foam (dawn)
+      light: RGBA.fromHex("#528e98"), // foam (dawn)
     },
     syntaxTag: {
       dark: RGBA.fromHex("#eb6f92"), // love (main)

--- a/src/tui/theme/themes/rose-pine.ts
+++ b/src/tui/theme/themes/rose-pine.ts
@@ -130,6 +130,44 @@ export const rosePine: ThemeDefinition = {
       light: RGBA.fromHex("#b4637a"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#31748f"), // pine (main)
+      light: RGBA.fromHex("#286983"), // pine (dawn)
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#f6c177"), // gold (main)
+      light: RGBA.fromHex("#ea9d34"), // gold (dawn)
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#6e6a86"), // muted (main)
+      light: RGBA.fromHex("#9893a5"), // muted (dawn)
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#c4a7e7"), // iris (main)
+      light: RGBA.fromHex("#907aa9"), // iris (dawn)
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#ebbcba"), // rose (main)
+      light: RGBA.fromHex("#d7827e"), // rose (dawn)
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#9ccfd8"), // foam (main)
+      light: RGBA.fromHex("#56949f"), // foam (dawn)
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#eb6f92"), // love (main)
+      light: RGBA.fromHex("#b4637a"), // love (dawn)
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#c4a7e7"), // iris (main)
+      light: RGBA.fromHex("#907aa9"), // iris (dawn)
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#908caa"), // subtle (main)
+      light: RGBA.fromHex("#797593"), // subtle (dawn)
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#9ccfd8"), // foam

--- a/src/tui/theme/themes/solarized.ts
+++ b/src/tui/theme/themes/solarized.ts
@@ -130,6 +130,44 @@ export const solarized: ThemeDefinition = {
       light: RGBA.fromHex("#6c71c4"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#859900"), // green
+      light: RGBA.fromHex("#859900"),
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#2aa198"), // cyan
+      light: RGBA.fromHex("#2aa198"),
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#586e75"), // base01
+      light: RGBA.fromHex("#93a1a1"), // base1
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#d33682"), // magenta
+      light: RGBA.fromHex("#d33682"),
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#268bd2"), // blue
+      light: RGBA.fromHex("#268bd2"),
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#b58900"), // yellow
+      light: RGBA.fromHex("#b58900"),
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#cb4b16"), // orange
+      light: RGBA.fromHex("#cb4b16"),
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#6c71c4"), // violet
+      light: RGBA.fromHex("#6c71c4"),
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#839496"), // base0
+      light: RGBA.fromHex("#657b83"), // base00
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#859900"),

--- a/src/tui/theme/themes/solarized.ts
+++ b/src/tui/theme/themes/solarized.ts
@@ -133,34 +133,34 @@ export const solarized: ThemeDefinition = {
     // ── Syntax Highlighting ──────────────────────────────────
     syntaxKeyword: {
       dark: RGBA.fromHex("#859900"), // green
-      light: RGBA.fromHex("#859900"),
+      light: RGBA.fromHex("#738500"),
     },
     syntaxString: {
       dark: RGBA.fromHex("#2aa198"), // cyan
-      light: RGBA.fromHex("#2aa198"),
+      light: RGBA.fromHex("#248981"),
     },
     syntaxComment: {
-      dark: RGBA.fromHex("#586e75"), // base01
-      light: RGBA.fromHex("#93a1a1"), // base1
+      dark: RGBA.fromHex("#657e86"), // base01
+      light: RGBA.fromHex("#7d8e8e"), // base1
     },
     syntaxNumber: {
-      dark: RGBA.fromHex("#d33682"), // magenta
+      dark: RGBA.fromHex("#da5797"), // magenta
       light: RGBA.fromHex("#d33682"),
     },
     syntaxFunction: {
       dark: RGBA.fromHex("#268bd2"), // blue
-      light: RGBA.fromHex("#268bd2"),
+      light: RGBA.fromHex("#2380c1"),
     },
     syntaxType: {
       dark: RGBA.fromHex("#b58900"), // yellow
-      light: RGBA.fromHex("#b58900"),
+      light: RGBA.fromHex("#967200"),
     },
     syntaxTag: {
-      dark: RGBA.fromHex("#cb4b16"), // orange
+      dark: RGBA.fromHex("#e65519"), // orange
       light: RGBA.fromHex("#cb4b16"),
     },
     syntaxAttr: {
-      dark: RGBA.fromHex("#6c71c4"), // violet
+      dark: RGBA.fromHex("#7b7fca"), // violet
       light: RGBA.fromHex("#6c71c4"),
     },
     syntaxPunctuation: {

--- a/src/tui/theme/themes/tokyonight.ts
+++ b/src/tui/theme/themes/tokyonight.ts
@@ -133,39 +133,39 @@ export const tokyonight: ThemeDefinition = {
     // ── Syntax Highlighting ──────────────────────────────────
     syntaxKeyword: {
       dark: RGBA.fromHex("#bb9af7"), // purple
-      light: RGBA.fromHex("#9854f1"),
+      light: RGBA.fromHex("#8d41ef"),
     },
     syntaxString: {
       dark: RGBA.fromHex("#9ece6a"), // green
       light: RGBA.fromHex("#587539"),
     },
     syntaxComment: {
-      dark: RGBA.fromHex("#565f89"), // comment
-      light: RGBA.fromHex("#8990b3"),
+      dark: RGBA.fromHex("#626c9c"), // comment
+      light: RGBA.fromHex("#7079a3"),
     },
     syntaxNumber: {
       dark: RGBA.fromHex("#ff9e64"), // orange
-      light: RGBA.fromHex("#b15c00"),
+      light: RGBA.fromHex("#a75700"),
     },
     syntaxFunction: {
       dark: RGBA.fromHex("#7aa2f7"), // blue
-      light: RGBA.fromHex("#2e7de9"),
+      light: RGBA.fromHex("#1768d8"),
     },
     syntaxType: {
       dark: RGBA.fromHex("#2ac3de"), // cyan
-      light: RGBA.fromHex("#07879d"),
+      light: RGBA.fromHex("#067689"),
     },
     syntaxTag: {
       dark: RGBA.fromHex("#f7768e"), // red
-      light: RGBA.fromHex("#c64343"),
+      light: RGBA.fromHex("#c43b3b"),
     },
     syntaxAttr: {
       dark: RGBA.fromHex("#e0af68"), // yellow
-      light: RGBA.fromHex("#8c6c3e"),
+      light: RGBA.fromHex("#85673b"),
     },
     syntaxPunctuation: {
       dark: RGBA.fromHex("#9aa5ce"), // fg_gutter
-      light: RGBA.fromHex("#6172b0"),
+      light: RGBA.fromHex("#5a6cad"),
     },
 
     // ── Diff ─────────────────────────────────────────────────

--- a/src/tui/theme/themes/tokyonight.ts
+++ b/src/tui/theme/themes/tokyonight.ts
@@ -130,6 +130,44 @@ export const tokyonight: ThemeDefinition = {
       light: RGBA.fromHex("#8c6c3e"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#bb9af7"), // purple
+      light: RGBA.fromHex("#9854f1"),
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#9ece6a"), // green
+      light: RGBA.fromHex("#587539"),
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#565f89"), // comment
+      light: RGBA.fromHex("#8990b3"),
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#ff9e64"), // orange
+      light: RGBA.fromHex("#b15c00"),
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#7aa2f7"), // blue
+      light: RGBA.fromHex("#2e7de9"),
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#2ac3de"), // cyan
+      light: RGBA.fromHex("#07879d"),
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#f7768e"), // red
+      light: RGBA.fromHex("#c64343"),
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#e0af68"), // yellow
+      light: RGBA.fromHex("#8c6c3e"),
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#9aa5ce"), // fg_gutter
+      light: RGBA.fromHex("#6172b0"),
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#449dab"),

--- a/src/tui/theme/themes/vesper.ts
+++ b/src/tui/theme/themes/vesper.ts
@@ -142,8 +142,8 @@ export const vesper: ThemeDefinition = {
       light: RGBA.fromHex("#007a5e"),
     },
     syntaxComment: {
-      dark: RGBA.fromHex("#505050"), // comment
-      light: RGBA.fromHex("#999999"),
+      dark: RGBA.fromHex("#5a5a5a"), // comment
+      light: RGBA.fromHex("#8f8f8f"),
     },
     syntaxNumber: {
       dark: RGBA.fromHex("#d4a0ff"), // purple
@@ -163,7 +163,7 @@ export const vesper: ThemeDefinition = {
     },
     syntaxAttr: {
       dark: RGBA.fromHex("#ffcb6b"), // yellow
-      light: RGBA.fromHex("#a67f00"),
+      light: RGBA.fromHex("#9c7700"),
     },
     syntaxPunctuation: {
       dark: RGBA.fromHex("#7a7a7a"), // muted

--- a/src/tui/theme/themes/vesper.ts
+++ b/src/tui/theme/themes/vesper.ts
@@ -132,6 +132,44 @@ export const vesper: ThemeDefinition = {
       light: RGBA.fromHex("#a67f00"),
     },
 
+    // ── Syntax Highlighting ──────────────────────────────────
+    syntaxKeyword: {
+      dark: RGBA.fromHex("#ffc799"), // orange/amber
+      light: RGBA.fromHex("#b35c00"),
+    },
+    syntaxString: {
+      dark: RGBA.fromHex("#99ffe4"), // teal
+      light: RGBA.fromHex("#007a5e"),
+    },
+    syntaxComment: {
+      dark: RGBA.fromHex("#505050"), // comment
+      light: RGBA.fromHex("#999999"),
+    },
+    syntaxNumber: {
+      dark: RGBA.fromHex("#d4a0ff"), // purple
+      light: RGBA.fromHex("#7e3aaf"),
+    },
+    syntaxFunction: {
+      dark: RGBA.fromHex("#a0c4ff"), // blue
+      light: RGBA.fromHex("#2563a0"),
+    },
+    syntaxType: {
+      dark: RGBA.fromHex("#ffc799"), // amber
+      light: RGBA.fromHex("#b35c00"),
+    },
+    syntaxTag: {
+      dark: RGBA.fromHex("#f14c4c"), // red
+      light: RGBA.fromHex("#c62828"),
+    },
+    syntaxAttr: {
+      dark: RGBA.fromHex("#ffcb6b"), // yellow
+      light: RGBA.fromHex("#a67f00"),
+    },
+    syntaxPunctuation: {
+      dark: RGBA.fromHex("#7a7a7a"), // muted
+      light: RGBA.fromHex("#666666"),
+    },
+
     // ── Diff ─────────────────────────────────────────────────
     diffAdded: {
       dark: RGBA.fromHex("#99ffe4"),

--- a/src/tui/theme/types.ts
+++ b/src/tui/theme/types.ts
@@ -87,6 +87,26 @@ export interface ThemeColors {
   /** Italic text */
   markdownEmph: RGBA;
 
+  // ── Syntax Highlighting ──────────────────────────────────
+  /** Keywords, control flow, built-ins */
+  syntaxKeyword: RGBA;
+  /** String literals */
+  syntaxString: RGBA;
+  /** Comments */
+  syntaxComment: RGBA;
+  /** Numeric literals */
+  syntaxNumber: RGBA;
+  /** Function names and calls */
+  syntaxFunction: RGBA;
+  /** Type names, interfaces, classes */
+  syntaxType: RGBA;
+  /** HTML/XML tags, variables */
+  syntaxTag: RGBA;
+  /** Attributes, parameters, properties */
+  syntaxAttr: RGBA;
+  /** Punctuation, operators */
+  syntaxPunctuation: RGBA;
+
   // ── Diff ─────────────────────────────────────────────────
   /** Added line foreground */
   diffAdded: RGBA;


### PR DESCRIPTION
### What does this PR do?

Makes code output syntax highlighting fully **theme-aware**, fixes a series of related light-mode readability bugs, and tightens the scrollbar UX in scrollable surfaces.

**Theme-aware syntax highlighting (original scope):**
- Each of the 18 built-in themes now defines its own syntax palette with dark and light variants, sourced from the canonical IDE color scheme for that theme. Previously, syntax highlighting used a single hardcoded palette for all themes.
- Added 9 new semantic color tokens to `ThemeColors`: `syntaxKeyword`, `syntaxString`, `syntaxComment`, `syntaxNumber`, `syntaxFunction`, `syntaxType`, `syntaxTag`, `syntaxAttr`, `syntaxPunctuation`.
- `highlightCode()` now takes resolved `ThemeColors` and builds the hljs class map from the active theme. `getResultSummary()` and call sites (`tool-renderer.tsx`, `tool-message.tsx`) pass `colors` through. Web search result styling uses theme tokens instead of a hardcoded `WS_COLORS` map.

**Light-mode rendering bugs (uncovered while testing the above):**

1. **Markdown prose rendered as opentui white default in light themes.** `markdownToStyledText` pushed plain-text, br, list-marker, paragraph/heading newline, html, blockquote-body, and space chunks with no `fg`. Opentui's StyledText chunks without `fg` fall back to a hardcoded white default — invisible on light dialog backgrounds — regardless of the parent `<text fg=…>`. Resolve `textColor` from `colors.text` and set `fg` on every chunk that doesn't already carry an explicit color (codespans, links, code blocks, blockquote indicator keep their existing colors).
2. **Unclassed code tokens rendered white in light themes.** Same chunk-fg-undefined issue at a different layer: `parseHljsHtml` pushed text-node chunks with `fg: colorStack[…]` where the initial stack was `[undefined]`. Any token outside an hljs span — whitespace, punctuation like `{ } | ; ,`, plain identifiers like `requireAdmin` that hljs doesn't classify — got `fg: undefined` and rendered as white. Pass `colors.text` as `defaultColor` and seed the stack with it.
3. **Many syntax tokens fell below readable contrast on the dialog background.** Audited all 18 themes × 9 syntax tokens × 2 modes (162 tokens) against `backgroundElement`. 75 tokens (mostly in light mode) were below WCAG AA Large (3:1), some under 2:1. For each failing token, adjusted lightness in HSL space (preserving hue and saturation) until contrast cleared the threshold — 3.0:1 floor for active tokens, 2.5:1 floor for comments (kept intentionally subdued). Also rebuilt the apex theme's syntax palette with hue-stable HSL values that boost saturation ~50% over the prior tone-down so it reads as "muted but not dull". After this pass, 0/162 tokens fail their threshold.

**Scrollbar UX (regression from the convention introduced in #682):**

4. **`scrollbarOptions: { visible: true }` painted a stray solid block on short surfaces.** With nothing to scroll, the thumb spanned the entire track and read as a colored rectangle on the right edge. Dropped `visible: true` on MessageList, SubagentHub, HelpDialog, SessionsDisplay so opentui's auto-visibility hides the bar when there's no overflow.
5. **Thumb painted in `colors.primary` was too loud.** Primary is the brand accent and shouldn't dominate every scrollable surface. Switched all 10 `foregroundColor: colors.primary` track options to `colors.textMuted` so the thumb is a subtle theme-aware gray. Track stays `colors.backgroundElement` so it blends with the dialog body. Updated `AGENTS.md` so the convention reflects the new behavior.

### How did you verify your code works?

- `bun run tsc` — type check passes
- `bun run lint` — no lint errors
- `bun run format:check` — formatting correct
- `bun run test` — 829 passed, 18 skipped
- Manual TUI verification across light and dark modes on tokyonight, github, dracula, apex, and others


https://github.com/user-attachments/assets/759684fe-f03c-41a5-b2ca-85250eefef75