### PR TITLE
ci: add fern-check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,20 @@
+name: fern-check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - canary
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Fern CLI tool
+        run: npm install -g fern-api
+
+      - name: Check docs and API are valid
+        run: fern check


### PR DESCRIPTION
Mirrors console's existing `.github/workflows/check.yml`. Runs `fern check` on every PR (and on pushes to canary), which hard-fails on broken internal links, anchors, and invalid docs/API config — the same gate that would have caught #674.

This is the only side that needed a change; console already runs `fern check` on every PR. The earlier external-link script idea was descoped (warn-only and didn't address the bug class from #674).

Closes #683.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CI gate that runs `fern check` on PRs and `canary` pushes, with no production code changes.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/check.yml`) that runs `fern check` on every pull request and on pushes to the `canary` branch.
> 
> The job checks out the repo, installs the `fern-api` CLI via npm, and fails CI if Fern docs/API validation fails (e.g., broken internal links/anchors or invalid config).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97a46ef9e1c2c4d436975be26e6cff7a2337d197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->