### PR TITLE
feat(api/cli): expand attack-surface management — apps, endpoints, search, pagination

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -134,6 +134,7 @@ Usage:
   pensar login                        Connect to Pensar Console
   pensar uninstall                    Uninstall Pensar (keeps sessions, memories, skills)
   pensar projects                     List workspace projects
+  pensar apps                         Manage the attack surface (apps & endpoints)
   pensar pentests                     List and manage pentests
   pensar issues                       List and manage security issues
   pensar fixes                        View security fixes
@@ -518,6 +519,9 @@ if (hasFlag("-p") || command === "--prompt") {
 } else if (command === "projects") {
   process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
   await import("./cli/projects");
+} else if (command === "apps") {
+  process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
+  await import("./cli/apps");
 } else if (command === "pentests") {
   process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
   await import("./cli/pentests");

--- a/src/cli/apps.ts
+++ b/src/cli/apps.ts
@@ -1,0 +1,410 @@
+#!/usr/bin/env bun
+
+/**
+ * pensar apps — Manage the project attack surface (apps & endpoints).
+ *
+ * Usage:
+ *   pensar apps <projectId>                                 List apps
+ *   pensar apps get <appId>                                 Show app details
+ *   pensar apps create <projectId> --name N --description D [opts]
+ *   pensar apps update <appId> [opts]                       Update app fields
+ *   pensar apps delete <appId>                              Delete an app
+ *   pensar apps endpoints <appId> [filters]                 List endpoints
+ *   pensar apps endpoint <endpointId>                       Show endpoint
+ *   pensar apps endpoint-create <appId> --endpoint E ...    Create endpoint
+ *   pensar apps endpoint-update <endpointId> [opts]         Update endpoint
+ *   pensar apps endpoint-delete <endpointId>                Delete endpoint
+ */
+
+import {
+  type ApplicationType,
+  type CreateAppInput,
+  type CreateEndpointInput,
+  createApp,
+  createEndpoint,
+  deleteApp,
+  deleteEndpoint,
+  type EndpointType,
+  getApp,
+  getEndpoint,
+  listApps,
+  listEndpoints,
+  type UpdateAppInput,
+  type UpdateEndpointInput,
+  updateApp,
+  updateEndpoint,
+} from "../core/api";
+
+const APPLICATION_TYPES: ApplicationType[] = [
+  "ui",
+  "api-service",
+  "web-application",
+  "full-stack",
+  "domain",
+  "subdomain",
+  "database",
+  "cloud-resource",
+  "storage",
+];
+
+const ENDPOINT_TYPES: EndpointType[] = [
+  "api-endpoint",
+  "web-endpoint",
+  "auth-endpoint",
+  "database",
+  "file-storage",
+  "asset",
+];
+
+function getFlag(flag: string, argv: string[]): string | undefined {
+  const idx = argv.indexOf(flag);
+  return idx !== -1 && idx + 1 < argv.length ? argv[idx + 1] : undefined;
+}
+
+function getAllFlags(flag: string, argv: string[]): string[] {
+  const values: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const next = argv[i + 1];
+    if (argv[i] === flag && next !== undefined) {
+      values.push(next);
+    }
+  }
+  return values;
+}
+
+function hasFlag(flag: string, argv: string[]): boolean {
+  return argv.includes(flag);
+}
+
+function parseAppType(value: string | undefined): ApplicationType | undefined {
+  if (value === undefined) return undefined;
+  if (!APPLICATION_TYPES.includes(value as ApplicationType)) {
+    throw new Error(
+      `Invalid --type "${value}". Must be one of: ${APPLICATION_TYPES.join(", ")}`,
+    );
+  }
+  return value as ApplicationType;
+}
+
+function parseEndpointType(
+  value: string | undefined,
+): EndpointType | undefined {
+  if (value === undefined) return undefined;
+  if (!ENDPOINT_TYPES.includes(value as EndpointType)) {
+    throw new Error(
+      `Invalid --type "${value}". Must be one of: ${ENDPOINT_TYPES.join(", ")}`,
+    );
+  }
+  return value as EndpointType;
+}
+
+function parseInteger(
+  flag: string,
+  value: string | undefined,
+): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n)) {
+    throw new Error(`${flag} must be an integer (got "${value}")`);
+  }
+  return n;
+}
+
+function parseNumber(
+  flag: string,
+  value: string | undefined,
+): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n)) {
+    throw new Error(`${flag} must be a number (got "${value}")`);
+  }
+  return n;
+}
+
+function showHelp(): void {
+  console.log(`pensar apps — Manage the project attack surface (apps & endpoints)
+
+Usage:
+  pensar apps <projectId>                                  List apps for a project
+  pensar apps get <appId>                                  Show app details
+  pensar apps create <projectId> [options]                 Create an app
+  pensar apps update <appId> [options]                     Update an app
+  pensar apps delete <appId>                               Delete an app
+  pensar apps endpoints <appId> [filters]                  List endpoints
+  pensar apps endpoint <endpointId>                        Show endpoint details
+  pensar apps endpoint-create <appId> [options]            Create an endpoint
+  pensar apps endpoint-update <endpointId> [options]       Update an endpoint
+  pensar apps endpoint-delete <endpointId>                 Delete an endpoint
+
+App fields (create requires --name and --description):
+  --name <text>                Application name
+  --description <text>         Application description
+  --type <type>                One of: ${APPLICATION_TYPES.join(", ")}
+  --framework <text>           Framework / runtime hint
+  --domain <id>                Linked domain UUID
+  --disallowed-actions <text>  Free-form disallowed actions notes
+
+Endpoint filters (for "endpoints"):
+  --type <type>                One of: ${ENDPOINT_TYPES.join(", ")}
+  --min-risk <score>           Minimum risk score (0–10)
+  --limit <n>                  Page size (enables paginated response)
+  --offset <n>                 Page offset (enables paginated response)
+
+Endpoint fields (create requires --endpoint and --description):
+  --endpoint <text>            Endpoint path / URL / route
+  --description <text>         Endpoint description
+  --type <type>                One of: ${ENDPOINT_TYPES.join(", ")}
+  --location <text>            Source file (whitebox)
+  --start-line <n>             Start line number
+  --end-line <n>               End line number
+  --objective <text>           Repeatable: testing objective for the endpoint
+  --auth-required              Mark endpoint as authentication-required
+  --no-auth-required           Mark endpoint as not requiring auth
+  --auth-details <text>        Free-form auth details
+  --business-logic <text>      Business-logic notes
+  --threat-model <text>        Per-endpoint threat model notes
+
+Options:
+  -h, --help                   Show this help message`);
+}
+
+function parseAppCreateOptions(argv: string[]): CreateAppInput {
+  const name = getFlag("--name", argv);
+  const description = getFlag("--description", argv);
+  if (!name) throw new Error("--name is required");
+  if (description === undefined) throw new Error("--description is required");
+
+  const type = parseAppType(getFlag("--type", argv));
+  const framework = getFlag("--framework", argv);
+  const domainId = getFlag("--domain", argv);
+  const disallowedActions = getFlag("--disallowed-actions", argv);
+
+  return {
+    name,
+    description,
+    ...(type !== undefined ? { type } : {}),
+    ...(framework !== undefined ? { framework } : {}),
+    ...(domainId !== undefined ? { domainId } : {}),
+    ...(disallowedActions !== undefined ? { disallowedActions } : {}),
+  };
+}
+
+function parseAppUpdateOptions(argv: string[]): UpdateAppInput {
+  const update: UpdateAppInput = {};
+  const name = getFlag("--name", argv);
+  if (name !== undefined) update.name = name;
+  const description = getFlag("--description", argv);
+  if (description !== undefined) update.description = description;
+  const type = parseAppType(getFlag("--type", argv));
+  if (type !== undefined) update.type = type;
+  const framework = getFlag("--framework", argv);
+  if (framework !== undefined) update.framework = framework;
+  const domain = getFlag("--domain", argv);
+  if (domain !== undefined) update.domainId = domain;
+  const disallowed = getFlag("--disallowed-actions", argv);
+  if (disallowed !== undefined) update.disallowedActions = disallowed;
+  return update;
+}
+
+function parseAuthenticationRequiredFlag(
+  argv: string[],
+): { required: boolean; details?: string } | undefined {
+  const yes = hasFlag("--auth-required", argv);
+  const no = hasFlag("--no-auth-required", argv);
+  const details = getFlag("--auth-details", argv);
+  if (!yes && !no && details === undefined) return undefined;
+  if (yes && no) {
+    throw new Error(
+      "--auth-required and --no-auth-required are mutually exclusive",
+    );
+  }
+  return {
+    required: yes,
+    ...(details !== undefined ? { details } : {}),
+  };
+}
+
+function parseEndpointCreateOptions(argv: string[]): CreateEndpointInput {
+  const endpoint = getFlag("--endpoint", argv);
+  const description = getFlag("--description", argv);
+  if (!endpoint) throw new Error("--endpoint is required");
+  if (description === undefined) throw new Error("--description is required");
+
+  const type = parseEndpointType(getFlag("--type", argv));
+  const location = getFlag("--location", argv);
+  const startLineNumber = parseInteger(
+    "--start-line",
+    getFlag("--start-line", argv),
+  );
+  const endLineNumber = parseInteger("--end-line", getFlag("--end-line", argv));
+  const objectives = getAllFlags("--objective", argv);
+  const authenticationRequired = parseAuthenticationRequiredFlag(argv);
+  const businessLogic = getFlag("--business-logic", argv);
+  const threatModel = getFlag("--threat-model", argv);
+
+  return {
+    endpoint,
+    description,
+    ...(type !== undefined ? { type } : {}),
+    ...(location !== undefined ? { location } : {}),
+    ...(startLineNumber !== undefined ? { startLineNumber } : {}),
+    ...(endLineNumber !== undefined ? { endLineNumber } : {}),
+    ...(objectives.length > 0 ? { objectives } : {}),
+    ...(authenticationRequired !== undefined ? { authenticationRequired } : {}),
+    ...(businessLogic !== undefined ? { businessLogic } : {}),
+    ...(threatModel !== undefined ? { threatModel } : {}),
+  };
+}
+
+function parseEndpointUpdateOptions(argv: string[]): UpdateEndpointInput {
+  const update: UpdateEndpointInput = {};
+  const endpoint = getFlag("--endpoint", argv);
+  if (endpoint !== undefined) update.endpoint = endpoint;
+  const description = getFlag("--description", argv);
+  if (description !== undefined) update.description = description;
+  const type = parseEndpointType(getFlag("--type", argv));
+  if (type !== undefined) update.type = type;
+  const location = getFlag("--location", argv);
+  if (location !== undefined) update.location = location;
+  const startLine = parseInteger("--start-line", getFlag("--start-line", argv));
+  if (startLine !== undefined) update.startLineNumber = startLine;
+  const endLine = parseInteger("--end-line", getFlag("--end-line", argv));
+  if (endLine !== undefined) update.endLineNumber = endLine;
+  const objectives = getAllFlags("--objective", argv);
+  if (objectives.length > 0) update.objectives = objectives;
+  const auth = parseAuthenticationRequiredFlag(argv);
+  if (auth !== undefined) update.authenticationRequired = auth;
+  const businessLogic = getFlag("--business-logic", argv);
+  if (businessLogic !== undefined) update.businessLogic = businessLogic;
+  const threatModel = getFlag("--threat-model", argv);
+  if (threatModel !== undefined) update.threatModel = threatModel;
+  return update;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+    showHelp();
+    return;
+  }
+
+  try {
+    if (sub === "get") {
+      const appId = args[1];
+      if (!appId) {
+        console.error("Error: app ID is required");
+        console.error("Usage: pensar apps get <appId>");
+        process.exit(1);
+      }
+      const app = await getApp(appId);
+      console.log(JSON.stringify(app, null, 2));
+    } else if (sub === "create") {
+      const projectId = args[1];
+      if (!projectId) {
+        console.error("Error: project ID is required");
+        console.error(
+          "Usage: pensar apps create <projectId> --name N --description D",
+        );
+        process.exit(1);
+      }
+      const opts = parseAppCreateOptions(args);
+      const result = await createApp(projectId, opts);
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub === "update") {
+      const appId = args[1];
+      if (!appId) {
+        console.error("Error: app ID is required");
+        console.error("Usage: pensar apps update <appId> [options]");
+        process.exit(1);
+      }
+      const opts = parseAppUpdateOptions(args);
+      const result = await updateApp(appId, opts);
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub === "delete") {
+      const appId = args[1];
+      if (!appId) {
+        console.error("Error: app ID is required");
+        console.error("Usage: pensar apps delete <appId>");
+        process.exit(1);
+      }
+      const result = await deleteApp(appId);
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub === "endpoints") {
+      const appId = args[1];
+      if (!appId) {
+        console.error("Error: app ID is required");
+        console.error("Usage: pensar apps endpoints <appId> [filters]");
+        process.exit(1);
+      }
+      const filters = {
+        type: parseEndpointType(getFlag("--type", args)),
+        minRiskScore: parseNumber("--min-risk", getFlag("--min-risk", args)),
+        limit: parseInteger("--limit", getFlag("--limit", args)),
+        offset: parseInteger("--offset", getFlag("--offset", args)),
+      };
+      const result = await listEndpoints(appId, filters);
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub === "endpoint") {
+      const endpointId = args[1];
+      if (!endpointId) {
+        console.error("Error: endpoint ID is required");
+        console.error("Usage: pensar apps endpoint <endpointId>");
+        process.exit(1);
+      }
+      const result = await getEndpoint(endpointId);
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub === "endpoint-create") {
+      const appId = args[1];
+      if (!appId) {
+        console.error("Error: app ID is required");
+        console.error(
+          "Usage: pensar apps endpoint-create <appId> --endpoint E --description D",
+        );
+        process.exit(1);
+      }
+      const opts = parseEndpointCreateOptions(args);
+      const result = await createEndpoint(appId, opts);
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub === "endpoint-update") {
+      const endpointId = args[1];
+      if (!endpointId) {
+        console.error("Error: endpoint ID is required");
+        console.error(
+          "Usage: pensar apps endpoint-update <endpointId> [options]",
+        );
+        process.exit(1);
+      }
+      const opts = parseEndpointUpdateOptions(args);
+      const result = await updateEndpoint(endpointId, opts);
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub === "endpoint-delete") {
+      const endpointId = args[1];
+      if (!endpointId) {
+        console.error("Error: endpoint ID is required");
+        console.error("Usage: pensar apps endpoint-delete <endpointId>");
+        process.exit(1);
+      }
+      const result = await deleteEndpoint(endpointId);
+      console.log(JSON.stringify(result, null, 2));
+    } else if (!sub.startsWith("-")) {
+      // Default: treat first arg as a project ID and list apps.
+      const projectId = sub;
+      const apps = await listApps(projectId);
+      console.log(JSON.stringify(apps, null, 2));
+    } else {
+      console.error(`Error: Unknown subcommand "${sub}"`);
+      showHelp();
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error(
+      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/cli/apps.ts
+++ b/src/cli/apps.ts
@@ -29,6 +29,8 @@ import {
   getEndpoint,
   listApps,
   listEndpoints,
+  searchApps,
+  searchEndpoints,
   type UpdateAppInput,
   type UpdateEndpointInput,
   updateApp,
@@ -136,6 +138,8 @@ Usage:
   pensar apps endpoint-create <appId> [options]            Create an endpoint
   pensar apps endpoint-update <endpointId> [options]       Update an endpoint
   pensar apps endpoint-delete <endpointId>                 Delete an endpoint
+  pensar apps search <query> [options]                     Substring-search apps
+  pensar apps search-endpoints <query> [options]           Substring-search endpoints
 
 App fields (create requires --name and --description):
   --name <text>                Application name
@@ -150,6 +154,16 @@ Endpoint filters (for "endpoints"):
   --min-risk <score>           Minimum risk score (0–10)
   --limit <n>                  Page size (enables paginated response)
   --offset <n>                 Page offset (enables paginated response)
+
+Search options:
+  --project <id>               Scope search to a project (search-endpoints also
+                               supports --app <id> to scope to a single app)
+  --type <type>                Filter by application or endpoint type
+  --min-risk <score>           Endpoint search only: minimum risk score
+  --auth-required              Endpoint search only: only auth-required endpoints
+  --no-auth-required           Endpoint search only: only public endpoints
+  --limit <n>                  Page size (default 50, max 200)
+  --offset <n>                 Page offset
 
 Endpoint fields (create requires --endpoint and --description):
   --endpoint <text>            Endpoint path / URL / route
@@ -388,6 +402,55 @@ async function main(): Promise<void> {
         process.exit(1);
       }
       const result = await deleteEndpoint(endpointId);
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub === "search") {
+      const query = args[1];
+      if (!query || query.startsWith("--")) {
+        console.error("Error: search query is required");
+        console.error("Usage: pensar apps search <query> [options]");
+        process.exit(1);
+      }
+      const projectId = getFlag("--project", args);
+      const type = parseAppType(getFlag("--type", args));
+      const limit = parseInteger("--limit", getFlag("--limit", args));
+      const offset = parseInteger("--offset", getFlag("--offset", args));
+      const result = await searchApps(query, {
+        ...(projectId !== undefined ? { projectId } : {}),
+        ...(type !== undefined ? { type } : {}),
+        ...(limit !== undefined ? { limit } : {}),
+        ...(offset !== undefined ? { offset } : {}),
+      });
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub === "search-endpoints") {
+      const query = args[1];
+      if (!query || query.startsWith("--")) {
+        console.error("Error: search query is required");
+        console.error("Usage: pensar apps search-endpoints <query> [options]");
+        process.exit(1);
+      }
+      const applicationId = getFlag("--app", args);
+      const projectId = getFlag("--project", args);
+      const type = parseEndpointType(getFlag("--type", args));
+      const minRiskScore = parseNumber(
+        "--min-risk",
+        getFlag("--min-risk", args),
+      );
+      const authRequired = hasFlag("--auth-required", args)
+        ? true
+        : hasFlag("--no-auth-required", args)
+          ? false
+          : undefined;
+      const limit = parseInteger("--limit", getFlag("--limit", args));
+      const offset = parseInteger("--offset", getFlag("--offset", args));
+      const result = await searchEndpoints(query, {
+        ...(applicationId !== undefined ? { applicationId } : {}),
+        ...(projectId !== undefined ? { projectId } : {}),
+        ...(type !== undefined ? { type } : {}),
+        ...(minRiskScore !== undefined ? { minRiskScore } : {}),
+        ...(authRequired !== undefined ? { authRequired } : {}),
+        ...(limit !== undefined ? { limit } : {}),
+        ...(offset !== undefined ? { offset } : {}),
+      });
       console.log(JSON.stringify(result, null, 2));
     } else if (!sub.startsWith("-")) {
       // Default: treat first arg as a project ID and list apps.

--- a/src/cli/apps.ts
+++ b/src/cli/apps.ts
@@ -149,11 +149,15 @@ App fields (create requires --name and --description):
   --domain <id>                Linked domain UUID
   --disallowed-actions <text>  Free-form disallowed actions notes
 
+List pagination (for "<projectId>" and "endpoints <appId>"):
+  --limit <n>                  Page size (default 100, max 200)
+  --offset <n>                 Page offset (default 0)
+  Responses include { ..., hasMore, limit, offset }; iterate by
+  incrementing --offset by --limit until hasMore is false.
+
 Endpoint filters (for "endpoints"):
   --type <type>                One of: ${ENDPOINT_TYPES.join(", ")}
   --min-risk <score>           Minimum risk score (0–10)
-  --limit <n>                  Page size (enables paginated response)
-  --offset <n>                 Page offset (enables paginated response)
 
 Search options:
   --project <id>               Scope search to a project (search-endpoints also
@@ -353,11 +357,18 @@ async function main(): Promise<void> {
         console.error("Usage: pensar apps endpoints <appId> [filters]");
         process.exit(1);
       }
+      const type = parseEndpointType(getFlag("--type", args));
+      const minRiskScore = parseNumber(
+        "--min-risk",
+        getFlag("--min-risk", args),
+      );
+      const limit = parseInteger("--limit", getFlag("--limit", args));
+      const offset = parseInteger("--offset", getFlag("--offset", args));
       const filters = {
-        type: parseEndpointType(getFlag("--type", args)),
-        minRiskScore: parseNumber("--min-risk", getFlag("--min-risk", args)),
-        limit: parseInteger("--limit", getFlag("--limit", args)),
-        offset: parseInteger("--offset", getFlag("--offset", args)),
+        ...(type !== undefined ? { type } : {}),
+        ...(minRiskScore !== undefined ? { minRiskScore } : {}),
+        ...(limit !== undefined ? { limit } : {}),
+        ...(offset !== undefined ? { offset } : {}),
       };
       const result = await listEndpoints(appId, filters);
       console.log(JSON.stringify(result, null, 2));
@@ -455,8 +466,13 @@ async function main(): Promise<void> {
     } else if (!sub.startsWith("-")) {
       // Default: treat first arg as a project ID and list apps.
       const projectId = sub;
-      const apps = await listApps(projectId);
-      console.log(JSON.stringify(apps, null, 2));
+      const limit = parseInteger("--limit", getFlag("--limit", args));
+      const offset = parseInteger("--offset", getFlag("--offset", args));
+      const result = await listApps(projectId, {
+        ...(limit !== undefined ? { limit } : {}),
+        ...(offset !== undefined ? { offset } : {}),
+      });
+      console.log(JSON.stringify(result, null, 2));
     } else {
       console.error(`Error: Unknown subcommand "${sub}"`);
       showHelp();

--- a/src/core/api/apiClient.ts
+++ b/src/core/api/apiClient.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared HTTP client helpers for the Pensar Console REST API.
+ *
+ * Auth is handled via Bearer token (WorkOS JWT) or API key, with an
+ * X-Workspace-Id header for JWT auth.
+ */
+
+import { ensureValidToken } from "../auth";
+import { config } from "../config";
+import { getPensarApiUrl } from "./constants";
+
+async function getAuthHeaders(): Promise<Record<string, string>> {
+  const cfg = await config.get();
+
+  const validToken = await ensureValidToken({
+    accessToken: cfg.accessToken,
+    refreshToken: cfg.refreshToken,
+    pensarAPIKey: cfg.pensarAPIKey,
+  });
+
+  if (!validToken) {
+    throw new Error(
+      "Not authenticated. Run `pensar login` to connect to Pensar Console.",
+    );
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${validToken.token}`,
+  };
+
+  if (cfg.workspaceId) {
+    headers["X-Workspace-Id"] = cfg.workspaceId;
+  }
+
+  return headers;
+}
+
+export async function apiRequest<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const baseUrl = getPensarApiUrl();
+  const headers = await getAuthHeaders();
+  const url = `${baseUrl}${path}`;
+
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(url, init);
+
+  if (!response.ok) {
+    const text = await response.text();
+    let message: string;
+    try {
+      const err = JSON.parse(text) as { error?: string };
+      message = err.error ?? text;
+    } catch {
+      message = text;
+    }
+    throw new Error(`API error (${response.status}): ${message}`);
+  }
+
+  // Some endpoints (e.g. 204-equivalent success responses) may return no body.
+  const text = await response.text();
+  if (!text) return undefined as T;
+  return JSON.parse(text) as T;
+}

--- a/src/core/api/apps.ts
+++ b/src/core/api/apps.ts
@@ -1,0 +1,234 @@
+/**
+ * REST API client for the Pensar attack surface (apps & endpoints).
+ *
+ * Wraps the apps/endpoints routes on the console's issues-api Lambda
+ * (`/{proxy+}` API Gateway).
+ *
+ * Endpoint surface:
+ *   GET    /projects/:projectId/apps
+ *   POST   /projects/:projectId/apps
+ *   GET    /apps/:appId
+ *   PATCH  /apps/:appId
+ *   DELETE /apps/:appId
+ *   GET    /apps/:appId/endpoints
+ *   POST   /apps/:appId/endpoints
+ *   GET    /endpoints/:endpointId
+ *   PATCH  /endpoints/:endpointId
+ *   DELETE /endpoints/:endpointId
+ */
+
+import { apiRequest } from "./apiClient";
+
+// ── Enums ────────────────────────────────────────────────────────────
+
+export type ApplicationType =
+  | "ui"
+  | "api-service"
+  | "web-application"
+  | "full-stack"
+  | "domain"
+  | "subdomain"
+  | "database"
+  | "cloud-resource"
+  | "storage";
+
+export type EndpointType =
+  | "api-endpoint"
+  | "web-endpoint"
+  | "auth-endpoint"
+  | "database"
+  | "file-storage"
+  | "asset";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface AppSummary {
+  id: string;
+  name: string;
+  type: string | null;
+  framework: string | null;
+  projectId: string;
+  domainId: string | null;
+  createdAt: string;
+}
+
+export interface AppDetail extends AppSummary {
+  description: string;
+  disallowedActions: string | null;
+}
+
+export interface EndpointSummary {
+  id: string;
+  endpoint: string;
+  type: string | null;
+  applicationId: string;
+  location: string | null;
+  riskScore: number | null;
+  objectives: string[];
+  createdAt: string;
+}
+
+export interface EndpointDetail extends EndpointSummary {
+  description: string;
+  startLineNumber: number | null;
+  endLineNumber: number | null;
+  authenticationRequired: {
+    required: boolean;
+    details: string | null;
+  } | null;
+  riskScoreBreakdown: {
+    score: number;
+    explanation: string;
+    breakdown: {
+      exposure: number;
+      dataSensitivity: number;
+      functionCriticality: number;
+      securityIndicators: number;
+    };
+  } | null;
+  businessLogic: string | null;
+  threatModel: string | null;
+}
+
+export interface ListEndpointsPage {
+  endpoints: EndpointSummary[];
+  hasMore: boolean;
+  limit: number;
+  offset: number;
+}
+
+export interface CreateAppInput {
+  name: string;
+  description: string;
+  type?: ApplicationType;
+  framework?: string;
+  domainId?: string;
+  disallowedActions?: string;
+}
+
+export interface UpdateAppInput {
+  name?: string;
+  description?: string;
+  type?: ApplicationType | null;
+  framework?: string | null;
+  domainId?: string | null;
+  disallowedActions?: string | null;
+}
+
+export interface CreateEndpointInput {
+  endpoint: string;
+  description: string;
+  type?: EndpointType;
+  location?: string;
+  startLineNumber?: number;
+  endLineNumber?: number;
+  objectives?: string[];
+  authenticationRequired?: {
+    required: boolean;
+    details?: string | null;
+  };
+  businessLogic?: string;
+  threatModel?: string;
+}
+
+export interface UpdateEndpointInput {
+  endpoint?: string;
+  description?: string;
+  type?: EndpointType | null;
+  location?: string | null;
+  startLineNumber?: number | null;
+  endLineNumber?: number | null;
+  objectives?: string[];
+  authenticationRequired?: {
+    required: boolean;
+    details?: string | null;
+  } | null;
+  businessLogic?: string | null;
+  threatModel?: string | null;
+}
+
+export interface DeleteResult {
+  success: boolean;
+  appId?: string;
+  endpointId?: string;
+}
+
+// ── Apps ─────────────────────────────────────────────────────────────
+
+export async function listApps(projectId: string): Promise<AppSummary[]> {
+  return apiRequest<AppSummary[]>("GET", `/projects/${projectId}/apps`);
+}
+
+export async function getApp(appId: string): Promise<AppDetail> {
+  return apiRequest<AppDetail>("GET", `/apps/${appId}`);
+}
+
+export async function createApp(
+  projectId: string,
+  data: CreateAppInput,
+): Promise<AppDetail> {
+  return apiRequest<AppDetail>("POST", `/projects/${projectId}/apps`, data);
+}
+
+export async function updateApp(
+  appId: string,
+  data: UpdateAppInput,
+): Promise<AppDetail> {
+  return apiRequest<AppDetail>("PATCH", `/apps/${appId}`, data);
+}
+
+export async function deleteApp(appId: string): Promise<DeleteResult> {
+  return apiRequest<DeleteResult>("DELETE", `/apps/${appId}`);
+}
+
+// ── Endpoints ────────────────────────────────────────────────────────
+
+export interface ListEndpointsFilters {
+  type?: EndpointType;
+  minRiskScore?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export async function listEndpoints(
+  appId: string,
+  filters?: ListEndpointsFilters,
+): Promise<EndpointSummary[] | ListEndpointsPage> {
+  const params = new URLSearchParams();
+  if (filters?.type) params.set("type", filters.type);
+  if (filters?.minRiskScore !== undefined) {
+    params.set("minRiskScore", String(filters.minRiskScore));
+  }
+  if (filters?.limit !== undefined) params.set("limit", String(filters.limit));
+  if (filters?.offset !== undefined) {
+    params.set("offset", String(filters.offset));
+  }
+
+  const qs = params.toString();
+  const path = `/apps/${appId}/endpoints${qs ? `?${qs}` : ""}`;
+  return apiRequest<EndpointSummary[] | ListEndpointsPage>("GET", path);
+}
+
+export async function getEndpoint(endpointId: string): Promise<EndpointDetail> {
+  return apiRequest<EndpointDetail>("GET", `/endpoints/${endpointId}`);
+}
+
+export async function createEndpoint(
+  appId: string,
+  data: CreateEndpointInput,
+): Promise<EndpointDetail> {
+  return apiRequest<EndpointDetail>("POST", `/apps/${appId}/endpoints`, data);
+}
+
+export async function updateEndpoint(
+  endpointId: string,
+  data: UpdateEndpointInput,
+): Promise<EndpointDetail> {
+  return apiRequest<EndpointDetail>("PATCH", `/endpoints/${endpointId}`, data);
+}
+
+export async function deleteEndpoint(
+  endpointId: string,
+): Promise<DeleteResult> {
+  return apiRequest<DeleteResult>("DELETE", `/endpoints/${endpointId}`);
+}

--- a/src/core/api/apps.ts
+++ b/src/core/api/apps.ts
@@ -57,6 +57,13 @@ export interface AppDetail extends AppSummary {
   disallowedActions: string | null;
 }
 
+/**
+ * Lean endpoint shape used by list/search responses. Heavy prose
+ * (description, full objectives list, businessLogic, threatModel,
+ * authentication details) is omitted to keep paginated responses well
+ * clear of the 6 MB Lambda response cap. Fetch
+ * {@link getEndpoint} for the full {@link EndpointDetail}.
+ */
 export interface EndpointSummary {
   id: string;
   endpoint: string;
@@ -64,12 +71,14 @@ export interface EndpointSummary {
   applicationId: string;
   location: string | null;
   riskScore: number | null;
-  objectives: string[];
+  objectivesCount: number;
+  authRequired: boolean | null;
   createdAt: string;
 }
 
 export interface EndpointDetail extends EndpointSummary {
   description: string;
+  objectives: string[];
   startLineNumber: number | null;
   endLineNumber: number | null;
   authenticationRequired: {
@@ -88,6 +97,13 @@ export interface EndpointDetail extends EndpointSummary {
   } | null;
   businessLogic: string | null;
   threatModel: string | null;
+}
+
+export interface ListAppsPage {
+  apps: AppSummary[];
+  hasMore: boolean;
+  limit: number;
+  offset: number;
 }
 
 export interface ListEndpointsPage {
@@ -155,8 +171,41 @@ export interface DeleteResult {
 
 // ── Apps ─────────────────────────────────────────────────────────────
 
-export async function listApps(projectId: string): Promise<AppSummary[]> {
-  return apiRequest<AppSummary[]>("GET", `/projects/${projectId}/apps`);
+export interface ListAppsOptions {
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * List apps in a project. Always paginated to avoid the 6 MB Lambda /
+ * 10 MB API Gateway response cap on large tenants. Default page size
+ * is 100 (max 200); use {@link listAppsAll} to auto-paginate.
+ */
+export async function listApps(
+  projectId: string,
+  opts?: ListAppsOptions,
+): Promise<ListAppsPage> {
+  const params = new URLSearchParams();
+  if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+  if (opts?.offset !== undefined) params.set("offset", String(opts.offset));
+  const qs = params.toString();
+  return apiRequest<ListAppsPage>(
+    "GET",
+    `/projects/${projectId}/apps${qs ? `?${qs}` : ""}`,
+  );
+}
+
+/** Auto-paginate {@link listApps} until exhaustion. */
+export async function listAppsAll(projectId: string): Promise<AppSummary[]> {
+  const all: AppSummary[] = [];
+  let offset = 0;
+  for (;;) {
+    const page = await listApps(projectId, { limit: 200, offset });
+    all.push(...page.apps);
+    if (!page.hasMore) break;
+    offset += page.limit;
+  }
+  return all;
 }
 
 export async function getApp(appId: string): Promise<AppDetail> {
@@ -190,10 +239,17 @@ export interface ListEndpointsFilters {
   offset?: number;
 }
 
+/**
+ * List endpoints in an application. Always paginated to avoid the 6 MB
+ * Lambda / 10 MB API Gateway response cap — endpoint rows carry heavy
+ * prose columns (threatModel, businessLogic, description, objectives).
+ * Default page size is 100 (max 200); use {@link listEndpointsAll} to
+ * auto-paginate.
+ */
 export async function listEndpoints(
   appId: string,
   filters?: ListEndpointsFilters,
-): Promise<EndpointSummary[] | ListEndpointsPage> {
+): Promise<ListEndpointsPage> {
   const params = new URLSearchParams();
   if (filters?.type) params.set("type", filters.type);
   if (filters?.minRiskScore !== undefined) {
@@ -206,7 +262,27 @@ export async function listEndpoints(
 
   const qs = params.toString();
   const path = `/apps/${appId}/endpoints${qs ? `?${qs}` : ""}`;
-  return apiRequest<EndpointSummary[] | ListEndpointsPage>("GET", path);
+  return apiRequest<ListEndpointsPage>("GET", path);
+}
+
+/** Auto-paginate {@link listEndpoints} until exhaustion. */
+export async function listEndpointsAll(
+  appId: string,
+  filters?: Omit<ListEndpointsFilters, "limit" | "offset">,
+): Promise<EndpointSummary[]> {
+  const all: EndpointSummary[] = [];
+  let offset = 0;
+  for (;;) {
+    const page = await listEndpoints(appId, {
+      ...filters,
+      limit: 200,
+      offset,
+    });
+    all.push(...page.endpoints);
+    if (!page.hasMore) break;
+    offset += page.limit;
+  }
+  return all;
 }
 
 export async function getEndpoint(endpointId: string): Promise<EndpointDetail> {

--- a/src/core/api/apps.ts
+++ b/src/core/api/apps.ts
@@ -336,7 +336,10 @@ export async function searchApps(
   if (opts?.type) params.set("type", opts.type);
   if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
   if (opts?.offset !== undefined) params.set("offset", String(opts.offset));
-  return apiRequest<SearchAppsResult>("GET", `/search/apps?${params.toString()}`);
+  return apiRequest<SearchAppsResult>(
+    "GET",
+    `/search/apps?${params.toString()}`,
+  );
 }
 
 export interface SearchEndpointsOptions {

--- a/src/core/api/apps.ts
+++ b/src/core/api/apps.ts
@@ -232,3 +232,75 @@ export async function deleteEndpoint(
 ): Promise<DeleteResult> {
   return apiRequest<DeleteResult>("DELETE", `/endpoints/${endpointId}`);
 }
+
+// ── Search (Tier 1: substring ILIKE) ─────────────────────────────────
+
+export interface SearchAppsOptions {
+  /** Optional: scope to a single project. Default: search across the workspace. */
+  projectId?: string;
+  type?: ApplicationType;
+  limit?: number;
+  offset?: number;
+}
+
+export interface SearchAppsResult {
+  apps: AppSummary[];
+  hasMore: boolean;
+  limit: number;
+  offset: number;
+  query: string;
+}
+
+export async function searchApps(
+  query: string,
+  opts?: SearchAppsOptions,
+): Promise<SearchAppsResult> {
+  const params = new URLSearchParams({ q: query });
+  if (opts?.projectId) params.set("projectId", opts.projectId);
+  if (opts?.type) params.set("type", opts.type);
+  if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+  if (opts?.offset !== undefined) params.set("offset", String(opts.offset));
+  return apiRequest<SearchAppsResult>("GET", `/search/apps?${params.toString()}`);
+}
+
+export interface SearchEndpointsOptions {
+  /** Scope to a single application. Most specific. */
+  applicationId?: string;
+  /** Scope to all apps in a project. */
+  projectId?: string;
+  type?: EndpointType;
+  minRiskScore?: number;
+  authRequired?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface SearchEndpointsResult {
+  endpoints: EndpointSummary[];
+  hasMore: boolean;
+  limit: number;
+  offset: number;
+  query: string;
+}
+
+export async function searchEndpoints(
+  query: string,
+  opts?: SearchEndpointsOptions,
+): Promise<SearchEndpointsResult> {
+  const params = new URLSearchParams({ q: query });
+  if (opts?.applicationId) params.set("applicationId", opts.applicationId);
+  if (opts?.projectId) params.set("projectId", opts.projectId);
+  if (opts?.type) params.set("type", opts.type);
+  if (opts?.minRiskScore !== undefined) {
+    params.set("minRiskScore", String(opts.minRiskScore));
+  }
+  if (opts?.authRequired !== undefined) {
+    params.set("authRequired", opts.authRequired ? "true" : "false");
+  }
+  if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+  if (opts?.offset !== undefined) params.set("offset", String(opts.offset));
+  return apiRequest<SearchEndpointsResult>(
+    "GET",
+    `/search/endpoints?${params.toString()}`,
+  );
+}

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -6,6 +6,7 @@
 //    (await import("./core/api/<feature>")) so `bun build --splitting`
 //    produces per-feature chunks. Routing those through this barrel would
 //    eliminate the split. The lint rule for module barriers exempts this.
+export * from "./apps";
 export * from "./attackSurface";
 export * from "./authentication";
 export * from "./benchmark";

--- a/src/core/api/issues.ts
+++ b/src/core/api/issues.ts
@@ -6,9 +6,7 @@
  * X-Workspace-Id header for JWT auth.
  */
 
-import { ensureValidToken } from "../auth";
-import { config } from "../config";
-import { getPensarApiUrl } from "./constants";
+import { apiRequest } from "./apiClient";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -115,66 +113,6 @@ export interface SearchAgentLogsResult {
     matchIndex: number;
     entries: Array<AgentLogEntry & { isMatch: boolean }>;
   }>;
-}
-
-// ── HTTP helpers ─────────────────────────────────────────────────────
-
-async function getAuthHeaders(): Promise<Record<string, string>> {
-  const cfg = await config.get();
-
-  const validToken = await ensureValidToken({
-    accessToken: cfg.accessToken,
-    refreshToken: cfg.refreshToken,
-    pensarAPIKey: cfg.pensarAPIKey,
-  });
-
-  if (!validToken) {
-    throw new Error(
-      "Not authenticated. Run `pensar login` to connect to Pensar Console.",
-    );
-  }
-
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${validToken.token}`,
-  };
-
-  if (cfg.workspaceId) {
-    headers["X-Workspace-Id"] = cfg.workspaceId;
-  }
-
-  return headers;
-}
-
-async function apiRequest<T>(
-  method: string,
-  path: string,
-  body?: unknown,
-): Promise<T> {
-  const baseUrl = getPensarApiUrl();
-  const headers = await getAuthHeaders();
-  const url = `${baseUrl}${path}`;
-
-  const init: RequestInit = { method, headers };
-  if (body !== undefined) {
-    init.body = JSON.stringify(body);
-  }
-
-  const response = await fetch(url, init);
-
-  if (!response.ok) {
-    const text = await response.text();
-    let message: string;
-    try {
-      const err = JSON.parse(text) as { error?: string };
-      message = err.error ?? text;
-    } catch {
-      message = text;
-    }
-    throw new Error(`API error (${response.status}): ${message}`);
-  }
-
-  return (await response.json()) as T;
 }
 
 // ── API functions ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds full attack-surface management to the Pensar Apex API client and the `pensar` CLI, in three layered commits on top of `canary`:

1. **Apps & endpoints CRUD** — wraps the new console REST routes for apps and endpoints behind a typed `apps.ts` client and a `pensar apps` CLI (list/get/create/update/delete for both apps and endpoints, including `--objective`, `--threat-model`, `--auth-required`, `--business-logic` flags so threat models and objectives can be edited from the CLI). Shared HTTP plumbing is extracted into `src/core/api/apiClient.ts` so `issues.ts` and `apps.ts` reuse the same auth + request logic.
2. **Substring search** — `searchApps()` / `searchEndpoints()` plus `pensar apps search` / `pensar apps search-endpoints` against the new `/search/apps` and `/search/endpoints` Tier‑1 ILIKE routes, with optional `--project`, `--app`, `--type`, `--min-risk`, `--auth-required` filters. Defaults to the active workspace.
3. **Always‑paginated lists + lean summaries** — `listApps` / `listEndpoints` now always return `{ apps|endpoints, hasMore, limit, offset }` (default page size 100, capped at 200), with `listAppsAll` / `listEndpointsAll` convenience helpers for callers that want to exhaust the cursor. The CLI gained `--limit` / `--offset`. `EndpointSummary` drops the unbounded `objectives` prose blob (replaced by `objectivesCount` + `authRequired`); full `objectives`, `description`, `businessLogic`, `threatModel`, and auth-detail fields remain on `EndpointDetail` via `GET /endpoints/:id`. This keeps list/search responses comfortably under the Lambda/API Gateway 6 MB / 10 MB sync response caps on heavily-annotated tenants.

Wire-up:
- `src/cli.ts` registers the new `apps` command group.
- `src/core/api/index.ts` exposes the `apps` module on the public API surface.
- `src/core/api/issues.ts` is slimmed down to use the shared `apiClient` helpers.

## Test plan

- [ ] `bun run check` — passes (already run; one biome auto-format fix committed).
- [ ] `bun run tsc` — passes (already run).
- [ ] `bun run test` — 1004 passed / 16 skipped (already run; integration suites that need a live console remain skipped).
- [ ] Smoke against staging console:
  - [ ] `pensar apps list <projectId>` returns paginated apps.
  - [ ] `pensar apps endpoints <appId>` returns paginated endpoints with `authRequired` + `objectivesCount`.
  - [ ] `pensar apps get-endpoint <endpointId>` returns the full detail shape (`objectives`, `threatModel`, `businessLogic`).
  - [ ] `pensar apps search <query>` and `pensar apps search-endpoints <query>` return matches scoped to the active workspace.
  - [ ] `pensar apps update-endpoint <id> --threat-model @path/to/tm.md --objective ...` round-trips.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI command group and a sizable new REST client surface area (CRUD + search + pagination) and centralizes HTTP/auth handling into a shared `apiRequest`, which could affect all console API interactions if request/response handling differs from prior behavior.
> 
> **Overview**
> Adds a new `pensar apps` command group to manage attack-surface **apps and endpoints** from the CLI, including CRUD operations, endpoint metadata flags (e.g. objectives, auth-required/details, business logic, threat model), and paginated listing/search with filtering.
> 
> Introduces a new typed REST client module `src/core/api/apps.ts` (apps/endpoints + search helpers and auto-pagination helpers) and exports it via `src/core/api/index.ts`.
> 
> Extracts shared console HTTP + auth header handling into `src/core/api/apiClient.ts` and updates `issues.ts` to use it (changing error/body parsing behavior to tolerate empty responses).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e59688665296021b340e7c04d68038c894b0b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->