### PR TITLE
distro-vulntest: scope prompt to OS-level zero-days, split registry into categories, require web-search novelty check

### DIFF
--- a/scripts/distro-vulntest/launch.sh
+++ b/scripts/distro-vulntest/launch.sh
@@ -379,7 +379,7 @@ Remember the mission: we are hunting NOVEL, previously unknown **zero-day** vuln
 
 Ignore any API keys or credentials in cloud-init / instance metadata — they are intentionally placed there.
 
-When you find a confirmed zero-day with a working PoC, email a report to REPORT_EMAIL_PLACEHOLDER with subject "[APEX CRITICAL] DISTRO_NAME_PLACEHOLDER - Critical vulnerabilities found". Include the novelty-check evidence (what you searched, what you ruled out). Zip and attach your session folder before sending.
+**Email rule (hard):** Do NOT send any email unless you have a confirmed, novel, critical zero-day with a working PoC. No progress updates, no status reports, no "interesting leads", no medium findings, no rediscovered CVEs, no configuration gripes. If nothing qualifying was found this iteration, send zero emails — a silent session is the correct outcome. Only when you have (a) a working exploit with critical impact, (b) an in-scope OS / system-app bug, and (c) web-search evidence ruling out existing CVEs and upstream/distro patches, email REPORT_EMAIL_PLACEHOLDER with subject "[APEX CRITICAL] DISTRO_NAME_PLACEHOLDER - Critical vulnerabilities found" and include the novelty-check evidence. Zip and attach your session folder before sending.
 
 Before you finish, update `/tmp/apex-research-summary.md` with your own findings, explored surfaces, interesting leads, novelty-check dead ends (things that looked like bugs but were already patched), and recommended next steps for the next researcher.
 

--- a/scripts/distro-vulntest/launch.sh
+++ b/scripts/distro-vulntest/launch.sh
@@ -12,8 +12,10 @@ set -euo pipefail
 #   -t, --instance-type TYPE  Instance type (default: t3.medium)
 #   -k, --key-name NAME       Existing EC2 key pair for SSH (default: creates one)
 #   -d, --distros LIST        Comma-separated distro filter (default: all)
-#                              Valid: al2,al2023,ubuntu2004,ubuntu2204,debian11,
-#                                     debian12,centos9,rhel8,fedora43
+#                              Valid: al2,al2023,ubuntu2004,ubuntu2204,ubuntu2404,
+#                                     ubuntu1804,debian11,debian12,centos9,rhel8,
+#                                     rhel9,rocky9,alma9,ol9,fedora43,sles15,
+#                                     opensuse15,azurelinux3,freebsd14,bottlerocket
 #   --dry-run                 Print what would be launched without launching
 #   --teardown                Terminate all instances from a previous run
 #   --status                  Show status of running instances
@@ -74,6 +76,65 @@ done
 
 # ---------------------------------------------------------------------------
 # Distro registry — each entry is "key|ami|user|name|pkg_mgr"
+#
+# AMI IDs below are for the configured $REGION (default at the top of this
+# script). To resolve placeholders before launching, run these against your
+# target region:
+#
+#   # Ubuntu 24.04 LTS (Canonical, owner 099720109477) -- already filled in
+#   aws ec2 describe-images --owners 099720109477 --region "$REGION" \
+#     --filters 'Name=name,Values=ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*' \
+#     --query 'reverse(sort_by(Images,&CreationDate))[0].ImageId' --output text
+#
+#   # Ubuntu 18.04 LTS (Canonical) -- ESM-eligible
+#   aws ec2 describe-images --owners 099720109477 --region "$REGION" \
+#     --filters 'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*' \
+#     --query 'reverse(sort_by(Images,&CreationDate))[0].ImageId' --output text
+#
+#   # RHEL 9 (Red Hat owner 309956199498)
+#   aws ec2 describe-images --owners 309956199498 --region "$REGION" \
+#     --filters 'Name=name,Values=RHEL-9*HVM-*x86_64*' \
+#                'Name=architecture,Values=x86_64' \
+#     --query 'reverse(sort_by(Images,&CreationDate))[0].ImageId' --output text
+#
+#   # Rocky Linux 9 (Rocky Enterprise Software Foundation owner 792107900819)
+#   aws ec2 describe-images --owners 792107900819 --region "$REGION" \
+#     --filters 'Name=name,Values=Rocky-9-EC2-Base-*.x86_64' \
+#     --query 'reverse(sort_by(Images,&CreationDate))[0].ImageId' --output text
+#
+#   # AlmaLinux 9 (AlmaLinux OS Foundation owner 764336703387)
+#   aws ec2 describe-images --owners 764336703387 --region "$REGION" \
+#     --filters 'Name=name,Values=AlmaLinux OS 9*x86_64' \
+#     --query 'reverse(sort_by(Images,&CreationDate))[0].ImageId' --output text
+#
+#   # Oracle Linux 9 (Oracle owner 131827586825)
+#   aws ec2 describe-images --owners 131827586825 --region "$REGION" \
+#     --filters 'Name=name,Values=OL9.*-x86_64-HVM-*' \
+#     --query 'reverse(sort_by(Images,&CreationDate))[0].ImageId' --output text
+#
+#   # SLES 15 (SUSE / Amazon -- subscription via marketplace)
+#   aws ec2 describe-images --owners amazon --region "$REGION" \
+#     --filters 'Name=name,Values=suse-sles-15-sp*-v*-hvm-ssd-x86_64' \
+#     --query 'reverse(sort_by(Images,&CreationDate))[0].ImageId' --output text
+#
+#   # openSUSE Leap 15 (openSUSE owner 679593333241)
+#   aws ec2 describe-images --owners 679593333241 --region "$REGION" \
+#     --filters 'Name=name,Values=openSUSE-Leap-15.*-v*-hvm-ssd-x86_64*' \
+#     --query 'reverse(sort_by(Images,&CreationDate))[0].ImageId' --output text
+#
+#   # Azure Linux 3.0 / CBL-Mariner (Microsoft owner 679593333241? -- check)
+#   # Microsoft does not publish public AMIs for Azure Linux; would need a
+#   # marketplace-subscribed AMI ID. Leaving as a placeholder.
+#
+#   # FreeBSD 14 (FreeBSD owner 782442783595)
+#   aws ec2 describe-images --owners 782442783595 --region "$REGION" \
+#     --filters 'Name=name,Values=FreeBSD 14*-RELEASE-amd64*' \
+#     --query 'reverse(sort_by(Images,&CreationDate))[0].ImageId' --output text
+#
+#   # Bottlerocket (use SSM public parameter, not describe-images)
+#   aws ssm get-parameter --region "$REGION" \
+#     --name /aws/service/bottlerocket/aws-k8s-1.31/x86_64/latest/image_id \
+#     --query 'Parameter.Value' --output text
 # ---------------------------------------------------------------------------
 
 ALL_DISTROS=(
@@ -81,11 +142,22 @@ ALL_DISTROS=(
     "al2023|ami-0c1e21d82fe9c9336|ec2-user|Amazon Linux 2023|dnf"
     "ubuntu2004|ami-0fb0b230890ccd1e6|ubuntu|Ubuntu 20.04 LTS|apt"
     "ubuntu2204|ami-0647fb535573be346|ubuntu|Ubuntu 22.04 LTS|apt"
+    "ubuntu2404|ami-05cf1e9f73fbad2e2|ubuntu|Ubuntu 24.04 LTS|apt"
+    "ubuntu1804|ami-055744c75048d8296|ubuntu|Ubuntu 18.04 LTS (ESM)|apt"
     "debian11|ami-01504cf49928e171e|admin|Debian 11 Bullseye|apt"
     "debian12|ami-0e7a3d4bf48d3897e|admin|Debian 12 Bookworm|apt"
     "centos9|ami-08c4793c8e3c335e7|ec2-user|CentOS Stream 9|dnf"
     "rhel8|ami-06ab04dfd55c423e4|ec2-user|RHEL 8.10|dnf"
+    "rhel9|ami-PLACEHOLDER-rhel9|ec2-user|RHEL 9|dnf"
+    "rocky9|ami-PLACEHOLDER-rocky9|rocky|Rocky Linux 9|dnf"
+    "alma9|ami-PLACEHOLDER-alma9|ec2-user|AlmaLinux 9|dnf"
+    "ol9|ami-PLACEHOLDER-ol9|ec2-user|Oracle Linux 9 (UEK)|dnf"
     "fedora43|ami-0999ee7db2370a764|fedora|Fedora 43|dnf"
+    "sles15|ami-PLACEHOLDER-sles15|ec2-user|SUSE Linux Enterprise Server 15 SP6|zypper"
+    "opensuse15|ami-PLACEHOLDER-opensuse15|ec2-user|openSUSE Leap 15.6|zypper"
+    "azurelinux3|ami-PLACEHOLDER-azurelinux3|azureuser|Azure Linux 3.0 (CBL-Mariner)|tdnf"
+    "freebsd14|ami-PLACEHOLDER-freebsd14|ec2-user|FreeBSD 14.4-RELEASE|pkg"
+    "bottlerocket|ami-PLACEHOLDER-bottlerocket|ec2-user|Bottlerocket aws-k8s|none"
 )
 
 get_field() { echo "$1" | cut -d'|' -f"$2"; }
@@ -192,17 +264,36 @@ OUTBOUND_EMAIL="${OUTBOUND_EMAIL:-researchagent@pensar.dev}"
 # Resolve distro list
 # ---------------------------------------------------------------------------
 
+ALL_KEYS=()
+for entry in "${ALL_DISTROS[@]}"; do
+    ALL_KEYS+=("$(get_field "$entry" 1)")
+done
+
 if [[ -n "$DISTRO_FILTER" ]]; then
     IFS=',' read -ra DISTRO_KEYS <<< "$DISTRO_FILTER"
 else
-    DISTRO_KEYS=(al2 al2023 ubuntu2004 ubuntu2204 debian11 debian12 centos9 rhel8 fedora43)
+    # Default: only the entries with real (non-PLACEHOLDER) AMIs.
+    DISTRO_KEYS=()
+    for entry in "${ALL_DISTROS[@]}"; do
+        ami=$(get_field "$entry" 2)
+        [[ "$ami" == ami-PLACEHOLDER* ]] && continue
+        DISTRO_KEYS+=("$(get_field "$entry" 1)")
+    done
 fi
 
 # Validate
 for key in "${DISTRO_KEYS[@]}"; do
     if ! lookup_distro "$key" >/dev/null; then
         echo "ERROR: Unknown distro '$key'"
-        echo "Valid: al2 al2023 ubuntu2004 ubuntu2204 debian11 debian12 centos9 rhel8 fedora43"
+        echo "Valid: ${ALL_KEYS[*]}"
+        exit 1
+    fi
+    entry=$(lookup_distro "$key")
+    ami=$(get_field "$entry" 2)
+    if [[ "$ami" == ami-PLACEHOLDER* ]]; then
+        echo "ERROR: '$key' has a placeholder AMI ($ami)."
+        echo "  Resolve it (see lookup commands at the top of ALL_DISTROS in this script),"
+        echo "  patch the registry, then re-run."
         exit 1
     fi
 done
@@ -317,6 +408,39 @@ dnf update -y
 dnf install -y curl unzip git gcc make nmap
 dnf groupinstall -y "Development Tools" || true
 BLOCK
+            ;;
+        zypper)
+            cat <<'BLOCK'
+zypper --non-interactive refresh
+zypper --non-interactive update
+zypper --non-interactive install curl unzip git gcc make nmap
+zypper --non-interactive install -t pattern devel_basis || true
+BLOCK
+            ;;
+        tdnf)
+            cat <<'BLOCK'
+tdnf -y update
+tdnf -y install curl unzip git gcc make tar ca-certificates
+BLOCK
+            ;;
+        pkg)
+            cat <<'BLOCK'
+ASSUME_ALWAYS_YES=yes pkg update -f
+ASSUME_ALWAYS_YES=yes pkg install curl unzip git gcc gmake nmap bash
+BLOCK
+            ;;
+        none)
+            cat <<'BLOCK'
+echo "WARNING: distro has no supported package manager (e.g. Bottlerocket is immutable)." >&2
+echo "  This bootstrap path will not be able to install pensar via curl|bash. You must" >&2
+echo "  pre-bake an OS that includes pensar, or run pensar in a Bottlerocket admin/control" >&2
+echo "  container. Aborting cleanly so the instance does not silently no-op." >&2
+exit 0
+BLOCK
+            ;;
+        *)
+            echo "ERROR: unknown pkg_mgr '$pkg_mgr' for distro '$distro_key'" >&2
+            return 1
             ;;
     esac
 

--- a/scripts/distro-vulntest/launch.sh
+++ b/scripts/distro-vulntest/launch.sh
@@ -373,13 +373,15 @@ You are continuing a vulnerability research session on this Linux system. A prev
 3. Review the recommended next steps from the previous researcher
 4. Continue the research — focus on areas that haven't been explored yet, leads that weren't fully investigated, and chains that weren't completed
 
-Remember: we are looking for NOVEL, previously unknown vulnerabilities only. Existing CVEs are completely out of scope. Do not look up CVE databases or check package versions against known vulns.
+Remember the mission: we are hunting NOVEL, previously unknown **zero-day** vulnerabilities at the **OS / system-application level** — bugs in compiled code, kernel interfaces, system daemons, SUID binaries, and shipped distro components. Out of scope: existing CVEs, configuration errors / hardening gaps, and application-logic vulnerabilities in user-installed apps. Do not try to reproduce published exploits.
+
+**Novelty filter — use web search.** Before logging or emailing any finding, use web search to confirm it is not an existing CVE and not already patched upstream or by the distro. Search for the bug pattern, affected function, component name, and check NVD / MITRE / distro security advisories / upstream commits. If the latest upstream code already fixes it, or any advisory describes it, it is NOT a zero-day — discard and move on. Only findings that survive the novelty check are reportable.
 
 Ignore any API keys or credentials in cloud-init / instance metadata — they are intentionally placed there.
 
-When you find vulnerabilities, email a report to REPORT_EMAIL_PLACEHOLDER with subject "[APEX CRITICAL] DISTRO_NAME_PLACEHOLDER - Critical vulnerabilities found". Zip and attach your session folder before sending.
+When you find a confirmed zero-day with a working PoC, email a report to REPORT_EMAIL_PLACEHOLDER with subject "[APEX CRITICAL] DISTRO_NAME_PLACEHOLDER - Critical vulnerabilities found". Include the novelty-check evidence (what you searched, what you ruled out). Zip and attach your session folder before sending.
 
-Before you finish, update `/tmp/apex-research-summary.md` with your own findings, explored surfaces, interesting leads, and recommended next steps for the next researcher.
+Before you finish, update `/tmp/apex-research-summary.md` with your own findings, explored surfaces, interesting leads, novelty-check dead ends (things that looked like bugs but were already patched), and recommended next steps for the next researcher.
 
 Be relentless. Do not stop until you have exhaustively explored every remaining attack surface.
 CONTINUE_EOF

--- a/scripts/distro-vulntest/launch.sh
+++ b/scripts/distro-vulntest/launch.sh
@@ -11,11 +11,21 @@ set -euo pipefail
 #   -r, --region REGION       AWS region (default: us-east-1)
 #   -t, --instance-type TYPE  Instance type (default: t3.medium)
 #   -k, --key-name NAME       Existing EC2 key pair for SSH (default: creates one)
-#   -d, --distros LIST        Comma-separated distro filter (default: all)
-#                              Valid: al2,al2023,ubuntu2004,ubuntu2204,ubuntu2404,
-#                                     ubuntu1804,debian11,debian12,centos9,rhel8,
-#                                     rhel9,rocky9,alma9,ol9,fedora43,sles15,
-#                                     opensuse15,azurelinux3,freebsd14,bottlerocket
+#   -d, --distros LIST        Comma-separated distro key filter
+#                              Valid keys: al2,al2023,ubuntu2004,ubuntu2204,
+#                                          ubuntu2404,ubuntu1804,debian11,debian12,
+#                                          centos9,rhel8,rhel9,rocky9,alma9,ol9,
+#                                          fedora43,sles15,opensuse15,azurelinux3,
+#                                          freebsd14,bottlerocket
+#   -c, --category LIST       Comma-separated category filter — launch a whole
+#                              category at once, independent of others. Categories:
+#                                mainstream      (AL2/AL2023, Ubuntu LTS, Debian, Fedora)
+#                                enterprise      (RHEL, Rocky, Alma, Oracle Linux, SLES, openSUSE — gov/financial)
+#                                legacy          (Ubuntu 18.04 ESM, CentOS Stream)
+#                                container_host  (Bottlerocket, Azure Linux — immutable / cloud-native)
+#                                bsd             (FreeBSD)
+#                              -d and -c are mutually exclusive. With no flag,
+#                              all non-placeholder entries from every category run.
 #   --dry-run                 Print what would be launched without launching
 #   --teardown                Terminate all instances from a previous run
 #   --status                  Show status of running instances
@@ -46,6 +56,7 @@ REGION="us-east-1"
 INSTANCE_TYPE="t3.medium"
 KEY_NAME=""
 DISTRO_FILTER=""
+CATEGORY_FILTER=""
 CUSTOM_PROMPT=""
 DRY_RUN=false
 TEARDOWN=false
@@ -65,6 +76,7 @@ while [[ $# -gt 0 ]]; do
         -t|--instance-type) INSTANCE_TYPE="$2"; shift 2 ;;
         -k|--key-name) KEY_NAME="$2"; shift 2 ;;
         -d|--distros) DISTRO_FILTER="$2"; shift 2 ;;
+        -c|--category) CATEGORY_FILTER="$2"; shift 2 ;;
         -p|--prompt) CUSTOM_PROMPT="$2"; shift 2 ;;
         --dry-run) DRY_RUN=true; shift ;;
         --teardown) TEARDOWN=true; shift ;;
@@ -137,28 +149,78 @@ done
 #     --query 'Parameter.Value' --output text
 # ---------------------------------------------------------------------------
 
-ALL_DISTROS=(
+# --- Categories ---------------------------------------------------------------
+# Each category is its own array. ALL_DISTROS is the union, built below. To add
+# a new entry, drop it in the appropriate category array — the rest (validation
+# list, default launch list, --category filter) flows automatically.
+
+# Mainstream cloud distros — broadest coverage, default targets.
+DISTROS_MAINSTREAM=(
     "al2|ami-02b9a589195146a8f|ec2-user|Amazon Linux 2|yum"
     "al2023|ami-0c1e21d82fe9c9336|ec2-user|Amazon Linux 2023|dnf"
     "ubuntu2004|ami-0fb0b230890ccd1e6|ubuntu|Ubuntu 20.04 LTS|apt"
     "ubuntu2204|ami-0647fb535573be346|ubuntu|Ubuntu 22.04 LTS|apt"
     "ubuntu2404|ami-05cf1e9f73fbad2e2|ubuntu|Ubuntu 24.04 LTS|apt"
-    "ubuntu1804|ami-055744c75048d8296|ubuntu|Ubuntu 18.04 LTS (ESM)|apt"
     "debian11|ami-01504cf49928e171e|admin|Debian 11 Bullseye|apt"
     "debian12|ami-0e7a3d4bf48d3897e|admin|Debian 12 Bookworm|apt"
-    "centos9|ami-08c4793c8e3c335e7|ec2-user|CentOS Stream 9|dnf"
+    "fedora43|ami-0999ee7db2370a764|fedora|Fedora 43|dnf"
+)
+
+# Enterprise / regulated — biggest gov + financial-services footprint.
+DISTROS_ENTERPRISE=(
     "rhel8|ami-06ab04dfd55c423e4|ec2-user|RHEL 8.10|dnf"
     "rhel9|ami-PLACEHOLDER-rhel9|ec2-user|RHEL 9|dnf"
     "rocky9|ami-PLACEHOLDER-rocky9|rocky|Rocky Linux 9|dnf"
     "alma9|ami-PLACEHOLDER-alma9|ec2-user|AlmaLinux 9|dnf"
     "ol9|ami-PLACEHOLDER-ol9|ec2-user|Oracle Linux 9 (UEK)|dnf"
-    "fedora43|ami-0999ee7db2370a764|fedora|Fedora 43|dnf"
     "sles15|ami-PLACEHOLDER-sles15|ec2-user|SUSE Linux Enterprise Server 15 SP6|zypper"
     "opensuse15|ami-PLACEHOLDER-opensuse15|ec2-user|openSUSE Leap 15.6|zypper"
+)
+
+# Legacy / extended-support — older code that's still deployed in regulated env.
+DISTROS_LEGACY=(
+    "ubuntu1804|ami-055744c75048d8296|ubuntu|Ubuntu 18.04 LTS (ESM)|apt"
+    "centos9|ami-08c4793c8e3c335e7|ec2-user|CentOS Stream 9|dnf"
+)
+
+# Container-host / immutable — minimal, cloud-native substrates.
+DISTROS_CONTAINER_HOST=(
     "azurelinux3|ami-PLACEHOLDER-azurelinux3|azureuser|Azure Linux 3.0 (CBL-Mariner)|tdnf"
-    "freebsd14|ami-PLACEHOLDER-freebsd14|ec2-user|FreeBSD 14.4-RELEASE|pkg"
     "bottlerocket|ami-PLACEHOLDER-bottlerocket|ec2-user|Bottlerocket aws-k8s|none"
 )
+
+# BSD family — separate kernel + userland entirely.
+DISTROS_BSD=(
+    "freebsd14|ami-PLACEHOLDER-freebsd14|ec2-user|FreeBSD 14.4-RELEASE|pkg"
+)
+
+# Category metadata: name -> array variable name. Order here also drives the
+# default launch order (mainstream first, then enterprise, etc.).
+CATEGORY_ORDER=(mainstream enterprise legacy container_host bsd)
+declare -A CATEGORY_VAR=(
+    [mainstream]=DISTROS_MAINSTREAM
+    [enterprise]=DISTROS_ENTERPRISE
+    [legacy]=DISTROS_LEGACY
+    [container_host]=DISTROS_CONTAINER_HOST
+    [bsd]=DISTROS_BSD
+)
+
+# Build ALL_DISTROS as the union of every category, preserving CATEGORY_ORDER.
+ALL_DISTROS=()
+for cat in "${CATEGORY_ORDER[@]}"; do
+    var="${CATEGORY_VAR[$cat]}"
+    eval "ALL_DISTROS+=(\"\${${var}[@]}\")"
+done
+
+# Reverse map: distro key -> category, used for tagging and reporting.
+declare -A DISTRO_CATEGORY=()
+for cat in "${CATEGORY_ORDER[@]}"; do
+    var="${CATEGORY_VAR[$cat]}"
+    eval "for entry in \"\${${var}[@]}\"; do
+        key=\$(echo \"\$entry\" | cut -d'|' -f1)
+        DISTRO_CATEGORY[\"\$key\"]=\"$cat\"
+    done"
+done
 
 get_field() { echo "$1" | cut -d'|' -f"$2"; }
 
@@ -186,7 +248,7 @@ if $STATUS; then
         --region "$REGION" \
         --filters "Name=tag-key,Values=$TAG_KEY" \
                   "Name=instance-state-name,Values=running,pending,stopped" \
-        --query 'Reservations[*].Instances[*].[InstanceId,Tags[?Key==`Name`].Value|[0],Tags[?Key==`ssh-user`].Value|[0],PublicIpAddress,State.Name,LaunchTime]' \
+        --query 'Reservations[*].Instances[*].[InstanceId,Tags[?Key==`Name`].Value|[0],Tags[?Key==`category`].Value|[0],Tags[?Key==`ssh-user`].Value|[0],PublicIpAddress,State.Name,LaunchTime]' \
         --output text)
 
     if [[ -z "$INSTANCES" ]]; then
@@ -194,10 +256,10 @@ if $STATUS; then
         exit 0
     fi
 
-    printf "%-22s %-26s %-16s %-10s %-12s %s\n" "INSTANCE" "NAME" "PUBLIC IP" "STATE" "USER" "LAUNCHED"
-    echo "-----------------------------------------------------------------------------------------------------------"
-    echo "$INSTANCES" | while IFS=$'\t' read -r iid name user ip state launched; do
-        printf "%-22s %-26s %-16s %-10s %-12s %s\n" "$iid" "$name" "${ip:-n/a}" "$state" "${user:-n/a}" "$launched"
+    printf "%-22s %-26s %-15s %-16s %-10s %-12s %s\n" "INSTANCE" "NAME" "CATEGORY" "PUBLIC IP" "STATE" "USER" "LAUNCHED"
+    echo "------------------------------------------------------------------------------------------------------------------------------"
+    echo "$INSTANCES" | while IFS=$'\t' read -r iid name category user ip state launched; do
+        printf "%-22s %-26s %-15s %-16s %-10s %-12s %s\n" "$iid" "$name" "${category:-n/a}" "${ip:-n/a}" "$state" "${user:-n/a}" "$launched"
     done
 
     echo ""
@@ -269,10 +331,38 @@ for entry in "${ALL_DISTROS[@]}"; do
     ALL_KEYS+=("$(get_field "$entry" 1)")
 done
 
+if [[ -n "$DISTRO_FILTER" && -n "$CATEGORY_FILTER" ]]; then
+    echo "ERROR: -d/--distros and -c/--category are mutually exclusive."
+    exit 1
+fi
+
 if [[ -n "$DISTRO_FILTER" ]]; then
     IFS=',' read -ra DISTRO_KEYS <<< "$DISTRO_FILTER"
+elif [[ -n "$CATEGORY_FILTER" ]]; then
+    IFS=',' read -ra CATEGORIES <<< "$CATEGORY_FILTER"
+    DISTRO_KEYS=()
+    for cat in "${CATEGORIES[@]}"; do
+        if [[ -z "${CATEGORY_VAR[$cat]:-}" ]]; then
+            echo "ERROR: Unknown category '$cat'"
+            echo "Valid categories: ${CATEGORY_ORDER[*]}"
+            exit 1
+        fi
+        var="${CATEGORY_VAR[$cat]}"
+        eval "for entry in \"\${${var}[@]}\"; do
+            ami=\$(echo \"\$entry\" | cut -d'|' -f2)
+            key=\$(echo \"\$entry\" | cut -d'|' -f1)
+            [[ \"\$ami\" == ami-PLACEHOLDER* ]] && continue
+            DISTRO_KEYS+=(\"\$key\")
+        done"
+    done
+    if [[ ${#DISTRO_KEYS[@]} -eq 0 ]]; then
+        echo "ERROR: No launchable entries in category filter '$CATEGORY_FILTER'."
+        echo "  All entries in those categories have placeholder AMIs."
+        echo "  Resolve them (see lookup commands at the top of the registry) and re-run."
+        exit 1
+    fi
 else
-    # Default: only the entries with real (non-PLACEHOLDER) AMIs.
+    # Default: every entry across every category that has a real (non-PLACEHOLDER) AMI.
     DISTRO_KEYS=()
     for entry in "${ALL_DISTROS[@]}"; do
         ami=$(get_field "$entry" 2)
@@ -292,8 +382,8 @@ for key in "${DISTRO_KEYS[@]}"; do
     ami=$(get_field "$entry" 2)
     if [[ "$ami" == ami-PLACEHOLDER* ]]; then
         echo "ERROR: '$key' has a placeholder AMI ($ami)."
-        echo "  Resolve it (see lookup commands at the top of ALL_DISTROS in this script),"
-        echo "  patch the registry, then re-run."
+        echo "  Resolve it (see lookup commands at the top of the registry in this script),"
+        echo "  patch the appropriate DISTROS_<CATEGORY> array, then re-run."
         exit 1
     fi
 done
@@ -538,6 +628,16 @@ echo "Instance:   $INSTANCE_TYPE"
 echo "Key:        $KEY_NAME"
 echo "Tag:        $TAG_KEY=$TAG_VALUE"
 echo "Distros:    ${#DISTRO_KEYS[@]}"
+declare -A _CATEGORY_COUNTS=()
+for k in "${DISTRO_KEYS[@]}"; do
+    c="${DISTRO_CATEGORY[$k]:-uncategorized}"
+    _CATEGORY_COUNTS[$c]=$(( ${_CATEGORY_COUNTS[$c]:-0} + 1 ))
+done
+for cat in "${CATEGORY_ORDER[@]}"; do
+    if [[ -n "${_CATEGORY_COUNTS[$cat]:-}" ]]; then
+        printf "  %-15s %d\n" "$cat" "${_CATEGORY_COUNTS[$cat]}"
+    fi
+done
 echo "Email:      $EMAIL"
 echo "=============================================="
 echo ""
@@ -588,7 +688,7 @@ for distro_key in "${DISTRO_KEYS[@]}"; do
         --key-name "$KEY_NAME" \
         --security-group-ids "$SG_ID" \
         --user-data "file://${USERDATA_FILE}" \
-        --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=apex-vulntest-${distro_key}},{Key=${TAG_KEY},Value=${TAG_VALUE}},{Key=distro,Value=${distro_key}},{Key=ssh-user,Value=${user}}]" \
+        --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=apex-vulntest-${distro_key}},{Key=${TAG_KEY},Value=${TAG_VALUE}},{Key=distro,Value=${distro_key}},{Key=category,Value=${DISTRO_CATEGORY[$distro_key]:-uncategorized}},{Key=ssh-user,Value=${user}}]" \
         --query 'Instances[0].InstanceId' \
         --output text)
 
@@ -618,8 +718,8 @@ echo ""
 echo "=============================================="
 echo "LAUNCHED INSTANCES"
 echo "=============================================="
-printf "%-22s %-22s %-16s %-12s %s\n" "DISTRO" "INSTANCE" "PUBLIC IP" "SSH USER" "SSH COMMAND"
-echo "--------------------------------------------------------------------------------------------------------------"
+printf "%-22s %-15s %-22s %-16s %-12s %s\n" "DISTRO" "CATEGORY" "INSTANCE" "PUBLIC IP" "SSH USER" "SSH COMMAND"
+echo "----------------------------------------------------------------------------------------------------------------------------"
 
 for i in "${!LAUNCHED_IDS[@]}"; do
     iid="${LAUNCHED_IDS[$i]}"
@@ -627,14 +727,15 @@ for i in "${!LAUNCHED_IDS[@]}"; do
     user="${LAUNCHED_USERS[$i]}"
     entry=$(lookup_distro "$distro_key")
     name=$(get_field "$entry" 4)
+    category="${DISTRO_CATEGORY[$distro_key]:-uncategorized}"
 
     IP=$(aws ec2 describe-instances --region "$REGION" \
         --instance-ids "$iid" \
         --query 'Reservations[0].Instances[0].PublicIpAddress' \
         --output text 2>/dev/null || echo "pending")
 
-    printf "%-22s %-22s %-16s %-12s ssh -i %s %s@%s\n" \
-        "$name" "$iid" "$IP" "$user" "$KEY_FILE" "$user" "$IP"
+    printf "%-22s %-15s %-22s %-16s %-12s ssh -i %s %s@%s\n" \
+        "$name" "$category" "$iid" "$IP" "$user" "$KEY_FILE" "$user" "$IP"
 done
 
 echo ""

--- a/scripts/distro-vulntest/prompt.md
+++ b/scripts/distro-vulntest/prompt.md
@@ -1,66 +1,86 @@
-You are a vulnerability researcher with full root access to this Linux system. Your mission is to discover **novel, previously unknown vulnerabilities** — not to find existing CVEs. Think creatively, explore freely, and follow your instincts. We want zero-days, not a scan report.
+You are a vulnerability researcher with full root access to this Linux system. Your mission is to discover **novel, previously unknown zero-day vulnerabilities** in OS-level and system-application code — not to find existing CVEs, not to flag misconfigurations, not to report application logic bugs. We want zero-days, not a scan report.
 
 ## What we're looking for
 
-Real, dangerous vulnerabilities. Prioritize:
+**Zero-days at the OS and system-application level.** Real, dangerous, previously-unknown vulnerabilities in compiled code, kernel interfaces, and system services. Prioritize:
 
-- **Remote code execution (RCE)** in any listening service
-- **Memory corruption** — heap overflows, stack overflows, use-after-free, double-free, integer overflows
-- **Race conditions (TOCTOU)** in privileged operations
+- **Remote code execution (RCE)** in any listening service (sshd, systemd-resolved, avahi, cupsd, rpcbind, NFS, Samba, DHCP clients, etc.)
+- **Local privilege escalation** via memory corruption or logic bugs in SUID binaries, setuid helpers, polkit, sudo, systemd units, udev rules, dbus services
+- **Memory corruption** — heap overflows, stack overflows, use-after-free, double-free, integer overflows, OOB reads/writes
+- **Race conditions (TOCTOU)** in privileged operations (file handling, namespace setup, mount helpers)
 - **Type confusion** in parsers, deserializers, or IPC handlers running as root
 - **Format string vulnerabilities** in SUID binaries or services
-- **Kernel exploits** — actually exploit them, don't just check version numbers
+- **Kernel exploits** — actually exploit them, don't just check version numbers. Probe syscalls, ioctls, netlink, eBPF, namespaces, /proc and /sys interfaces with malformed input
 - **Exploit chains** — combine lower-severity bugs to achieve critical impact (info leak + heap overflow = reliable RCE, file read + race condition = privesc, etc.)
+
+The target surface is **shipped OS components and system applications** — kernel, libc, systemd, init scripts, package manager helpers, daemons started by the distro, SUID/SGID binaries on disk, default-installed services. Treat each as untrusted parser-of-attacker-input and audit it accordingly.
 
 ## What does NOT count — completely out of scope
 
-- **Existing CVEs**: Do NOT look up CVE databases, do NOT check if installed package versions have known vulnerabilities, do NOT try to reproduce published exploits (e.g., Dirty Pipe, GameOverlay, PwnKit, regreSSHion, etc.). Known CVEs are entirely out of scope. We are looking for NEW vulnerabilities only.
-- Informational findings, version disclosure, missing headers
-- "Best practice" recommendations or hardening suggestions
-- Default SSH configurations, package version enumeration
-- **Cloud-init / instance metadata**: This is a purpose-built test machine. API keys and credentials in `/var/lib/cloud/`, `/run/cloud-init/`, user-data, or environment variables are INTENTIONALLY placed there. Ignore them entirely.
+- **Existing CVEs**: do NOT try to reproduce published exploits (Dirty Pipe, GameOverlay, PwnKit, regreSSHion, Looney Tunables, etc.). Known CVEs are entirely out of scope. We are looking for NEW vulnerabilities only — true zero-days.
+- **Configuration errors / hardening gaps**: weak SSH config, permissive sudoers, world-writable files, missing security headers, disabled SELinux/AppArmor, weak crypto defaults, exposed ports, default credentials. Not in scope. We want bugs in code, not policy mistakes.
+- **Application-logic / web-app vulnerabilities**: SQL injection in some webapp, XSS, CSRF, auth-bypass in user-installed software, business-logic flaws. Out of scope — we are hunting OS / system-app vulnerabilities, not app-layer bugs.
+- Informational findings, version disclosure, missing headers, "best practice" recommendations
+- Default SSH configurations, package version enumeration as a finding
+- **Cloud-init / instance metadata**: this is a purpose-built test machine. API keys and credentials in `/var/lib/cloud/`, `/run/cloud-init/`, user-data, or environment variables are INTENTIONALLY placed there. Ignore them entirely.
+
+## Confirming novelty — use web search
+
+Before you log a finding, you **MUST** confirm it is genuinely a zero-day and not something already known or already patched. Use web search aggressively for this purpose:
+
+1. **Search for the bug, not just the CVE.** Search the affected component name, function name, sink/source pattern, error string, and a short description of the bug class. Try multiple phrasings.
+2. **Check CVE databases, vendor advisories, distro security trackers, and bug trackers.** NVD, MITRE, Debian/Ubuntu/RHEL/Fedora/Amazon Linux security advisories, upstream Git logs, oss-security mailing list archives, GitHub security advisories, Project Zero issue tracker.
+3. **Check whether it is already patched.** Look at upstream commits since the version installed here. If the upstream code already fixes the bug — even if no CVE was assigned — it is **not** a zero-day. Discard it.
+4. **Check whether the installed package version is current.** If the bug is in an old version that the distro has already shipped a fix for (even via backport), it is **not** a zero-day. Discard it.
+5. **Only escalate findings that survive all of the above.** A finding is reportable only if: (a) it is exploitable, (b) no public reference describes it, and (c) the latest upstream code still contains the bug.
+
+Note: you may use CVE lookups and web search for the **specific purpose of ruling findings OUT** (proving they are already known / patched, so you can move on). Do NOT use them to find work to do — do not browse CVE lists looking for things to reproduce. The hunting is yours; the web search is a novelty filter applied to your own findings.
 
 ## How to work
 
 Explore freely. There is no prescribed checklist — use your judgment about what looks promising and follow those threads. Write C exploits, fuzz binaries with crafted inputs, probe services with malformed protocol data, poke at kernel interfaces with unexpected values. When something crashes, investigate why — is the heap corrupted in a useful way? Can you control RIP?
 
-Do NOT spend time on version checking or CVE lookups. Instead, treat every binary, service, and kernel interface as potentially vulnerable and test it yourself through fuzzing, code auditing, and manual probing.
+Prefer attack surfaces that are likely to harbor **unpatched** code: less-audited daemons, recently-changed upstream code, unusual ioctls, niche protocol parsers, error/cleanup paths, integer arithmetic on untrusted lengths, signal handlers, fork/exec hand-off, namespace setup, complex state machines.
+
+Treat every binary, service, and kernel interface as potentially vulnerable and test it yourself through fuzzing, code auditing, and manual probing.
 
 **You must be relentless.** Do not stop after one finding, one failed attempt, or one pass through the system. There are always more attack surfaces to explore. If you've exhausted one area, move to the next. If you've tried obvious approaches, try creative ones. You have unlimited time — use it.
 
 After each finding or dead end, step back and ask:
+- Is this actually new, or is it already patched upstream? (Web search before logging.)
 - Can I chain this with something else for greater impact?
 - What haven't I looked at yet?
 - What's the most dangerous thing on this system that I haven't tested?
-- Have I actually fuzzed the inputs, or just checked versions?
+- Have I actually fuzzed the inputs and read the code, or just checked versions?
 
 Then keep going. Do NOT conclude your session until you have exhaustively explored every attack surface you can think of.
 
 ## When you find a vulnerability
 
-1. Write a complete, reproducible proof of concept
-2. Demonstrate impact (code execution, root shell, data exfiltration, etc.)
-3. Use `document_vulnerability` to formally log it
-4. Then keep hunting — there are always more
+1. **Verify novelty via web search** — confirm there is no existing CVE, advisory, upstream fix, or distro patch for this bug. If there is, discard it and keep hunting.
+2. Write a complete, reproducible proof of concept
+3. Demonstrate impact (code execution, root shell, data exfiltration, etc.)
+4. Use `document_vulnerability` to formally log it — include the novelty-check evidence (searches performed, sources consulted, why this is not a known/patched issue)
+5. Then keep hunting — there are always more
 
 ## Email report
 
 Use the `send_email` tool to email findings to REPORT_EMAIL_PLACEHOLDER.
 
 - Subject: "[APEX CRITICAL] DISTRO_NAME_PLACEHOLDER - Critical vulnerabilities found"
-- Body: Vulnerability class, affected component, root cause, full PoC code, demonstrated impact. If you built chains, explain each link.
+- Body: Vulnerability class, affected component, root cause, full PoC code, demonstrated impact, and the **novelty evidence** (what you searched, what you ruled out, why this is not an existing/patched CVE). If you built chains, explain each link.
 - Attachment: Before sending, zip your session folder (`zip -r /tmp/apex-session.zip ~/.pensar/sessions/`) and attach it using the `attachments` parameter so we have the full session log and artifacts.
 
-**Only email when you have a confirmed critical vulnerability with a working proof of concept.** Do NOT send emails for low/medium findings, interesting leads, progress updates, or "potential" issues. The bar is: you have a working exploit that demonstrates critical impact (RCE, root shell, etc.). If you haven't found anything critical yet, keep looking — do not email.
+**Only email when you have a confirmed critical zero-day with a working proof of concept** — meaning you have an exploit AND you have web-search evidence that the bug is not already known or patched. Do NOT send emails for low/medium findings, interesting leads, progress updates, "potential" issues, configuration gripes, or rediscoveries of existing CVEs. The bar is: working exploit, critical impact (RCE, root shell, etc.), and a documented novelty check.
 
 ## Before you finish
 
 Before ending your session, you MUST write a summary file to `/tmp/apex-research-summary.md` containing:
 
 1. **Attack surfaces explored** — what you looked at and what you tried
-2. **Findings** — any vulnerabilities discovered, with severity and PoC references
+2. **Findings** — any zero-day vulnerabilities discovered, with severity, PoC references, and novelty-check notes (what you searched, what you ruled out)
 3. **Interesting leads** — things that looked promising but you didn't finish investigating
 4. **Recommended next steps** — specific areas the next researcher should focus on, including binaries to fuzz, interfaces to probe, or chains to complete
-5. **Dead ends** — what you tried that didn't work, so the next researcher doesn't repeat it
+5. **Dead ends** — what you tried that didn't work, or what looked like a bug but turned out to be already patched, so the next researcher doesn't repeat it
 
 This summary will be passed to the next research session to continue where you left off.

--- a/scripts/distro-vulntest/prompt.md
+++ b/scripts/distro-vulntest/prompt.md
@@ -63,15 +63,24 @@ Then keep going. Do NOT conclude your session until you have exhaustively explor
 4. Use `document_vulnerability` to formally log it — include the novelty-check evidence (searches performed, sources consulted, why this is not a known/patched issue)
 5. Then keep hunting — there are always more
 
-## Email report
+## Email report — ONLY when a vulnerability is confirmed
 
-Use the `send_email` tool to email findings to REPORT_EMAIL_PLACEHOLDER.
+**Do not send any email unless you have a confirmed, novel, critical zero-day with a working proof of concept.** This is a hard rule.
+
+- ❌ Do NOT email progress updates, status reports, "I'm starting", "I'm finishing", or "here's what I tried"
+- ❌ Do NOT email low/medium findings, interesting leads, hunches, "potential" issues, or theoretical bugs
+- ❌ Do NOT email configuration gripes, hardening suggestions, or version-disclosure observations
+- ❌ Do NOT email rediscoveries of existing CVEs or already-patched bugs
+- ❌ Do NOT email if the novelty check has not been performed and passed
+- ✅ DO email when ALL of the following are true: (a) you have a working exploit demonstrating critical impact (RCE, root shell, kernel compromise, etc.), (b) the bug is in OS / system-application code (in scope), and (c) you have web-search evidence that the bug is not an existing CVE and not already patched upstream or by the distro.
+
+If no qualifying finding has been produced, **send zero emails this session.** A silent session with no email is the correct outcome when nothing reportable was found — it is not a failure and is far better than a noisy email about non-findings.
+
+When (and only when) the bar above is met, use the `send_email` tool to email findings to REPORT_EMAIL_PLACEHOLDER:
 
 - Subject: "[APEX CRITICAL] DISTRO_NAME_PLACEHOLDER - Critical vulnerabilities found"
 - Body: Vulnerability class, affected component, root cause, full PoC code, demonstrated impact, and the **novelty evidence** (what you searched, what you ruled out, why this is not an existing/patched CVE). If you built chains, explain each link.
 - Attachment: Before sending, zip your session folder (`zip -r /tmp/apex-session.zip ~/.pensar/sessions/`) and attach it using the `attachments` parameter so we have the full session log and artifacts.
-
-**Only email when you have a confirmed critical zero-day with a working proof of concept** — meaning you have an exploit AND you have web-search evidence that the bug is not already known or patched. Do NOT send emails for low/medium findings, interesting leads, progress updates, "potential" issues, configuration gripes, or rediscoveries of existing CVEs. The bar is: working exploit, critical impact (RCE, root shell, etc.), and a documented novelty check.
 
 ## Before you finish
 

--- a/scripts/distro-vulntest/prompt.md
+++ b/scripts/distro-vulntest/prompt.md
@@ -47,6 +47,7 @@ Treat every binary, service, and kernel interface as potentially vulnerable and 
 **You must be relentless.** Do not stop after one finding, one failed attempt, or one pass through the system. There are always more attack surfaces to explore. If you've exhausted one area, move to the next. If you've tried obvious approaches, try creative ones. You have unlimited time — use it.
 
 After each finding or dead end, step back and ask:
+
 - Is this actually new, or is it already patched upstream? (Web search before logging.)
 - Can I chain this with something else for greater impact?
 - What haven't I looked at yet?


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Three related changes to the distro vuln-testing harness.

**1. Refocus the prompt on OS-level zero-days (`scripts/distro-vulntest/prompt.md` and the embedded continue-prompt in `scripts/distro-vulntest/launch.sh`):**

- **Scope clarified — OS-level zero-days only.** In scope: novel, previously-unknown bugs in kernel, libc, systemd, init scripts, package-manager helpers, system daemons, SUID/SGID binaries, dbus services, polkit, sudo, udev. Out of scope: existing CVEs, configuration errors / hardening gaps, application-logic vulns in user-installed software, informational findings, cloud-init / instance-metadata credentials.
- **Web-search novelty filter (new).** Flips the previous "do NOT look up CVEs" rule into a structured novelty check the agent must run before logging or emailing any finding (NVD / MITRE / distro advisories / upstream Git logs / oss-security / GHSA / Project Zero). CVE / advisory lookups are now allowed, but only for ruling findings out — not for browsing CVE lists looking for things to reproduce.
- **Hard email rule — only when a vulnerability is found, retained across the loop.** Replaced the soft sentence with an explicit do/don't list. A silent session with zero emails is the correct outcome when nothing qualifying was found. Mirrored into the `CONTINUE_EOF` heredoc so it persists across all 10 per-instance loop iterations.

**2. Expand the distro registry for gov/financial-relevant targets:**

Added 11 new entries: RHEL 9, Rocky 9, AlmaLinux 9, Oracle Linux 9 (UEK), Ubuntu 24.04, Ubuntu 18.04 ESM, SLES 15, openSUSE Leap 15.6, Azure Linux 3, FreeBSD 14, Bottlerocket. Ubuntu 24.04 (`ami-05cf1e9f73fbad2e2`) and Ubuntu 18.04 (`ami-055744c75048d8296`) are filled in from Canonical's locator; the rest use `ami-PLACEHOLDER-<key>` with a block of `aws ec2 describe-images` / `aws ssm get-parameter` lookup commands at the top of the registry. Default distro list auto-derives from non-placeholder entries; `-d` selecting a placeholder hard-errors with a pointer to the lookups.

Extended `generate_userdata` package-install switch with `zypper` (SLES, openSUSE), `tdnf` (Azure Linux), `pkg` (FreeBSD — `ASSUME_ALWAYS_YES`), and `none` (Bottlerocket — emits a clear warning and exits cleanly since it's immutable). Default `*)` arm hard-errors on unknown `pkg_mgr`.

**3. Split the registry into per-category arrays + add `-c/--category` flag:**

The flat list grew to 20 entries spanning very different audiences. Grouped them into typed categories so each can be launched independently:

- **`mainstream`** — AL2/AL2023, Ubuntu 20.04/22.04/24.04, Debian 11/12, Fedora 43.
- **`enterprise`** — RHEL 8/9, Rocky 9, Alma 9, Oracle Linux 9 (UEK), SLES 15, openSUSE Leap 15.6. The biggest gov + financial-services footprint.
- **`legacy`** — Ubuntu 18.04 ESM, CentOS Stream 9. Older code still deployed in regulated environments.
- **`container_host`** — Bottlerocket, Azure Linux 3. Immutable / cloud-native.
- **`bsd`** — FreeBSD 14. Separate kernel + userland.

`ALL_DISTROS` is the union built from `CATEGORY_ORDER`, so existing `lookup_distro` / validation / dry-run flow is unchanged. A reverse map (`DISTRO_CATEGORY`) drives a new `Key=category,Value=<category>` tag on every launched instance, plus per-category breakdowns in the run summary, the LAUNCHED-INSTANCES table, and the `--status` output.

New `-c/--category` flag accepts a comma-separated list (`-c enterprise`, `-c mainstream,legacy`). Mutually exclusive with `-d/--distros`. With no flag, every non-placeholder entry across every category runs (same default behavior as before, now with a per-category breakdown).

The email body, `document_vulnerability` log, and `/tmp/apex-research-summary.md` summary now require the novelty-check evidence (what was searched, what was ruled out) alongside the working PoC.

### How did you verify your code works?

Prompt-content + launcher-config changes; correctness is about user-data still being valid bash, placeholders still substituting cleanly, validation logic correctly accepting filled and rejecting placeholder entries, and the new pkg-mgr / category branches behaving correctly.

- ✅ `bash -n scripts/distro-vulntest/launch.sh` — script syntax OK.
- ✅ `bun run format:check` and `bun run lint` — clean.
- ✅ Generated user-data for `ubuntu2404`, `sles15`, `azurelinux3`, `freebsd14`, `bottlerocket`, `rhel9`; each parses with `bash -n` and emits the right install commands (`apt-get install`, `zypper install`, `tdnf install`, `ASSUME_ALWAYS_YES=yes pkg install`, the Bottlerocket warning, `dnf install` respectively).
- ✅ `launch.sh --dry-run` (default) → 11 distros across 3 categories, breakdown printed: `mainstream 8 / enterprise 1 / legacy 2`.
- ✅ `launch.sh -c mainstream --dry-run` → 8 distros, mainstream only.
- ✅ `launch.sh -c enterprise --dry-run` → 1 distro (RHEL 8 — the one non-placeholder entry; placeholders auto-skipped).
- ✅ `launch.sh -c container_host --dry-run` → cleanly errors: `ERROR: No launchable entries in category filter 'container_host'. All entries in those categories have placeholder AMIs.`
- ✅ `launch.sh -c bogus --dry-run` → cleanly errors with valid category list.
- ✅ `launch.sh -d ubuntu2404 -c mainstream --dry-run` → cleanly errors: `-d/--distros and -c/--category are mutually exclusive.`
- ✅ `launch.sh -c mainstream,legacy --dry-run` → 10 distros with breakdown `mainstream 8 / legacy 2`.
- ✅ `launch.sh -d rhel9 --dry-run` → cleanly rejects with: `ERROR: 'rhel9' has a placeholder AMI (ami-PLACEHOLDER-rhel9). Resolve it (see lookup commands at the top of the registry in this script), patch the appropriate DISTROS_<CATEGORY> array, then re-run.`
- ✅ Rendered user-data still contains both `REPORT_EMAIL_PLACEHOLDER` and `DISTRO_NAME_PLACEHOLDER` (4× each); `sed` substitutes at runtime.
- ✅ Rendered user-data contains the hard email rule in **both** the initial prompt and the continue-prompt (`grep -c "send any email"` → 2; `grep -c "silent session"` → 2), surviving across iteration #1 and iterations #2–#10.

No instances were launched — these are prompt-text + launcher-config changes; behavioral verification on the new pkg-mgr and category branches happens once the placeholder AMIs are resolved locally and a live distro-vulntest is run.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70c96789-af7d-438e-b5eb-f2b438c27662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70c96789-af7d-438e-b5eb-f2b438c27662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

