### PR TITLE
fix(operator): stop leaking internal approval IDs into LoadingIndicator (#708)

### DIFF
--- a/src/core/operator/approvalGate.test.ts
+++ b/src/core/operator/approvalGate.test.ts
@@ -3,7 +3,9 @@ import {
   ApprovalGate,
   ApprovalTimeoutError,
   DEFAULT_DECISION_TIMEOUT_MS,
+  INTERNAL_ID_PATTERN,
 } from "./approvalGate";
+import type { PendingApproval } from "./types";
 
 describe("ApprovalGate — operator decision timeout", () => {
   beforeEach(() => {
@@ -128,5 +130,171 @@ describe("ApprovalGate — operator decision timeout", () => {
     expect(result).toBe("auto-approved");
     await vi.advanceTimersByTimeAsync(5_000);
     expect(gate.getPendingApprovals()).toHaveLength(0);
+  });
+});
+
+describe("ApprovalGate — approval-resolved payload shape", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("includes the full PendingApproval on approve()", async () => {
+    const gate = new ApprovalGate({
+      requireApproval: true,
+      decisionTimeoutMs: 0,
+    });
+
+    const resolvedEvents: Array<{
+      id: string;
+      decision: string;
+      approval: PendingApproval;
+    }> = [];
+    gate.on("approval-resolved", (e) => resolvedEvents.push(e));
+
+    let approvalId = "";
+    gate.once("approval-needed", (e) => {
+      approvalId = (e as { approval: { id: string } }).approval.id;
+    });
+
+    const pending = gate.check("execute_command", "tc_payload_1", {
+      command: "ffuf -u https://example.com/FUZZ -w wordlist.txt",
+      toolCallDescription: "Running ffuf against example.com",
+    });
+
+    gate.approve(approvalId);
+    await expect(pending).resolves.toBe("approved");
+
+    expect(resolvedEvents).toHaveLength(1);
+    const [event] = resolvedEvents;
+    expect(event.decision).toBe("approved");
+    expect(event.approval.toolName).toBe("execute_command");
+    expect(event.approval.args.toolCallDescription).toBe(
+      "Running ffuf against example.com",
+    );
+    expect(event.approval.args.command).toBe(
+      "ffuf -u https://example.com/FUZZ -w wordlist.txt",
+    );
+  });
+
+  it("includes the full PendingApproval on deny()", async () => {
+    const gate = new ApprovalGate({
+      requireApproval: true,
+      decisionTimeoutMs: 0,
+    });
+
+    const resolvedEvents: Array<{
+      id: string;
+      decision: string;
+      approval: PendingApproval;
+    }> = [];
+    gate.on("approval-resolved", (e) => resolvedEvents.push(e));
+
+    let approvalId = "";
+    gate.once("approval-needed", (e) => {
+      approvalId = (e as { approval: { id: string } }).approval.id;
+    });
+
+    const pending = gate.check("http_request", "tc_payload_2", {
+      url: "https://example.com/admin",
+    });
+    const assertion = expect(pending).rejects.toThrow("Action denied by user");
+
+    gate.deny(approvalId);
+    await assertion;
+
+    expect(resolvedEvents).toHaveLength(1);
+    const [event] = resolvedEvents;
+    expect(event.decision).toBe("denied");
+    expect(event.approval.toolName).toBe("http_request");
+    expect(event.approval.args.url).toBe("https://example.com/admin");
+  });
+
+  it("includes the full PendingApproval on timeout", async () => {
+    const gate = new ApprovalGate({
+      requireApproval: true,
+      decisionTimeoutMs: 1_000,
+    });
+
+    const resolvedEvents: Array<{
+      id: string;
+      decision: string;
+      approval: PendingApproval;
+    }> = [];
+    gate.on("approval-resolved", (e) => resolvedEvents.push(e));
+
+    const pending = gate.check("nuclei_scan", "tc_payload_3", {
+      target: "https://example.com",
+    });
+    const assertion =
+      expect(pending).rejects.toBeInstanceOf(ApprovalTimeoutError);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await assertion;
+
+    expect(resolvedEvents).toHaveLength(1);
+    const [event] = resolvedEvents;
+    expect(event.decision).toBe("denied");
+    expect(event.approval.toolName).toBe("nuclei_scan");
+    expect(event.approval.args.target).toBe("https://example.com");
+  });
+});
+
+/**
+ * Pin `INTERNAL_ID_PATTERN` to the format the gate actually mints. If anyone
+ * changes either side without updating the other, this test fails before the
+ * regex silently rots and stops catching leaked correlation IDs in the UI.
+ */
+describe("ApprovalGate — INTERNAL_ID_PATTERN format-source coupling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("matches the apr_ IDs minted for pending approvals", async () => {
+    const gate = new ApprovalGate({
+      requireApproval: true,
+      decisionTimeoutMs: 0,
+    });
+
+    let approvalId = "";
+    gate.once("approval-needed", (e) => {
+      approvalId = (e as { approval: { id: string } }).approval.id;
+    });
+
+    const pending = gate.check("http_request", "tc_pin_1", {});
+    const assertion = expect(pending).rejects.toThrow("Action denied by user");
+
+    expect(approvalId).toMatch(INTERNAL_ID_PATTERN);
+    expect(approvalId.startsWith("apr_")).toBe(true);
+
+    gate.deny(approvalId);
+    await assertion;
+  });
+
+  it("matches the act_ IDs minted for action-history entries", async () => {
+    const gate = new ApprovalGate({
+      requireApproval: true,
+      decisionTimeoutMs: 0,
+    });
+
+    let approvalId = "";
+    gate.once("approval-needed", (e) => {
+      approvalId = (e as { approval: { id: string } }).approval.id;
+    });
+
+    const pending = gate.check("http_request", "tc_pin_2", {});
+    gate.approve(approvalId);
+    await expect(pending).resolves.toBe("approved");
+
+    const [historyEntry] = gate.getActionHistory();
+    expect(historyEntry.id).toMatch(INTERNAL_ID_PATTERN);
+    expect(historyEntry.id.startsWith("act_")).toBe(true);
   });
 });

--- a/src/core/operator/approvalGate.ts
+++ b/src/core/operator/approvalGate.ts
@@ -23,6 +23,9 @@ export interface ApprovalGateConfig {
 /** Default operator decision SLA when `requireApproval` is true. */
 export const DEFAULT_DECISION_TIMEOUT_MS = 15 * 60 * 1000;
 
+/** Internal correlation IDs minted by this module: `apr_*`, `act_*`, `tc_*`. Never user-facing. */
+export const INTERNAL_ID_PATTERN = /^(apr|act|tc)_\d+_[0-9a-f]{8}$/;
+
 interface DeferredApproval {
   approval: PendingApproval;
   resolve: (decision: ApprovalDecision) => void;
@@ -123,10 +126,11 @@ export class ApprovalGate extends EventEmitter {
     const deferred = this.pendingApprovals.get(approvalId);
     if (!deferred) return;
 
+    const approval = deferred.approval;
     this.pendingApprovals.delete(approvalId);
     const entry = this.recordAction(
-      deferred.approval.toolName,
-      deferred.approval.toolCallId,
+      approval.toolName,
+      approval.toolCallId,
       "denied",
     );
     entry.resultSummary = `decision_timeout:${timeoutMs}ms`;
@@ -135,11 +139,12 @@ export class ApprovalGate extends EventEmitter {
       type: "approval-resolved",
       id: approvalId,
       decision: "denied",
+      approval,
     });
     this.emitEvent({ type: "action-completed", entry });
     deferred.reject(
       new ApprovalTimeoutError(
-        `Operator decision timeout after ${timeoutMs}ms for ${deferred.approval.toolName} — default-safe deny`,
+        `Operator decision timeout after ${timeoutMs}ms for ${approval.toolName} — default-safe deny`,
       ),
     );
   }
@@ -151,10 +156,11 @@ export class ApprovalGate extends EventEmitter {
     }
 
     if (deferred.timeoutHandle) clearTimeout(deferred.timeoutHandle);
+    const approval = deferred.approval;
     this.pendingApprovals.delete(approvalId);
     const entry = this.recordAction(
-      deferred.approval.toolName,
-      deferred.approval.toolCallId,
+      approval.toolName,
+      approval.toolCallId,
       "approved",
     );
 
@@ -162,6 +168,7 @@ export class ApprovalGate extends EventEmitter {
       type: "approval-resolved",
       id: approvalId,
       decision: "approved",
+      approval,
     });
     this.emitEvent({ type: "action-completed", entry });
     deferred.resolve("approved");
@@ -172,10 +179,11 @@ export class ApprovalGate extends EventEmitter {
     if (!deferred) return;
 
     if (deferred.timeoutHandle) clearTimeout(deferred.timeoutHandle);
+    const approval = deferred.approval;
     this.pendingApprovals.delete(approvalId);
     const entry = this.recordAction(
-      deferred.approval.toolName,
-      deferred.approval.toolCallId,
+      approval.toolName,
+      approval.toolCallId,
       "denied",
     );
 
@@ -183,6 +191,7 @@ export class ApprovalGate extends EventEmitter {
       type: "approval-resolved",
       id: approvalId,
       decision: "denied",
+      approval,
     });
     this.emitEvent({ type: "action-completed", entry });
     deferred.reject(new ApprovalDeniedError("Action denied by user"));

--- a/src/core/operator/index.ts
+++ b/src/core/operator/index.ts
@@ -56,6 +56,7 @@ export {
   ApprovalDeniedError,
   ApprovalTimeoutError,
   DEFAULT_DECISION_TIMEOUT_MS,
+  INTERNAL_ID_PATTERN,
   wrapToolWithApproval,
   type ApprovalGateConfig,
 } from "./approvalGate";

--- a/src/core/operator/types.ts
+++ b/src/core/operator/types.ts
@@ -191,7 +191,7 @@ export function getNextStage(current: OperatorStage): OperatorStage | null {
   return idx === -1 || idx === stages.length - 1 ? null : stages[idx + 1].stage;
 }
 
-/** Pending approval request */
+/** Pending approval request. `id` is an internal correlation key, not a label. */
 export interface PendingApproval {
   id: string;
   toolName: string;
@@ -323,7 +323,12 @@ export type OperatorEvent =
   | { type: "mode-changed"; mode: OperatorMode }
   | { type: "stage-changed"; stage: OperatorStage }
   | { type: "approval-needed"; approval: PendingApproval }
-  | { type: "approval-resolved"; id: string; decision: ApprovalDecision }
+  | {
+      type: "approval-resolved";
+      id: string;
+      decision: ApprovalDecision;
+      approval: PendingApproval;
+    }
   | { type: "action-completed"; entry: ActionHistoryEntry }
   // Sidebar population events
   | { type: "attack-surface-updated"; endpoints: DiscoveredEndpoint[] }

--- a/src/tui/components/chat/approval-inline.tsx
+++ b/src/tui/components/chat/approval-inline.tsx
@@ -7,20 +7,19 @@
 
 import { useTheme } from "../../theme";
 import { getToolSummary } from "../shared/tool-registry";
+import { deriveApprovedActionLabel } from "../shared/action-label";
 import type { PendingApproval } from "../../../core/operator";
 
 interface InlineApprovalPromptProps {
   approval: PendingApproval;
 }
 
-/**
- * Inline approval prompt — shows pending tool call awaiting approval.
- */
 export function InlineApprovalPrompt({ approval }: InlineApprovalPromptProps) {
   const { colors } = useTheme();
 
-  const description = approval.args?.toolCallDescription as string | undefined;
+  const label = deriveApprovedActionLabel(approval);
   const summary = getToolSummary(approval.toolName, approval.args || {});
+  const showSummaryLine = summary !== label;
 
   return (
     <box flexDirection="row" marginTop={1}>
@@ -28,17 +27,16 @@ export function InlineApprovalPrompt({ approval }: InlineApprovalPromptProps) {
       <text fg={colors.warning}>{"  │ "}</text>
 
       <box flexDirection="column">
-        {description && (
-          <box flexDirection="row" marginBottom={1}>
-            <text fg={colors.text} content={description} />
+        <box flexDirection="row" marginBottom={showSummaryLine ? 1 : 0}>
+          <text fg={colors.text} content={label} />
+        </box>
+
+        {showSummaryLine && (
+          <box flexDirection="row" gap={1}>
+            <text fg={colors.warning} content="?" />
+            <text fg={colors.info} content={summary} />
           </box>
         )}
-
-        {/* Approval line */}
-        <box flexDirection="row" gap={1}>
-          <text fg={colors.warning} content="?" />
-          <text fg={colors.info} content={summary} />
-        </box>
 
         {/* Shortcut hints */}
         <box flexDirection="row" gap={2} marginLeft={2} marginTop={1}>

--- a/src/tui/components/chat/loading-indicator.test.ts
+++ b/src/tui/components/chat/loading-indicator.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { INTERNAL_ID_PATTERN } from "../../../core/operator";
+
+describe("INTERNAL_ID_PATTERN", () => {
+  it.each([
+    "apr_1777922893504_0d385b65",
+    "act_1777922893504_0d385b65",
+    "tc_1777922893504_0d385b65",
+    "apr_1_aaaaaaaa",
+    "tc_999999999999999_ffffffff",
+  ])("matches internal correlation ID %s", (id) => {
+    expect(INTERNAL_ID_PATTERN.test(id)).toBe(true);
+  });
+
+  it.each([
+    "Running ffuf against example.com",
+    "$ ffuf -u https://example.com/FUZZ -w wordlist.txt",
+    "GET https://example.com/api/users",
+    "nuclei cves -> https://example.com",
+    "finding: SQL injection in /login",
+    "read /etc/passwd",
+    "Executing",
+    "Running execute_command",
+    "",
+    "apr_not_a_real_id",
+    "apr_1777922893504_zzzzzzzz",
+    "apr_1777922893504_0d385b65 plus suffix",
+    "prefix apr_1777922893504_0d385b65",
+    "APR_1777922893504_0d385b65",
+  ])("does not match human-readable string %s", (label) => {
+    expect(INTERNAL_ID_PATTERN.test(label)).toBe(false);
+  });
+});

--- a/src/tui/components/chat/loading-indicator.tsx
+++ b/src/tui/components/chat/loading-indicator.tsx
@@ -6,6 +6,7 @@
 
 import { useState, useEffect } from "react";
 import { useTheme } from "../../theme";
+import { INTERNAL_ID_PATTERN } from "../../../core/operator";
 
 // Braille spinner frames for smooth animation
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -67,8 +68,13 @@ export function LoadingIndicator({
       case "waiting":
         return `Waiting for agents${dots}`;
       case "executing":
-        if (action) {
+        if (action && !INTERNAL_ID_PATTERN.test(action)) {
           return action;
+        }
+        if (action && process.env.NODE_ENV !== "production") {
+          console.warn(
+            `[LoadingIndicator] internal correlation ID leaked into action prop: ${action}`,
+          );
         }
         if (toolName) {
           return `Running ${toolName}${dots}`;

--- a/src/tui/components/chat/loading-indicator.tsx
+++ b/src/tui/components/chat/loading-indicator.tsx
@@ -4,7 +4,7 @@
  * Animated spinner with contextual messages for agent states.
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useTheme } from "../../theme";
 import { INTERNAL_ID_PATTERN } from "../../../core/operator";
 
@@ -38,6 +38,7 @@ export function LoadingIndicator({
   const { colors } = useTheme();
   const [spinnerFrame, setSpinnerFrame] = useState(0);
   const [dotsFrame, setDotsFrame] = useState(0);
+  const warnedIdsRef = useRef<Set<string>>(new Set());
 
   // Spinner animation
   useEffect(() => {
@@ -71,7 +72,12 @@ export function LoadingIndicator({
         if (action && !INTERNAL_ID_PATTERN.test(action)) {
           return action;
         }
-        if (action && process.env.NODE_ENV !== "production") {
+        if (
+          action &&
+          process.env.NODE_ENV !== "production" &&
+          !warnedIdsRef.current.has(action)
+        ) {
+          warnedIdsRef.current.add(action);
           console.warn(
             `[LoadingIndicator] internal correlation ID leaked into action prop: ${action}`,
           );

--- a/src/tui/components/chat/message-list.tsx
+++ b/src/tui/components/chat/message-list.tsx
@@ -11,6 +11,7 @@ import type { DisplayMessage } from "../agent-display";
 import type { PendingApproval } from "../../../core/operator";
 import { InlineApprovalPrompt } from "./approval-inline";
 import { LoadingIndicator, type LoadingState } from "./loading-indicator";
+import { deriveActionLabel } from "../shared/action-label";
 
 /** Tools that spawn subagents — show "Waiting for agents" instead of "Executing" */
 const SUBAGENT_TOOLS = new Set([
@@ -42,17 +43,23 @@ function getLoadingState(
   return "thinking";
 }
 
-/**
- * Get the name of any pending tool from recent messages
- */
-function getPendingToolName(messages: DisplayMessage[]): string | null {
+interface PendingToolInfo {
+  toolName: string;
+  args: Record<string, unknown>;
+}
+
+/** Most recent pending or streaming tool message in the last 5, or null. */
+function getPendingToolInfo(
+  messages: DisplayMessage[],
+): PendingToolInfo | null {
   const recentMessages = messages.slice(-5);
   for (const msg of recentMessages.reverse()) {
     if (
       isToolMessage(msg) &&
-      (msg.status === "pending" || msg.status === "streaming")
+      (msg.status === "pending" || msg.status === "streaming") &&
+      msg.toolName
     ) {
-      return msg.toolName || null;
+      return { toolName: msg.toolName, args: msg.args ?? {} };
     }
   }
   return null;
@@ -218,19 +225,21 @@ export function MessageList({
         !hasPendingApproval &&
         hasMessages &&
         (() => {
-          const pendingTool = getPendingToolName(messages);
-          const effectiveHasPendingTool =
-            hasPendingTool || pendingTool !== null;
+          const pendingToolInfo = getPendingToolInfo(messages);
+          const pendingToolName = pendingToolInfo?.toolName ?? null;
+          const liveLabel = pendingToolInfo
+            ? deriveActionLabel(pendingToolInfo.toolName, pendingToolInfo.args)
+            : null;
           return (
             <LoadingIndicator
               state={getLoadingState(
                 messages,
-                effectiveHasPendingTool,
+                hasPendingTool || pendingToolName !== null,
                 isLastAssistant,
-                pendingTool,
+                pendingToolName,
               )}
-              action={lastApprovedAction}
-              toolName={pendingTool}
+              action={liveLabel ?? lastApprovedAction}
+              toolName={pendingToolName}
             />
           );
         })()}

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -51,6 +51,7 @@ import { useDialog } from "../../context/dialog";
 import { useFocus } from "../../context/focus";
 import { MessageList } from "../chat/message-list";
 import { InputArea } from "../chat/input-area";
+import { deriveApprovedActionLabel } from "../shared/action-label";
 import { useTheme } from "../../theme";
 import type { DisplayMessage, WorkflowData } from "../agent-display";
 import { isToolMessage } from "../shared/type-guards";
@@ -331,12 +332,17 @@ export default function OperatorDashboard({
       setStatus("waiting");
     };
 
-    const onApprovalResolved = (event: { id: string; decision: string }) => {
-      setPendingApprovals(gate.getPendingApprovals());
+    const onApprovalResolved = (event: {
+      id: string;
+      decision: string;
+      approval: PendingApproval;
+    }) => {
+      const pending = gate.getPendingApprovals();
+      setPendingApprovals(pending);
       if (event.decision === "approved") {
-        setLastApprovedAction(event.id);
+        setLastApprovedAction(deriveApprovedActionLabel(event.approval));
       }
-      if (gate.getPendingApprovals().length === 0) {
+      if (pending.length === 0) {
         setStatus("running");
       }
     };

--- a/src/tui/components/shared/action-label.test.ts
+++ b/src/tui/components/shared/action-label.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { deriveActionLabel, deriveApprovedActionLabel } from "./action-label";
+import type { PendingApproval } from "../../../core/operator";
+
+function makeApproval(
+  overrides: Partial<PendingApproval> = {},
+): PendingApproval {
+  return {
+    id: "apr_1777922893504_0d385b65",
+    toolName: "execute_command",
+    toolCallId: "tc_test_1",
+    args: { command: "ls -la" },
+    tier: 1,
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+describe("deriveApprovedActionLabel", () => {
+  it("returns args.toolCallDescription when present and non-empty", () => {
+    const approval = makeApproval({
+      args: {
+        command: "ffuf -u https://example.com/FUZZ -w wordlist.txt",
+        toolCallDescription: "Running ffuf against example.com",
+      },
+    });
+
+    expect(deriveApprovedActionLabel(approval)).toBe(
+      "Running ffuf against example.com",
+    );
+  });
+
+  it("trims whitespace from the description", () => {
+    const approval = makeApproval({
+      args: {
+        toolCallDescription: "  Running scan  \n",
+      },
+    });
+
+    expect(deriveApprovedActionLabel(approval)).toBe("Running scan");
+  });
+
+  it("falls back to getToolSummary when description is absent", () => {
+    const approval = makeApproval({
+      toolName: "execute_command",
+      args: { command: "ls -la" },
+    });
+
+    expect(deriveApprovedActionLabel(approval)).toBe("$ ls -la");
+  });
+
+  it("falls back to getToolSummary when description is an empty string", () => {
+    const approval = makeApproval({
+      toolName: "http_request",
+      args: {
+        url: "https://example.com/api/users",
+        method: "GET",
+        toolCallDescription: "",
+      },
+    });
+
+    expect(deriveApprovedActionLabel(approval)).toBe(
+      "GET https://example.com/api/users",
+    );
+  });
+
+  it("falls back to getToolSummary when description is whitespace only", () => {
+    const approval = makeApproval({
+      toolName: "http_request",
+      args: {
+        url: "https://example.com/api/users",
+        toolCallDescription: "   \n\t  ",
+      },
+    });
+
+    expect(deriveApprovedActionLabel(approval)).toBe(
+      "GET https://example.com/api/users",
+    );
+  });
+
+  it("ignores a non-string toolCallDescription and falls back to summary", () => {
+    const approval = makeApproval({
+      toolName: "execute_command",
+      args: {
+        command: "ls -la",
+        toolCallDescription: 42 as unknown as string,
+      },
+    });
+
+    expect(deriveApprovedActionLabel(approval)).toBe("$ ls -la");
+  });
+
+  it("delegates to deriveActionLabel with the same precedence", () => {
+    const approval = makeApproval({
+      toolName: "execute_command",
+      args: {
+        command: "gobuster -u https://example.com",
+        toolCallDescription: "Running gobuster against example.com",
+      },
+    });
+
+    expect(deriveApprovedActionLabel(approval)).toBe(
+      deriveActionLabel(approval.toolName, approval.args),
+    );
+  });
+});
+
+describe("deriveActionLabel", () => {
+  it("returns the description when present", () => {
+    expect(
+      deriveActionLabel("execute_command", {
+        command: "gobuster -u https://example.com",
+        toolCallDescription: "Running gobuster against example.com",
+      }),
+    ).toBe("Running gobuster against example.com");
+  });
+
+  it("falls back to getToolSummary for execute_command in auto mode", () => {
+    expect(
+      deriveActionLabel("execute_command", {
+        command: "gobuster -u https://example.com -w wordlist.txt",
+      }),
+    ).toBe("$ gobuster -u https://example.com -w wordlist.txt");
+  });
+
+  it("handles undefined args without throwing", () => {
+    expect(deriveActionLabel("scratchpad", undefined)).toBe("note");
+  });
+
+  it("handles empty args gracefully (returns the tool name itself)", () => {
+    expect(deriveActionLabel("custom_tool", {})).toBe("custom_tool");
+  });
+});

--- a/src/tui/components/shared/action-label.ts
+++ b/src/tui/components/shared/action-label.ts
@@ -1,0 +1,18 @@
+import type { PendingApproval } from "../../../core/operator";
+import { getToolSummary } from "./tool-registry";
+
+/** Derive a human-readable label for a tool call. Prefers `args.toolCallDescription`, falls back to `getToolSummary`. */
+export function deriveActionLabel(
+  toolName: string,
+  args: Record<string, unknown> | undefined,
+): string {
+  const description = args?.toolCallDescription;
+  if (typeof description === "string" && description.trim().length > 0) {
+    return description.trim();
+  }
+  return getToolSummary(toolName, args ?? {});
+}
+
+export function deriveApprovedActionLabel(approval: PendingApproval): string {
+  return deriveActionLabel(approval.toolName, approval.args);
+}

--- a/src/tui/components/shared/approval-prompt.tsx
+++ b/src/tui/components/shared/approval-prompt.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect } from "react";
 import { useKeyboard } from "@opentui/react";
 import { useTheme } from "../../theme";
 import { getToolSummary } from "./tool-registry";
+import { deriveApprovedActionLabel } from "./action-label";
 import type { PendingApproval } from "../../../core/operator";
 import { getPasteText } from "../../utils/paste";
 import { useDialog } from "../../context/dialog";
@@ -16,29 +17,26 @@ interface InlineApprovalPromptProps {
   approval: PendingApproval;
 }
 
-/**
- * Inline approval prompt - shows pending tool call.
- * Displayed in the chat flow.
- */
 export function InlineApprovalPrompt({ approval }: InlineApprovalPromptProps) {
   const { colors } = useTheme();
 
-  const description = approval.args?.toolCallDescription as string | undefined;
+  const label = deriveApprovedActionLabel(approval);
   const summary = getToolSummary(approval.toolName, approval.args || {});
+  const showSummaryLine = summary !== label;
 
   return (
     <box flexDirection="column" marginTop={2}>
-      {description && (
-        <box flexDirection="row" marginBottom={1}>
-          <text fg={colors.primary} content="| " />
-          <text fg={colors.text} content={description} />
+      <box flexDirection="row" marginBottom={showSummaryLine ? 1 : 0}>
+        <text fg={colors.primary} content="| " />
+        <text fg={colors.text} content={label} />
+      </box>
+
+      {showSummaryLine && (
+        <box flexDirection="row" gap={1} marginLeft={2}>
+          <text fg={colors.warning} content="?" />
+          <text fg={colors.info} content={summary} />
         </box>
       )}
-
-      <box flexDirection="row" gap={1} marginLeft={2}>
-        <text fg={colors.warning} content="?" />
-        <text fg={colors.info} content={summary} />
-      </box>
     </box>
   );
 }


### PR DESCRIPTION
Closes #708.

## Summary

After the operator approved a tool call (`Y` / batch-approve `A`), the spinner replacing the inline approval prompt rendered the raw approval correlation ID — e.g. `apr_1777922893504_0d385b65` — instead of a human-readable description like `Running ffuf against example.com with the default wordlist`.

The string was internal: `apr_*` is the prefix `ApprovalGate` mints for `PendingApproval` map keys + event correlation. It was never meant to surface in any rendered string.

## Root cause

End-to-end leak path:

1. `approval-resolved` carried only `{ id, decision }` ([`src/core/operator/types.ts:326`](src/core/operator/types.ts#L326)) — no toolName, no description, no `PendingApproval` reference.
2. `ApprovalGate.{approve,deny,timeoutApproval}` all called `pendingApprovals.delete(approvalId)` *before* `emitEvent(...)`, so any subscriber lost the original approval object before it could derive a label.
3. The dashboard handler grabbed `event.id` because that was the only string in scope:

```ts
if (event.decision === "approved") {
  setLastApprovedAction(event.id); // BUG: stores "apr_<ts>_<hex>"
}
```

4. State flowed `OperatorDashboard` → `MessageList` → `LoadingIndicator.action`, and `LoadingIndicator` short-circuited `Running ${toolName}…` whenever `action` was truthy, so the raw ID rendered verbatim.

The TS checker accepted the assignment because `lastApprovedAction: string | null` had no nominal guard distinguishing "human label" from "correlation key".

## Fix (Option B from the issue + belt-and-suspenders guard)

### Layer 1 — enrich the event payload (root cause)

[`src/core/operator/types.ts`](src/core/operator/types.ts) — `approval-resolved` now carries the full `approval: PendingApproval`. Additive only; existing `id` / `decision` fields are preserved for any other listener.

```ts
| {
    type: "approval-resolved";
    id: string;
    decision: ApprovalDecision;
    approval: PendingApproval;
  }
```

[`src/core/operator/approvalGate.ts`](src/core/operator/approvalGate.ts) — `approve` / `deny` / `timeoutApproval` now capture `deferred.approval` *before* `pendingApprovals.delete(...)` (synchronously, no `setImmediate` — preserves tool-call latency invariant) and include it in the emitted event.

### Layer 2 — single source of truth for labels (DRY-knowledge)

[`src/tui/components/shared/action-label.ts`](src/tui/components/shared/action-label.ts) (new, 18 lines) — extracted the `args.toolCallDescription ?? getToolSummary(toolName, args)` precedence into one pure helper:

- `deriveActionLabel(toolName, args)` — low-level, works for live tool messages.
- `deriveApprovedActionLabel(approval)` — thin wrapper over `PendingApproval`.

Refactored both inline approval prompts ([`approval-inline.tsx`](src/tui/components/chat/approval-inline.tsx), [`shared/approval-prompt.tsx`](src/tui/components/shared/approval-prompt.tsx)), the dashboard handler ([`operator-dashboard/index.tsx`](src/tui/components/operator-dashboard/index.tsx)), and the message list ([`chat/message-list.tsx`](src/tui/components/chat/message-list.tsx)) to call through the helper. This eliminates the visual jolt where the prompt's nice description gets replaced by a different summary in the spinner — both surfaces now derive from the same precedence on the same data.

The two prompts also gained a `showSummaryLine = summary !== label` guard so the `?` summary line is suppressed when it would duplicate the description above it.

### Layer 3 — runtime guardrail at the UI sink (defense-in-depth)

[`src/tui/components/chat/loading-indicator.tsx`](src/tui/components/chat/loading-indicator.tsx) — the `executing` branch now rejects any `action` matching `INTERNAL_ID_PATTERN` and falls back to `Running ${toolName}…` (with a dev-mode `console.warn`). Catches future regressions of this exact bug class even if a new caller misuses the `action` prop.

`INTERNAL_ID_PATTERN = /^(apr|act|tc)_\d+_[0-9a-f]{8}$/` is exported from [`src/core/operator/approvalGate.ts`](src/core/operator/approvalGate.ts) — pinned next to where IDs are minted so the pattern and its source can't drift.

### Bonus — auto-mode label fix

[`src/tui/components/chat/message-list.tsx`](src/tui/components/chat/message-list.tsx) — `getPendingToolName` widened to `getPendingToolInfo` (returns `{toolName, args}`) so the `LoadingIndicator.action` prop now uses `deriveActionLabel(toolName, args)` for any in-flight tool, not just for previously-approved ones. In auto-mode (no approval prompt), users now see e.g. `⠦ $ gobuster dir -u …` instead of the generic `⠦ Running execute_command…`.

## Why this prevents recurrence

| Layer | Guarantee |
|---|---|
| Enriched event payload | Any `approval-resolved` listener has the full `PendingApproval` in scope — `event.id` is never the only string available. |
| `INTERNAL_ID_PATTERN` exported next to the minting site | Pattern + format coupled in one file; pinned by tests so a format change without an export update fails CI. |
| `LoadingIndicator` guardrail | Even if a future contributor passes a correlation key to `action`, the regex rejects it and falls back to a real label. |
| Single label-derivation helper | Pre-approval prompt + post-approval spinner + auto-mode spinner share one source of truth — they cannot drift. |

## Test plan

CI gates (all passing locally):
- [x] `bun run tsc` — clean
- [x] `bun run test` — 902 passed / 16 skipped (24 new across `approvalGate.test.ts`, `action-label.test.ts`, `loading-indicator.test.ts`)
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean

New regression tests:
- `approvalGate.test.ts` — `approval-resolved` payload includes the full `PendingApproval` for `approve`, `deny`, and `timeoutApproval` paths; `INTERNAL_ID_PATTERN` matches the actually-minted `apr_*` and `act_*` ID formats (format-source coupling pin).
- `action-label.test.ts` — `deriveActionLabel` precedence (description > getToolSummary fallback), whitespace handling, undefined/empty args; `deriveApprovedActionLabel` delegation.
- `loading-indicator.test.ts` — `INTERNAL_ID_PATTERN` matches `apr_/act_/tc_` IDs and rejects human-readable labels (parameterized).

Manual TUI smoke:
- [x] `/operator` in `manual` mode → trigger an approval-required tool call (`run gobuster dir on example.com`) → press `Y` → spinner now reads `⠦ Running gobuster directory enumeration on example.com with default wordlist` instead of `⠦ apr_…`.
- [x] Same flow in `auto` mode → spinner shows the description for the live tool call rather than the generic `Running execute_command…`.

## Out of scope (deferred)

- Visual spacing nit between the spinner glyph and message text (`gap={1}` on the parent `<box>` doesn't reliably space `<text>` siblings in this opentui version). Independent layout issue, separate fix.
- ID format change in `ApprovalGate` — the `apr_<ts>_<hex>` format is fine; the bug was consuming it as a label.
- `LoadingIndicator` color/animation refactor.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes the `approval-resolved` event contract and how the operator UI derives labels, which could affect any downstream listeners or UI state transitions. Behavior is covered by new unit tests and includes a UI-side fallback guard for regressions.
> 
> **Overview**
> Fixes a TUI bug where **internal approval correlation IDs** (e.g. `apr_*`) could be rendered as the loading spinner action after an approval.
> 
> `approval-resolved` events are enriched to include the full `PendingApproval`, and `ApprovalGate` now emits that approval object on approve/deny/timeout before clearing internal state. The operator dashboard and chat UI now derive human-readable action labels via a new shared helper (`deriveActionLabel`/`deriveApprovedActionLabel`), and the inline approval prompts suppress duplicate summary lines.
> 
> Adds a defense-in-depth UI guard by exporting `INTERNAL_ID_PATTERN` and having `LoadingIndicator` ignore/warn on leaked internal IDs (with tests pinning the ID format and label derivation behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3a882f739e6d90ba905d47a46785295fa067439. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->