### PR TITLE
ci: integration-ci to bun (unblock apex PRs after console migration)

### DIFF
--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -55,17 +55,19 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
 
       - name: Install console dependencies
         working-directory: console
-        run: npm install
+        run: bun install --frozen-lockfile
 
       - name: Install SST providers
         working-directory: console
         run: |
-          npx sst version
-          npx sst install
+          bun sst version
+          bun sst install
 
       - name: Typecheck console
         working-directory: console
-        run: npm run tsc
+        run: bun run tsc


### PR DESCRIPTION
## Summary
- Console migrated from npm to bun in pensarai/console#1473 and removed package-lock.json.
- Apex's `integration-ci` workflow still ran `npm install` against the console checkout, which now fails with ERESOLVE on the openai@5.x ↔ zod@4.x peer-dep conflict that bun resolves cleanly.
- Switch the workflow to `bun install --frozen-lockfile`, `bun sst install`, and `bun run tsc` to match console's own CI. Pin `bun-version: 1.3.10` to match console.

## Repro
The failing job on recent apex PRs:
```
npm error code ERESOLVE
npm error While resolving: openai@5.23.2
npm error Found: zod@4.4.3
npm error peerOptional zod@^3.23.8 from openai@5.23.2
```

## Test plan
- [ ] Integration CI on this PR passes (clones console main, runs `bun install` + `bun run tsc`).
- [ ] No regression in apex's own checks (this only changes integration-ci.yml).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that swap package manager commands and pin Bun; impact is limited to CI execution and could only affect dependency install/typecheck behavior in the integration job.
> 
> **Overview**
> Updates `integration-ci` to run the downstream console typecheck using Bun instead of npm/npx.
> 
> Pins `bun-version: 1.3.10`, switches dependency install to `bun install --frozen-lockfile`, and runs SST provider install and `tsc` via `bun` to align with the console repo’s Bun-based tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6da7fb4920071739211f967c044e8e5830c6a80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->