### PR TITLE
feat(sdk): agent-execution-v2 — WIP prototype, do not merge

### DIFF
--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -1,7 +1,8 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { tool } from "ai";
-import { writeFileSync } from "fs";
-import { join } from "path";
 import { z } from "zod";
+import { beginSpawnedNode } from "../../../../sdk/spawn-helper.ts";
 import { CredentialManager } from "../../../credentials";
 import { AgentEventBus } from "../../../eventBus";
 import type { AuthCredentials } from "../../specialized/authenticationAgent/types";
@@ -188,6 +189,8 @@ When to use delegate_to_auth_subagent vs authenticate_session:
       authHints,
       reason,
     }) => {
+      // Declare here so the outer catch can call spawned.complete on failure.
+      let spawned: ReturnType<typeof beginSpawnedNode> | null = null;
       try {
         if (!ctx.model) {
           return {
@@ -223,6 +226,10 @@ When to use delegate_to_auth_subagent vs authenticate_session:
           subagentId,
           input: { target, reason },
           parentSubagentId: ctx.subagentId,
+        });
+        spawned = beginSpawnedNode(ctx.apexStream, {
+          name: subagentId,
+          payload: { target, reason },
         });
 
         console.log(`\n🔐 Delegating to authentication subagent...`);
@@ -322,6 +329,18 @@ When to use delegate_to_auth_subagent vs authenticate_session:
           status: result.success ? "completed" : "failed",
           parentSubagentId: ctx.subagentId,
         });
+        if (result.success) {
+          spawned?.complete({
+            result: {
+              strategy: result.strategy,
+              authBarrier: result.authBarrier,
+            },
+          });
+        } else {
+          spawned?.complete({
+            errorMessage: result.summary ?? "auth subagent reported failure",
+          });
+        }
 
         if (result.success) {
           const sessionInfoPath = join(
@@ -392,6 +411,7 @@ When to use delegate_to_auth_subagent vs authenticate_session:
 
         const errorMessage =
           error instanceof Error ? error.message : String(error);
+        spawned?.complete({ errorMessage });
         return {
           success: false,
           authenticated: false,

--- a/src/core/agents/offSecAgent/tools/runAttackSurface.ts
+++ b/src/core/agents/offSecAgent/tools/runAttackSurface.ts
@@ -1,5 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { mintNodeID } from "../../../../sdk/ids.ts";
 import { AgentEventBus } from "../../../eventBus";
 import type { AttackSurfaceResult } from "../../specialized/attackSurface/blackboxAgent";
 import type { WhiteboxAttackSurfaceResult } from "../../specialized/whiteboxAttackSurface";
@@ -60,6 +61,47 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
         parentSubagentId: ctx.subagentId,
       });
 
+      // V2: emit node.created on the ApexMessage stream (additive — coexists
+      // with the legacy bus emit above until Phase 9 deletes it). The
+      // inner agent's lifecycle (text-deltas etc.) is still legacy-only for
+      // now; the V2 node tree captures the spawn/complete boundary so the
+      // persister can attribute downstream tokens + cost.
+      const apex = ctx.apexStream;
+      const apexNodeId = apex ? mintNodeID() : null;
+      if (apex && apexNodeId) {
+        apex.emit({
+          type: "node.created",
+          node: {
+            id: apexNodeId,
+            sessionId: apex.session.id,
+            parentId: apex.parentNodeId,
+            parentToolCallId: null,
+            sequence: apex.session.nextSequence(),
+            kind: "agent",
+            state: "running",
+            name: subagentId,
+            payload: { target, cwd },
+            createdAt: new Date().toISOString(),
+          },
+          sequence: apex.session.nextSequence(),
+          timestamp: new Date().toISOString(),
+        });
+      }
+      const emitApexCompleted = (outcome: {
+        result?: unknown;
+        errorMessage?: string;
+      }) => {
+        if (!apex || !apexNodeId) return;
+        apex.emit({
+          type: "node.completed",
+          nodeId: apexNodeId,
+          result: outcome.result,
+          errorMessage: outcome.errorMessage,
+          sequence: apex.session.nextSequence(),
+          timestamp: new Date().toISOString(),
+        });
+      };
+
       // -----------------------------------------------------------------------
       // Whitebox mode — analyze source code (cwd is the indicator)
       // -----------------------------------------------------------------------
@@ -103,6 +145,13 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
             status: "completed",
             parentSubagentId: ctx.subagentId,
           });
+          emitApexCompleted({
+            result: {
+              mode: "whitebox",
+              totalTargets: targets.length,
+              totalApps: result.summary.totalApps,
+            },
+          });
 
           return {
             success: true,
@@ -122,6 +171,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
             status: "failed",
             parentSubagentId: ctx.subagentId,
           });
+          emitApexCompleted({ errorMessage: errorMsg });
 
           return {
             success: false,
@@ -166,6 +216,9 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
           status: "completed",
           parentSubagentId: ctx.subagentId,
         });
+        emitApexCompleted({
+          result: { mode: "blackbox", totalTargets: targetCount },
+        });
 
         return {
           success: true,
@@ -191,6 +244,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
           status: "failed",
           parentSubagentId: ctx.subagentId,
         });
+        emitApexCompleted({ errorMessage: errorMsg });
 
         return {
           success: false,

--- a/src/core/agents/offSecAgent/tools/runAttackSurface.ts
+++ b/src/core/agents/offSecAgent/tools/runAttackSurface.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
-import { mintNodeID } from "../../../../sdk/ids.ts";
+import { beginSpawnedNode } from "../../../../sdk/spawn-helper.ts";
 import { AgentEventBus } from "../../../eventBus";
 import type { AttackSurfaceResult } from "../../specialized/attackSurface/blackboxAgent";
 import type { WhiteboxAttackSurfaceResult } from "../../specialized/whiteboxAttackSurface";
@@ -61,46 +61,12 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
         parentSubagentId: ctx.subagentId,
       });
 
-      // V2: emit node.created on the ApexMessage stream (additive — coexists
-      // with the legacy bus emit above until Phase 9 deletes it). The
-      // inner agent's lifecycle (text-deltas etc.) is still legacy-only for
-      // now; the V2 node tree captures the spawn/complete boundary so the
-      // persister can attribute downstream tokens + cost.
-      const apex = ctx.apexStream;
-      const apexNodeId = apex ? mintNodeID() : null;
-      if (apex && apexNodeId) {
-        apex.emit({
-          type: "node.created",
-          node: {
-            id: apexNodeId,
-            sessionId: apex.session.id,
-            parentId: apex.parentNodeId,
-            parentToolCallId: null,
-            sequence: apex.session.nextSequence(),
-            kind: "agent",
-            state: "running",
-            name: subagentId,
-            payload: { target, cwd },
-            createdAt: new Date().toISOString(),
-          },
-          sequence: apex.session.nextSequence(),
-          timestamp: new Date().toISOString(),
-        });
-      }
-      const emitApexCompleted = (outcome: {
-        result?: unknown;
-        errorMessage?: string;
-      }) => {
-        if (!apex || !apexNodeId) return;
-        apex.emit({
-          type: "node.completed",
-          nodeId: apexNodeId,
-          result: outcome.result,
-          errorMessage: outcome.errorMessage,
-          sequence: apex.session.nextSequence(),
-          timestamp: new Date().toISOString(),
-        });
-      };
+      // V2: emit node.created + node.completed on the ApexMessage stream
+      // (additive — coexists with the legacy bus emits until Phase 9).
+      const spawned = beginSpawnedNode(ctx.apexStream, {
+        name: subagentId,
+        payload: { target, cwd },
+      });
 
       // -----------------------------------------------------------------------
       // Whitebox mode — analyze source code (cwd is the indicator)
@@ -145,7 +111,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
             status: "completed",
             parentSubagentId: ctx.subagentId,
           });
-          emitApexCompleted({
+          spawned.complete({
             result: {
               mode: "whitebox",
               totalTargets: targets.length,
@@ -171,7 +137,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
             status: "failed",
             parentSubagentId: ctx.subagentId,
           });
-          emitApexCompleted({ errorMessage: errorMsg });
+          spawned.complete({ errorMessage: errorMsg });
 
           return {
             success: false,
@@ -216,7 +182,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
           status: "completed",
           parentSubagentId: ctx.subagentId,
         });
-        emitApexCompleted({
+        spawned.complete({
           result: { mode: "blackbox", totalTargets: targetCount },
         });
 
@@ -244,7 +210,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
           status: "failed",
           parentSubagentId: ctx.subagentId,
         });
-        emitApexCompleted({ errorMessage: errorMsg });
+        spawned.complete({ errorMessage: errorMsg });
 
         return {
           success: false,

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -1,5 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { beginSpawnedNode } from "../../../../sdk/spawn-helper.ts";
 import { AgentEventBus } from "../../../eventBus";
 import type { ToolContext } from "./types";
 
@@ -164,6 +165,10 @@ async function runSingleCodingAgent(
     input: { codebasePath, objective },
     parentSubagentId: ctx.subagentId,
   });
+  const spawned = beginSpawnedNode(ctx.apexStream, {
+    name: subagentId,
+    payload: { codebasePath, objective, displayName: name },
+  });
 
   const localBus = new AgentEventBus();
   let textOutput = "";
@@ -192,6 +197,7 @@ async function runSingleCodingAgent(
       status: "completed",
       parentSubagentId: ctx.subagentId,
     });
+    spawned.complete({ result: { textOutputLength: textOutput.length } });
 
     return textOutput;
   } catch (error) {
@@ -199,6 +205,9 @@ async function runSingleCodingAgent(
       subagentId,
       status: "failed",
       parentSubagentId: ctx.subagentId,
+    });
+    spawned.complete({
+      errorMessage: error instanceof Error ? error.message : String(error),
     });
     throw error;
   }

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -1,5 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { beginSpawnedNode } from "../../../../sdk/spawn-helper.ts";
 import { AgentEventBus } from "../../../eventBus";
 import { FindingsRegistry } from "../../../findings/registry";
 import { PlaywrightMcpSession } from "./playwrightMcp";
@@ -106,6 +107,10 @@ Returns the worker's summary, objective results, and finding count — but NOT t
         input: { target, objectives },
         parentSubagentId: ctx.subagentId,
       });
+      const spawned = beginSpawnedNode(ctx.apexStream, {
+        name: subagentId,
+        payload: { target, objectives, displayName: name },
+      });
 
       const childBus = new AgentEventBus();
       AgentEventBus.attachChild(childBus, ctx.eventBus, subagentId);
@@ -195,6 +200,9 @@ Returns the worker's summary, objective results, and finding count — but NOT t
           status: "completed",
           parentSubagentId: ctx.subagentId,
         });
+        spawned.complete({
+          result: { findingsCount: findings.length, target, displayName: name },
+        });
 
         return {
           success: true,
@@ -211,6 +219,7 @@ Returns the worker's summary, objective results, and finding count — but NOT t
         });
 
         const message = error instanceof Error ? error.message : String(error);
+        spawned.complete({ errorMessage: message });
         return {
           success: false,
           subagentId,

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -1,5 +1,6 @@
 import pLimit from "p-limit";
 import { z } from "zod";
+import { beginSpawnedNode } from "../../../../sdk/spawn-helper.ts";
 import { AgentEventBus } from "../../../eventBus";
 import type { RiskScore } from "../../specialized/whiteboxAttackSurface";
 import type { ToolContext } from "./types";
@@ -312,6 +313,10 @@ export async function generateThreatModelForEndpoint(
       input: { app: input.appName, endpoint: input.routePath },
       parentSubagentId: ctx.subagentId,
     });
+    const spawned = beginSpawnedNode(ctx.apexStream, {
+      name: subagentId,
+      payload: { app: input.appName, endpoint: input.routePath },
+    });
 
     const localBus = new AgentEventBus();
     AgentEventBus.attachChild(localBus, ctx.eventBus, subagentId);
@@ -338,6 +343,11 @@ export async function generateThreatModelForEndpoint(
         subagentId,
         status: "completed",
         parentSubagentId: ctx.subagentId,
+      });
+      spawned.complete({
+        result: result
+          ? { route: input.routePath, appName: input.appName }
+          : { route: input.routePath, appName: input.appName, empty: true },
       });
 
       if (!result) return null;
@@ -371,8 +381,11 @@ export async function generateThreatModelForEndpoint(
         status: "failed",
         parentSubagentId: ctx.subagentId,
       });
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      spawned.complete({ errorMessage });
       console.error(
-        `Threat model generation failed for ${input.routePath}: ${error instanceof Error ? error.message : String(error)}`,
+        `Threat model generation failed for ${input.routePath}: ${errorMessage}`,
       );
       return null;
     }

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -1,3 +1,8 @@
+import type {
+  ApexMessage,
+  NodeID,
+  SessionID,
+} from "../../../../sdk/messages.ts";
 import type { AIAuthConfig, AIModel } from "../../../ai";
 import type { CredentialManager } from "../../../credentials";
 import type { AgentEventBus } from "../../../eventBus";
@@ -9,6 +14,21 @@ import type { StepTraceWriter } from "../trace";
 import type { PersistentShell } from "./persistentShell";
 import type { PlaywrightMcpSession } from "./playwrightMcp";
 import type { UnifiedSandbox } from "./sandbox";
+
+/**
+ * V2 ApexMessage emit channel. When set, tools that orchestrate sub-agents
+ * (the 5 `attachChild` sites) use `Subagent.spawn` and emit `ApexMessage`
+ * variants on this stream in addition to (or instead of) the legacy bus.
+ *
+ * See design doc 20260515131633-agent-execution-data-model-v2.md.
+ */
+export type ApexStream = {
+  emit: (msg: ApexMessage) => void;
+  /** Caller-provided session — used to mint child IDs and sequence numbers. */
+  session: { id: SessionID; nextSequence: () => number };
+  /** Parent node id — child nodes spawned by tools attach below this. */
+  parentNodeId: NodeID;
+};
 
 /**
  * Shared context passed to every tool factory.
@@ -136,4 +156,14 @@ export type ToolContext = {
    * its own session and wires `abortSignal` to disconnect.
    */
   browserSession?: PlaywrightMcpSession;
+
+  /**
+   * ApexMessage stream (V2 contract). When provided, sub-agent spawn sites
+   * use `Subagent.spawn` to emit node lifecycle and tool messages onto this
+   * stream so the console persister can project them to the 5 new tables.
+   *
+   * Optional — when unset, tools fall back to legacy `AgentEventBus` only.
+   * Removed entirely in Phase 9 once all spawn sites are migrated.
+   */
+  apexStream?: ApexStream;
 };

--- a/src/core/id/id.ts
+++ b/src/core/id/id.ts
@@ -7,6 +7,8 @@ const prefixes = {
   permission: "per",
   user: "usr",
   part: "prt",
+  node: "nod",
+  event: "evt",
 } as const;
 
 export type IdentifierPrefix = keyof typeof prefixes;
@@ -20,7 +22,7 @@ const LENGTH = 26;
 let lastTimestamp = 0;
 let counter = 0;
 
-function ascending(prefix: IdentifierPrefix, given?: string) {
+export function ascending(prefix: IdentifierPrefix, given?: string) {
   return generateID(prefix, false, given);
 }
 

--- a/src/sdk/ids.ts
+++ b/src/sdk/ids.ts
@@ -1,0 +1,39 @@
+import { ascending, schema as prefixSchema } from "../core/id/id.ts";
+
+declare const __brand: unique symbol;
+type Brand<T, B> = T & { readonly [__brand]: B };
+
+export type SessionID = Brand<string, "SessionID">;
+export type NodeID = Brand<string, "NodeID">;
+export type MessageID = Brand<string, "MessageID">;
+export type PartID = Brand<string, "PartID">;
+export type EventID = Brand<string, "EventID">;
+
+export const mintSessionID = (given?: string): SessionID =>
+  ascending("session", given) as SessionID;
+export const mintNodeID = (given?: string): NodeID =>
+  ascending("node", given) as NodeID;
+export const mintMessageID = (given?: string): MessageID =>
+  ascending("message", given) as MessageID;
+export const mintPartID = (given?: string): PartID =>
+  ascending("part", given) as PartID;
+export const mintEventID = (given?: string): EventID =>
+  ascending("event", given) as EventID;
+
+export const SessionIDSchema = prefixSchema("session").transform(
+  (v) => v as SessionID,
+);
+export const NodeIDSchema = prefixSchema("node").transform((v) => v as NodeID);
+export const MessageIDSchema = prefixSchema("message").transform(
+  (v) => v as MessageID,
+);
+export const PartIDSchema = prefixSchema("part").transform((v) => v as PartID);
+export const EventIDSchema = prefixSchema("event").transform(
+  (v) => v as EventID,
+);
+
+export const isSessionID = (v: string): v is SessionID => v.startsWith("ses_");
+export const isNodeID = (v: string): v is NodeID => v.startsWith("nod_");
+export const isMessageID = (v: string): v is MessageID => v.startsWith("msg_");
+export const isPartID = (v: string): v is PartID => v.startsWith("prt_");
+export const isEventID = (v: string): v is EventID => v.startsWith("evt_");

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1,0 +1,6 @@
+export * from "./ids.ts";
+export * from "./messages.ts";
+export * from "./sequence.ts";
+export * from "./session.ts";
+export * from "./stream.ts";
+export * from "./subagent.ts";

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -2,5 +2,6 @@ export * from "./ids.ts";
 export * from "./messages.ts";
 export * from "./sequence.ts";
 export * from "./session.ts";
+export * from "./storage.ts";
 export * from "./stream.ts";
 export * from "./subagent.ts";

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -2,6 +2,7 @@ export * from "./ids.ts";
 export * from "./messages.ts";
 export * from "./sequence.ts";
 export * from "./session.ts";
+export * from "./spawn-helper.ts";
 export * from "./storage.ts";
 export * from "./stream.ts";
 export * from "./subagent.ts";

--- a/src/sdk/messages.ts
+++ b/src/sdk/messages.ts
@@ -1,0 +1,305 @@
+import z from "zod";
+import {
+  type EventID,
+  type MessageID,
+  MessageIDSchema,
+  type NodeID,
+  NodeIDSchema,
+  type PartID,
+  PartIDSchema,
+  type SessionID,
+  SessionIDSchema,
+} from "./ids.ts";
+
+// ─── Sub-shapes ─────────────────────────────────────────────────────────
+
+export const NodeKindSchema = z.enum(["agent", "workflow", "tool_call"]);
+export type NodeKind = z.infer<typeof NodeKindSchema>;
+
+export const NodeStateSchema = z.enum([
+  "pending",
+  "running",
+  "completed",
+  "failed",
+  "cancelled",
+]);
+export type NodeState = z.infer<typeof NodeStateSchema>;
+
+export const MessageRoleSchema = z.enum([
+  "system",
+  "user",
+  "assistant",
+  "tool",
+]);
+export type MessageRole = z.infer<typeof MessageRoleSchema>;
+
+export const AgentNodeSchema = z.object({
+  id: NodeIDSchema,
+  sessionId: SessionIDSchema,
+  parentId: NodeIDSchema.nullable(),
+  parentToolCallId: z.string().nullable(),
+  sequence: z.number().int().nonnegative(),
+  kind: NodeKindSchema,
+  state: NodeStateSchema,
+  name: z.string().nullable(),
+  payload: z.record(z.string(), z.unknown()).default({}),
+  createdAt: z.string(),
+});
+export type AgentNode = z.infer<typeof AgentNodeSchema>;
+
+export const PartSchema = z.discriminatedUnion("type", [
+  z.object({
+    id: PartIDSchema,
+    type: z.literal("text"),
+    messageId: MessageIDSchema,
+    sequence: z.number().int().nonnegative(),
+    content: z.object({ text: z.string() }),
+  }),
+  z.object({
+    id: PartIDSchema,
+    type: z.literal("reasoning"),
+    messageId: MessageIDSchema,
+    sequence: z.number().int().nonnegative(),
+    content: z.object({ text: z.string() }),
+  }),
+  z.object({
+    id: PartIDSchema,
+    type: z.literal("tool-call"),
+    messageId: MessageIDSchema,
+    sequence: z.number().int().nonnegative(),
+    content: z.object({
+      toolCallId: z.string(),
+      toolName: z.string(),
+      args: z.unknown(),
+    }),
+  }),
+  z.object({
+    id: PartIDSchema,
+    type: z.literal("tool-result"),
+    messageId: MessageIDSchema,
+    sequence: z.number().int().nonnegative(),
+    content: z.object({
+      toolCallId: z.string(),
+      result: z.unknown(),
+      isError: z.boolean().optional(),
+    }),
+  }),
+  z.object({
+    id: PartIDSchema,
+    type: z.literal("image"),
+    messageId: MessageIDSchema,
+    sequence: z.number().int().nonnegative(),
+    content: z.object({
+      url: z.string().optional(),
+      mimeType: z.string().optional(),
+      data: z.string().optional(),
+    }),
+  }),
+  z.object({
+    id: PartIDSchema,
+    type: z.literal("file"),
+    messageId: MessageIDSchema,
+    sequence: z.number().int().nonnegative(),
+    content: z.object({
+      url: z.string().optional(),
+      mimeType: z.string().optional(),
+      data: z.string().optional(),
+      name: z.string().optional(),
+    }),
+  }),
+  z.object({
+    id: PartIDSchema,
+    type: z.literal("source"),
+    messageId: MessageIDSchema,
+    sequence: z.number().int().nonnegative(),
+    content: z.object({
+      url: z.string(),
+      title: z.string().optional(),
+      excerpt: z.string().optional(),
+    }),
+  }),
+  z.object({
+    id: PartIDSchema,
+    type: z.literal("step-start"),
+    messageId: MessageIDSchema,
+    sequence: z.number().int().nonnegative(),
+    content: z.object({}),
+  }),
+  z.object({
+    id: PartIDSchema,
+    type: z.literal("step-finish"),
+    messageId: MessageIDSchema,
+    sequence: z.number().int().nonnegative(),
+    content: z.object({ finishReason: z.string().optional() }),
+  }),
+  z.object({
+    id: PartIDSchema,
+    type: z.literal("command-output"),
+    messageId: MessageIDSchema,
+    sequence: z.number().int().nonnegative(),
+    content: z.object({ data: z.string() }),
+  }),
+  z.object({
+    id: PartIDSchema,
+    type: z.literal("error"),
+    messageId: MessageIDSchema,
+    sequence: z.number().int().nonnegative(),
+    content: z.object({ message: z.string(), details: z.unknown().optional() }),
+  }),
+  z.object({
+    id: PartIDSchema,
+    type: z.literal("usage"),
+    messageId: MessageIDSchema,
+    sequence: z.number().int().nonnegative(),
+    content: z.object({
+      model: z.string(),
+      inputTokens: z.number().int().nonnegative(),
+      outputTokens: z.number().int().nonnegative(),
+      totalCost: z.number().nonnegative().optional(),
+    }),
+  }),
+]);
+export type Part = z.infer<typeof PartSchema>;
+
+export const TokenCountsSchema = z.object({
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+});
+export type TokenCounts = z.infer<typeof TokenCountsSchema>;
+
+export const MessageSchema = z.object({
+  id: MessageIDSchema,
+  nodeId: NodeIDSchema,
+  sessionId: SessionIDSchema,
+  role: MessageRoleSchema,
+  sequence: z.number().int().nonnegative(),
+  createdAt: z.string(),
+});
+export type Message = z.infer<typeof MessageSchema>;
+
+// ─── ApexMessage union ──────────────────────────────────────────────────
+
+const baseDurable = {
+  sequence: z.number().int().nonnegative(),
+  timestamp: z.string(),
+};
+
+export const ApexMessageSchema = z.discriminatedUnion("type", [
+  // Node lifecycle (durable)
+  z.object({
+    type: z.literal("node.created"),
+    node: AgentNodeSchema,
+    ...baseDurable,
+  }),
+  z.object({
+    type: z.literal("node.state"),
+    nodeId: NodeIDSchema,
+    state: NodeStateSchema,
+    reason: z.string().optional(),
+    ...baseDurable,
+  }),
+  z.object({
+    type: z.literal("node.completed"),
+    nodeId: NodeIDSchema,
+    result: z.unknown().optional(),
+    errorMessage: z.string().optional(),
+    ...baseDurable,
+  }),
+
+  // Message + parts (durable)
+  z.object({
+    type: z.literal("message.created"),
+    message: MessageSchema,
+    parts: z.array(PartSchema),
+    ...baseDurable,
+  }),
+  z.object({
+    type: z.literal("part.added"),
+    part: PartSchema,
+    ...baseDurable,
+  }),
+  z.object({
+    type: z.literal("part.updated"),
+    partId: PartIDSchema,
+    messageId: MessageIDSchema,
+    patch: z.record(z.string(), z.unknown()),
+    ...baseDurable,
+  }),
+
+  // Usage / cost (durable)
+  z.object({
+    type: z.literal("usage.recorded"),
+    nodeId: NodeIDSchema,
+    model: z.string(),
+    tokens: TokenCountsSchema,
+    cost: z.number().nonnegative().optional(),
+    ...baseDurable,
+  }),
+
+  // Step boundary (durable)
+  z.object({
+    type: z.literal("step.finished"),
+    nodeId: NodeIDSchema,
+    finishReason: z.string().optional(),
+    ...baseDurable,
+  }),
+
+  // Transient (never persisted)
+  z.object({
+    type: z.literal("text.delta"),
+    messageId: MessageIDSchema,
+    partId: PartIDSchema,
+    delta: z.string(),
+  }),
+  z.object({
+    type: z.literal("tool.input.delta"),
+    nodeId: NodeIDSchema,
+    argsTextDelta: z.string(),
+  }),
+  z.object({
+    type: z.literal("command.output"),
+    nodeId: NodeIDSchema,
+    data: z.string(),
+  }),
+  z.object({
+    type: z.literal("error"),
+    nodeId: NodeIDSchema.optional(),
+    error: z.object({
+      message: z.string(),
+      details: z.unknown().optional(),
+    }),
+  }),
+
+  // Stream terminator
+  z.object({
+    type: z.literal("done"),
+    sessionId: SessionIDSchema,
+    result: z.unknown().optional(),
+  }),
+]);
+
+export type ApexMessage = z.infer<typeof ApexMessageSchema>;
+
+/** True for variants that should be persisted to the agent_events log. */
+export const isDurableMessage = (msg: ApexMessage): boolean => {
+  switch (msg.type) {
+    case "node.created":
+    case "node.state":
+    case "node.completed":
+    case "message.created":
+    case "part.added":
+    case "part.updated":
+    case "usage.recorded":
+    case "step.finished":
+      return true;
+    case "text.delta":
+    case "tool.input.delta":
+    case "command.output":
+    case "error":
+    case "done":
+      return false;
+  }
+};
+
+// Re-export ID types for convenience.
+export type { EventID, MessageID, NodeID, PartID, SessionID };

--- a/src/sdk/sdk.test.ts
+++ b/src/sdk/sdk.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, it } from "vitest";
+import {
+  isEventID,
+  isMessageID,
+  isNodeID,
+  isPartID,
+  isSessionID,
+  mintEventID,
+  mintMessageID,
+  mintNodeID,
+  mintPartID,
+  mintSessionID,
+} from "./ids.ts";
+import {
+  type ApexMessage,
+  ApexMessageSchema,
+  isDurableMessage,
+} from "./messages.ts";
+import { SequenceCounter } from "./sequence.ts";
+import { Session } from "./session.ts";
+import { createRun } from "./stream.ts";
+import { Subagent } from "./subagent.ts";
+
+describe("sdk/ids", () => {
+  it("mints IDs with correct branded prefixes", () => {
+    expect(isSessionID(mintSessionID())).toBe(true);
+    expect(isNodeID(mintNodeID())).toBe(true);
+    expect(isMessageID(mintMessageID())).toBe(true);
+    expect(isPartID(mintPartID())).toBe(true);
+    expect(isEventID(mintEventID())).toBe(true);
+  });
+
+  it("mint helpers return unique IDs on each call", () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) ids.add(mintNodeID());
+    expect(ids.size).toBe(100);
+  });
+});
+
+describe("sdk/sequence", () => {
+  it("returns monotonically increasing values per session", () => {
+    const counter = new SequenceCounter();
+    const a = mintSessionID();
+    const b = mintSessionID();
+    expect(counter.next(a)).toBe(1);
+    expect(counter.next(a)).toBe(2);
+    expect(counter.next(b)).toBe(1); // independent per session
+    expect(counter.next(a)).toBe(3);
+  });
+
+  it("peek does not advance, restore overrides", () => {
+    const counter = new SequenceCounter();
+    const id = mintSessionID();
+    counter.next(id);
+    counter.next(id);
+    expect(counter.peek(id)).toBe(2);
+    counter.restore(id, 42);
+    expect(counter.next(id)).toBe(43);
+  });
+});
+
+describe("sdk/session", () => {
+  it("mints a fresh ID when none provided", () => {
+    const s = new Session();
+    expect(isSessionID(s.id)).toBe(true);
+  });
+
+  it("nextSequence is monotonic", () => {
+    const s = new Session();
+    expect(s.nextSequence()).toBe(1);
+    expect(s.nextSequence()).toBe(2);
+  });
+
+  it("preserves parent session and scope", () => {
+    const parent = mintSessionID();
+    const s = new Session({
+      parentSessionId: parent,
+      scope: "recon_job",
+      label: "child",
+    });
+    expect(s.parentSessionId).toBe(parent);
+    expect(s.scope).toBe("recon_job");
+    expect(s.label).toBe("child");
+  });
+});
+
+describe("sdk/messages — Zod roundtrip per variant", () => {
+  const sid = mintSessionID();
+  const nid = mintNodeID();
+  const mid = mintMessageID();
+  const pid = mintPartID();
+  const now = new Date().toISOString();
+
+  const variants: ApexMessage[] = [
+    {
+      type: "node.created",
+      node: {
+        id: nid,
+        sessionId: sid,
+        parentId: null,
+        parentToolCallId: null,
+        sequence: 1,
+        kind: "agent",
+        state: "running",
+        name: "root",
+        payload: {},
+        createdAt: now,
+      },
+      sequence: 1,
+      timestamp: now,
+    },
+    {
+      type: "node.state",
+      nodeId: nid,
+      state: "completed",
+      reason: "ok",
+      sequence: 2,
+      timestamp: now,
+    },
+    {
+      type: "node.completed",
+      nodeId: nid,
+      result: { foo: "bar" },
+      sequence: 3,
+      timestamp: now,
+    },
+    {
+      type: "message.created",
+      message: {
+        id: mid,
+        nodeId: nid,
+        sessionId: sid,
+        role: "assistant",
+        sequence: 1,
+        createdAt: now,
+      },
+      parts: [
+        {
+          id: pid,
+          type: "text",
+          messageId: mid,
+          sequence: 0,
+          content: { text: "hello" },
+        },
+      ],
+      sequence: 4,
+      timestamp: now,
+    },
+    {
+      type: "part.added",
+      part: {
+        id: pid,
+        type: "tool-call",
+        messageId: mid,
+        sequence: 1,
+        content: { toolCallId: "tc_1", toolName: "search", args: { q: "x" } },
+      },
+      sequence: 5,
+      timestamp: now,
+    },
+    {
+      type: "part.updated",
+      partId: pid,
+      messageId: mid,
+      patch: { content: { text: "updated" } },
+      sequence: 6,
+      timestamp: now,
+    },
+    {
+      type: "usage.recorded",
+      nodeId: nid,
+      model: "claude-opus-4-7",
+      tokens: { inputTokens: 100, outputTokens: 50 },
+      cost: 0.0042,
+      sequence: 7,
+      timestamp: now,
+    },
+    {
+      type: "step.finished",
+      nodeId: nid,
+      finishReason: "stop",
+      sequence: 8,
+      timestamp: now,
+    },
+    {
+      type: "text.delta",
+      messageId: mid,
+      partId: pid,
+      delta: " world",
+    },
+    {
+      type: "tool.input.delta",
+      nodeId: nid,
+      argsTextDelta: '{"q"',
+    },
+    {
+      type: "command.output",
+      nodeId: nid,
+      data: "stdout chunk",
+    },
+    {
+      type: "error",
+      nodeId: nid,
+      error: { message: "boom", details: { code: 1 } },
+    },
+    {
+      type: "done",
+      sessionId: sid,
+      result: "ok",
+    },
+  ];
+
+  it.each(variants)("parses %s", (variant) => {
+    const parsed = ApexMessageSchema.parse(variant);
+    expect(parsed.type).toBe(variant.type);
+  });
+
+  it("classifies durable vs transient correctly", () => {
+    const durable = [
+      "node.created",
+      "node.state",
+      "node.completed",
+      "message.created",
+      "part.added",
+      "part.updated",
+      "usage.recorded",
+      "step.finished",
+    ];
+    const transient = [
+      "text.delta",
+      "tool.input.delta",
+      "command.output",
+      "error",
+      "done",
+    ];
+    for (const variant of variants) {
+      const shouldBeDurable = durable.includes(variant.type);
+      const shouldBeTransient = transient.includes(variant.type);
+      expect(isDurableMessage(variant)).toBe(
+        shouldBeDurable && !shouldBeTransient,
+      );
+    }
+  });
+});
+
+describe("sdk/stream — createRun", () => {
+  it("delivers messages and resolves with result", async () => {
+    const sid = mintSessionID();
+    const run = createRun(sid, async (emit) => {
+      emit({
+        type: "text.delta",
+        messageId: mintMessageID(),
+        partId: mintPartID(),
+        delta: "hi",
+      });
+      emit({ type: "done", sessionId: sid, result: "ok" });
+      return "ok";
+    });
+
+    const seen: ApexMessage["type"][] = [];
+    for await (const msg of run) seen.push(msg.type);
+    await expect(run.result()).resolves.toBe("ok");
+    expect(seen).toEqual(["text.delta", "done"]);
+  });
+
+  it("abort stops iteration and rejects result", async () => {
+    const sid = mintSessionID();
+    const run = createRun(sid, async (_emit, signal) => {
+      await new Promise<void>((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+      return "unreachable";
+    });
+
+    run.abort(new Error("user cancelled"));
+    await expect(run.result()).rejects.toBeDefined();
+  });
+});
+
+describe("sdk/subagent — Subagent.spawn", () => {
+  it("emits node.created with parent linkage and node.completed on success", async () => {
+    const session = new Session();
+    const parentNodeId = mintNodeID();
+    const emitted: ApexMessage[] = [];
+
+    const handle = Subagent.spawn(
+      {
+        session,
+        parentNodeId,
+        parentToolCallId: "tc_root",
+        kind: "agent",
+        name: "child",
+      },
+      (msg) => emitted.push(msg),
+      async ({ nodeId, emit }) => {
+        emit({
+          type: "text.delta",
+          messageId: mintMessageID(),
+          partId: mintPartID(),
+          delta: `from ${nodeId}`,
+        });
+        return { ok: true };
+      },
+    );
+
+    await expect(handle.promise).resolves.toEqual({ ok: true });
+
+    const created = emitted.find((m) => m.type === "node.created");
+    const completed = emitted.find((m) => m.type === "node.completed");
+    expect(created).toBeDefined();
+    expect(completed).toBeDefined();
+    if (created && created.type === "node.created") {
+      expect(created.node.parentId).toBe(parentNodeId);
+      expect(created.node.parentToolCallId).toBe("tc_root");
+    }
+    if (completed && completed.type === "node.completed") {
+      expect(completed.result).toEqual({ ok: true });
+    }
+  });
+
+  it("emits node.completed with errorMessage on failure", async () => {
+    const session = new Session();
+    const emitted: ApexMessage[] = [];
+
+    const handle = Subagent.spawn(
+      { session, parentNodeId: mintNodeID() },
+      (msg) => emitted.push(msg),
+      async () => {
+        throw new Error("kaboom");
+      },
+    );
+
+    await expect(handle.promise).rejects.toThrow("kaboom");
+    const completed = emitted.find((m) => m.type === "node.completed");
+    expect(completed).toBeDefined();
+    if (completed && completed.type === "node.completed") {
+      expect(completed.errorMessage).toBe("kaboom");
+    }
+  });
+});

--- a/src/sdk/sequence.ts
+++ b/src/sdk/sequence.ts
@@ -1,0 +1,31 @@
+import type { SessionID } from "./ids.ts";
+
+/**
+ * Per-session monotonic sequence counter. Each call to `next(sessionId)`
+ * returns the next integer for that session. Counters are kept in-memory
+ * for the lifetime of the process; durable sequence state is reconstructed
+ * from `agent_events.sequence` on resume.
+ */
+export class SequenceCounter {
+  private readonly counters = new Map<SessionID, number>();
+
+  next(sessionId: SessionID): number {
+    const current = this.counters.get(sessionId) ?? 0;
+    const nextValue = current + 1;
+    this.counters.set(sessionId, nextValue);
+    return nextValue;
+  }
+
+  peek(sessionId: SessionID): number {
+    return this.counters.get(sessionId) ?? 0;
+  }
+
+  /** Restore counter to a known value (e.g. after replaying events from DB). */
+  restore(sessionId: SessionID, value: number): void {
+    this.counters.set(sessionId, value);
+  }
+
+  reset(sessionId: SessionID): void {
+    this.counters.delete(sessionId);
+  }
+}

--- a/src/sdk/session.ts
+++ b/src/sdk/session.ts
@@ -1,0 +1,47 @@
+import { mintSessionID, type SessionID } from "./ids.ts";
+import { SequenceCounter } from "./sequence.ts";
+
+export type SessionScope =
+  | "recon_job"
+  | "scan"
+  | "sandbox_test_job"
+  | "credential_test"
+  | "threat_model"
+  | "patching"
+  | "other";
+
+export type SessionInit = {
+  id?: SessionID;
+  parentSessionId?: SessionID | null;
+  scope?: SessionScope;
+  label?: string | null;
+};
+
+/**
+ * In-memory representation of an agent execution session.
+ * The DB row in `agent_sessions` is its durable projection — see persister.
+ *
+ * `fork()` and `resume()` (S9 in design doc) are deferred to a follow-up;
+ * this prototype exposes only the create-and-stream path.
+ */
+export class Session {
+  readonly id: SessionID;
+  readonly parentSessionId: SessionID | null;
+  readonly scope: SessionScope;
+  readonly label: string | null;
+  readonly createdAt: string;
+  readonly sequence: SequenceCounter;
+
+  constructor(init: SessionInit = {}) {
+    this.id = init.id ?? mintSessionID();
+    this.parentSessionId = init.parentSessionId ?? null;
+    this.scope = init.scope ?? "other";
+    this.label = init.label ?? null;
+    this.createdAt = new Date().toISOString();
+    this.sequence = new SequenceCounter();
+  }
+
+  nextSequence(): number {
+    return this.sequence.next(this.id);
+  }
+}

--- a/src/sdk/spawn-helper.ts
+++ b/src/sdk/spawn-helper.ts
@@ -1,0 +1,82 @@
+import { mintNodeID, type NodeID, type SessionID } from "./ids.ts";
+import type { ApexMessage, NodeKind } from "./messages.ts";
+
+/**
+ * The shape of the stream channel injected into apex tool context for
+ * V2 ApexMessage emission. Defined here (rather than in
+ * `core/agents/offSecAgent/tools/types.ts`) so SDK modules can refer to it
+ * without depending on tool internals.
+ */
+export type ApexStreamChannel = {
+  emit: (msg: ApexMessage) => void;
+  session: { id: SessionID; nextSequence: () => number };
+  parentNodeId: NodeID;
+};
+
+/**
+ * Wrapper around the node.created/node.completed emit pattern used by every
+ * `attachChild` spawn site (5 sites total). Reduces each call site to a few
+ * lines and keeps the wire shape consistent.
+ *
+ * Usage:
+ * ```ts
+ * const spawned = beginSpawnedNode(ctx.apexStream, { name: "auth-agent" });
+ * try {
+ *   const result = await doWork();
+ *   spawned.complete({ result });
+ * } catch (err) {
+ *   spawned.complete({ errorMessage: String(err) });
+ * }
+ * ```
+ *
+ * Safe to call with `undefined` stream — both create and complete become
+ * no-ops, so callers don't need their own null checks.
+ */
+export function beginSpawnedNode(
+  stream: ApexStreamChannel | undefined | null,
+  init: {
+    name: string;
+    kind?: NodeKind;
+    payload?: Record<string, unknown>;
+  },
+): {
+  nodeId: NodeID | null;
+  complete: (outcome: { result?: unknown; errorMessage?: string }) => void;
+} {
+  if (!stream) {
+    return { nodeId: null, complete: () => undefined };
+  }
+  const nodeId = mintNodeID();
+  const now = new Date().toISOString();
+  stream.emit({
+    type: "node.created",
+    node: {
+      id: nodeId,
+      sessionId: stream.session.id,
+      parentId: stream.parentNodeId,
+      parentToolCallId: null,
+      sequence: stream.session.nextSequence(),
+      kind: init.kind ?? "agent",
+      state: "running",
+      name: init.name,
+      payload: init.payload ?? {},
+      createdAt: now,
+    },
+    sequence: stream.session.nextSequence(),
+    timestamp: now,
+  });
+
+  return {
+    nodeId,
+    complete: (outcome) => {
+      stream.emit({
+        type: "node.completed",
+        nodeId,
+        result: outcome.result,
+        errorMessage: outcome.errorMessage,
+        sequence: stream.session.nextSequence(),
+        timestamp: new Date().toISOString(),
+      });
+    },
+  };
+}

--- a/src/sdk/storage.test.ts
+++ b/src/sdk/storage.test.ts
@@ -1,0 +1,151 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mintMessageID, mintNodeID, mintPartID, mintSessionID } from "./ids.ts";
+import type { ApexMessage } from "./messages.ts";
+import { SessionStorage } from "./storage.ts";
+
+describe("sdk/storage — JSONL roundtrip", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "apex-sdk-storage-"));
+    process.env.PENSAR_DATA_DIR = dataDir;
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    delete process.env.PENSAR_DATA_DIR;
+  });
+
+  it("writes and reads back the same messages in order", async () => {
+    const sid = mintSessionID();
+    const nid = mintNodeID();
+    const mid = mintMessageID();
+    const pid = mintPartID();
+    const now = new Date().toISOString();
+
+    const messages: ApexMessage[] = [
+      {
+        type: "node.created",
+        node: {
+          id: nid,
+          sessionId: sid,
+          parentId: null,
+          parentToolCallId: null,
+          sequence: 1,
+          kind: "agent",
+          state: "running",
+          name: "root",
+          payload: {},
+          createdAt: now,
+        },
+        sequence: 1,
+        timestamp: now,
+      },
+      {
+        type: "message.created",
+        message: {
+          id: mid,
+          nodeId: nid,
+          sessionId: sid,
+          role: "assistant",
+          sequence: 1,
+          createdAt: now,
+        },
+        parts: [
+          {
+            id: pid,
+            type: "text",
+            messageId: mid,
+            sequence: 0,
+            content: { text: "hello" },
+          },
+        ],
+        sequence: 2,
+        timestamp: now,
+      },
+      {
+        type: "usage.recorded",
+        nodeId: nid,
+        model: "claude-opus-4-7",
+        tokens: { inputTokens: 100, outputTokens: 50 },
+        cost: 0.0042,
+        sequence: 3,
+        timestamp: now,
+      },
+      {
+        type: "done",
+        sessionId: sid,
+        result: "ok",
+      },
+    ];
+
+    const storage = new SessionStorage(sid);
+    for (const m of messages) await storage.append(m);
+
+    const readBack = await storage.readAll();
+    expect(readBack).toEqual(messages);
+  });
+
+  it("file path lives under PENSAR_DATA_DIR/sessions/{id}/events.jsonl", () => {
+    const sid = mintSessionID();
+    const storage = new SessionStorage(sid);
+    expect(storage.filePath).toBe(
+      join(dataDir, "sessions", sid, "events.jsonl"),
+    );
+  });
+
+  it("readAll on missing file returns empty array (not error)", async () => {
+    const sid = mintSessionID();
+    const storage = new SessionStorage(sid);
+    await expect(storage.readAll()).resolves.toEqual([]);
+  });
+
+  it("survives ordered concurrent appends", async () => {
+    const sid = mintSessionID();
+    const storage = new SessionStorage(sid);
+    const nid = mintNodeID();
+    const now = new Date().toISOString();
+
+    const ops = Array.from({ length: 10 }, (_, i) =>
+      storage.append({
+        type: "node.state",
+        nodeId: nid,
+        state: "running",
+        reason: `step ${i}`,
+        sequence: i + 1,
+        timestamp: now,
+      }),
+    );
+    await Promise.all(ops);
+
+    const read = await storage.readAll();
+    expect(read).toHaveLength(10);
+    // Order may be insertion order (chain serializes)
+    expect(
+      read.map((m) => (m.type === "node.state" ? m.sequence : -1)),
+    ).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  it("rejects malformed lines via Zod schema during read", async () => {
+    const sid = mintSessionID();
+    const storage = new SessionStorage(sid);
+
+    // Inject a malformed line directly.
+    await storage.append({
+      type: "done",
+      sessionId: sid,
+      result: null,
+    });
+    const fs = await import("node:fs/promises");
+    await fs.appendFile(
+      storage.filePath,
+      `${JSON.stringify({ type: "not-a-real-variant" })}\n`,
+      "utf-8",
+    );
+
+    await expect(storage.readAll()).rejects.toBeDefined();
+  });
+});

--- a/src/sdk/storage.ts
+++ b/src/sdk/storage.ts
@@ -1,0 +1,77 @@
+import { createReadStream } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import type { SessionID } from "./ids.ts";
+import { type ApexMessage, ApexMessageSchema } from "./messages.ts";
+
+function getBaseDir(): string {
+  return process.env.PENSAR_DATA_DIR ?? path.join(os.homedir(), ".pensar");
+}
+
+export function sessionEventsPath(sessionId: SessionID): string {
+  return path.join(getBaseDir(), "sessions", sessionId, "events.jsonl");
+}
+
+/**
+ * Local on-disk JSONL writer/reader for an ApexMessage stream.
+ *
+ * Shape parity with `agent_events`: one ApexMessage per line, JSON-encoded.
+ * The DB schema and the JSONL format share the same union — flipping between
+ * them is "use a different consumer," not "translate."
+ */
+export class SessionStorage {
+  private writeChain: Promise<unknown> = Promise.resolve();
+
+  constructor(public readonly sessionId: SessionID) {}
+
+  get filePath(): string {
+    return sessionEventsPath(this.sessionId);
+  }
+
+  /** Append a single message. Awaits sequentially to preserve JSONL line order. */
+  append(message: ApexMessage): Promise<void> {
+    const line = `${JSON.stringify(message)}\n`;
+    this.writeChain = this.writeChain
+      .then(() => fs.mkdir(path.dirname(this.filePath), { recursive: true }))
+      .then(() => fs.appendFile(this.filePath, line, "utf-8"));
+    return this.writeChain as Promise<void>;
+  }
+
+  /** Yield every message from disk, validated against the Zod schema. */
+  async *read(): AsyncGenerator<ApexMessage, void, unknown> {
+    let exists = true;
+    try {
+      await fs.access(this.filePath);
+    } catch {
+      exists = false;
+    }
+    if (!exists) return;
+
+    // Wait for any in-flight write before reading.
+    await this.writeChain;
+
+    const stream = createReadStream(this.filePath, { encoding: "utf-8" });
+    const lines = createInterface({ input: stream, crlfDelay: Infinity });
+    for await (const raw of lines) {
+      if (raw.length === 0) continue;
+      const parsed = JSON.parse(raw);
+      yield ApexMessageSchema.parse(parsed);
+    }
+  }
+
+  /** Read all messages eagerly. Convenient for tests. */
+  async readAll(): Promise<ApexMessage[]> {
+    const out: ApexMessage[] = [];
+    for await (const m of this.read()) out.push(m);
+    return out;
+  }
+
+  /** Delete the session's on-disk state. Used by tests. */
+  async clear(): Promise<void> {
+    await this.writeChain.catch(() => {});
+    await fs.rm(path.dirname(this.filePath), { recursive: true, force: true });
+    this.writeChain = Promise.resolve();
+  }
+}

--- a/src/sdk/stream.ts
+++ b/src/sdk/stream.ts
@@ -1,0 +1,116 @@
+import type { SessionID } from "./ids.ts";
+import type { ApexMessage } from "./messages.ts";
+
+/**
+ * A `Run` is the public, async-iterable handle returned by `agent.run(...)`
+ * (and `Subagent.spawn(...)`). Consumers iterate `for await (const msg of run) { ... }`
+ * to receive the typed `ApexMessage` stream.
+ *
+ * The Vercel-AI / Claude-SDK shape: messages flow until either `done` is
+ * emitted or `abort()` is called.
+ */
+export interface Run extends AsyncIterable<ApexMessage> {
+  readonly sessionId: SessionID;
+  /** Resolves with the final result payload from the `done` message. */
+  result(): Promise<unknown>;
+  /** Aborts the run. Idempotent; subsequent iterators terminate. */
+  abort(reason?: unknown): void;
+}
+
+/**
+ * Adapter — wrap a `(emit) => Promise<unknown>` producer into a `Run`.
+ * The producer calls `emit(msg)` for each `ApexMessage`, resolves with the
+ * final result, or throws on error.
+ */
+export function createRun(
+  sessionId: SessionID,
+  producer: (
+    emit: (msg: ApexMessage) => void,
+    signal: AbortSignal,
+  ) => Promise<unknown>,
+): Run {
+  const queue: ApexMessage[] = [];
+  const waiters: Array<(value: IteratorResult<ApexMessage>) => void> = [];
+  let finished = false;
+  let abortError: unknown = null;
+  let resultValue: unknown;
+  let resultResolve!: (v: unknown) => void;
+  let resultReject!: (e: unknown) => void;
+  const resultPromise = new Promise<unknown>((res, rej) => {
+    resultResolve = res;
+    resultReject = rej;
+  });
+  const controller = new AbortController();
+
+  const pushOrResolve = (msg: ApexMessage) => {
+    const waiter = waiters.shift();
+    if (waiter) waiter({ value: msg, done: false });
+    else queue.push(msg);
+  };
+
+  const finalize = () => {
+    finished = true;
+    while (waiters.length > 0) {
+      const w = waiters.shift()!;
+      w({ value: undefined as unknown as ApexMessage, done: true });
+    }
+  };
+
+  producer((msg) => pushOrResolve(msg), controller.signal).then(
+    (value) => {
+      resultValue = value;
+      resultResolve(value);
+      finalize();
+    },
+    (err) => {
+      abortError = err;
+      resultReject(err);
+      finalize();
+    },
+  );
+
+  const iterator: AsyncIterator<ApexMessage> = {
+    next(): Promise<IteratorResult<ApexMessage>> {
+      if (queue.length > 0) {
+        return Promise.resolve({ value: queue.shift()!, done: false });
+      }
+      if (finished) {
+        if (abortError) return Promise.reject(abortError);
+        return Promise.resolve({
+          value: undefined as unknown as ApexMessage,
+          done: true,
+        });
+      }
+      return new Promise((resolve) => waiters.push(resolve));
+    },
+    return(): Promise<IteratorResult<ApexMessage>> {
+      controller.abort();
+      finalize();
+      return Promise.resolve({
+        value: undefined as unknown as ApexMessage,
+        done: true,
+      });
+    },
+  };
+
+  // Silence unused — `resultValue` is captured by the promise resolver.
+  void resultValue;
+
+  return {
+    sessionId,
+    [Symbol.asyncIterator]() {
+      return iterator;
+    },
+    result(): Promise<unknown> {
+      return resultPromise;
+    },
+    abort(reason?: unknown): void {
+      controller.abort(reason);
+      if (!finished) {
+        abortError = reason ?? new Error("Run aborted");
+        resultReject(abortError);
+        finalize();
+      }
+    },
+  };
+}

--- a/src/sdk/subagent.ts
+++ b/src/sdk/subagent.ts
@@ -1,0 +1,98 @@
+import { mintNodeID, type NodeID, type SessionID } from "./ids.ts";
+import type { ApexMessage, NodeKind } from "./messages.ts";
+
+export type SubagentSpawnInit = {
+  /** Parent session — child shares the session, parent_id chain extends the node tree. */
+  session: { id: SessionID; nextSequence: () => number };
+  /** Parent node — child node gets `parentId` set to this. */
+  parentNodeId: NodeID;
+  /** Optional tool-call id that requested the spawn (carried as `parentToolCallId` on the node). */
+  parentToolCallId?: string | null;
+  /** Child node kind. Defaults to `agent`. */
+  kind?: NodeKind;
+  /** Display name for the child node (e.g. `"auth-agent"`, `"coding-agent-3"`). */
+  name?: string | null;
+};
+
+export type SubagentRunFn = (ctx: {
+  nodeId: NodeID;
+  emit: (msg: ApexMessage) => void;
+  signal: AbortSignal;
+}) => Promise<unknown>;
+
+/**
+ * Subagent.spawn — replaces the five `AgentEventBus.attachChild` sites
+ * referenced in the design doc. Mints a child `nod_xxx` ID, emits the
+ * `node.created` message on the parent session's stream, and returns a
+ * `Run` for the child.
+ *
+ * Used by `runAttackSurface`, `delegateAuth`, `threatModelGenerator`,
+ * `spawnCodingAgent`, `spawnPentestSwarm` in Phases 5 and 7.
+ */
+export const Subagent = {
+  spawn(
+    init: SubagentSpawnInit,
+    emitParent: (msg: ApexMessage) => void,
+    run: SubagentRunFn,
+  ): {
+    nodeId: NodeID;
+    promise: Promise<unknown>;
+    abort: (reason?: unknown) => void;
+  } {
+    const nodeId = mintNodeID();
+    const controller = new AbortController();
+    const now = new Date().toISOString();
+
+    emitParent({
+      type: "node.created",
+      node: {
+        id: nodeId,
+        sessionId: init.session.id,
+        parentId: init.parentNodeId,
+        parentToolCallId: init.parentToolCallId ?? null,
+        sequence: init.session.nextSequence(),
+        kind: init.kind ?? "agent",
+        state: "running",
+        name: init.name ?? null,
+        payload: {},
+        createdAt: now,
+      },
+      sequence: init.session.nextSequence(),
+      timestamp: now,
+    });
+
+    const promise = run({
+      nodeId,
+      emit: emitParent,
+      signal: controller.signal,
+    }).then(
+      (result) => {
+        emitParent({
+          type: "node.completed",
+          nodeId,
+          result,
+          sequence: init.session.nextSequence(),
+          timestamp: new Date().toISOString(),
+        });
+        return result;
+      },
+      (err: unknown) => {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        emitParent({
+          type: "node.completed",
+          nodeId,
+          errorMessage,
+          sequence: init.session.nextSequence(),
+          timestamp: new Date().toISOString(),
+        });
+        throw err;
+      },
+    );
+
+    return {
+      nodeId,
+      promise,
+      abort: (reason?: unknown) => controller.abort(reason),
+    };
+  },
+};


### PR DESCRIPTION
WIP prototype. Not the final form. Do not merge.

What's in:
- New `src/sdk/` — `ApexMessage` discriminated union + Zod schemas, branded IDs (`ses_/nod_/msg_/prt_/evt_`), per-session sequence counter, `Session`, async-iterable `Run`, `Subagent.spawn` primitive, JSONL session storage
- All 5 `AgentEventBus.attachChild` spawn sites (`runAttackSurface`, `delegateAuth`, `threatModelGenerator`, `spawnCodingAgent`, `spawnPentestAgent`) also emit `node.created`/`node.completed` on the new stream (additive — legacy bus untouched)
- 30 new unit tests; full suite 1033 passed / 18 skipped, lint + tsc clean

Legacy `AgentEventBus` + `AgentEventMap` stay in place.