### PR TITLE
fix: add stream idle timeout with automatic resume for stalled responses

### DIFF
--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -107,6 +107,55 @@ function checkIfRateLimitError(error: unknown): boolean {
 }
 
 const MAX_RATE_LIMIT_RETRIES = 20;
+const MAX_IDLE_RESUME_RETRIES = 3;
+const STREAM_IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+class StreamIdleTimeoutError extends Error {
+  constructor(idleMs: number) {
+    super(`Stream idle for ${Math.round(idleMs / 1000)}s — no chunks received`);
+    this.name = "StreamIdleTimeoutError";
+  }
+}
+
+/**
+ * Wraps an async iterable with a per-chunk idle timeout. If no chunk arrives
+ * within `idleMs`, throws a {@link StreamIdleTimeoutError} so the caller can
+ * resume the conversation from accumulated messages.
+ */
+async function* withIdleTimeout<T>(
+  stream: AsyncIterable<T>,
+  idleMs: number,
+): AsyncGenerator<T> {
+  const iterator = stream[Symbol.asyncIterator]();
+  try {
+    while (true) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const result = await Promise.race([
+        iterator.next(),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new StreamIdleTimeoutError(idleMs)),
+            idleMs,
+          );
+          if (typeof timer === "object" && "unref" in timer) timer.unref();
+        }),
+      ]);
+      clearTimeout(timer);
+
+      if (result.done) return;
+      yield result.value;
+    }
+  } finally {
+    // Best-effort cleanup — don't block on a stuck iterator. The underlying
+    // stream may be wedged (that's why we're here), so a hanging return()
+    // would deadlock the consumer.
+    iterator.return?.()?.catch?.(() => {});
+  }
+}
+
+function isStreamIdleTimeoutError(error: unknown): boolean {
+  return error instanceof StreamIdleTimeoutError;
+}
 
 // Helper function to wrap a stream with error handling for async errors
 function wrapStreamWithErrorHandler(
@@ -116,6 +165,7 @@ function wrapStreamWithErrorHandler(
   model: LanguageModel,
   silent?: boolean,
   rateLimitRetryCount: number = 0,
+  idleResumeCount: number = 0,
 ): StreamTextResult<ToolSet, never> {
   // Create a lazy getter for fullStream that wraps it with error handling
   let wrappedStream: AsyncIterable<TextStreamPart<ToolSet>> | null = null;
@@ -127,7 +177,10 @@ function wrapStreamWithErrorHandler(
         if (!wrappedStream) {
           wrappedStream = (async function* () {
             try {
-              for await (const chunk of originalStream.fullStream) {
+              for await (const chunk of withIdleTimeout(
+                originalStream.fullStream,
+                STREAM_IDLE_TIMEOUT_MS,
+              )) {
                 // Only stream-level errors are fatal; tool-level errors
                 // flow through so the UI renders them as failed tool results.
                 if (chunk.type === "error") {
@@ -143,6 +196,41 @@ function wrapStreamWithErrorHandler(
               // Check context length FIRST — these should never be retried
               // as-is; the prompt must be reduced via summarization.
               const isCtxError = checkIfContextLengthError(error);
+
+              // Handle stream idle timeout — resume from accumulated messages
+              if (
+                !isCtxError &&
+                isStreamIdleTimeoutError(error) &&
+                idleResumeCount < MAX_IDLE_RESUME_RETRIES &&
+                messagesContainer.current.length > 0
+              ) {
+                const nextIdleCount = idleResumeCount + 1;
+                if (!silent) {
+                  console.warn(
+                    `Stream stalled (attempt ${nextIdleCount}/${MAX_IDLE_RESUME_RETRIES}), resuming with ${messagesContainer.current.length} messages: ${errorMessage}`,
+                  );
+                }
+
+                const retriedStream = streamResponse({
+                  ...opts,
+                  messages: messagesContainer.current,
+                });
+
+                const wrappedRetriedStream = wrapStreamWithErrorHandler(
+                  retriedStream,
+                  messagesContainer,
+                  opts,
+                  model,
+                  silent,
+                  rateLimitRetryCount,
+                  nextIdleCount,
+                );
+
+                for await (const chunk of wrappedRetriedStream.fullStream) {
+                  yield chunk;
+                }
+                return;
+              }
 
               // Handle rate limit errors with exponential backoff retry
               if (
@@ -176,6 +264,7 @@ function wrapStreamWithErrorHandler(
                   model,
                   silent,
                   nextRetryCount,
+                  idleResumeCount,
                 );
 
                 for await (const chunk of wrappedRetriedStream.fullStream) {
@@ -229,6 +318,7 @@ function wrapStreamWithErrorHandler(
                       model,
                       silent,
                       rateLimitRetryCount,
+                      idleResumeCount,
                     );
                     for await (const chunk of wrappedRetry.fullStream) {
                       yield chunk;
@@ -728,3 +818,10 @@ export class ContextLengthError extends Error {
     this.name = "ContextLengthError";
   }
 }
+
+export {
+  StreamIdleTimeoutError,
+  withIdleTimeout,
+  STREAM_IDLE_TIMEOUT_MS,
+  MAX_IDLE_RESUME_RETRIES,
+};

--- a/src/core/ai/streamIdleTimeout.test.ts
+++ b/src/core/ai/streamIdleTimeout.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  StreamIdleTimeoutError,
+  withIdleTimeout,
+} from "./ai";
+
+describe("withIdleTimeout", () => {
+  it("passes through chunks when stream is healthy", async () => {
+    async function* source() {
+      yield "a";
+      yield "b";
+      yield "c";
+    }
+
+    const collected: string[] = [];
+    for await (const chunk of withIdleTimeout(source(), 1000)) {
+      collected.push(chunk);
+    }
+    expect(collected).toEqual(["a", "b", "c"]);
+  });
+
+  it("throws StreamIdleTimeoutError when stream stalls", async () => {
+    async function* stallingSource() {
+      yield "a";
+      // Stall forever after first chunk
+      await new Promise(() => {});
+    }
+
+    const collected: string[] = [];
+    await expect(async () => {
+      for await (const chunk of withIdleTimeout(stallingSource(), 50)) {
+        collected.push(chunk);
+      }
+    }).rejects.toThrow(StreamIdleTimeoutError);
+
+    expect(collected).toEqual(["a"]);
+  });
+
+  it("throws StreamIdleTimeoutError when stream never yields", async () => {
+    async function* neverYields() {
+      await new Promise(() => {});
+    }
+
+    await expect(async () => {
+      for await (const _chunk of withIdleTimeout(neverYields(), 50)) {
+        // should not reach here
+      }
+    }).rejects.toThrow(StreamIdleTimeoutError);
+  });
+
+  it("resets the idle timer on each chunk", async () => {
+    async function* slowButAlive() {
+      for (let i = 0; i < 5; i++) {
+        await new Promise((r) => setTimeout(r, 30));
+        yield i;
+      }
+    }
+
+    const collected: number[] = [];
+    for await (const chunk of withIdleTimeout(slowButAlive(), 80)) {
+      collected.push(chunk);
+    }
+    expect(collected).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("calls iterator.return on timeout to clean up the source", async () => {
+    const returnSpy = vi.fn().mockResolvedValue({ done: true, value: undefined });
+
+    const fakeIterable: AsyncIterable<string> = {
+      [Symbol.asyncIterator]() {
+        let first = true;
+        return {
+          async next() {
+            if (first) {
+              first = false;
+              return { done: false as const, value: "a" };
+            }
+            return new Promise(() => {});
+          },
+          return: returnSpy,
+        };
+      },
+    };
+
+    const collected: string[] = [];
+    try {
+      for await (const chunk of withIdleTimeout(fakeIterable, 50)) {
+        collected.push(chunk);
+      }
+    } catch {
+      // expected
+    }
+
+    expect(collected).toEqual(["a"]);
+    expect(returnSpy).toHaveBeenCalled();
+  });
+});
+
+describe("StreamIdleTimeoutError", () => {
+  it("has the correct name and message", () => {
+    const err = new StreamIdleTimeoutError(300_000);
+    expect(err.name).toBe("StreamIdleTimeoutError");
+    expect(err.message).toBe("Stream idle for 300s — no chunks received");
+    expect(err).toBeInstanceOf(Error);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `withIdleTimeout` async generator that wraps the AI stream with a 5-minute per-chunk idle timeout
- When triggered, the stream resumes from the last completed step using accumulated `messagesContainer` messages — identical to the existing rate-limit retry pattern (no work is lost)
- Max 3 resume attempts before propagating the error
- Includes 6 unit tests covering healthy streams, stall detection, timer reset, and iterator cleanup

## Context

Recon jobs on staging have been hanging for 22+ hours because Bedrock streaming responses stall mid-stream with an open TCP connection. The `wrapStreamWithErrorHandler` in `ai.ts` handles rate limits and context length errors but had no idle detection — once the SSE stream stops producing chunks, `for await (const chunk of fullStream)` blocks indefinitely.

The comment on line 34 of `utils.ts` references an "SSE idle timeout" as the "primary stall guard" but it was never implemented — until now.

## Changes

**`src/core/ai/ai.ts`**
- `withIdleTimeout<T>()` — async generator that races each `iterator.next()` against a `setTimeout`, clearing the timer when a chunk arrives
- `StreamIdleTimeoutError` — typed error for stall detection
- `wrapStreamWithErrorHandler` now wraps `originalStream.fullStream` with `withIdleTimeout(stream, 5min)` and catches `StreamIdleTimeoutError` to retry via `streamResponse({...opts, messages: messagesContainer.current})`
- `idleResumeCount` threaded through all retry paths to cap resume attempts at 3

**`src/core/ai/streamIdleTimeout.test.ts`**
- 6 unit tests (no API keys required): healthy passthrough, stall detection, never-yields, timer reset on chunks, iterator cleanup on timeout, error shape

## Test plan

- [x] `vitest run src/core/ai/streamIdleTimeout.test.ts` — 6/6 passing
- [x] Lint clean, no new type errors
- [ ] Deploy to staging and trigger recon jobs to verify stalled streams resume


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the build workflow’s post-build validation and adds large bundled wordlist assets that will ship in the npm package, impacting package size and runtime expectations.
> 
> **Overview**
> Strengthens CI by replacing the single package smoke check with a fuller matrix that installs the packed npm tarball globally and verifies the CLI works under **Node**, under **Bun**, shows a clear error when Bun is missing for TUI mode, and that the standalone compiled binary runs.
> 
> Bundles curated web-content wordlists under `assets/wordlists/` (with MIT license/attribution docs) so recon tooling can reliably reference a portable `-w` path across non-Kali hosts.
> 
> Updates docs (`README.md`, `AGENTS.md`) with revised messaging, installation/usage guidance, and additional TUI UI/UX conventions, and tweaks `.gitignore` (newline fix + ignore `sst-env.d.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a84f88e5b46120402d59f2ea98e7f2227e2c201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->