### PR TITLE
fix: add right padding to sessions dialog when no scrollbar

### DIFF
--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -280,6 +280,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
                 contentOptions: {
                   gap: 2,
                   flexDirection: "column",
+                  paddingRight: 1,
                 },
                 scrollbarOptions: {
                   trackOptions: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes the missing right-side padding in the Sessions (resume) dialog when there is no scrollbar.

The `flushRight` prop on `DialogLayout` (introduced in #682) removes right padding from the dialog body so scrollbars sit flush against the dialog edge. However, when there aren't enough sessions to trigger a scrollbar, session rows are rendered with zero spacing from the right edge of the dialog, which looks bad.

The fix adds `paddingRight: 1` to the scrollbox's `contentOptions` in `SessionsDisplay`. This ensures 1 character of spacing between session rows and:
- The scrollbar track (when enough sessions are present to overflow)
- The dialog edge (when there's no scrollbar)

### How did you verify your code works?

- All CI checks pass: lint (ESLint + Prettier), type check (`tsc --noEmit`), format check, and unit tests (pre-existing failures unrelated to this change)
- Manually tested in the TUI by opening the sessions dialog with 2 mock sessions (no scrollbar scenario) and verified proper right-side spacing:

![Sessions dialog with proper right padding](https://cursor.com/artifacts/c/art-074201aa-9b99-4953-b059-7c8729c2b001)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2543b132-e052-4270-a6ee-44a1879eb2bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2543b132-e052-4270-a6ee-44a1879eb2bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

