### PR TITLE
feat: support Brave Search API as direct web search provider

### DIFF
--- a/src/core/agents/offSecAgent/tools/webSearch.ts
+++ b/src/core/agents/offSecAgent/tools/webSearch.ts
@@ -32,6 +32,72 @@ export interface WebSearchResponse {
   error?: string;
 }
 
+const BRAVE_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search";
+
+async function braveSearch(
+  query: string,
+  apiKey: string,
+): Promise<WebSearchResponse> {
+  const url = new URL(BRAVE_SEARCH_URL);
+  url.searchParams.set("q", query);
+  url.searchParams.set("count", "10");
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      "Accept-Encoding": "gzip",
+      "X-Subscription-Token": apiKey,
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      return {
+        success: false,
+        results: [],
+        error:
+          "Brave API authentication failed. Check that your brave_api_key is valid.",
+      };
+    }
+
+    if (response.status === 429) {
+      return {
+        success: false,
+        results: [],
+        error:
+          "Brave API rate limit exceeded. Please wait a moment before searching again.",
+      };
+    }
+
+    const errorText = await response.text().catch(() => "Unknown error");
+    return {
+      success: false,
+      results: [],
+      error: `Brave search failed: ${response.status} ${response.statusText}. ${errorText}`,
+    };
+  }
+
+  const data = (await response.json()) as {
+    web?: {
+      results?: Array<{
+        title?: string;
+        url?: string;
+        description?: string;
+      }>;
+    };
+  };
+
+  const results: WebSearchResult[] =
+    data.web?.results?.map((r) => ({
+      title: r.title ?? "",
+      url: r.url ?? "",
+      snippet: r.description ?? "",
+    })) ?? [];
+
+  return { success: true, results };
+}
+
 export function webSearch(_ctx: ToolContext) {
   return tool({
     description: `Search the web for real-time information about any topic. Returns summarized information from search results.
@@ -43,7 +109,7 @@ USAGE GUIDANCE:
 - Find documentation for tools, APIs, and security testing techniques
 - Look up default credentials, common misconfigurations, and hardening guides
 
-IMPORTANT: This tool requires a Pensar account. If you're not signed in, you'll receive an error message with instructions to sign in.
+IMPORTANT: This tool requires either a Pensar account or a Brave API key. If neither is configured, you'll receive an error message with instructions.
 
 COMMON SEARCH PATTERNS:
 - "CVE-2024-XXXX exploit" — Find details about specific CVEs
@@ -55,6 +121,12 @@ COMMON SEARCH PATTERNS:
     execute: async ({ query }): Promise<WebSearchResponse> => {
       try {
         const cfg = await config.get();
+
+        // Brave API direct mode: bypass Pensar API entirely
+        if (cfg.braveAPIKey) {
+          return braveSearch(query, cfg.braveAPIKey);
+        }
+
         const apiUrl = getPensarApiUrl();
         const body = JSON.stringify({ query });
 
@@ -83,7 +155,7 @@ COMMON SEARCH PATTERNS:
             success: false,
             results: [],
             error:
-              "Web search requires a Pensar account. Please sign in to your Pensar account to use this feature. You can sign in via the TUI settings or by running 'pensar login'.",
+              "Web search requires a Pensar account or a Brave API key. Please sign in to your Pensar account or configure a Brave API key (set BRAVE_API_KEY or brave_api_key in config).",
           };
         }
 

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -21,6 +21,8 @@ export interface Config {
   daytonaAPIKey?: string | null;
   daytonaOrgId?: string | null;
   runloopAPIKey?: string | null;
+  // Direct search
+  braveAPIKey?: string | null;
   // Local LLM
   localModelUrl?: string | null;
   localModelName?: string | null;
@@ -88,6 +90,7 @@ function applyEnvFallbacks(parsedConfig: Partial<Config>): Config {
     daytonaAPIKey: parsedConfig.daytonaAPIKey ?? process.env.DAYTONA_API_KEY,
     daytonaOrgId: parsedConfig.daytonaOrgId ?? process.env.DAYTONA_ORG_ID,
     runloopAPIKey: parsedConfig.runloopAPIKey ?? process.env.RUNLOOP_API_KEY,
+    braveAPIKey: parsedConfig.braveAPIKey ?? process.env.BRAVE_API_KEY,
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds support for calling the Brave Search API directly from the `web_search` tool, bypassing the Pensar API when a Brave API key is configured.
- New `braveAPIKey` config field with `BRAVE_API_KEY` env var fallback.
- When set, Brave takes priority over all Pensar API auth modes. Existing Pensar API flows are unchanged as fallback.

## Test plan
- [ ] Set `BRAVE_API_KEY` env var and verify `web_search` calls Brave directly (check no Pensar API calls)
- [ ] Unset `BRAVE_API_KEY` and verify existing Pensar API auth modes still work
- [ ] Test with an invalid Brave key — should return clear auth error
- [ ] Verify `braveAPIKey` can also be set via `~/.pensar/config.json`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `webSearch` execution flow and introduces a new outbound call path with different auth/error handling that can affect runtime behavior when `braveAPIKey` is set.
> 
> **Overview**
> The `web_search` tool now supports a **direct Brave Search** mode: when `braveAPIKey` is configured it calls Brave’s `/res/v1/web/search` endpoint (with dedicated handling for auth and rate-limit errors) and bypasses all Pensar API flows.
> 
> Config adds a new `braveAPIKey` field with `BRAVE_API_KEY` env-var fallback, and user-facing error/help text is updated to reflect that web search can be enabled via either Pensar sign-in or a Brave key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0545c0331c7330e8567d79fb9beb5b1a88cb3def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->