### PR TITLE
Enable Biome useIterableCallbackReturn

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -52,8 +52,7 @@
         "noArrayIndexKey": "off",
         "noImplicitAnyLet": "error",
         "noAssignInExpressions": "error",
-        // Existing pattern with intentional void callbacks; revisit in a follow-up triage PR.
-        "useIterableCallbackReturn": "off"
+        "useIterableCallbackReturn": "error"
       },
       "complexity": {
         // Carryover from previous ESLint config (no-useless-escape: off).

--- a/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
+++ b/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
@@ -120,9 +120,9 @@ export function crawlAuthenticated(ctx: ToolContext) {
               });
 
               if (jsEndpoints.endpoints) {
-                jsEndpoints.endpoints.forEach((ep: EndpointInfo) =>
-                  allEndpoints.add(ep.endpoint),
-                );
+                jsEndpoints.endpoints.forEach((ep: EndpointInfo) => {
+                  allEndpoints.add(ep.endpoint);
+                });
               }
 
               pages.push({

--- a/src/core/agents/specialized/benchmark/flag-detector.ts
+++ b/src/core/agents/specialized/benchmark/flag-detector.ts
@@ -657,7 +657,9 @@ export async function detectFlagInArtifacts(
     );
     // Deduplicate foundIn for cleaner output
     const uniqueFiles = [...new Set(foundIn)];
-    uniqueFiles.forEach((file) => console.log(`[${branch}]    - ${file}`));
+    uniqueFiles.forEach((file) => {
+      console.log(`[${branch}]    - ${file}`);
+    });
 
     // Output specific locations with line numbers
     console.log(

--- a/src/tests/authPentestHandoff.test.ts
+++ b/src/tests/authPentestHandoff.test.ts
@@ -193,7 +193,9 @@ describe.skip("Auth → Pentest Cookie Handoff", () => {
       // ── Step 5: Verify the pentest agent used the auth cookies ──
       const allToolInputs = toolCallLog.map((t) => t.input).join("\n");
       console.log("Tool calls made by pentest agent:");
-      toolCallLog.forEach((t) => console.log(`  - ${t.tool}`));
+      toolCallLog.forEach((t) => {
+        console.log(`  - ${t.tool}`);
+      });
 
       const cookieStr = authData.cookies || "";
       const headerValues = Object.values(authData.headers || {}) as string[];

--- a/src/tests/browserCookies.test.ts
+++ b/src/tests/browserCookies.test.ts
@@ -106,9 +106,9 @@ describe.skip("Browser Cookie Extraction", () => {
       }> = typeof parsed === "string" ? JSON.parse(parsed) : parsed;
 
       console.log(`Extracted ${cookies.length} cookies:`);
-      cookies.forEach((c) =>
-        console.log(`  ${c.name} (${c.domain}, httpOnly=${c.httpOnly})`),
-      );
+      cookies.forEach((c) => {
+        console.log(`  ${c.name} (${c.domain}, httpOnly=${c.httpOnly})`);
+      });
 
       expect(cookies.length).toBeGreaterThan(0);
 

--- a/src/tui/components/chat/petri-animation.tsx
+++ b/src/tui/components/chat/petri-animation.tsx
@@ -20,7 +20,9 @@ function startGlobalTick() {
   if (!globalInterval) {
     globalInterval = setInterval(() => {
       globalTick = (globalTick + 1) % 1000;
-      globalListeners.forEach((listener) => listener());
+      globalListeners.forEach((listener) => {
+        listener();
+      });
     }, 50); // ~20fps
   }
 }

--- a/src/tui/components/loaders.tsx
+++ b/src/tui/components/loaders.tsx
@@ -21,7 +21,9 @@ function ensureTick() {
   if (!interval) {
     interval = setInterval(() => {
       tick = (tick + 1) % 100_000;
-      listeners.forEach((fn) => fn());
+      listeners.forEach((fn) => {
+        fn();
+      });
     }, 50); // 20 fps
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Enables the `useIterableCallbackReturn` Biome rule (previously disabled in `biome.jsonc` as a follow-up triage item). This rule catches:
- Missing `return` in `.map()`/`.reduce()`/`.filter()` callbacks
- Intentional void callbacks that should use `.forEach()` block body syntax

**Changes:**

- **`biome.jsonc`**: Changed `useIterableCallbackReturn` from `"off"` to `"error"` and removed the triage comment.
- **6 source files**: Converted concise arrow `forEach` callbacks to block body syntax so they no longer implicitly return a value. All were side-effect-only callbacks (`Set.add`, `console.log`, listener invocations) — behavior is unchanged.

| File | Fix |
|------|-----|
| `src/core/agents/offSecAgent/tools/crawlAuthenticated.ts` | `forEach(ep => allEndpoints.add(...))` → block body |
| `src/core/agents/specialized/benchmark/flag-detector.ts` | `forEach(file => console.log(...))` → block body |
| `src/tests/authPentestHandoff.test.ts` | `forEach(t => console.log(...))` → block body |
| `src/tests/browserCookies.test.ts` | `forEach(c => console.log(...))` → block body |
| `src/tui/components/chat/petri-animation.tsx` | `forEach(listener => listener())` → block body |
| `src/tui/components/loaders.tsx` | `forEach(fn => fn())` → block body |

### How did you verify your code works?

- `bun run lint` — passes (0 errors; remaining warnings/infos are pre-existing and unrelated)
- `bun run tsc` — passes clean
- `bun run test` — 54 test files pass, 1029 tests pass (7 files / 15 tests skipped are pre-existing integration test skips)
- `bun run build` — succeeds

All fixes are mechanical (concise arrow → block body in `.forEach()`) and don't change runtime behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c416b7a5-353a-4c04-852f-88b626fe853d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c416b7a5-353a-4c04-852f-88b626fe853d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

