### PR TITLE
feat: add `pensar -p` for headless operator sessions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -97,6 +97,7 @@ function showHelp() {
 
 Usage:
   pensar                             Launch the TUI
+  pensar -p <prompt>                 Start an operator session with a prompt
   pensar pentest [options]            Run a full pentest orchestration
   pensar targeted-pentest [options]   Run a targeted pentest on a single target
   pensar threat-model [options]       Generate application-centric threat model
@@ -111,6 +112,11 @@ Usage:
   pensar doctor                       Check dependencies and install missing tools
   pensar help                         Show this help message
   pensar version                      Show version number
+
+operator options (-p):
+  -p, --prompt <text|@file>  (required) Prompt for the operator agent
+  --target <url>             Target URL / domain / IP
+  --model <model>            AI model (default: claude-sonnet-4-5)
 
 pentest options:
   --target <url>           (required) Target URL / domain / IP
@@ -340,6 +346,121 @@ Model:    ${model}
   );
 }
 
+async function runOperator() {
+  const { config } = await import("dotenv");
+  config();
+
+  const { runOffensiveSecurityAgent } = await import(
+    "./core/api/offesecAgent"
+  );
+  const { sessions, normalizeMessages, getResumeMessages } = await import(
+    "./core/session"
+  );
+  const { ALL_TOOL_NAMES, SKILL_TOOL_NAMES } = await import(
+    "./core/agents/offSecAgent"
+  );
+  const { config: appConfig } = await import("./core/config");
+  const { getDefaultModelForConfig } = await import("./core/providers/utils");
+  const { createInterface } = await import("readline");
+  const { readFileSync, existsSync } = await import("fs");
+  const path = await import("path");
+  const { stepCountIs } = await import("ai");
+  type AIModel = import("./core/ai").AIModel;
+  type ModelMessage = import("ai").ModelMessage;
+
+  const promptRaw = getArg("-p") ?? getArg("--prompt");
+  if (!promptRaw) {
+    console.error("Error: -p <prompt> is required");
+    process.exit(1);
+  }
+
+  const prompt = resolveFlagValue(promptRaw);
+  const target = getArg("--target");
+  const pensarConfig = await appConfig.get();
+  const dynamicDefault =
+    getDefaultModelForConfig(pensarConfig)?.id ?? "claude-sonnet-4-5";
+  const model = (getArg("--model") ?? dynamicDefault) as AIModel;
+
+  const sep = "─".repeat(60);
+  console.log(`${sep}
+OPERATOR SESSION
+${sep}
+Model:   ${model}${target ? `\nTarget:  ${target}` : ""}
+${sep}\n`);
+
+  const session = await sessions.create({
+    name: "Operator Session",
+    targets: target ? [target] : [],
+    config: {
+      mode: "operator",
+      agentCwd: process.cwd(),
+      operatorSettings: {
+        initialMode: "auto",
+        requireApproval: false,
+        enableSuggestions: false,
+      },
+    },
+  });
+
+  const { bus, cleanup: wandbCleanup } = await createInstrumentedBus(session);
+
+  let currentPrompt = prompt;
+  let messages: ModelMessage[] | undefined;
+
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const askFollowUp = (): Promise<string | null> =>
+    new Promise((resolve) => {
+      process.stdout.write(`\n${sep}\n`);
+      rl.question("follow-up (empty to exit): ", (answer) => {
+        const trimmed = answer.trim();
+        resolve(trimmed || null);
+      });
+    });
+
+  try {
+    for (;;) {
+      await runOffensiveSecurityAgent({
+        prompt: currentPrompt,
+        model,
+        target,
+        activeTools: [...ALL_TOOL_NAMES, ...SKILL_TOOL_NAMES] as string[],
+        stopWhen: stepCountIs(10000),
+        authConfig: buildAuthConfig(pensarConfig),
+        eventBus: bus,
+        session,
+        messages,
+      });
+
+      // Read back persisted messages for the next turn
+      const messagesPath = path.join(session.rootPath, "messages.json");
+      if (existsSync(messagesPath)) {
+        const raw = JSON.parse(readFileSync(messagesPath, "utf-8"));
+        const allMessages: ModelMessage[] = Array.isArray(raw) ? raw : [];
+        messages = normalizeMessages(getResumeMessages(allMessages));
+      }
+
+      const followUp = await askFollowUp();
+      if (!followUp) break;
+      currentPrompt = followUp;
+      // Append the follow-up as a user message so the conversation
+      // ends with a user turn (required by Anthropic models).
+      messages = normalizeMessages([
+        ...(messages ?? []),
+        { role: "user" as const, content: followUp },
+      ]);
+    }
+  } finally {
+    rl.close();
+    await wandbCleanup();
+  }
+
+  console.log(`\nSession: ${session.rootPath}`);
+}
+
 async function runUpgrade() {
   const currentVersion = getCurrentVersion();
   console.log(`Current version: v${currentVersion}\nChecking for updates...`);
@@ -354,7 +475,9 @@ async function runUpgrade() {
 // Router
 // ---------------------------------------------------------------------------
 
-if (command === "version" || command === "--version" || command === "-v") {
+if (hasFlag("-p") || command === "--prompt") {
+  await runOperator();
+} else if (command === "version" || command === "--version" || command === "-v") {
   console.log(`v${version}`);
 } else if (command === "help" || command === "--help" || command === "-h") {
   showHelp();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -350,15 +350,11 @@ async function runOperator() {
   const { config } = await import("dotenv");
   config();
 
-  const { runOffensiveSecurityAgent } = await import(
-    "./core/api/offesecAgent"
-  );
-  const { sessions, normalizeMessages, getResumeMessages } = await import(
-    "./core/session"
-  );
-  const { ALL_TOOL_NAMES, SKILL_TOOL_NAMES } = await import(
-    "./core/agents/offSecAgent"
-  );
+  const { runOffensiveSecurityAgent } = await import("./core/api/offesecAgent");
+  const { sessions, normalizeMessages, getResumeMessages } =
+    await import("./core/session");
+  const { ALL_TOOL_NAMES, SKILL_TOOL_NAMES } =
+    await import("./core/agents/offSecAgent");
   const { config: appConfig } = await import("./core/config");
   const { getDefaultModelForConfig } = await import("./core/providers/utils");
   const { createInterface } = await import("readline");
@@ -477,7 +473,11 @@ async function runUpgrade() {
 
 if (hasFlag("-p") || command === "--prompt") {
   await runOperator();
-} else if (command === "version" || command === "--version" || command === "-v") {
+} else if (
+  command === "version" ||
+  command === "--version" ||
+  command === "-v"
+) {
   console.log(`v${version}`);
 } else if (command === "help" || command === "--help" || command === "-h") {
   showHelp();

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -20,7 +20,7 @@ function log(...args: unknown[]) {
 }
 
 function logInfo(...args: unknown[]) {
-  console.error("[pensar]", ...args);
+  if (DEBUG) console.error("[pensar]", ...args);
 }
 
 function logError(...args: unknown[]) {

--- a/src/core/ai/providers/pensarSSE.ts
+++ b/src/core/ai/providers/pensarSSE.ts
@@ -6,6 +6,9 @@
  * whenever a complete SSE message boundary (blank line) is encountered.
  */
 
+const DEBUG =
+  process.env.PENSAR_DEBUG === "1" || process.env.PENSAR_DEBUG === "true";
+
 export interface SSEEvent {
   event: string;
   data: string;
@@ -57,11 +60,15 @@ export async function* parseSSE(
         if (timeoutId) clearTimeout(timeoutId);
       }
       if (result.done) {
-        console.error(
-          `[parseSSE] stream done: ${chunkCount} chunks, ${totalBytes} bytes, ${eventCount} events yielded, remaining buffer=${buffer.length} chars`,
-        );
-        if (buffer.length > 0) {
-          console.error(`[parseSSE] remaining buffer: ${buffer.slice(0, 500)}`);
+        if (DEBUG) {
+          console.error(
+            `[parseSSE] stream done: ${chunkCount} chunks, ${totalBytes} bytes, ${eventCount} events yielded, remaining buffer=${buffer.length} chars`,
+          );
+          if (buffer.length > 0) {
+            console.error(
+              `[parseSSE] remaining buffer: ${buffer.slice(0, 500)}`,
+            );
+          }
         }
         break;
       }
@@ -71,7 +78,7 @@ export async function* parseSSE(
       totalBytes += value.byteLength;
       const decoded = decoder.decode(value, { stream: true });
 
-      if (chunkCount <= 3) {
+      if (DEBUG && chunkCount <= 3) {
         console.error(
           `[parseSSE] chunk #${chunkCount}: ${value.byteLength} bytes, preview: ${decoded.slice(0, 200)}`,
         );
@@ -102,7 +109,8 @@ export async function* parseSSE(
 
     if (currentData.length > 0) {
       eventCount++;
-      console.error(`[parseSSE] flushing final event: ${currentEvent}`);
+      if (DEBUG)
+        console.error(`[parseSSE] flushing final event: ${currentEvent}`);
       yield { event: currentEvent, data: currentData.join("\n") };
     }
 

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -454,8 +454,6 @@ export async function create(input: CreateInputProps) {
     findingsPath,
   };
 
-  console.info("created session", result);
-
   // Exclude non-serializable fields (class instances with methods)
   const { _rateLimiter, credentialManager: _cm, ...sessionData } = result;
   await createSessionDirs({ session: result });
@@ -512,7 +510,6 @@ export async function update(
       draft.time.updated = Date.now();
     },
   );
-  console.info("updated session", result);
   return result;
 }
 


### PR DESCRIPTION
## Summary
- Adds a `-p <prompt>` flag to the CLI that launches an operator session directly from the command line, running the offsec agent in auto mode with no approval gating
- After the agent completes each turn, prompts for follow-up input — supports multi-turn conversations with full context preservation via `messages.json`
- Gates verbose `[pensar]` and `[parseSSE]` provider logs behind `PENSAR_DEBUG`, and removes noisy full-object session dumps from `sessions.create()` / `sessions.update()`

## Usage
```bash
pensar -p "scan example.com for auth bypass vulnerabilities"
pensar -p "test the login flow" --target https://example.com --model claude-sonnet-4-5
pensar -p @prompt.txt   # read prompt from file
```

## Test plan
- [ ] `pensar -p "hello"` starts an operator session and streams agent output
- [ ] Follow-up prompt works without "assistant message prefill" errors
- [ ] Empty follow-up exits cleanly, prints session path
- [ ] `pensar pentest --prompt "test"` still works (no routing conflict)
- [ ] Verbose SSE/provider logs are suppressed unless `PENSAR_DEBUG=1`
- [ ] `PENSAR_DEBUG=1 pensar -p "test"` still shows provider logs


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new CLI execution path that runs the offensive-security agent in unattended multi-turn mode with broad tool access, which could change how/when potentially destructive actions are triggered. Also adjusts logging behavior, reducing observability unless `PENSAR_DEBUG` is set.
> 
> **Overview**
> Adds `pensar -p/--prompt` to start a headless *operator session* from the CLI, optionally scoped by `--target`/`--model`, then loops for follow-up prompts while reloading and normalizing conversation context from `messages.json` between turns.
> 
> Routes `-p` early in `src/cli.ts` and creates an operator-mode session with auto execution settings (no approval/suggestions) and a high step limit.
> 
> Reduces console noise by gating `[pensar]` provider info logs and `parseSSE` debug output behind `PENSAR_DEBUG`, and removes full session object dumps from `sessions.create()`/`sessions.update()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1178795330c45747ead0714861c0090b18bf5154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->