### PR TITLE
feat(eventBus): track parent/child relationships across nested subagents

### DIFF
--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -222,6 +222,7 @@ When to use delegate_to_auth_subagent vs authenticate_session:
         ctx.eventBus?.emit("subagent-spawn", {
           subagentId,
           input: { target, reason },
+          parentSubagentId: ctx.subagentId,
         });
 
         console.log(`\n🔐 Delegating to authentication subagent...`);
@@ -319,6 +320,7 @@ When to use delegate_to_auth_subagent vs authenticate_session:
         ctx.eventBus?.emit("subagent-complete", {
           subagentId,
           status: result.success ? "completed" : "failed",
+          parentSubagentId: ctx.subagentId,
         });
 
         if (result.success) {
@@ -385,6 +387,7 @@ When to use delegate_to_auth_subagent vs authenticate_session:
         ctx.eventBus?.emit("subagent-complete", {
           subagentId: "auth-agent",
           status: "failed",
+          parentSubagentId: ctx.subagentId,
         });
 
         const errorMessage =

--- a/src/core/agents/offSecAgent/tools/documentApp.ts
+++ b/src/core/agents/offSecAgent/tools/documentApp.ts
@@ -65,8 +65,8 @@ function validateDomainUrl(value: string): {
  * Documents a discovered application during attack surface analysis —
  * writes a JSON file to the session's apps directory. This tool is
  * specifically for application-level entities (web apps, APIs, admin panels,
- * services) and is designed for incremental creation via the MessageManager
- * in Console.
+ * services) and is designed for incremental creation via the agent log
+ * persister in Console.
  */
 export function documentApp(ctx: ToolContext) {
   const baseAppsPath = join(ctx.session.rootPath, "apps");

--- a/src/core/agents/offSecAgent/tools/documentEndpoint.ts
+++ b/src/core/agents/offSecAgent/tools/documentEndpoint.ts
@@ -103,7 +103,7 @@ type DocumentEndpointInput = z.infer<typeof documentEndpointInputSchema>;
  * Documents a discovered endpoint during attack surface analysis —
  * writes a JSON file to the session's assets directory (scoped by
  * app name). This tool is specifically for individual endpoints and
- * is designed for incremental creation via the MessageManager in Console.
+ * is designed for incremental creation via the agent log persister in Console.
  */
 export function documentEndpoint(ctx: ToolContext) {
   const baseAssetsPath = join(ctx.session.rootPath, "assets");

--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -182,7 +182,7 @@ export { ASK_USER_QUESTIONS_TOOL_NAME } from "./askUserQuestions";
  * pick which ones to activate via the `activeTools` string array — the
  * AI SDK handles the filtering at the model level.
  */
-export function createAllTools(ctx: ToolContext & { subagentId?: string }) {
+export function createAllTools(ctx: ToolContext) {
   return {
     // Browser automation tools (8 tools from Playwright MCP)
     ...createBrowserToolset(ctx),

--- a/src/core/agents/offSecAgent/tools/runAttackSurface.ts
+++ b/src/core/agents/offSecAgent/tools/runAttackSurface.ts
@@ -57,6 +57,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
       ctx.eventBus?.emit("subagent-spawn", {
         subagentId,
         input: { target, cwd },
+        parentSubagentId: ctx.subagentId,
       });
 
       // -----------------------------------------------------------------------
@@ -100,6 +101,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
           ctx.eventBus?.emit("subagent-complete", {
             subagentId,
             status: "completed",
+            parentSubagentId: ctx.subagentId,
           });
 
           return {
@@ -118,6 +120,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
           ctx.eventBus?.emit("subagent-complete", {
             subagentId,
             status: "failed",
+            parentSubagentId: ctx.subagentId,
           });
 
           return {
@@ -161,6 +164,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
         ctx.eventBus?.emit("subagent-complete", {
           subagentId,
           status: "completed",
+          parentSubagentId: ctx.subagentId,
         });
 
         return {
@@ -185,6 +189,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
         ctx.eventBus?.emit("subagent-complete", {
           subagentId,
           status: "failed",
+          parentSubagentId: ctx.subagentId,
         });
 
         return {

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -162,6 +162,7 @@ async function runSingleCodingAgent(
     subagentId,
     name,
     input: { codebasePath, objective },
+    parentSubagentId: ctx.subagentId,
   });
 
   const localBus = new AgentEventBus();
@@ -189,6 +190,7 @@ async function runSingleCodingAgent(
     ctx.eventBus?.emit("subagent-complete", {
       subagentId,
       status: "completed",
+      parentSubagentId: ctx.subagentId,
     });
 
     return textOutput;
@@ -196,6 +198,7 @@ async function runSingleCodingAgent(
     ctx.eventBus?.emit("subagent-complete", {
       subagentId,
       status: "failed",
+      parentSubagentId: ctx.subagentId,
     });
     throw error;
   }

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -306,10 +306,14 @@ export async function generateThreatModelForEndpoint(
 
     const subagentId = `threat-model-${sanitize(input.appName)}-${sanitize(input.routePath)}`;
 
+    console.log(
+      `[threatModel] emit subagent-spawn id="${subagentId}" parent="${ctx.subagentId ?? "(top-level)"}"`,
+    );
     ctx.eventBus?.emit("subagent-spawn", {
       subagentId,
       name: `Threat Model: ${input.routePath}`,
       input: { app: input.appName, endpoint: input.routePath },
+      parentSubagentId: ctx.subagentId,
     });
 
     const localBus = new AgentEventBus();
@@ -336,6 +340,7 @@ export async function generateThreatModelForEndpoint(
       ctx.eventBus?.emit("subagent-complete", {
         subagentId,
         status: "completed",
+        parentSubagentId: ctx.subagentId,
       });
 
       if (!result) return null;
@@ -367,6 +372,7 @@ export async function generateThreatModelForEndpoint(
       ctx.eventBus?.emit("subagent-complete", {
         subagentId,
         status: "failed",
+        parentSubagentId: ctx.subagentId,
       });
       console.error(
         `Threat model generation failed for ${input.routePath}: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -306,9 +306,6 @@ export async function generateThreatModelForEndpoint(
 
     const subagentId = `threat-model-${sanitize(input.appName)}-${sanitize(input.routePath)}`;
 
-    console.log(
-      `[threatModel] emit subagent-spawn id="${subagentId}" parent="${ctx.subagentId ?? "(top-level)"}"`,
-    );
     ctx.eventBus?.emit("subagent-spawn", {
       subagentId,
       name: `Threat Model: ${input.routePath}`,

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -114,11 +114,6 @@ export type ToolContext = {
    */
   planSubagentId?: string;
 
-  /**
-   * The id of the subagent that owns this tool context. Used by
-   * orchestration tools (e.g. spawn_coding_agent, delegate_to_auth_subagent)
-   * to record parent/child relationships when emitting `subagent-spawn`
-   * events on the bus.
-   */
+  /** Owner subagent id — emitted as `parentSubagentId` on lifecycle events. */
   subagentId?: string;
 };

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -113,4 +113,12 @@ export type ToolContext = {
    * plan agents to write plans scoped to their corresponding execution agent.
    */
   planSubagentId?: string;
+
+  /**
+   * The id of the subagent that owns this tool context. Used by
+   * orchestration tools (e.g. spawn_coding_agent, delegate_to_auth_subagent)
+   * to record parent/child relationships when emitting `subagent-spawn`
+   * events on the bus.
+   */
+  subagentId?: string;
 };

--- a/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.ts
@@ -44,12 +44,7 @@ interface SharedAgentOptions {
   onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
   onCacheMetrics?: (metrics: CacheMetrics) => void;
   projectThreatModel?: string;
-  /**
-   * Parent subagent id for hierarchy tracking. When set, emitted
-   * `subagent-spawn` / `subagent-complete` events carry this as
-   * `parentSubagentId` so the UI can nest endpoint-doc agents under
-   * their per-app synthetic node.
-   */
+  /** Parent subagent id for hierarchy tracking on emitted lifecycle events. */
   parentSubagentId?: string;
 }
 

--- a/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.ts
@@ -44,6 +44,13 @@ interface SharedAgentOptions {
   onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
   onCacheMetrics?: (metrics: CacheMetrics) => void;
   projectThreatModel?: string;
+  /**
+   * Parent subagent id for hierarchy tracking. When set, emitted
+   * `subagent-spawn` / `subagent-complete` events carry this as
+   * `parentSubagentId` so the UI can nest endpoint-doc agents under
+   * their per-app synthetic node.
+   */
+  parentSubagentId?: string;
 }
 
 interface EndpointDocumentationInput extends SharedAgentOptions {
@@ -161,6 +168,7 @@ async function runEndpointDocumentationAgent(
     onStepFinish,
     onCacheMetrics,
     projectThreatModel,
+    parentSubagentId,
   } = opts;
 
   const subagentId = `endpoint-doc-${slug(app.name)}-${slug(endpoint.path)}`;
@@ -176,6 +184,7 @@ async function runEndpointDocumentationAgent(
       method: displayMethod,
       path: endpoint.path,
     },
+    parentSubagentId,
   });
 
   const objective = buildEndpointDocumentationObjective({
@@ -213,6 +222,7 @@ async function runEndpointDocumentationAgent(
     eventBus?.emit("subagent-complete", {
       subagentId,
       status: "completed",
+      parentSubagentId,
     });
   } catch (error) {
     console.error(
@@ -222,6 +232,7 @@ async function runEndpointDocumentationAgent(
     eventBus?.emit("subagent-complete", {
       subagentId,
       status: "failed",
+      parentSubagentId,
     });
   }
 }

--- a/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.ts
@@ -148,7 +148,7 @@ This agent is responsible for **exactly one** endpoint. Do not document other en
 
 async function runEndpointDocumentationAgent(
   opts: EndpointDocumentationInput,
-): Promise<void> {
+): Promise<boolean> {
   const {
     codebasePath,
     app,
@@ -219,6 +219,7 @@ async function runEndpointDocumentationAgent(
       status: "completed",
       parentSubagentId,
     });
+    return true;
   } catch (error) {
     console.error(
       `[endpoint-documentation-agent] "${subagentId}" FAILED:`,
@@ -229,6 +230,7 @@ async function runEndpointDocumentationAgent(
       status: "failed",
       parentSubagentId,
     });
+    return false;
   }
 }
 
@@ -242,11 +244,23 @@ export async function runAppEndpointDocumentation(
   const { endpoints, ...shared } = opts;
   if (endpoints.length === 0) return;
 
+  let anyFailed = false;
   await runWithBoundedConcurrency(
     endpoints,
     ENDPOINT_DOCUMENTATION_CONCURRENCY,
     async (endpoint) => {
-      await runEndpointDocumentationAgent({ ...shared, endpoint });
+      const ok = await runEndpointDocumentationAgent({ ...shared, endpoint });
+      if (!ok) anyFailed = true;
     },
   );
+
+  // Surface per-endpoint failure to the workflow so per-app status reflects
+  // it. Each endpoint already emits its own subagent-complete (failed); this
+  // throw lets the workflow's outer catch set appAnyTaskFailed, matching the
+  // legacy spawnDiscoveryAgent path's failure propagation.
+  if (anyFailed) {
+    throw new Error(
+      `One or more endpoint documentation agents failed for app ${opts.app.name}`,
+    );
+  }
 }

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -631,9 +631,8 @@ export function streamResponse(
   } = opts;
 
   // Wrap onStepFinish to fire usage callback for every step.
-  // Must be async so that callers returning a Promise (e.g. MessageManager
-  // persisting messages / queuing issues) are fully awaited before the
-  // AI SDK starts the next step.
+  // Must be async so that callers returning a Promise (e.g. persistence /
+  // issue queuing) are fully awaited before the AI SDK starts the next step.
   const onStepFinish: typeof userOnStepFinish = async (step) => {
     await userOnStepFinish?.(step);
     if (_usageCallback) {

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -37,10 +37,23 @@ export type AgentEventMap = {
     subagentId: string;
     name?: string;
     input: unknown;
+    /**
+     * The subagent that spawned this subagent. When omitted, the
+     * spawned subagent is a top-level child of the root agent /
+     * workflow. Populated automatically by {@link AgentEventBus.attachChild}
+     * when not explicitly provided by the emitter.
+     */
+    parentSubagentId?: string;
   };
   "subagent-complete": {
     subagentId: string;
     status: "completed" | "failed";
+    /**
+     * Mirrors {@link AgentEventMap["subagent-spawn"].parentSubagentId}.
+     * Populated automatically by {@link AgentEventBus.attachChild}
+     * when not explicitly provided by the emitter.
+     */
+    parentSubagentId?: string;
   };
   "workflow-phase-start": {
     phase: "discovery" | "pentesting" | "reporting";
@@ -183,6 +196,13 @@ export class AgentEventBus {
    * `command-output`) without `subagentId`. This method injects the
    * ID so the parent's routing logic (subagent store vs main view)
    * works correctly.
+   *
+   * For `subagent-spawn` and `subagent-complete` events, the payload
+   * already carries the *new* subagent's ID (the one being spawned /
+   * completing). To preserve parent/child hierarchy across nested
+   * sub-agents, this method also injects `parentSubagentId` (the
+   * `subagentId` argument passed here) on those two events when not
+   * already set by the emitter.
    */
   static attachChild(
     child: AgentEventBus,
@@ -191,12 +211,33 @@ export class AgentEventBus {
   ): void {
     if (!parent) return;
     for (const key of CHILD_BUS_FORWARDED_EVENTS) {
-      child.on(key, (payload: AgentEventMap[typeof key]) => {
+      // Re-bind to a fresh local with a parametric type so TS treats
+      // `key` and the emitted payload as the same K for the duration
+      // of the handler. Without this, the union of payload shapes from
+      // AgentEventMap is too wide for `parent.emit(key, payload)` to
+      // typecheck on the forwarding branch.
+      const forwardKey = key as keyof AgentEventMap;
+      child.on(forwardKey, (payload: AgentEventMap[typeof forwardKey]) => {
         const p = payload as Record<string, unknown>;
+
+        const isLifecycle =
+          forwardKey === "subagent-spawn" ||
+          forwardKey === "subagent-complete";
+
+        if (isLifecycle) {
+          const next = { ...p };
+          // The new subagent's id always stays on the payload
+          if (!next.parentSubagentId) {
+            next.parentSubagentId = subagentId;
+          }
+          parent.emit(forwardKey, next as never);
+          return;
+        }
+
         if (!p.subagentId) {
-          parent.emit(key, { ...p, subagentId } as AgentEventMap[typeof key]);
+          parent.emit(forwardKey, { ...p, subagentId } as never);
         } else {
-          parent.emit(key, payload);
+          parent.emit(forwardKey, payload as never);
         }
       });
     }

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -208,11 +208,11 @@ export class AgentEventBus {
           forwardKey === "subagent-complete";
 
         if (isLifecycle) {
-          const next = { ...p };
-          if (!next.parentSubagentId) {
-            next.parentSubagentId = subagentId;
+          if (p.parentSubagentId) {
+            parent.emit(forwardKey, payload as never);
+          } else {
+            parent.emit(forwardKey, { ...p, parentSubagentId: subagentId } as never);
           }
-          parent.emit(forwardKey, next as never);
           return;
         }
 

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -37,22 +37,13 @@ export type AgentEventMap = {
     subagentId: string;
     name?: string;
     input: unknown;
-    /**
-     * The subagent that spawned this subagent. When omitted, the
-     * spawned subagent is a top-level child of the root agent /
-     * workflow. Populated automatically by {@link AgentEventBus.attachChild}
-     * when not explicitly provided by the emitter.
-     */
+    /** Omitted means top-level. Auto-populated by {@link AgentEventBus.attachChild}. */
     parentSubagentId?: string;
   };
   "subagent-complete": {
     subagentId: string;
     status: "completed" | "failed";
-    /**
-     * Mirrors {@link AgentEventMap["subagent-spawn"].parentSubagentId}.
-     * Populated automatically by {@link AgentEventBus.attachChild}
-     * when not explicitly provided by the emitter.
-     */
+    /** Omitted means top-level. Auto-populated by {@link AgentEventBus.attachChild}. */
     parentSubagentId?: string;
   };
   "workflow-phase-start": {
@@ -195,14 +186,9 @@ export class AgentEventBus {
    * Tools running inside a subagent emit side-channel events (e.g.
    * `command-output`) without `subagentId`. This method injects the
    * ID so the parent's routing logic (subagent store vs main view)
-   * works correctly.
-   *
-   * For `subagent-spawn` and `subagent-complete` events, the payload
-   * already carries the *new* subagent's ID (the one being spawned /
-   * completing). To preserve parent/child hierarchy across nested
-   * sub-agents, this method also injects `parentSubagentId` (the
-   * `subagentId` argument passed here) on those two events when not
-   * already set by the emitter.
+   * works correctly. For `subagent-spawn` / `subagent-complete` it
+   * additionally injects `parentSubagentId` to preserve hierarchy
+   * across nested subagents.
    */
   static attachChild(
     child: AgentEventBus,
@@ -211,11 +197,8 @@ export class AgentEventBus {
   ): void {
     if (!parent) return;
     for (const key of CHILD_BUS_FORWARDED_EVENTS) {
-      // Re-bind to a fresh local with a parametric type so TS treats
-      // `key` and the emitted payload as the same K for the duration
-      // of the handler. Without this, the union of payload shapes from
-      // AgentEventMap is too wide for `parent.emit(key, payload)` to
-      // typecheck on the forwarding branch.
+      // Re-bind so the handler's payload type tracks `key` as a single K —
+      // without this, the union of payload shapes is too wide for `emit`.
       const forwardKey = key as keyof AgentEventMap;
       child.on(forwardKey, (payload: AgentEventMap[typeof forwardKey]) => {
         const p = payload as Record<string, unknown>;
@@ -226,7 +209,6 @@ export class AgentEventBus {
 
         if (isLifecycle) {
           const next = { ...p };
-          // The new subagent's id always stays on the payload
           if (!next.parentSubagentId) {
             next.parentSubagentId = subagentId;
           }

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -204,14 +204,16 @@ export class AgentEventBus {
         const p = payload as Record<string, unknown>;
 
         const isLifecycle =
-          forwardKey === "subagent-spawn" ||
-          forwardKey === "subagent-complete";
+          forwardKey === "subagent-spawn" || forwardKey === "subagent-complete";
 
         if (isLifecycle) {
           if (p.parentSubagentId) {
             parent.emit(forwardKey, payload as never);
           } else {
-            parent.emit(forwardKey, { ...p, parentSubagentId: subagentId } as never);
+            parent.emit(forwardKey, {
+              ...p,
+              parentSubagentId: subagentId,
+            } as never);
           }
           return;
         }

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -168,13 +168,8 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     onCacheMetrics,
     responseSchema: AppsDiscoveryResultSchema,
     projectThreatModel,
-    // Phase 1 ONLY discovers apps. document_endpoint is reserved for
-    // Phase 2's per-app task agents — exposing it here causes the
-    // apps-discovery agent to document endpoints inline (and spawn
-    // threat models under itself), which flattens the UI hierarchy
-    // and makes Phase 2's per-app subagents redundant. Also a tool-level
-    // guard symmetric to Phase 2's `excludeTools: ["document_app"]` in
-    // spawnDiscoveryAgent and endpointDocumentationAgent.
+    // Reserved for Phase 2's per-app task agents. Inline documentation
+    // here would flatten the UI hierarchy under Phase 1.
     excludeTools: ["document_endpoint"],
   });
 
@@ -182,10 +177,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     `[whitebox-workflow] Phase 1: discovering apps in ${codebasePath}${domains?.length ? ` (${domains.length} known domains)` : ""}`,
   );
 
-  // Phase 1's subagent stays open until Phase 2 finishes — it's the
-  // umbrella under which per-app synthetic nodes nest. The agent's own
-  // run finishes inside `appsAgent.consume()`, but we hold the
-  // lifecycle row open so child events anchor here.
+  // Held open until Phase 2 finishes so per-app synthetic nodes can nest under it.
   const WORKFLOW_UMBRELLA_ID = "whitebox-apps-discovery";
 
   console.log(
@@ -288,18 +280,8 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     completedApps: 0,
   });
 
-  // Per-app synthetic parent nodes. These aren't real agents — they're
-  // grouping nodes that live between the umbrella ("Whitebox Apps
-  // Discovery") and the per-task agents (pages/api/cloud/endpoint-doc).
-  // Their lifecycle anchors child events so the UI can render the desired
-  // hierarchy:
-  //   whitebox-apps-discovery
-  //     ├── app:myapp1
-  //     │     ├── pages-myapp1
-  //     │     │     └── threat-model-...
-  //     │     └── apiEndpoints-myapp1
-  //     └── app:myapp2
-  //           └── ...
+  // Synthetic grouping nodes between the umbrella and per-task agents,
+  // so the UI nests pages/api/endpoint-doc agents under their app.
   const appNodeIdFor = (appName: string) => `app:${sanitizeName(appName)}`;
   const appAnyTaskFailed = new Map<string, boolean>();
   for (const app of appsResult.apps) {
@@ -460,8 +442,6 @@ export async function runWhiteboxAttackSurfaceWorkflow(
       } finally {
         completedAppCount++;
 
-        // All tasks for this app finished — close the synthetic per-app
-        // node so the UI shows it as done.
         const appStatus = appAnyTaskFailed.get(app.name)
           ? ("failed" as const)
           : ("completed" as const);
@@ -483,7 +463,6 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     },
   );
 
-  // Close the umbrella now that all per-app nodes are done.
   console.log(
     `[whitebox-workflow] emit subagent-complete id="${WORKFLOW_UMBRELLA_ID}" parent="(top-level)" status=completed`,
   );

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -39,15 +39,10 @@ import { runWithBoundedConcurrency } from "../utils/concurrency";
 
 const DEFAULT_CONCURRENCY = 5;
 
-// Phase 2 spawns one CodeAgent per task type per app. The discriminated
-// union below is the source of truth — adding a value here requires a
-// matching entry in TASK_TYPE_LABELS (enforced via `satisfies`).
 type DiscoveryTaskType = "pages" | "apiEndpoints" | "cloudResourceEndpoints";
 
-// Human-readable labels for Phase 2 task agents. The parent card
-// (synthetic `app:<name>` node) already carries the app name, so child
-// labels should describe what each agent *does* — that's the
-// distinguishing axis between siblings under one app.
+// Sibling cards under an app share the app name from their parent;
+// label children by what they *do* instead.
 const TASK_TYPE_LABELS = {
   pages: "Pages",
   apiEndpoints: "API Endpoints",

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -289,6 +289,19 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     });
   }
 
+  // Human-readable labels for Phase 2 task agents. The parent card
+  // (synthetic `app:<name>` node) already carries the app name, so child
+  // labels should describe what each agent *does* — that's the
+  // distinguishing axis between siblings under one app.
+  const TASK_TYPE_LABELS = {
+    pages: "Pages",
+    apiEndpoints: "API Endpoints",
+    cloudResourceEndpoints: "Cloud Resources",
+  } as const satisfies Record<
+    "pages" | "apiEndpoints" | "cloudResourceEndpoints",
+    string
+  >;
+
   const spawnDiscoveryAgent = async (
     app: AppInfo,
     type: "pages" | "apiEndpoints" | "cloudResourceEndpoints",
@@ -303,7 +316,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
 
     eventBus?.emit("subagent-spawn", {
       subagentId,
-      name: app.name,
+      name: TASK_TYPE_LABELS[type],
       input: { app: app.name, type },
       parentSubagentId: appNodeId,
     });

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -39,6 +39,21 @@ import { runWithBoundedConcurrency } from "../utils/concurrency";
 
 const DEFAULT_CONCURRENCY = 5;
 
+// Phase 2 spawns one CodeAgent per task type per app. The discriminated
+// union below is the source of truth — adding a value here requires a
+// matching entry in TASK_TYPE_LABELS (enforced via `satisfies`).
+type DiscoveryTaskType = "pages" | "apiEndpoints" | "cloudResourceEndpoints";
+
+// Human-readable labels for Phase 2 task agents. The parent card
+// (synthetic `app:<name>` node) already carries the app name, so child
+// labels should describe what each agent *does* — that's the
+// distinguishing axis between siblings under one app.
+const TASK_TYPE_LABELS = {
+  pages: "Pages",
+  apiEndpoints: "API Endpoints",
+  cloudResourceEndpoints: "Cloud Resources",
+} as const satisfies Record<DiscoveryTaskType, string>;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -289,22 +304,9 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     });
   }
 
-  // Human-readable labels for Phase 2 task agents. The parent card
-  // (synthetic `app:<name>` node) already carries the app name, so child
-  // labels should describe what each agent *does* — that's the
-  // distinguishing axis between siblings under one app.
-  const TASK_TYPE_LABELS = {
-    pages: "Pages",
-    apiEndpoints: "API Endpoints",
-    cloudResourceEndpoints: "Cloud Resources",
-  } as const satisfies Record<
-    "pages" | "apiEndpoints" | "cloudResourceEndpoints",
-    string
-  >;
-
   const spawnDiscoveryAgent = async (
     app: AppInfo,
-    type: "pages" | "apiEndpoints" | "cloudResourceEndpoints",
+    type: DiscoveryTaskType,
     objective: string,
   ): Promise<void> => {
     const subagentId = `${type}-${app.name}`;

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -168,8 +168,13 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     onCacheMetrics,
     responseSchema: AppsDiscoveryResultSchema,
     projectThreatModel,
-    // Tool-level guard symmetric to Phase 2's `excludeTools: ["document_app"]`
-    // (in spawnDiscoveryAgent + endpointDocumentationAgent).
+    // Phase 1 ONLY discovers apps. document_endpoint is reserved for
+    // Phase 2's per-app task agents — exposing it here causes the
+    // apps-discovery agent to document endpoints inline (and spawn
+    // threat models under itself), which flattens the UI hierarchy
+    // and makes Phase 2's per-app subagents redundant. Also a tool-level
+    // guard symmetric to Phase 2's `excludeTools: ["document_app"]` in
+    // spawnDiscoveryAgent and endpointDocumentationAgent.
     excludeTools: ["document_endpoint"],
   });
 
@@ -177,18 +182,22 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     `[whitebox-workflow] Phase 1: discovering apps in ${codebasePath}${domains?.length ? ` (${domains.length} known domains)` : ""}`,
   );
 
+  // Phase 1's subagent stays open until Phase 2 finishes — it's the
+  // umbrella under which per-app synthetic nodes nest. The agent's own
+  // run finishes inside `appsAgent.consume()`, but we hold the
+  // lifecycle row open so child events anchor here.
+  const WORKFLOW_UMBRELLA_ID = "whitebox-apps-discovery";
+
+  console.log(
+    `[whitebox-workflow] emit subagent-spawn id="${WORKFLOW_UMBRELLA_ID}" parent="(top-level)"`,
+  );
   eventBus?.emit("subagent-spawn", {
-    subagentId: "whitebox-apps-discovery",
+    subagentId: WORKFLOW_UMBRELLA_ID,
     name: "Whitebox Apps Discovery",
     input: { codebasePath },
   });
 
   const appsResult = await appsAgent.consume();
-
-  eventBus?.emit("subagent-complete", {
-    subagentId: "whitebox-apps-discovery",
-    status: "completed",
-  });
 
   console.log(
     `[whitebox-workflow] Phase 1 complete: ${appsResult?.apps.length ?? 0} apps discovered` +
@@ -206,6 +215,13 @@ export async function runWhiteboxAttackSurfaceWorkflow(
   }
 
   if (!appsResult || appsResult.apps.length === 0) {
+    console.log(
+      `[whitebox-workflow] emit subagent-complete id="${WORKFLOW_UMBRELLA_ID}" parent="(top-level)" status=completed (no apps found, closing umbrella)`,
+    );
+    eventBus?.emit("subagent-complete", {
+      subagentId: WORKFLOW_UMBRELLA_ID,
+      status: "completed",
+    });
     return {
       repoType: appsResult?.repoType ?? "unknown",
       packageManager: appsResult?.packageManager ?? "unknown",
@@ -272,21 +288,51 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     completedApps: 0,
   });
 
+  // Per-app synthetic parent nodes. These aren't real agents — they're
+  // grouping nodes that live between the umbrella ("Whitebox Apps
+  // Discovery") and the per-task agents (pages/api/cloud/endpoint-doc).
+  // Their lifecycle anchors child events so the UI can render the desired
+  // hierarchy:
+  //   whitebox-apps-discovery
+  //     ├── app:myapp1
+  //     │     ├── pages-myapp1
+  //     │     │     └── threat-model-...
+  //     │     └── apiEndpoints-myapp1
+  //     └── app:myapp2
+  //           └── ...
+  const appNodeIdFor = (appName: string) => `app:${sanitizeName(appName)}`;
+  const appAnyTaskFailed = new Map<string, boolean>();
+  for (const app of appsResult.apps) {
+    const appNodeId = appNodeIdFor(app.name);
+    appAnyTaskFailed.set(app.name, false);
+    console.log(
+      `[whitebox-workflow] emit subagent-spawn id="${appNodeId}" parent="${WORKFLOW_UMBRELLA_ID}" (synthetic per-app node)`,
+    );
+    eventBus?.emit("subagent-spawn", {
+      subagentId: appNodeId,
+      name: app.name,
+      input: { app: app.name, type: app.type, framework: app.framework },
+      parentSubagentId: WORKFLOW_UMBRELLA_ID,
+    });
+  }
+
   const spawnDiscoveryAgent = async (
     app: AppInfo,
     type: "pages" | "apiEndpoints" | "cloudResourceEndpoints",
     objective: string,
   ): Promise<void> => {
     const subagentId = `${type}-${app.name}`;
+    const appNodeId = appNodeIdFor(app.name);
 
     console.log(
-      `[whitebox-workflow] Phase 2: spawning agent "${subagentId}" (app="${app.name}", type=${type}, appType=${app.type})`,
+      `[whitebox-workflow] Phase 2: spawning agent id="${subagentId}" parent="${appNodeId}" (app="${app.name}", type=${type}, appType=${app.type})`,
     );
 
     eventBus?.emit("subagent-spawn", {
       subagentId,
       name: app.name,
       input: { app: app.name, type },
+      parentSubagentId: appNodeId,
     });
 
     const agent = new CodeAgent<DiscoverySummary>({
@@ -317,6 +363,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
       eventBus?.emit("subagent-complete", {
         subagentId,
         status: "completed",
+        parentSubagentId: appNodeId,
       });
     } catch (error) {
       console.error(
@@ -324,9 +371,11 @@ export async function runWhiteboxAttackSurfaceWorkflow(
         error instanceof Error ? error.message : String(error),
       );
 
+      appAnyTaskFailed.set(app.name, true);
       eventBus?.emit("subagent-complete", {
         subagentId,
         status: "failed",
+        parentSubagentId: appNodeId,
       });
     }
   };
@@ -356,6 +405,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     appsResult.apps,
     DEFAULT_CONCURRENCY,
     async (app) => {
+      const appNodeId = appNodeIdFor(app.name);
       try {
         if (NON_SERVICE_TYPES.includes(app.type)) {
           // Cloud resources: surface doesn't enumerate these — always fallback.
@@ -392,6 +442,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
               onStepFinish,
               onCacheMetrics,
               projectThreatModel,
+              parentSubagentId: appNodeId,
             });
           } else {
             console.log(
@@ -403,8 +454,26 @@ export async function runWhiteboxAttackSurfaceWorkflow(
             ]);
           }
         }
+      } catch (error) {
+        appAnyTaskFailed.set(app.name, true);
+        throw error;
       } finally {
         completedAppCount++;
+
+        // All tasks for this app finished — close the synthetic per-app
+        // node so the UI shows it as done.
+        const appStatus = appAnyTaskFailed.get(app.name)
+          ? ("failed" as const)
+          : ("completed" as const);
+        console.log(
+          `[whitebox-workflow] emit subagent-complete id="${appNodeId}" parent="${WORKFLOW_UMBRELLA_ID}" status=${appStatus}`,
+        );
+        eventBus?.emit("subagent-complete", {
+          subagentId: appNodeId,
+          status: appStatus,
+          parentSubagentId: WORKFLOW_UMBRELLA_ID,
+        });
+
         eventBus?.emit("app-analysis-progress", {
           totalApps,
           completedApps: completedAppCount,
@@ -413,6 +482,15 @@ export async function runWhiteboxAttackSurfaceWorkflow(
       }
     },
   );
+
+  // Close the umbrella now that all per-app nodes are done.
+  console.log(
+    `[whitebox-workflow] emit subagent-complete id="${WORKFLOW_UMBRELLA_ID}" parent="(top-level)" status=completed`,
+  );
+  eventBus?.emit("subagent-complete", {
+    subagentId: WORKFLOW_UMBRELLA_ID,
+    status: "completed",
+  });
 
   // =========================================================================
   // Phase 3: Read assets directory to build endpoint data
@@ -664,6 +742,14 @@ function buildAppsDiscoveryObjective(
     : "";
 
   return `# Identify All Applications in the Repository
+
+## Phase scope — read this first
+This objective is **Phase 1: app discovery only**. Your job is to enumerate
+applications and call \`document_app\` for each. **Do NOT call
+\`document_endpoint\` in this phase** — endpoints are documented in a later
+phase by per-app subagents. The \`document_endpoint\` tool is intentionally
+unavailable here. Ignore any general guidance in the system prompt that
+tells you to call it; that guidance applies only to later phases.
 
 ## Codebase
 - **Path:** ${codebasePath}

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -180,9 +180,6 @@ export async function runWhiteboxAttackSurfaceWorkflow(
   // Held open until Phase 2 finishes so per-app synthetic nodes can nest under it.
   const WORKFLOW_UMBRELLA_ID = "whitebox-apps-discovery";
 
-  console.log(
-    `[whitebox-workflow] emit subagent-spawn id="${WORKFLOW_UMBRELLA_ID}" parent="(top-level)"`,
-  );
   eventBus?.emit("subagent-spawn", {
     subagentId: WORKFLOW_UMBRELLA_ID,
     name: "Whitebox Apps Discovery",
@@ -207,9 +204,6 @@ export async function runWhiteboxAttackSurfaceWorkflow(
   }
 
   if (!appsResult || appsResult.apps.length === 0) {
-    console.log(
-      `[whitebox-workflow] emit subagent-complete id="${WORKFLOW_UMBRELLA_ID}" parent="(top-level)" status=completed (no apps found, closing umbrella)`,
-    );
     eventBus?.emit("subagent-complete", {
       subagentId: WORKFLOW_UMBRELLA_ID,
       status: "completed",
@@ -287,9 +281,6 @@ export async function runWhiteboxAttackSurfaceWorkflow(
   for (const app of appsResult.apps) {
     const appNodeId = appNodeIdFor(app.name);
     appAnyTaskFailed.set(app.name, false);
-    console.log(
-      `[whitebox-workflow] emit subagent-spawn id="${appNodeId}" parent="${WORKFLOW_UMBRELLA_ID}" (synthetic per-app node)`,
-    );
     eventBus?.emit("subagent-spawn", {
       subagentId: appNodeId,
       name: app.name,
@@ -436,18 +427,14 @@ export async function runWhiteboxAttackSurfaceWorkflow(
             ]);
           }
         }
-      } catch (error) {
+      } catch {
         appAnyTaskFailed.set(app.name, true);
-        throw error;
       } finally {
         completedAppCount++;
 
         const appStatus = appAnyTaskFailed.get(app.name)
           ? ("failed" as const)
           : ("completed" as const);
-        console.log(
-          `[whitebox-workflow] emit subagent-complete id="${appNodeId}" parent="${WORKFLOW_UMBRELLA_ID}" status=${appStatus}`,
-        );
         eventBus?.emit("subagent-complete", {
           subagentId: appNodeId,
           status: appStatus,
@@ -463,9 +450,6 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     },
   );
 
-  console.log(
-    `[whitebox-workflow] emit subagent-complete id="${WORKFLOW_UMBRELLA_ID}" parent="(top-level)" status=completed`,
-  );
   eventBus?.emit("subagent-complete", {
     subagentId: WORKFLOW_UMBRELLA_ID,
     status: "completed",

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -1009,6 +1009,8 @@ export default function OperatorDashboard({
 
       eventBus.on("subagent-spawn", ({ subagentId, name }) => {
         if (gen !== generationRef.current) return;
+        // Hide whitebox per-app synthetic grouping nodes until #744 lands a hierarchical view.
+        if (subagentId.startsWith("app:")) return;
         subagentHelpers.spawnSession(subagentId, name);
         if (!isPentestAgent(subagentId)) return;
         // Pentest swarm agents → workflowData.pentesting.subagents

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -1032,6 +1032,9 @@ export default function OperatorDashboard({
 
       eventBus.on("subagent-complete", ({ subagentId, status }) => {
         if (gen !== generationRef.current) return;
+        // Mirror the spawn-handler filter: synthetic per-app grouping nodes
+        // were never registered as sessions, so don't try to complete them.
+        if (subagentId.startsWith("app:")) return;
         subagentHelpers.completeSession(subagentId, status);
         if (!isPentestAgent(subagentId)) return;
         // Update workflowData swarm status

--- a/src/tui/theme/context.tsx
+++ b/src/tui/theme/context.tsx
@@ -92,7 +92,7 @@ export function ThemeProvider({
   }, []);
 
   return (
-    <ThemeContext
+    <ThemeContext.Provider
       value={{
         theme,
         colors,
@@ -104,7 +104,7 @@ export function ThemeProvider({
       }}
     >
       {children}
-    </ThemeContext>
+    </ThemeContext.Provider>
   );
 }
 

--- a/src/util/lock.ts
+++ b/src/util/lock.ts
@@ -9,15 +9,17 @@ const locks = new Map<
 >();
 
 function getLock(key: string) {
-  if (!locks.has(key)) {
-    locks.set(key, {
+  let lock = locks.get(key);
+  if (!lock) {
+    lock = {
       readers: 0,
       writer: false,
       waitingReaders: [],
       waitingWriters: [],
-    });
+    };
+    locks.set(key, lock);
   }
-  return locks.get(key)!;
+  return lock;
 }
 
 function processQueue(key: string) {


### PR DESCRIPTION
Continuation of @joshkotrous's work in [`feat/subagent-parent-child-tracking`](https://github.com/pensarai/apex/tree/feat/subagent-parent-child-tracking), rebased onto current canary and adapted to integrate with the surface-driven endpoint documentation path that landed after the original commit.

## Summary
- `eventBus`: optional `parentSubagentId` on `subagent-spawn` / `subagent-complete` payloads, populated automatically in `AgentEventBus.attachChild` so nested child→parent forwarding preserves the spawner.
- Orchestration tools that emit lifecycle events directly (`spawn_coding_agent`, `delegate_to_auth_subagent`, `run_attack_surface`, `generate_threat_model`) now pass `ctx.subagentId` as the parent. `ToolContext` gains an optional `subagentId`.
- Whitebox attack-surface workflow:
  - Phase 1 `apps-discovery` excludes `document_endpoint` so it can't accidentally inline-document endpoints (which would flatten the UI hierarchy under Phase 1 instead of nesting under per-app nodes).
  - The umbrella subagent (`whitebox-apps-discovery`) stays open until Phase 2 completes — it's the parent for per-app synthetic nodes.
  - Per-app synthetic nodes (`app:<name>`) are emitted before Phase 2 dispatch so the UI sees the full tree upfront. Both the legacy (`spawnDiscoveryAgent`) and surface-driven (`runAppEndpointDocumentation`) paths now anchor under these nodes via `parentSubagentId`.
  - Per-app status reflects whether any child task failed.
- Diagnostic `console.log`s at every emit site for cross-referencing against the lifecycle JSONL log on the console side.

## Test plan
- [x] Run a whitebox pentest against a multi-app repo and verify the UI shows the desired hierarchy: `whitebox-apps-discovery` → `app:<name>` → `{pages,apiEndpoints,cloudResourceEndpoints,endpoint-doc-*}-<name>` → `threat-model-*`.
- [ ] Same as above with `surfaceIntegrationEnabled=true` and a surface-able app — confirm `endpoint-doc-*` events carry `parentSubagentId: app:<name>`.
- [ ] Force a Phase 2 agent to fail and confirm the per-app synthetic node closes with `status: failed`.
- [ ] Confirm no `subagent-*` events are emitted with a dangling `parentSubagentId` (i.e. parent id always corresponds to a previously-spawned subagent).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core event payloads and forwarding behavior (`AgentEventBus.attachChild`) plus modifies whitebox orchestration failure propagation; mistakes could break UI lifecycle tracking or misreport agent status, but scope is contained to observability/orchestration paths.
> 
> **Overview**
> Adds hierarchical subagent lifecycle tracking by extending `subagent-spawn`/`subagent-complete` events with optional `parentSubagentId`, and teaching `AgentEventBus.attachChild` to auto-inject it when forwarding nested lifecycle events.
> 
> Updates orchestration tools and subagent spawners (`delegateAuth`, `run_attack_surface`, `spawn_coding_agent`, threat model generation, endpoint documentation) to pass through parent IDs, and extends `ToolContext` with `subagentId` for ownership.
> 
> Refactors the whitebox attack-surface workflow to keep an umbrella node open through Phase 2, emit synthetic per-app grouping nodes, nest task agents under them, and propagate per-endpoint failures so per-app status can reflect any child failure; the TUI temporarily filters out these synthetic `app:` nodes until a hierarchical view ships. Also includes minor comment/doc tweaks and a small `lock.ts` cleanup to avoid double map lookups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76f1ab5a2d3e9332ac9b6dcbbdee96330f1cbbfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->