### PR TITLE
fix: derive default model from configured provider instead of hardcoding

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import {
   resolveThreatModelPrompt,
   combinePromptParts,
 } from "./tui/utils/command-flags";
+import type { AIModel } from "./core/ai";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -88,6 +89,35 @@ async function createInstrumentedBus(
   return { bus, cleanup: async () => wandbCleanup?.() };
 }
 
+/**
+ * Resolve the AI model from --model flag or configured provider default.
+ * Errors clearly if no provider is configured instead of silently picking
+ * a model that will fail at the API call level.
+ */
+async function resolveCliModel(): Promise<AIModel> {
+  const explicit = getArg("--model");
+  if (explicit) return explicit as AIModel;
+
+  const { config: appConfig } = await import("./core/config");
+  const { getDefaultModelForConfig } = await import("./core/providers/utils");
+  const pensarConfig = await appConfig.get();
+  const defaultModel = getDefaultModelForConfig(pensarConfig);
+
+  if (!defaultModel) {
+    console.error(
+      "Error: No AI provider configured. Set one of:\n" +
+        "  PENSAR_API_KEY     — Pensar Console (recommended)\n" +
+        "  ANTHROPIC_API_KEY  — Anthropic direct\n" +
+        "  OPENAI_API_KEY     — OpenAI\n" +
+        "  OPENROUTER_API_KEY — OpenRouter\n" +
+        "\nOr run 'pensar login' to connect to Pensar Console.",
+    );
+    process.exit(1);
+  }
+
+  return defaultModel.id as AIModel;
+}
+
 // ---------------------------------------------------------------------------
 // Help
 // ---------------------------------------------------------------------------
@@ -116,13 +146,13 @@ Usage:
 operator options (-p):
   -p, --prompt <text|@file>  (required) Prompt for the operator agent
   --target <url>             Target URL / domain / IP
-  --model <model>            AI model (default: claude-sonnet-4-5)
+  --model <model>            AI model (default: auto-selected from configured provider)
 
 pentest options:
   --target <url>           (required) Target URL / domain / IP
   --cwd <path>             Source code path — enables whitebox attack surface
   --mode <mode>            Pentest mode: exfil (pivoting & flag extraction)
-  --model <model>          AI model (default: claude-sonnet-4-5)
+  --model <model>          AI model (default: auto-selected from configured provider)
   --extended-thinking       Enable extended thinking for supported models
   --task-driven             Enable task-driven architecture (experimental)
   --prompt <text|@file>    Guidance for the pentest agent (inline text or @filepath)
@@ -131,11 +161,11 @@ pentest options:
 targeted-pentest options:
   --target <url>          (required) Target URL / domain / IP
   --objective <text>      (required, repeatable) Testing objective
-  --model <model>         AI model (default: claude-sonnet-4-5)
+  --model <model>         AI model (default: auto-selected from configured provider)
 
 threat-model options:
   --output, -o <path>  Output file path (default: ./threat-model.md)
-  --model <model>      AI model (default: claude-sonnet-4-5)
+  --model <model>      AI model (default: auto-selected from configured provider)
 
 Global options:
   -h, --help         Show this help message
@@ -157,8 +187,6 @@ async function runPentest() {
   const { runPentestAgent } = await import("./core/api/blackboxPentest");
   const { sessions } = await import("./core/session");
   const { config: appConfig } = await import("./core/config");
-  const { getDefaultModelForConfig } = await import("./core/providers/utils");
-  type AIModel = import("./core/ai").AIModel;
 
   const target = getArgRequired("--target");
   const cwd = getArg("--cwd");
@@ -176,9 +204,7 @@ async function runPentest() {
   const prompt = combinePromptParts(resolvedTm, resolvedPrompt);
 
   const pensarConfig = await appConfig.get();
-  const dynamicDefault =
-    getDefaultModelForConfig(pensarConfig)?.id ?? "claude-sonnet-4-5";
-  const model = (getArg("--model") ?? dynamicDefault) as AIModel;
+  const model = await resolveCliModel();
   const { exfilMode, warning: modeWarning } = resolvePentestMode(mode);
 
   if (modeWarning) {
@@ -239,16 +265,12 @@ async function runTargetedPentest() {
     await import("./core/api/targetedPentest");
   const { sessions } = await import("./core/session");
   const { config: appConfig } = await import("./core/config");
-  const { getDefaultModelForConfig } = await import("./core/providers/utils");
-  type AIModel = import("./core/ai").AIModel;
 
   const target = getArgRequired("--target");
   const objectives = getAllArgs("--objective");
 
   const pensarConfig = await appConfig.get();
-  const dynamicDefault =
-    getDefaultModelForConfig(pensarConfig)?.id ?? "claude-sonnet-4-5";
-  const model = (getArg("--model") ?? dynamicDefault) as AIModel;
+  const model = await resolveCliModel();
 
   if (objectives.length === 0) {
     console.error("Error: at least one --objective is required");
@@ -304,14 +326,10 @@ async function runThreatModel() {
 
   const { runThreatModelWorkflow } = await import("./core/api/threatModel");
   const { config: appConfig } = await import("./core/config");
-  const { getDefaultModelForConfig } = await import("./core/providers/utils");
   const path = await import("path");
-  type AIModel = import("./core/ai").AIModel;
 
   const pensarConfig = await appConfig.get();
-  const dynamicDefault =
-    getDefaultModelForConfig(pensarConfig)?.id ?? "claude-sonnet-4-5";
-  const model = (getArg("--model") ?? dynamicDefault) as AIModel;
+  const model = await resolveCliModel();
 
   const outputArg = getArg("--output") ?? getArg("-o") ?? "threat-model.md";
   const resolvedPath = path.isAbsolute(outputArg)
@@ -356,12 +374,10 @@ async function runOperator() {
   const { ALL_TOOL_NAMES, SKILL_TOOL_NAMES } =
     await import("./core/agents/offSecAgent");
   const { config: appConfig } = await import("./core/config");
-  const { getDefaultModelForConfig } = await import("./core/providers/utils");
   const { createInterface } = await import("readline");
   const { readFileSync, existsSync } = await import("fs");
   const path = await import("path");
   const { stepCountIs } = await import("ai");
-  type AIModel = import("./core/ai").AIModel;
   type ModelMessage = import("ai").ModelMessage;
 
   const promptRaw = getArg("-p") ?? getArg("--prompt");
@@ -373,9 +389,7 @@ async function runOperator() {
   const prompt = resolveFlagValue(promptRaw);
   const target = getArg("--target");
   const pensarConfig = await appConfig.get();
-  const dynamicDefault =
-    getDefaultModelForConfig(pensarConfig)?.id ?? "claude-sonnet-4-5";
-  const model = (getArg("--model") ?? dynamicDefault) as AIModel;
+  const model = await resolveCliModel();
 
   const sep = "─".repeat(60);
   console.log(`${sep}

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -64,25 +64,16 @@ export async function init() {
   return { ...DEFAULT_CONFIG, version };
 }
 
-export async function get(): Promise<Config> {
-  const folder = path.join(os.homedir(), ".pensar");
-  const file = path.join(folder, "config.json");
-  const exists = await fs
-    .access(file)
-    .then(() => true)
-    .catch(() => false);
-  if (!exists) {
-    return await init();
-  }
-  const config = await fs.readFile(file, "utf8");
-
-  const parsedConfig = JSON.parse(config);
-
+/**
+ * Apply environment variable fallbacks for API keys.
+ * Used by both `get()` and `init()` so fresh installs pick up env vars.
+ */
+function applyEnvFallbacks(parsedConfig: Partial<Config>): Config {
   const version = getCurrentVersion();
-
   return {
     ...parsedConfig,
-    version: version,
+    responsibleUseAccepted: parsedConfig.responsibleUseAccepted ?? false,
+    version,
     openAiAPIKey: parsedConfig.openAiAPIKey ?? process.env.OPENAI_API_KEY,
     anthropicAPIKey:
       parsedConfig.anthropicAPIKey ?? process.env.ANTHROPIC_API_KEY,
@@ -98,6 +89,22 @@ export async function get(): Promise<Config> {
     daytonaOrgId: parsedConfig.daytonaOrgId ?? process.env.DAYTONA_ORG_ID,
     runloopAPIKey: parsedConfig.runloopAPIKey ?? process.env.RUNLOOP_API_KEY,
   };
+}
+
+export async function get(): Promise<Config> {
+  const folder = path.join(os.homedir(), ".pensar");
+  const file = path.join(folder, "config.json");
+  const exists = await fs
+    .access(file)
+    .then(() => true)
+    .catch(() => false);
+  if (!exists) {
+    await init();
+    return applyEnvFallbacks(DEFAULT_CONFIG);
+  }
+  const config = await fs.readFile(file, "utf8");
+  const parsedConfig = JSON.parse(config);
+  return applyEnvFallbacks(parsedConfig);
 }
 
 export async function update(config: Partial<Config>) {

--- a/src/core/providers/utils.ts
+++ b/src/core/providers/utils.ts
@@ -22,6 +22,7 @@ const PREFERRED_MODEL_BY_PROVIDER: Record<string, string> = {
   openai: "gpt-5.2-pro",
   google: "gemini-3.1-pro-preview",
   openrouter: "anthropic/claude-opus-4.6",
+  bedrock: "anthropic.claude-opus-4-6-v1",
 };
 
 export function getConfiguredProviders(config: Config): ConfiguredProvider[] {


### PR DESCRIPTION
## Summary
- **Fix fresh install bug**: `config.get()` on fresh installs (no `~/.pensar/config.json`) called `init()` which returned the bare default config without applying env var fallbacks — so `PENSAR_API_KEY` set via environment was invisible to model selection, causing a crash with "Anthropic API key is missing"
- **Remove hardcoded fallback**: Replace all four `?? "claude-sonnet-4-5"` fallbacks in `cli.ts` with `resolveCliModel()` that picks the best model for whichever provider is actually configured, or exits with a clear error listing which env vars to set
- **Add bedrock default**: Add bedrock to `PREFERRED_MODEL_BY_PROVIDER` so it defaults to opus 4.6 instead of the first alphabetical model

## Test plan
- [x] `bun run tsc` passes
- [x] `bun run test` — all 838 tests pass
- [ ] Run `PENSAR_API_KEY=... pensar -p "hello"` without `ANTHROPIC_API_KEY` set — should route through Pensar gateway with opus 4.6
- [ ] Run `pensar -p "hello"` with no provider keys set — should show clear error listing env vars
- [ ] Run `ANTHROPIC_API_KEY=... pensar -p "hello"` — should default to `claude-opus-4-6`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI model-selection behavior and config loading on first run; mistakes could prevent the CLI from starting or route requests to an unexpected provider/model.
> 
> **Overview**
> Fixes default model resolution across CLI commands by introducing `resolveCliModel()`, which uses `--model` when provided, otherwise selects a provider-appropriate default via `getDefaultModelForConfig()` and exits with a clear error when no provider is configured. Updates CLI help text to reflect auto-selection instead of a hardcoded default.
> 
> Fixes fresh-install config behavior by centralizing env-var API key fallbacks in `applyEnvFallbacks()` and applying it in `config.get()` even when `~/.pensar/config.json` doesn’t exist. Also adds a Bedrock preferred model mapping so Bedrock defaults to an opus-class model rather than an arbitrary first choice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20bb47394a041b221ced61d8a760f42eda697fbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->