### PR TITLE
feat: add -s/--system flag for operator system prompt override

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -145,6 +145,7 @@ Usage:
 
 operator options (-p):
   -p, --prompt <text|@file>  (required) Prompt for the operator agent
+  -s, --system <text|@file>  Override the default system prompt
   --target <url>             Target URL / domain / IP
   --model <model>            AI model (default: auto-selected from configured provider)
 
@@ -387,6 +388,8 @@ async function runOperator() {
   }
 
   const prompt = resolveFlagValue(promptRaw);
+  const systemRaw = getArg("-s") ?? getArg("--system");
+  const systemPrompt = systemRaw ? resolveFlagValue(systemRaw) : undefined;
   const target = getArg("--target");
   const pensarConfig = await appConfig.get();
   const model = await resolveCliModel();
@@ -435,6 +438,7 @@ ${sep}\n`);
     for (;;) {
       await runOffensiveSecurityAgent({
         prompt: currentPrompt,
+        ...(systemPrompt ? { system: systemPrompt } : {}),
         model,
         target,
         activeTools: [...ALL_TOOL_NAMES, ...SKILL_TOOL_NAMES] as string[],


### PR DESCRIPTION
## Summary
- Adds `-s` / `--system` flag to `pensar -p` operator mode for overriding the default system prompt
- Supports inline text and `@file` syntax, consistent with the existing `-p` flag
- Passes the override through to `runOffensiveSecurityAgent` via the existing `system` field on `OffensiveSecurityAgentInput`

## Test plan
- [ ] `pensar -p "test" -s "You are a helpful assistant"` — verify custom system prompt is used
- [ ] `pensar -p "test" -s @system.txt` — verify @file resolution works
- [ ] `pensar -p "test"` without `-s` — verify default system prompt is unchanged
- [ ] `pensar help` — verify new flag appears in help text


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional CLI flag and plumbs it through to the operator agent without changing default behavior when omitted.
> 
> **Overview**
> Adds a new `-s/--system <text|@file>` flag to `pensar -p` operator mode so users can override the default system prompt.
> 
> The operator command now resolves the system prompt (including `@file` support via `resolveFlagValue`) and conditionally passes it to `runOffensiveSecurityAgent`, and the help text is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed12d3bb4da6878bb0f570734e8d29c639f4be43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->