### PR TITLE
fix(offsec-agent): wrap consume() stream loop in try/finally to dispose shell on error

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Unit tests for OffensiveSecurityAgent.consume().
+ *
+ * Verifies that persistentShell.dispose() is called even when the
+ * fullStream throws — the shell-leak bug described in the PR.
+ *
+ * Heavy transitive dependencies (tools, AI SDK, zod) are stubbed so
+ * the test loads cleanly without external provider keys.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Module stubs — prevent the full tool/AI/zod import chain from loading.
+//
+// vi.mock factories are hoisted above all imports, so they cannot
+// reference top-level variables. All helper logic must be inlined.
+// ---------------------------------------------------------------------------
+
+vi.mock("zod", () => {
+  const handler: ProxyHandler<CallableFunction> = {
+    get(_target, _prop) {
+      return new Proxy(function () {}, handler);
+    },
+    apply(_target, _thisArg, _args) {
+      return new Proxy(function () {}, handler);
+    },
+  };
+  const z = new Proxy(function () {}, handler);
+  return { z, default: z };
+});
+
+vi.mock("./tools", () => ({
+  createAllTools: () => ({}),
+  EMAIL_TOOL_NAMES_ACTIVE: [],
+  SEND_EMAIL_TOOL_NAME: "send_email",
+  PLAN_MODE_TOOL_NAMES: [],
+}));
+vi.mock("./tools/response", () => ({
+  createResponseTool: () => {},
+  RESPONSE_TOOL_NAME: "response",
+}));
+vi.mock("./tools/askUserQuestions", () => ({
+  ASK_USER_QUESTIONS_TOOL_NAME: "ask_user_questions",
+}));
+vi.mock("./tools/persistentShell", () => ({
+  PersistentShell: class {},
+}));
+vi.mock("../../ai", () => ({ streamResponse: () => {} }));
+vi.mock("../../session", () => ({ create: () => {} }));
+vi.mock("../specialized/utils", () => ({
+  detectOSAndEnhancePrompt: (p: string) => p,
+}));
+vi.mock("./prompt", () => ({
+  buildBaseSystemPrompt: () => "system",
+  buildSessionWorkspaceSection: () => "",
+}));
+vi.mock("./trace", () => ({
+  StepTraceWriter: class {
+    onStepFinish() {}
+  },
+}));
+vi.mock("../../operator", () => ({
+  ApprovalDeniedError: class extends Error {},
+}));
+vi.mock("ai", () => ({ hasToolCall: () => () => false }));
+
+import { OffensiveSecurityAgent } from "./offensiveSecurityAgent";
+import { AgentEventBus } from "../../eventBus";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a minimal OffensiveSecurityAgent with mocked internals.
+ *
+ * Bypasses the constructor (which needs a real session, model, tools, etc.)
+ * via Object.create so we can unit-test consume() in isolation.
+ */
+function buildStubAgent(overrides: {
+  fullStream: AsyncIterable<unknown>;
+  persistentShell?: { dispose: () => void };
+  abortSignal?: AbortSignal;
+  resolveResult?: (sr: unknown) => unknown;
+}): OffensiveSecurityAgent<unknown> {
+  const agent = Object.create(
+    OffensiveSecurityAgent.prototype,
+  ) as OffensiveSecurityAgent<unknown>;
+
+  const bus = new AgentEventBus();
+  vi.spyOn(bus, "emitStreamPart").mockImplementation(() => {});
+
+  Object.defineProperty(agent, "eventBus", { value: bus });
+  Object.defineProperty(agent, "streamResult", {
+    value: { fullStream: overrides.fullStream },
+  });
+  Object.defineProperty(agent, "subagentId", { value: undefined });
+  Object.defineProperty(agent, "persistentShell", {
+    value: overrides.persistentShell,
+  });
+  Object.defineProperty(agent, "abortSignal", {
+    value: overrides.abortSignal,
+  });
+  Object.defineProperty(agent, "resolveResult", {
+    value: overrides.resolveResult,
+  });
+
+  return agent;
+}
+
+async function* yieldChunks(
+  chunks: unknown[],
+): AsyncGenerator<unknown, void, undefined> {
+  for (const c of chunks) yield c;
+}
+
+async function* yieldThenThrow(
+  chunks: unknown[],
+  error: Error,
+): AsyncGenerator<unknown, void, undefined> {
+  for (const c of chunks) yield c;
+  throw error;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("OffensiveSecurityAgent.consume()", () => {
+  const textDelta = { type: "text-delta", text: "hi" };
+
+  describe("persistentShell disposal on stream error (leak fix)", () => {
+    it("disposes shell after a successful stream", async () => {
+      const dispose = vi.fn();
+      const agent = buildStubAgent({
+        fullStream: yieldChunks([textDelta]),
+        persistentShell: { dispose },
+      });
+
+      await agent.consume();
+      expect(dispose).toHaveBeenCalledOnce();
+    });
+
+    it("disposes shell when the stream throws mid-iteration", async () => {
+      const dispose = vi.fn();
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow([textDelta], new Error("stream exploded")),
+        persistentShell: { dispose },
+      });
+
+      await expect(agent.consume()).rejects.toThrow("stream exploded");
+      expect(dispose).toHaveBeenCalledOnce();
+    });
+
+    it("disposes shell when the stream throws immediately (no chunks)", async () => {
+      const dispose = vi.fn();
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow([], new Error("instant failure")),
+        persistentShell: { dispose },
+      });
+
+      await expect(agent.consume()).rejects.toThrow("instant failure");
+      expect(dispose).toHaveBeenCalledOnce();
+    });
+
+    it("disposes shell when emitStreamPart throws", async () => {
+      const dispose = vi.fn();
+      const agent = buildStubAgent({
+        fullStream: yieldChunks([textDelta]),
+        persistentShell: { dispose },
+      });
+
+      vi.spyOn(agent.eventBus, "emitStreamPart").mockImplementation(() => {
+        throw new Error("bus emit failed");
+      });
+
+      await expect(agent.consume()).rejects.toThrow("bus emit failed");
+      expect(dispose).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("no-shell scenarios (sandbox mode)", () => {
+    it("succeeds without shell when stream completes normally", async () => {
+      const agent = buildStubAgent({
+        fullStream: yieldChunks([textDelta]),
+        persistentShell: undefined,
+      });
+
+      await expect(agent.consume()).resolves.toBeUndefined();
+    });
+
+    it("propagates stream error without shell (no dispose to call)", async () => {
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow([], new Error("sandbox boom")),
+        persistentShell: undefined,
+      });
+
+      await expect(agent.consume()).rejects.toThrow("sandbox boom");
+    });
+  });
+
+  describe("disposal ordering", () => {
+    it("disposes shell before resolveResult runs", async () => {
+      const callOrder: string[] = [];
+
+      const dispose = vi.fn(() => callOrder.push("dispose"));
+      const resolveResult = vi.fn(() => {
+        callOrder.push("resolveResult");
+        return "result";
+      });
+
+      const agent = buildStubAgent({
+        fullStream: yieldChunks([textDelta]),
+        persistentShell: { dispose },
+        resolveResult,
+      });
+
+      const result = await agent.consume();
+      expect(result).toBe("result");
+      expect(dispose).toHaveBeenCalledOnce();
+      expect(resolveResult).toHaveBeenCalledOnce();
+      expect(callOrder).toEqual(["dispose", "resolveResult"]);
+    });
+  });
+
+  describe("abort signal", () => {
+    it("disposes shell even when abort signal causes throw", async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const dispose = vi.fn();
+      const agent = buildStubAgent({
+        fullStream: yieldChunks([textDelta]),
+        persistentShell: { dispose },
+        abortSignal: controller.signal,
+      });
+
+      await expect(agent.consume()).rejects.toThrow("Agent aborted by user");
+      expect(dispose).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("resolveResult", () => {
+    it("returns resolved value when resolveResult is provided", async () => {
+      const agent = buildStubAgent({
+        fullStream: yieldChunks([textDelta]),
+        resolveResult: () => 42,
+      });
+
+      const result = await agent.consume();
+      expect(result).toBe(42);
+    });
+
+    it("returns undefined when resolveResult is absent", async () => {
+      const agent = buildStubAgent({
+        fullStream: yieldChunks([textDelta]),
+      });
+
+      const result = await agent.consume();
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -443,11 +443,13 @@ export class OffensiveSecurityAgent<TResult = void> {
     const sid = this.subagentId;
     const bus = this.eventBus;
 
-    for await (const chunk of this.streamResult.fullStream) {
-      bus.emitStreamPart(chunk, sid);
+    try {
+      for await (const chunk of this.streamResult.fullStream) {
+        bus.emitStreamPart(chunk, sid);
+      }
+    } finally {
+      this.persistentShell?.dispose();
     }
-
-    this.persistentShell?.dispose();
 
     if (this.abortSignal?.aborted) {
       throw new DOMException("Agent aborted by user", "AbortError");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

`OffensiveSecurityAgent.consume()` called `this.persistentShell?.dispose()` **after** the `for await` loop over `this.streamResult.fullStream`. If anything inside the loop threw — a stream-level error chunk, `StreamIdleTimeoutError` after resumes are exhausted, a failure in `bus.emitStreamPart`, or any other exception — `dispose()` was skipped and the bash subprocess leaked for the lifetime of the apex process.

The fix wraps the stream iteration in `try/finally` so the persistent shell is always disposed, regardless of whether the stream completes normally or throws:

```ts
async consume(): Promise<TResult> {
  const sid = this.subagentId;
  const bus = this.eventBus;

  try {
    for await (const chunk of this.streamResult.fullStream) {
      bus.emitStreamPart(chunk, sid);
    }
  } finally {
    this.persistentShell?.dispose();
  }
  // ...rest unchanged
}
```

The `finally` block guarantees disposal on every exit path: normal completion, stream errors, bus errors, and abort signals. The rest of `consume()` (abort check, `resolveResult`) remains outside the `try/finally` — if the stream threw, the error propagates naturally without reaching those paths.

### How did you verify your code works?

Added 10 unit tests in `offensiveSecurityAgent.test.ts` that exercise `consume()` in isolation using `Object.create` to bypass the heavy constructor. The tests cover:

- **Shell disposal on stream error (3 tests)** — stream throws mid-iteration, throws immediately with no chunks, and `emitStreamPart` throws. All 3 **fail without the fix** (`dispose` never called) and **pass with the fix**.
- **Disposal ordering (1 test)** — verifies `dispose()` is called before `resolveResult`.
- **Abort signal (1 test)** — verifies `dispose()` is called even when the abort signal triggers a throw after the stream.
- **Sandbox / no-shell (2 tests)** — verifies `consume()` works correctly without a persistent shell.
- **resolveResult (2 tests)** — verifies the return value behavior.
- **Happy-path disposal (1 test)** — verifies normal stream completion still calls `dispose()`.

All CI checks pass: `tsc`, `eslint`, `prettier`, and `vitest` (29 passing test files; 19 pre-existing failures are the known zod ESM import issue unrelated to this change).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5df06313-d01a-4472-b7ae-0b24d5ab1f37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5df06313-d01a-4472-b7ae-0b24d5ab1f37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

