### PR TITLE
fix(offSecAgent): emit synthetic tool-result on stream abort/error

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -318,6 +318,26 @@ describe("OffensiveSecurityAgent.consume()", () => {
       expect(emittedResults).toHaveLength(0);
     });
 
+    it("closes a truncated tool-call (started, args never completed) at finish-step", async () => {
+      const agent = buildStubAgent({
+        fullStream: yieldChunks([
+          { type: "tool-input-start", id: "tc1", toolName: "response" },
+          { type: "finish-step" },
+        ]),
+      });
+
+      const emittedResults: Array<{ toolCallId: string; result: unknown }> = [];
+      agent.eventBus.on("tool-result", (e) => {
+        emittedResults.push({ toolCallId: e.toolCallId, result: e.result });
+      });
+
+      await agent.consume();
+
+      expect(emittedResults).toHaveLength(1);
+      expect(emittedResults[0].toolCallId).toBe("tc1");
+      expect(emittedResults[0].result).toMatchObject({ type: "error-text" });
+    });
+
     it("uses 'Agent aborted by user' when abortSignal is set", async () => {
       const controller = new AbortController();
       controller.abort();

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -7,6 +7,8 @@
  * Heavy transitive dependencies (tools, AI SDK, zod) are stubbed so
  * the test loads cleanly without external provider keys.
  */
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -76,6 +78,8 @@ function buildStubAgent(overrides: {
   persistentShell?: { dispose: () => void };
   abortSignal?: AbortSignal;
   resolveResult?: (sr: unknown) => unknown;
+  messagesPath?: string | null;
+  latestMessages?: unknown[] | null;
 }): OffensiveSecurityAgent<unknown> {
   const agent = Object.create(
     OffensiveSecurityAgent.prototype,
@@ -97,6 +101,18 @@ function buildStubAgent(overrides: {
   });
   Object.defineProperty(agent, "resolveResult", {
     value: overrides.resolveResult,
+  });
+  Object.defineProperty(agent, "latestMessages", {
+    value: overrides.latestMessages ?? null,
+    writable: true,
+  });
+  Object.defineProperty(agent, "messagesPath", {
+    value: overrides.messagesPath ?? null,
+  });
+  Object.defineProperty(agent, "cancelPersistTimer", { value: () => {} });
+  Object.defineProperty(agent, "syntheticsPersisted", {
+    value: false,
+    writable: true,
   });
 
   return agent;
@@ -252,6 +268,178 @@ describe("OffensiveSecurityAgent.consume()", () => {
 
       const result = await agent.consume();
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("synthetic tool-result on stream abort/error", () => {
+    const toolCallChunk = {
+      type: "tool-call",
+      toolCallId: "tc1",
+      toolName: "execute_command",
+    };
+
+    it("emits synthetic tool-result for in-flight tool when stream throws", async () => {
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow(
+          [toolCallChunk],
+          new Error("connection reset"),
+        ),
+      });
+
+      const emittedResults: Array<{ toolCallId: string; result: unknown }> = [];
+      agent.eventBus.on("tool-result", (e) => {
+        emittedResults.push({ toolCallId: e.toolCallId, result: e.result });
+      });
+
+      await expect(agent.consume()).rejects.toThrow("connection reset");
+
+      expect(emittedResults).toHaveLength(1);
+      expect(emittedResults[0].toolCallId).toBe("tc1");
+      expect(emittedResults[0].result).toMatchObject({
+        type: "error-text",
+        value: expect.stringContaining("connection reset"),
+      });
+    });
+
+    it("does not emit synthetic when tool-result already streamed", async () => {
+      const toolResultChunk = {
+        type: "tool-result",
+        toolCallId: "tc1",
+        result: { type: "text", value: "done" },
+      };
+      const agent = buildStubAgent({
+        fullStream: yieldChunks([toolCallChunk, toolResultChunk]),
+      });
+
+      const emittedResults: unknown[] = [];
+      agent.eventBus.on("tool-result", (e) => emittedResults.push(e));
+
+      await agent.consume();
+      expect(emittedResults).toHaveLength(0);
+    });
+
+    it("uses 'Agent aborted by user' when abortSignal is set", async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow(
+          [toolCallChunk],
+          new DOMException("Aborted", "AbortError"),
+        ),
+        abortSignal: controller.signal,
+      });
+
+      const emittedResults: Array<{ result: unknown }> = [];
+      agent.eventBus.on("tool-result", (e) =>
+        emittedResults.push({ result: e.result }),
+      );
+
+      await expect(agent.consume()).rejects.toBeInstanceOf(DOMException);
+
+      expect(emittedResults[0].result).toMatchObject({
+        type: "error-text",
+        value: expect.stringContaining("aborted by user"),
+      });
+    });
+
+    it("propagates original stream error when event listener throws", async () => {
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow(
+          [toolCallChunk],
+          new Error("original error"),
+        ),
+      });
+
+      agent.eventBus.on("tool-result", () => {
+        throw new Error("listener explosion");
+      });
+
+      await expect(agent.consume()).rejects.toThrow("original error");
+    });
+
+    it("persists synthetic results to messages.json", async () => {
+      const tmpDir = join("/tmp", `pensar-test-${Date.now()}-persist`);
+      mkdirSync(tmpDir, { recursive: true });
+      const messagesPath = join(tmpDir, "messages.json");
+
+      const existingMessages = [
+        { role: "user", content: [{ type: "text", text: "run nmap" }] },
+      ];
+      writeFileSync(messagesPath, JSON.stringify(existingMessages));
+
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow([toolCallChunk], new Error("timeout")),
+        messagesPath,
+        latestMessages: null,
+      });
+
+      try {
+        await agent.consume();
+      } catch {}
+      await new Promise((r) => setTimeout(r, 50));
+
+      const written = JSON.parse(readFileSync(messagesPath, "utf-8"));
+      expect(written.length).toBeGreaterThan(1);
+      expect(written[0].role).toBe("user");
+      const toolMsg = written.find((m: { role: string }) => m.role === "tool");
+      expect(toolMsg).toBeDefined();
+      expect(toolMsg.content[0].output.type).toBe("error-text");
+
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("includes completed parallel tool results on abort", async () => {
+      const tmpDir = join("/tmp", `pensar-test-${Date.now()}-parallel`);
+      mkdirSync(tmpDir, { recursive: true });
+      const messagesPath = join(tmpDir, "messages.json");
+      writeFileSync(
+        messagesPath,
+        JSON.stringify([
+          { role: "user", content: [{ type: "text", text: "scan" }] },
+        ]),
+      );
+
+      const toolCallA = {
+        type: "tool-call",
+        toolCallId: "tcA",
+        toolName: "read_file",
+      };
+      const toolCallB = {
+        type: "tool-call",
+        toolCallId: "tcB",
+        toolName: "execute_command",
+      };
+      const toolResultA = {
+        type: "tool-result",
+        toolCallId: "tcA",
+        toolName: "read_file",
+        result: { type: "text", value: "file contents" },
+      };
+
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow(
+          [toolCallA, toolCallB, toolResultA],
+          new Error("connection lost"),
+        ),
+        messagesPath,
+        latestMessages: null,
+      });
+
+      try {
+        await agent.consume();
+      } catch {}
+      await new Promise((r) => setTimeout(r, 50));
+
+      const written = JSON.parse(readFileSync(messagesPath, "utf-8"));
+      const toolMsg = written.find((m: { role: string }) => m.role === "tool");
+      expect(toolMsg.content).toHaveLength(2);
+      const ids = toolMsg.content
+        .map((c: { toolCallId: string }) => c.toolCallId)
+        .sort();
+      expect(ids).toEqual(["tcA", "tcB"]);
+
+      rmSync(tmpDir, { recursive: true, force: true });
     });
   });
 });

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -1,14 +1,16 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import type {
   ModelMessage,
   StopCondition,
   StreamTextResult,
   TextStreamPart,
+  ToolCallPart,
+  ToolResultPart,
   ToolSet,
 } from "ai";
 import { hasToolCall } from "ai";
-import { existsSync, mkdirSync } from "fs";
-import { writeFile } from "fs/promises";
-import { join } from "path";
 import { streamResponse } from "../../ai";
 import { AgentEventBus } from "../../eventBus";
 import {
@@ -120,6 +122,16 @@ export class OffensiveSecurityAgent<TResult = void> {
 
   /** The session this agent is operating within. */
   private readonly _session: SessionInfo;
+
+  /** Shared with stream callbacks so consume() can read messages on abort. */
+  private latestMessages: ModelMessage[] | null = null;
+
+  private messagesPath: string | null = null;
+
+  private cancelPersistTimer: (() => void) | null = null;
+
+  /** Set after emitSyntheticToolResults writes successfully; gates onFinish write. */
+  private syntheticsPersisted = false;
 
   /**
    * Async factory that creates a session when one is not provided,
@@ -332,7 +344,8 @@ export class OffensiveSecurityAgent<TResult = void> {
     if (!existsSync(messagesDir)) {
       mkdirSync(messagesDir, { recursive: true });
     }
-    const messagesPath = join(messagesDir, "messages.json");
+    this.messagesPath = join(messagesDir, "messages.json");
+    const messagesPath = this.messagesPath;
 
     // Mutable so that summarization can clear stale history.
     const initialMessagesRef: { current: ModelMessage[] } = {
@@ -350,18 +363,24 @@ export class OffensiveSecurityAgent<TResult = void> {
     // JSON.stringify on every step when many agents run concurrently.
     const PERSIST_INTERVAL_MS = 15_000;
     let persistTimer: ReturnType<typeof setTimeout> | null = null;
-    let latestMessages: ModelMessage[] | null = null;
 
     const schedulePersist = () => {
       if (persistTimer) return;
       persistTimer = setTimeout(() => {
         persistTimer = null;
-        if (latestMessages) {
-          const toWrite = latestMessages;
-          latestMessages = null;
+        if (this.latestMessages) {
+          const toWrite = this.latestMessages;
+          this.latestMessages = null;
           writeFile(messagesPath, JSON.stringify(toWrite)).catch(() => {});
         }
       }, PERSIST_INTERVAL_MS);
+    };
+
+    this.cancelPersistTimer = () => {
+      if (persistTimer) {
+        clearTimeout(persistTimer);
+        persistTimer = null;
+      }
     };
 
     // -- Init record (trace.jsonl first line) ---------------------------------
@@ -407,7 +426,7 @@ export class OffensiveSecurityAgent<TResult = void> {
         toolChoice: "auto",
         sessionPath: input.session.rootPath,
         onStepFinish: async (event) => {
-          latestMessages = [
+          this.latestMessages = [
             ...initialMessagesRef.current,
             ...event.response.messages,
           ];
@@ -436,13 +455,15 @@ export class OffensiveSecurityAgent<TResult = void> {
             clearTimeout(persistTimer);
             persistTimer = null;
           }
-          const finalMessages = latestMessages ?? [
-            ...initialMessagesRef.current,
-            ...event.response.messages,
-          ];
-          await writeFile(messagesPath, JSON.stringify(finalMessages)).catch(
-            () => {},
-          );
+          if (!this.syntheticsPersisted) {
+            const finalMessages = this.latestMessages ?? [
+              ...initialMessagesRef.current,
+              ...event.response.messages,
+            ];
+            await writeFile(messagesPath, JSON.stringify(finalMessages)).catch(
+              () => {},
+            );
+          }
           await input.onFinish?.(event);
         },
         abortSignal: input.abortSignal,
@@ -517,12 +538,58 @@ export class OffensiveSecurityAgent<TResult = void> {
     const bus = this.eventBus;
 
     const runConsume = async (): Promise<TResult> => {
+      const inFlightTools = new Map<string, string>();
+      const completedResults: ToolResultPart[] = [];
+      let streamError: unknown = null;
+
       try {
         for await (const chunk of this.streamResult.fullStream) {
+          if (chunk.type === "tool-call") {
+            inFlightTools.set(chunk.toolCallId, chunk.toolName);
+          } else if (chunk.type === "tool-result") {
+            const tc = chunk as {
+              toolCallId: string;
+              toolName: string;
+              result?: unknown;
+              output?: unknown;
+            };
+            inFlightTools.delete(tc.toolCallId);
+            completedResults.push({
+              type: "tool-result",
+              toolCallId: tc.toolCallId,
+              toolName: tc.toolName,
+              output: (tc.result ?? tc.output) as ToolResultPart["output"],
+            });
+          }
           bus.emitStreamPart(chunk, sid);
         }
+        // Stream completed normally — onStepFinish persists everything.
+        completedResults.length = 0;
+      } catch (err) {
+        streamError = err;
       } finally {
         this.persistentShell?.dispose();
+
+        if (inFlightTools.size > 0) {
+          const reason = this.abortSignal?.aborted
+            ? "Agent aborted by user"
+            : streamError instanceof Error && streamError.message
+              ? streamError.message
+              : "Stream terminated unexpectedly";
+          try {
+            await this.emitSyntheticToolResults(
+              inFlightTools,
+              completedResults,
+              reason,
+            );
+          } catch {
+            // Swallow — never mask the original streamError with a listener error.
+          }
+        }
+      }
+
+      if (streamError) {
+        throw streamError;
       }
 
       if (this.abortSignal?.aborted) {
@@ -566,6 +633,107 @@ export class OffensiveSecurityAgent<TResult = void> {
    */
   get response() {
     return this.streamResult.response;
+  }
+
+  private async emitSyntheticToolResults(
+    inFlightTools: Map<string, string>,
+    completedResults: ToolResultPart[],
+    reason: string,
+  ): Promise<void> {
+    const sid = this.subagentId;
+    const output = {
+      type: "error-text" as const,
+      value: `Tool execution aborted: ${reason}`,
+    };
+    const syntheticParts: ToolResultPart[] = [];
+
+    for (const [toolCallId, toolName] of inFlightTools) {
+      this.eventBus.emit("tool-result", {
+        toolCallId,
+        toolName,
+        result: output,
+        subagentId: sid,
+      });
+      syntheticParts.push({
+        type: "tool-result",
+        toolCallId,
+        toolName,
+        output,
+      });
+    }
+
+    if (!this.messagesPath) return;
+
+    this.cancelPersistTimer?.();
+
+    let base: ModelMessage[] = this.latestMessages ?? [];
+    if (base.length === 0 && existsSync(this.messagesPath)) {
+      try {
+        base = JSON.parse(readFileSync(this.messagesPath, "utf-8"));
+      } catch {
+        // Best-effort: corrupt file → proceed with empty base.
+      }
+    }
+
+    // If onStepFinish never fired for the current step, reconstruct the
+    // assistant tool-call message so resumed sessions have valid pairs.
+    const allToolCallIds = new Set([
+      ...inFlightTools.keys(),
+      ...completedResults.map((r) => r.toolCallId),
+    ]);
+    const lastMsg = base[base.length - 1];
+    const needsStepReconstruction =
+      !lastMsg ||
+      lastMsg.role !== "assistant" ||
+      !this.baseContainsToolCalls(lastMsg, allToolCallIds);
+
+    const appended: ModelMessage[] = [];
+    if (needsStepReconstruction) {
+      const toolCalls: ToolCallPart[] = [
+        ...[...inFlightTools.entries()].map(([toolCallId, toolName]) => ({
+          type: "tool-call" as const,
+          toolCallId,
+          toolName,
+          input: {},
+        })),
+        ...completedResults.map((r) => ({
+          type: "tool-call" as const,
+          toolCallId: r.toolCallId,
+          toolName: r.toolName,
+          input: {},
+        })),
+      ];
+      appended.push({ role: "assistant", content: toolCalls });
+    }
+    appended.push({
+      role: "tool",
+      content: [...completedResults, ...syntheticParts],
+    });
+
+    const next: ModelMessage[] = [...base, ...appended];
+    this.latestMessages = next;
+    try {
+      await writeFile(this.messagesPath, JSON.stringify(next));
+      this.syntheticsPersisted = true;
+    } catch {
+      // Write failed — leave syntheticsPersisted false so onFinish can retry.
+    }
+  }
+
+  private baseContainsToolCalls(
+    msg: ModelMessage,
+    toolCallIds: Set<string>,
+  ): boolean {
+    if (!Array.isArray(msg.content)) return false;
+    const contentToolIds = new Set(
+      (msg.content as Array<{ type: string; toolCallId?: string }>)
+        .filter((p) => p.type === "tool-call" && p.toolCallId)
+        .map((p) => p.toolCallId),
+    );
+    for (const toolCallId of toolCallIds) {
+      if (!contentToolIds.has(toolCallId)) return false;
+    }
+    return true;
   }
 }
 

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -589,7 +589,7 @@ export class OffensiveSecurityAgent<TResult = void> {
       } finally {
         this.persistentShell?.dispose();
 
-        if (inFlightTools.size > 0) {
+        if (inFlightTools.size > 0 || completedResults.length > 0) {
           const reason = this.abortSignal?.aborted
             ? "Agent aborted by user"
             : streamError instanceof Error && streamError.message

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -579,6 +579,7 @@ export class OffensiveSecurityAgent<TResult = void> {
               });
             }
             inFlightTools.clear();
+            completedResults.length = 0;
           }
           bus.emitStreamPart(chunk, sid);
         }

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -544,7 +544,11 @@ export class OffensiveSecurityAgent<TResult = void> {
 
       try {
         for await (const chunk of this.streamResult.fullStream) {
-          if (chunk.type === "tool-call") {
+          if (chunk.type === "tool-input-start") {
+            // Track from the start so a truncated call (started, args never
+            // completed) still gets closed and isn't left "running".
+            inFlightTools.set(chunk.id, chunk.toolName);
+          } else if (chunk.type === "tool-call") {
             inFlightTools.set(chunk.toolCallId, chunk.toolName);
           } else if (chunk.type === "tool-result") {
             const tc = chunk as {
@@ -560,6 +564,21 @@ export class OffensiveSecurityAgent<TResult = void> {
               toolName: tc.toolName,
               output: (tc.result ?? tc.output) as ToolResultPart["output"],
             });
+          } else if (chunk.type === "finish-step") {
+            // Close any call that started this step but produced no result
+            // (truncated args) so it doesn't render stuck "running".
+            for (const [toolCallId, toolName] of inFlightTools) {
+              bus.emit("tool-result", {
+                toolCallId,
+                toolName,
+                result: {
+                  type: "error-text",
+                  value: "Tool call did not complete",
+                },
+                subagentId: sid,
+              });
+            }
+            inFlightTools.clear();
           }
           bus.emitStreamPart(chunk, sid);
         }


### PR DESCRIPTION
Closes #778. Emit synthetic `tool-result` (`error-text`) for in-flight tool calls when `consume()`'s stream throws/aborts; also append to `messagesPath` for resume.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent streaming, event bus, and session message persistence on failure paths; behavior is well covered by new unit tests but affects resume UX and conversation history integrity.
> 
> **Overview**
> **Fixes stuck in-flight tools and broken resume when the agent stream aborts or errors** (closes #778).
> 
> `consume()` now tracks tool calls from `tool-input-start` / `tool-call` through `tool-result`, and on stream failure or user abort emits synthetic **`tool-result`** events with **`error-text`** so the UI is not left showing tools as still running. Truncated calls (args never finished) get closed at **`finish-step`** with a “did not complete” error. **`emitSyntheticToolResults`** also appends assistant/tool message pairs to **`messages.json`** (including parallel tools where one finished and another did not), cancels the debounced persist timer, and sets **`syntheticsPersisted`** so **`onFinish`** does not overwrite that write.
> 
> Message persistence state (**`latestMessages`**, **`messagesPath`**, persist timer cancel) is lifted onto the agent instance so abort paths can read/write history. Listener failures during synthetic emit are swallowed so the **original stream error** still propagates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c77cbba27442dd8074814b863238c89582f9b1fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->