### PR TITLE
Add informational severity for findings

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -12,6 +12,7 @@ import { join } from "path";
 import { z } from "zod";
 import { hasCanonicalName } from "../../../../lib/cwe/types";
 import type { EvidenceFileEntry } from "../../../../lib/evidence/types";
+import { findingSeverityFromCvssSeverity } from "../../../findings/severity";
 import {
   type CVSSScorerInput,
   type CVSSScorerResult,
@@ -338,8 +339,7 @@ CRITICAL RULES — READ BEFORE CALLING:
           }
         }
 
-        const severity =
-          cvssResult.severity === "NONE" ? "LOW" : cvssResult.severity;
+        const severity = findingSeverityFromCvssSeverity(cvssResult.severity);
 
         // Phase 4: Build finding and register with dedup
         const finding: Finding = {

--- a/src/core/agents/offSecAgent/types.test.ts
+++ b/src/core/agents/offSecAgent/types.test.ts
@@ -42,6 +42,17 @@ describe("ApexFindingObject", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts informational severity", () => {
+    const result = ApexFindingObject.safeParse({
+      ...baseFinding,
+      severity: "INFORMATIONAL",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.severity).toBe("INFORMATIONAL");
+    }
+  });
+
   it("accepts finding with cwes", () => {
     const result = ApexFindingObject.safeParse({ ...baseFinding, cwes });
     expect(result.success).toBe(true);
@@ -90,6 +101,17 @@ describe("DocumentFindingSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("normalizes informational severity", () => {
+    const result = DocumentFindingSchema.safeParse({
+      ...baseFinding,
+      severity: "info",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.severity).toBe("INFORMATIONAL");
+    }
+  });
+
   it("accepts finding with cwes", () => {
     const result = DocumentFindingSchema.safeParse({ ...baseFinding, cwes });
     expect(result.success).toBe(true);
@@ -135,6 +157,14 @@ describe("DocumentFindingSchema", () => {
 describe("PentestReportFindingSchema", () => {
   it("accepts finding without cwes (backward compatible)", () => {
     const result = PentestReportFindingSchema.safeParse(baseFinding);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts informational report findings", () => {
+    const result = PentestReportFindingSchema.safeParse({
+      ...baseFinding,
+      severity: "INFORMATIONAL",
+    });
     expect(result.success).toBe(true);
   });
 

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -18,6 +18,7 @@ import type { CredentialManager } from "../../credentials";
 import type { AgentEventBus } from "../../eventBus";
 import type { AttackSurfaceRegistry } from "../../findings/attackSurfaceRegistry";
 import type { FindingsRegistry } from "../../findings/registry";
+import { FindingSeveritySchema } from "../../findings/severity";
 import type { ApprovalGate } from "../../operator";
 import type { SessionConfig, SessionInfo } from "../../session";
 import type { SkillsRegistry } from "../../skills/registry";
@@ -26,19 +27,7 @@ import type { PlaywrightMcpSession, ToolName, UnifiedSandbox } from "./tools";
 // Backward-compatible Finding schema (toolCallDescription is optional for parsing old findings)
 export const ApexFindingObject = z.object({
   title: z.string(),
-  severity: z.preprocess(
-    (val) => {
-      if (typeof val === "string") {
-        const upper = val.toUpperCase();
-        if (upper.includes("CRITICAL")) return "CRITICAL";
-        if (upper.includes("HIGH")) return "HIGH";
-        if (upper.includes("MEDIUM")) return "MEDIUM";
-        if (upper.includes("LOW")) return "LOW";
-      }
-      return val;
-    },
-    z.enum(["CRITICAL", "HIGH", "MEDIUM", "LOW"]),
-  ),
+  severity: FindingSeveritySchema,
   description: z.string(),
   impact: z.string(),
   evidence: z.string(),

--- a/src/core/agents/specialized/cvssScorer/index.ts
+++ b/src/core/agents/specialized/cvssScorer/index.ts
@@ -9,7 +9,11 @@
  */
 
 import { z } from "zod";
-import { type CVSS4Metrics, calculateCVSS4Score } from "../../../../lib/cvss";
+import {
+  type CVSS4Metrics,
+  type CVSS4Severity,
+  calculateCVSS4Score,
+} from "../../../../lib/cvss";
 import {
   CweEntrySchema,
   type ValidatedCweEntry,
@@ -44,7 +48,7 @@ export interface CVSSScorerResult {
   /** Numeric score (0.0-10.0) */
   score: number;
   /** Qualitative severity (NONE, LOW, MEDIUM, HIGH, CRITICAL) */
-  severity: string;
+  severity: CVSS4Severity;
   /** Full vector string (CVSS:4.0/AV:N/...) */
   vectorString: string;
   /** Individual metric values */

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -865,7 +865,7 @@ export function streamResponse(
                 `Error encountered: ${error}`,
                 "Please fix the inputs to match the schema.",
                 "",
-                "IMPORTANT: For enum fields like 'severity' or 'riskLevel', use ONLY the exact values from the enum (e.g., 'HIGH', 'CRITICAL', 'MEDIUM', 'LOW').",
+                "IMPORTANT: For enum fields like 'severity' or 'riskLevel', use ONLY the exact values from the enum (e.g., 'HIGH', 'CRITICAL', 'MEDIUM', 'LOW', 'INFORMATIONAL').",
                 "Do not add prefixes, suffixes, or formatting characters like '>', '-', '!', etc.",
               ].join("\n"),
               abortSignal,

--- a/src/core/findings/severity.test.ts
+++ b/src/core/findings/severity.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  FindingSeveritySchema,
+  findingSeverityFromCvssSeverity,
+} from "./severity";
+
+describe("FindingSeveritySchema", () => {
+  it("accepts informational severity values below low", () => {
+    const result = FindingSeveritySchema.safeParse("informational");
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBe("INFORMATIONAL");
+    }
+  });
+
+  it("normalizes prefixed severity strings", () => {
+    const result = FindingSeveritySchema.safeParse("> info");
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBe("INFORMATIONAL");
+    }
+  });
+
+  it("maps CVSS NONE to informational findings", () => {
+    expect(findingSeverityFromCvssSeverity("NONE")).toBe("INFORMATIONAL");
+    expect(findingSeverityFromCvssSeverity("LOW")).toBe("LOW");
+  });
+});

--- a/src/core/findings/severity.ts
+++ b/src/core/findings/severity.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import type { CVSS4Severity } from "../../lib/cvss";
+
+export const FINDING_SEVERITIES = [
+  "CRITICAL",
+  "HIGH",
+  "MEDIUM",
+  "LOW",
+  "INFORMATIONAL",
+] as const;
+
+export type FindingSeverity = (typeof FINDING_SEVERITIES)[number];
+
+export const FindingSeveritySchema = z.preprocess((val) => {
+  if (typeof val === "string") {
+    const upper = val.toUpperCase();
+    if (upper.includes("CRITICAL")) return "CRITICAL";
+    if (upper.includes("HIGH")) return "HIGH";
+    if (upper.includes("MEDIUM")) return "MEDIUM";
+    if (upper.includes("LOW")) return "LOW";
+    if (upper.includes("INFORMATIONAL") || upper.includes("INFO")) {
+      return "INFORMATIONAL";
+    }
+  }
+  return val;
+}, z.enum(FINDING_SEVERITIES));
+
+export const FINDING_SEVERITY_ORDER = FINDING_SEVERITIES;
+
+export function findingSeverityFromCvssSeverity(
+  severity: CVSS4Severity,
+): FindingSeverity {
+  return severity === "NONE" ? "INFORMATIONAL" : severity;
+}

--- a/src/core/report/builder.test.ts
+++ b/src/core/report/builder.test.ts
@@ -47,6 +47,7 @@ describe("buildPentestReport", () => {
       HIGH: 1,
       MEDIUM: 0,
       LOW: 1,
+      INFORMATIONAL: 0,
     });
     expect(report.findings).toHaveLength(3);
   });
@@ -62,13 +63,18 @@ describe("buildPentestReport", () => {
       HIGH: 0,
       MEDIUM: 0,
       LOW: 0,
+      INFORMATIONAL: 0,
     });
     expect(report.findings).toHaveLength(0);
   });
 
-  it("sorts findings by severity: CRITICAL > HIGH > MEDIUM > LOW", () => {
+  it("sorts findings by severity: CRITICAL > HIGH > MEDIUM > LOW > INFORMATIONAL", () => {
     const findings: Finding[] = [
       makeFinding({ title: "Low Issue", severity: "LOW" }),
+      makeFinding({
+        title: "Informational Issue",
+        severity: "INFORMATIONAL",
+      }),
       makeFinding({ title: "Critical Issue", severity: "CRITICAL" }),
       makeFinding({ title: "Medium Issue", severity: "MEDIUM" }),
       makeFinding({ title: "High Issue", severity: "HIGH" }),
@@ -80,6 +86,7 @@ describe("buildPentestReport", () => {
     expect(report.findings[1].title).toBe("High Issue");
     expect(report.findings[2].title).toBe("Medium Issue");
     expect(report.findings[3].title).toBe("Low Issue");
+    expect(report.findings[4].title).toBe("Informational Issue");
   });
 
   it("strips toolCallDescription from findings", () => {
@@ -106,16 +113,18 @@ describe("buildPentestReport", () => {
       makeFinding({ title: "Medium 2", severity: "MEDIUM" }),
       makeFinding({ title: "Medium 3", severity: "MEDIUM" }),
       makeFinding({ title: "Low 1", severity: "LOW" }),
+      makeFinding({ title: "Info 1", severity: "INFORMATIONAL" }),
     ];
 
     const report = buildPentestReport(findings, defaultContext);
 
-    expect(report.summary.totalFindings).toBe(7);
+    expect(report.summary.totalFindings).toBe(8);
     expect(report.summary.bySeverity).toEqual({
       CRITICAL: 2,
       HIGH: 1,
       MEDIUM: 3,
       LOW: 1,
+      INFORMATIONAL: 1,
     });
   });
 

--- a/src/core/report/builder.ts
+++ b/src/core/report/builder.ts
@@ -1,4 +1,5 @@
 import type { Finding } from "../agents/offSecAgent";
+import { FINDING_SEVERITY_ORDER } from "../findings/severity";
 import { type PentestReport, REPORT_VERSION } from "./schemas";
 
 export interface ReportContext {
@@ -8,18 +9,23 @@ export interface ReportContext {
   mode: "blackbox" | "whitebox" | "targeted";
 }
 
-const SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW"] as const;
-
 export function buildPentestReport(
   findings: Finding[],
   context: ReportContext,
 ): PentestReport {
   const sorted = [...findings].sort(
     (a, b) =>
-      SEVERITY_ORDER.indexOf(a.severity) - SEVERITY_ORDER.indexOf(b.severity),
+      FINDING_SEVERITY_ORDER.indexOf(a.severity) -
+      FINDING_SEVERITY_ORDER.indexOf(b.severity),
   );
 
-  const bySeverity = { CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 0 };
+  const bySeverity = {
+    CRITICAL: 0,
+    HIGH: 0,
+    MEDIUM: 0,
+    LOW: 0,
+    INFORMATIONAL: 0,
+  };
   for (const f of findings) {
     bySeverity[f.severity]++;
   }

--- a/src/core/report/renderers/json.test.ts
+++ b/src/core/report/renderers/json.test.ts
@@ -15,7 +15,7 @@ function makeSampleReport(): PentestReport {
     },
     summary: {
       totalFindings: 1,
-      bySeverity: { CRITICAL: 0, HIGH: 1, MEDIUM: 0, LOW: 0 },
+      bySeverity: { CRITICAL: 0, HIGH: 1, MEDIUM: 0, LOW: 0, INFORMATIONAL: 0 },
     },
     findings: [
       {

--- a/src/core/report/renderers/markdown.test.ts
+++ b/src/core/report/renderers/markdown.test.ts
@@ -16,7 +16,7 @@ function makeSampleReport(
     },
     summary: {
       totalFindings: 1,
-      bySeverity: { CRITICAL: 0, HIGH: 1, MEDIUM: 0, LOW: 0 },
+      bySeverity: { CRITICAL: 0, HIGH: 1, MEDIUM: 0, LOW: 0, INFORMATIONAL: 0 },
     },
     findings: [
       {
@@ -116,7 +116,13 @@ describe("renderMarkdown", () => {
       ],
       summary: {
         totalFindings: 1,
-        bySeverity: { CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 1 },
+        bySeverity: {
+          CRITICAL: 0,
+          HIGH: 0,
+          MEDIUM: 0,
+          LOW: 1,
+          INFORMATIONAL: 0,
+        },
       },
     });
     const output = renderMarkdown(report);
@@ -156,7 +162,13 @@ describe("renderMarkdown", () => {
       ],
       summary: {
         totalFindings: 2,
-        bySeverity: { CRITICAL: 0, HIGH: 1, MEDIUM: 1, LOW: 0 },
+        bySeverity: {
+          CRITICAL: 0,
+          HIGH: 1,
+          MEDIUM: 1,
+          LOW: 0,
+          INFORMATIONAL: 0,
+        },
       },
     });
     const output = renderMarkdown(report);

--- a/src/core/report/schemas.ts
+++ b/src/core/report/schemas.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
 import { CweEntrySchema, ValidatedCweEntrySchema } from "../../lib/cwe/types";
+import { FindingSeveritySchema } from "../findings/severity";
 import { EvidenceFileEntrySchema } from "../../lib/evidence/types";
 
 export const PentestReportFindingSchema = z.object({
   title: z.string(),
-  severity: z.enum(["CRITICAL", "HIGH", "MEDIUM", "LOW"]),
+  severity: FindingSeveritySchema,
   description: z.string(),
   impact: z.string(),
   evidence: z.string(),
@@ -34,6 +35,7 @@ export const PentestReportSchema = z.object({
       HIGH: z.number(),
       MEDIUM: z.number(),
       LOW: z.number(),
+      INFORMATIONAL: z.number(),
     }),
   }),
   findings: z.array(PentestReportFindingSchema),

--- a/src/core/report/schemas.ts
+++ b/src/core/report/schemas.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { CweEntrySchema, ValidatedCweEntrySchema } from "../../lib/cwe/types";
-import { FindingSeveritySchema } from "../findings/severity";
 import { EvidenceFileEntrySchema } from "../../lib/evidence/types";
+import { FindingSeveritySchema } from "../findings/severity";
 
 export const PentestReportFindingSchema = z.object({
   title: z.string(),

--- a/src/core/session/types.ts
+++ b/src/core/session/types.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { CweEntrySchema, ValidatedCweEntrySchema } from "../../lib/cwe/types";
 import { EvidenceFileEntrySchema } from "../../lib/evidence/types";
+import { FindingSeveritySchema } from "../findings/severity";
 
 /**
  * Supported vulnerability classes for testing
@@ -92,19 +93,7 @@ interface VulnerabilityTestResult {
  */
 export const DocumentFindingSchema = z.object({
   title: z.string().describe("Clear, concise finding title"),
-  severity: z.preprocess(
-    (val) => {
-      if (typeof val === "string") {
-        const upper = val.toUpperCase();
-        if (upper.includes("CRITICAL")) return "CRITICAL";
-        if (upper.includes("HIGH")) return "HIGH";
-        if (upper.includes("MEDIUM")) return "MEDIUM";
-        if (upper.includes("LOW")) return "LOW";
-      }
-      return val;
-    },
-    z.enum(["CRITICAL", "HIGH", "MEDIUM", "LOW"]),
-  ),
+  severity: FindingSeveritySchema,
   description: z.string().describe("Detailed technical description"),
   impact: z.string().describe("Potential impact if exploited"),
   evidence: z

--- a/src/tui/components/shared/pentest-workflow-display.tsx
+++ b/src/tui/components/shared/pentest-workflow-display.tsx
@@ -292,7 +292,14 @@ const ReportingSection = memo(function ReportingSection({
       ? `Report Complete · ${reporting.findingsCount ?? 0} finding${(reporting.findingsCount ?? 0) !== 1 ? "s" : ""}`
       : reporting.label || "Report Generation";
 
-  const severityOrder = ["critical", "high", "medium", "low", "info"];
+  const severityOrder = [
+    "critical",
+    "high",
+    "medium",
+    "low",
+    "informational",
+    "info",
+  ];
   const severityParts = reporting.findingsBySeverity
     ? severityOrder
         .filter((s) => reporting.findingsBySeverity![s])

--- a/src/tui/components/shared/pentest-workflow-display.tsx
+++ b/src/tui/components/shared/pentest-workflow-display.tsx
@@ -300,10 +300,11 @@ const ReportingSection = memo(function ReportingSection({
     "informational",
     "info",
   ];
-  const severityParts = reporting.findingsBySeverity
+  const findingsBySeverity = reporting.findingsBySeverity;
+  const severityParts = findingsBySeverity
     ? severityOrder
-        .filter((s) => reporting.findingsBySeverity![s])
-        .map((s) => `${reporting.findingsBySeverity![s]} ${s}`)
+        .filter((s) => findingsBySeverity[s])
+        .map((s) => `${findingsBySeverity[s]} ${s}`)
     : [];
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Adds `INFORMATIONAL` as a finding/report severity below `LOW`, centralizes finding severity normalization, and maps CVSS `NONE` / score `0.0` findings to `INFORMATIONAL` instead of `LOW`.

Fixes #734.

### How did you verify your code works?

- `bun run test src/core/findings/severity.test.ts src/core/agents/offSecAgent/types.test.ts src/core/report/builder.test.ts src/core/report/renderers/json.test.ts src/core/report/renderers/markdown.test.ts`
- `bun run tsc`
- `bunx biome check --write src/core/findings/severity.ts src/core/findings/severity.test.ts src/core/agents/offSecAgent/types.ts src/core/session/types.ts src/core/report/schemas.ts src/core/report/builder.ts src/core/agents/offSecAgent/tools/documentFinding.ts src/core/agents/specialized/cvssScorer/index.ts src/core/ai/ai.ts src/tui/components/shared/pentest-workflow-display.tsx src/core/agents/offSecAgent/types.test.ts src/core/report/builder.test.ts src/core/report/renderers/markdown.test.ts src/core/report/renderers/json.test.ts`
- `bun run test`
- `bun run build`
- Manual TUI harness showing `1 low, 1 informational` in the workflow report summary.

![Informational severity workflow summary](https://cursor.com/artifacts/c/art-bf0b2127-1a4b-43ee-8c30-52827b2a5e49)

<a href="https://cursor.com/agents/bc-a4e8dc9f-1737-427f-b9a1-f26041bdf76a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finformational_severity_tui_summary.mp4"><img src="https://cursor.com/artifacts/c/art-6e381112-b8af-4b28-b84f-01d29fb7215f" alt="informational_severity_tui_summary.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4e8dc9f-1737-427f-b9a1-f26041bdf76a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4e8dc9f-1737-427f-b9a1-f26041bdf76a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

