### PR TITLE
Enable Biome noImplicitAnyLet

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -50,8 +50,7 @@
         "noUselessEscapeInString": "off",
         // Existing pattern across many TUI list components; revisit in a follow-up triage PR.
         "noArrayIndexKey": "off",
-        // Existing pattern in tightly-scoped imperative blocks; revisit in a follow-up triage PR.
-        "noImplicitAnyLet": "off",
+        "noImplicitAnyLet": "error",
         // Existing pattern in defensive/initialization code; revisit in a follow-up triage PR.
         "noAssignInExpressions": "off",
         // Existing pattern with intentional void callbacks; revisit in a follow-up triage PR.

--- a/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
+++ b/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
@@ -78,7 +78,7 @@ export function crawlAuthenticated(ctx: ToolContext) {
               // Extract links
               const linkRegex = /<a[^>]+href=['"]([^'"]+)['"]/gi;
               const links: string[] = [];
-              let linkMatch;
+              let linkMatch: RegExpExecArray | null;
               while ((linkMatch = linkRegex.exec(html)) !== null) {
                 const link = linkMatch[1];
                 if (link.startsWith("/") && !link.startsWith("//")) {
@@ -92,7 +92,7 @@ export function crawlAuthenticated(ctx: ToolContext) {
               // Extract forms
               const formRegex = /<form[^>]+action=['"]([^'"]+)['"]/gi;
               const forms: string[] = [];
-              let formMatch;
+              let formMatch: RegExpExecArray | null;
               while ((formMatch = formRegex.exec(html)) !== null) {
                 forms.push(formMatch[1]);
               }

--- a/src/core/agents/offSecAgent/tools/listFiles.ts
+++ b/src/core/agents/offSecAgent/tools/listFiles.ts
@@ -44,7 +44,7 @@ async function listRecursive(
   let total = 0;
 
   async function walk(current: string) {
-    let entries;
+    let entries: import("fs").Dirent[];
     try {
       entries = await readdir(current, { withFileTypes: true });
     } catch {

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -30,7 +30,7 @@ import type {
   BrowserNavigateResult,
   BrowserScreenshotResult,
 } from "./playwrightMcp";
-import type { UnifiedSandbox } from "./sandbox";
+import type { SandboxExecutionResult, UnifiedSandbox } from "./sandbox";
 import type { ToolContext } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -136,7 +136,7 @@ export async function installSandboxPlaywright(
       { timeout: 10 },
     );
 
-    let browserResult;
+    let browserResult: SandboxExecutionResult | undefined;
     for (let attempt = 1; attempt <= 3; attempt++) {
       browserResult = await sandbox.execute(
         `cd ${SANDBOX_PW_DIR} && npx playwright install chromium --with-deps 2>&1`,

--- a/src/core/agents/specialized/attackSurface/jsExtraction.ts
+++ b/src/core/agents/specialized/attackSurface/jsExtraction.ts
@@ -75,13 +75,13 @@ export async function extractJavascriptEndpoints(
 
     // Extract inline script content
     const scriptTagRegex = /<script[^>]*>([\s\S]*?)<\/script>/gi;
-    let scriptMatch;
+    let scriptMatch: RegExpExecArray | null;
     while ((scriptMatch = scriptTagRegex.exec(html)) !== null) {
       const scriptContent = scriptMatch[1];
 
       // Apply all patterns to script content
       for (const pattern of endpointPatterns) {
-        let match;
+        let match: RegExpExecArray | null;
         const patternCopy = new RegExp(pattern.source, pattern.flags);
         while ((match = patternCopy.exec(scriptContent)) !== null) {
           const endpoint = match[1] || match[2];
@@ -99,7 +99,7 @@ export async function extractJavascriptEndpoints(
     // Extract external JS file URLs
     if (includeExternalJS) {
       const scriptSrcRegex = /<script[^>]+src=['"]([^'"]+)['"]/gi;
-      let srcMatch;
+      let srcMatch: RegExpExecArray | null;
       while ((srcMatch = scriptSrcRegex.exec(html)) !== null) {
         jsFiles.push(srcMatch[1]);
       }

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -139,7 +139,7 @@ export function getProviderModel(
     process.env.LOCAL_MODEL_URL ||
     "http://127.0.0.1:1234/v1";
 
-  let providerModel;
+  let providerModel: LanguageModel;
 
   switch (provider) {
     case "openai": {

--- a/src/core/benchmark/runner.ts
+++ b/src/core/benchmark/runner.ts
@@ -16,7 +16,10 @@ import {
 import type { CacheMetrics } from "../ai";
 import { AgentEventBus } from "../eventBus";
 import * as sessions from "../session";
-import { runPentestWorkflow } from "../workflows/pentest";
+import {
+  type PentestWorkflowResult,
+  runPentestWorkflow,
+} from "../workflows/pentest";
 import type {
   BenchmarkMetadata,
   BenchmarkRunResult,
@@ -383,7 +386,7 @@ export async function runSingleBenchmark(
       console.log(`[${branch}] [${subagentId}] ${status}`),
     );
 
-    let pentestResult;
+    let pentestResult: PentestWorkflowResult | undefined;
     try {
       pentestResult = await runPentestWorkflow({
         target: targetUrl,

--- a/src/core/whitebox/repoProfile.ts
+++ b/src/core/whitebox/repoProfile.ts
@@ -116,7 +116,7 @@ async function walkFiles(rootPath: string): Promise<string[]> {
 
   async function walk(current: string): Promise<void> {
     if (files.length >= MAX_PROFILE_FILES) return;
-    let entries;
+    let entries: import("node:fs").Dirent[];
     try {
       entries = await readdir(current, { withFileTypes: true });
     } catch {

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -37,7 +37,10 @@ import {
   modelSupportsOpenAIReasoning,
   modelSupportsThinking,
 } from "../../../core/ai";
-import { runOffensiveSecurityAgent } from "../../../core/api";
+import {
+  type RunAgentResult,
+  runOffensiveSecurityAgent,
+} from "../../../core/api";
 import { attachWandbToEventBus } from "../../../core/integrations/wandb/upload";
 import type { OperatorMode, PendingApproval } from "../../../core/operator";
 import {
@@ -1223,7 +1226,7 @@ export default function OperatorDashboard({
       }
 
       try {
-        let agentResult;
+        let agentResult: RunAgentResult;
 
         const systemPrompt = buildOperatorSystemPrompt(
           initialConfig?.target,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Enables the `suspicious/noImplicitAnyLet` Biome rule (previously disabled as a triage follow-up). This rule catches `let x;` declarations with no type annotation and no initializer — implicit `any` that survives strict mode.

All 11 flagged sites were annotated with explicit types:

| File | Variable | Type |
|------|----------|------|
| `crawlAuthenticated.ts` | `linkMatch`, `formMatch` | `RegExpExecArray \| null` |
| `listFiles.ts` | `entries` | `import("fs").Dirent[]` |
| `sandboxPlaywright.ts` | `browserResult` | `SandboxExecutionResult \| undefined` |
| `jsExtraction.ts` | `scriptMatch`, `match`, `srcMatch` | `RegExpExecArray \| null` |
| `utils.ts` | `providerModel` | `LanguageModel` |
| `runner.ts` | `pentestResult` | `PentestWorkflowResult \| undefined` |
| `repoProfile.ts` | `entries` | `import("node:fs").Dirent[]` |
| `operator-dashboard/index.tsx` | `agentResult` | `RunAgentResult` |

All changes are **type-only annotations** — no runtime behavior change.

### How did you verify your code works?

- `bun run tsc` — passes (no type errors)
- `bun run lint` — passes (0 errors, no remaining `noImplicitAnyLet` violations)
- `bun run test` — 54 test files, 1029 tests pass, 7 files skipped (integration tests requiring live services)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac9cb867-630b-43aa-a6e7-0115a80c116c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac9cb867-630b-43aa-a6e7-0115a80c116c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

