### PR TITLE
feat(whitebox-recon): gate surface integration + rename enrichment agent

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -242,6 +242,7 @@ Model:   ${model}${enableThinking ? "\nThinking: enabled" : ""}${taskDriven ? "\
         session,
         model,
         enableThinking,
+        surfaceIntegrationEnabled: pensarConfig.surfaceIntegrationEnabled,
         authConfig: buildAuthConfig(pensarConfig),
         eventBus: pentestBus,
       });

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -197,6 +197,7 @@ export class OffensiveSecurityAgent<TResult = void> {
       traceWriter,
       tasksDir,
       enableThinking: input.enableThinking,
+      surfaceIntegrationEnabled: input.surfaceIntegrationEnabled,
       projectThreatModel: input.projectThreatModel,
       planSubagentId: input.planSubagentId,
       subagentId: input.subagentId,

--- a/src/core/agents/offSecAgent/tools/runPentestWorkflow.ts
+++ b/src/core/agents/offSecAgent/tools/runPentestWorkflow.ts
@@ -61,6 +61,7 @@ Omit \`cwd\` for blackbox mode (live target probing only).`,
           abortSignal: ctx.abortSignal,
           eventBus: ctx.eventBus,
           enableThinking: ctx.enableThinking,
+          surfaceIntegrationEnabled: ctx.surfaceIntegrationEnabled,
         });
 
         const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -95,6 +95,13 @@ export type ToolContext = {
   enableThinking?: boolean;
 
   /**
+   * Whitebox attack surface flag. Forwarded into `runPentestWorkflow` so the
+   * orchestrator-driven pentest path honors the user's config / env override.
+   * Defaults to `true` when undefined.
+   */
+  surfaceIntegrationEnabled?: boolean;
+
+  /**
    * Project-level threat model content (e.g. from `.pensar/threat_model.md`).
    * Passed to spawned per-endpoint threat-model sub-agents as additional
    * context so they can incorporate deployment details, compliance

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -265,6 +265,12 @@ export type OffensiveSecurityAgentInput<TResult = void> = {
   enableThinking?: boolean;
 
   /**
+   * Whitebox attack surface flag forwarded into the {@link ToolContext} for
+   * orchestrator-driven pentests. Defaults to `true` when undefined.
+   */
+  surfaceIntegrationEnabled?: boolean;
+
+  /**
    * Project-level threat model content (e.g. from `.pensar/threat_model.md`).
    * Forwarded into the {@link ToolContext} so tools that spawn dedicated
    * per-endpoint threat-model sub-agents can include this as additional
@@ -338,6 +344,12 @@ export interface SpecializedAgentInput {
 
   /** Enable extended thinking (reasoning) for supported models. */
   enableThinking?: boolean;
+
+  /**
+   * Whitebox attack surface flag forwarded into the {@link ToolContext} for
+   * orchestrator-driven pentests. Defaults to `true` when undefined.
+   */
+  surfaceIntegrationEnabled?: boolean;
 
   /**
    * Project-level threat model content. Forwarded into {@link ToolContext}

--- a/src/core/agents/specialized/attackSurface/blackboxAgent.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxAgent.ts
@@ -26,7 +26,14 @@ export type AttackSurfaceAgentInput = SpecializedAgentInput &
         /** Working directory for source-code based analysis */
         cwd: string;
       }
-  );
+  ) & {
+    /**
+     * Whitebox-only: when false, the workflow skips the `@pensar/surface`
+     * deterministic-enumeration path and uses the legacy pages+apiEndpoints
+     * discovery agents. Defaults to `true`. Has no effect on blackbox runs.
+     */
+    surfaceIntegrationEnabled?: boolean;
+  };
 
 /** The typed result returned by `AttackSurfaceAgent.consume()`. */
 export interface AttackSurfaceResult {

--- a/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.test.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { buildEnrichmentObjective } from "./enrichmentAgent";
+import { buildEndpointDocumentationObjective } from "./endpointDocumentationAgent";
 import type { AppInfo } from "./types";
 import type { ConsolidatedEndpoint } from "../../../integrations/surface/types";
 
-describe("buildEnrichmentObjective (per-endpoint)", () => {
+describe("buildEndpointDocumentationObjective (per-endpoint)", () => {
   const app: AppInfo = {
     name: "myapp",
     framework: "Next.js 14 App Router",
-    description: "Synthetic app for enrichment-prompt unit tests.",
+    description: "Synthetic app for endpoint-documentation prompt unit tests.",
     location: "apps/myapp",
     type: "full_stack",
   };
@@ -40,7 +40,7 @@ describe("buildEnrichmentObjective (per-endpoint)", () => {
   };
 
   describe("page endpoint", () => {
-    const objective = buildEnrichmentObjective({
+    const objective = buildEndpointDocumentationObjective({
       app,
       codebasePath: "/repo",
       endpoint: pageEndpoint,
@@ -48,7 +48,7 @@ describe("buildEnrichmentObjective (per-endpoint)", () => {
     });
 
     it("opens with the per-endpoint header (single endpoint scope)", () => {
-      expect(objective).toContain("# Enrich Endpoint: PAGE /dashboard");
+      expect(objective).toContain("# Document Endpoint: PAGE /dashboard");
     });
 
     it("renders codebase context (root, app name, app location, framework)", () => {
@@ -113,7 +113,7 @@ describe("buildEnrichmentObjective (per-endpoint)", () => {
   });
 
   describe("api endpoint with multiple methods", () => {
-    const objective = buildEnrichmentObjective({
+    const objective = buildEndpointDocumentationObjective({
       app,
       codebasePath: "/repo",
       endpoint: apiEndpoint,
@@ -121,7 +121,7 @@ describe("buildEnrichmentObjective (per-endpoint)", () => {
     });
 
     it("opens with comma-joined methods", () => {
-      expect(objective).toContain("# Enrich Endpoint: GET,POST /api/users");
+      expect(objective).toContain("# Document Endpoint: GET,POST /api/users");
     });
 
     it("renders endpointType as api-endpoint", () => {
@@ -139,7 +139,7 @@ describe("buildEnrichmentObjective (per-endpoint)", () => {
   });
 
   it("falls back to 'unknown' framework label when none detected", () => {
-    const obj = buildEnrichmentObjective({
+    const obj = buildEndpointDocumentationObjective({
       app,
       codebasePath: "/repo",
       endpoint: apiEndpoint,

--- a/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.ts
@@ -5,7 +5,7 @@ import {
   type AppInfo,
   type DiscoverySummary,
 } from "./types";
-import { WHITEBOX_ENRICHMENT_SYSTEM_PROMPT } from "./prompts";
+import { WHITEBOX_ENDPOINT_DOCUMENTATION_SYSTEM_PROMPT } from "./prompts";
 import type {
   ConsolidatedEndpoint,
   FrameworkId,
@@ -22,12 +22,12 @@ import { runWithBoundedConcurrency } from "../../../utils/concurrency";
 // ---------------------------------------------------------------------------
 
 /**
- * Per-app fan-out concurrency. Each app's enrichment runs N endpoint agents
- * in parallel up to this cap. Workflow-level concurrency (across apps) is
- * separately bounded by `DEFAULT_CONCURRENCY` in
+ * Per-app fan-out concurrency. Each app's documentation runs N endpoint
+ * agents in parallel up to this cap. Workflow-level concurrency (across
+ * apps) is separately bounded by `DEFAULT_CONCURRENCY` in
  * `runWhiteboxAttackSurfaceWorkflow` Phase 2.
  */
-const ENRICHMENT_CONCURRENCY = 10;
+const ENDPOINT_DOCUMENTATION_CONCURRENCY = 10;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -46,13 +46,13 @@ interface SharedAgentOptions {
   projectThreatModel?: string;
 }
 
-export interface EndpointEnrichmentInput extends SharedAgentOptions {
+export interface EndpointDocumentationInput extends SharedAgentOptions {
   app: AppInfo;
   endpoint: ConsolidatedEndpoint;
   frameworks: FrameworkId[];
 }
 
-export interface AppEnrichmentInput extends SharedAgentOptions {
+export interface AppEndpointDocumentationInput extends SharedAgentOptions {
   app: AppInfo;
   endpoints: ConsolidatedEndpoint[];
   frameworks: FrameworkId[];
@@ -73,7 +73,7 @@ function getDocumentMethod(endpoint: ConsolidatedEndpoint): string[] {
   return endpoint.kind === "page" ? ["PAGE"] : endpoint.method;
 }
 
-export function buildEnrichmentObjective(opts: {
+export function buildEndpointDocumentationObjective(opts: {
   app: AppInfo;
   codebasePath: string;
   endpoint: ConsolidatedEndpoint;
@@ -99,7 +99,7 @@ export function buildEnrichmentObjective(opts: {
   const auth = endpoint.auth.length > 0 ? endpoint.auth.join(", ") : "none";
   const authPrefill = endpoint.auth.length > 0;
 
-  return `# Enrich Endpoint: ${methodDisplay} ${endpoint.path}
+  return `# Document Endpoint: ${methodDisplay} ${endpoint.path}
 
 ## Codebase
 - **Repository root:** ${codebasePath}
@@ -144,8 +144,8 @@ This agent is responsible for **exactly one** endpoint. Do not document other en
 // Per-endpoint agent runner
 // ---------------------------------------------------------------------------
 
-export async function runEnrichmentAgent(
-  opts: EndpointEnrichmentInput,
+export async function runEndpointDocumentationAgent(
+  opts: EndpointDocumentationInput,
 ): Promise<void> {
   const {
     codebasePath,
@@ -163,7 +163,7 @@ export async function runEnrichmentAgent(
     projectThreatModel,
   } = opts;
 
-  const subagentId = `enrich-${slug(app.name)}-${slug(endpoint.path)}`;
+  const subagentId = `endpoint-doc-${slug(app.name)}-${slug(endpoint.path)}`;
   const displayMethod = getDocumentMethod(endpoint);
   const displayName = `${app.name}: ${displayMethod.join(",")} ${endpoint.path}`;
 
@@ -172,13 +172,13 @@ export async function runEnrichmentAgent(
     name: displayName,
     input: {
       app: app.name,
-      type: "enrichment",
+      type: "endpointDocumentation",
       method: displayMethod,
       path: endpoint.path,
     },
   });
 
-  const objective = buildEnrichmentObjective({
+  const objective = buildEndpointDocumentationObjective({
     app,
     codebasePath,
     endpoint,
@@ -188,7 +188,7 @@ export async function runEnrichmentAgent(
   const agent = new CodeAgent<DiscoverySummary>({
     codebasePath,
     objective,
-    system: WHITEBOX_ENRICHMENT_SYSTEM_PROMPT,
+    system: WHITEBOX_ENDPOINT_DOCUMENTATION_SYSTEM_PROMPT,
     model,
     session,
     authConfig,
@@ -199,7 +199,7 @@ export async function runEnrichmentAgent(
     onStepFinish: (event) => onStepFinish?.(event),
     onCacheMetrics,
     responseSchema: DiscoverySummarySchema,
-    // Hard-exclude tools an enrichment agent must never use:
+    // Hard-exclude tools an endpoint documentation agent must never use:
     // - document_app: Phase 1 owns app discovery.
     // - list_files / grep: route enumeration is surface's job; without this,
     //   soft prompt guidance gets overridden by the model's discovery instinct
@@ -216,7 +216,7 @@ export async function runEnrichmentAgent(
     });
   } catch (error) {
     console.error(
-      `[enrichment-agent] "${subagentId}" FAILED:`,
+      `[endpoint-documentation-agent] "${subagentId}" FAILED:`,
       error instanceof Error ? error.message : String(error),
     );
     eventBus?.emit("subagent-complete", {
@@ -230,17 +230,17 @@ export async function runEnrichmentAgent(
 // App-level fan-out
 // ---------------------------------------------------------------------------
 
-export async function runAppEnrichment(
-  opts: AppEnrichmentInput,
+export async function runAppEndpointDocumentation(
+  opts: AppEndpointDocumentationInput,
 ): Promise<void> {
   const { endpoints, ...shared } = opts;
   if (endpoints.length === 0) return;
 
   await runWithBoundedConcurrency(
     endpoints,
-    ENRICHMENT_CONCURRENCY,
+    ENDPOINT_DOCUMENTATION_CONCURRENCY,
     async (endpoint) => {
-      await runEnrichmentAgent({ ...shared, endpoint });
+      await runEndpointDocumentationAgent({ ...shared, endpoint });
     },
   );
 }

--- a/src/core/agents/specialized/whiteboxAttackSurface/prompts.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/prompts.ts
@@ -89,21 +89,21 @@ ${RESPONSE_TOOL_DOC}
 `;
 
 /**
- * Enrichment-only system prompt for the per-app enrichment agent that runs
- * on the surface-driven path of Phase 2.
+ * System prompt for the per-app endpoint-documentation agent that runs on
+ * the surface-driven path of Phase 2.
  *
  * The agent receives a complete, deterministic list of endpoints (extracted
- * by `@pensar/surface`) and its only job is to enrich each one with a
+ * by `@pensar/surface`) and its only job is to document each one with a
  * description, refined auth assessment, and risk level — then call
  * `document_endpoint` once per entry. It must NOT re-enumerate routes,
  * grep for new ones, or list directories looking for handlers.
  *
  * The shared discovery prompt has heavy "orient first / list files /
- * search-then-read / be thorough" framing that an enrichment agent reads as
+ * search-then-read / be thorough" framing that this agent reads as
  * discovery instructions, causing it to ignore the deterministic list and
  * start over from scratch. This variant strips that framing.
  */
-export const WHITEBOX_ENRICHMENT_SYSTEM_PROMPT = `You are an expert security analyst. Your job is to enrich a complete, deterministic list of endpoints that has already been extracted from the source code by a separate phase. You will be given the full list in your objective; do not re-enumerate routes.
+export const WHITEBOX_ENDPOINT_DOCUMENTATION_SYSTEM_PROMPT = `You are an expert security analyst. Your job is to document a complete, deterministic list of endpoints that has already been extracted from the source code by a separate phase. You will be given the full list in your objective; do not re-enumerate routes.
 
 # Tool Usage Guide
 
@@ -117,12 +117,12 @@ Generally NOT needed. Your endpoint list already includes the file path for ever
 Generally NOT needed. The endpoint list is final and complete. Use this only when an endpoint's auth signal is ambiguous and you must locate a middleware definition referenced from the handler. **Do NOT use \`grep\` to look for additional routes** — route discovery is a previous phase's job and your list will not be changed.
 
 ## execute_command
-Run shell commands when needed (rare for enrichment).
+Run shell commands when needed (rare for endpoint documentation).
 
 ## document_endpoint
 **This is your primary output tool.** Call it exactly once per endpoint in your input list. Each call persists a JSON record to the session's assets directory.
 
-**CRITICAL — endpoint enrichment rules:**
+**CRITICAL — endpoint documentation rules:**
 - **One \`document_endpoint\` call per entry in your input list.** The number of calls you make must equal the number of endpoints provided. Do not skip entries. Do not add new entries.
 - **Use the structural fields from your input as-is:** \`routePath\`, \`method\`, \`file\`, \`line\`, \`handler\`. Don't "verify" them by re-discovering — they are deterministic.
 - **Always set \`appName\`** to the application name provided in your objective.
@@ -139,7 +139,7 @@ When you have called \`document_endpoint\` for every endpoint in your input list
 1. **Read your input list first.** The objective contains every endpoint with its file, line, handler, method, and prefilled auth signals already located. This is the entire scope of your work.
 2. **Per endpoint, read just enough handler code** at the indicated \`file:line\` to write a meaningful description and assess risk. Don't read whole files — use line ranges.
 3. **Document immediately.** Call \`document_endpoint\` directly per endpoint, the moment you have enough context. Do not collect entries in a buffer to "process later."
-4. **Stay scoped.** Your job is enrichment, not discovery. Do not call \`list_files\` or \`grep\` to look for additional routes — the list is final.
+4. **Stay scoped.** Your job is documentation, not discovery. Do not call \`list_files\` or \`grep\` to look for additional routes — the list is final.
 `;
 
 /**

--- a/src/core/api/attackSurface.ts
+++ b/src/core/api/attackSurface.ts
@@ -73,6 +73,7 @@ async function runWhiteboxAttackSurface(
     abortSignal: input.abortSignal,
     attackSurfaceRegistry: input.attackSurfaceRegistry,
     eventBus: input.eventBus,
+    surfaceIntegrationEnabled: input.surfaceIntegrationEnabled,
   });
 
   console.log(

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -33,6 +33,10 @@ export interface Config {
   selectedModelId?: string | null;
   // Extended thinking / reasoning
   reasoningEnabled?: boolean;
+  // Whitebox attack surface: when false, skip the @pensar/surface deterministic
+  // enumeration path and use the legacy pages+apiEndpoints discovery agents.
+  // Defaults to true when unset.
+  surfaceIntegrationEnabled?: boolean;
   // WorkOS CLI auth (replaces pensarAPIKey for new auth flow)
   accessToken?: string | null;
   refreshToken?: string | null;
@@ -67,6 +71,18 @@ export async function init() {
 }
 
 /**
+ * Parse a truthy/falsy env value. Returns undefined when unset so callers can
+ * fall through to their own default. "0", "false", "no", "off" → false;
+ * anything else non-empty → true.
+ */
+function parseBoolEnv(value: string | undefined): boolean | undefined {
+  if (value === undefined || value === "") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return true;
+}
+
+/**
  * Apply environment variable fallbacks for API keys.
  * Used by both `get()` and `init()` so fresh installs pick up env vars.
  */
@@ -75,6 +91,9 @@ function applyEnvFallbacks(parsedConfig: Partial<Config>): Config {
   return {
     ...parsedConfig,
     responsibleUseAccepted: parsedConfig.responsibleUseAccepted ?? false,
+    surfaceIntegrationEnabled:
+      parsedConfig.surfaceIntegrationEnabled ??
+      parseBoolEnv(process.env.PENSAR_SURFACE_INTEGRATION),
     version,
     openAiAPIKey: parsedConfig.openAiAPIKey ?? process.env.OPENAI_API_KEY,
     anthropicAPIKey:

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -90,6 +90,14 @@ export interface PentestWorkflowInput {
   /** Optional raw threat model content — wrapped with standard preamble and
    *  injected into discovery agent system prompts alongside `prompt` */
   threatModel?: string;
+
+  /**
+   * Whitebox-only: when false, the attack surface workflow skips the
+   * `@pensar/surface` deterministic-enumeration path and uses the legacy
+   * pages+apiEndpoints discovery agents for every service app. Defaults
+   * to `true`. Has no effect on blackbox runs.
+   */
+  surfaceIntegrationEnabled?: boolean;
 }
 
 export interface PentestWorkflowResult {
@@ -355,6 +363,7 @@ export async function runPentestWorkflow(
     enableThinking,
     prompt,
     threatModel,
+    surfaceIntegrationEnabled,
   } = input;
 
   // Merge prompt/threatModel into session.config.prompt for discovery agents
@@ -440,6 +449,7 @@ export async function runPentestWorkflow(
           eventBus,
           onStepFinish: wrappedOnStepFinish,
           onCacheMetrics,
+          surfaceIntegrationEnabled,
         });
       } else {
         swarmTargets = await runBlackboxPhase({
@@ -597,6 +607,7 @@ async function runWhiteboxPhase(opts: {
   eventBus?: AgentEventBus;
   onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
   onCacheMetrics?: (metrics: CacheMetrics) => void;
+  surfaceIntegrationEnabled?: boolean;
 }): Promise<SwarmTarget[]> {
   const workflowInput: WhiteboxAttackSurfaceWorkflowInput = {
     codebasePath: opts.codebasePath,
@@ -607,6 +618,7 @@ async function runWhiteboxPhase(opts: {
     eventBus: opts.eventBus,
     onStepFinish: opts.onStepFinish,
     onCacheMetrics: opts.onCacheMetrics,
+    surfaceIntegrationEnabled: opts.surfaceIntegrationEnabled,
   };
 
   const result = await runWhiteboxAttackSurfaceWorkflow(workflowInput);

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -34,7 +34,7 @@ import { execFileSync } from "child_process";
 import { createHash } from "crypto";
 import type { StreamTextOnStepFinishCallback, ToolSet } from "ai";
 import { mapAppWithSurface } from "../integrations/surface";
-import { runAppEnrichment } from "../agents/specialized/whiteboxAttackSurface/enrichmentAgent";
+import { runAppEndpointDocumentation } from "../agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -93,6 +93,12 @@ export interface WhiteboxAttackSurfaceWorkflowInput {
   projectThreatModel?: string;
   /** Deployment environment names (e.g. ["production", "staging"]) from project settings. */
   environments?: string[];
+  /**
+   * When false, Phase 2 skips the deterministic `@pensar/surface` path and
+   * always runs the legacy pages + apiEndpoints discovery agent pair for
+   * service apps. Defaults to `true`.
+   */
+  surfaceIntegrationEnabled?: boolean;
 }
 
 export interface IncrementalWhiteboxInput extends WhiteboxAttackSurfaceWorkflowInput {
@@ -110,12 +116,14 @@ export interface IncrementalWhiteboxInput extends WhiteboxAttackSurfaceWorkflowI
  *
  * Phase 1: Spawn a single CodeAgent to identify all apps in the repo.
  * Phase 1.5: Create app folders with app.json metadata.
- * Phase 2: Per-app dispatch. Service apps run `mapAppWithSurface`; on
- *           `surface` mode a per-endpoint enrichment CodeAgent enriches the
- *           deterministic list, on `fallback` the legacy pages+apiEndpoints
- *           agent pair runs. Cloud resources always use the specialized
- *           cloud-resource agent. Threat models and risk scores are
- *           generated inline by document_endpoint.
+ * Phase 2: Per-app dispatch. When `surfaceIntegrationEnabled` (default), service
+ *           apps run `mapAppWithSurface`; on `surface` mode a per-endpoint
+ *           endpoint-documentation CodeAgent documents the deterministic list,
+ *           on `fallback` the legacy pages+apiEndpoints agent pair runs. When
+ *           `surfaceIntegrationEnabled` is false, every service app uses the
+ *           legacy pair directly. Cloud resources always use the specialized
+ *           cloud-resource agent. Threat models and risk scores are generated
+ *           inline by document_endpoint.
  * Phase 3: Read the assets directory to build endpoint data.
  * Phase 4: Final assembly.
  */
@@ -135,6 +143,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     domains,
     projectThreatModel,
     environments,
+    surfaceIntegrationEnabled = true,
   } = input;
 
   // =========================================================================
@@ -163,7 +172,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     responseSchema: AppsDiscoveryResultSchema,
     projectThreatModel,
     // Tool-level guard symmetric to Phase 2's `excludeTools: ["document_app"]`
-    // (in spawnDiscoveryAgent + enrichmentAgent).
+    // (in spawnDiscoveryAgent + endpointDocumentationAgent).
     excludeTools: ["document_endpoint"],
   });
 
@@ -231,13 +240,20 @@ export async function runWhiteboxAttackSurfaceWorkflow(
   }
 
   // =========================================================================
-  // Phase 2: Per-app dispatch — surface-driven enrichment vs. fallback agents.
-  //          Service apps try `mapAppWithSurface`; on `surface` mode run a
-  //          per-endpoint enrichment CodeAgent against the deterministic list,
+  // Phase 2: Per-app dispatch — surface-driven documentation vs. fallback.
+  //          When `surfaceIntegrationEnabled` is true, service apps try
+  //          `mapAppWithSurface`; on `surface` mode run a per-endpoint
+  //          endpoint-documentation CodeAgent against the deterministic list,
   //          on `fallback` run the legacy pages+apiEndpoints CodeAgent pair.
+  //          When `surfaceIntegrationEnabled` is false, every service app
+  //          uses the legacy pair directly — pre-PR behavior.
   //          Cloud resources always take the specialized objective — surface
   //          is HTTP-route-focused and doesn't enumerate cloud assets.
   // =========================================================================
+
+  console.log(
+    `[whitebox-workflow] Phase 2: surfaceIntegrationEnabled=${surfaceIntegrationEnabled}`,
+  );
 
   const NON_SERVICE_TYPES = ["cloud_resource", "storage", "database"];
   const serviceApps = appsResult.apps.filter(
@@ -347,6 +363,14 @@ export async function runWhiteboxAttackSurfaceWorkflow(
         if (NON_SERVICE_TYPES.includes(app.type)) {
           // Cloud resources: surface doesn't enumerate these — always fallback.
           await spawnCloudResourceAgent(app);
+        } else if (!surfaceIntegrationEnabled) {
+          console.log(
+            `[whitebox] ${app.name}: legacy (surfaceIntegrationEnabled=false)`,
+          );
+          await Promise.all([
+            spawnPagesAgent(app),
+            spawnApiEndpointsAgent(app),
+          ]);
         } else {
           const surfaceResult = mapAppWithSurface(
             join(codebasePath, app.location),
@@ -357,7 +381,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
               `[whitebox] ${app.name}: surface-driven (${surfaceResult.endpoints.length} endpoints, frameworks=${surfaceResult.frameworks.join(",")})`,
             );
 
-            await runAppEnrichment({
+            await runAppEndpointDocumentation({
               codebasePath,
               app,
               endpoints: surfaceResult.endpoints,

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -1134,6 +1134,7 @@ export default function OperatorDashboard({
         commandCancelHandle: cancelHandleRef.current,
         skillsRegistry,
         enableThinking: reasoningEnabled && modelSupportsThinking(model.id),
+        surfaceIntegrationEnabled: config.data?.surfaceIntegrationEnabled,
         onStepFinish,
         onCacheMetrics: (metrics: CacheMetrics) => {
           addCacheUsage(


### PR DESCRIPTION
Stacked on #664. Two related follow-ups before merge:

## 1. Gate surface integration behind a config flag (default: **enabled**)

Adds `surfaceIntegrationEnabled` to `~/.pensar/config.json`, with a `PENSAR_SURFACE_INTEGRATION` env-var fallback (`0` / `false` / `no` / `off` → disabled; anything else → enabled).

When `false`, Phase 2 of `runWhiteboxAttackSurfaceWorkflow` skips `mapAppWithSurface` entirely and runs the legacy `pages` + `apiEndpoints` discovery agent pair for every service app — i.e. byte-for-byte pre-PR behavior. Cloud resources still take the existing `cloudResourceEndpoints` agent in either mode.

Plumbed through:
- `PentestWorkflowInput.surfaceIntegrationEnabled`
- `AttackSurfaceAgentInput.surfaceIntegrationEnabled` (SDK entry point)
- `OffensiveSecurityAgentInput` → `ToolContext.surfaceIntegrationEnabled` → `run_pentest_workflow` tool (orchestrator path)
- `src/cli.ts` reads `pensarConfig.surfaceIntegrationEnabled`
- TUI operator dashboard reads `config.data?.surfaceIntegrationEnabled`

Defaults to `true` everywhere — undefined means "use surface integration".

## 2. Rename "enrichment agent" → "Endpoint Documentation Agent"

The old name was opaque to end users (especially in the Pensar Console UI). The new name matches the underlying tool (`document_endpoint`) and what the agent actually does — it is hard-blocked from `list_files` / `grep` / `document_app`, so "enrichment" was misleading.

User-visible changes:
- `subagentId` prefix: `enrich-*` → `endpoint-doc-*`
- `subagent-spawn` event `input.type: "enrichment"` → `input.type: "endpointDocumentation"` — **Pensar Console label-rendering needs a corresponding update wherever it keys off this string**
- Log prefix `[enrichment-agent]` → `[endpoint-documentation-agent]`
- System prompt rewritten to self-identify as "endpoint documentation agent"

Files renamed via `git mv` to preserve history:
- `enrichmentAgent.ts` → `endpointDocumentationAgent.ts`
- `enrichmentAgent.test.ts` → `endpointDocumentationAgent.test.ts`

Function/type renames: `runEnrichmentAgent` → `runEndpointDocumentationAgent`, `runAppEnrichment` → `runAppEndpointDocumentation`, `buildEnrichmentObjective` → `buildEndpointDocumentationObjective`, `WHITEBOX_ENRICHMENT_SYSTEM_PROMPT` → `WHITEBOX_ENDPOINT_DOCUMENTATION_SYSTEM_PROMPT`.

## Test plan
- [x] `bun run test src/core/agents/specialized/whiteboxAttackSurface/ src/core/integrations/surface/` — 35/35 pass
- [ ] Manual: `PENSAR_SURFACE_INTEGRATION=0 bun run pensar` against a fixture; confirm logs show `[whitebox] <app>: legacy (surfaceIntegrationEnabled=false)` for every service app and no surface scan logs appear
- [ ] Manual: default run; confirm subagent IDs in logs use `endpoint-doc-*` prefix and `subagent-spawn` events emit `type: "endpointDocumentation"`
- [ ] Coordinate Pensar Console label change for `input.type === "endpointDocumentation"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the whitebox attack-surface execution path via a new config/env flag and updates subagent identifiers/event payloads, which may impact workflow behavior and any downstream consumers (e.g. console UI) relying on the previous strings.
> 
> **Overview**
> Adds a `surfaceIntegrationEnabled` toggle (config + `PENSAR_SURFACE_INTEGRATION` env fallback) and plumbs it through CLI/TUI, agent/tool contexts, and `runPentestWorkflow` so whitebox runs can explicitly **skip the `@pensar/surface` deterministic enumeration** and fall back to the legacy pages+API discovery.
> 
> Renames the Phase 2 per-endpoint “enrichment” subagent to an **endpoint documentation agent** (new prompt constant, function/type names, subagentId prefix, and `subagent-spawn` event `input.type`), and updates the whitebox workflow to call the renamed runner and to log which path (surface vs legacy) is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e01e57bcf088dd56283b3a87e981e4363959c40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->