### PR TITLE
Enable Biome noAssignInExpressions

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -51,8 +51,7 @@
         // Existing pattern across many TUI list components; revisit in a follow-up triage PR.
         "noArrayIndexKey": "off",
         "noImplicitAnyLet": "error",
-        // Existing pattern in defensive/initialization code; revisit in a follow-up triage PR.
-        "noAssignInExpressions": "off",
+        "noAssignInExpressions": "error",
         // Existing pattern with intentional void callbacks; revisit in a follow-up triage PR.
         "useIterableCallbackReturn": "off"
       },

--- a/scripts/generate-models.ts
+++ b/scripts/generate-models.ts
@@ -31,8 +31,11 @@ function extractUnionMembers(dtsPath: string, typeName: string): string[] {
   const unionBody = match[1]!;
   const members: string[] = [];
   const literalRegex = /'([^']+)'/g;
-  let m: RegExpExecArray | null;
-  while ((m = literalRegex.exec(unionBody)) !== null) {
+  for (
+    let m = literalRegex.exec(unionBody);
+    m !== null;
+    m = literalRegex.exec(unionBody)
+  ) {
     members.push(m[1]!);
   }
   return members;

--- a/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
+++ b/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
@@ -78,8 +78,11 @@ export function crawlAuthenticated(ctx: ToolContext) {
               // Extract links
               const linkRegex = /<a[^>]+href=['"]([^'"]+)['"]/gi;
               const links: string[] = [];
-              let linkMatch: RegExpExecArray | null;
-              while ((linkMatch = linkRegex.exec(html)) !== null) {
+              for (
+                let linkMatch = linkRegex.exec(html);
+                linkMatch !== null;
+                linkMatch = linkRegex.exec(html)
+              ) {
                 const link = linkMatch[1];
                 if (link.startsWith("/") && !link.startsWith("//")) {
                   links.push(link);
@@ -92,8 +95,11 @@ export function crawlAuthenticated(ctx: ToolContext) {
               // Extract forms
               const formRegex = /<form[^>]+action=['"]([^'"]+)['"]/gi;
               const forms: string[] = [];
-              let formMatch: RegExpExecArray | null;
-              while ((formMatch = formRegex.exec(html)) !== null) {
+              for (
+                let formMatch = formRegex.exec(html);
+                formMatch !== null;
+                formMatch = formRegex.exec(html)
+              ) {
                 forms.push(formMatch[1]);
               }
 

--- a/src/core/agents/specialized/attackSurface/jsExtraction.ts
+++ b/src/core/agents/specialized/attackSurface/jsExtraction.ts
@@ -75,15 +75,21 @@ export async function extractJavascriptEndpoints(
 
     // Extract inline script content
     const scriptTagRegex = /<script[^>]*>([\s\S]*?)<\/script>/gi;
-    let scriptMatch: RegExpExecArray | null;
-    while ((scriptMatch = scriptTagRegex.exec(html)) !== null) {
+    for (
+      let scriptMatch = scriptTagRegex.exec(html);
+      scriptMatch !== null;
+      scriptMatch = scriptTagRegex.exec(html)
+    ) {
       const scriptContent = scriptMatch[1];
 
       // Apply all patterns to script content
       for (const pattern of endpointPatterns) {
-        let match: RegExpExecArray | null;
         const patternCopy = new RegExp(pattern.source, pattern.flags);
-        while ((match = patternCopy.exec(scriptContent)) !== null) {
+        for (
+          let match = patternCopy.exec(scriptContent);
+          match !== null;
+          match = patternCopy.exec(scriptContent)
+        ) {
           const endpoint = match[1] || match[2];
           if (endpoint && endpoint.startsWith("/")) {
             endpoints.push({
@@ -99,8 +105,11 @@ export async function extractJavascriptEndpoints(
     // Extract external JS file URLs
     if (includeExternalJS) {
       const scriptSrcRegex = /<script[^>]+src=['"]([^'"]+)['"]/gi;
-      let srcMatch: RegExpExecArray | null;
-      while ((srcMatch = scriptSrcRegex.exec(html)) !== null) {
+      for (
+        let srcMatch = scriptSrcRegex.exec(html);
+        srcMatch !== null;
+        srcMatch = scriptSrcRegex.exec(html)
+      ) {
         jsFiles.push(srcMatch[1]);
       }
     }

--- a/src/tui/components/commands/skills-dialog.tsx
+++ b/src/tui/components/commands/skills-dialog.tsx
@@ -85,7 +85,8 @@ export default function SkillsDialog({
     const grouped: Record<string, SkillEntry[]> = {};
     for (const skill of allSkills) {
       const key = skill.source;
-      (grouped[key] ??= []).push(skill);
+      grouped[key] ??= [];
+      grouped[key].push(skill);
     }
 
     const groups: Array<{ label: string; skills: SkillEntry[] }> = [];

--- a/src/tui/components/shared/prompt-input-logic.ts
+++ b/src/tui/components/shared/prompt-input-logic.ts
@@ -319,8 +319,11 @@ export function filterInlineOptionSuggestions(
   // Find all --flags already used in the input
   const usedFlags = new Set<string>();
   const flagPattern = /--[a-zA-Z][-a-zA-Z0-9]*/g;
-  let match: RegExpExecArray | null;
-  while ((match = flagPattern.exec(fullText)) !== null) {
+  for (
+    let match = flagPattern.exec(fullText);
+    match !== null;
+    match = flagPattern.exec(fullText)
+  ) {
     usedFlags.add(match[0].toLowerCase());
   }
 

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -396,8 +396,11 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       ta.removeHighlightsByRef(SLASH_HL_REF);
       if (knownSlugs.size === 0) return;
       SLASH_PATTERN.lastIndex = 0;
-      let match: RegExpExecArray | null;
-      while ((match = SLASH_PATTERN.exec(text)) !== null) {
+      for (
+        let match = SLASH_PATTERN.exec(text);
+        match !== null;
+        match = SLASH_PATTERN.exec(text)
+      ) {
         if (knownSlugs.has(match[0].toLowerCase())) {
           ta.addHighlightByCharRange({
             start: match.index,

--- a/src/tui/components/shared/syntax-highlight.ts
+++ b/src/tui/components/shared/syntax-highlight.ts
@@ -164,9 +164,8 @@ function parseHljsHtml(
   const colorStack: RGBA[] = [defaultColor];
 
   const TAG_RE = /<span\s+class="([^"]*)"[^>]*>|<\/span>|([^<]+)|(<[^>]*>)/g;
-  let m: RegExpExecArray | null;
 
-  while ((m = TAG_RE.exec(html)) !== null) {
+  for (let m = TAG_RE.exec(html); m !== null; m = TAG_RE.exec(html)) {
     if (m[1] !== undefined) {
       // Opening <span class="...">
       const classes = m[1].split(/\s+/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Enables the `suspicious/noAssignInExpressions` Biome rule, which was previously disabled (`"off"`) as a follow-up triage item. This rule catches assignments inside expressions (`if (x = foo())`) which are almost always typos for `==`/`===`.

All 10 violations were the idiomatic `while ((m = regex.exec(str)) !== null)` regex iteration pattern. Each was rewritten to an equivalent `for`-loop that separates the assignment from the condition:

```ts
// Before (flagged by noAssignInExpressions)
while ((m = regex.exec(str)) !== null) { ... }

// After (equivalent behavior, lint-clean)
for (let m = regex.exec(str); m !== null; m = regex.exec(str)) { ... }
```

One `??=` expression assignment in `skills-dialog.tsx` was split into separate assignment and push statements.

No `biome-ignore` suppressions were needed — every call site was cleanly rewritable.

**Files changed (8):**
- `biome.jsonc` — rule `"off"` → `"error"`, removed triage comment
- `scripts/generate-models.ts` — 1 while-assign → for-loop
- `src/core/agents/offSecAgent/tools/crawlAuthenticated.ts` — 2 while-assigns → for-loops
- `src/core/agents/specialized/attackSurface/jsExtraction.ts` — 3 while-assigns → for-loops
- `src/tui/components/commands/skills-dialog.tsx` — `??=` expression split into two statements
- `src/tui/components/shared/prompt-input-logic.ts` — 1 while-assign → for-loop
- `src/tui/components/shared/prompt-input.tsx` — 1 while-assign → for-loop
- `src/tui/components/shared/syntax-highlight.ts` — 1 while-assign → for-loop

### How did you verify your code works?

- `bun run lint` — passes (0 errors)
- `bun run tsc` — passes (no type errors)
- `bun run test` — all 1029 tests pass, 15 pre-existing skips
- `bun run format:check` — passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-659686db-2278-47d7-a94a-19c7bd129f67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-659686db-2278-47d7-a94a-19c7bd129f67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

