### PR TITLE
Remove [operator] badge from session titles in sessions dialog

### DIFF
--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -303,9 +303,6 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
                       minute: "2-digit",
                       hour12: true,
                     });
-                    const mode = session.config?.mode || "auto";
-                    const modeBadge =
-                      mode === "operator" ? "[operator]" : "[auto]";
                     const statusBadge = session.hasReport ? "✓" : "…";
                     const findingsText =
                       session.findingsCount > 0
@@ -344,15 +341,6 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
                             }
                           >
                             {statusBadge}
-                          </text>
-                          <text
-                            fg={
-                              mode === "operator"
-                                ? colors.primary
-                                : colors.textMuted
-                            }
-                          >
-                            {modeBadge}
                           </text>
                           {findingsText ? (
                             <text fg={colors.textMuted}>{findingsText}</text>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes the issue where every session in the sessions dialog shows an `[operator]` indicator badge to the right of the session title. Since every session is an operator session, this badge serves no purpose and adds visual noise.

**Changes in `src/tui/components/commands/sessions-display.tsx`:**
- Removed the `mode` variable (derived from `session.config?.mode`)
- Removed the `modeBadge` variable (`"[operator]"` / `"[auto]"` text)
- Removed the `<text>` element that rendered the badge with theme-aware coloring

The remaining session row elements (selection indicator, session name, status badge, findings count, timestamp) are preserved unchanged.

### How did you verify your code works?

- Confirmed `bun run tsc` passes with no type errors
- Confirmed `bun run lint` passes with no lint issues
- Confirmed `bun run test` — all 575 passing tests continue to pass (pre-existing Zod-related failures in unrelated test suites remain unchanged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3d1a953-f3a4-48f5-809d-320e8ca73576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3d1a953-f3a4-48f5-809d-320e8ca73576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

