### PR TITLE
fix(ai): close 'prompt is too long' bug class structurally

### DIFF
--- a/src/core/ai/ai.contract.test.ts
+++ b/src/core/ai/ai.contract.test.ts
@@ -1,0 +1,43 @@
+// Structural contract for the context-recovery state machine. No network.
+import { describe, it, expect } from "vitest";
+import { streamResponse, ContextLengthExhaustedError } from "./ai";
+
+describe("streamResponse recovery-depth contract", () => {
+  it("throws ContextLengthExhaustedError when _restartDepth exceeds the bound", () => {
+    expect(() =>
+      streamResponse({
+        model: "claude-sonnet-4-5",
+        prompt: "anything",
+        _restartDepth: 10,
+      }),
+    ).toThrow(ContextLengthExhaustedError);
+  });
+
+  it("ContextLengthExhaustedError carries the depth that triggered it", () => {
+    try {
+      streamResponse({
+        model: "claude-sonnet-4-5",
+        prompt: "anything",
+        _restartDepth: 7,
+      });
+      throw new Error("expected ContextLengthExhaustedError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContextLengthExhaustedError);
+      expect((err as ContextLengthExhaustedError).restartDepth).toBe(7);
+      expect((err as ContextLengthExhaustedError).name).toBe(
+        "ContextLengthExhaustedError",
+      );
+    }
+  });
+
+  it("does NOT throw the depth guard on the initial call", () => {
+    // Other errors are fine (e.g. missing API key) — the guard mustn't fire.
+    let thrown: unknown;
+    try {
+      streamResponse({ model: "claude-sonnet-4-5", prompt: "anything" });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).not.toBeInstanceOf(ContextLengthExhaustedError);
+  });
+});

--- a/src/core/ai/ai.outer-catch-recovery.test.ts
+++ b/src/core/ai/ai.outer-catch-recovery.test.ts
@@ -1,0 +1,81 @@
+// Pins invariant I4 ("error containment") on the outer-catch path of
+// `streamResponse`. When `streamText` throws synchronously with a
+// context-length error, the catch block falls back to
+// `createSummarizationStream`. Before this wrapping, an overflow inside
+// that summarization stream — or a non-`ContextLengthExhaustedError`
+// thrown by the resumed `streamResponse` — escaped uncaught and leaked
+// the raw `AI_APICallError prompt is too long` to the consumer.
+//
+// This test exists to fail loudly if a future refactor un-wraps that
+// path again.
+import { vi, describe, it, expect } from "vitest";
+import type { ModelMessage, StreamTextResult, ToolSet } from "ai";
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    streamText: vi.fn(() => {
+      // Sync-throw a context-length error from streamText. In the AI SDK
+      // this is rare but possible (e.g. provider validation rejects the
+      // payload before any I/O). The outer try/catch in `streamResponse`
+      // exists for exactly this case.
+      throw new Error("prompt is too long: 999999 tokens > 200000 maximum");
+    }),
+  };
+});
+
+vi.mock("./utils", async () => {
+  const actual = await vi.importActual<typeof import("./utils")>("./utils");
+  return {
+    ...actual,
+    createSummarizationStream: vi.fn(
+      () =>
+        ({
+          // eslint-disable-next-line require-yield
+          fullStream: (async function* () {
+            throw new Error(
+              "prompt is too long: 999999 tokens > 200000 maximum",
+            );
+          })(),
+          response: Promise.resolve({ messages: [] }),
+        }) as unknown as StreamTextResult<ToolSet, never>,
+    ),
+  };
+});
+
+const { streamResponse, ContextLengthExhaustedError } = await import("./ai");
+
+describe("outer-catch summarization is wrapped (I4)", () => {
+  it("sync streamText ctx error → recovery cascade → typed terminal error", async () => {
+    // A small message set that fits the proactive budget so we DON'T take
+    // the proactive escalation branch — we want the outer try/catch to fire.
+    const messages: ModelMessage[] = [
+      { role: "user" as const, content: "small payload" },
+    ];
+
+    const stream = streamResponse({
+      model: "claude-sonnet-4-5",
+      prompt: "anything",
+      messages,
+      silent: true,
+      // = MAX_RESTART_DEPTH; the very next recursive recovery step will
+      // bump past the bound and synthesize the typed terminal error.
+      _restartDepth: 3,
+    });
+
+    let observed: unknown;
+    try {
+      for await (const chunk of stream.fullStream) {
+        void chunk;
+      }
+    } catch (err) {
+      observed = err;
+    }
+
+    // The decisive assertion: the typed terminal error escapes, NOT a raw
+    // "prompt is too long" SDK error. If the outer catch were re-unwrapped,
+    // this would surface the underlying ctx error instead.
+    expect(observed).toBeInstanceOf(ContextLengthExhaustedError);
+  });
+});

--- a/src/core/ai/ai.proactive-recovery.test.ts
+++ b/src/core/ai/ai.proactive-recovery.test.ts
@@ -1,0 +1,68 @@
+// Pins invariant I4 ("error containment") on the proactive-summarization
+// escalation path. Before wrapping the proactive return with
+// `wrapStreamWithErrorHandler`, an overflow inside the summarization stream
+// itself escaped uncaught — the same `AI_APICallError prompt is too long`
+// shape that motivated this work in the first place. This test exists to
+// fail loudly if a future refactor un-wraps that path.
+import { vi, describe, it, expect } from "vitest";
+import type { ModelMessage, StreamTextResult, ToolSet } from "ai";
+
+vi.mock("./utils", async () => {
+  const actual = await vi.importActual<typeof import("./utils")>("./utils");
+  return {
+    ...actual,
+    // Both the proactive escalation and the reactive Layer 3 fall through
+    // to this stream — both should be caught + recovered by the wrapper.
+    createSummarizationStream: vi.fn(
+      () =>
+        ({
+          // eslint-disable-next-line require-yield
+          fullStream: (async function* () {
+            throw new Error(
+              "prompt is too long: 999999 tokens > 200000 maximum",
+            );
+          })(),
+          response: Promise.resolve({ messages: [] }),
+        }) as unknown as StreamTextResult<ToolSet, never>,
+    ),
+  };
+});
+
+// Imported AFTER vi.mock so the streamResponse closure picks up the stub.
+const { streamResponse, ContextLengthExhaustedError } = await import("./ai");
+
+describe("proactive summarization is wrapped (I4)", () => {
+  it("recovery exhausts to ContextLengthExhaustedError, not a raw provider error", async () => {
+    // Force `proactiveFitFailed=true`: many large user-text messages, no
+    // sessionPath. Layer 1 needs sessionPath to run; Layer 2 only touches
+    // tool results — neither reduces user text, so fitsBudget stays false.
+    const messages: ModelMessage[] = Array.from({ length: 100 }, () => ({
+      role: "user" as const,
+      content: "x".repeat(50_000),
+    }));
+
+    const stream = streamResponse({
+      model: "claude-sonnet-4-5",
+      prompt: "anything",
+      messages,
+      silent: true,
+      // = MAX_RESTART_DEPTH; any recursive recovery cycle will trip the
+      // depth guard at the top of `streamResponse`.
+      _restartDepth: 3,
+    });
+
+    let observed: unknown;
+    try {
+      for await (const chunk of stream.fullStream) {
+        void chunk;
+      }
+    } catch (err) {
+      observed = err;
+    }
+
+    // The decisive assertion: the typed terminal error escapes, NOT a raw
+    // "prompt is too long" SDK error. If the proactive path were unwrapped
+    // again, this would surface the underlying ctx error instead.
+    expect(observed).toBeInstanceOf(ContextLengthExhaustedError);
+  });
+});

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -923,14 +923,26 @@ export function streamResponse(
       // through the same recovery cascade as the proactive and reactive
       // paths — invariant I4: every context-recovery failure must be caught
       // at the `streamResponse` boundary, never escape raw to the consumer.
+      //
+      // Like the proactive escalation, this fall-through to summarization
+      // IS a depth slot. Bump `_restartDepth` before passing so the
+      // wrapper's reactive recovery (when the summarization stream itself
+      // errors) starts `postReactiveDepth` from the bumped value, not from
+      // the unmodified outer `opts._restartDepth` — otherwise the cascade
+      // gets one extra cycle on top of the slot just spent. Same bug class
+      // as the proactive-side fix in 75cb1d76.
+      const escalatedOpts: StreamResponseOpts = {
+        ...opts,
+        _restartDepth: (opts._restartDepth ?? 0) + 1,
+      };
       return wrapStreamWithErrorHandler(
         createSummarizationStream(
           messagesContainer.current,
-          opts,
+          escalatedOpts,
           providerModel,
         ),
         messagesContainer,
-        opts,
+        escalatedOpts,
         providerModel,
         silent,
       );

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -647,10 +647,20 @@ export function streamResponse(
         `Proactive context fit returned fitsBudget=false on ${fittedMessages.length} messages — escalating to summarization before send`,
       );
     }
+    // Escalation IS a depth slot — `summarizeConversation` will spawn
+    // `streamResponse({ ..., _restartDepth: depth + 1 })` for the resumed
+    // call. Pass the bumped value here so any reactive recovery inside
+    // the wrapper (when the summarization stream itself errors) starts
+    // from the correct depth, instead of granting one extra cycle by
+    // resetting `postReactiveDepth` to the outer `opts._restartDepth`.
+    const escalatedOpts: StreamResponseOpts = {
+      ...opts,
+      _restartDepth: (opts._restartDepth ?? 0) + 1,
+    };
     return wrapStreamWithErrorHandler(
-      createSummarizationStream(fittedMessages, opts, providerModel),
+      createSummarizationStream(fittedMessages, escalatedOpts, providerModel),
       messagesContainer,
-      opts,
+      escalatedOpts,
       providerModel,
       silent,
     );

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -416,8 +416,24 @@ function wrapStreamWithErrorHandler(
                     }
                     return;
                   } catch (retryError) {
-                    // Auth / model errors must propagate.
-                    if (!checkIfContextLengthError(retryError)) {
+                    // Always propagate the typed terminal error and
+                    // cancellations — these MUST escape the cascade
+                    // immediately. Currently `ContextLengthExhaustedError`
+                    // propagates only by accident (its message
+                    // "Context-length recovery exhausted…" uses a hyphen
+                    // that doesn't match any `checkIfContextLengthError`
+                    // pattern); the explicit `instanceof` and abort
+                    // checks are defensive against a future message-text
+                    // tweak that would otherwise silently swallow
+                    // recovery exhaustion. Mirrors the Layer 3
+                    // `summarizeError` catch below for symmetry.
+                    if (
+                      retryError instanceof ContextLengthExhaustedError ||
+                      (retryError instanceof Error &&
+                        retryError.name === "AbortError") ||
+                      opts.abortSignal?.aborted ||
+                      !checkIfContextLengthError(retryError)
+                    ) {
                       throw retryError;
                     }
                     // Account for the depth slot the failed retry just

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -380,9 +380,18 @@ function wrapStreamWithErrorHandler(
                     );
                   }
                   try {
+                    // Bump `_restartDepth` so a tokenizer-drift loop where
+                    // every reactive retry trips the same provider rejection
+                    // (fitsBudget=true by our estimator, still rejected by
+                    // the provider) eventually exhausts the depth bound at
+                    // the top of `streamResponse` instead of looping
+                    // forever. Without this, only Layer-3 escalation
+                    // increments depth and a drift-driven loop can burn
+                    // arbitrarily many failed provider calls.
                     const retried = streamResponse({
                       ...opts,
                       messages: fitted.messages,
+                      _restartDepth: (opts._restartDepth ?? 0) + 1,
                     });
                     const wrappedRetry = wrapStreamWithErrorHandler(
                       retried,

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -23,7 +23,8 @@ import {
   type AIAuthConfig,
 } from "./utils";
 import { withCachedSystemPrompt, withCachedLastMessage } from "./caching";
-import { applyToolResultBudget, snipOldSteps } from "./contextManagement";
+import { fitMessagesToContext, truncateWithMarker } from "./contextManagement";
+import { getModelInfo, getMaxOutputTokens } from "./models";
 
 export type AIModel = AnthropicMessagesModelId | OpenAIChatModelId | string; // For OpenRouter and Bedrock models
 
@@ -49,6 +50,11 @@ export type AIModelProvider =
   | "pensar"
   | "inception"
   | "local";
+
+/** Conservative default when `getModelInfo` doesn't have a `contextLength`. */
+function getContextWindow(modelId: string): number {
+  return getModelInfo(modelId).contextLength ?? 200_000;
+}
 
 function checkIfRateLimitError(error: unknown): boolean {
   const errObj =
@@ -354,35 +360,29 @@ function wrapStreamWithErrorHandler(
                     currentMessages = response.messages as ModelMessage[];
                   }
                 } catch {
-                  // Fall back to container messages if response is not available
+                  // Fall back to container messages.
                 }
 
-                // Layer 1+2: Try lightweight compaction before full summarization.
-                // applyToolResultBudget truncates large tool results to previews;
-                // snipOldSteps replaces old tool results with 1-line summaries.
-                const afterBudget = opts.sessionPath
-                  ? applyToolResultBudget(currentMessages, {
-                      sessionPath: opts.sessionPath,
-                    })
-                  : currentMessages;
-                const compacted = snipOldSteps(afterBudget);
+                const fitted = fitMessagesToContext(currentMessages, {
+                  contextWindow: getContextWindow(opts.model),
+                  maxOutputTokens: getMaxOutputTokens(opts.model),
+                  system: opts.system,
+                  tools: opts.tools,
+                  sessionPath: opts.sessionPath,
+                });
 
-                // Update the container so any nested retry reads
-                // already-compacted messages instead of the original
-                // pre-compaction ones (prevents unbounded retry loops).
-                messagesContainer.current = compacted;
+                messagesContainer.current = fitted.messages;
 
-                // snipOldSteps returns the input array unchanged when nothing was modified
-                if (compacted !== currentMessages) {
+                if (fitted.fitsBudget && fitted.modified) {
                   if (!silent) {
                     console.warn(
-                      `Context length error — trying lightweight compaction on ${currentMessages.length} messages`,
+                      `Context length error — Layer 1+2 reduced to ~${fitted.estimatedInputTokens} tokens, retrying`,
                     );
                   }
                   try {
                     const retried = streamResponse({
                       ...opts,
-                      messages: compacted,
+                      messages: fitted.messages,
                     });
                     const wrappedRetry = wrapStreamWithErrorHandler(
                       retried,
@@ -398,15 +398,16 @@ function wrapStreamWithErrorHandler(
                     }
                     return;
                   } catch (retryError) {
-                    // Only fall through to full summarization for context length errors.
-                    // Other errors (auth failures, model errors) must propagate.
+                    // Auth / model errors must propagate.
                     if (!checkIfContextLengthError(retryError)) {
                       throw retryError;
                     }
                   }
                 }
 
-                // Layer 3: Full summarization (existing behavior)
+                // Layer 3: full summarization. Wrapped because
+                // `summarizeConversation` itself calls `generateText` and
+                // can throw — fall back to a minimal-context restart.
                 const messagesForSummary = messagesContainer.current;
                 if (!silent) {
                   console.warn(
@@ -414,13 +415,39 @@ function wrapStreamWithErrorHandler(
                   );
                 }
 
-                const summarizationStream = createSummarizationStream(
-                  messagesForSummary,
-                  opts,
-                  model,
-                );
-                for await (const chunk of summarizationStream.fullStream) {
-                  yield chunk;
+                try {
+                  const summarizationStream = createSummarizationStream(
+                    messagesForSummary,
+                    opts,
+                    model,
+                  );
+                  for await (const chunk of summarizationStream.fullStream) {
+                    yield chunk;
+                  }
+                } catch (summarizeError) {
+                  if (!silent) {
+                    const sumMsg =
+                      summarizeError instanceof Error
+                        ? summarizeError.message
+                        : String(summarizeError);
+                    console.error(
+                      `Layer 3 summarization failed (${sumMsg}). Falling back to minimal-context restart.`,
+                    );
+                  }
+                  opts.onSummarized?.("");
+                  const minimalPrompt =
+                    typeof opts.prompt === "string" && opts.prompt.length > 0
+                      ? opts.prompt.slice(0, 4_000)
+                      : MINIMAL_RESTART_PROMPT;
+                  const fallback = streamResponse({
+                    ...opts,
+                    prompt: minimalPrompt,
+                    messages: undefined,
+                    _restartDepth: (opts._restartDepth ?? 0) + 1,
+                  });
+                  for await (const chunk of fallback.fullStream) {
+                    yield chunk;
+                  }
                 }
               } else {
                 if (!silent) {
@@ -511,11 +538,25 @@ export interface StreamResponseOpts {
   enableThinking?: boolean;
   /** Session root path — used by context management layers to persist truncated tool results */
   sessionPath?: string;
+  /**
+   * Internal: recovery-recursion depth. Bumped at each summarize → resume
+   * boundary; throws `ContextLengthExhaustedError` past `MAX_RESTART_DEPTH`.
+   */
+  _restartDepth?: number;
 }
 
 export function streamResponse(
   opts: StreamResponseOpts,
 ): StreamTextResult<ToolSet, never> {
+  // Bound recovery recursion (summarize → resume → overflow → …).
+  const restartDepth = opts._restartDepth ?? 0;
+  if (restartDepth > MAX_RESTART_DEPTH) {
+    throw new ContextLengthExhaustedError(
+      `Context-length recovery exhausted after ${restartDepth} restart cycles`,
+      restartDepth,
+    );
+  }
+
   const {
     prompt,
     system,
@@ -546,18 +587,60 @@ export function streamResponse(
       if (inp > 0 || out > 0) _usageCallback(model, inp, out);
     }
   };
-  // Use a container object so the reference stays stable but the value can be updated
-  const messagesContainer = { current: messages || [] };
   const providerModel = getProviderModel(model, authConfig);
   const useAnthropicCaching = isAnthropicProvider(model);
+
+  // Proactive context fit: compact before the call. Reactive recovery
+  // below is a safety net for tokenizer drift the estimate doesn't catch.
+  let fittedMessages = messages;
+  let proactiveFitFailed = false;
+  if (messages && messages.length > 0) {
+    const fitted = fitMessagesToContext(messages, {
+      contextWindow: getContextWindow(model),
+      maxOutputTokens: getMaxOutputTokens(model),
+      system,
+      tools,
+      sessionPath: opts.sessionPath,
+    });
+    fittedMessages = fitted.messages;
+    proactiveFitFailed = !fitted.fitsBudget;
+    if (fitted.modified && !silent) {
+      console.warn(
+        `Proactive context fit: compacted messages to ~${fitted.estimatedInputTokens} tokens (fits=${fitted.fitsBudget})`,
+      );
+    }
+  }
+
+  // Container reference is stable; value gets reassigned by `prepareStep`
+  // and the recovery paths so nested retries read the latest compacted view.
+  const messagesContainer = { current: fittedMessages || [] };
+
+  // Layer 1+2 alone can't fit — escalate before sending a doomed request.
+  // Wrap with the same error handler the streamText path uses, otherwise
+  // an overflow inside the summarization call itself escapes uncaught while
+  // the equivalent post-streamText path (line ~880) recovers.
+  if (proactiveFitFailed && fittedMessages) {
+    if (!silent) {
+      console.warn(
+        `Proactive context fit returned fitsBudget=false on ${fittedMessages.length} messages — escalating to summarization before send`,
+      );
+    }
+    return wrapStreamWithErrorHandler(
+      createSummarizationStream(fittedMessages, opts, providerModel),
+      messagesContainer,
+      opts,
+      providerModel,
+      silent,
+    );
+  }
 
   // For Anthropic models, move the system prompt into messages with cache_control.
   // This caches tools + system prompt across multi-turn conversations (~90% cost reduction on cache hits).
   let effectiveSystem: string | undefined = system;
-  let effectiveMessages: ModelMessage[] | undefined = messages;
+  let effectiveMessages: ModelMessage[] | undefined = fittedMessages;
 
   if (useAnthropicCaching && system) {
-    const baseMessages: ModelMessage[] = messages ?? [
+    const baseMessages: ModelMessage[] = fittedMessages ?? [
       { role: "user" as const, content: prompt },
     ];
     effectiveMessages = withCachedSystemPrompt(system, baseMessages);
@@ -683,8 +766,21 @@ export function streamResponse(
             return null;
           }
 
-          // Get JSONSchema7 for display purposes
           const jsonSchema = inputSchema({ toolName: toolCall.toolName });
+
+          // Bound input + schema so the repair call can't itself overflow.
+          const rawInput = toolCall.input;
+          const inputAsText =
+            typeof rawInput === "string" ? rawInput : JSON.stringify(rawInput);
+          const boundedInput = truncateWithMarker(
+            inputAsText,
+            MAX_TOOL_INPUT_CHARS,
+          );
+          const boundedSchema = truncateWithMarker(
+            JSON.stringify(jsonSchema),
+            MAX_SCHEMA_CHARS,
+            "schema",
+          );
 
           const { output: repairedArgs, usage: repairUsage } =
             await generateText({
@@ -695,9 +791,9 @@ export function streamResponse(
               prompt: [
                 `The model tried to call the tool "${toolCall.toolName}"` +
                   ` with the following inputs:`,
-                toolCall.input,
+                boundedInput,
                 `The tool accepts the following schema:`,
-                JSON.stringify(jsonSchema),
+                boundedSchema,
                 `Error encountered: ${error}`,
                 "Please fix the inputs to match the schema.",
                 "",
@@ -891,6 +987,27 @@ export class ContextLengthError extends Error {
     this.name = "ContextLengthError";
   }
 }
+
+/**
+ * Terminal: all recovery paths exhausted. The only context-length error
+ * allowed to escape `streamResponse` — others are recoverable by design.
+ */
+export class ContextLengthExhaustedError extends Error {
+  readonly restartDepth: number;
+  constructor(message: string, restartDepth: number) {
+    super(message);
+    this.name = "ContextLengthExhaustedError";
+    this.restartDepth = restartDepth;
+  }
+}
+
+const MAX_RESTART_DEPTH = 3;
+
+const MAX_TOOL_INPUT_CHARS = 8_000;
+const MAX_SCHEMA_CHARS = 6_000;
+
+const MINIMAL_RESTART_PROMPT =
+  "Continue the previous task. Earlier context was discarded due to repeated context-length errors.";
 
 export {
   StreamIdleTimeoutError,

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -880,11 +880,21 @@ export function streamResponse(
           outerErrorMessage,
         );
       }
-      // Return a wrapped stream that shows summarization and then continues
-      return createSummarizationStream(
-        messagesContainer.current,
+      // Wrap so a context error inside the summarization stream itself
+      // (or the resumed `streamResponse` it triggers) is caught and routed
+      // through the same recovery cascade as the proactive and reactive
+      // paths — invariant I4: every context-recovery failure must be caught
+      // at the `streamResponse` boundary, never escape raw to the consumer.
+      return wrapStreamWithErrorHandler(
+        createSummarizationStream(
+          messagesContainer.current,
+          opts,
+          providerModel,
+        ),
+        messagesContainer,
         opts,
         providerModel,
+        silent,
       );
     }
     if (!silent) {

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -373,6 +373,15 @@ function wrapStreamWithErrorHandler(
 
                 messagesContainer.current = fitted.messages;
 
+                // Track depth across the reactive paths so that a failed
+                // Layer 1+2 retry CONTRIBUTES to the Layer 3 budget too.
+                // Without this, a failed retry's increment is "lost" on
+                // fall-through (Layer 3 reads outer `opts._restartDepth`,
+                // not the post-retry value) and recovery can burn close
+                // to double the intended provider calls before
+                // `MAX_RESTART_DEPTH` finally trips.
+                let postReactiveDepth = opts._restartDepth ?? 0;
+
                 if (fitted.fitsBudget && fitted.modified) {
                   if (!silent) {
                     console.warn(
@@ -391,7 +400,7 @@ function wrapStreamWithErrorHandler(
                     const retried = streamResponse({
                       ...opts,
                       messages: fitted.messages,
-                      _restartDepth: (opts._restartDepth ?? 0) + 1,
+                      _restartDepth: postReactiveDepth + 1,
                     });
                     const wrappedRetry = wrapStreamWithErrorHandler(
                       retried,
@@ -411,6 +420,10 @@ function wrapStreamWithErrorHandler(
                     if (!checkIfContextLengthError(retryError)) {
                       throw retryError;
                     }
+                    // Account for the depth slot the failed retry just
+                    // consumed so the Layer 3 paths below don't grant a
+                    // fresh budget on top of the already-spent cycle.
+                    postReactiveDepth += 1;
                   }
                 }
 
@@ -427,7 +440,7 @@ function wrapStreamWithErrorHandler(
                 try {
                   const summarizationStream = createSummarizationStream(
                     messagesForSummary,
-                    opts,
+                    { ...opts, _restartDepth: postReactiveDepth },
                     model,
                   );
                   for await (const chunk of summarizationStream.fullStream) {
@@ -452,7 +465,7 @@ function wrapStreamWithErrorHandler(
                     ...opts,
                     prompt: minimalPrompt,
                     messages: undefined,
-                    _restartDepth: (opts._restartDepth ?? 0) + 1,
+                    _restartDepth: postReactiveDepth + 1,
                   });
                   for await (const chunk of fallback.fullStream) {
                     yield chunk;

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -700,6 +700,12 @@ export function streamResponse(
       tools,
       maxRetries: 3,
       providerOptions,
+      // Pin actual emission to the same value `fitMessagesToContext`
+      // reserved for output. Without this, the SDK applies provider
+      // defaults that can exceed our budget — e.g. GPT-4o defaults to
+      // 16K output but our messages were sized assuming a smaller
+      // reservation. Making the value explicit closes that drift class.
+      maxOutputTokens: getMaxOutputTokens(model),
       prepareStep: (opts) => {
         // Update the container with the latest messages
         messagesContainer.current = opts.messages;

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -447,6 +447,23 @@ function wrapStreamWithErrorHandler(
                     yield chunk;
                   }
                 } catch (summarizeError) {
+                  // Only fall through to minimal-restart for context-length
+                  // errors. For everything else — auth failures, network
+                  // errors, abort signals, the typed terminal
+                  // `ContextLengthExhaustedError`, or non-`Error` throws —
+                  // propagate immediately. Without this, an aborted call
+                  // would spawn a new provider request, and a transient
+                  // auth failure would burn an extra cycle that fails
+                  // identically.
+                  if (
+                    summarizeError instanceof ContextLengthExhaustedError ||
+                    (summarizeError instanceof Error &&
+                      summarizeError.name === "AbortError") ||
+                    opts.abortSignal?.aborted ||
+                    !checkIfContextLengthError(summarizeError)
+                  ) {
+                    throw summarizeError;
+                  }
                   if (!silent) {
                     const sumMsg =
                       summarizeError instanceof Error

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -664,20 +664,18 @@ export function streamResponse(
         `Proactive context fit returned fitsBudget=false on ${fittedMessages.length} messages — escalating to summarization before send`,
       );
     }
-    // Escalation IS a depth slot — `summarizeConversation` will spawn
-    // `streamResponse({ ..., _restartDepth: depth + 1 })` for the resumed
-    // call. Pass the bumped value here so any reactive recovery inside
-    // the wrapper (when the summarization stream itself errors) starts
-    // from the correct depth, instead of granting one extra cycle by
-    // resetting `postReactiveDepth` to the outer `opts._restartDepth`.
-    const escalatedOpts: StreamResponseOpts = {
-      ...opts,
-      _restartDepth: (opts._restartDepth ?? 0) + 1,
-    };
+    // Pass `opts` through unchanged. The slot for this escalation is
+    // consumed by `summarizeConversation`'s internal `_restartDepth + 1`
+    // bump on the resumed `streamResponse` call — pre-bumping here would
+    // double-count vs the reactive Layer 3 path (which also passes
+    // `opts._restartDepth` to `createSummarizationStream` after a
+    // no-retry fall-through). With the post-bump, all three escalation
+    // entry points (proactive, outer-catch, reactive Layer 3) consume
+    // exactly one depth slot per summarization attempt — symmetric.
     return wrapStreamWithErrorHandler(
-      createSummarizationStream(fittedMessages, escalatedOpts, providerModel),
+      createSummarizationStream(fittedMessages, opts, providerModel),
       messagesContainer,
-      escalatedOpts,
+      opts,
       providerModel,
       silent,
     );
@@ -941,25 +939,18 @@ export function streamResponse(
       // paths — invariant I4: every context-recovery failure must be caught
       // at the `streamResponse` boundary, never escape raw to the consumer.
       //
-      // Like the proactive escalation, this fall-through to summarization
-      // IS a depth slot. Bump `_restartDepth` before passing so the
-      // wrapper's reactive recovery (when the summarization stream itself
-      // errors) starts `postReactiveDepth` from the bumped value, not from
-      // the unmodified outer `opts._restartDepth` — otherwise the cascade
-      // gets one extra cycle on top of the slot just spent. Same bug class
-      // as the proactive-side fix in 75cb1d76.
-      const escalatedOpts: StreamResponseOpts = {
-        ...opts,
-        _restartDepth: (opts._restartDepth ?? 0) + 1,
-      };
+      // Pass `opts` through unchanged — the slot is consumed by
+      // `summarizeConversation`'s internal `_restartDepth + 1` bump on
+      // the resumed call. See the proactive escalation comment above
+      // for the symmetry rationale.
       return wrapStreamWithErrorHandler(
         createSummarizationStream(
           messagesContainer.current,
-          escalatedOpts,
+          opts,
           providerModel,
         ),
         messagesContainer,
-        escalatedOpts,
+        opts,
         providerModel,
         silent,
       );

--- a/src/core/ai/contextManagement.test.ts
+++ b/src/core/ai/contextManagement.test.ts
@@ -162,6 +162,56 @@ describe("applyToolResultBudget", () => {
     expect(value).toMatch(/truncated 700 chars/);
     expect(value).not.toMatch(/truncated -/);
   });
+
+  it("cascading thresholds preserve the ORIGINAL dropped-char count", () => {
+    // Reproduces the metadata-corruption case Bugbot flagged: 50K text
+    // truncated at 10K → ~2080-char preview, then re-truncated at 2K.
+    // Pre-fix the second pass reported "truncated 80 chars" (preview→
+    // smaller-preview delta), hiding the true ~48K of data loss. The
+    // metadata must keep referencing the ORIGINAL length and the file
+    // path written on the FIRST pass.
+    const sessionPath = mkdtempSync(join(tmpdir(), "tool-budget-cascade-"));
+    const original = "x".repeat(50_000);
+    const msgs = makeAssistantWithToolResult(
+      "execute_command",
+      original,
+      "cascade-id",
+    );
+
+    const persistedIds = new Set<string>();
+    const afterPass1 = applyToolResultBudget(msgs, {
+      sessionPath,
+      maxResultChars: 10_000,
+      persistedIds,
+    });
+    const pass1Value = (
+      (afterPass1[1]!.content as Array<Record<string, unknown>>)[0]!.output as {
+        value: string;
+      }
+    ).value;
+    expect(pass1Value).toMatch(/truncated 48000 chars/);
+    const pass1FilePath = pass1Value.match(
+      /full output saved to (.+?)\]$/,
+    )![1]!;
+
+    const afterPass2 = applyToolResultBudget(afterPass1, {
+      sessionPath,
+      maxResultChars: 2_000,
+      persistedIds,
+    });
+    const pass2Value = (
+      (afterPass2[1]!.content as Array<Record<string, unknown>>)[0]!.output as {
+        value: string;
+      }
+    ).value;
+
+    // The headline assertion: dropped-char count references the ORIGINAL
+    // 50K, not the 2080-char preview. Pre-fix this would say `truncated 80`.
+    expect(pass2Value).toMatch(/truncated 48000 chars/);
+    // Path must point to the FIRST pass's persisted file, not a fresh one.
+    expect(pass2Value).toContain(pass1FilePath);
+    expect(pass2Value).not.toMatch(/truncated 80 chars/);
+  });
 });
 
 describe("fitMessagesToContext", () => {

--- a/src/core/ai/contextManagement.test.ts
+++ b/src/core/ai/contextManagement.test.ts
@@ -9,6 +9,7 @@ import {
   estimateMessageTokens,
   estimateToolsOverheadTokens,
   fitMessagesToContext,
+  applyToolResultBudget,
 } from "./contextManagement";
 
 function makeAssistantWithToolResult(
@@ -88,6 +89,35 @@ describe("estimateToolsOverheadTokens", () => {
     const tokens = estimateToolsOverheadTokens(tools);
     // Should reflect the multi-thousand-char `huge` tool, not be a tiny constant.
     expect(tokens).toBeGreaterThan(500);
+  });
+});
+
+describe("applyToolResultBudget", () => {
+  it("never emits a preview larger than maxResultChars at tight thresholds", () => {
+    const sessionPath = mkdtempSync(join(tmpdir(), "tool-budget-"));
+    // Result sized between the smallest cascading thresholds (500 < 1200 < 2000):
+    // the previous fixed 2000-char preview would have captured the entire
+    // text and reported a negative truncation count.
+    const msgs = makeAssistantWithToolResult(
+      "http_request",
+      "x".repeat(1_200),
+      "tight-threshold",
+    );
+
+    const result = applyToolResultBudget(msgs, {
+      sessionPath,
+      maxResultChars: 500,
+    });
+
+    const toolMsg = result[1]!;
+    const part = (toolMsg.content as Array<Record<string, unknown>>)[0]!;
+    const value = (part.output as { value: string }).value;
+
+    // Output must be smaller than the original — the whole point of compaction.
+    expect(value.length).toBeLessThan(1_200);
+    // Truncation marker must report a positive number.
+    expect(value).toMatch(/truncated 700 chars/);
+    expect(value).not.toMatch(/truncated -/);
   });
 });
 

--- a/src/core/ai/contextManagement.test.ts
+++ b/src/core/ai/contextManagement.test.ts
@@ -10,6 +10,7 @@ import {
   estimateToolsOverheadTokens,
   fitMessagesToContext,
   applyToolResultBudget,
+  truncateWithMarker,
 } from "./contextManagement";
 
 function makeAssistantWithToolResult(
@@ -89,6 +90,48 @@ describe("estimateToolsOverheadTokens", () => {
     const tokens = estimateToolsOverheadTokens(tools);
     // Should reflect the multi-thousand-char `huge` tool, not be a tiny constant.
     expect(tokens).toBeGreaterThan(500);
+  });
+});
+
+describe("truncateWithMarker", () => {
+  it("returns input unchanged when text fits", () => {
+    expect(truncateWithMarker("hi", 10)).toBe("hi");
+    expect(truncateWithMarker("hi", 10, "label")).toBe("hi");
+  });
+
+  it("treats `max` as a strict upper bound — labeled marker", () => {
+    // Pinning the hard-cap contract that auxiliary-LLM input caps
+    // (MAX_TOOL_INPUT_CHARS, MAX_SCHEMA_CHARS, etc.) rely on. Soft caps
+    // would silently inflate budgets by ~30 chars per call.
+    const out = truncateWithMarker("x".repeat(10_000), 100, "schema");
+    expect(out.length).toBeLessThanOrEqual(100);
+    expect(out).toMatch(/…\[schema truncated\]$/);
+  });
+
+  it("treats `max` as a strict upper bound — unlabeled marker", () => {
+    const out = truncateWithMarker("x".repeat(10_000), 100);
+    expect(out.length).toBeLessThanOrEqual(100);
+    expect(out).toMatch(/…\[truncated \d+ chars\]$/);
+  });
+
+  it("dropped-char count reflects sliceLen (post-reservation), not max", () => {
+    // sliceLen = max - widestMarker.length, so dropped = text.length - sliceLen
+    // — strictly more chars are dropped than `text.length - max`. Pin the
+    // exact relationship so future regressions are loud.
+    const text = "x".repeat(10_000);
+    const out = truncateWithMarker(text, 100);
+    const m = out.match(/…\[truncated (\d+) chars\]$/);
+    expect(m).not.toBeNull();
+    const dropped = Number(m![1]);
+    // sliceLen is at most ~75 (100 - widestMarker(~25)), so dropped ≥ 9925.
+    expect(dropped).toBeGreaterThanOrEqual(10_000 - 100);
+    expect(dropped).toBeLessThan(10_000);
+  });
+
+  it("degenerate max < marker length still returns just the marker", () => {
+    // Better signal than a ~5-char head with no marker.
+    const out = truncateWithMarker("x".repeat(100), 5);
+    expect(out).toContain("truncated");
   });
 });
 

--- a/src/core/ai/contextManagement.test.ts
+++ b/src/core/ai/contextManagement.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import type { ModelMessage, ToolSet } from "ai";
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { z } from "zod";
+import {
+  estimateTokens,
+  estimateMessageTokens,
+  estimateToolsOverheadTokens,
+  fitMessagesToContext,
+} from "./contextManagement";
+
+function makeAssistantWithToolResult(
+  toolName: string,
+  resultText: string,
+  toolCallId = `${toolName}-${Math.random().toString(36).slice(2, 8)}`,
+): ModelMessage[] {
+  return [
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId,
+          toolName,
+          input: {},
+        },
+      ],
+    },
+    {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId,
+          toolName,
+          output: { type: "text", value: resultText },
+        },
+      ],
+    },
+  ] as unknown as ModelMessage[];
+}
+
+describe("estimateTokens", () => {
+  it("returns 0 for empty input", () => {
+    expect(estimateTokens("")).toBe(0);
+  });
+
+  it("scales linearly with chars/4", () => {
+    expect(estimateTokens("a".repeat(100))).toBe(25);
+    expect(estimateTokens("a".repeat(1000))).toBe(250);
+  });
+});
+
+describe("estimateMessageTokens", () => {
+  it("counts string content", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "x".repeat(400) },
+    ] as unknown as ModelMessage[];
+    // 400 chars + 8 structural overhead = 408 chars / 4 = 102 tokens.
+    expect(estimateMessageTokens(msgs)).toBe(102);
+  });
+
+  it("counts tool-result text in array content", () => {
+    const msgs = makeAssistantWithToolResult("http_request", "x".repeat(4_000));
+    // Just sanity: should be on the order of 1K tokens, not zero.
+    expect(estimateMessageTokens(msgs)).toBeGreaterThan(900);
+  });
+});
+
+describe("estimateToolsOverheadTokens", () => {
+  it("returns 0 when no tools provided", () => {
+    expect(estimateToolsOverheadTokens(undefined)).toBe(0);
+  });
+
+  it("scales with tool description + schema size", () => {
+    const tools: ToolSet = {
+      tiny: {
+        description: "x",
+        inputSchema: z.object({ a: z.string() }),
+      } as unknown as ToolSet[string],
+      huge: {
+        description: "x".repeat(2_000),
+        inputSchema: z.object({ b: z.string().describe("y".repeat(2_000)) }),
+      } as unknown as ToolSet[string],
+    };
+    const tokens = estimateToolsOverheadTokens(tools);
+    // Should reflect the multi-thousand-char `huge` tool, not be a tiny constant.
+    expect(tokens).toBeGreaterThan(500);
+  });
+});
+
+describe("fitMessagesToContext", () => {
+  it("returns input array when messages already fit", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "hello" },
+    ] as unknown as ModelMessage[];
+
+    const result = fitMessagesToContext(msgs, {
+      contextWindow: 200_000,
+      maxOutputTokens: 64_000,
+    });
+
+    expect(result.modified).toBe(false);
+    expect(result.fitsBudget).toBe(true);
+    expect(result.messages).toBe(msgs);
+  });
+
+  it("returns fitsBudget=false when budget is non-positive", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "hello" },
+    ] as unknown as ModelMessage[];
+
+    const result = fitMessagesToContext(msgs, {
+      contextWindow: 1_000,
+      maxOutputTokens: 1_000,
+    });
+
+    expect(result.fitsBudget).toBe(false);
+  });
+
+  it("invokes Layer 1 when a tool result is over the per-result budget", () => {
+    const sessionPath = mkdtempSync(join(tmpdir(), "fit-ctx-"));
+    const msgs = makeAssistantWithToolResult(
+      "http_request",
+      "x".repeat(250_000),
+    );
+
+    const result = fitMessagesToContext(msgs, {
+      contextWindow: 100_000,
+      maxOutputTokens: 50_000,
+      overheadTokens: 0,
+      safetyMarginTokens: 0,
+      sessionPath,
+    });
+
+    expect(result.modified).toBe(true);
+    expect(result.estimatedInputTokens).toBeLessThan(60_000);
+  });
+
+  it("derives overhead from `tools` when overheadTokens is not set", () => {
+    const tinyTools: ToolSet = {
+      a: {
+        description: "x",
+        inputSchema: z.object({ a: z.string() }),
+      } as unknown as ToolSet[string],
+    };
+    const heavyTools: ToolSet = Object.fromEntries(
+      Array.from({ length: 20 }, (_, i) => [
+        `tool_${i}`,
+        {
+          description: "x".repeat(1_500),
+          inputSchema: z.object({
+            arg: z.string().describe("y".repeat(1_500)),
+          }),
+        } as unknown as ToolSet[string],
+      ]),
+    );
+
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "x".repeat(400_000) },
+    ] as unknown as ModelMessage[];
+
+    const tinyResult = fitMessagesToContext(msgs, {
+      contextWindow: 200_000,
+      maxOutputTokens: 64_000,
+      tools: tinyTools,
+    });
+    const heavyResult = fitMessagesToContext(msgs, {
+      contextWindow: 200_000,
+      maxOutputTokens: 64_000,
+      tools: heavyTools,
+    });
+
+    // Heavier tool surface ⇒ tighter messages budget.
+    expect(heavyResult.estimatedInputTokens).toBeLessThanOrEqual(
+      tinyResult.estimatedInputTokens,
+    );
+  });
+});

--- a/src/core/ai/contextManagement.test.ts
+++ b/src/core/ai/contextManagement.test.ts
@@ -158,9 +158,50 @@ describe("applyToolResultBudget", () => {
 
     // Output must be smaller than the original — the whole point of compaction.
     expect(value.length).toBeLessThan(1_200);
-    // Truncation marker must report a positive number.
-    expect(value).toMatch(/truncated 700 chars/);
+    // previewSize at maxChars=500 is `max(100, 500/5) = 100`, so 1200 - 100 = 1100.
+    expect(value).toMatch(/truncated 1100 chars/);
     expect(value).not.toMatch(/truncated -/);
+  });
+
+  it("cascading thresholds progressively reduce already-truncated entries", () => {
+    // Bugbot flagged that a fixed 2000-char preview made the 5K and
+    // 2K cascading thresholds no-ops on entries the 10K pass had
+    // shrunk to ~2080 chars — only the 500 threshold did anything.
+    // Now `previewSize = max(100, maxChars / 5)` scales with the
+    // threshold, so each pass produces a strictly smaller preview.
+    const sessionPath = mkdtempSync(join(tmpdir(), "tool-budget-progressive-"));
+    const msgs = makeAssistantWithToolResult(
+      "execute_command",
+      "y".repeat(50_000),
+      "progressive-id",
+    );
+
+    const persistedIds = new Set<string>();
+    let current = msgs;
+    const lengths: number[] = [];
+    for (const maxResultChars of [10_000, 5_000, 2_000, 500]) {
+      current = applyToolResultBudget(current, {
+        sessionPath,
+        maxResultChars,
+        persistedIds,
+      });
+      const value = (
+        (current[1]!.content as Array<Record<string, unknown>>)[0]!.output as {
+          value: string;
+        }
+      ).value;
+      lengths.push(value.length);
+    }
+
+    // Each subsequent pass MUST yield a strictly shorter output. Pre-fix
+    // the array would be e.g. [2080, 2080, 2080, 580] — three identical
+    // values means three wasted iterations.
+    for (let i = 1; i < lengths.length; i++) {
+      expect(
+        lengths[i]!,
+        `pass ${i}: ${lengths[i - 1]} → ${lengths[i]} (must shrink)`,
+      ).toBeLessThan(lengths[i - 1]!);
+    }
   });
 
   it("cascading thresholds preserve the ORIGINAL dropped-char count", () => {
@@ -206,10 +247,15 @@ describe("applyToolResultBudget", () => {
     ).value;
 
     // The headline assertion: dropped-char count references the ORIGINAL
-    // 50K, not the 2080-char preview. Pre-fix this would say `truncated 80`.
-    expect(pass2Value).toMatch(/truncated 48000 chars/);
+    // 50K, not the 2080-char preview. Pre-fix this would say `truncated 80
+    // chars` (preview→smaller-preview delta), hiding the real ~48K of
+    // data loss. With `previewSize = max(100, maxChars / 5)` the second
+    // pass produces a 400-char preview, so dropped = 50000 - 400 = 49600.
+    expect(pass2Value).toMatch(/truncated 49600 chars/);
     // Path must point to the FIRST pass's persisted file, not a fresh one.
     expect(pass2Value).toContain(pass1FilePath);
+    // Negative-shape assertion: must NOT report the misleading delta-
+    // against-preview count that the metadata-corruption bug produced.
     expect(pass2Value).not.toMatch(/truncated 80 chars/);
   });
 });

--- a/src/core/ai/contextManagement.ts
+++ b/src/core/ai/contextManagement.ts
@@ -123,6 +123,24 @@ export function applyToolResultBudget(
         ? tailMatch[2]!
         : join(resultsDir, `${toolCallId}.txt`);
 
+      // Preview must never exceed `maxChars`, otherwise tighter cascading
+      // thresholds (e.g. 500) would emit the full text plus metadata —
+      // making the "truncated" message larger than the original and
+      // reporting a negative dropped-char count.
+      const previewSize = Math.min(maxChars, 2000);
+      const preview = previewBody.slice(0, previewSize);
+      const newValue = `${preview}\n\n[... truncated ${originalLength - previewSize} chars — full output saved to ${filePath}]`;
+
+      // Monotone-reduction guard: near the threshold boundary
+      // (e.g. text.length=2050 against maxChars=2000), preview + ~80
+      // chars of metadata can be LARGER than the original. Returning a
+      // bigger value would inflate `estimatedInputTokens` and break
+      // invariant I2. Bail out BEFORE persistence — we don't want to
+      // write the file for an entry we won't actually compact, and the
+      // next tighter cascading threshold (or Layer 2 / Layer 3) will get
+      // another shot at it.
+      if (newValue.length >= text.length) return part;
+
       if (!persistedIds || !persistedIds.has(toolCallId)) {
         // If this entry already carried a truncation tail, the full
         // output was persisted by an earlier pass — `text` is just the
@@ -143,17 +161,11 @@ export function applyToolResultBudget(
       }
 
       msgModified = true;
-      // Preview must never exceed `maxChars`, otherwise tighter cascading
-      // thresholds (e.g. 500) would emit the full text plus metadata —
-      // making the "truncated" message larger than the original and
-      // reporting a negative dropped-char count.
-      const previewSize = Math.min(maxChars, 2000);
-      const preview = previewBody.slice(0, previewSize);
       return {
         ...p,
         output: {
           type: "text" as const,
-          value: `${preview}\n\n[... truncated ${originalLength - previewSize} chars — full output saved to ${filePath}]`,
+          value: newValue,
         },
       };
     });

--- a/src/core/ai/contextManagement.ts
+++ b/src/core/ai/contextManagement.ts
@@ -93,12 +93,17 @@ export function applyToolResultBudget(
       }
 
       msgModified = true;
-      const preview = text.slice(0, 2000);
+      // Preview must never exceed `maxChars`, otherwise tighter cascading
+      // thresholds (e.g. 500) would emit the full text plus metadata —
+      // making the "truncated" message larger than the original and
+      // reporting a negative dropped-char count.
+      const previewSize = Math.min(maxChars, 2000);
+      const preview = text.slice(0, previewSize);
       return {
         ...p,
         output: {
           type: "text" as const,
-          value: `${preview}\n\n[... truncated ${text.length - 2000} chars — full output saved to ${filePath}]`,
+          value: `${preview}\n\n[... truncated ${text.length - previewSize} chars — full output saved to ${filePath}]`,
         },
       };
     });

--- a/src/core/ai/contextManagement.ts
+++ b/src/core/ai/contextManagement.ts
@@ -138,7 +138,13 @@ export function applyToolResultBudget(
       // monotone-reduction guard below catches any pathological case.
       const previewSize = Math.max(100, Math.floor(maxChars / 5));
       const preview = previewBody.slice(0, previewSize);
-      const newValue = `${preview}\n\n[... truncated ${originalLength - previewSize} chars — full output saved to ${filePath}]`;
+      // `preview.length`, not `previewSize`: when re-entering on a
+      // small `previewBody` (already heavily truncated), the slice
+      // is shorter than `previewSize`, so the dropped-char count must
+      // reference what the preview ACTUALLY contains, otherwise the
+      // metadata understates the data loss by `previewSize -
+      // previewBody.length` chars.
+      const newValue = `${preview}\n\n[... truncated ${originalLength - preview.length} chars — full output saved to ${filePath}]`;
 
       // Monotone-reduction guard: near the threshold boundary
       // (e.g. text.length=2050 against maxChars=2000), preview + ~80

--- a/src/core/ai/contextManagement.ts
+++ b/src/core/ai/contextManagement.ts
@@ -11,11 +11,20 @@ import { writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 
 /**
- * Truncate `text` to `max` chars and append a marker noting how many were
- * dropped. `label` selects the marker form: omit for the verbose
- * `"…[truncated N chars]"` (used wherever the recipient might benefit from
- * the byte count), pass a label for `"…[<label> truncated]"` when the count
- * would be misleading or noisy.
+ * Truncate `text` so the returned string fits in **at most** `max` chars,
+ * and append a marker noting how many were dropped. `label` selects the
+ * marker form: omit for the verbose `"…[truncated N chars]"` (used wherever
+ * the recipient might benefit from the byte count), pass a label for
+ * `"…[<label> truncated]"` when the count would be misleading or noisy.
+ *
+ * `max` is a strict upper bound — the marker length is reserved INSIDE
+ * `max`, not appended outside it. Callers (`MAX_TOOL_INPUT_CHARS`,
+ * `MAX_SCHEMA_CHARS`, `MAX_PER_MESSAGE_CHARS`, `SYSTEM_PROMPT_SNIPPET_CHARS`)
+ * treat the cap as a hard ceiling on auxiliary-LLM input size; soft caps
+ * would silently inflate budgets by ~30 chars per call.
+ *
+ * Degenerate `max < marker.length` returns just the marker (still useful
+ * signal vs. a meaningless ≤30-char head slice).
  */
 export function truncateWithMarker(
   text: string,
@@ -23,10 +32,19 @@ export function truncateWithMarker(
   label?: string,
 ): string {
   if (text.length <= max) return text;
-  const marker = label
-    ? `…[${label} truncated]`
-    : `…[truncated ${text.length - max} chars]`;
-  return `${text.slice(0, max)}${marker}`;
+  if (label) {
+    const marker = `…[${label} truncated]`;
+    const sliceLen = Math.max(0, max - marker.length);
+    return `${text.slice(0, sliceLen)}${marker}`;
+  }
+  // Marker width depends on the dropped-char count — but the count itself
+  // depends on the slice length. Reserve the worst-case width (digits of
+  // `text.length`, an upper bound on `dropped`) so the final output is
+  // always ≤ `max` regardless of how the count formats.
+  const widestMarker = `…[truncated ${text.length} chars]`;
+  const sliceLen = Math.max(0, max - widestMarker.length);
+  const dropped = text.length - sliceLen;
+  return `${text.slice(0, sliceLen)}…[truncated ${dropped} chars]`;
 }
 
 // Layer 1: Tool Result Truncation

--- a/src/core/ai/contextManagement.ts
+++ b/src/core/ai/contextManagement.ts
@@ -1,26 +1,41 @@
 /**
- * Multi-Layer Context Management
- *
- * Tiered compaction strategy inspired by Claude Code's 5-layer system,
- * adapted for Apex's architecture. Applied in order when context overflows:
- *
- * Layer 1: Tool result truncation — large results replaced with previews
- * Layer 2: Step snipping — old tool results condensed to 1-line summaries
- *
- * Full summarization (existing in utils.ts) remains as Layer 3 fallback.
+ * Tiered context compaction. Layer 1 truncates large tool results;
+ * Layer 2 snips old tool results to 1-line summaries; Layer 3
+ * (`summarizeConversation` in utils.ts) is the fallback.
+ * {@link fitMessagesToContext} composes Layer 1+2 against an explicit
+ * token budget so callers can compact proactively, not only on error.
  */
 
-import type { ModelMessage } from "ai";
+import type { ModelMessage, ToolSet } from "ai";
 import { writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 
-// ---------------------------------------------------------------------------
+/**
+ * Truncate `text` to `max` chars and append a marker noting how many were
+ * dropped. `label` selects the marker form: omit for the verbose
+ * `"…[truncated N chars]"` (used wherever the recipient might benefit from
+ * the byte count), pass a label for `"…[<label> truncated]"` when the count
+ * would be misleading or noisy.
+ */
+export function truncateWithMarker(
+  text: string,
+  max: number,
+  label?: string,
+): string {
+  if (text.length <= max) return text;
+  const marker = label
+    ? `…[${label} truncated]`
+    : `…[truncated ${text.length - max} chars]`;
+  return `${text.slice(0, max)}${marker}`;
+}
+
 // Layer 1: Tool Result Truncation
-// ---------------------------------------------------------------------------
 
-const DEFAULT_MAX_RESULT_CHARS = 50_000;
+// 10K chars (~2.5K tokens). Larger thresholds let many mid-size results
+// collectively exceed the budget without any single one tripping it.
+const DEFAULT_MAX_RESULT_CHARS = 10_000;
 
-/** Task tool results are small and critical for agent state — never snip them. */
+/** Small + critical for agent state — never snip. */
 const TASK_TOOL_NAMES = new Set(["create_task", "update_task", "list_tasks"]);
 
 /**
@@ -28,13 +43,22 @@ const TASK_TOOL_NAMES = new Set(["create_task", "update_task", "list_tasks"]);
  * Full results are persisted to disk at `{sessionPath}/tool-results/`.
  *
  * Returns a new messages array (does not mutate the input).
+ *
+ * `persistedIds`, when passed, deduplicates writes across cascading calls
+ * (e.g. `fitMessagesToContext` invokes this with progressively tighter
+ * thresholds — the original full output only needs to land on disk once).
  */
 export function applyToolResultBudget(
   messages: ModelMessage[],
-  opts: { sessionPath: string; maxResultChars?: number },
+  opts: {
+    sessionPath: string;
+    maxResultChars?: number;
+    persistedIds?: Set<string>;
+  },
 ): ModelMessage[] {
   const maxChars = opts.maxResultChars ?? DEFAULT_MAX_RESULT_CHARS;
   const resultsDir = join(opts.sessionPath, "tool-results");
+  const persistedIds = opts.persistedIds;
   let dirCreated = false;
   let anyModified = false;
 
@@ -46,25 +70,26 @@ export function applyToolResultBudget(
       const p = part as Record<string, unknown>;
       if (p.type !== "tool-result") return part;
 
-      // Task tool results are small and critical for agent state — never truncate them.
       const toolName = String(p.toolName ?? "tool");
       if (TASK_TOOL_NAMES.has(toolName)) return part;
 
       const text = stringifyToolOutput(p.output ?? p.result);
       if (text.length <= maxChars) return part;
 
-      // Persist full result to disk
-      if (!dirCreated) {
-        mkdirSync(resultsDir, { recursive: true });
-        dirCreated = true;
-      }
-
       const toolCallId = String(p.toolCallId ?? "unknown");
       const filePath = join(resultsDir, `${toolCallId}.txt`);
-      try {
-        writeFileSync(filePath, text, "utf-8");
-      } catch {
-        // Non-critical — worst case, full output is lost
+
+      if (!persistedIds || !persistedIds.has(toolCallId)) {
+        if (!dirCreated) {
+          mkdirSync(resultsDir, { recursive: true });
+          dirCreated = true;
+        }
+        try {
+          writeFileSync(filePath, text, "utf-8");
+        } catch {
+          // Non-critical: full output may be lost.
+        }
+        persistedIds?.add(toolCallId);
       }
 
       msgModified = true;
@@ -84,22 +109,19 @@ export function applyToolResultBudget(
       : msg;
   });
 
-  // Return original array when nothing was truncated so callers
-  // can use reference equality to detect changes.
+  // Reference equality lets callers detect "no change".
   return anyModified ? result : messages;
 }
 
-// ---------------------------------------------------------------------------
 // Layer 2: Step Snipping
-// ---------------------------------------------------------------------------
 
-const DEFAULT_KEEP_RECENT_STEPS = 15;
+// Larger windows can blow the budget on the "recent" slice alone; 6 leaves
+// enough recent context to make progress while letting Layer 2 actually compact.
+const DEFAULT_KEEP_RECENT_STEPS = 6;
 
 /**
  * For tool results older than `keepRecentSteps`, replace with 1-line summaries.
- * Keeps full content for recent steps to preserve context for active work.
- *
- * Returns a new messages array (does not mutate the input).
+ * Returns a new array (does not mutate input).
  */
 export function snipOldSteps(
   messages: ModelMessage[],
@@ -107,7 +129,6 @@ export function snipOldSteps(
 ): ModelMessage[] {
   const keepRecent = opts?.keepRecentSteps ?? DEFAULT_KEEP_RECENT_STEPS;
 
-  // Find the index where "recent" starts by counting assistant messages from the end
   let stepCount = 0;
   let cutoffIdx = 0;
   for (let i = messages.length - 1; i >= 0; i--) {
@@ -120,12 +141,10 @@ export function snipOldSteps(
     }
   }
 
-  // Nothing to snip — all messages are within the recent window
   if (cutoffIdx === 0) return messages;
 
   let anyModified = false;
   const result = messages.map((msg, idx) => {
-    // Keep recent messages intact
     if (idx >= cutoffIdx) return msg;
     if (!Array.isArray(msg.content)) return msg;
 
@@ -135,14 +154,11 @@ export function snipOldSteps(
       if (p.type !== "tool-result") return part;
 
       const toolName = String(p.toolName ?? "tool");
-
-      // Preserve task tool results — they're small and the agent
-      // needs them to track task state after context compaction.
       if (TASK_TOOL_NAMES.has(toolName)) return part;
 
       const text = stringifyToolOutput(p.output ?? p.result);
 
-      // Already a 1-line summary from a previous compaction pass — no further reduction possible
+      // Already a 1-line summary from a previous pass.
       if (text.startsWith(`[${toolName}] →`) && !text.includes("\n"))
         return part;
 
@@ -162,18 +178,12 @@ export function snipOldSteps(
       : msg;
   });
 
-  // Return original array when nothing was snipped so callers
-  // can use reference equality to detect changes.
   return anyModified ? result : messages;
 }
 
-// ---------------------------------------------------------------------------
-// Task state extraction (for preserving through summarization)
-// ---------------------------------------------------------------------------
-
 /**
- * Extract a task summary from messages for inclusion in context summaries.
- * Looks for recent list_tasks tool results to find the latest task state.
+ * Pull the latest task summary from a `list_tasks` tool result so it can
+ * survive Layer 3 summarization.
  */
 export function extractTaskSummaryFromMessages(
   messages: ModelMessage[],
@@ -212,9 +222,189 @@ export function extractTaskSummaryFromMessages(
   return null;
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+// Token estimation + budget-driven fitting
+
+/** Conservative ~4 chars/token; `safetyMarginTokens` absorbs drift. */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Tool schemas are the dominant per-request overhead for tool-heavy agents
+ * (15–25K tokens in production traces), not a small constant. Estimating
+ * directly from the actual `ToolSet` keeps the budget honest.
+ *
+ * Memoized by `ToolSet` reference: schemas are immutable once registered,
+ * and this runs on every `streamResponse` call (proactive fit + reactive
+ * recovery), so re-stringifying every schema each time is pure waste.
+ */
+const toolsOverheadCache = new WeakMap<ToolSet, number>();
+export function estimateToolsOverheadTokens(tools?: ToolSet): number {
+  if (!tools) return 0;
+  const cached = toolsOverheadCache.get(tools);
+  if (cached !== undefined) return cached;
+  let chars = 0;
+  for (const [name, tool] of Object.entries(tools)) {
+    chars += name.length;
+    const t = tool as Record<string, unknown>;
+    if (typeof t.description === "string") chars += t.description.length;
+    if (t.inputSchema) {
+      try {
+        chars += JSON.stringify(t.inputSchema).length;
+      } catch {
+        // Cyclic / non-serialisable — never zero.
+        chars += 500;
+      }
+    }
+  }
+  const tokens = Math.ceil(chars / 4);
+  toolsOverheadCache.set(tools, tokens);
+  return tokens;
+}
+
+/** Walks parts directly to avoid `JSON.stringify` on a large history. */
+export function estimateMessageTokens(messages: ModelMessage[]): number {
+  let chars = 0;
+  for (const msg of messages) {
+    chars += 8;
+    if (typeof msg.content === "string") {
+      chars += msg.content.length;
+      continue;
+    }
+    if (!Array.isArray(msg.content)) continue;
+    for (const part of msg.content as Array<Record<string, unknown>>) {
+      const t = part.type;
+      if (t === "text" && typeof part.text === "string") {
+        chars += part.text.length;
+      } else if (t === "tool-call") {
+        const input = part.input;
+        chars +=
+          typeof input === "string"
+            ? input.length
+            : JSON.stringify(input ?? "").length;
+        if (typeof part.toolName === "string") chars += part.toolName.length;
+      } else if (t === "tool-result") {
+        chars += stringifyToolOutput(part.output ?? part.result).length;
+        if (typeof part.toolName === "string") chars += part.toolName.length;
+      } else {
+        chars += JSON.stringify(part).length;
+      }
+    }
+  }
+  return Math.ceil(chars / 4);
+}
+
+export interface FitContextResult {
+  messages: ModelMessage[];
+  /** Token estimate of `messages` (excludes system + overhead). */
+  estimatedInputTokens: number;
+  /** Reference inequality vs. input. */
+  modified: boolean;
+  /** `false` ⇒ caller must escalate to Layer 3 summarization. */
+  fitsBudget: boolean;
+}
+
+export interface FitContextOpts {
+  contextWindow: number;
+  /** Tokens reserved for the model's response (`max_tokens`). */
+  maxOutputTokens: number;
+  /** Counted toward input; never compacted here. */
+  system?: string;
+  /** Used to size tool-schema overhead. Pass `tools` OR `overheadTokens`. */
+  tools?: ToolSet;
+  /** Explicit override; otherwise derived from `tools` + 1K fmt allowance. */
+  overheadTokens?: number;
+  /** Absorbs chars/4 drift; default 10_000. */
+  safetyMarginTokens?: number;
+  /** Required to enable Layer 1 (results persisted to disk). */
+  sessionPath?: string;
+}
+
+/**
+ * Single entry point for proactive AND reactive compaction. Iteratively
+ * tightens thresholds — Layer 1 ∈ {10K, 5K, 2K, 500} chars, then Layer 2
+ * ∈ {6, 3, 1} steps — and short-circuits the moment the estimate fits.
+ * Returns `fitsBudget: false` when the caller must escalate to Layer 3.
+ */
+export function fitMessagesToContext(
+  messages: ModelMessage[],
+  opts: FitContextOpts,
+): FitContextResult {
+  const overhead =
+    opts.overheadTokens ?? estimateToolsOverheadTokens(opts.tools) + 1_000;
+  const safety = opts.safetyMarginTokens ?? 10_000;
+  const systemTokens = opts.system ? estimateTokens(opts.system) : 0;
+  const messagesBudget =
+    opts.contextWindow -
+    opts.maxOutputTokens -
+    overhead -
+    safety -
+    systemTokens;
+
+  // Even an empty message list exceeds the budget — escalate.
+  if (messagesBudget <= 0) {
+    return {
+      messages,
+      estimatedInputTokens: estimateMessageTokens(messages),
+      modified: false,
+      fitsBudget: false,
+    };
+  }
+
+  let current = messages;
+  let estimate = estimateMessageTokens(current);
+  if (estimate <= messagesBudget) {
+    return {
+      messages,
+      estimatedInputTokens: estimate,
+      modified: false,
+      fitsBudget: true,
+    };
+  }
+
+  // Shared across cascading Layer 1 thresholds so the same full tool result
+  // is persisted to disk at most once, not 4× at progressively smaller
+  // preview sizes.
+  const persistedIds = opts.sessionPath ? new Set<string>() : undefined;
+
+  const fits = (): FitContextResult => ({
+    messages: current,
+    estimatedInputTokens: estimate,
+    modified: current !== messages,
+    fitsBudget: true,
+  });
+
+  // Layer 1 requires sessionPath (results are persisted to disk).
+  if (opts.sessionPath) {
+    for (const maxResultChars of [10_000, 5_000, 2_000, 500]) {
+      const next = applyToolResultBudget(current, {
+        sessionPath: opts.sessionPath,
+        maxResultChars,
+        persistedIds,
+      });
+      // No-op layer ⇒ re-estimation would yield the same number.
+      if (next === current) continue;
+      current = next;
+      estimate = estimateMessageTokens(current);
+      if (estimate <= messagesBudget) return fits();
+    }
+  }
+
+  for (const keepRecentSteps of [6, 3, 1]) {
+    const next = snipOldSteps(current, { keepRecentSteps });
+    if (next === current) continue;
+    current = next;
+    estimate = estimateMessageTokens(current);
+    if (estimate <= messagesBudget) return fits();
+  }
+
+  return {
+    messages: current,
+    estimatedInputTokens: estimate,
+    modified: current !== messages,
+    fitsBudget: false,
+  };
+}
 
 function stringifyToolOutput(output: unknown): string {
   if (output == null) return "";

--- a/src/core/ai/contextManagement.ts
+++ b/src/core/ai/contextManagement.ts
@@ -53,6 +53,16 @@ export function truncateWithMarker(
 // collectively exceed the budget without any single one tripping it.
 const DEFAULT_MAX_RESULT_CHARS = 10_000;
 
+/**
+ * Matches the trailing metadata block emitted by `applyToolResultBudget`.
+ * Lets cascading-threshold re-truncation recover the ORIGINAL length and
+ * disk path so the new metadata reports the correct dropped-char count
+ * instead of the (preview→smaller-preview) delta — which would hide the
+ * true magnitude of data loss from the model.
+ */
+const TOOL_RESULT_TRUNCATION_TAIL =
+  /\n\n\[\.\.\. truncated (\d+) chars — full output saved to (.+?)\]$/;
+
 /** Small + critical for agent state — never snip. */
 const TASK_TOOL_NAMES = new Set(["create_task", "update_task", "list_tasks"]);
 
@@ -92,20 +102,42 @@ export function applyToolResultBudget(
       if (TASK_TOOL_NAMES.has(toolName)) return part;
 
       const text = stringifyToolOutput(p.output ?? p.result);
-      if (text.length <= maxChars) return part;
+
+      // Detect re-entry on cascading thresholds. If this entry was
+      // truncated by an earlier pass (10K → 5K → 2K → 500), `text` is
+      // already a `<preview>\n\n[... truncated N chars — full output
+      // saved to PATH]` composite. Strip the tail so the budget check
+      // and subsequent slice operate on the preview body, and recover
+      // the original length / disk path so the new metadata stays
+      // honest instead of reporting `previewLen - newPreviewLen` (which
+      // hides the real magnitude of data loss).
+      const tailMatch = text.match(TOOL_RESULT_TRUNCATION_TAIL);
+      const previewBody = tailMatch ? text.slice(0, tailMatch.index) : text;
+      const previousDropped = tailMatch ? Number(tailMatch[1]) : 0;
+      const originalLength = previewBody.length + previousDropped;
+
+      if (previewBody.length <= maxChars) return part;
 
       const toolCallId = String(p.toolCallId ?? "unknown");
-      const filePath = join(resultsDir, `${toolCallId}.txt`);
+      const filePath = tailMatch
+        ? tailMatch[2]!
+        : join(resultsDir, `${toolCallId}.txt`);
 
       if (!persistedIds || !persistedIds.has(toolCallId)) {
-        if (!dirCreated) {
-          mkdirSync(resultsDir, { recursive: true });
-          dirCreated = true;
-        }
-        try {
-          writeFileSync(filePath, text, "utf-8");
-        } catch {
-          // Non-critical: full output may be lost.
+        // If this entry already carried a truncation tail, the full
+        // output was persisted by an earlier pass — `text` is just the
+        // preview, so writing it back would clobber the disk file with
+        // a partial. The earlier path stays the source of truth.
+        if (!tailMatch) {
+          if (!dirCreated) {
+            mkdirSync(resultsDir, { recursive: true });
+            dirCreated = true;
+          }
+          try {
+            writeFileSync(filePath, text, "utf-8");
+          } catch {
+            // Non-critical: full output may be lost.
+          }
         }
         persistedIds?.add(toolCallId);
       }
@@ -116,12 +148,12 @@ export function applyToolResultBudget(
       // making the "truncated" message larger than the original and
       // reporting a negative dropped-char count.
       const previewSize = Math.min(maxChars, 2000);
-      const preview = text.slice(0, previewSize);
+      const preview = previewBody.slice(0, previewSize);
       return {
         ...p,
         output: {
           type: "text" as const,
-          value: `${preview}\n\n[... truncated ${text.length - previewSize} chars — full output saved to ${filePath}]`,
+          value: `${preview}\n\n[... truncated ${originalLength - previewSize} chars — full output saved to ${filePath}]`,
         },
       };
     });

--- a/src/core/ai/contextManagement.ts
+++ b/src/core/ai/contextManagement.ts
@@ -116,18 +116,27 @@ export function applyToolResultBudget(
       const previousDropped = tailMatch ? Number(tailMatch[1]) : 0;
       const originalLength = previewBody.length + previousDropped;
 
-      if (previewBody.length <= maxChars) return part;
+      // Brand-new entries that already fit need no compaction. Re-entries
+      // (`tailMatch !== null`) skip this guard so the cascading thresholds
+      // {10K, 5K, 2K, 500} can each progressively tighten an already-
+      // truncated preview — the monotone-reduction guard below ensures
+      // we never replace with something larger than what's already there.
+      if (!tailMatch && previewBody.length <= maxChars) return part;
 
       const toolCallId = String(p.toolCallId ?? "unknown");
       const filePath = tailMatch
         ? tailMatch[2]!
         : join(resultsDir, `${toolCallId}.txt`);
 
-      // Preview must never exceed `maxChars`, otherwise tighter cascading
-      // thresholds (e.g. 500) would emit the full text plus metadata —
-      // making the "truncated" message larger than the original and
-      // reporting a negative dropped-char count.
-      const previewSize = Math.min(maxChars, 2000);
+      // Preview must scale with `maxChars` so cascading thresholds
+      // {10K, 5K, 2K, 500} achieve progressively tighter compaction on
+      // already-truncated entries (a fixed 2000-char preview would
+      // make the 5K and 2K passes no-ops on entries the 10K pass had
+      // already shrunk to ~2080 chars). 1/5 of the threshold gives:
+      // 10K → 2000-char preview, 5K → 1000, 2K → 400, 500 → 100.
+      // Floor of 100 keeps the smallest preview useful; the
+      // monotone-reduction guard below catches any pathological case.
+      const previewSize = Math.max(100, Math.floor(maxChars / 5));
       const preview = previewBody.slice(0, previewSize);
       const newValue = `${preview}\n\n[... truncated ${originalLength - previewSize} chars — full output saved to ${filePath}]`;
 

--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -51,38 +51,43 @@ export function getMaxOutputTokens(modelId: string): number {
 }
 
 function lookupOutputBudgetByPattern(modelId: string): number {
+  // OpenRouter uses dots in Claude version numbers (anthropic/claude-opus-4.6)
+  // while native Anthropic uses dashes (claude-opus-4-6-20250929). Normalize
+  // digit.digit sequences to dashes so all Claude patterns match both forms.
+  const n = modelId.replace(/(\d)\.(\d)/g, "$1-$2");
+
   // Latest-tier Claude (4.6, 4.7) ship 128K output. Match these BEFORE the
   // generic `claude-opus-4-` / `claude-sonnet-4-` catch-alls below — those
   // exist only as a 32K/64K floor for older 4.x revisions and would
   // otherwise clamp a top-tier model to a 4× smaller budget.
   if (
-    modelId.includes("claude-opus-4-6") ||
-    modelId.includes("claude-opus-4-7") ||
-    modelId.includes("claude-sonnet-4-6") ||
-    modelId.includes("claude-sonnet-4-7")
+    n.includes("claude-opus-4-6") ||
+    n.includes("claude-opus-4-7") ||
+    n.includes("claude-sonnet-4-6") ||
+    n.includes("claude-sonnet-4-7")
   ) {
     return 128_000;
   }
   if (
-    modelId.includes("claude-sonnet-4-5") ||
-    modelId.includes("claude-opus-4-5") ||
-    modelId.includes("claude-haiku-4-5")
+    n.includes("claude-sonnet-4-5") ||
+    n.includes("claude-opus-4-5") ||
+    n.includes("claude-haiku-4-5")
   ) {
     return 64_000;
   }
-  if (modelId.includes("claude-opus-4-1")) {
+  if (n.includes("claude-opus-4-1")) {
     return 32_000;
   }
   if (
-    modelId.includes("claude-sonnet-4-") ||
-    modelId.includes("claude-3-7-sonnet")
+    n.includes("claude-sonnet-4-") ||
+    n.includes("claude-3-7-sonnet")
   ) {
     return 64_000;
   }
-  if (modelId.includes("claude-opus-4-")) {
+  if (n.includes("claude-opus-4-")) {
     return 32_000;
   }
-  if (modelId.includes("claude-3-5-haiku")) {
+  if (n.includes("claude-3-5-haiku") || n.includes("claude-3-5-sonnet")) {
     return 8_192;
   }
 

--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -78,10 +78,7 @@ function lookupOutputBudgetByPattern(modelId: string): number {
   if (n.includes("claude-opus-4-1")) {
     return 32_000;
   }
-  if (
-    n.includes("claude-sonnet-4-") ||
-    n.includes("claude-3-7-sonnet")
-  ) {
+  if (n.includes("claude-sonnet-4-") || n.includes("claude-3-7-sonnet")) {
     return 64_000;
   }
   if (n.includes("claude-opus-4-")) {

--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -85,5 +85,50 @@ function lookupOutputBudgetByPattern(modelId: string): number {
   if (modelId.includes("claude-3-5-haiku")) {
     return 8_192;
   }
+
+  // OpenAI families. `getMaxOutputTokens` is now the single source of truth
+  // for both `streamResponse`'s budget math AND the value passed as
+  // `maxOutputTokens` to `streamText`, so an underestimate here would make
+  // `fitMessagesToContext` overly permissive on input — exactly the
+  // overflow class this PR closes. Defaults below come from each family's
+  // documented max output; the per-model `contextLength` clamp in
+  // `getMaxOutputTokens` handles legacy small-window variants.
+  if (modelId.includes("gpt-5")) {
+    return 128_000;
+  }
+  if (modelId.includes("gpt-4.1")) {
+    return 32_000;
+  }
+  if (modelId.includes("gpt-4o")) {
+    return 16_000;
+  }
+  // Reasoning models (o1 / o3 / o4-*) emit up to ~100K incl. reasoning tokens.
+  if (
+    /\bo1\b/.test(modelId) ||
+    /\bo3(\b|-)/.test(modelId) ||
+    /\bo4(\b|-)/.test(modelId)
+  ) {
+    return 100_000;
+  }
+  if (modelId.includes("gpt-3.5")) {
+    return 4_096;
+  }
+
+  // Google Gemini families.
+  if (modelId.includes("gemini-3")) {
+    return 64_000;
+  }
+  if (modelId.includes("gemini-2.5")) {
+    return 65_000;
+  }
+  if (
+    modelId.includes("gemini-2.0") ||
+    modelId.includes("gemini-1.5") ||
+    modelId.includes("gemini-pro") ||
+    modelId.includes("gemini-flash")
+  ) {
+    return 8_192;
+  }
+
   return 4_096;
 }

--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -51,9 +51,15 @@ export function getMaxOutputTokens(modelId: string): number {
 }
 
 function lookupOutputBudgetByPattern(modelId: string): number {
+  // Latest-tier Claude (4.6, 4.7) ship 128K output. Match these BEFORE the
+  // generic `claude-opus-4-` / `claude-sonnet-4-` catch-alls below — those
+  // exist only as a 32K/64K floor for older 4.x revisions and would
+  // otherwise clamp a top-tier model to a 4× smaller budget.
   if (
     modelId.includes("claude-opus-4-6") ||
-    modelId.includes("claude-sonnet-4-6")
+    modelId.includes("claude-opus-4-7") ||
+    modelId.includes("claude-sonnet-4-6") ||
+    modelId.includes("claude-sonnet-4-7")
   ) {
     return 128_000;
   }

--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -31,3 +31,53 @@ export function getModelInfo(model: AIModel): ModelInfo {
     }
   );
 }
+
+/**
+ * Single source of truth for a model's default `max_tokens`. Both
+ * `streamResponse`'s budget and the Pensar gateway formatter must agree,
+ * so the lookup lives next to the registry it queries against.
+ *
+ * Adding a Claude model? Add a pattern AND a regression row in
+ * `models.test.ts:"recognizes Claude tier-specific budgets"`.
+ */
+export function getMaxOutputTokens(modelId: string): number {
+  const fromPattern = lookupOutputBudgetByPattern(modelId);
+  const ctx = AVAILABLE_MODELS.find((m) => m.id === modelId)?.contextLength;
+  // Reserve ≥25% of the window for input on tiny-context legacy models.
+  if (ctx && fromPattern >= ctx * 0.75) {
+    return Math.floor(ctx * 0.5);
+  }
+  return fromPattern;
+}
+
+function lookupOutputBudgetByPattern(modelId: string): number {
+  if (
+    modelId.includes("claude-opus-4-6") ||
+    modelId.includes("claude-sonnet-4-6")
+  ) {
+    return 128_000;
+  }
+  if (
+    modelId.includes("claude-sonnet-4-5") ||
+    modelId.includes("claude-opus-4-5") ||
+    modelId.includes("claude-haiku-4-5")
+  ) {
+    return 64_000;
+  }
+  if (modelId.includes("claude-opus-4-1")) {
+    return 32_000;
+  }
+  if (
+    modelId.includes("claude-sonnet-4-") ||
+    modelId.includes("claude-3-7-sonnet")
+  ) {
+    return 64_000;
+  }
+  if (modelId.includes("claude-opus-4-")) {
+    return 32_000;
+  }
+  if (modelId.includes("claude-3-5-haiku")) {
+    return 8_192;
+  }
+  return 4_096;
+}

--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -121,6 +121,19 @@ function lookupOutputBudgetByPattern(modelId: string): number {
   if (modelId.includes("gemini-2.5")) {
     return 65_000;
   }
+  // Version-less `*-latest` aliases (registered with 1M context) point to
+  // current top-tier Gemini, NOT the legacy 2.0/1.5 generations. Match
+  // these BEFORE the `gemini-pro` / `gemini-flash` catch-alls below,
+  // otherwise they'd inherit the 8192-token legacy budget — and since
+  // `getMaxOutputTokens` is now passed explicitly to `streamText`, that
+  // would hard-cap them at 8K instead of the 65K modern default.
+  if (
+    modelId === "gemini-pro-latest" ||
+    modelId === "gemini-flash-latest" ||
+    modelId === "gemini-flash-lite-latest"
+  ) {
+    return 65_000;
+  }
   if (
     modelId.includes("gemini-2.0") ||
     modelId.includes("gemini-1.5") ||

--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -84,6 +84,16 @@ function lookupOutputBudgetByPattern(modelId: string): number {
   if (n.includes("claude-opus-4-")) {
     return 32_000;
   }
+  // Bare `claude-{sonnet,opus}-4` (OpenRouter) — generation 4 with no tier
+  // suffix. Anthropic-canonical IDs always carry a date / `-v1` suffix so
+  // they hit the dashed branches above; the negative-lookahead ensures the
+  // bare-form branches only trigger when nothing follows the `-4`.
+  if (/claude-sonnet-4(?![-\d])/.test(n)) {
+    return 64_000;
+  }
+  if (/claude-opus-4(?![-\d])/.test(n)) {
+    return 32_000;
+  }
   if (n.includes("claude-3-5-haiku") || n.includes("claude-3-5-sonnet")) {
     return 8_192;
   }

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -60,6 +60,17 @@ describe("getMaxOutputTokens", () => {
     );
   });
 
+  it("matches OpenRouter Claude IDs that use dots instead of dashes", () => {
+    // OpenRouter uses dots in version numbers (anthropic/claude-opus-4.6)
+    // while native Anthropic uses dashes (claude-opus-4-6). Both must resolve
+    // to the same budget — not fall through to the 4,096 default.
+    expect(getMaxOutputTokens("anthropic/claude-opus-4.6")).toBe(128_000);
+    expect(getMaxOutputTokens("anthropic/claude-sonnet-4.5")).toBe(64_000);
+    expect(getMaxOutputTokens("anthropic/claude-opus-4.5")).toBe(64_000);
+    expect(getMaxOutputTokens("anthropic/claude-haiku-4.5")).toBe(64_000);
+    expect(getMaxOutputTokens("anthropic/claude-3.5-sonnet")).toBe(8_192);
+  });
+
   it("recognizes OpenAI family budgets", () => {
     // Bugbot flagged that the 4096 catch-all underestimated non-Claude
     // output budgets, making `fitMessagesToContext` overly permissive on

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -71,6 +71,22 @@ describe("getMaxOutputTokens", () => {
     expect(getMaxOutputTokens("anthropic/claude-3.5-sonnet")).toBe(8_192);
   });
 
+  it("matches bare generation-4 Claude IDs (OpenRouter, no tier suffix)", () => {
+    // OpenRouter ships `anthropic/claude-sonnet-4` and
+    // `anthropic/claude-opus-4` — IDs with NO tier-revision suffix.
+    // Anthropic-canonical IDs always carry a date / `-v1` suffix so they
+    // hit the dashed `claude-{tier}-4-` branches; the bare-gen-4 variants
+    // would otherwise fall through to the 4,096 catch-all (and now that
+    // `getMaxOutputTokens` is passed explicitly to `streamText`, get
+    // hard-capped at 4K instead of the documented per-tier limit).
+    expect(getMaxOutputTokens("anthropic/claude-sonnet-4")).toBe(64_000);
+    expect(getMaxOutputTokens("anthropic/claude-opus-4")).toBe(32_000);
+    // Negative-lookahead must NOT misfire on the dashed canonical
+    // forms: `claude-sonnet-4-5` still resolves via the explicit branch.
+    expect(getMaxOutputTokens("anthropic/claude-sonnet-4-5")).toBe(64_000);
+    expect(getMaxOutputTokens("anthropic/claude-opus-4-1")).toBe(32_000);
+  });
+
   it("recognizes OpenAI family budgets", () => {
     // Bugbot flagged that the 4096 catch-all underestimated non-Claude
     // output budgets, making `fitMessagesToContext` overly permissive on

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+
+import { AVAILABLE_MODELS, getMaxOutputTokens } from "./index";
+
+describe("getMaxOutputTokens", () => {
+  it("returns a positive value for every model in AVAILABLE_MODELS", () => {
+    for (const model of AVAILABLE_MODELS) {
+      const max = getMaxOutputTokens(model.id);
+      expect(max, `model=${model.id}`).toBeGreaterThan(0);
+    }
+  });
+
+  it("never returns a value ≥ contextLength (would zero out input budget)", () => {
+    for (const model of AVAILABLE_MODELS) {
+      if (!model.contextLength) continue;
+      const max = getMaxOutputTokens(model.id);
+      expect(
+        max,
+        `${model.id}: max_output (${max}) must be < context (${model.contextLength})`,
+      ).toBeLessThan(model.contextLength);
+    }
+  });
+
+  it("leaves ≥50K input headroom on every Anthropic model", () => {
+    // Catches new Claude models silently inheriting the 4_096 default.
+    const MIN = 50_000;
+    for (const model of AVAILABLE_MODELS) {
+      if (model.provider !== "anthropic" || !model.contextLength) continue;
+      const headroom = model.contextLength - getMaxOutputTokens(model.id);
+      expect(
+        headroom,
+        `${model.id}: headroom=${headroom}`,
+      ).toBeGreaterThanOrEqual(MIN);
+    }
+  });
+
+  it("recognizes Claude tier-specific budgets", () => {
+    expect(getMaxOutputTokens("claude-sonnet-4-5-20250929")).toBe(64_000);
+    expect(getMaxOutputTokens("claude-opus-4-5-20250101")).toBe(64_000);
+    expect(getMaxOutputTokens("claude-haiku-4-5-20251001")).toBe(64_000);
+    expect(getMaxOutputTokens("claude-opus-4-1-20250805")).toBe(32_000);
+    expect(getMaxOutputTokens("claude-3-7-sonnet-20250219")).toBe(64_000);
+    expect(getMaxOutputTokens("claude-3-5-haiku-20241022")).toBe(8_192);
+  });
+
+  it("falls back to a small default for unknown providers", () => {
+    expect(getMaxOutputTokens("gpt-4o-mini")).toBe(4_096);
+    expect(getMaxOutputTokens("gemini-2.5-pro")).toBe(4_096);
+    expect(getMaxOutputTokens("totally-unknown-model")).toBe(4_096);
+  });
+});

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -84,6 +84,13 @@ describe("getMaxOutputTokens", () => {
     expect(getMaxOutputTokens("gemini-2.5-flash")).toBe(65_000);
     expect(getMaxOutputTokens("gemini-2.0-flash")).toBe(8_192);
     expect(getMaxOutputTokens("gemini-3-pro-preview")).toBe(64_000);
+    // `*-latest` aliases (1M context) must NOT inherit the 8K legacy
+    // catch-all — they resolve to current top-tier Gemini at the
+    // provider, so getMaxOutputTokens (now passed explicitly to
+    // streamText) must match the 65K modern default.
+    expect(getMaxOutputTokens("gemini-pro-latest")).toBe(65_000);
+    expect(getMaxOutputTokens("gemini-flash-latest")).toBe(65_000);
+    expect(getMaxOutputTokens("gemini-flash-lite-latest")).toBe(65_000);
   });
 
   it("falls back to a small default for genuinely unknown providers", () => {

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -43,6 +43,23 @@ describe("getMaxOutputTokens", () => {
     expect(getMaxOutputTokens("claude-3-5-haiku-20241022")).toBe(8_192);
   });
 
+  it("pins latest-tier Claude (4.6 + 4.7) to 128K output", () => {
+    // These four ship the 128K window; they MUST not fall through to the
+    // generic `claude-opus-4-` / `claude-sonnet-4-` catch-alls (32K/64K)
+    // and silently get clamped to a 4× smaller budget. Pensar-prefixed
+    // IDs go through the same lookup, so cover them too.
+    expect(getMaxOutputTokens("claude-opus-4-6-v1")).toBe(128_000);
+    expect(getMaxOutputTokens("claude-opus-4-7")).toBe(128_000);
+    expect(getMaxOutputTokens("claude-sonnet-4-6-v1")).toBe(128_000);
+    expect(getMaxOutputTokens("claude-sonnet-4-7")).toBe(128_000);
+    expect(getMaxOutputTokens("pensar:anthropic.claude-opus-4-7")).toBe(
+      128_000,
+    );
+    expect(getMaxOutputTokens("pensar:anthropic.claude-opus-4-6-v1")).toBe(
+      128_000,
+    );
+  });
+
   it("falls back to a small default for unknown providers", () => {
     expect(getMaxOutputTokens("gpt-4o-mini")).toBe(4_096);
     expect(getMaxOutputTokens("gemini-2.5-pro")).toBe(4_096);

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -60,9 +60,33 @@ describe("getMaxOutputTokens", () => {
     );
   });
 
-  it("falls back to a small default for unknown providers", () => {
-    expect(getMaxOutputTokens("gpt-4o-mini")).toBe(4_096);
-    expect(getMaxOutputTokens("gemini-2.5-pro")).toBe(4_096);
+  it("recognizes OpenAI family budgets", () => {
+    // Bugbot flagged that the 4096 catch-all underestimated non-Claude
+    // output budgets, making `fitMessagesToContext` overly permissive on
+    // input. Pin the per-family values so future families (gpt-6, etc.)
+    // can't silently inherit the small fallback again.
+    expect(getMaxOutputTokens("gpt-5")).toBe(128_000);
+    expect(getMaxOutputTokens("gpt-5-mini")).toBe(128_000);
+    expect(getMaxOutputTokens("gpt-4.1")).toBe(32_000);
+    expect(getMaxOutputTokens("gpt-4o")).toBe(16_000);
+    expect(getMaxOutputTokens("gpt-4o-mini")).toBe(16_000);
+    expect(getMaxOutputTokens("gpt-3.5-turbo")).toBe(4_096);
+    expect(getMaxOutputTokens("o1")).toBe(100_000);
+    expect(getMaxOutputTokens("o3")).toBe(100_000);
+    expect(getMaxOutputTokens("o4-mini")).toBe(100_000);
+    // `o3-mini` has only 128K context — `getMaxOutputTokens` clamps the
+    // 100K pattern down to 50% of the window so input keeps headroom.
+    expect(getMaxOutputTokens("o3-mini")).toBe(64_000);
+  });
+
+  it("recognizes Google Gemini family budgets", () => {
+    expect(getMaxOutputTokens("gemini-2.5-pro")).toBe(65_000);
+    expect(getMaxOutputTokens("gemini-2.5-flash")).toBe(65_000);
+    expect(getMaxOutputTokens("gemini-2.0-flash")).toBe(8_192);
+    expect(getMaxOutputTokens("gemini-3-pro-preview")).toBe(64_000);
+  });
+
+  it("falls back to a small default for genuinely unknown providers", () => {
     expect(getMaxOutputTokens("totally-unknown-model")).toBe(4_096);
   });
 });

--- a/src/core/ai/providers/pensarFormatters.ts
+++ b/src/core/ai/providers/pensarFormatters.ts
@@ -5,6 +5,7 @@ import type {
   LanguageModelV3TextPart,
   LanguageModelV3ToolResultPart,
 } from "@ai-sdk/provider";
+import { getMaxOutputTokens } from "../models";
 
 export function convertToBedrockFormat(
   modelId: string,
@@ -16,38 +17,6 @@ export function convertToBedrockFormat(
 
   // Fallback: attempt Anthropic format for unknown models
   return convertToAnthropicFormat(modelId, options);
-}
-
-function getDefaultMaxOutputTokens(modelId: string): number {
-  if (
-    modelId.includes("claude-opus-4-6") ||
-    modelId.includes("claude-sonnet-4-6")
-  ) {
-    return 128_000;
-  }
-  if (
-    modelId.includes("claude-sonnet-4-5") ||
-    modelId.includes("claude-opus-4-5") ||
-    modelId.includes("claude-haiku-4-5")
-  ) {
-    return 64_000;
-  }
-  if (modelId.includes("claude-opus-4-1")) {
-    return 32_000;
-  }
-  if (
-    modelId.includes("claude-sonnet-4-") ||
-    modelId.includes("claude-3-7-sonnet")
-  ) {
-    return 64_000;
-  }
-  if (modelId.includes("claude-opus-4-")) {
-    return 32_000;
-  }
-  if (modelId.includes("claude-3-5-haiku")) {
-    return 8_192;
-  }
-  return 4_096;
 }
 
 const EPHEMERAL_CACHE_CONTROL = { type: "ephemeral" as const };
@@ -185,7 +154,7 @@ function convertToAnthropicFormat(
   const body: Record<string, unknown> = {
     anthropic_version: "bedrock-2023-05-31",
     messages,
-    max_tokens: options.maxOutputTokens ?? getDefaultMaxOutputTokens(modelId),
+    max_tokens: options.maxOutputTokens ?? getMaxOutputTokens(modelId),
   };
 
   if (systemPrompt) {

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -1,6 +1,9 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import { streamResponse, type AIModel, type StreamResponseOpts } from "./ai";
-import { extractTaskSummaryFromMessages } from "./contextManagement";
+import {
+  extractTaskSummaryFromMessages,
+  truncateWithMarker,
+} from "./contextManagement";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
@@ -300,32 +303,69 @@ export async function summarizeConversation(
     })
     .filter(Boolean) as ModelMessage[];
 
-  let slicedMessages: ModelMessage[] = [];
+  // Hard caps so summarization can never itself overflow.
+  // ~30K chars ≈ ~7.5K tokens — well below any model's window.
+  const MAX_PER_MESSAGE_CHARS = 4_000;
+  const MAX_SLICED_TOTAL_CHARS = 25_000;
+  const SYSTEM_PROMPT_SNIPPET_CHARS = 2_000;
+
+  const truncateMessageContent = (msg: ModelMessage): ModelMessage => {
+    // Tool-role messages require array content; nothing to truncate by char count.
+    if (msg.role === "tool" || typeof msg.content !== "string") return msg;
+    if (msg.content.length <= MAX_PER_MESSAGE_CHARS) return msg;
+    return {
+      ...msg,
+      content: truncateWithMarker(msg.content, MAX_PER_MESSAGE_CHARS),
+    };
+  };
+
+  let slicedMessages: ModelMessage[];
   if (
     cleanMessages.length === 1 &&
     typeof cleanMessages[0]!.content === "string"
   ) {
-    // For a single message with very long content, take just the last portion
     const content = cleanMessages[0]!.content;
     const lines = content.split("\n");
-    const truncatedContent = lines.slice(-50).join("\n"); // Last 50 lines
-
+    const truncatedContent = lines.slice(-50).join("\n");
     slicedMessages = [
-      {
+      truncateMessageContent({
         role: "user",
         content: truncatedContent,
-      },
+      }),
     ];
   } else {
-    // Take the last 20 messages for context
-    slicedMessages = cleanMessages.slice(-20);
+    // Last 20 messages, drop from the front until cumulative budget fits.
+    const candidate = cleanMessages.slice(-20).map(truncateMessageContent);
+    let totalChars = 0;
+    for (const msg of candidate) {
+      totalChars +=
+        typeof msg.content === "string"
+          ? msg.content.length
+          : JSON.stringify(msg.content ?? "").length;
+    }
+    let trimmed = candidate;
+    while (totalChars > MAX_SLICED_TOTAL_CHARS && trimmed.length > 1) {
+      const dropped = trimmed[0]!;
+      const droppedChars =
+        typeof dropped.content === "string"
+          ? dropped.content.length
+          : JSON.stringify(dropped.content ?? "").length;
+      totalChars -= droppedChars;
+      trimmed = trimmed.slice(1);
+    }
+    slicedMessages = trimmed;
   }
+
+  const systemSnippet = truncateWithMarker(
+    opts.system ?? "",
+    SYSTEM_PROMPT_SNIPPET_CHARS,
+  );
 
   const summarizedMessages: ModelMessage[] = [
     ...slicedMessages,
     {
       role: "user",
-      content: `Summarize this conversation to pass to another agent. This was the system prompt: ${opts.system} `,
+      content: `Summarize this conversation to pass to another agent. This was the original system prompt (truncated for safety): ${systemSnippet}`,
     },
   ];
 
@@ -385,12 +425,13 @@ export async function summarizeConversation(
   // Notify callers that context was reset so they can discard stale history.
   opts.onSummarized?.(summary);
 
-  // streamResponse always wraps with error handling, so if this call
-  // also hits context length limits, it will recursively summarize again
+  // Bump depth so a recursive overflow eventually trips
+  // `ContextLengthExhaustedError` instead of looping forever.
   const resumed = streamResponse({
     ...opts,
     prompt: enhancedPrompt,
     messages: undefined,
+    _restartDepth: (opts._restartDepth ?? 0) + 1,
   });
   return resumed;
 }


### PR DESCRIPTION
## Summary

Production was emitting recurring context-length errors:

```
[AI_APICallError]   prompt is too long: 201755 tokens > 200000 maximum
[AI_RetryError]     Failed after 2 attempts ... prompt is too long: 210190 tokens > 200000 maximum
[AI_RetryError]     Failed after 2 attempts ... prompt is too long: 213021 tokens > 200000 maximum
[AI_ToolCallRepairError] Error repairing tool call: ...
```

The 1–7% overshoots (201K → 213K against a 200K window) traced to three compounding causes. This PR replaces the heuristics with structural invariants so the bug class can't recur — every code path that can construct provider input now either fits-by-construction or escalates with a typed terminal signal.

## Root cause analysis

The previous fix layered Layer 1 (tool-result truncation) + Layer 2 (step snipping) + Layer 3 (full summarization), and they did work — when invoked. But three things let oversized prompts still reach the provider:

### 1. Tool-schema overhead was not counted toward the budget
`fitMessagesToContext` reserved a fixed `5_000`-token constant for "everything else" (tool definitions + envelope). Apex's offensive-security agent has 15+ tools with detailed descriptions and Zod schemas — actual schema overhead is **15–25K tokens**, not 5K. So the proactive fit thought it had ~120K tokens of headroom for messages when reality was ~100K. A history that fit "comfortably" by our math overflowed the provider by exactly the gap (~1–7%, matching the production logs).

### 2. Reactive-only compaction (`fitsBudget=false` was treated as advisory)
When `fitMessagesToContext` returned `fitsBudget: false`, `streamResponse` still passed those messages to `streamText`. The doomed call hit the provider, the SDK threw `AI_APICallError`, and only **then** did recovery run. Every overshoot in the logs was a "send-and-pray" pattern at one level deeper than the user-visible call site.

### 3. Recovery paths could themselves overflow
- `summarizeConversation` embedded the full `opts.system` (often 50K+ chars for the operator/pentest prompt) verbatim in a user message, then sliced the last 20 messages with no size cap. A single 100K-char assistant turn walked through.
- `experimental_repairToolCall` embedded `toolCall.input` raw — a tool that takes a multi-megabyte content field (`write_file`, `http_request` body, `execute_command` heredocs) blew the repair `generateText` call.
- The `summarize → resume → still over budget → summarize` chain had no termination condition; it could loop indefinitely or stack-overflow.

## How this fixes the issue

The fix converts "context fits the budget" from a heuristic property to a structural invariant. Every site that can send oversized input is guarded by a check that either fits it or escalates with a typed signal — never sends and prays.

### Invariants now enforced

| # | Invariant | Enforcement |
|---|-----------|-------------|
| **I1** | `estimate(input) + max_output + safety ≤ contextWindow` before any provider call | `streamResponse` calls `fitMessagesToContext` proactively; `fitsBudget=false` routes to summarization **before** `streamText` (closes RCA 2) |
| **I2** | Compaction is monotone — never claims success on unchanged-and-still-over input | `fitMessagesToContext` returns `{ messages, modified, fitsBudget }`; tested |
| **I3** | Auxiliary LLM calls (summarization, repair) have hard caps independent of caller input | `MAX_PER_MESSAGE_CHARS = 4_000`, `MAX_SLICED_TOTAL_CHARS = 25_000`, `SYSTEM_PROMPT_SNIPPET_CHARS = 2_000`, `MAX_TOOL_INPUT_CHARS = 8_000`, `MAX_SCHEMA_CHARS = 6_000` (closes RCA 3, parts a/b) |
| **I4** | Any failure in any context-recovery path is caught at the `streamResponse` boundary | `wrapStreamWithErrorHandler` wraps **both** the post-`streamText` path AND the proactive-summarization escalation. Pinned by `ai.proactive-recovery.test.ts`. |
| **I5** | `streamResponse` ↔ Pensar gateway formatter agree on `max_output_tokens` | Single source of truth: `models/index.ts:getMaxOutputTokens`, imported by both consumers. Self-clamps against `contextLength` (catches legacy Bedrock models with tiny windows). |
| **I6** | Every model in `AVAILABLE_MODELS` has a sane budget | Exhaustive registry test (`models.test.ts`) iterates registry; fails if any model has `max ≥ ctx` or insufficient input headroom. |
| **I7** | `streamResponse` always counts tool-schema overhead toward the budget | `fitMessagesToContext` accepts `tools: ToolSet`; `estimateToolsOverheadTokens` derives overhead from the actual schemas (closes RCA 1). |
| **I8** | Recursive recovery is bounded | `_restartDepth` plumbed through `StreamResponseOpts`, bumped at every summarize→resume boundary. Past `MAX_RESTART_DEPTH=3`, throws typed `ContextLengthExhaustedError`. |

### State machine

```
[pre-flight fit] ──fits──→ send ─ok─→ done
       │                     │ ctx_err
       │                     ↓
       │              [reactive fit]
       │                fits → retry → done
       │                not_fits → Layer 3 summarize
       │                              ok → continue
       │                              fail → minimal-restart (bumps _restartDepth)
       │                                       depth ≤ MAX → loop
       │                                       depth > MAX → ContextLengthExhaustedError (typed terminal)
       └──not_fits──→ proactive summarize (also wrapped) → same recovery as above
```

Every edge that touches a provider goes through `fitMessagesToContext` or a hard char cap. The only context-related error allowed to escape `streamResponse` is the typed `ContextLengthExhaustedError` — never a raw `AI_APICallError prompt is too long`.

## Files changed

| File | Net change | What it does |
|------|------------|---------------|
| `src/core/ai/contextManagement.ts` | +258 | New `fitMessagesToContext` primitive; token estimators including `estimateToolsOverheadTokens` (memoized via `WeakMap<ToolSet, number>`); shared `truncateWithMarker` helper; Layer 1 cascading thresholds share `persistedIds: Set` so the same toolCallId is written to disk at most once per fit |
| `src/core/ai/ai.ts` | +193 / −0 (net) | Proactive escalation; reactive recovery uses same primitive; bounded repair-call inputs; `_restartDepth` plumbing; typed `ContextLengthExhaustedError`; proactive-summarization stream wrapped through `wrapStreamWithErrorHandler` |
| `src/core/ai/utils.ts` | +65 / −0 (net) | Bounded `summarizeConversation` (per-message + cumulative caps + system snippet); depth bump on resumed call |
| `src/core/ai/models/index.ts` | +50 | `getMaxOutputTokens` single-source-of-truth + self-clamp |
| `src/core/ai/providers/pensarFormatters.ts` | +35 / −35 | Removes duplicate `getDefaultMaxOutputTokens`; imports canonical helper |

### New tests

| File | Pins |
|------|------|
| `src/core/ai/contextManagement.test.ts` | The primitive: budget math, Layer 1 triggers on huge tool results, tools-overhead derived from `ToolSet`, reference-equality on no-op |
| `src/core/ai/ai.contract.test.ts` | Recursion bound: `_restartDepth > MAX` → synchronous `ContextLengthExhaustedError` carrying the depth |
| `src/core/ai/ai.proactive-recovery.test.ts` | I4 on the proactive path: a context error inside the proactive-summarization stream is caught by the wrapper; exhausted recovery surfaces `ContextLengthExhaustedError`, never the raw provider error |
| `src/core/ai/models/models.test.ts` | Every model has `max < ctx` and ≥50K input headroom; tier-specific Claude budgets are pinned |

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun run test` — 959 passed, 16 skipped (pre-existing API-key-gated integration tests)
- [ ] Production validation after merge:
  - Day-1 log search for `AI_APICallError.*prompt is too long` should drop to zero
  - Watch for any new `ContextLengthExhaustedError` (typed terminal — signals the agent hit a genuinely unrecoverable input shape, surfaces a clean error rather than a raw SDK trace)
  - Watch the `Proactive context fit returned fitsBudget=false` warning as an early signal of input shapes that needed escalation

## Risks

| Risk | Mitigation | Severity |
|------|-----------|----------|
| chars/4 token estimate drifts on code-dense content | 10K-token safety margin + reactive path with same estimator + depth bound | Low |
| Proactive escalation fires on borderline cases that previously slipped through | Those would have failed anyway; this prevents the bad call instead of recovering from it | None — strictly an improvement |
| `MAX_RESTART_DEPTH=3` caps recovery in pathological cases | Typed error preferable to infinite loop; 3 cycles is generous | Low |
| `getMaxOutputTokens` clamp tightens output on legacy Bedrock models (e.g. cohere with ctx=4000) | Not actively used in Apex routing | None |

## Out of scope (follow-up)

The structural fix closes the production bug class. The following are quality-of-life follow-ups, not blockers:

- **Layer 2.5**: per-tool-call-input + per-text-part caps in conversation history (closes the theoretical "single huge agent-generated message" path; would convert any remaining `ContextLengthExhaustedError` from agent self-growth into transparent recovery)
- **Per-tool structure-aware Layer 1 previews**: replace head-only truncation with extractor-per-tool (status/exit-code/findings preservation)
- **`read_tool_result` tool**: lets the agent fetch the full disk-persisted output of a truncated tool call by `toolCallId` when it realizes truncation removed something it needs


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `streamResponse` request/recovery logic and model output-token budgeting, which can change production behavior (when/if summarization triggers and how errors propagate). Main risk is unintended escalation/termination in edge cases or overly aggressive truncation, though changes are heavily pinned by new unit tests.
> 
> **Overview**
> Prevents oversized prompts from reaching providers by adding **proactive context fitting** before `streamText` and escalating directly to summarization when Layer 1+2 can’t fit the budget.
> 
> Hardens the context-length recovery state machine: all summarization entry points (proactive, reactive, and outer `try/catch`) are now wrapped so raw provider “prompt is too long” errors don’t leak, recovery recursion is **bounded** via `_restartDepth` and a typed terminal `ContextLengthExhaustedError`, and summarization failures fall back to a minimal-context restart.
> 
> Improves budget correctness and safety caps: introduces `fitMessagesToContext` with token estimation that includes **tool/schema overhead**, makes Layer 1 truncation cascaded/monotone with correct metadata + deduped persistence, adds strict char caps for summarization and tool-call repair inputs, and centralizes per-model `maxOutputTokens` via `getMaxOutputTokens` (used by both `streamResponse` and Pensar formatting) with exhaustive tests pinning model budgets and invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73586546f7b5eb68741847feef283a2279cbfdad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->