### PR TITLE
Enforce minimum release age on dependencies via bunfig

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,7 +1,4 @@
 [install]
-# Refuse to install package versions published less than 3 days ago.
-# Mitigates supply chain attacks where a compromised maintainer publishes
-# a malicious version that gets auto-installed before the community detects it.
-# Requires Bun >= 1.3.
+# Refuse to install packages published less than 3 days ago (supply chain mitigation).
 minimumReleaseAge = 259200
 minimumReleaseAgeExcludes = []

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,7 @@
+[install]
+# Refuse to install package versions published less than 3 days ago.
+# Mitigates supply chain attacks where a compromised maintainer publishes
+# a malicious version that gets auto-installed before the community detects it.
+# Requires Bun >= 1.3.
+minimumReleaseAge = 259200
+minimumReleaseAgeExcludes = []


### PR DESCRIPTION
Closes #755

## Summary
- Adds `bunfig.toml` with `minimumReleaseAge = 259200` (3 days), using Bun's native install-time enforcement (Bun >= 1.3).
- Refuses to install packages published less than 3 days ago, mitigating fast-moving supply chain attacks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit eee19e5c06ec2a16b559b730429d941f5c322f48. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->