### PR TITLE
fix(tui): anchor home input vertically and cap dropdown to fit terminal

### DIFF
--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -136,27 +136,36 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
 
   // Content visibility: hide decorative elements first
   const showCommands = height >= 22;
-  const showHelpText = height >= 18;
   const inputPadding = height >= 20 ? 1 : 0;
   const inputWidth = Math.min(80, dimensions.width - 10);
 
-  // Estimate rows consumed above the input to size the autocomplete dropdown
-  const rowsAboveInput =
-    animationHeight +
+  // Static content height (without the autocomplete dropdown) used to
+  // compute a fixed top-margin anchor and size the dropdown window.
+  // The petri animation is absolutely positioned and excluded from flow.
+  const baseContentHeight =
     titleMarginTop +
     2 + // title + subtitle
     (showCommands ? menuMarginTop + 5 : 0) +
     inputMarginTop +
-    inputPadding + // top padding
-    1; // input row itself
-  const rowsBelowInput =
-    (showHelpText ? 2 : 0) + // help text + marginTop
-    inputPadding + // bottom padding
-    3; // footer bar approximate
-  // Subtract 3 extra rows: 1 margin + 1 "↑ more above" + 1 "↓ more below" indicators
+    inputPadding * 2 + // top + bottom padding of the input box
+    2; // input row + operator mode bar
+
+  const footerRows = 3;
+  // Anchor the content block at a fixed vertical position so the input
+  // doesn't drift when the dropdown opens or the textarea grows.
+  const contentTopMargin = Math.max(
+    0,
+    Math.floor((height - footerRows - baseContentHeight) / 2),
+  );
+
+  // Available rows below the anchored content for the autocomplete dropdown.
+  // Each suggestion item can occupy up to 2 terminal rows (label + wrapped
+  // description), plus 3 rows of chrome (margin + scroll indicators).
+  const rowsBelowContent =
+    height - footerRows - contentTopMargin - baseContentHeight;
   const maxSuggestions = Math.max(
     2,
-    height - rowsAboveInput - rowsBelowInput - 3,
+    Math.floor((rowsBelowContent - 3) / 2),
   );
 
   return (
@@ -185,8 +194,7 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
       <box
         flexDirection="column"
         alignItems="center"
-        justifyContent="center"
-        height="100%"
+        marginTop={contentTopMargin}
       >
         {/* Title - centered */}
         <box

--- a/src/tui/components/chat/home-view.tsx
+++ b/src/tui/components/chat/home-view.tsx
@@ -163,10 +163,7 @@ export function HomeView({ onNavigate, onStartSession }: HomeViewProps) {
   // description), plus 3 rows of chrome (margin + scroll indicators).
   const rowsBelowContent =
     height - footerRows - contentTopMargin - baseContentHeight;
-  const maxSuggestions = Math.max(
-    2,
-    Math.floor((rowsBelowContent - 3) / 2),
-  );
+  const maxSuggestions = Math.max(2, Math.floor((rowsBelowContent - 3) / 2));
 
   return (
     <box


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes two related issues with the home-view prompt input:

**1. Dropdown overflows on tall windows**

With ~50 skills installed, the slash command dropdown would render too many items on tall terminals — items got clipped beyond the viewport. The root cause: `maxVisibleSuggestions` was computed by counting available rows but treating each suggestion as 1 row, when each item can actually occupy up to 2 terminal rows (label + wrapped description). The fix divides available space by 2 to account for multi-line items, plus reserves 3 rows for scroll indicators and margin.

**2. Input box drifts vertically**

The content column used `justifyContent="center"` + `height="100%"`, which meant any change in content height (dropdown appearing, multiline input) caused the entire block to reposition vertically. The fix replaces centering with a computed `marginTop` that anchors the content at a fixed position. The dropdown now expands downward from the anchor without shifting the input.

Also removes the unused `showHelpText` variable (vestigial from a removed feature).

### How did you verify your code works?

- `bun run tsc` — passes (no type errors)
- `bun run lint` — passes (only pre-existing warnings)
- `bun run test` — all 51 test files pass (984 tests), 7 skipped integration tests
- Manual TUI testing: launched the app, typed `/` to trigger the dropdown, verified items fit within the terminal and the input stays anchored when the dropdown appears/disappears

**Before (from issue):** Input centered, dropdown overflows

<img alt="Before - dropdown overflow" src="https://github.com/user-attachments/assets/4226521d-a0a6-4085-aad8-91631fdcbf43" />

**After:** Input anchored, dropdown capped to fit

![Home screen with anchored input](https://cursor.com/artifacts/c/art-c10165ec-4d79-4482-955b-7a16566ce5fa)
![Dropdown visible - fits within terminal](https://cursor.com/artifacts/c/art-17af0400-0d72-4760-9602-a94273f80591)
![Dropdown filtered](https://cursor.com/artifacts/c/art-17772766-647c-46aa-8f29-de34eeb8f0b1)

**Demo video:**

<a href="https://cursor.com/agents/bc-e4906239-08df-4774-b996-4be69e54d305/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdropdown_overflow_and_anchor_fix_demo.mp4"><img src="https://cursor.com/artifacts/c/art-ed6149fd-30c1-4e4e-a213-698a69cde60e" alt="dropdown_overflow_and_anchor_fix_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4906239-08df-4774-b996-4be69e54d305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4906239-08df-4774-b996-4be69e54d305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

