### PR TITLE
Scrollbars: fix offset from edge and color in light theme

### DIFF
--- a/src/tui/components/chat/message-list.tsx
+++ b/src/tui/components/chat/message-list.tsx
@@ -124,13 +124,13 @@ export function MessageList({
           flexDirection: "column",
         },
         scrollbarOptions: {
+          visible: true,
           trackOptions: {
             foregroundColor: colors.primary,
             backgroundColor: colors.backgroundElement,
           },
         },
       }}
-      scrollbarOptions={{ visible: true }}
       stickyScroll={true}
       stickyStart="bottom"
       focused={focused}

--- a/src/tui/components/chat/message-list.tsx
+++ b/src/tui/components/chat/message-list.tsx
@@ -123,7 +123,14 @@ export function MessageList({
           paddingBottom: 2,
           flexDirection: "column",
         },
+        scrollbarOptions: {
+          trackOptions: {
+            foregroundColor: colors.primary,
+            backgroundColor: colors.backgroundElement,
+          },
+        },
       }}
+      scrollbarOptions={{ visible: true }}
       stickyScroll={true}
       stickyStart="bottom"
       focused={focused}

--- a/src/tui/components/commands/help-dialog.tsx
+++ b/src/tui/components/commands/help-dialog.tsx
@@ -174,6 +174,7 @@ export default function HelpDialog({ onClose }: HelpDialogProps) {
     <Dialog size="large" onClose={onClose}>
       <DialogLayout
         title="Commands"
+        flushRight
         footerActions={[{ key: "Enter", label: "details", variant: "primary" }]}
       >
         {/* Commands list grouped by category */}
@@ -182,7 +183,14 @@ export default function HelpDialog({ onClose }: HelpDialogProps) {
           style={{
             rootOptions: { flexGrow: 1, width: "100%" },
             contentOptions: { flexDirection: "column" },
+            scrollbarOptions: {
+              trackOptions: {
+                foregroundColor: colors.primary,
+                backgroundColor: colors.backgroundElement,
+              },
+            },
           }}
+          scrollbarOptions={{ visible: true }}
           stickyScroll={false}
           focused={true}
         >

--- a/src/tui/components/commands/help-dialog.tsx
+++ b/src/tui/components/commands/help-dialog.tsx
@@ -184,13 +184,13 @@ export default function HelpDialog({ onClose }: HelpDialogProps) {
             rootOptions: { flexGrow: 1, width: "100%" },
             contentOptions: { flexDirection: "column" },
             scrollbarOptions: {
+              visible: true,
               trackOptions: {
                 foregroundColor: colors.primary,
                 backgroundColor: colors.backgroundElement,
               },
             },
           }}
-          scrollbarOptions={{ visible: true }}
           stickyScroll={false}
           focused={true}
         >

--- a/src/tui/components/commands/provider-selection.tsx
+++ b/src/tui/components/commands/provider-selection.tsx
@@ -66,6 +66,7 @@ export default function ProviderSelection({
     <Dialog size="large" onClose={onClose}>
       <DialogLayout
         title="Select provider"
+        flushRight
         footerActions={[{ key: "Enter", label: "select", variant: "primary" }]}
       >
         {/* Provider List */}
@@ -79,6 +80,12 @@ export default function ProviderSelection({
             contentOptions: {
               flexDirection: "column",
               gap: 1,
+            },
+            scrollbarOptions: {
+              trackOptions: {
+                foregroundColor: colors.primary,
+                backgroundColor: colors.backgroundElement,
+              },
             },
           }}
           stickyScroll={false}

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -242,7 +242,6 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
           >
             <scrollbox
               ref={scroll}
-              scrollbarOptions={{ visible: true }}
               style={{
                 rootOptions: {
                   width: "100%",
@@ -258,6 +257,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
                   flexDirection: "column",
                 },
                 scrollbarOptions: {
+                  visible: true,
                   trackOptions: {
                     foregroundColor: colors.primary,
                     backgroundColor: colors.backgroundElement,

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -208,7 +208,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
 
   return (
     <Dialog size="large" onClose={handleClose}>
-      <DialogLayout title="Sessions" footerActions={footerActions}>
+      <DialogLayout title="Sessions" flushRight footerActions={footerActions}>
         {/* Search Input */}
         <box
           width="100%"
@@ -256,6 +256,12 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
                 contentOptions: {
                   gap: 2,
                   flexDirection: "column",
+                },
+                scrollbarOptions: {
+                  trackOptions: {
+                    foregroundColor: colors.primary,
+                    backgroundColor: colors.backgroundElement,
+                  },
                 },
               }}
             >

--- a/src/tui/components/commands/skills-dialog.tsx
+++ b/src/tui/components/commands/skills-dialog.tsx
@@ -180,6 +180,7 @@ export default function SkillsDialog({
         <DialogLayout
           title={detailTitle}
           escLabel="back"
+          flushRight
           footerActions={[
             { key: "E", label: "open in editor", variant: "primary" },
           ]}
@@ -253,6 +254,7 @@ export default function SkillsDialog({
     <Dialog size="large" onClose={onClose}>
       <DialogLayout
         title="Skills"
+        flushRight
         footerActions={[{ key: "Enter", label: "details", variant: "primary" }]}
       >
         {/* Skill list */}

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -556,6 +556,7 @@ export default function WebWizard({
     <Dialog size="large" onClose={onClose}>
       <DialogLayout
         title={`Configure Web App Pentest - ${modeLabel}`}
+        flushRight
         footerActions={[
           { key: "Enter", label: "start pentest", variant: "primary" },
           { key: "↑/↓", label: "navigate" },
@@ -570,6 +571,12 @@ export default function WebWizard({
               flexDirection: "column",
               gap: 1,
               paddingBottom: 1,
+            },
+            scrollbarOptions: {
+              trackOptions: {
+                foregroundColor: colors.primary,
+                backgroundColor: colors.backgroundElement,
+              },
             },
           }}
           stickyScroll={false}

--- a/src/tui/components/dialog-layout.tsx
+++ b/src/tui/components/dialog-layout.tsx
@@ -8,6 +8,8 @@ export interface DialogLayoutProps {
   title: string | ReactNode;
   escLabel?: string | null;
   footerActions?: ControlItem[];
+  /** Remove right padding from the body so scrollbars sit flush against the dialog edge. */
+  flushRight?: boolean;
   children: ReactNode;
 }
 
@@ -15,6 +17,7 @@ export default function DialogLayout({
   title,
   escLabel = "close",
   footerActions,
+  flushRight = false,
   children,
 }: DialogLayoutProps) {
   const { colors } = useTheme();
@@ -24,7 +27,7 @@ export default function DialogLayout({
       flexDirection="column"
       width="100%"
       paddingLeft={2}
-      paddingRight={2}
+      paddingRight={flushRight ? 0 : 2}
       paddingTop={1}
       paddingBottom={1}
     >
@@ -34,6 +37,7 @@ export default function DialogLayout({
         justifyContent="space-between"
         width="100%"
         flexShrink={0}
+        paddingRight={flushRight ? 2 : 0}
       >
         {typeof title === "string" ? (
           <text fg={colors.primary}>{title}</text>
@@ -60,7 +64,7 @@ export default function DialogLayout({
 
       {/* Footer */}
       {footerActions && footerActions.length > 0 && (
-        <box marginTop={1} flexShrink={0}>
+        <box marginTop={1} flexShrink={0} paddingRight={flushRight ? 2 : 0}>
           <DialogControls controls={footerActions} />
         </box>
       )}

--- a/src/tui/components/operator-dashboard/subagent-dialog.tsx
+++ b/src/tui/components/operator-dashboard/subagent-dialog.tsx
@@ -104,6 +104,7 @@ export default function SubagentDialog({ store }: SubagentDialogProps) {
       <DialogLayout
         title={title}
         escLabel="back"
+        flushRight
         footerActions={[
           { key: "\u2190\u2192", label: "prev/next" },
           { key: "\u2191\u2193", label: "scroll" },
@@ -127,6 +128,7 @@ export default function SubagentDialog({ store }: SubagentDialogProps) {
   return (
     <DialogLayout
       title={`Agents (${sessions.size})`}
+      flushRight
       footerActions={[
         { key: "Enter", label: "view", variant: "primary" },
         { key: "\u2191\u2193", label: "navigate" },

--- a/src/tui/components/operator-dashboard/subagent-hub.tsx
+++ b/src/tui/components/operator-dashboard/subagent-hub.tsx
@@ -232,7 +232,14 @@ export const SubagentHub = memo(function SubagentHub({
               paddingTop: 1,
               paddingBottom: 1,
             },
+            scrollbarOptions: {
+              trackOptions: {
+                foregroundColor: colors.primary,
+                backgroundColor: colors.backgroundElement,
+              },
+            },
           }}
+          scrollbarOptions={{ visible: true }}
           stickyScroll={false}
           focused={true}
         >

--- a/src/tui/components/operator-dashboard/subagent-hub.tsx
+++ b/src/tui/components/operator-dashboard/subagent-hub.tsx
@@ -233,13 +233,13 @@ export const SubagentHub = memo(function SubagentHub({
               paddingBottom: 1,
             },
             scrollbarOptions: {
+              visible: true,
               trackOptions: {
                 foregroundColor: colors.primary,
                 backgroundColor: colors.backgroundElement,
               },
             },
           }}
-          scrollbarOptions={{ visible: true }}
           stickyScroll={false}
           focused={true}
         >

--- a/src/tui/components/report-viewer-dialog.tsx
+++ b/src/tui/components/report-viewer-dialog.tsx
@@ -61,7 +61,7 @@ export default function ReportViewerDialog({
 
   return (
     <Dialog size="xlarge" onClose={onClose}>
-      <DialogLayout title={title} footerActions={footerActions}>
+      <DialogLayout title={title} flushRight footerActions={footerActions}>
         {/* Report Content */}
         <scrollbox
           ref={scrollRef}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes scrollbar offset in dialog overlays and wires up theme-aware scrollbar colors on scrollboxes that were missing them.

1. **Scrollbar gap from dialog edge** — `DialogLayout` applied uniform `paddingRight={2}` on its outer wrapper, pushing scrollbars 2 characters inward from the dialog border, making them look detached from the container.

   **Fix:** Added a `flushRight` prop to `DialogLayout`. When set, right padding is removed from the body wrapper so the scrollbar sits flush against the dialog edge, while header and footer retain their own right padding for proper text alignment.

2. **Scrollbar colors not theme-aware** — Several scrollboxes had no `trackOptions` set, falling back to OpenTUI's hardcoded dark-mode defaults regardless of theme.

   **Fix:** Added `scrollbarOptions.trackOptions` (`foregroundColor: colors.primary`, `backgroundColor: colors.backgroundElement`) to scrollboxes that were missing them, so they pick up the active theme. Also sets `scrollbarOptions.visible: true` on SubagentHub and MessageList per AGENTS.md convention.

**Files changed:**
- `dialog-layout.tsx` — new `flushRight` prop
- `subagent-dialog.tsx` — enable `flushRight` on both hub and detail views
- `subagent-hub.tsx` — add themed scrollbar trackOptions + visible
- `message-list.tsx` — add themed scrollbar trackOptions + visible
- `help-dialog.tsx` — add themed scrollbar trackOptions + `flushRight`
- `sessions-display.tsx` — add themed scrollbar trackOptions + `flushRight`
- `skills-dialog.tsx` — enable `flushRight` on both list and detail views
- `report-viewer-dialog.tsx` — enable `flushRight`
- `provider-selection.tsx` — add themed scrollbar trackOptions + `flushRight`
- `web-wizard.tsx` — add themed scrollbar trackOptions + `flushRight`

### How did you verify your code works?

- `bun run tsc` — type check passes
- `bun run lint` — no lint errors
- `bun run format:check` — formatting correct
- `bun run test` — all tests pass
- Manual TUI testing in dark and light modes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0d749bf-bc32-4a31-96bf-02a57673a17a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0d749bf-bc32-4a31-96bf-02a57673a17a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>