### PR TITLE
fix(operator): always hydrate plan content on session resume

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -417,20 +417,11 @@ export default function OperatorDashboard({
                 // Best-effort — subagent files may not exist
               }
 
-              // Restore plan approval state from a prior session so the
-              // cycleMode gate doesn't force a redundant re-approval on
-              // Shift+Tab.
               const planContent = readPlan(s.rootPath);
               if (planContent) {
                 if (restoredMode !== "plan") {
-                  // Session left plan mode before ending — the plan was
-                  // previously approved, so hydrate it for the agent.
                   setApprovedPlanContent(planContent);
                 } else {
-                  // Session ended while still in plan mode — the plan may
-                  // never have been approved. Don't mark it as approved (to
-                  // avoid sending it to the agent as an execution plan), but
-                  // allow the user to cycle away without the stale gate.
                   planGateBypassedOnResumeRef.current = true;
                 }
               }
@@ -1902,9 +1893,6 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
     const idx = OPERATOR_MODE_CYCLE.indexOf(current);
     const next = OPERATOR_MODE_CYCLE[(idx + 1) % OPERATOR_MODE_CYCLE.length];
 
-    // Gate: if leaving plan mode and a plan exists but isn't approved, show review.
-    // Skip the gate when resuming a session that was already in plan mode — the
-    // user should be able to cycle away without re-approving a stale plan.
     if (
       current === "plan" &&
       sessionRef.current &&
@@ -1916,7 +1904,6 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
       return;
     }
 
-    // Entering plan mode — reset plan state for fresh cycle
     if (next === "plan") {
       setApprovedPlanContent(null);
       planRejectedRef.current = false;

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -978,6 +978,7 @@ export default function OperatorDashboard({
           (d.result as Record<string, unknown> | null)?.success === true
         ) {
           planSubmittedRef.current = true;
+          planGateBypassedOnResumeRef.current = false;
         }
       });
 

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -418,13 +418,11 @@ export default function OperatorDashboard({
 
               // Restore plan content from a prior session so the cycleMode
               // gate doesn't force a redundant re-approval on Shift+Tab.
-              // Only mark the plan as approved if the user previously left
-              // plan mode (restoredMode !== "plan"), which signals prior approval.
-              if (restoredMode !== "plan") {
-                const planContent = readPlan(s.rootPath);
-                if (planContent) {
-                  setApprovedPlanContent(planContent);
-                }
+              // Always hydrate on resume — whether the previous mode was plan
+              // or not — so cycling away doesn't trigger a stale approval gate.
+              const planContent = readPlan(s.rootPath);
+              if (planContent) {
+                setApprovedPlanContent(planContent);
               }
             }
           } else if (s.config?.operatorSettings) {

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -303,6 +303,7 @@ export default function OperatorDashboard({
   const planSubmittedRef = useRef(false);
   const planRejectedRef = useRef(false);
   const planApprovedPendingRunRef = useRef(false);
+  const planGateBypassedOnResumeRef = useRef(false);
 
   const [pendingQuestions, setPendingQuestions] = useState<
     AskUserQuestion[] | null
@@ -416,13 +417,22 @@ export default function OperatorDashboard({
                 // Best-effort — subagent files may not exist
               }
 
-              // Restore plan content from a prior session so the cycleMode
-              // gate doesn't force a redundant re-approval on Shift+Tab.
-              // Always hydrate on resume — whether the previous mode was plan
-              // or not — so cycling away doesn't trigger a stale approval gate.
+              // Restore plan approval state from a prior session so the
+              // cycleMode gate doesn't force a redundant re-approval on
+              // Shift+Tab.
               const planContent = readPlan(s.rootPath);
               if (planContent) {
-                setApprovedPlanContent(planContent);
+                if (restoredMode !== "plan") {
+                  // Session left plan mode before ending — the plan was
+                  // previously approved, so hydrate it for the agent.
+                  setApprovedPlanContent(planContent);
+                } else {
+                  // Session ended while still in plan mode — the plan may
+                  // never have been approved. Don't mark it as approved (to
+                  // avoid sending it to the agent as an execution plan), but
+                  // allow the user to cycle away without the stale gate.
+                  planGateBypassedOnResumeRef.current = true;
+                }
               }
             }
           } else if (s.config?.operatorSettings) {
@@ -1891,12 +1901,15 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
     const idx = OPERATOR_MODE_CYCLE.indexOf(current);
     const next = OPERATOR_MODE_CYCLE[(idx + 1) % OPERATOR_MODE_CYCLE.length];
 
-    // Gate: if leaving plan mode and a plan exists but isn't approved, show review
+    // Gate: if leaving plan mode and a plan exists but isn't approved, show review.
+    // Skip the gate when resuming a session that was already in plan mode — the
+    // user should be able to cycle away without re-approving a stale plan.
     if (
       current === "plan" &&
       sessionRef.current &&
       hasPlan(sessionRef.current.rootPath) &&
-      !approvedPlanRef.current
+      !approvedPlanRef.current &&
+      !planGateBypassedOnResumeRef.current
     ) {
       setShowPlanReview(true);
       return;
@@ -1906,6 +1919,7 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
     if (next === "plan") {
       setApprovedPlanContent(null);
       planRejectedRef.current = false;
+      planGateBypassedOnResumeRef.current = false;
     }
 
     transitionToMode(next);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes #709 — When resuming a session that ended in plan mode and pressing Shift+Tab to cycle modes, the old plan approval gate would fire, blocking the user with a stale approval dialog.

**Root cause:** On session resume, the code deliberately skipped hydrating `approvedPlanContent` when `restoredMode === "plan"` (the original assumption was that being in plan mode implied the plan wasn't yet approved). This meant `approvedPlanRef.current` was null, so the `cycleMode` gate (`hasPlan && !approvedPlanRef.current`) would always trigger, showing the plan review dialog for a plan that was already written in a previous session.

**Fix:** Introduces a dedicated `planGateBypassedOnResumeRef` that decouples the mode-cycling gate bypass from plan approval semantics:

- When resuming in plan mode with an existing `plan.md`, the ref is set to `true` — this allows `cycleMode` to skip the review gate
- `approvedPlanContent` stays `null` so the plan is **never** sent to the agent as an approved execution plan
- The bypass ref is cleared in three situations to re-engage the gate:
  1. When the user cycles into plan mode fresh (new plan submissions will be gated)
  2. When `submit_plan` succeeds (a fresh plan was generated in this session and must be reviewed)
- When `restoredMode !== "plan"`, behavior is unchanged: `approvedPlanContent` is hydrated since leaving plan mode previously implies prior approval

### How did you verify your code works?

Reproduced the bug before the fix, then verified the fix works after:

**Before fix** — Session resumes in plan mode, pressing Shift+Tab triggers stale plan approval dialog:

![Before fix: session resumed in plan mode](https://cursor.com/artifacts/c/art-6d8cc6fc-cff7-498b-9e94-319869539626)

![Before fix: stale plan approval gate appears on Shift+Tab](https://cursor.com/artifacts/c/art-4c56dab8-cb86-41b9-9a68-281e47afa4e1)

**After fix** — Session resumes in plan mode, pressing Shift+Tab cleanly cycles to "Approvals On" without any dialog:

![After fix: session in plan mode before cycling](https://cursor.com/artifacts/c/art-9f9c9ba6-c8e0-418f-83eb-57f4a982b76a)

![After fix: mode cycles cleanly without approval gate](https://cursor.com/artifacts/c/art-7b77d0d6-83ca-49c0-8e92-57c247a10ee1)

**Video walkthrough of the final fix working end-to-end:**

<a href="https://cursor.com/agents/bc-62b6df73-6783-4411-bcaf-f8f8967201ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffinal_fix_mode_cycle_verified.mp4"><img src="https://cursor.com/artifacts/c/art-6536fd0b-e480-4cd4-9d64-8cdb1a605ba7" alt="final_fix_mode_cycle_verified.mp4" /></a>

Additionally:
- `bun run tsc` — passes (no type errors)
- `bun run lint` — passes
- `bun run test` — all passing tests remain passing (pre-existing test file failures are unrelated zod import issues on the base branch)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62b6df73-6783-4411-bcaf-f8f8967201ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62b6df73-6783-4411-bcaf-f8f8967201ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

