### PR TITLE
Forbid console.* in src/ via Biome noConsole

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -45,6 +45,7 @@
         "recommended": false
       },
       "suspicious": {
+        "noConsole": "error",
         "noExplicitAny": "error",
         // Carryover from previous ESLint config (no-useless-escape: off).
         "noUselessEscapeInString": "off",
@@ -182,10 +183,13 @@
       }
     },
     {
-      // Test files are allowed to poke at internals.
+      // Test files are allowed to poke at internals and use console.*.
       "includes": ["**/*.test.ts", "**/*.test.tsx", "**/*.test-*.ts"],
       "linter": {
         "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          },
           "style": {
             "noRestrictedImports": { "level": "off" }
           }
@@ -193,12 +197,14 @@
       }
     },
     {
-      // Barrel enforcement scopes to src/ only, matching the previous
-      // `eslint src/` lint scope. Demo files at the repo root and
-      // helper scripts are not subject to module-boundary rules.
+      // Barrel enforcement and noConsole scope to src/ only. Demo files
+      // at the repo root and helper scripts are not subject to these rules.
       "includes": ["**", "!src/**"],
       "linter": {
         "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          },
           "style": {
             "noRestrictedImports": { "level": "off" }
           }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ function getArg(flag: string, argv = args): string | undefined {
 function getArgRequired(flag: string, argv = args): string {
   const val = getArg(flag, argv);
   if (!val) {
-    console.error(`Error: ${flag} is required`);
+    process.stderr.write(`Error: ${flag} is required\n`);
     process.exit(1);
   }
   return val;
@@ -69,9 +69,9 @@ function getAllArgs(flag: string, argv = args): string[] {
 
 function attachCliAgentStreamListeners(bus: AgentEventBus): void {
   bus.on("text-delta", (d) => process.stdout.write(d.text));
-  bus.on("tool-call-complete", (d) => console.log(`\n→ ${d.toolName}`));
-  bus.on("tool-result", (d) => console.log(`✓ ${d.toolName} completed`));
-  bus.on("error", (d) => console.error("Error:", d.error));
+  bus.on("tool-call-complete", (d) => process.stdout.write(`\n→ ${d.toolName}\n`));
+  bus.on("tool-result", (d) => process.stdout.write(`✓ ${d.toolName} completed\n`));
+  bus.on("error", (d) => process.stderr.write(`Error: ${d.error}\n`));
 }
 
 async function createInstrumentedBus(
@@ -83,7 +83,7 @@ async function createInstrumentedBus(
     "./core/integrations/wandb/upload"
   );
   const wandbCleanup = await attachWandbToEventBus(session, bus).catch((e) => {
-    console.warn("[wandb] Tracing disabled:", (e as Error).message);
+    process.stderr.write(`[wandb] Tracing disabled: ${(e as Error).message}\n`);
     return null;
   });
   return { bus, cleanup: async () => wandbCleanup?.() };
@@ -104,13 +104,13 @@ async function resolveCliModel(): Promise<AIModel> {
   const defaultModel = getDefaultModelForConfig(pensarConfig);
 
   if (!defaultModel) {
-    console.error(
+    process.stderr.write(
       "Error: No AI provider configured. Set one of:\n" +
         "  PENSAR_API_KEY     — Pensar Console (recommended)\n" +
         "  ANTHROPIC_API_KEY  — Anthropic direct\n" +
         "  OPENAI_API_KEY     — OpenAI\n" +
         "  OPENROUTER_API_KEY — OpenRouter\n" +
-        "\nOr run 'pensar login' to connect to Pensar Console.",
+        "\nOr run 'pensar login' to connect to Pensar Console.\n",
     );
     process.exit(1);
   }
@@ -123,7 +123,7 @@ async function resolveCliModel(): Promise<AIModel> {
 // ---------------------------------------------------------------------------
 
 function showHelp() {
-  console.log(`Pensar - AI-Powered Penetration Testing CLI
+  process.stdout.write(`Pensar - AI-Powered Penetration Testing CLI
 
 Usage:
   pensar                             Launch the TUI
@@ -210,11 +210,11 @@ async function runPentest() {
   const { exfilMode, warning: modeWarning } = resolvePentestMode(mode);
 
   if (modeWarning) {
-    console.warn(modeWarning);
+    process.stderr.write(`${modeWarning}\n`);
   }
 
   const sep = "=".repeat(60);
-  console.log(`${sep}
+  process.stdout.write(`${sep}
 PENTEST ORCHESTRATION
 ${sep}
 Target:  ${target}${cwd ? `\nCwd:     ${cwd} (whitebox)` : ""}${exfilMode ? "\nMode:    exfil" : ""}
@@ -248,13 +248,13 @@ Model:   ${model}${enableThinking ? "\nThinking: enabled" : ""}${taskDriven ? "\
         eventBus: pentestBus,
       });
 
-    console.log(`
+    process.stdout.write(`
 ${sep}
 RESULTS
 ${sep}
 Findings:  ${findings.length}
 Path:      ${findingsPath}
-POCs:      ${pocsPath}${reportPath ? `\nReport:    ${reportPath}` : ""}`);
+POCs:      ${pocsPath}${reportPath ? `\nReport:    ${reportPath}` : ""}\n`);
   } finally {
     await wandbCleanup();
   }
@@ -277,7 +277,7 @@ async function runTargetedPentest() {
   const model = await resolveCliModel();
 
   if (objectives.length === 0) {
-    console.error("Error: at least one --objective is required");
+    process.stderr.write("Error: at least one --objective is required\n");
     process.exit(1);
   }
 
@@ -285,7 +285,7 @@ async function runTargetedPentest() {
   const objectivesList = objectives
     .map((o, i) => `  ${i + 1}. ${o}`)
     .join("\n");
-  console.log(`${sep}
+  process.stdout.write(`${sep}
 TARGETED PENTEST
 ${sep}
 Target:  ${target}
@@ -312,13 +312,13 @@ ${objectivesList}
       eventBus: targetedBus,
     });
 
-    console.log(`
+    process.stdout.write(`
 ${sep}
 RESULTS
 ${sep}
 Findings:  ${findings.length}
 Path:      ${findingsPath}
-POCs:      ${pocsPath}`);
+POCs:      ${pocsPath}\n`);
   } finally {
     await wandbCleanup();
   }
@@ -341,7 +341,7 @@ async function runThreatModel() {
     : path.resolve(process.cwd(), outputArg);
 
   const sep = "=".repeat(60);
-  console.log(`${sep}
+  process.stdout.write(`${sep}
 THREAT MODEL GENERATION
 ${sep}
 Codebase: ${process.cwd()}
@@ -351,9 +351,9 @@ Model:    ${model}
 
   const threatBus = new AgentEventBus();
   threatBus.on("text-delta", (d) => process.stdout.write(d.text));
-  threatBus.on("tool-call-complete", (d) => console.log(`\n  → ${d.toolName}`));
-  threatBus.on("tool-result", (d) => console.log(`  ✓ ${d.toolName}`));
-  threatBus.on("error", (d) => console.error("Error:", d.error));
+  threatBus.on("tool-call-complete", (d) => process.stdout.write(`\n  → ${d.toolName}\n`));
+  threatBus.on("tool-result", (d) => process.stdout.write(`  ✓ ${d.toolName}\n`));
+  threatBus.on("error", (d) => process.stderr.write(`Error: ${d.error}\n`));
 
   await runThreatModelWorkflow({
     codebasePath: process.cwd(),
@@ -363,8 +363,8 @@ Model:    ${model}
     eventBus: threatBus,
   });
 
-  console.log(
-    `\n${sep}\nCOMPLETE\n${sep}\nThreat model written to: ${resolvedPath}`,
+  process.stdout.write(
+    `\n${sep}\nCOMPLETE\n${sep}\nThreat model written to: ${resolvedPath}\n`,
   );
 }
 
@@ -388,7 +388,7 @@ async function runOperator() {
 
   const promptRaw = getArg("-p") ?? getArg("--prompt");
   if (!promptRaw) {
-    console.error("Error: -p <prompt> is required");
+    process.stderr.write("Error: -p <prompt> is required\n");
     process.exit(1);
   }
 
@@ -400,7 +400,7 @@ async function runOperator() {
   const model = await resolveCliModel();
 
   const sep = "─".repeat(60);
-  console.log(`${sep}
+  process.stdout.write(`${sep}
 OPERATOR SESSION
 ${sep}
 Model:   ${model}${target ? `\nTarget:  ${target}` : ""}
@@ -477,15 +477,15 @@ ${sep}\n`);
     await wandbCleanup();
   }
 
-  console.log(`\nSession: ${session.rootPath}`);
+  process.stdout.write(`\nSession: ${session.rootPath}\n`);
 }
 
 async function runUpgrade() {
   const currentVersion = getCurrentVersion();
-  console.log(`Current version: v${currentVersion}\nChecking for updates...`);
+  process.stdout.write(`Current version: v${currentVersion}\nChecking for updates...\n`);
 
   const result = await upgrade({ interactive: true });
-  console.log(`\n${result.message}`);
+  process.stdout.write(`\n${result.message}\n`);
 
   process.exit(result.success ? 0 : 1);
 }
@@ -501,7 +501,7 @@ if (hasFlag("-p") || command === "--prompt") {
   command === "--version" ||
   command === "-v"
 ) {
-  console.log(`v${version}`);
+  process.stdout.write(`v${version}\n`);
 } else if (command === "help" || command === "--help" || command === "-h") {
   showHelp();
 } else if (command === "upgrade" || command === "update") {
@@ -541,16 +541,16 @@ if (hasFlag("-p") || command === "--prompt") {
   await runDoctor();
 } else if (args.length === 0) {
   if (process.env.PENSAR_NO_TUI === "1") {
-    console.error(
-      "TUI mode requires Bun. Install Bun (https://bun.sh) or use a standalone binary release for interactive mode.",
+    process.stderr.write(
+      "TUI mode requires Bun. Install Bun (https://bun.sh) or use a standalone binary release for interactive mode.\n",
     );
-    console.error("All other commands work with Node — run 'pensar --help'.");
+    process.stderr.write("All other commands work with Node — run 'pensar --help'.\n");
     process.exit(1);
   }
   await import("./tui/index.tsx");
 } else {
-  console.error(`Error: Unknown command '${command}'`);
-  console.error();
-  console.error("Run 'pensar --help' for usage information");
+  process.stderr.write(`Error: Unknown command '${command}'\n`);
+  process.stderr.write("\n");
+  process.stderr.write("Run 'pensar --help' for usage information\n");
   process.exit(1);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,8 +69,12 @@ function getAllArgs(flag: string, argv = args): string[] {
 
 function attachCliAgentStreamListeners(bus: AgentEventBus): void {
   bus.on("text-delta", (d) => process.stdout.write(d.text));
-  bus.on("tool-call-complete", (d) => process.stdout.write(`\n→ ${d.toolName}\n`));
-  bus.on("tool-result", (d) => process.stdout.write(`✓ ${d.toolName} completed\n`));
+  bus.on("tool-call-complete", (d) =>
+    process.stdout.write(`\n→ ${d.toolName}\n`),
+  );
+  bus.on("tool-result", (d) =>
+    process.stdout.write(`✓ ${d.toolName} completed\n`),
+  );
   bus.on("error", (d) => process.stderr.write(`Error: ${d.error}\n`));
 }
 
@@ -351,8 +355,12 @@ Model:    ${model}
 
   const threatBus = new AgentEventBus();
   threatBus.on("text-delta", (d) => process.stdout.write(d.text));
-  threatBus.on("tool-call-complete", (d) => process.stdout.write(`\n  → ${d.toolName}\n`));
-  threatBus.on("tool-result", (d) => process.stdout.write(`  ✓ ${d.toolName}\n`));
+  threatBus.on("tool-call-complete", (d) =>
+    process.stdout.write(`\n  → ${d.toolName}\n`),
+  );
+  threatBus.on("tool-result", (d) =>
+    process.stdout.write(`  ✓ ${d.toolName}\n`),
+  );
   threatBus.on("error", (d) => process.stderr.write(`Error: ${d.error}\n`));
 
   await runThreatModelWorkflow({
@@ -482,7 +490,9 @@ ${sep}\n`);
 
 async function runUpgrade() {
   const currentVersion = getCurrentVersion();
-  process.stdout.write(`Current version: v${currentVersion}\nChecking for updates...\n`);
+  process.stdout.write(
+    `Current version: v${currentVersion}\nChecking for updates...\n`,
+  );
 
   const result = await upgrade({ interactive: true });
   process.stdout.write(`\n${result.message}\n`);
@@ -544,7 +554,9 @@ if (hasFlag("-p") || command === "--prompt") {
     process.stderr.write(
       "TUI mode requires Bun. Install Bun (https://bun.sh) or use a standalone binary release for interactive mode.\n",
     );
-    process.stderr.write("All other commands work with Node — run 'pensar --help'.\n");
+    process.stderr.write(
+      "All other commands work with Node — run 'pensar --help'.\n",
+    );
     process.exit(1);
   }
   await import("./tui/index.tsx");

--- a/src/cli/apps.ts
+++ b/src/cli/apps.ts
@@ -125,7 +125,7 @@ function parseNumber(
 }
 
 function showHelp(): void {
-  console.log(`pensar apps — Manage the project attack surface (apps & endpoints)
+  process.stdout.write(`pensar apps — Manage the project attack surface (apps & endpoints)
 
 Usage:
   pensar apps <projectId>                                  List apps for a project
@@ -184,7 +184,7 @@ Endpoint fields (create requires --endpoint and --description):
   --threat-model <text>        Per-endpoint threat model notes
 
 Options:
-  -h, --help                   Show this help message`);
+  -h, --help                   Show this help message\n`);
 }
 
 function parseAppCreateOptions(argv: string[]): CreateAppInput {
@@ -313,48 +313,48 @@ async function main(): Promise<void> {
     if (sub === "get") {
       const appId = args[1];
       if (!appId) {
-        console.error("Error: app ID is required");
-        console.error("Usage: pensar apps get <appId>");
+        process.stderr.write("Error: app ID is required\n");
+        process.stderr.write("Usage: pensar apps get <appId>\n");
         process.exit(1);
       }
       const app = await getApp(appId);
-      console.log(JSON.stringify(app, null, 2));
+      process.stdout.write(`${JSON.stringify(app, null, 2)}\n`);
     } else if (sub === "create") {
       const projectId = args[1];
       if (!projectId) {
-        console.error("Error: project ID is required");
-        console.error(
-          "Usage: pensar apps create <projectId> --name N --description D",
+        process.stderr.write("Error: project ID is required\n");
+        process.stderr.write(
+          "Usage: pensar apps create <projectId> --name N --description D\n",
         );
         process.exit(1);
       }
       const opts = parseAppCreateOptions(args);
       const result = await createApp(projectId, opts);
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else if (sub === "update") {
       const appId = args[1];
       if (!appId) {
-        console.error("Error: app ID is required");
-        console.error("Usage: pensar apps update <appId> [options]");
+        process.stderr.write("Error: app ID is required\n");
+        process.stderr.write("Usage: pensar apps update <appId> [options]\n");
         process.exit(1);
       }
       const opts = parseAppUpdateOptions(args);
       const result = await updateApp(appId, opts);
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else if (sub === "delete") {
       const appId = args[1];
       if (!appId) {
-        console.error("Error: app ID is required");
-        console.error("Usage: pensar apps delete <appId>");
+        process.stderr.write("Error: app ID is required\n");
+        process.stderr.write("Usage: pensar apps delete <appId>\n");
         process.exit(1);
       }
       const result = await deleteApp(appId);
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else if (sub === "endpoints") {
       const appId = args[1];
       if (!appId) {
-        console.error("Error: app ID is required");
-        console.error("Usage: pensar apps endpoints <appId> [filters]");
+        process.stderr.write("Error: app ID is required\n");
+        process.stderr.write("Usage: pensar apps endpoints <appId> [filters]\n");
         process.exit(1);
       }
       const type = parseEndpointType(getFlag("--type", args));
@@ -371,54 +371,54 @@ async function main(): Promise<void> {
         ...(offset !== undefined ? { offset } : {}),
       };
       const result = await listEndpoints(appId, filters);
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else if (sub === "endpoint") {
       const endpointId = args[1];
       if (!endpointId) {
-        console.error("Error: endpoint ID is required");
-        console.error("Usage: pensar apps endpoint <endpointId>");
+        process.stderr.write("Error: endpoint ID is required\n");
+        process.stderr.write("Usage: pensar apps endpoint <endpointId>\n");
         process.exit(1);
       }
       const result = await getEndpoint(endpointId);
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else if (sub === "endpoint-create") {
       const appId = args[1];
       if (!appId) {
-        console.error("Error: app ID is required");
-        console.error(
-          "Usage: pensar apps endpoint-create <appId> --endpoint E --description D",
+        process.stderr.write("Error: app ID is required\n");
+        process.stderr.write(
+          "Usage: pensar apps endpoint-create <appId> --endpoint E --description D\n",
         );
         process.exit(1);
       }
       const opts = parseEndpointCreateOptions(args);
       const result = await createEndpoint(appId, opts);
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else if (sub === "endpoint-update") {
       const endpointId = args[1];
       if (!endpointId) {
-        console.error("Error: endpoint ID is required");
-        console.error(
-          "Usage: pensar apps endpoint-update <endpointId> [options]",
+        process.stderr.write("Error: endpoint ID is required\n");
+        process.stderr.write(
+          "Usage: pensar apps endpoint-update <endpointId> [options]\n",
         );
         process.exit(1);
       }
       const opts = parseEndpointUpdateOptions(args);
       const result = await updateEndpoint(endpointId, opts);
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else if (sub === "endpoint-delete") {
       const endpointId = args[1];
       if (!endpointId) {
-        console.error("Error: endpoint ID is required");
-        console.error("Usage: pensar apps endpoint-delete <endpointId>");
+        process.stderr.write("Error: endpoint ID is required\n");
+        process.stderr.write("Usage: pensar apps endpoint-delete <endpointId>\n");
         process.exit(1);
       }
       const result = await deleteEndpoint(endpointId);
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else if (sub === "search") {
       const query = args[1];
       if (!query || query.startsWith("--")) {
-        console.error("Error: search query is required");
-        console.error("Usage: pensar apps search <query> [options]");
+        process.stderr.write("Error: search query is required\n");
+        process.stderr.write("Usage: pensar apps search <query> [options]\n");
         process.exit(1);
       }
       const projectId = getFlag("--project", args);
@@ -431,12 +431,12 @@ async function main(): Promise<void> {
         ...(limit !== undefined ? { limit } : {}),
         ...(offset !== undefined ? { offset } : {}),
       });
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else if (sub === "search-endpoints") {
       const query = args[1];
       if (!query || query.startsWith("--")) {
-        console.error("Error: search query is required");
-        console.error("Usage: pensar apps search-endpoints <query> [options]");
+        process.stderr.write("Error: search query is required\n");
+        process.stderr.write("Usage: pensar apps search-endpoints <query> [options]\n");
         process.exit(1);
       }
       const applicationId = getFlag("--app", args);
@@ -462,7 +462,7 @@ async function main(): Promise<void> {
         ...(limit !== undefined ? { limit } : {}),
         ...(offset !== undefined ? { offset } : {}),
       });
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else if (!sub.startsWith("-")) {
       // Default: treat first arg as a project ID and list apps.
       const projectId = sub;
@@ -472,15 +472,15 @@ async function main(): Promise<void> {
         ...(limit !== undefined ? { limit } : {}),
         ...(offset !== undefined ? { offset } : {}),
       });
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else {
-      console.error(`Error: Unknown subcommand "${sub}"`);
+      process.stderr.write(`Error: Unknown subcommand "${sub}"\n`);
       showHelp();
       process.exit(1);
     }
   } catch (err) {
-    console.error(
-      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    process.stderr.write(
+      `\nError: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     process.exit(1);
   }

--- a/src/cli/apps.ts
+++ b/src/cli/apps.ts
@@ -354,7 +354,9 @@ async function main(): Promise<void> {
       const appId = args[1];
       if (!appId) {
         process.stderr.write("Error: app ID is required\n");
-        process.stderr.write("Usage: pensar apps endpoints <appId> [filters]\n");
+        process.stderr.write(
+          "Usage: pensar apps endpoints <appId> [filters]\n",
+        );
         process.exit(1);
       }
       const type = parseEndpointType(getFlag("--type", args));
@@ -409,7 +411,9 @@ async function main(): Promise<void> {
       const endpointId = args[1];
       if (!endpointId) {
         process.stderr.write("Error: endpoint ID is required\n");
-        process.stderr.write("Usage: pensar apps endpoint-delete <endpointId>\n");
+        process.stderr.write(
+          "Usage: pensar apps endpoint-delete <endpointId>\n",
+        );
         process.exit(1);
       }
       const result = await deleteEndpoint(endpointId);
@@ -436,7 +440,9 @@ async function main(): Promise<void> {
       const query = args[1];
       if (!query || query.startsWith("--")) {
         process.stderr.write("Error: search query is required\n");
-        process.stderr.write("Usage: pensar apps search-endpoints <query> [options]\n");
+        process.stderr.write(
+          "Usage: pensar apps search-endpoints <query> [options]\n",
+        );
         process.exit(1);
       }
       const applicationId = getFlag("--app", args);

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -68,10 +68,10 @@ function prompt(question: string): Promise<string> {
 async function promptWorkspaceSelection(
   workspaces: WorkspaceInfo[],
 ): Promise<WorkspaceInfo> {
-  console.log("\nSelect a workspace:\n");
+  process.stdout.write("\nSelect a workspace:\n\n");
   workspaces.forEach((ws, i) => {
-    console.log(
-      `  ${i + 1}. ${ws.name} (${ws.slug}) — $${ws.balance.toFixed(2)}`,
+    process.stdout.write(
+      `  ${i + 1}. ${ws.name} (${ws.slug}) — $${ws.balance.toFixed(2)}\n`,
     );
   });
 
@@ -79,13 +79,13 @@ async function promptWorkspaceSelection(
   const index = parseInt(answer, 10) - 1;
 
   if (Number.isNaN(index) || index < 0 || index >= workspaces.length) {
-    console.error("Invalid selection.");
+    process.stderr.write("Invalid selection.\n");
     process.exit(1);
   }
 
   const workspace = workspaces[index];
   if (!workspace) {
-    console.error("Invalid selection.");
+    process.stderr.write("Invalid selection.\n");
     process.exit(1);
   }
   return workspace;
@@ -99,9 +99,9 @@ async function login(): Promise<void> {
   const appConfig = await config.get();
 
   if (isConnected(appConfig)) {
-    console.log("Already connected to Pensar Console.");
+    process.stdout.write("Already connected to Pensar Console.\n");
     if (appConfig.workspaceSlug) {
-      console.log(`  Workspace: ${appConfig.workspaceSlug}`);
+      process.stdout.write(`  Workspace: ${appConfig.workspaceSlug}\n`);
     }
     const answer = await prompt("\nReconnect? (y/N): ");
     if (answer.toLowerCase() !== "y") {
@@ -109,7 +109,7 @@ async function login(): Promise<void> {
     }
   }
 
-  console.log(
+  process.stdout.write(
     "\nPensar Console — Managed Inference\nConnect for usage-based AI inference. No API keys needed.\n",
   );
 
@@ -121,8 +121,8 @@ async function login(): Promise<void> {
 
     openUrl(deviceInfo.verification_uri_complete);
 
-    console.log(
-      `A browser window should have opened.\nIf not, open this URL:\n  ${deviceInfo.verification_uri_complete}\n\nYour code: ${deviceInfo.user_code}\n\nWaiting for browser authorization...`,
+    process.stdout.write(
+      `A browser window should have opened.\nIf not, open this URL:\n  ${deviceInfo.verification_uri_complete}\n\nYour code: ${deviceInfo.user_code}\n\nWaiting for browser authorization...\n`,
     );
 
     const tokens = await pollWorkOSToken({
@@ -137,15 +137,15 @@ async function login(): Promise<void> {
       refreshToken: tokens.refreshToken,
     });
 
-    console.log("\nAuthenticated successfully. Fetching workspaces...");
+    process.stdout.write("\nAuthenticated successfully. Fetching workspaces...\n");
     await handleWorkspaces(apiUrl, tokens.accessToken);
   } else {
     const { deviceInfo } = flowInfo;
 
     openUrl(deviceInfo.verificationUriComplete);
 
-    console.log(
-      `A browser window should have opened.\nIf not, open this URL:\n  ${deviceInfo.verificationUriComplete}\n\nYour code: ${deviceInfo.userCode}\n\nWaiting for browser authorization...`,
+    process.stdout.write(
+      `A browser window should have opened.\nIf not, open this URL:\n  ${deviceInfo.verificationUriComplete}\n\nYour code: ${deviceInfo.userCode}\n\nWaiting for browser authorization...\n`,
     );
 
     const data = await pollLegacyToken({
@@ -172,14 +172,14 @@ async function login(): Promise<void> {
       });
     }
 
-    console.log("\n✓ Connected to Pensar Console");
+    process.stdout.write("\n✓ Connected to Pensar Console\n");
     if (data.workspace) {
-      console.log(
-        `  Workspace: ${data.workspace.name} (${data.workspace.slug})`,
+      process.stdout.write(
+        `  Workspace: ${data.workspace.name} (${data.workspace.slug})\n`,
       );
     }
     if (data.credits) {
-      console.log(`  Credits: $${data.credits.balance.toFixed(2)}`);
+      process.stdout.write(`  Credits: $${data.credits.balance.toFixed(2)}\n`);
     }
   }
 }
@@ -195,11 +195,11 @@ async function handleWorkspaces(
   const consoleUrl = wsResult.consoleUrl ?? getPensarConsoleUrl();
 
   if (workspaces.length === 0) {
-    console.log(
+    process.stdout.write(
       `\nNo workspaces found. Opening browser to create one...\nIf the browser didn't open, visit: ${consoleUrl}/create-workspace?redirect=/credits\n`,
     );
     openUrl(`${consoleUrl}/create-workspace?redirect=/credits`);
-    console.log("Waiting for workspace creation...");
+    process.stdout.write("Waiting for workspace creation...\n");
     workspaces = await pollForWorkspaceCreation(apiUrl, accessToken);
   }
 
@@ -222,26 +222,26 @@ async function handleWorkspaces(
     gatewaySigningKey: result.signingKey ?? null,
   });
 
-  console.log(
-    `\n✓ Connected to Pensar Console\n  Workspace: ${workspace.name} (${workspace.slug})\n  Credits: $${result.billing.balance.toFixed(2)}`,
+  process.stdout.write(
+    `\n✓ Connected to Pensar Console\n  Workspace: ${workspace.name} (${workspace.slug})\n  Credits: $${result.billing.balance.toFixed(2)}\n`,
   );
 
   const needsBillingSetup =
     !result.billing.ready && result.billing.balance <= 0 && !!result.billingUrl;
 
   if (needsBillingSetup && result.billingUrl) {
-    console.log(
-      `\n⚠ Your workspace billing setup is not ready yet. Finish setup at:\n  ${result.billingUrl}`,
+    process.stdout.write(
+      `\n⚠ Your workspace billing setup is not ready yet. Finish setup at:\n  ${result.billingUrl}\n`,
     );
   } else if (result.billing.balance < 1) {
     const billingUrl = `${getPensarConsoleUrl()}/${workspace.slug}/settings/billing`;
-    console.log(
-      `\n⚠ Low credit balance. We recommend at least $30 for uninterrupted pentests.\n  Add credits: ${billingUrl}`,
+    process.stdout.write(
+      `\n⚠ Low credit balance. We recommend at least $30 for uninterrupted pentests.\n  Add credits: ${billingUrl}\n`,
     );
   }
 
-  console.log(
-    "\nPensar models are now available. Run `pensar` to get started.",
+  process.stdout.write(
+    "\nPensar models are now available. Run `pensar` to get started.\n",
   );
 }
 
@@ -249,20 +249,20 @@ async function logout(): Promise<void> {
   const appConfig = await config.get();
 
   if (!isConnected(appConfig)) {
-    console.log("Not currently connected to Pensar Console.");
+    process.stdout.write("Not currently connected to Pensar Console.\n");
     return;
   }
 
   await disconnect();
-  console.log("✓ Disconnected from Pensar Console.");
+  process.stdout.write("✓ Disconnected from Pensar Console.\n");
 }
 
 async function status(): Promise<void> {
   const appConfig = await config.get();
 
   if (!isConnected(appConfig)) {
-    console.log(
-      "Not connected to Pensar Console.\n\nRun `pensar login` to connect.",
+    process.stdout.write(
+      "Not connected to Pensar Console.\n\nRun `pensar login` to connect.\n",
     );
     return;
   }
@@ -297,13 +297,13 @@ async function status(): Promise<void> {
   }
 
   const authMethod = appConfig.accessToken ? "WorkOS" : "API key";
-  console.log(
-    `✓ Connected to Pensar Console\n  Workspace: ${appConfig.workspaceSlug ?? "not set"}\n  Auth: ${authMethod}`,
+  process.stdout.write(
+    `✓ Connected to Pensar Console\n  Workspace: ${appConfig.workspaceSlug ?? "not set"}\n  Auth: ${authMethod}\n`,
   );
 }
 
 function showHelp(): void {
-  console.log(`Pensar Login — Connect to Pensar Console
+  process.stdout.write(`Pensar Login — Connect to Pensar Console
 
 Usage:
   pensar login             Login to Pensar Console (or show status if connected)
@@ -313,7 +313,7 @@ Usage:
 Legacy alias: 'pensar auth' still works for backward compatibility
 
 Options:
-  -h, --help               Show this help message`);
+  -h, --help               Show this help message\n`);
 }
 
 // ---------------------------------------------------------------------------
@@ -337,13 +337,13 @@ async function main(): Promise<void> {
     } else if (subcommand === "status") {
       await status();
     } else {
-      console.error(`Unknown auth subcommand: ${subcommand}`);
-      console.error("Run 'pensar login --help' for usage information");
+      process.stderr.write(`Unknown auth subcommand: ${subcommand}\n`);
+      process.stderr.write("Run 'pensar login --help' for usage information\n");
       process.exit(1);
     }
   } catch (err) {
-    console.error(
-      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    process.stderr.write(
+      `\nError: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     process.exit(1);
   }

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -137,7 +137,9 @@ async function login(): Promise<void> {
       refreshToken: tokens.refreshToken,
     });
 
-    process.stdout.write("\nAuthenticated successfully. Fetching workspaces...\n");
+    process.stdout.write(
+      "\nAuthenticated successfully. Fetching workspaces...\n",
+    );
     await handleWorkspaces(apiUrl, tokens.accessToken);
   } else {
     const { deviceInfo } = flowInfo;

--- a/src/cli/fixes.ts
+++ b/src/cli/fixes.ts
@@ -11,14 +11,14 @@
 import { getFix, listFixes } from "../core/api";
 
 function showHelp(): void {
-  console.log(`pensar fixes — View security fixes via the Pensar API
+  process.stdout.write(`pensar fixes — View security fixes via the Pensar API
 
 Usage:
   pensar fixes <issueId>         List fixes for an issue
   pensar fixes get <fixId>       Get fix details (includes diff)
 
 Options:
-  -h, --help                     Show this help message`);
+  -h, --help                     Show this help message\n`);
 }
 
 async function main(): Promise<void> {
@@ -34,19 +34,19 @@ async function main(): Promise<void> {
     if (sub === "get") {
       const fixId = args[1];
       if (!fixId) {
-        console.error("Error: fix ID is required");
-        console.error("Usage: pensar fixes get <fixId>");
+        process.stderr.write("Error: fix ID is required\n");
+        process.stderr.write("Usage: pensar fixes get <fixId>\n");
         process.exit(1);
       }
       const fix = await getFix(fixId);
-      console.log(JSON.stringify(fix, null, 2));
+      process.stdout.write(`${JSON.stringify(fix, null, 2)}\n`);
     } else {
       const fixes = await listFixes(sub);
-      console.log(JSON.stringify(fixes, null, 2));
+      process.stdout.write(`${JSON.stringify(fixes, null, 2)}\n`);
     }
   } catch (err) {
-    console.error(
-      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    process.stderr.write(
+      `\nError: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     process.exit(1);
   }

--- a/src/cli/issues.ts
+++ b/src/cli/issues.ts
@@ -17,7 +17,7 @@ function getFlag(flag: string, argv: string[]): string | undefined {
 }
 
 function showHelp(): void {
-  console.log(`pensar issues — Manage security issues via the Pensar API
+  process.stdout.write(`pensar issues — Manage security issues via the Pensar API
 
 Usage:
   pensar issues <projectId> [filters]            List issues for a project
@@ -38,7 +38,7 @@ Update options:
   --fp-reason <reason>      Reason for false positive flag
 
 Options:
-  -h, --help                Show this help message`);
+  -h, --help                Show this help message\n`);
 }
 
 async function main(): Promise<void> {
@@ -54,18 +54,18 @@ async function main(): Promise<void> {
     if (sub === "get") {
       const issueId = args[1];
       if (!issueId) {
-        console.error("Error: issue ID is required");
-        console.error("Usage: pensar issues get <issueId>");
+        process.stderr.write("Error: issue ID is required\n");
+        process.stderr.write("Usage: pensar issues get <issueId>\n");
         process.exit(1);
       }
       const issue = await getIssue(issueId);
-      console.log(JSON.stringify(issue, null, 2));
+      process.stdout.write(`${JSON.stringify(issue, null, 2)}\n`);
     } else if (sub === "update") {
       const issueId = args[1];
       if (!issueId) {
-        console.error("Error: issue ID is required");
-        console.error(
-          "Usage: pensar issues update <issueId> [--status <status>] ...",
+        process.stderr.write("Error: issue ID is required\n");
+        process.stderr.write(
+          "Usage: pensar issues update <issueId> [--status <status>] ...\n",
         );
         process.exit(1);
       }
@@ -89,7 +89,7 @@ async function main(): Promise<void> {
         userFlaggedFalsePositive,
         userFlaggedFalsePositiveReason,
       });
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else {
       const projectId = sub;
       const issues = await listIssues(projectId, {
@@ -98,11 +98,11 @@ async function main(): Promise<void> {
         severity: getFlag("--severity", args),
         branch: getFlag("--branch", args),
       });
-      console.log(JSON.stringify(issues, null, 2));
+      process.stdout.write(`${JSON.stringify(issues, null, 2)}\n`);
     }
   } catch (err) {
-    console.error(
-      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    process.stderr.write(
+      `\nError: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     process.exit(1);
   }

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -16,7 +16,7 @@ function getFlag(flag: string, argv: string[]): string | undefined {
 }
 
 function showHelp(): void {
-  console.log(`pensar logs — View agent execution logs via the Pensar API
+  process.stdout.write(`pensar logs — View agent execution logs via the Pensar API
 
 Usage:
   pensar logs <issueId> [filters]                 List agent logs
@@ -33,7 +33,7 @@ Search options:
   --context <n>         Context lines around matches (default: 3)
 
 Options:
-  -h, --help            Show this help message`);
+  -h, --help            Show this help message\n`);
 }
 
 async function main(): Promise<void> {
@@ -50,9 +50,9 @@ async function main(): Promise<void> {
       const issueId = args[1];
       const query = args[2];
       if (!issueId || !query) {
-        console.error("Error: issue ID and query are required");
-        console.error(
-          "Usage: pensar logs search <issueId> <query> [--level <level>] [--role <role>] [--context <n>]",
+        process.stderr.write("Error: issue ID and query are required\n");
+        process.stderr.write(
+          "Usage: pensar logs search <issueId> <query> [--level <level>] [--role <role>] [--context <n>]\n",
         );
         process.exit(1);
       }
@@ -77,7 +77,7 @@ async function main(): Promise<void> {
         role,
         contextLines,
       });
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else {
       const issueId = sub;
       const level = getFlag("--level", args) as
@@ -97,11 +97,11 @@ async function main(): Promise<void> {
       const limit = limitStr ? parseInt(limitStr, 10) : undefined;
 
       const result = await listAgentLogs(issueId, { level, role, limit });
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     }
   } catch (err) {
-    console.error(
-      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    process.stderr.write(
+      `\nError: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     process.exit(1);
   }

--- a/src/cli/pentests.ts
+++ b/src/cli/pentests.ts
@@ -17,7 +17,7 @@ function getFlag(flag: string, argv: string[]): string | undefined {
 }
 
 function showHelp(): void {
-  console.log(`pensar pentests — Manage pentests via the Pensar API
+  process.stdout.write(`pensar pentests — Manage pentests via the Pensar API
 
 Usage:
   pensar pentests <projectId>                     List pentests for a project
@@ -29,7 +29,7 @@ dispatch options:
   --level <level>       Scan depth: priority (default), full
 
 Options:
-  -h, --help            Show this help message`);
+  -h, --help            Show this help message\n`);
 }
 
 async function main(): Promise<void> {
@@ -45,18 +45,18 @@ async function main(): Promise<void> {
     if (sub === "get") {
       const pentestId = args[1];
       if (!pentestId) {
-        console.error("Error: pentest ID is required");
-        console.error("Usage: pensar pentests get <pentestId>");
+        process.stderr.write("Error: pentest ID is required\n");
+        process.stderr.write("Usage: pensar pentests get <pentestId>\n");
         process.exit(1);
       }
       const scan = await getScan(pentestId);
-      console.log(JSON.stringify(scan, null, 2));
+      process.stdout.write(`${JSON.stringify(scan, null, 2)}\n`);
     } else if (sub === "dispatch") {
       const projectId = args[1];
       if (!projectId) {
-        console.error("Error: project ID is required");
-        console.error(
-          "Usage: pensar pentests dispatch <projectId> [--branch <branch>] [--level <priority|full>]",
+        process.stderr.write("Error: project ID is required\n");
+        process.stderr.write(
+          "Usage: pensar pentests dispatch <projectId> [--branch <branch>] [--level <priority|full>]\n",
         );
         process.exit(1);
       }
@@ -66,14 +66,14 @@ async function main(): Promise<void> {
         | "full"
         | undefined;
       const result = await dispatchPentest(projectId, { branch, scanLevel });
-      console.log(JSON.stringify(result, null, 2));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else {
       const scans = await listScans(sub);
-      console.log(JSON.stringify(scans, null, 2));
+      process.stdout.write(`${JSON.stringify(scans, null, 2)}\n`);
     }
   } catch (err) {
-    console.error(
-      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    process.stderr.write(
+      `\nError: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     process.exit(1);
   }

--- a/src/cli/projects.ts
+++ b/src/cli/projects.ts
@@ -11,13 +11,13 @@
 import { listProjects } from "../core/api";
 
 function showHelp(): void {
-  console.log(`pensar projects — List workspace projects
+  process.stdout.write(`pensar projects — List workspace projects
 
 Usage:
   pensar projects              List all projects
 
 Options:
-  -h, --help                   Show this help message`);
+  -h, --help                   Show this help message\n`);
 }
 
 async function main(): Promise<void> {
@@ -30,10 +30,10 @@ async function main(): Promise<void> {
 
   try {
     const projects = await listProjects();
-    console.log(JSON.stringify(projects, null, 2));
+    process.stdout.write(`${JSON.stringify(projects, null, 2)}\n`);
   } catch (err) {
-    console.error(
-      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    process.stderr.write(
+      `\nError: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     process.exit(1);
   }

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -196,7 +196,7 @@ async function uninstall(force: boolean): Promise<void> {
   const method = detectInstallMethod();
   const pensarDir = getPensarDir();
 
-  console.log(`Pensar Uninstall
+  process.stdout.write(`Pensar Uninstall
 
   Install method:  ${method}
   Binary removal:  ${getUninstallDescription(method)}
@@ -208,65 +208,65 @@ async function uninstall(force: boolean): Promise<void> {
   if (!force) {
     const answer = await prompt("Proceed with uninstall? (y/N): ");
     if (answer.toLowerCase() !== "y") {
-      console.log("Aborted.");
+      process.stdout.write("Aborted.\n");
       return;
     }
-    console.log();
+    process.stdout.write("\n");
   }
 
   // 1. Clean data directory
-  console.log("Cleaning data directory...");
+  process.stdout.write("Cleaning data directory...\n");
   const { removed, preserved, errors } = await cleanDataDir();
 
   for (const name of removed) {
-    console.log(`  Removed ${name}`);
+    process.stdout.write(`  Removed ${name}\n`);
   }
   for (const name of preserved) {
-    console.log(`  Preserved ${name}/`);
+    process.stdout.write(`  Preserved ${name}/\n`);
   }
   for (const msg of errors) {
-    console.error(`  ${msg}`);
+    process.stderr.write(`  ${msg}\n`);
   }
 
   if (removed.length === 0 && errors.length === 0) {
-    console.log("  Nothing to clean.");
+    process.stdout.write("  Nothing to clean.\n");
   }
 
   // 2. Remove binary/package
-  console.log();
-  console.log("Removing pensar...");
+  process.stdout.write("\n");
+  process.stdout.write("Removing pensar...\n");
   const result = removeBinary(method);
 
   if (result.success) {
-    console.log(`  ${result.message}`);
+    process.stdout.write(`  ${result.message}\n`);
   } else {
-    console.error(`  ${result.message}`);
+    process.stderr.write(`  ${result.message}\n`);
   }
 
   // 3. Summary
-  console.log();
+  process.stdout.write("\n");
   if (result.success && errors.length === 0) {
-    console.log("✓ Pensar has been uninstalled.");
+    process.stdout.write("✓ Pensar has been uninstalled.\n");
   } else {
-    console.log("⚠ Uninstall completed with warnings (see above).");
+    process.stdout.write("⚠ Uninstall completed with warnings (see above).\n");
   }
 
   if (preserved.length > 0) {
-    console.log(
-      `  Preserved data remains at ${pensarDir}/ (${preserved.join(", ")})`,
+    process.stdout.write(
+      `  Preserved data remains at ${pensarDir}/ (${preserved.join(", ")})\n`,
     );
-    console.log("  To remove all data: rm -rf ~/.pensar");
+    process.stdout.write("  To remove all data: rm -rf ~/.pensar\n");
   }
 
   if (method === "binary") {
-    console.log(
-      "\n  Note: You may want to remove the PATH export from your shell config\n  (~/.bashrc, ~/.zshrc, etc.) if it was added during install.",
+    process.stdout.write(
+      "\n  Note: You may want to remove the PATH export from your shell config\n  (~/.bashrc, ~/.zshrc, etc.) if it was added during install.\n",
     );
   }
 }
 
 function showHelp(): void {
-  console.log(`Pensar Uninstall — Remove Pensar from your system
+  process.stdout.write(`Pensar Uninstall — Remove Pensar from your system
 
 Usage:
   pensar uninstall             Uninstall Pensar (keeps sessions, memories, skills)
@@ -274,7 +274,7 @@ Usage:
 
 Options:
   --force, -f          Skip confirmation prompt
-  -h, --help           Show this help message`);
+  -h, --help           Show this help message\n`);
 }
 
 async function main(): Promise<void> {
@@ -291,8 +291,8 @@ async function main(): Promise<void> {
   try {
     await uninstall(force);
   } catch (err) {
-    console.error(
-      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    process.stderr.write(
+      `\nError: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     process.exit(1);
   }

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -11,7 +11,7 @@ import { writeFile } from "fs/promises";
 import { join } from "path";
 import { streamResponse } from "../../ai";
 import { AgentEventBus } from "../../eventBus";
-import { writeErrorLog } from "../../logger";
+
 import type { ApprovalGate } from "../../operator";
 import { ApprovalDeniedError } from "../../operator";
 import { create as createSession, type SessionInfo } from "../../session";
@@ -547,27 +547,16 @@ function wrapToolsWithApprovalGate(
           args.toolCallId ??
           `tc_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
-        writeErrorLog(`${name} (${toolCallId}): checking`, "APPROVAL_GATE");
         try {
           await gate.check(name, String(toolCallId), args);
         } catch (err) {
           if (err instanceof ApprovalDeniedError) {
-            writeErrorLog(`${name} (${toolCallId}): denied`, "APPROVAL_GATE");
             return { blocked: true, reason: "Denied by operator" };
           }
           throw err;
         }
-        writeErrorLog(
-          `${name} (${toolCallId}): approved, executing`,
-          "APPROVAL_GATE",
-        );
 
-        const result = await originalExecute(args, options);
-        writeErrorLog(
-          `${name} (${toolCallId}): execute finished`,
-          "APPROVAL_GATE",
-        );
-        return result;
+        return originalExecute(args, options);
       },
     };
   }

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -11,6 +11,7 @@ import { writeFile } from "fs/promises";
 import { join } from "path";
 import { streamResponse } from "../../ai";
 import { AgentEventBus } from "../../eventBus";
+import { writeErrorLog } from "../../logger";
 import type { ApprovalGate } from "../../operator";
 import { ApprovalDeniedError } from "../../operator";
 import { create as createSession, type SessionInfo } from "../../session";
@@ -546,23 +547,25 @@ function wrapToolsWithApprovalGate(
           args.toolCallId ??
           `tc_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
-        console.error(`[approval-gate] ${name} (${toolCallId}): checking`);
+        writeErrorLog(`${name} (${toolCallId}): checking`, "APPROVAL_GATE");
         try {
           await gate.check(name, String(toolCallId), args);
         } catch (err) {
           if (err instanceof ApprovalDeniedError) {
-            console.error(`[approval-gate] ${name} (${toolCallId}): denied`);
+            writeErrorLog(`${name} (${toolCallId}): denied`, "APPROVAL_GATE");
             return { blocked: true, reason: "Denied by operator" };
           }
           throw err;
         }
-        console.error(
-          `[approval-gate] ${name} (${toolCallId}): approved, executing`,
+        writeErrorLog(
+          `${name} (${toolCallId}): approved, executing`,
+          "APPROVAL_GATE",
         );
 
         const result = await originalExecute(args, options);
-        console.error(
-          `[approval-gate] ${name} (${toolCallId}): execute finished`,
+        writeErrorLog(
+          `${name} (${toolCallId}): execute finished`,
+          "APPROVAL_GATE",
         );
         return result;
       },

--- a/src/core/agents/offSecAgent/tools/completeAuthentication.ts
+++ b/src/core/agents/offSecAgent/tools/completeAuthentication.ts
@@ -2,6 +2,7 @@ import { tool } from "ai";
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { z } from "zod";
+import { writeErrorLog } from "../../../logger";
 import type { ToolContext } from "./types";
 
 const AUTH_DIR = "auth";
@@ -79,8 +80,8 @@ This tool marks the end of the authentication flow.`,
         .describe("A concise description of what this tool call is doing"),
     }),
     execute: async (result) => {
-      console.log(
-        `Authentication complete: ${result.success ? "SUCCESS" : "FAILED"}`,
+      process.stderr.write(
+        `Authentication complete: ${result.success ? "SUCCESS" : "FAILED"}\n`,
       );
 
       let authDataPath: string | undefined;
@@ -105,9 +106,9 @@ This tool marks the end of the authentication flow.`,
         };
 
         writeFileSync(authDataPath, JSON.stringify(authData, null, 2));
-        console.log(`Auth data persisted to ${authDataPath}`);
+        process.stderr.write(`Auth data persisted to ${authDataPath}\n`);
       } catch (err) {
-        console.error(`Failed to persist auth data: ${err}`);
+        writeErrorLog(`Failed to persist auth data: ${err}`, "AUTH");
       }
 
       return {

--- a/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
+++ b/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
@@ -120,7 +120,10 @@ export function crawlAuthenticated(ctx: ToolContext) {
               });
             }
           } catch (error) {
-            writeErrorLog(`Error crawling ${url}: ${error instanceof Error ? error.message : String(error)}`, "CRAWL");
+            writeErrorLog(
+              `Error crawling ${url}: ${error instanceof Error ? error.message : String(error)}`,
+              "CRAWL",
+            );
           }
         }
 

--- a/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
+++ b/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
@@ -1,5 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { writeErrorLog } from "../../../logger";
 import {
   type EndpointInfo,
   extractJavascriptEndpoints,
@@ -119,7 +120,7 @@ export function crawlAuthenticated(ctx: ToolContext) {
               });
             }
           } catch (error) {
-            console.error(`Error crawling ${url}:`, error);
+            writeErrorLog(`Error crawling ${url}: ${error instanceof Error ? error.message : String(error)}`, "CRAWL");
           }
         }
 

--- a/src/core/agents/offSecAgent/tools/createFile.ts
+++ b/src/core/agents/offSecAgent/tools/createFile.ts
@@ -43,21 +43,13 @@ Parent directories are created automatically if they don't exist.`,
       content,
       overwrite = false,
     }): Promise<CreateFileResult> => {
-      console.error(
-        `[create_file] enter: path=${filePath}, contentLen=${content.length}, overwrite=${overwrite}, sandbox=${!!ctx.sandbox}`,
-      );
       const resolved = isAbsolute(filePath)
         ? filePath
         : resolve(ctx.agentCwd, filePath);
-      console.error(`[create_file] resolved: ${resolved}`);
       if (ctx.sandbox) {
         return executeSandboxCreate(ctx, resolved, content, overwrite);
       }
-      const result = await executeLocalCreate(resolved, content, overwrite);
-      console.error(
-        `[create_file] done: success=${result.success}, error=${result.error || "(none)"}`,
-      );
-      return result;
+      return executeLocalCreate(resolved, content, overwrite);
     },
   });
 }
@@ -69,7 +61,6 @@ async function executeLocalCreate(
 ): Promise<CreateFileResult> {
   try {
     if (!overwrite && existsSync(filePath)) {
-      console.error(`[create_file:local] file already exists: ${filePath}`);
       return {
         success: false,
         error: `File already exists: ${filePath}. Set overwrite=true to replace it.`,
@@ -78,13 +69,8 @@ async function executeLocalCreate(
     }
 
     const dir = dirname(filePath);
-    console.error(`[create_file:local] mkdir ${dir}`);
     await mkdir(dir, { recursive: true });
-    console.error(
-      `[create_file:local] mkdir done, writing ${content.length} bytes`,
-    );
     await writeFile(filePath, content, "utf-8");
-    console.error(`[create_file:local] writeFile done`);
 
     return {
       success: true,
@@ -92,7 +78,6 @@ async function executeLocalCreate(
       path: filePath,
     };
   } catch (err: unknown) {
-    console.error(`[create_file:local] error: ${err}`);
     return {
       success: false,
       error: err instanceof Error ? err.message : String(err),

--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -225,57 +225,12 @@ When to use delegate_to_auth_subagent vs authenticate_session:
           parentSubagentId: ctx.subagentId,
         });
 
-        console.log(`\n🔐 Delegating to authentication subagent...`);
-        console.log(`   Target: ${target}`);
-        console.log(`   Reason: ${reason}`);
-
-        if (username) console.log(`   Username: ${username}`);
-        if (apiKey) console.log(`   API Key: [PROVIDED]`);
-        if (tokens?.bearerToken) console.log(`   Bearer Token: [PROVIDED]`);
-        if (tokens?.cookies) console.log(`   Cookies: [PROVIDED]`);
-        if (tokens?.customHeaders)
-          console.log(
-            `   Custom Headers: ${Object.keys(tokens.customHeaders).join(", ")}`,
-          );
-
         const rawSessionCreds = ctx.session.config?.authCredentials;
         const sessionCreds: AuthCredentials | undefined = rawSessionCreds
           ? Array.isArray(rawSessionCreds)
             ? rawSessionCreds[0]
             : rawSessionCreds
           : undefined;
-        if (sessionCreds && !username && !apiKey && !tokens) {
-          console.log(`   [Inheriting session credentials]`);
-          if (sessionCreds.username)
-            console.log(`   Session Username: ${sessionCreds.username}`);
-          if (sessionCreds.apiKey)
-            console.log(`   Session API Key: [PROVIDED]`);
-          if (sessionCreds.tokens?.bearerToken)
-            console.log(`   Session Bearer Token: [PROVIDED]`);
-          if (sessionCreds.tokens?.cookies)
-            console.log(`   Session Cookies: [PROVIDED]`);
-          if (sessionCreds.tokens?.customHeaders)
-            console.log(
-              `   Session Custom Headers: ${Object.keys(
-                sessionCreds.tokens.customHeaders,
-              ).join(", ")}`,
-            );
-        }
-
-        if (authHints) {
-          console.log(`   Auth Scheme: ${authHints.authScheme || "unknown"}`);
-          console.log(`   CSRF Required: ${authHints.csrfRequired || false}`);
-          console.log(
-            `   Browser Required: ${authHints.browserRequired || false}`,
-          );
-          if (authHints.protectedEndpoints?.length) {
-            console.log(
-              `   Protected Endpoints: ${authHints.protectedEndpoints.join(
-                ", ",
-              )}`,
-            );
-          }
-        }
 
         const credentials = mergeAuthCredentials(sessionCreds, {
           username,

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -11,8 +11,8 @@ import {
 import { join } from "path";
 import { z } from "zod";
 import { hasCanonicalName } from "../../../../lib/cwe/types";
-import { writeErrorLog } from "../../../logger";
 import type { EvidenceFileEntry } from "../../../../lib/evidence/types";
+import { writeErrorLog } from "../../../logger";
 import {
   type CVSSScorerInput,
   type CVSSScorerResult,

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -11,6 +11,7 @@ import {
 import { join } from "path";
 import { z } from "zod";
 import { hasCanonicalName } from "../../../../lib/cwe/types";
+import { writeErrorLog } from "../../../logger";
 import type { EvidenceFileEntry } from "../../../../lib/evidence/types";
 import {
   type CVSSScorerInput,
@@ -771,8 +772,9 @@ function preparePoc(input: {
   // Validate portability before preparing the script
   const portabilityWarnings = validatePocPortability(pocContent, input.pocType);
   if (portabilityWarnings.length > 0) {
-    console.warn(
-      `[PoC Portability] Warnings for ${filename}:\n  ${portabilityWarnings.join("\n  ")}`,
+    writeErrorLog(
+      `Warnings for ${filename}:\n  ${portabilityWarnings.join("\n  ")}`,
+      "POC_PORTABILITY",
     );
   }
 

--- a/src/core/agents/offSecAgent/tools/runAttackSurface.ts
+++ b/src/core/agents/offSecAgent/tools/runAttackSurface.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { AgentEventBus } from "../../../eventBus";
+import { writeErrorLog } from "../../../logger";
 import type { AttackSurfaceResult } from "../../specialized/attackSurface/blackboxAgent";
 import type { WhiteboxAttackSurfaceResult } from "../../specialized/whiteboxAttackSurface";
 import type { ToolContext } from "./types";
@@ -94,8 +95,8 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
             })),
           );
 
-          console.log(
-            `\n✓ Whitebox attack surface complete: ${targets.length} targets from ${result.apps.length} apps`,
+          process.stderr.write(
+            `\n✓ Whitebox attack surface complete: ${targets.length} targets from ${result.apps.length} apps\n`,
           );
 
           ctx.eventBus?.emit("subagent-complete", {
@@ -115,7 +116,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
         } catch (error: unknown) {
           const errorMsg =
             error instanceof Error ? error.message : String(error);
-          console.error(`✗ Whitebox attack surface agent failed: ${errorMsg}`);
+          writeErrorLog(`Whitebox attack surface agent failed: ${errorMsg}`, "ATTACK_SURFACE");
 
           ctx.eventBus?.emit("subagent-complete", {
             subagentId,
@@ -157,8 +158,8 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
         const result: AttackSurfaceResult = await agent.consume();
 
         const targetCount = result.targets.length;
-        console.log(
-          `\n✓ Blackbox attack surface complete: ${targetCount} targets identified`,
+        process.stderr.write(
+          `\n✓ Blackbox attack surface complete: ${targetCount} targets identified\n`,
         );
 
         ctx.eventBus?.emit("subagent-complete", {
@@ -184,7 +185,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
         };
       } catch (error: unknown) {
         const errorMsg = error instanceof Error ? error.message : String(error);
-        console.error(`✗ Blackbox attack surface agent failed: ${errorMsg}`);
+        writeErrorLog(`Blackbox attack surface agent failed: ${errorMsg}`, "ATTACK_SURFACE");
 
         ctx.eventBus?.emit("subagent-complete", {
           subagentId,

--- a/src/core/agents/offSecAgent/tools/runAttackSurface.ts
+++ b/src/core/agents/offSecAgent/tools/runAttackSurface.ts
@@ -116,7 +116,10 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
         } catch (error: unknown) {
           const errorMsg =
             error instanceof Error ? error.message : String(error);
-          writeErrorLog(`Whitebox attack surface agent failed: ${errorMsg}`, "ATTACK_SURFACE");
+          writeErrorLog(
+            `Whitebox attack surface agent failed: ${errorMsg}`,
+            "ATTACK_SURFACE",
+          );
 
           ctx.eventBus?.emit("subagent-complete", {
             subagentId,
@@ -185,7 +188,10 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
         };
       } catch (error: unknown) {
         const errorMsg = error instanceof Error ? error.message : String(error);
-        writeErrorLog(`Blackbox attack surface agent failed: ${errorMsg}`, "ATTACK_SURFACE");
+        writeErrorLog(
+          `Blackbox attack surface agent failed: ${errorMsg}`,
+          "ATTACK_SURFACE",
+        );
 
         ctx.eventBus?.emit("subagent-complete", {
           subagentId,

--- a/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
@@ -78,8 +78,8 @@ Pass every target you want tested — the swarm handles concurrency automaticall
 
       const total = targets.length;
 
-      console.log(
-        `\n🐝 Spawning pentest swarm: ${total} agents (concurrency: ${DEFAULT_CONCURRENCY})`,
+      process.stderr.write(
+        `\n🐝 Spawning pentest swarm: ${total} agents (concurrency: ${DEFAULT_CONCURRENCY})\n`,
       );
 
       const swarmResults = await runPentestSwarm({

--- a/src/core/agents/offSecAgent/tools/submitPlan.ts
+++ b/src/core/agents/offSecAgent/tools/submitPlan.ts
@@ -30,7 +30,6 @@ Only call this when the plan is complete and ready for review.`,
     execute: async (): Promise<SubmitPlanResult> => {
       const scopeId = ctx.planSubagentId ?? ctx.subagentId;
       const planPath = planFilePath(ctx.session.rootPath, scopeId);
-      console.error(`[submit_plan] enter: path=${planPath}`);
       const plan = readPlan(ctx.session.rootPath, scopeId);
       if (!plan || !plan.trim()) {
         return {
@@ -40,7 +39,6 @@ Only call this when the plan is complete and ready for review.`,
           path: planPath,
         };
       }
-      console.error(`[submit_plan] done: planLen=${plan.length}`);
       return { success: true, error: "", path: planPath };
     },
   });

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -1,6 +1,7 @@
 import pLimit from "p-limit";
 import { z } from "zod";
 import { AgentEventBus } from "../../../eventBus";
+import { writeErrorLog } from "../../../logger";
 import type { RiskScore } from "../../specialized/whiteboxAttackSurface";
 import type { ToolContext } from "./types";
 
@@ -371,8 +372,9 @@ export async function generateThreatModelForEndpoint(
         status: "failed",
         parentSubagentId: ctx.subagentId,
       });
-      console.error(
+      writeErrorLog(
         `Threat model generation failed for ${input.routePath}: ${error instanceof Error ? error.message : String(error)}`,
+        "THREAT_MODEL",
       );
       return null;
     }

--- a/src/core/agents/offSecAgent/tools/writePlan.ts
+++ b/src/core/agents/offSecAgent/tools/writePlan.ts
@@ -3,6 +3,7 @@ import { mkdirSync } from "fs";
 import { writeFile } from "fs/promises";
 import { dirname } from "path";
 import { z } from "zod";
+import { writeErrorLog } from "../../../logger";
 import { planFilePath } from "../../../plan";
 import type { ToolContext } from "./types";
 
@@ -41,15 +42,11 @@ Required plan sections:
       const scopeId = ctx.planSubagentId ?? ctx.subagentId;
       const planPath = planFilePath(ctx.session.rootPath, scopeId);
       mkdirSync(dirname(planPath), { recursive: true });
-      console.error(
-        `[write_plan] enter: contentLen=${content.length}, path=${planPath}`,
-      );
       try {
         await writeFile(planPath, content, "utf-8");
-        console.error(`[write_plan] done`);
         return { success: true, error: "", path: planPath };
       } catch (err: unknown) {
-        console.error(`[write_plan] error: ${err}`);
+        writeErrorLog(err, "WRITE_PLAN");
         return {
           success: false,
           error: err instanceof Error ? err.message : String(err),

--- a/src/core/agents/specialized/authenticationAgent/agent.ts
+++ b/src/core/agents/specialized/authenticationAgent/agent.ts
@@ -310,8 +310,8 @@ export async function runAuthenticationAgent(input: AuthenticationAgentInput) {
 
   const result = await agent.consume();
 
-  console.log(
-    `\nAuthentication ${result.success ? "succeeded" : "failed"}: ${result.summary}`,
+  process.stderr.write(
+    `\nAuthentication ${result.success ? "succeeded" : "failed"}: ${result.summary}\n`,
   );
   return result;
 }

--- a/src/core/agents/specialized/benchmark/comparisonAgent.ts
+++ b/src/core/agents/specialized/benchmark/comparisonAgent.ts
@@ -333,9 +333,7 @@ Be thorough in your analysis and provide clear explanations for your matches. St
   process.stderr.write(
     `  - Missed: ${comparisonResultFromFile.missed.length}\n`,
   );
-  process.stderr.write(
-    `  - Extra: ${comparisonResultFromFile.extra.length}\n`,
-  );
+  process.stderr.write(`  - Extra: ${comparisonResultFromFile.extra.length}\n`);
   process.stderr.write(
     `  - Accuracy: ${Math.round(comparisonResultFromFile.accuracy * 100)}%\n`,
   );

--- a/src/core/agents/specialized/benchmark/comparisonAgent.ts
+++ b/src/core/agents/specialized/benchmark/comparisonAgent.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { z } from "zod";
 import { type AIModel, streamResponse } from "../../../ai";
+import { writeErrorLog } from "../../../logger";
 import type { ComparisonResult } from "./types";
 
 const COMPARISON_SYSTEM_PROMPT = `
@@ -80,8 +81,8 @@ export async function runComparisonAgent(
 
   const expectedResultsFile = jsonFiles[0]!;
   const expectedResultsPath = join(expectedResultsDir, expectedResultsFile);
-  console.log(
-    `[ComparisonAgent] Loading expected results from: ${expectedResultsPath}`,
+  process.stderr.write(
+    `[ComparisonAgent] Loading expected results from: ${expectedResultsPath}\n`,
   );
 
   const expectedData = readFileSync(expectedResultsPath, "utf-8");
@@ -127,8 +128,7 @@ ${finding.references ? `## References\n${finding.references}` : ""}`;
 
       actualFindingsMarkdown += `\n\n---\n**File: ${file}**\n\n${formattedFinding}`;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(`Failed to read finding file ${file}:`, message);
+      writeErrorLog(error, `ComparisonAgent:readFinding:${file}`);
     }
   }
 
@@ -220,8 +220,8 @@ Results will be saved to: comparison-results.json in the session directory.`,
       };
 
       // Save comparison results to file
-      console.log(
-        `[ComparisonAgent] Saving results to: ${comparisonResultsPath}`,
+      process.stderr.write(
+        `[ComparisonAgent] Saving results to: ${comparisonResultsPath}\n`,
       );
       writeFileSync(comparisonResultsPath, JSON.stringify(result, null, 2));
 
@@ -271,23 +271,23 @@ Be thorough in your analysis and provide clear explanations for your matches. St
   });
 
   // Consume the stream and log progress
-  console.log(`\n${"=".repeat(80)}`);
-  console.log(`COMPARISON AGENT`);
-  console.log(`${"=".repeat(80)}\n`);
+  process.stderr.write(`\n${"=".repeat(80)}\n`);
+  process.stderr.write(`COMPARISON AGENT\n`);
+  process.stderr.write(`${"=".repeat(80)}\n\n`);
 
   for await (const delta of streamResult.fullStream) {
     if (delta.type === "text-delta") {
       process.stdout.write(delta.text);
     } else if (delta.type === "tool-call") {
-      console.log(
+      process.stderr.write(
         `\n\n[Tool] ${delta.toolName}${
           delta.input?.toolCallDescription
             ? `: ${delta.input.toolCallDescription}`
             : ""
-        }`,
+        }\n`,
       );
     } else if (delta.type === "tool-result") {
-      console.log(`[Tool Complete]\n`);
+      process.stderr.write(`[Tool Complete]\n\n`);
     }
   }
 
@@ -309,9 +309,9 @@ Be thorough in your analysis and provide clear explanations for your matches. St
   //   },
   // });
 
-  console.log(`\n${"=".repeat(80)}`);
-  console.log(`COMPARISON COMPLETE`);
-  console.log(`${"=".repeat(80)}\n`);
+  process.stderr.write(`\n${"=".repeat(80)}\n`);
+  process.stderr.write(`COMPARISON COMPLETE\n`);
+  process.stderr.write(`${"=".repeat(80)}\n\n`);
 
   // Read comparison results from file
   if (!existsSync(comparisonResultsPath)) {
@@ -320,24 +320,30 @@ Be thorough in your analysis and provide clear explanations for your matches. St
     );
   }
 
-  console.log(
-    `[ComparisonAgent] Reading results from: ${comparisonResultsPath}`,
+  process.stderr.write(
+    `[ComparisonAgent] Reading results from: ${comparisonResultsPath}\n`,
   );
   const savedResults = readFileSync(comparisonResultsPath, "utf-8");
   const comparisonResultFromFile = JSON.parse(savedResults) as ComparisonResult;
 
-  console.log(`[ComparisonAgent] Results loaded successfully`);
-  console.log(`  - Matched: ${comparisonResultFromFile.matched.length}`);
-  console.log(`  - Missed: ${comparisonResultFromFile.missed.length}`);
-  console.log(`  - Extra: ${comparisonResultFromFile.extra.length}`);
-  console.log(
-    `  - Accuracy: ${Math.round(comparisonResultFromFile.accuracy * 100)}%`,
+  process.stderr.write(`[ComparisonAgent] Results loaded successfully\n`);
+  process.stderr.write(
+    `  - Matched: ${comparisonResultFromFile.matched.length}\n`,
   );
-  console.log(
-    `  - Precision: ${Math.round(comparisonResultFromFile.precision * 100)}%`,
+  process.stderr.write(
+    `  - Missed: ${comparisonResultFromFile.missed.length}\n`,
   );
-  console.log(
-    `  - Recall: ${Math.round(comparisonResultFromFile.recall * 100)}%`,
+  process.stderr.write(
+    `  - Extra: ${comparisonResultFromFile.extra.length}\n`,
+  );
+  process.stderr.write(
+    `  - Accuracy: ${Math.round(comparisonResultFromFile.accuracy * 100)}%\n`,
+  );
+  process.stderr.write(
+    `  - Precision: ${Math.round(comparisonResultFromFile.precision * 100)}%\n`,
+  );
+  process.stderr.write(
+    `  - Recall: ${Math.round(comparisonResultFromFile.recall * 100)}%\n`,
   );
 
   return comparisonResultFromFile;

--- a/src/core/agents/specialized/benchmark/docker-utils.ts
+++ b/src/core/agents/specialized/benchmark/docker-utils.ts
@@ -76,7 +76,9 @@ export function parseDockerComposePort(
         for (const [serviceName, service] of Object.entries(parsed.services)) {
           // Skip infrastructure services
           if (isInfrastructureService(serviceName)) {
-            process.stderr.write(`  ⏭️  Skipping infrastructure service: ${serviceName}\n`);
+            process.stderr.write(
+              `  ⏭️  Skipping infrastructure service: ${serviceName}\n`,
+            );
             continue;
           }
 
@@ -197,7 +199,9 @@ export function parseDockerComposePort(
   }
 
   // Default to port 80 if not found
-  process.stderr.write(`  ⚠️  Could not find docker-compose file, defaulting to port 80\n`);
+  process.stderr.write(
+    `  ⚠️  Could not find docker-compose file, defaulting to port 80\n`,
+  );
   return {
     hostPort: 80,
     containerPort: 80,

--- a/src/core/agents/specialized/benchmark/docker-utils.ts
+++ b/src/core/agents/specialized/benchmark/docker-utils.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import path from "path";
 import { promisify } from "util";
 import yaml from "yaml";
+import { writeErrorLog } from "../../../logger";
 
 const exec = promisify(nodeExec);
 
@@ -75,7 +76,7 @@ export function parseDockerComposePort(
         for (const [serviceName, service] of Object.entries(parsed.services)) {
           // Skip infrastructure services
           if (isInfrastructureService(serviceName)) {
-            console.log(`  ⏭️  Skipping infrastructure service: ${serviceName}`);
+            process.stderr.write(`  ⏭️  Skipping infrastructure service: ${serviceName}\n`);
             continue;
           }
 
@@ -90,8 +91,8 @@ export function parseDockerComposePort(
               if (typeof firstPort === "string") {
                 const match = firstPort.match(/^(\d+):(\d+)$/);
                 if (match && match[1] && match[2]) {
-                  console.log(
-                    `  ✅ Found web service: ${serviceName} on port ${match[1]}`,
+                  process.stderr.write(
+                    `  ✅ Found web service: ${serviceName} on port ${match[1]}\n`,
                   );
                   return {
                     hostPort: parseInt(match[1], 10),
@@ -102,8 +103,8 @@ export function parseDockerComposePort(
                   };
                 }
               } else if (typeof firstPort === "number") {
-                console.log(
-                  `  ✅ Found web service: ${serviceName} on port ${firstPort}`,
+                process.stderr.write(
+                  `  ✅ Found web service: ${serviceName} on port ${firstPort}\n`,
                 );
                 return {
                   hostPort: firstPort,
@@ -127,8 +128,8 @@ export function parseDockerComposePort(
                   ? parseInt(exposePort, 10)
                   : exposePort;
 
-              console.log(
-                `  ⚠️  Service ${serviceName} has expose but no ports - will add port mapping`,
+              process.stderr.write(
+                `  ⚠️  Service ${serviceName} has expose but no ports - will add port mapping\n`,
               );
 
               // Add port mapping to the service
@@ -139,8 +140,8 @@ export function parseDockerComposePort(
 
               // Write back the modified compose file
               writeFileSync(composePath, yaml.stringify(parsed));
-              console.log(
-                `  ✅ Added port mapping ${port}:${port} to ${serviceName}`,
+              process.stderr.write(
+                `  ✅ Added port mapping ${port}:${port} to ${serviceName}\n`,
               );
 
               return {
@@ -156,8 +157,8 @@ export function parseDockerComposePort(
       }
 
       // If we get here, no ports were found - find first non-infrastructure service
-      console.log(
-        `  ⚠️  No ports found in ${composePath}, adding default port to first web service...`,
+      process.stderr.write(
+        `  ⚠️  No ports found in ${composePath}, adding default port to first web service...\n`,
       );
 
       if (parsed?.services) {
@@ -177,8 +178,8 @@ export function parseDockerComposePort(
           (serviceObj.ports as string[]).push(`${defaultPort}:${defaultPort}`);
 
           writeFileSync(composePath, yaml.stringify(parsed));
-          console.log(
-            `  ✅ Added default port mapping ${defaultPort}:${defaultPort} to ${serviceName}`,
+          process.stderr.write(
+            `  ✅ Added default port mapping ${defaultPort}:${defaultPort} to ${serviceName}\n`,
           );
 
           return {
@@ -191,13 +192,12 @@ export function parseDockerComposePort(
         }
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(`Warning: Failed to parse ${composePath}: ${message}`);
+      writeErrorLog(error, `DockerUtils:parseCompose:${composePath}`);
     }
   }
 
   // Default to port 80 if not found
-  console.log(`  ⚠️  Could not find docker-compose file, defaulting to port 80`);
+  process.stderr.write(`  ⚠️  Could not find docker-compose file, defaulting to port 80\n`);
   return {
     hostPort: 80,
     containerPort: 80,
@@ -224,8 +224,8 @@ export async function getActualDockerPort(
 
     const containerId = stdout.trim();
     if (!containerId) {
-      console.log(
-        `  ⚠️  Could not find running container for service: ${serviceName}`,
+      process.stderr.write(
+        `  ⚠️  Could not find running container for service: ${serviceName}\n`,
       );
       return containerPort;
     }
@@ -239,19 +239,18 @@ export async function getActualDockerPort(
     const match = portOutput.match(/0\.0\.0\.0:(\d+)/);
     if (match && match[1]) {
       const hostPort = parseInt(match[1], 10);
-      console.log(
-        `  ✅ Container ${serviceName}:${containerPort} is mapped to localhost:${hostPort}`,
+      process.stderr.write(
+        `  ✅ Container ${serviceName}:${containerPort} is mapped to localhost:${hostPort}\n`,
       );
       return hostPort;
     }
 
-    console.log(
-      `  ⚠️  Could not parse port mapping, using container port: ${containerPort}`,
+    process.stderr.write(
+      `  ⚠️  Could not parse port mapping, using container port: ${containerPort}\n`,
     );
     return containerPort;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(`  ⚠️  Error getting Docker port mapping: ${message}`);
+    writeErrorLog(error, "DockerUtils:getActualDockerPort");
     return containerPort;
   }
 }

--- a/src/core/agents/specialized/benchmark/flag-detector.ts
+++ b/src/core/agents/specialized/benchmark/flag-detector.ts
@@ -4,6 +4,7 @@ import fs from "fs/promises";
 import { glob } from "glob";
 import path from "path";
 import yaml from "yaml";
+import { writeErrorLog } from "../../../logger";
 import type { FlagDetectionResult, FlagLocation } from "./types";
 
 /**
@@ -137,10 +138,10 @@ export async function extractFlagFromRepo(
   // First, check for Argus benchmark.json (APEX-XXX-XX pattern)
   const argusFlag = await extractFlagFromBenchmarkJson(repoPath);
   if (argusFlag) {
-    console.log(
-      `[${branch}] 🎯 Detected Argus benchmark with flag from benchmark.json`,
+    process.stderr.write(
+      `[${branch}] 🎯 Detected Argus benchmark with flag from benchmark.json\n`,
     );
-    console.log(`[${branch}] ✅ FLAG: ${argusFlag.substring(0, 30)}...`);
+    process.stderr.write(`[${branch}] ✅ FLAG: ${argusFlag.substring(0, 30)}...\n`);
     return argusFlag;
   }
 
@@ -149,15 +150,15 @@ export async function extractFlagFromRepo(
   const benchmarkName = extractBenchmarkName(repoPath);
   if (benchmarkName) {
     const flag = computeBenchmarkFlag(benchmarkName);
-    console.log(`[${branch}] 🎯 Detected XBOW benchmark: ${benchmarkName}`);
-    console.log(
-      `[${branch}] ✅ Computed FLAG (SHA256): ${flag.substring(0, 30)}...`,
+    process.stderr.write(`[${branch}] 🎯 Detected XBOW benchmark: ${benchmarkName}\n`);
+    process.stderr.write(
+      `[${branch}] ✅ Computed FLAG (SHA256): ${flag.substring(0, 30)}...\n`,
     );
     return flag;
   }
 
   // For non-benchmark repos, search configuration files
-  console.log(`[${branch}] 🔍 Searching for FLAG in configuration files...`);
+  process.stderr.write(`[${branch}] 🔍 Searching for FLAG in configuration files...\n`);
 
   const searchFiles = [
     ".env",
@@ -185,20 +186,17 @@ export async function extractFlagFromRepo(
       const flag = extractFlagFromContent(content, file);
 
       if (flag) {
-        console.log(
-          `[${branch}] ✅ FLAG found in ${file}: ${flag.substring(0, 20)}...`,
+        process.stderr.write(
+          `[${branch}] ✅ FLAG found in ${file}: ${flag.substring(0, 20)}...\n`,
         );
         return flag;
       }
     } catch (error) {
-      console.log(
-        `[${branch}] ⚠️  Error reading ${file}:`,
-        error instanceof Error ? error.message : String(error),
-      );
+      writeErrorLog(error, `FlagDetector:readConfig:${file}`);
     }
   }
 
-  console.log(`[${branch}] ❌ FLAG not found in any configuration file`);
+  process.stderr.write(`[${branch}] ❌ FLAG not found in any configuration file\n`);
   return null;
 }
 
@@ -224,8 +222,8 @@ export async function extractPACEFlags(
 ): Promise<Array<{ name: string; value: string }>> {
   const flags: Array<{ name: string; value: string }> = [];
 
-  console.log(
-    `[${benchmarkName}] 🔍 Extracting PACEbench flags from ${benchmarkPath}...`,
+  process.stderr.write(
+    `[${benchmarkName}] 🔍 Extracting PACEbench flags from ${benchmarkPath}...\n`,
   );
 
   // Check flags/ directory
@@ -241,16 +239,14 @@ export async function extractPACEFlags(
           if (flagValue.startsWith("flag{")) {
             const flagName = file.replace(".txt", "");
             flags.push({ name: flagName, value: flagValue });
-            console.log(
-              `[${benchmarkName}]    Found flag: ${flagName} = ${flagValue.substring(0, 20)}...`,
+            process.stderr.write(
+              `[${benchmarkName}]    Found flag: ${flagName} = ${flagValue.substring(0, 20)}...\n`,
             );
           }
         }
       }
     } catch (error) {
-      console.log(
-        `[${benchmarkName}] ⚠️  Error reading flags/ directory: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      writeErrorLog(error, `FlagDetector:readFlagsDir:${benchmarkName}`);
     }
   }
 
@@ -267,20 +263,18 @@ export async function extractPACEFlags(
           if (flagValue.startsWith("flag{")) {
             const flagName = file.replace(".txt", "");
             flags.push({ name: flagName, value: flagValue });
-            console.log(
-              `[${benchmarkName}]    Found flag: ${flagName} = ${flagValue.substring(0, 20)}...`,
+            process.stderr.write(
+              `[${benchmarkName}]    Found flag: ${flagName} = ${flagValue.substring(0, 20)}...\n`,
             );
           }
         }
       }
     } catch (error) {
-      console.log(
-        `[${benchmarkName}] ⚠️  Error reading flag_without_ignore/ directory: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      writeErrorLog(error, `FlagDetector:readAltFlagsDir:${benchmarkName}`);
     }
   }
 
-  console.log(`[${benchmarkName}] ✅ Extracted ${flags.length} flags`);
+  process.stderr.write(`[${benchmarkName}] ✅ Extracted ${flags.length} flags\n`);
   return flags;
 }
 
@@ -293,8 +287,8 @@ export async function detectMultipleFlagsInArtifacts(
   expectedFlags: Array<{ name: string; value: string }>,
   benchmarkName: string,
 ): Promise<FlagDetectionResult> {
-  console.log(
-    `[${benchmarkName}] 🔎 Searching for ${expectedFlags.length} flags in pentest artifacts...`,
+  process.stderr.write(
+    `[${benchmarkName}] 🔎 Searching for ${expectedFlags.length} flags in pentest artifacts...\n`,
   );
 
   const multiFlag = {
@@ -314,7 +308,7 @@ export async function detectMultipleFlagsInArtifacts(
 
   // For each expected flag, search for it in artifacts
   for (const { name, value } of expectedFlags) {
-    console.log(`[${benchmarkName}]    Searching for ${name}...`);
+    process.stderr.write(`[${benchmarkName}]    Searching for ${name}...\n`);
 
     // Use the existing detectFlagInArtifacts function
     const result = await detectFlagInArtifacts(
@@ -344,8 +338,8 @@ export async function detectMultipleFlagsInArtifacts(
   }
 
   const detected = multiFlag.found > 0;
-  console.log(
-    `[${benchmarkName}] ${detected ? "✅" : "❌"} Found ${multiFlag.found} of ${multiFlag.total} flags`,
+  process.stderr.write(
+    `[${benchmarkName}] ${detected ? "✅" : "❌"} Found ${multiFlag.found} of ${multiFlag.total} flags\n`,
   );
 
   return {
@@ -488,7 +482,7 @@ export async function detectFlagInArtifacts(
   expectedFlag: string,
   branch: string,
 ): Promise<FlagDetectionResult> {
-  console.log(`[${branch}] 🔎 Searching for FLAG in pentest artifacts...`);
+  process.stderr.write(`[${branch}] 🔎 Searching for FLAG in pentest artifacts...\n`);
 
   const foundIn: string[] = [];
   const locations: FlagLocation[] = [];
@@ -513,10 +507,7 @@ export async function detectFlagInArtifacts(
         return true;
       }
     } catch (error) {
-      console.log(
-        `[${branch}] ⚠️  Error reading ${file}:`,
-        error instanceof Error ? error.message : String(error),
-      );
+      writeErrorLog(error, `FlagDetector:searchFile:${file}`);
     }
     return false;
   }
@@ -652,26 +643,26 @@ export async function detectFlagInArtifacts(
   const detected = foundIn.length > 0;
 
   if (detected) {
-    console.log(
-      `[${branch}] ✅ FLAG DETECTED in ${foundIn.length} artifact(s):`,
+    process.stderr.write(
+      `[${branch}] ✅ FLAG DETECTED in ${foundIn.length} artifact(s):\n`,
     );
-    // Deduplicate foundIn for cleaner output
     const uniqueFiles = [...new Set(foundIn)];
-    uniqueFiles.forEach((file) => console.log(`[${branch}]    - ${file}`));
+    uniqueFiles.forEach((file) =>
+      process.stderr.write(`[${branch}]    - ${file}\n`),
+    );
 
-    // Output specific locations with line numbers
-    console.log(
-      `[${branch}] 📍 Exact locations (${locations.length} occurrences):`,
+    process.stderr.write(
+      `[${branch}] 📍 Exact locations (${locations.length} occurrences):\n`,
     );
     for (const loc of locations) {
-      console.log(`[${branch}]    ${loc.file}:${loc.line}`);
-      console.log(
-        `[${branch}]      └─ ${loc.context.substring(0, 100)}${loc.context.length > 100 ? "..." : ""}`,
+      process.stderr.write(`[${branch}]    ${loc.file}:${loc.line}\n`);
+      process.stderr.write(
+        `[${branch}]      └─ ${loc.context.substring(0, 100)}${loc.context.length > 100 ? "..." : ""}\n`,
       );
     }
   } else {
-    console.log(`[${branch}] ❌ FLAG NOT DETECTED in artifacts`);
-    console.log(`[${branch}]    Searched: ${searchLocations.join(", ")}`);
+    process.stderr.write(`[${branch}] ❌ FLAG NOT DETECTED in artifacts\n`);
+    process.stderr.write(`[${branch}]    Searched: ${searchLocations.join(", ")}\n`);
   }
 
   return {

--- a/src/core/agents/specialized/benchmark/flag-detector.ts
+++ b/src/core/agents/specialized/benchmark/flag-detector.ts
@@ -141,7 +141,9 @@ export async function extractFlagFromRepo(
     process.stderr.write(
       `[${branch}] 🎯 Detected Argus benchmark with flag from benchmark.json\n`,
     );
-    process.stderr.write(`[${branch}] ✅ FLAG: ${argusFlag.substring(0, 30)}...\n`);
+    process.stderr.write(
+      `[${branch}] ✅ FLAG: ${argusFlag.substring(0, 30)}...\n`,
+    );
     return argusFlag;
   }
 
@@ -150,7 +152,9 @@ export async function extractFlagFromRepo(
   const benchmarkName = extractBenchmarkName(repoPath);
   if (benchmarkName) {
     const flag = computeBenchmarkFlag(benchmarkName);
-    process.stderr.write(`[${branch}] 🎯 Detected XBOW benchmark: ${benchmarkName}\n`);
+    process.stderr.write(
+      `[${branch}] 🎯 Detected XBOW benchmark: ${benchmarkName}\n`,
+    );
     process.stderr.write(
       `[${branch}] ✅ Computed FLAG (SHA256): ${flag.substring(0, 30)}...\n`,
     );
@@ -158,7 +162,9 @@ export async function extractFlagFromRepo(
   }
 
   // For non-benchmark repos, search configuration files
-  process.stderr.write(`[${branch}] 🔍 Searching for FLAG in configuration files...\n`);
+  process.stderr.write(
+    `[${branch}] 🔍 Searching for FLAG in configuration files...\n`,
+  );
 
   const searchFiles = [
     ".env",
@@ -196,7 +202,9 @@ export async function extractFlagFromRepo(
     }
   }
 
-  process.stderr.write(`[${branch}] ❌ FLAG not found in any configuration file\n`);
+  process.stderr.write(
+    `[${branch}] ❌ FLAG not found in any configuration file\n`,
+  );
   return null;
 }
 
@@ -274,7 +282,9 @@ export async function extractPACEFlags(
     }
   }
 
-  process.stderr.write(`[${benchmarkName}] ✅ Extracted ${flags.length} flags\n`);
+  process.stderr.write(
+    `[${benchmarkName}] ✅ Extracted ${flags.length} flags\n`,
+  );
   return flags;
 }
 
@@ -482,7 +492,9 @@ export async function detectFlagInArtifacts(
   expectedFlag: string,
   branch: string,
 ): Promise<FlagDetectionResult> {
-  process.stderr.write(`[${branch}] 🔎 Searching for FLAG in pentest artifacts...\n`);
+  process.stderr.write(
+    `[${branch}] 🔎 Searching for FLAG in pentest artifacts...\n`,
+  );
 
   const foundIn: string[] = [];
   const locations: FlagLocation[] = [];
@@ -662,7 +674,9 @@ export async function detectFlagInArtifacts(
     }
   } else {
     process.stderr.write(`[${branch}] ❌ FLAG NOT DETECTED in artifacts\n`);
-    process.stderr.write(`[${branch}]    Searched: ${searchLocations.join(", ")}\n`);
+    process.stderr.write(
+      `[${branch}]    Searched: ${searchLocations.join(", ")}\n`,
+    );
   }
 
   return {

--- a/src/core/agents/specialized/benchmark/remote/circuit-breaker.ts
+++ b/src/core/agents/specialized/benchmark/remote/circuit-breaker.ts
@@ -68,7 +68,9 @@ export class CircuitBreaker {
 
     if (this.state === "HALF_OPEN") {
       if (this.successes >= this.options.successThreshold) {
-        process.stderr.write("🟢 Circuit breaker: Entering CLOSED state (recovered)\n");
+        process.stderr.write(
+          "🟢 Circuit breaker: Entering CLOSED state (recovered)\n",
+        );
         this.state = "CLOSED";
         this.successes = 0;
       }

--- a/src/core/agents/specialized/benchmark/remote/circuit-breaker.ts
+++ b/src/core/agents/specialized/benchmark/remote/circuit-breaker.ts
@@ -1,3 +1,5 @@
+import { writeErrorLog } from "../../../../logger";
+
 /**
  * Circuit Breaker Pattern Implementation
  *
@@ -33,8 +35,8 @@ export class CircuitBreaker {
       const timeSinceLastFailure = now - this.lastFailureTime;
 
       if (timeSinceLastFailure >= this.options.resetTimeout) {
-        console.log(
-          "🟡 Circuit breaker: Entering HALF_OPEN state (attempting recovery)",
+        process.stderr.write(
+          "🟡 Circuit breaker: Entering HALF_OPEN state (attempting recovery)\n",
         );
         this.state = "HALF_OPEN";
       } else {
@@ -66,7 +68,7 @@ export class CircuitBreaker {
 
     if (this.state === "HALF_OPEN") {
       if (this.successes >= this.options.successThreshold) {
-        console.log("🟢 Circuit breaker: Entering CLOSED state (recovered)");
+        process.stderr.write("🟢 Circuit breaker: Entering CLOSED state (recovered)\n");
         this.state = "CLOSED";
         this.successes = 0;
       }
@@ -82,8 +84,9 @@ export class CircuitBreaker {
       this.failures >= this.options.failureThreshold &&
       this.state !== "OPEN"
     ) {
-      console.error(
-        `🔴 Circuit breaker: OPENING circuit after ${this.failures} consecutive failures`,
+      writeErrorLog(
+        `Circuit breaker: OPENING circuit after ${this.failures} consecutive failures`,
+        "CircuitBreaker",
       );
       this.state = "OPEN";
     }

--- a/src/core/agents/specialized/benchmark/remote/daytona-wrapper.ts
+++ b/src/core/agents/specialized/benchmark/remote/daytona-wrapper.ts
@@ -187,7 +187,9 @@ async function runSingleBranchBenchmark(
     await cloneRepo(sandbox, repoUrl, branch);
 
     // Clone Apex source repo (contains the benchmark runner script)
-    process.stderr.write(`[${branch}] 📦 Cloning Apex source for benchmark runner...\n`);
+    process.stderr.write(
+      `[${branch}] 📦 Cloning Apex source for benchmark runner...\n`,
+    );
     await retryWithBackoff(
       () =>
         sbx.git.clone(
@@ -436,7 +438,9 @@ async function installBun(sandbox: Sandbox, branch?: string): Promise<void> {
     throw new Error("Bun installation verification failed");
   }
 
-  process.stderr.write(`${prefix}✅ Bun installed: v${verifyResult.result.trim()}\n`);
+  process.stderr.write(
+    `${prefix}✅ Bun installed: v${verifyResult.result.trim()}\n`,
+  );
 }
 
 /**
@@ -530,10 +534,16 @@ async function installDocker(sandbox: Sandbox, branch?: string): Promise<void> {
     const checkLocations = await sandbox.process.executeCommand(
       'ls -la /usr/bin/docker /usr/local/bin/docker 2>&1 || echo "Docker not in standard locations"',
     );
-    writeErrorLog(`Docker binary check: ${checkLocations.result}`, "DaytonaWrapper:installDocker");
+    writeErrorLog(
+      `Docker binary check: ${checkLocations.result}`,
+      "DaytonaWrapper:installDocker",
+    );
 
     const pathCheck = await sandbox.process.executeCommand("echo $PATH");
-    writeErrorLog(`Current PATH: ${pathCheck.result}`, "DaytonaWrapper:installDocker");
+    writeErrorLog(
+      `Current PATH: ${pathCheck.result}`,
+      "DaytonaWrapper:installDocker",
+    );
 
     throw new Error("Docker binary not found after installation");
   }
@@ -573,7 +583,9 @@ async function installDocker(sandbox: Sandbox, branch?: string): Promise<void> {
   );
 
   // Wait for Docker daemon to be ready (up to 60 seconds with retries)
-  process.stderr.write(`${prefix}⏳ Waiting for Docker daemon to be ready...\n`);
+  process.stderr.write(
+    `${prefix}⏳ Waiting for Docker daemon to be ready...\n`,
+  );
 
   let attempts = 0;
   const maxAttempts = 60;
@@ -585,7 +597,9 @@ async function installDocker(sandbox: Sandbox, branch?: string): Promise<void> {
     );
 
     if (checkResult.exitCode === 0) {
-      process.stderr.write(`${prefix}✅ Docker daemon ready after ${attempts} seconds\n`);
+      process.stderr.write(
+        `${prefix}✅ Docker daemon ready after ${attempts} seconds\n`,
+      );
       break;
     }
 
@@ -594,7 +608,9 @@ async function installDocker(sandbox: Sandbox, branch?: string): Promise<void> {
 
     // Show progress every 10 seconds
     if (attempts % 10 === 0) {
-      process.stderr.write(`${prefix}Still waiting... (${attempts}s elapsed)\n`);
+      process.stderr.write(
+        `${prefix}Still waiting... (${attempts}s elapsed)\n`,
+      );
     }
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -605,8 +621,14 @@ async function installDocker(sandbox: Sandbox, branch?: string): Promise<void> {
     const logResult = await sandbox.process.executeCommand(
       "cat /tmp/dockerd.log 2>&1 || echo 'No log file'",
     );
-    writeErrorLog(`Docker daemon logs:\n${logResult.result}`, "DaytonaWrapper:installDocker");
-    writeErrorLog(`Last docker info error:\n${lastError}`, "DaytonaWrapper:installDocker");
+    writeErrorLog(
+      `Docker daemon logs:\n${logResult.result}`,
+      "DaytonaWrapper:installDocker",
+    );
+    writeErrorLog(
+      `Last docker info error:\n${lastError}`,
+      "DaytonaWrapper:installDocker",
+    );
     throw new Error(
       `Docker daemon failed to start within ${maxAttempts} seconds`,
     );
@@ -635,7 +657,9 @@ async function cloneRepo(
   branch: string,
 ): Promise<void> {
   const prefix = `[${branch}] `;
-  process.stderr.write(`${prefix}📦 Cloning repository: ${repoUrl} (${branch})...\n`);
+  process.stderr.write(
+    `${prefix}📦 Cloning repository: ${repoUrl} (${branch})...\n`,
+  );
 
   // Use Daytona's git.clone() - automatically clones and checks out branch
   await retryWithBackoff(() => sandbox.git.clone(repoUrl, "repo", branch), {
@@ -745,7 +769,9 @@ async function downloadResults(
       expectedFlag = benchmarkData.win_condition?.flag_pattern ?? null;
 
       if (expectedFlag) {
-        process.stderr.write(`${prefix}🔎 Searching for flag: ${expectedFlag}\n`);
+        process.stderr.write(
+          `${prefix}🔎 Searching for flag: ${expectedFlag}\n`,
+        );
         const { detectFlagInArtifacts } = await import("../flag-detector.js");
         const flagResult = await detectFlagInArtifacts(
           localSessionPath,
@@ -768,7 +794,9 @@ async function downloadResults(
     writeErrorLog(error, `DaytonaWrapper:detectFlag:${branch}`);
   }
 
-  process.stderr.write(`${prefix}✅ Results downloaded to ${localSessionPath}\n`);
+  process.stderr.write(
+    `${prefix}✅ Results downloaded to ${localSessionPath}\n`,
+  );
   process.stderr.write(
     `${prefix}📊 Tokens: ${totalTokens.toLocaleString()} (in: ${tokensIn.toLocaleString()}, out: ${tokensOut.toLocaleString()})\n`,
   );
@@ -822,7 +850,9 @@ async function downloadDirectoryRecursive(
     try {
       if (file.isDirectory) {
         // Recursively download subdirectory
-        process.stderr.write(`${prefix}  📁 Downloading directory: ${file.name}\n`);
+        process.stderr.write(
+          `${prefix}  📁 Downloading directory: ${file.name}\n`,
+        );
         await downloadDirectoryRecursive(
           sandbox,
           remoteFilePath,
@@ -845,7 +875,9 @@ async function downloadDirectoryRecursive(
         errorMessage?.includes("file not found") ||
         errorMessage?.includes("invalid")
       ) {
-        process.stderr.write(`${prefix}  📁 Retrying ${file.name} as directory...\n`);
+        process.stderr.write(
+          `${prefix}  📁 Retrying ${file.name} as directory...\n`,
+        );
         try {
           await downloadDirectoryRecursive(
             sandbox,

--- a/src/core/agents/specialized/benchmark/remote/daytona-wrapper.ts
+++ b/src/core/agents/specialized/benchmark/remote/daytona-wrapper.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import pLimit from "p-limit";
 import path from "path";
 import type { AIModel } from "../../../../ai";
+import { writeErrorLog } from "../../../../logger";
 import { CircuitBreaker } from "./circuit-breaker";
 
 /**
@@ -61,8 +62,8 @@ async function retryWithBackoff<T>(
         throw error;
       }
 
-      console.log(
-        `${prefix}⚠️  Retry ${attempt + 1}/${maxRetries} after ${delay}ms (Error: ${errorMessage ?? String(error)})`,
+      process.stderr.write(
+        `${prefix}⚠️  Retry ${attempt + 1}/${maxRetries} after ${delay}ms (Error: ${errorMessage ?? String(error)})\n`,
       );
 
       // Wait with exponential backoff
@@ -135,7 +136,7 @@ async function runSingleBranchBenchmark(
   const startTime = Date.now();
 
   try {
-    console.log(`[${branch}] 🚀 Creating Daytona sandbox...`);
+    process.stderr.write(`[${branch}] 🚀 Creating Daytona sandbox...\n`);
     sandbox = await daytonaCircuitBreaker.execute(() =>
       retryWithBackoff(
         () =>
@@ -168,14 +169,14 @@ async function runSingleBranchBenchmark(
       ),
     );
 
-    console.log(`[${branch}] ✅ Sandbox created: ${sandbox.id}`);
+    process.stderr.write(`[${branch}] ✅ Sandbox created: ${sandbox.id}\n`);
 
     // Capture definite reference for use in closures
     const sbx = sandbox;
 
     // Disable auto-stop for long-running benchmarks
     await retryWithBackoff(() => sbx.setAutostopInterval(0), { branch });
-    console.log(`[${branch}] ✅ Auto-stop disabled`);
+    process.stderr.write(`[${branch}] ✅ Auto-stop disabled\n`);
 
     // Install dependencies
     await installBun(sandbox, branch);
@@ -186,7 +187,7 @@ async function runSingleBranchBenchmark(
     await cloneRepo(sandbox, repoUrl, branch);
 
     // Clone Apex source repo (contains the benchmark runner script)
-    console.log(`[${branch}] 📦 Cloning Apex source for benchmark runner...`);
+    process.stderr.write(`[${branch}] 📦 Cloning Apex source for benchmark runner...\n`);
     await retryWithBackoff(
       () =>
         sbx.git.clone(
@@ -198,7 +199,7 @@ async function runSingleBranchBenchmark(
     );
 
     // Install Apex dependencies
-    console.log(`[${branch}] 📦 Installing Apex dependencies...`);
+    process.stderr.write(`[${branch}] 📦 Installing Apex dependencies...\n`);
     await retryWithBackoff(
       () =>
         sbx.process.executeCommand(
@@ -208,12 +209,12 @@ async function runSingleBranchBenchmark(
     );
 
     // Create session and run benchmark via scripts/run-benchmarks.ts
-    console.log(`[${branch}] 🔬 Creating benchmark session...`);
+    process.stderr.write(`[${branch}] 🔬 Creating benchmark session...\n`);
     await retryWithBackoff(() => sbx.process.createSession("benchmark"), {
       branch,
     });
 
-    console.log(`[${branch}] 📊 Running benchmark...\n`);
+    process.stderr.write(`[${branch}] 📊 Running benchmark...\n`);
     const { cmdId } = await sandbox.process.executeSessionCommand("benchmark", {
       command: [
         `export BUN_INSTALL="$HOME/.bun"`,
@@ -250,8 +251,8 @@ async function runSingleBranchBenchmark(
     const command = await sandbox.process.getSessionCommand("benchmark", cmdId);
     const exitCode = command?.exitCode;
 
-    console.log(
-      `[${branch}] ✅ Benchmark completed with exit code: ${exitCode}`,
+    process.stderr.write(
+      `[${branch}] ✅ Benchmark completed with exit code: ${exitCode}\n`,
     );
 
     if (exitCode !== 0) {
@@ -262,7 +263,7 @@ async function runSingleBranchBenchmark(
     const results = await downloadResults(sandbox, branch);
 
     const duration = ((Date.now() - startTime) / 1000 / 60).toFixed(2);
-    console.log(`[${branch}] ✅ Completed in ${duration}m`);
+    process.stderr.write(`[${branch}] ✅ Completed in ${duration}m\n`);
 
     return results;
   } catch (error) {
@@ -273,16 +274,11 @@ async function runSingleBranchBenchmark(
         ? message.substring(0, 500) + "... (truncated)"
         : message;
     const duration = ((Date.now() - startTime) / 1000 / 60).toFixed(2);
-    console.error(
-      `[${branch}] ❌ Failed after ${duration}m: ${truncatedMessage}`,
+    process.stderr.write(
+      `[${branch}] ❌ Failed after ${duration}m: ${truncatedMessage}\n`,
     );
 
-    // Log full error for debugging
-    if (error instanceof Error && error.stack) {
-      console.error(
-        `[${branch}] Error stack: ${error.stack.substring(0, 1000)}`,
-      );
-    }
+    writeErrorLog(error, `DaytonaWrapper:runBranch:${branch}`);
     return {
       repoPath: repoUrl,
       branch,
@@ -303,7 +299,7 @@ async function runSingleBranchBenchmark(
   } finally {
     if (sandbox) {
       try {
-        console.log(`[${branch}] 🧹 Cleaning up sandbox...`);
+        process.stderr.write(`[${branch}] 🧹 Cleaning up sandbox...\n`);
 
         let attempts = 0;
         while (attempts < 10) {
@@ -316,11 +312,9 @@ async function runSingleBranchBenchmark(
         }
 
         await sandbox.delete();
-        console.log(`[${branch}] ✅ Cleanup complete`);
+        process.stderr.write(`[${branch}] ✅ Cleanup complete\n`);
       } catch (cleanupError) {
-        console.error(
-          `[${branch}] ⚠️  Cleanup failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
-        );
+        writeErrorLog(cleanupError, `DaytonaWrapper:cleanup:${branch}`);
       }
     }
   }
@@ -353,12 +347,12 @@ export async function runBenchmarkInDaytona(
   const maxParallel = options.maxParallel || 4;
   const startTime = Date.now();
 
-  console.log("🚀 Starting parallel benchmark execution");
-  console.log(`   Repository: ${options.repoUrl}`);
-  console.log(`   Branches: ${branches.join(", ")}`);
-  console.log(`   Model: ${options.model}`);
-  console.log(`   Max Parallel: ${maxParallel}`);
-  console.log();
+  process.stderr.write("🚀 Starting parallel benchmark execution\n");
+  process.stderr.write(`   Repository: ${options.repoUrl}\n`);
+  process.stderr.write(`   Branches: ${branches.join(", ")}\n`);
+  process.stderr.write(`   Model: ${options.model}\n`);
+  process.stderr.write(`   Max Parallel: ${maxParallel}\n`);
+  process.stderr.write("\n");
 
   // Initialize SDK
   const daytona = new Daytona({
@@ -393,18 +387,18 @@ export async function runBenchmarkInDaytona(
   );
   const totalTokens = results.reduce((sum, r) => sum + (r.totalTokens ?? 0), 0);
 
-  console.log("\n" + "=".repeat(80));
-  console.log("📊 PARALLEL BENCHMARK SUMMARY");
-  console.log("=".repeat(80));
-  console.log(`Total Duration: ${totalDuration}m`);
-  console.log(`Successful: ${successful}/${branches.length}`);
-  console.log(`Failed: ${failed}/${branches.length}`);
-  console.log(
-    `Flags Captured: ${flagsCaptured}/${branches.length} (${((flagsCaptured / branches.length) * 100).toFixed(1)}%)`,
+  process.stderr.write("\n" + "=".repeat(80) + "\n");
+  process.stderr.write("📊 PARALLEL BENCHMARK SUMMARY\n");
+  process.stderr.write("=".repeat(80) + "\n");
+  process.stderr.write(`Total Duration: ${totalDuration}m\n`);
+  process.stderr.write(`Successful: ${successful}/${branches.length}\n`);
+  process.stderr.write(`Failed: ${failed}/${branches.length}\n`);
+  process.stderr.write(
+    `Flags Captured: ${flagsCaptured}/${branches.length} (${((flagsCaptured / branches.length) * 100).toFixed(1)}%)\n`,
   );
-  console.log(`Total Findings: ${totalFindings}`);
-  console.log(`Total Tokens: ${totalTokens.toLocaleString()}`);
-  console.log();
+  process.stderr.write(`Total Findings: ${totalFindings}\n`);
+  process.stderr.write(`Total Tokens: ${totalTokens.toLocaleString()}\n`);
+  process.stderr.write("\n");
 
   // Generate summary report
   await generateSummaryReport(
@@ -422,7 +416,7 @@ export async function runBenchmarkInDaytona(
  */
 async function installBun(sandbox: Sandbox, branch?: string): Promise<void> {
   const prefix = branch ? `[${branch}] ` : "";
-  console.log(`${prefix}📦 Installing Bun...`);
+  process.stderr.write(`${prefix}📦 Installing Bun...\n`);
 
   await sandbox.process.executeCommand(
     "curl -fsSL https://bun.sh/install | bash",
@@ -442,7 +436,7 @@ async function installBun(sandbox: Sandbox, branch?: string): Promise<void> {
     throw new Error("Bun installation verification failed");
   }
 
-  console.log(`${prefix}✅ Bun installed: v${verifyResult.result.trim()}`);
+  process.stderr.write(`${prefix}✅ Bun installed: v${verifyResult.result.trim()}\n`);
 }
 
 /**
@@ -450,7 +444,7 @@ async function installBun(sandbox: Sandbox, branch?: string): Promise<void> {
  */
 async function installApex(sandbox: Sandbox, branch?: string): Promise<void> {
   const prefix = branch ? `[${branch}] ` : "";
-  console.log(`${prefix}📦 Installing Apex globally via bun...`);
+  process.stderr.write(`${prefix}📦 Installing Apex globally via bun...\n`);
 
   try {
     // Install using bun (ensures bun PATH is working)
@@ -476,7 +470,7 @@ async function installApex(sandbox: Sandbox, branch?: string): Promise<void> {
       );
     }
 
-    console.log(`${prefix}✅ Apex installed at: ${installedPath}`);
+    process.stderr.write(`${prefix}✅ Apex installed at: ${installedPath}\n`);
   } catch (error) {
     throw new Error(
       `Failed to install Apex: ${error instanceof Error ? error.message : String(error)}`,
@@ -491,11 +485,11 @@ async function installApex(sandbox: Sandbox, branch?: string): Promise<void> {
  */
 async function installDocker(sandbox: Sandbox, branch?: string): Promise<void> {
   const prefix = branch ? `[${branch}] ` : "";
-  console.log(`${prefix}🐳 Installing Docker...`);
+  process.stderr.write(`${prefix}🐳 Installing Docker...\n`);
 
   // Fix broken yarn repository that blocks apt-get update
   // The Docker install script runs apt-get update which fails on the yarn repo
-  console.log(`${prefix}Fixing apt repositories...`);
+  process.stderr.write(`${prefix}Fixing apt repositories...\n`);
   await sandbox.process.executeCommand(
     "(sudo rm -f /etc/apt/sources.list.d/yarn.list || rm -f /etc/apt/sources.list.d/yarn.list) 2>/dev/null || true",
   );
@@ -512,13 +506,14 @@ async function installDocker(sandbox: Sandbox, branch?: string): Promise<void> {
     const output = installResult.result.trim();
     const preview =
       output.length > 500 ? output.substring(0, 500) + "..." : output;
-    console.log(`${prefix}Docker install output: ${preview}`);
+    process.stderr.write(`${prefix}Docker install output: ${preview}\n`);
   }
 
   // Check installation exit code
   if (installResult.exitCode !== 0) {
-    console.error(
-      `${prefix}Docker installation failed with exit code ${installResult.exitCode}`,
+    writeErrorLog(
+      `Docker installation failed with exit code ${installResult.exitCode}`,
+      "DaytonaWrapper:installDocker",
     );
     throw new Error(
       `Docker installation script failed with exit code ${installResult.exitCode}`,
@@ -535,20 +530,18 @@ async function installDocker(sandbox: Sandbox, branch?: string): Promise<void> {
     const checkLocations = await sandbox.process.executeCommand(
       'ls -la /usr/bin/docker /usr/local/bin/docker 2>&1 || echo "Docker not in standard locations"',
     );
-    console.error(`${prefix}Docker binary check: ${checkLocations.result}`);
+    writeErrorLog(`Docker binary check: ${checkLocations.result}`, "DaytonaWrapper:installDocker");
 
-    // Check if it's in PATH without explicit export
     const pathCheck = await sandbox.process.executeCommand("echo $PATH");
-    console.error(`${prefix}Current PATH: ${pathCheck.result}`);
+    writeErrorLog(`Current PATH: ${pathCheck.result}`, "DaytonaWrapper:installDocker");
 
     throw new Error("Docker binary not found after installation");
   }
 
   const dockerPath = whichResult.result.trim();
-  console.log(`${prefix}✅ Docker installed at: ${dockerPath}`);
+  process.stderr.write(`${prefix}✅ Docker installed at: ${dockerPath}\n`);
 
-  // Start Docker daemon in background
-  console.log(`${prefix}Starting Docker daemon...`);
+  process.stderr.write(`${prefix}Starting Docker daemon...\n`);
 
   // Use nohup to properly detach the daemon - try with sudo first, fall back to direct
   const daemonStart = await sandbox.process.executeCommand(
@@ -557,18 +550,19 @@ async function installDocker(sandbox: Sandbox, branch?: string): Promise<void> {
 
   // Check if the command itself failed (not the daemon startup)
   if (daemonStart.exitCode !== 0 && daemonStart.result) {
-    console.error(
-      `${prefix}Failed to start daemon command: ${daemonStart.result.substring(0, 200)}`,
+    writeErrorLog(
+      `Failed to start daemon command: ${daemonStart.result.substring(0, 200)}`,
+      "DaytonaWrapper:installDocker",
     );
     throw new Error("Failed to execute dockerd command");
   }
 
   // Give daemon a moment to start before checking
-  console.log(`${prefix}Waiting for daemon to initialize...`);
+  process.stderr.write(`${prefix}Waiting for daemon to initialize...\n`);
   await new Promise((resolve) => setTimeout(resolve, 5000));
 
   // Add current user to docker group for socket access
-  console.log(`${prefix}Configuring Docker permissions...`);
+  process.stderr.write(`${prefix}Configuring Docker permissions...\n`);
   await sandbox.process.executeCommand(
     "(sudo usermod -aG docker $(whoami) || usermod -aG docker $(whoami)) 2>/dev/null || true",
   );
@@ -579,7 +573,7 @@ async function installDocker(sandbox: Sandbox, branch?: string): Promise<void> {
   );
 
   // Wait for Docker daemon to be ready (up to 60 seconds with retries)
-  console.log(`${prefix}⏳ Waiting for Docker daemon to be ready...`);
+  process.stderr.write(`${prefix}⏳ Waiting for Docker daemon to be ready...\n`);
 
   let attempts = 0;
   const maxAttempts = 60;
@@ -591,7 +585,7 @@ async function installDocker(sandbox: Sandbox, branch?: string): Promise<void> {
     );
 
     if (checkResult.exitCode === 0) {
-      console.log(`${prefix}✅ Docker daemon ready after ${attempts} seconds`);
+      process.stderr.write(`${prefix}✅ Docker daemon ready after ${attempts} seconds\n`);
       break;
     }
 
@@ -600,7 +594,7 @@ async function installDocker(sandbox: Sandbox, branch?: string): Promise<void> {
 
     // Show progress every 10 seconds
     if (attempts % 10 === 0) {
-      console.log(`${prefix}Still waiting... (${attempts}s elapsed)`);
+      process.stderr.write(`${prefix}Still waiting... (${attempts}s elapsed)\n`);
     }
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -611,8 +605,8 @@ async function installDocker(sandbox: Sandbox, branch?: string): Promise<void> {
     const logResult = await sandbox.process.executeCommand(
       "cat /tmp/dockerd.log 2>&1 || echo 'No log file'",
     );
-    console.error(`${prefix}Docker daemon logs:\n${logResult.result}`);
-    console.error(`${prefix}Last docker info error:\n${lastError}`);
+    writeErrorLog(`Docker daemon logs:\n${logResult.result}`, "DaytonaWrapper:installDocker");
+    writeErrorLog(`Last docker info error:\n${lastError}`, "DaytonaWrapper:installDocker");
     throw new Error(
       `Docker daemon failed to start within ${maxAttempts} seconds`,
     );
@@ -629,7 +623,7 @@ async function installDocker(sandbox: Sandbox, branch?: string): Promise<void> {
     );
   }
 
-  console.log(`${prefix}✅ Docker daemon running, compose ready`);
+  process.stderr.write(`${prefix}✅ Docker daemon running, compose ready\n`);
 }
 
 /**
@@ -641,14 +635,14 @@ async function cloneRepo(
   branch: string,
 ): Promise<void> {
   const prefix = `[${branch}] `;
-  console.log(`${prefix}📦 Cloning repository: ${repoUrl} (${branch})...`);
+  process.stderr.write(`${prefix}📦 Cloning repository: ${repoUrl} (${branch})...\n`);
 
   // Use Daytona's git.clone() - automatically clones and checks out branch
   await retryWithBackoff(() => sandbox.git.clone(repoUrl, "repo", branch), {
     branch,
   });
 
-  console.log(`${prefix}✅ Repository cloned to ~/repo`);
+  process.stderr.write(`${prefix}✅ Repository cloned to ~/repo\n`);
 }
 
 /**
@@ -661,7 +655,7 @@ async function downloadResults(
   branch: string,
 ): Promise<BenchmarkResults> {
   const prefix = `[${branch}] `;
-  console.log(`${prefix}⬇️  Downloading results...`);
+  process.stderr.write(`${prefix}⬇️  Downloading results...\n`);
 
   // Get user home directory
   const userHome = await sandbox.getUserHomeDir();
@@ -678,7 +672,7 @@ async function downloadResults(
       branch,
     },
   )) as unknown as Array<{ name: string; isDirectory: boolean }>;
-  console.log(`${prefix}Found ${files.length} session directories`);
+  process.stderr.write(`${prefix}Found ${files.length} session directories\n`);
 
   if (files.length === 0) {
     throw new Error(`No sessions found for branch ${branch}`);
@@ -687,7 +681,7 @@ async function downloadResults(
   // Get the most recent session (last in array)
   const sessionDir = files[files.length - 1]!.name;
 
-  console.log(`${prefix}Downloading session: ${sessionDir}`);
+  process.stderr.write(`${prefix}Downloading session: ${sessionDir}\n`);
 
   // Download all files in the session directory recursively
   const sessionPath = path.join(sessionsPath, sessionDir);
@@ -751,7 +745,7 @@ async function downloadResults(
       expectedFlag = benchmarkData.win_condition?.flag_pattern ?? null;
 
       if (expectedFlag) {
-        console.log(`${prefix}🔎 Searching for flag: ${expectedFlag}`);
+        process.stderr.write(`${prefix}🔎 Searching for flag: ${expectedFlag}\n`);
         const { detectFlagInArtifacts } = await import("../flag-detector.js");
         const flagResult = await detectFlagInArtifacts(
           localSessionPath,
@@ -762,26 +756,24 @@ async function downloadResults(
         flagValue = flagResult.flagValue;
 
         if (flagDetected) {
-          console.log(
-            `${prefix}✅ Flag captured! Found in: ${flagResult.foundIn.join(", ")}`,
+          process.stderr.write(
+            `${prefix}✅ Flag captured! Found in: ${flagResult.foundIn.join(", ")}\n`,
           );
         } else {
-          console.log(`${prefix}❌ Flag not found`);
+          process.stderr.write(`${prefix}❌ Flag not found\n`);
         }
       }
     }
   } catch (error) {
-    console.log(
-      `${prefix}⚠️  Could not detect flag: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    writeErrorLog(error, `DaytonaWrapper:detectFlag:${branch}`);
   }
 
-  console.log(`${prefix}✅ Results downloaded to ${localSessionPath}`);
-  console.log(
-    `${prefix}📊 Tokens: ${totalTokens.toLocaleString()} (in: ${tokensIn.toLocaleString()}, out: ${tokensOut.toLocaleString()})`,
+  process.stderr.write(`${prefix}✅ Results downloaded to ${localSessionPath}\n`);
+  process.stderr.write(
+    `${prefix}📊 Tokens: ${totalTokens.toLocaleString()} (in: ${tokensIn.toLocaleString()}, out: ${tokensOut.toLocaleString()})\n`,
   );
-  console.log(`${prefix}📝 Findings: ${findingsCount}`);
-  console.log(`${prefix}🚩 Flag: ${flagDetected ? "✓" : "✗"}`);
+  process.stderr.write(`${prefix}📝 Findings: ${findingsCount}\n`);
+  process.stderr.write(`${prefix}🚩 Flag: ${flagDetected ? "✓" : "✗"}\n`);
 
   return {
     repoPath: "",
@@ -830,7 +822,7 @@ async function downloadDirectoryRecursive(
     try {
       if (file.isDirectory) {
         // Recursively download subdirectory
-        console.log(`${prefix}  📁 Downloading directory: ${file.name}`);
+        process.stderr.write(`${prefix}  📁 Downloading directory: ${file.name}\n`);
         await downloadDirectoryRecursive(
           sandbox,
           remoteFilePath,
@@ -838,7 +830,7 @@ async function downloadDirectoryRecursive(
           branch,
         );
       } else {
-        console.log(`${prefix}  📄 Downloading file: ${file.name}`);
+        process.stderr.write(`${prefix}  📄 Downloading file: ${file.name}\n`);
         await retryWithBackoff(
           () => sandbox.fs.downloadFile(remoteFilePath, localFilePath),
           {
@@ -853,7 +845,7 @@ async function downloadDirectoryRecursive(
         errorMessage?.includes("file not found") ||
         errorMessage?.includes("invalid")
       ) {
-        console.log(`${prefix}  📁 Retrying ${file.name} as directory...`);
+        process.stderr.write(`${prefix}  📁 Retrying ${file.name} as directory...\n`);
         try {
           await downloadDirectoryRecursive(
             sandbox,
@@ -862,12 +854,10 @@ async function downloadDirectoryRecursive(
             branch,
           );
         } catch (retryError) {
-          console.error(
-            `${prefix}  ⚠️  Skipping ${file.name}: ${retryError instanceof Error ? retryError.message : String(retryError)}`,
-          );
+          writeErrorLog(retryError, `DaytonaWrapper:downloadDir:${file.name}`);
         }
       } else {
-        console.error(`${prefix}  ⚠️  Skipping ${file.name}: ${errorMessage}`);
+        writeErrorLog(errorMessage, `DaytonaWrapper:downloadFile:${file.name}`);
       }
     }
   }
@@ -1001,5 +991,5 @@ async function generateSummaryReport(
   const mdPath = path.join(summaryDir, "summary.md");
   writeFileSync(mdPath, markdown.join("\n"));
 
-  console.log(`📄 Summary reports saved to: ${summaryDir}`);
+  process.stderr.write(`📄 Summary reports saved to: ${summaryDir}\n`);
 }

--- a/src/core/agents/specialized/findingJudge/index.ts
+++ b/src/core/agents/specialized/findingJudge/index.ts
@@ -7,6 +7,7 @@
  */
 
 import type { AIModel } from "../../../ai";
+import { writeErrorLog } from "../../../logger";
 import type { ToolContext } from "../../offSecAgent/tools";
 import type {
   FindingJudgeAgentOutput,
@@ -70,8 +71,9 @@ export async function judgeFinding(
     return normalizeJudgeResult(result);
   } catch (err: unknown) {
     const fallback = createJudgeFailureResult(err, ctx.model);
-    console.error(
-      `[FindingJudge] Agentic validation failed: model=${fallback.error?.model} type=${fallback.error?.type} message=${fallback.error?.message}`,
+    writeErrorLog(
+      `Agentic validation failed: model=${fallback.error?.model} type=${fallback.error?.type} message=${fallback.error?.message}`,
+      "FINDING_JUDGE",
     );
     return fallback;
   }

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -925,9 +925,9 @@ async function runPentestAgent(input: PentestAgentInput) {
   const { findings, findingsPath, pocsPath, objectiveResults } =
     await agent.consume();
 
-  console.log(`\nFound ${findings.length} vulnerabilities`);
-  console.log(`Findings: ${findingsPath}`);
-  console.log(`POCs: ${pocsPath}`);
+  process.stderr.write(`\nFound ${findings.length} vulnerabilities\n`);
+  process.stderr.write(`Findings: ${findingsPath}\n`);
+  process.stderr.write(`POCs: ${pocsPath}\n`);
 
   return { findings, findingsPath, pocsPath, objectiveResults };
 }

--- a/src/core/agents/specialized/utils.ts
+++ b/src/core/agents/specialized/utils.ts
@@ -1,6 +1,7 @@
 import { execSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { getBundledWordlists } from "../../assets/wordlists";
+import { writeErrorLog } from "../../logger";
 
 type DetectedEnvironment = {
   isDocker: boolean;
@@ -149,7 +150,7 @@ export function detectOSAndEnhancePrompt(prompt: string): string {
 
     return `${lines.join("\n")}\n${prompt}`;
   } catch (error) {
-    console.error("Error detecting environment:", error);
+    writeErrorLog(error, "ENV_DETECT");
     return prompt;
   }
 }

--- a/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.ts
@@ -7,6 +7,7 @@ import type {
   ConsolidatedEndpoint,
   FrameworkId,
 } from "../../../integrations/surface/types";
+import { writeErrorLog } from "../../../logger";
 import type { SessionInfo } from "../../../session";
 import { runWithBoundedConcurrency } from "../../../utils/concurrency";
 import { CodeAgent } from "../codeAgent/agent";
@@ -224,9 +225,9 @@ async function runEndpointDocumentationAgent(
     });
     return true;
   } catch (error) {
-    console.error(
-      `[endpoint-documentation-agent] "${subagentId}" FAILED:`,
-      error instanceof Error ? error.message : String(error),
+    writeErrorLog(
+      `"${subagentId}" FAILED: ${error instanceof Error ? error.message : String(error)}`,
+      "ENDPOINT_DOC_AGENT",
     );
     eventBus?.emit("subagent-complete", {
       subagentId,

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -16,6 +16,7 @@ import {
   type ToolSet,
 } from "ai";
 import type { z } from "zod";
+import { writeErrorLog } from "../logger";
 import { withCachedLastMessage, withCachedSystemPrompt } from "./caching";
 import { fitMessagesToContext, truncateWithMarker } from "./contextManagement";
 import { getMaxOutputTokens, getModelInfo } from "./models";
@@ -312,8 +313,9 @@ function wrapStreamWithErrorHandler(
               ) {
                 const nextIdleCount = idleResumeCount + 1;
                 if (!silent) {
-                  console.warn(
+                  writeErrorLog(
                     `Stream stalled (attempt ${nextIdleCount}/${MAX_IDLE_RESUME_RETRIES}), resuming with ${messagesContainer.current.length} messages: ${errorMessage}`,
+                    "AI_STREAM",
                   );
                 }
 
@@ -348,8 +350,9 @@ function wrapStreamWithErrorHandler(
                 const delayMs = Math.min(1000 * nextRetryCount, 30000);
 
                 if (!silent) {
-                  console.warn(
+                  writeErrorLog(
                     `Rate limit error (attempt ${nextRetryCount}/${MAX_RATE_LIMIT_RETRIES}), waiting ${delayMs}ms: ${errorMessage}`,
+                    "AI_STREAM",
                   );
                 }
 
@@ -411,8 +414,9 @@ function wrapStreamWithErrorHandler(
 
                 if (fitted.fitsBudget && fitted.modified) {
                   if (!silent) {
-                    console.warn(
+                    writeErrorLog(
                       `Context length error — Layer 1+2 reduced to ~${fitted.estimatedInputTokens} tokens, retrying`,
+                      "AI_STREAM",
                     );
                   }
                   try {
@@ -475,8 +479,9 @@ function wrapStreamWithErrorHandler(
                 // can throw — fall back to a minimal-context restart.
                 const messagesForSummary = messagesContainer.current;
                 if (!silent) {
-                  console.warn(
+                  writeErrorLog(
                     `Context length error — summarizing ${messagesForSummary.length} messages`,
+                    "AI_STREAM",
                   );
                 }
 
@@ -512,8 +517,9 @@ function wrapStreamWithErrorHandler(
                       summarizeError instanceof Error
                         ? summarizeError.message
                         : String(summarizeError);
-                    console.error(
+                    writeErrorLog(
                       `Layer 3 summarization failed (${sumMsg}). Falling back to minimal-context restart.`,
+                      "AI_STREAM",
                     );
                   }
                   opts.onSummarized?.("");
@@ -533,9 +539,9 @@ function wrapStreamWithErrorHandler(
                 }
               } else {
                 if (!silent) {
-                  console.error(
-                    "Non-recoverable stream error, re-throwing:",
-                    errorMessage,
+                  writeErrorLog(
+                    `Non-recoverable stream error, re-throwing: ${errorMessage}`,
+                    "AI_STREAM",
                   );
                 }
                 throw error;
@@ -717,8 +723,9 @@ export function streamResponse(
     fittedMessages = fitted.messages;
     proactiveFitFailed = !fitted.fitsBudget;
     if (fitted.modified && !silent) {
-      console.warn(
+      writeErrorLog(
         `Proactive context fit: compacted messages to ~${fitted.estimatedInputTokens} tokens (fits=${fitted.fitsBudget})`,
+        "AI_STREAM",
       );
     }
   }
@@ -733,8 +740,9 @@ export function streamResponse(
   // the equivalent post-streamText path (line ~880) recovers.
   if (proactiveFitFailed && fittedMessages) {
     if (!silent) {
-      console.warn(
+      writeErrorLog(
         `Proactive context fit returned fitsBudget=false on ${fittedMessages.length} messages — escalating to summarization before send`,
+        "AI_STREAM",
       );
     }
     // Pass `opts` through unchanged. The slot for this escalation is
@@ -890,28 +898,13 @@ export function streamResponse(
         error,
       }) => {
         try {
-          if (!silent) {
-            console.log(`🔧 Repairing tool call: ${toolCall.toolName}`);
-            console.log(`   Error: ${error.message || error}`);
-
-            // Log specific details for common enum errors
-            if (
-              error.message &&
-              (error.message.includes("severity") ||
-                error.message.includes("riskLevel"))
-            ) {
-              console.log(
-                `   Note: This appears to be an enum validation error. Tool call repair will normalize the value.`,
-              );
-            }
-          }
-
           // Get the actual tool definition which contains the Zod schema
           const tool = tools[toolCall.toolName];
           if (!tool || !tool.inputSchema) {
             if (!silent) {
-              console.error(
+              writeErrorLog(
                 `Cannot repair tool call: ${toolCall.toolName} not found or has no schema`,
+                "AI_STREAM",
               );
             }
             return null;
@@ -988,8 +981,9 @@ export function streamResponse(
 
           if (repairedArgs === undefined || repairedArgs === null) {
             if (!silent) {
-              console.error(
+              writeErrorLog(
                 `Tool call repair for "${toolCall.toolName}" produced no valid output`,
+                "AI_STREAM",
               );
             }
             return null;
@@ -997,11 +991,9 @@ export function streamResponse(
           return { ...toolCall, input: JSON.stringify(repairedArgs) };
         } catch (repairError) {
           if (!silent) {
-            console.error(
-              "Error repairing tool call:",
-              repairError instanceof Error
-                ? repairError.message
-                : String(repairError),
+            writeErrorLog(
+              `Error repairing tool call: ${repairError instanceof Error ? repairError.message : String(repairError)}`,
+              "AI_STREAM",
             );
           }
           return null;
@@ -1026,9 +1018,9 @@ export function streamResponse(
 
     if (isContextLengthError) {
       if (!silent) {
-        console.warn(
-          `Context length error, summarizing ${messagesContainer.current.length} messages: `,
-          outerErrorMessage,
+        writeErrorLog(
+          `Context length error, summarizing ${messagesContainer.current.length} messages: ${outerErrorMessage}`,
+          "AI_STREAM",
         );
       }
       // Wrap so a context error inside the summarization stream itself
@@ -1054,7 +1046,10 @@ export function streamResponse(
       );
     }
     if (!silent) {
-      console.error("Non-context length error, re-throwing", outerErrorMessage);
+      writeErrorLog(
+        `Non-context length error, re-throwing: ${outerErrorMessage}`,
+        "AI_STREAM",
+      );
     }
 
     // Re-throw if it's not a context length error

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -7,6 +7,7 @@ import type {
   LanguageModelV3Usage,
   SharedV3Warning,
 } from "@ai-sdk/provider";
+import { writeErrorLog } from "../../logger";
 import { buildStreamingFetchSignal } from "../utils";
 import { convertToBedrockFormat } from "./pensarFormatters";
 import { signGatewayRequest } from "./pensarSigning";
@@ -16,15 +17,15 @@ const DEBUG =
   process.env.PENSAR_DEBUG === "1" || process.env.PENSAR_DEBUG === "true";
 
 function log(...args: unknown[]) {
-  if (DEBUG) console.error("[pensar:debug]", ...args);
+  if (DEBUG) writeErrorLog(args.map(String).join(" "), "PENSAR_DEBUG");
 }
 
 function logInfo(...args: unknown[]) {
-  if (DEBUG) console.error("[pensar]", ...args);
+  if (DEBUG) writeErrorLog(args.map(String).join(" "), "PENSAR_DEBUG");
 }
 
 function logError(...args: unknown[]) {
-  console.error("[pensar:error]", ...args);
+  writeErrorLog(args.map(String).join(" "), "PENSAR");
 }
 
 export interface PensarModelConfig {

--- a/src/core/ai/providers/pensarSSE.ts
+++ b/src/core/ai/providers/pensarSSE.ts
@@ -6,6 +6,8 @@
  * whenever a complete SSE message boundary (blank line) is encountered.
  */
 
+import { writeErrorLog } from "../../logger";
+
 const DEBUG =
   process.env.PENSAR_DEBUG === "1" || process.env.PENSAR_DEBUG === "true";
 
@@ -61,12 +63,14 @@ export async function* parseSSE(
       }
       if (result.done) {
         if (DEBUG) {
-          console.error(
+          writeErrorLog(
             `[parseSSE] stream done: ${chunkCount} chunks, ${totalBytes} bytes, ${eventCount} events yielded, remaining buffer=${buffer.length} chars`,
+            "PENSAR_SSE",
           );
           if (buffer.length > 0) {
-            console.error(
+            writeErrorLog(
               `[parseSSE] remaining buffer: ${buffer.slice(0, 500)}`,
+              "PENSAR_SSE",
             );
           }
         }
@@ -79,8 +83,9 @@ export async function* parseSSE(
       const decoded = decoder.decode(value, { stream: true });
 
       if (DEBUG && chunkCount <= 3) {
-        console.error(
+        writeErrorLog(
           `[parseSSE] chunk #${chunkCount}: ${value.byteLength} bytes, preview: ${decoded.slice(0, 200)}`,
+          "PENSAR_SSE",
         );
       }
 
@@ -110,13 +115,17 @@ export async function* parseSSE(
     if (currentData.length > 0) {
       eventCount++;
       if (DEBUG)
-        console.error(`[parseSSE] flushing final event: ${currentEvent}`);
+        writeErrorLog(
+          `[parseSSE] flushing final event: ${currentEvent}`,
+          "PENSAR_SSE",
+        );
       yield { event: currentEvent, data: currentData.join("\n") };
     }
 
     if (eventCount === 0) {
-      console.error(
+      writeErrorLog(
         `[parseSSE] WARNING: stream ended with 0 events! totalBytes=${totalBytes}, chunks=${chunkCount}`,
+        "PENSAR_SSE",
       );
     }
   } finally {

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -17,6 +17,7 @@ import {
 import { getPensarGatewayUrl } from "../api/constants";
 import { ensureValidToken } from "../auth";
 import { config } from "../config";
+import { writeErrorLog } from "../logger";
 import { type AIModel, type StreamResponseOpts, streamResponse } from "./ai";
 import {
   extractTaskSummaryFromMessages,
@@ -223,8 +224,9 @@ export function getProviderModel(
         process.env.PENSAR_DEBUG === "1" ||
         process.env.PENSAR_DEBUG === "true"
       ) {
-        console.log(
+        writeErrorLog(
           `[pensar] getProviderModel: ${model} → bedrock:${bedrockModelId} via ${gatewayUrl}`,
+          "PENSAR_PROVIDER",
         );
       }
 

--- a/src/core/api/attackSurface.ts
+++ b/src/core/api/attackSurface.ts
@@ -51,9 +51,11 @@ async function runBlackboxAttackSurface(
 
   const { results, targets, resultsPath, assetsPath } = await agent.consume();
 
-  console.log(`\nIdentified ${targets.length} targets for deep testing`);
-  console.log(`Results: ${resultsPath}`);
-  console.log(`Assets: ${assetsPath}`);
+  process.stdout.write(
+    `\nIdentified ${targets.length} targets for deep testing\n`,
+  );
+  process.stdout.write(`Results: ${resultsPath}\n`);
+  process.stdout.write(`Assets: ${assetsPath}\n`);
 
   return { results, targets, resultsPath, assetsPath };
 }
@@ -76,10 +78,10 @@ async function runWhiteboxAttackSurface(
     surfaceIntegrationEnabled: input.surfaceIntegrationEnabled,
   });
 
-  console.log(
+  process.stdout.write(
     `\nWhitebox analysis complete: ${result.summary.totalApps} apps, ` +
       `${result.summary.totalApiEndpoints} API endpoints, ` +
-      `${result.summary.totalPages} pages`,
+      `${result.summary.totalPages} pages\n`,
   );
 
   return result;

--- a/src/core/api/benchmark.ts
+++ b/src/core/api/benchmark.ts
@@ -13,23 +13,25 @@ export async function runBenchmarkComparisonAgent(
 
   agent.eventBus.on("text-delta", (d) => process.stdout.write(d.text));
   agent.eventBus.on("tool-call-complete", (d) =>
-    console.log(`→ calling ${d.toolName}`),
+    process.stdout.write(`→ calling ${d.toolName}\n`),
   );
   agent.eventBus.on("tool-result", (d) =>
-    console.log(`✓ ${d.toolName} completed`),
+    process.stdout.write(`✓ ${d.toolName} completed\n`),
   );
-  agent.eventBus.on("error", (d) => console.error("Agent error:", d.error));
+  agent.eventBus.on("error", (d) =>
+    process.stderr.write(`Agent error: ${d.error}\n`),
+  );
 
   const { comparison, resultsPath } = await agent.consume();
 
   if (comparison) {
-    console.log(
+    process.stdout.write(
       `\nComparison: ${comparison.matched.length}/${comparison.totalExpected} matched, ` +
         `Precision: ${Math.round(comparison.precision * 100)}%, ` +
-        `Recall: ${Math.round(comparison.recall * 100)}%`,
+        `Recall: ${Math.round(comparison.recall * 100)}%\n`,
     );
   }
-  console.log(`Results: ${resultsPath}`);
+  process.stdout.write(`Results: ${resultsPath}\n`);
 
   return { comparison, resultsPath };
 }

--- a/src/core/api/blackboxPentest.ts
+++ b/src/core/api/blackboxPentest.ts
@@ -24,10 +24,10 @@ export async function runPentestAgent(
   const { findings, findingsPath, pocsPath, reportPath } =
     await runPentestWorkflow(input);
 
-  console.log(`\nFound ${findings.length} vulnerabilities`);
-  console.log(`Findings: ${findingsPath}`);
-  console.log(`POCs: ${pocsPath}`);
-  if (reportPath) console.log(`Report: ${reportPath}`);
+  process.stdout.write(`\nFound ${findings.length} vulnerabilities\n`);
+  process.stdout.write(`Findings: ${findingsPath}\n`);
+  process.stdout.write(`POCs: ${pocsPath}\n`);
+  if (reportPath) process.stdout.write(`Report: ${reportPath}\n`);
 
   return { findings, findingsPath, pocsPath, reportPath };
 }

--- a/src/core/api/environment.ts
+++ b/src/core/api/environment.ts
@@ -13,13 +13,13 @@ function attachDefaultEnvironmentStreamListeners(
     process.stdout.write(e.text);
   });
   agent.eventBus.on("tool-call-complete", (e) => {
-    console.log(`→ calling ${e.toolName}`);
+    process.stdout.write(`→ calling ${e.toolName}\n`);
   });
   agent.eventBus.on("tool-result", (e) => {
-    console.log(`✓ ${e.toolName} completed`);
+    process.stdout.write(`✓ ${e.toolName} completed\n`);
   });
   agent.eventBus.on("error", (e) => {
-    console.error("Environment agent error:", e.error);
+    process.stderr.write(`Environment agent error: ${e.error}\n`);
   });
 }
 

--- a/src/core/api/patching.ts
+++ b/src/core/api/patching.ts
@@ -11,13 +11,13 @@ function attachDefaultPatchingStreamListeners(agent: PatchingAgent): void {
     process.stdout.write(e.text);
   });
   agent.eventBus.on("tool-call-complete", (e) => {
-    console.log(`→ calling ${e.toolName}`);
+    process.stdout.write(`→ calling ${e.toolName}\n`);
   });
   agent.eventBus.on("tool-result", (e) => {
-    console.log(`✓ ${e.toolName} completed`);
+    process.stdout.write(`✓ ${e.toolName} completed\n`);
   });
   agent.eventBus.on("error", (e) => {
-    console.error("Patching agent error:", e.error);
+    process.stderr.write(`Patching agent error: ${e.error}\n`);
   });
 }
 

--- a/src/core/api/targetedPentest.ts
+++ b/src/core/api/targetedPentest.ts
@@ -9,20 +9,22 @@ export async function runTargetedPentestAgent(input: PentestAgentInput) {
   if (!input.eventBus) {
     agent.eventBus.on("text-delta", (d) => process.stdout.write(d.text));
     agent.eventBus.on("tool-call-complete", (d) =>
-      console.log(`→ calling ${d.toolName}`),
+      process.stdout.write(`→ calling ${d.toolName}\n`),
     );
     agent.eventBus.on("tool-result", (d) =>
-      console.log(`✓ ${d.toolName} completed`),
+      process.stdout.write(`✓ ${d.toolName} completed\n`),
     );
-    agent.eventBus.on("error", (d) => console.error("Agent error:", d.error));
+    agent.eventBus.on("error", (d) =>
+      process.stderr.write(`Agent error: ${d.error}\n`),
+    );
   }
 
   const { findings, findingsPath, pocsPath, objectiveResults } =
     await agent.consume();
 
-  console.log(`\nFound ${findings.length} vulnerabilities`);
-  console.log(`Findings: ${findingsPath}`);
-  console.log(`POCs: ${pocsPath}`);
+  process.stdout.write(`\nFound ${findings.length} vulnerabilities\n`);
+  process.stdout.write(`Findings: ${findingsPath}\n`);
+  process.stdout.write(`POCs: ${pocsPath}\n`);
 
   return { findings, findingsPath, pocsPath, objectiveResults };
 }

--- a/src/core/auth/token.ts
+++ b/src/core/auth/token.ts
@@ -2,6 +2,7 @@
 // module directly.
 import { getPensarApiUrl } from "../api/constants";
 import { config } from "../config";
+import { writeErrorLog } from "../logger";
 import type { ValidToken } from "./types";
 
 /**
@@ -82,8 +83,9 @@ async function refreshAccessToken(
     );
 
     if (!response.ok) {
-      console.error(
-        `[pensar] Token refresh failed: ${response.status} ${response.statusText}`,
+      writeErrorLog(
+        `Token refresh failed: ${response.status} ${response.statusText}`,
+        "AUTH",
       );
       return null;
     }
@@ -100,7 +102,7 @@ async function refreshAccessToken(
 
     return data.access_token;
   } catch (err) {
-    console.error("[pensar] Token refresh error:", err);
+    writeErrorLog(err, "AUTH");
     return null;
   }
 }

--- a/src/core/benchmark/runner.ts
+++ b/src/core/benchmark/runner.ts
@@ -15,6 +15,7 @@ import {
 } from "../agents/specialized/benchmarkComparisonAgent";
 import type { CacheMetrics } from "../ai";
 import { AgentEventBus } from "../eventBus";
+import { writeErrorLog } from "../logger";
 import * as sessions from "../session";
 import { runPentestWorkflow } from "../workflows/pentest";
 import type {
@@ -112,15 +113,15 @@ async function runLocalMode(
 
   for (let i = 0; i < config.branches.length; i++) {
     const branch = config.branches[i]!;
-    console.log(
-      `\n${"=".repeat(60)}\n[${i + 1}/${config.branches.length}] Running benchmark: ${branch}\n${"=".repeat(60)}`,
+    process.stderr.write(
+      `\n${"=".repeat(60)}\n[${i + 1}/${config.branches.length}] Running benchmark: ${branch}\n${"=".repeat(60)}\n`,
     );
 
     const result = await runSingleBenchmark(branch, config);
     results.push(result);
 
-    console.log(
-      `[${branch}] ${result.status.toUpperCase()} | Flag: ${result.flagDetected ? "Y" : "N"} | Findings: ${result.findingsCount} | ${(result.duration / 60000).toFixed(1)}m`,
+    process.stderr.write(
+      `[${branch}] ${result.status.toUpperCase()} | Flag: ${result.flagDetected ? "Y" : "N"} | Findings: ${result.findingsCount} | ${(result.duration / 60000).toFixed(1)}m\n`,
     );
   }
 
@@ -134,8 +135,8 @@ async function runLocalMode(
 async function runDaytonaMode(
   config: BenchmarkSuiteConfig,
 ): Promise<BenchmarkRunResult[]> {
-  console.log(
-    `Running ${config.branches.length} benchmarks in Daytona (batch size: ${config.daytonaBatchSize})`,
+  process.stderr.write(
+    `Running ${config.branches.length} benchmarks in Daytona (batch size: ${config.daytonaBatchSize})\n`,
   );
 
   const daytonaResults = await runBenchmarkInDaytona({
@@ -185,16 +186,16 @@ export async function runSingleBenchmark(
     if (config.repoDir) {
       benchmarkPath = config.repoDir;
       // If a shared repo dir is provided, checkout the branch
-      console.log(`[${branch}] Using repo dir: ${benchmarkPath}`);
+      process.stderr.write(`[${branch}] Using repo dir: ${benchmarkPath}\n`);
       try {
         await exec(`git checkout ${branch}`, { cwd: benchmarkPath });
       } catch {
         // May already be on the branch or using worktrees
-        console.log(`[${branch}] Note: git checkout failed, continuing...`);
+        process.stderr.write(`[${branch}] Note: git checkout failed, continuing...\n`);
       }
     } else {
       clonedDir = path.join("/tmp", `apex-bench-${branch}-${Date.now()}`);
-      console.log(`[${branch}] Cloning ${config.repoUrl} branch ${branch}...`);
+      process.stderr.write(`[${branch}] Cloning ${config.repoUrl} branch ${branch}...\n`);
       await exec(
         `git clone --branch ${branch} --depth 1 ${config.repoUrl} ${clonedDir}`,
         { timeout: 120000 },
@@ -226,7 +227,7 @@ export async function runSingleBenchmark(
     // -----------------------------------------------------------------------
     // Step 3: Start Docker environment
     // -----------------------------------------------------------------------
-    console.log(`[${branch}] Starting Docker environment...`);
+    process.stderr.write(`[${branch}] Starting Docker environment...\n`);
     try {
       // In resource-constrained environments (e.g., Daytona), building all services
       // in parallel can cause OOM. Try standard build first, fall back to sequential.
@@ -242,8 +243,8 @@ export async function runSingleBenchmark(
           err.message?.includes("137") ||
           err.message?.toLowerCase().includes("killed")
         ) {
-          console.log(
-            `[${branch}] Build failed (likely OOM), retrying with sequential build...`,
+          process.stderr.write(
+            `[${branch}] Build failed (likely OOM), retrying with sequential build...\n`,
           );
 
           // Get list of services
@@ -259,7 +260,7 @@ export async function runSingleBenchmark(
           // Build each service sequentially
           for (const service of services) {
             if (service.trim()) {
-              console.log(`[${branch}] Building service: ${service}`);
+              process.stderr.write(`[${branch}] Building service: ${service}\n`);
               await exec(`docker compose build ${service}`, {
                 cwd: composeDir,
                 timeout: 600000, // 10 minutes per service
@@ -268,7 +269,7 @@ export async function runSingleBenchmark(
           }
 
           // Start all services
-          console.log(`[${branch}] Starting services...`);
+          process.stderr.write(`[${branch}] Starting services...\n`);
           await exec("docker compose up -d", {
             cwd: composeDir,
             timeout: 120000,
@@ -285,17 +286,17 @@ export async function runSingleBenchmark(
         stderr?: string;
         stdout?: string;
       };
-      console.error(`[${branch}] Docker compose failed!`);
+      writeErrorLog(`Docker compose failed for ${branch}`, "BenchmarkRunner:docker");
 
-      // Try to get docker logs for more context
       try {
         const logs = await exec("docker compose logs --tail=50 2>&1", {
           cwd: composeDir,
           timeout: 10000,
         });
         if (logs.stdout) {
-          console.error(
-            `[${branch}] Container logs: ${logs.stdout.substring(0, 1000)}`,
+          writeErrorLog(
+            `Container logs: ${logs.stdout.substring(0, 1000)}`,
+            `BenchmarkRunner:docker:${branch}`,
           );
         }
       } catch {
@@ -303,10 +304,10 @@ export async function runSingleBenchmark(
       }
 
       if (error.stdout) {
-        console.error(`[${branch}] stdout: ${error.stdout.substring(0, 2000)}`);
+        writeErrorLog(`stdout: ${error.stdout.substring(0, 2000)}`, `BenchmarkRunner:docker:${branch}`);
       }
       if (error.stderr) {
-        console.error(`[${branch}] stderr: ${error.stderr.substring(0, 2000)}`);
+        writeErrorLog(`stderr: ${error.stderr.substring(0, 2000)}`, `BenchmarkRunner:docker:${branch}`);
       }
       throw new Error(
         `Docker compose failed: ${error.stderr || error.message || "Unknown error"}`,
@@ -328,7 +329,7 @@ export async function runSingleBenchmark(
     // -----------------------------------------------------------------------
     // Step 4: Create session
     // -----------------------------------------------------------------------
-    console.log(`[${branch}] Creating pentest session...`);
+    process.stderr.write(`[${branch}] Creating pentest session...\n`);
     const session = await sessions.create({
       name: `Benchmark ${branch}`,
       targets: [targetUrl],
@@ -343,7 +344,7 @@ export async function runSingleBenchmark(
     // -----------------------------------------------------------------------
     // Step 5: Run pentest workflow
     // -----------------------------------------------------------------------
-    console.log(`[${branch}] Running pentest workflow against ${targetUrl}...`);
+    process.stderr.write(`[${branch}] Running pentest workflow against ${targetUrl}...\n`);
     const controller = new AbortController();
     const timeout = setTimeout(
       () => controller.abort(),
@@ -358,29 +359,28 @@ export async function runSingleBenchmark(
     benchBus.on("text-delta", (d) => process.stdout.write(d.text));
     benchBus.on("tool-call-start", (d) => {
       const p = d.subagentId ? `[${branch}] [${d.subagentId}]` : `[${branch}]`;
-      console.log(`${p} -> ${d.toolName} (streaming)`);
+      process.stderr.write(`${p} -> ${d.toolName} (streaming)\n`);
     });
     benchBus.on("tool-call-delta", (d) => {
       const p = d.subagentId ? `[${branch}] [${d.subagentId}]` : `[${branch}]`;
-      console.log(`${p} -> ${d.toolCallId} delta`);
+      process.stderr.write(`${p} -> ${d.toolCallId} delta\n`);
     });
     benchBus.on("tool-call-complete", (d) => {
       const p = d.subagentId ? `[${branch}] [${d.subagentId}]` : `[${branch}]`;
-      console.log(`${p} -> ${d.toolName}`);
+      process.stderr.write(`${p} -> ${d.toolName}\n`);
     });
     benchBus.on("tool-result", (d) => {
       const p = d.subagentId ? `[${branch}] [${d.subagentId}]` : `[${branch}]`;
-      console.log(`${p} <- ${d.toolName} done`);
+      process.stderr.write(`${p} <- ${d.toolName} done\n`);
     });
     benchBus.on("error", (d) => {
-      const p = d.subagentId ? `[${branch}] [subagent]` : `[${branch}]`;
-      console.error(`${p} Error:`, d.error);
+      writeErrorLog(d.error, `BenchmarkRunner:${branch}:${d.subagentId ?? "main"}`);
     });
     benchBus.on("subagent-spawn", ({ subagentId }) =>
-      console.log(`[${branch}] [${subagentId}] spawned`),
+      process.stderr.write(`[${branch}] [${subagentId}] spawned\n`),
     );
     benchBus.on("subagent-complete", ({ subagentId, status }) =>
-      console.log(`[${branch}] [${subagentId}] ${status}`),
+      process.stderr.write(`[${branch}] [${subagentId}] ${status}\n`),
     );
 
     let pentestResult;
@@ -416,7 +416,7 @@ export async function runSingleBenchmark(
     let flagValue: string | null = null;
 
     if (expectedFlag) {
-      console.log(`[${branch}] Searching for flag in artifacts...`);
+      process.stderr.write(`[${branch}] Searching for flag in artifacts...\n`);
       const flagResult = await detectFlagInArtifacts(
         session.rootPath,
         expectedFlag,
@@ -433,22 +433,19 @@ export async function runSingleBenchmark(
     const comparisonModel = config.comparisonModel || "claude-haiku-4-5";
 
     try {
-      console.log(`[${branch}] Running benchmark comparison...`);
+      process.stderr.write(`[${branch}] Running benchmark comparison...\n`);
       const compAgent = new BenchmarkComparisonAgent({
         repoPath: benchmarkPath,
         model: comparisonModel,
         session,
       });
       compAgent.eventBus.on("error", (d) =>
-        console.error(`[${branch}] Comparison error:`, d.error),
+        writeErrorLog(d.error, `BenchmarkRunner:comparison:${branch}`),
       );
       const compResult = await compAgent.consume();
       comparisonResult = compResult.comparison;
     } catch (e) {
-      console.error(
-        `[${branch}] Comparison failed:`,
-        e instanceof Error ? e.message : String(e),
-      );
+      writeErrorLog(e, `BenchmarkRunner:comparison:${branch}`);
     }
 
     // -----------------------------------------------------------------------
@@ -496,8 +493,9 @@ export async function runSingleBenchmark(
     const message = error instanceof Error ? error.message : String(error);
     const isTimeout = message.includes("aborted") || message.includes("abort");
 
-    console.error(
-      `[${branch}] ${isTimeout ? "TIMEOUT" : "FAILED"}: ${message}`,
+    writeErrorLog(
+      `${isTimeout ? "TIMEOUT" : "FAILED"}: ${message}`,
+      `BenchmarkRunner:${branch}`,
     );
 
     // Cleanup docker on failure
@@ -534,7 +532,7 @@ function readBenchmarkMetadata(
 ): BenchmarkMetadata | null {
   const jsonPath = path.join(benchmarkPath, "src", "benchmark.json");
   if (!existsSync(jsonPath)) {
-    console.log(`[${branch}] No benchmark.json found at ${jsonPath}`);
+    process.stderr.write(`[${branch}] No benchmark.json found at ${jsonPath}\n`);
     return null;
   }
 
@@ -554,10 +552,7 @@ function readBenchmarkMetadata(
       services: raw.services || {},
     };
   } catch (e) {
-    console.error(
-      `[${branch}] Failed to parse benchmark.json:`,
-      e instanceof Error ? e.message : String(e),
-    );
+    writeErrorLog(e, `BenchmarkRunner:readMetadata:${branch}`);
     return null;
   }
 }
@@ -570,7 +565,7 @@ async function waitForTarget(
   const start = Date.now();
   const pollInterval = 3000;
 
-  console.log(`[${branch}] Waiting for ${url} to be ready...`);
+  process.stderr.write(`[${branch}] Waiting for ${url} to be ready...\n`);
 
   while (Date.now() - start < maxWaitMs) {
     try {
@@ -578,8 +573,8 @@ async function waitForTarget(
         signal: AbortSignal.timeout(5000),
       });
       if (response.ok || response.status < 500) {
-        console.log(
-          `[${branch}] Target ready (${response.status}) after ${((Date.now() - start) / 1000).toFixed(1)}s`,
+        process.stderr.write(
+          `[${branch}] Target ready (${response.status}) after ${((Date.now() - start) / 1000).toFixed(1)}s\n`,
         );
         return;
       }
@@ -589,8 +584,8 @@ async function waitForTarget(
     await new Promise((resolve) => setTimeout(resolve, pollInterval));
   }
 
-  console.warn(
-    `[${branch}] ⚠️  Target ${url} not ready after ${(maxWaitMs / 1000).toFixed(0)}s — continuing anyway`,
+  process.stderr.write(
+    `[${branch}] ⚠️  Target ${url} not ready after ${(maxWaitMs / 1000).toFixed(0)}s — continuing anyway\n`,
   );
 }
 
@@ -599,16 +594,13 @@ async function cleanupDocker(
   branch: string,
 ): Promise<void> {
   try {
-    console.log(`[${branch}] Stopping Docker containers...`);
+    process.stderr.write(`[${branch}] Stopping Docker containers...\n`);
     await exec("docker compose down --volumes --remove-orphans", {
       cwd: composeDir,
       timeout: 60000,
     });
   } catch (e) {
-    console.error(
-      `[${branch}] Docker cleanup failed:`,
-      e instanceof Error ? e.message : String(e),
-    );
+    writeErrorLog(e, `BenchmarkRunner:dockerCleanup:${branch}`);
   }
 }
 

--- a/src/core/benchmark/runner.ts
+++ b/src/core/benchmark/runner.ts
@@ -191,11 +191,15 @@ export async function runSingleBenchmark(
         await exec(`git checkout ${branch}`, { cwd: benchmarkPath });
       } catch {
         // May already be on the branch or using worktrees
-        process.stderr.write(`[${branch}] Note: git checkout failed, continuing...\n`);
+        process.stderr.write(
+          `[${branch}] Note: git checkout failed, continuing...\n`,
+        );
       }
     } else {
       clonedDir = path.join("/tmp", `apex-bench-${branch}-${Date.now()}`);
-      process.stderr.write(`[${branch}] Cloning ${config.repoUrl} branch ${branch}...\n`);
+      process.stderr.write(
+        `[${branch}] Cloning ${config.repoUrl} branch ${branch}...\n`,
+      );
       await exec(
         `git clone --branch ${branch} --depth 1 ${config.repoUrl} ${clonedDir}`,
         { timeout: 120000 },
@@ -260,7 +264,9 @@ export async function runSingleBenchmark(
           // Build each service sequentially
           for (const service of services) {
             if (service.trim()) {
-              process.stderr.write(`[${branch}] Building service: ${service}\n`);
+              process.stderr.write(
+                `[${branch}] Building service: ${service}\n`,
+              );
               await exec(`docker compose build ${service}`, {
                 cwd: composeDir,
                 timeout: 600000, // 10 minutes per service
@@ -286,7 +292,10 @@ export async function runSingleBenchmark(
         stderr?: string;
         stdout?: string;
       };
-      writeErrorLog(`Docker compose failed for ${branch}`, "BenchmarkRunner:docker");
+      writeErrorLog(
+        `Docker compose failed for ${branch}`,
+        "BenchmarkRunner:docker",
+      );
 
       try {
         const logs = await exec("docker compose logs --tail=50 2>&1", {
@@ -304,10 +313,16 @@ export async function runSingleBenchmark(
       }
 
       if (error.stdout) {
-        writeErrorLog(`stdout: ${error.stdout.substring(0, 2000)}`, `BenchmarkRunner:docker:${branch}`);
+        writeErrorLog(
+          `stdout: ${error.stdout.substring(0, 2000)}`,
+          `BenchmarkRunner:docker:${branch}`,
+        );
       }
       if (error.stderr) {
-        writeErrorLog(`stderr: ${error.stderr.substring(0, 2000)}`, `BenchmarkRunner:docker:${branch}`);
+        writeErrorLog(
+          `stderr: ${error.stderr.substring(0, 2000)}`,
+          `BenchmarkRunner:docker:${branch}`,
+        );
       }
       throw new Error(
         `Docker compose failed: ${error.stderr || error.message || "Unknown error"}`,
@@ -344,7 +359,9 @@ export async function runSingleBenchmark(
     // -----------------------------------------------------------------------
     // Step 5: Run pentest workflow
     // -----------------------------------------------------------------------
-    process.stderr.write(`[${branch}] Running pentest workflow against ${targetUrl}...\n`);
+    process.stderr.write(
+      `[${branch}] Running pentest workflow against ${targetUrl}...\n`,
+    );
     const controller = new AbortController();
     const timeout = setTimeout(
       () => controller.abort(),
@@ -374,7 +391,10 @@ export async function runSingleBenchmark(
       process.stderr.write(`${p} <- ${d.toolName} done\n`);
     });
     benchBus.on("error", (d) => {
-      writeErrorLog(d.error, `BenchmarkRunner:${branch}:${d.subagentId ?? "main"}`);
+      writeErrorLog(
+        d.error,
+        `BenchmarkRunner:${branch}:${d.subagentId ?? "main"}`,
+      );
     });
     benchBus.on("subagent-spawn", ({ subagentId }) =>
       process.stderr.write(`[${branch}] [${subagentId}] spawned\n`),
@@ -532,7 +552,9 @@ function readBenchmarkMetadata(
 ): BenchmarkMetadata | null {
   const jsonPath = path.join(benchmarkPath, "src", "benchmark.json");
   if (!existsSync(jsonPath)) {
-    process.stderr.write(`[${branch}] No benchmark.json found at ${jsonPath}\n`);
+    process.stderr.write(
+      `[${branch}] No benchmark.json found at ${jsonPath}\n`,
+    );
     return null;
   }
 

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -124,7 +124,9 @@ export async function runDoctor(): Promise<void> {
         if (result.status === 0) {
           process.stdout.write("✓ nmap installed successfully!\n");
         } else {
-          process.stdout.write("✗ Installation failed. You can install manually:\n");
+          process.stdout.write(
+            "✗ Installation failed. You can install manually:\n",
+          );
           process.stdout.write(`    ${pm.installCmd}\n`);
         }
       } else {

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -54,14 +54,14 @@ function checkApiKeys(): { provider: string; configured: boolean }[] {
 }
 
 export async function runDoctor(): Promise<void> {
-  console.log();
-  console.log("Pensar Doctor");
-  console.log("=============");
-  console.log();
+  process.stdout.write("\n");
+  process.stdout.write("Pensar Doctor\n");
+  process.stdout.write("=============\n");
+  process.stdout.write("\n");
 
   // --- nmap check ---
-  console.log("System Tools");
-  console.log("------------");
+  process.stdout.write("System Tools\n");
+  process.stdout.write("------------\n");
 
   const nmapInstalled = toolExists("nmap");
   if (nmapInstalled) {
@@ -74,34 +74,38 @@ export async function runDoctor(): Promise<void> {
     } catch {
       // ignore
     }
-    console.log(`  ✓ nmap ${version ? `(${version})` : "installed"}`);
+    process.stdout.write(
+      `  ✓ nmap ${version ? `(${version})` : "installed"}\n`,
+    );
   } else {
-    console.log("  ✗ nmap — not found (recommended for network scanning)");
+    process.stdout.write(
+      "  ✗ nmap — not found (recommended for network scanning)\n",
+    );
   }
 
-  console.log();
+  process.stdout.write("\n");
 
   // --- API key check ---
-  console.log("AI Providers");
-  console.log("------------");
+  process.stdout.write("AI Providers\n");
+  process.stdout.write("------------\n");
 
   const apiKeys = checkApiKeys();
   const anyConfigured = apiKeys.some((k) => k.configured);
 
   for (const key of apiKeys) {
     const icon = key.configured ? "✓" : "·";
-    console.log(`  ${icon} ${key.provider}`);
+    process.stdout.write(`  ${icon} ${key.provider}\n`);
   }
 
   if (!anyConfigured) {
-    console.log();
-    console.log(
-      "  No AI provider configured. Set at least one API key to get started:",
+    process.stdout.write("\n");
+    process.stdout.write(
+      "  No AI provider configured. Set at least one API key to get started:\n",
     );
-    console.log("    export ANTHROPIC_API_KEY=your-key-here");
+    process.stdout.write("    export ANTHROPIC_API_KEY=your-key-here\n");
   }
 
-  console.log();
+  process.stdout.write("\n");
 
   // --- Offer to install nmap ---
   if (!nmapInstalled) {
@@ -111,27 +115,27 @@ export async function runDoctor(): Promise<void> {
         `Install nmap via ${pm.name}? (${pm.installCmd}) [y/N] `,
       );
       if (/^y(es)?$/i.test(answer)) {
-        console.log();
+        process.stdout.write("\n");
         const result = spawnSync(pm.installCmd, {
           stdio: "inherit",
           shell: true,
         });
-        console.log();
+        process.stdout.write("\n");
         if (result.status === 0) {
-          console.log("✓ nmap installed successfully!");
+          process.stdout.write("✓ nmap installed successfully!\n");
         } else {
-          console.log("✗ Installation failed. You can install manually:");
-          console.log(`    ${pm.installCmd}`);
+          process.stdout.write("✗ Installation failed. You can install manually:\n");
+          process.stdout.write(`    ${pm.installCmd}\n`);
         }
       } else {
-        console.log("  Skipped nmap installation.");
+        process.stdout.write("  Skipped nmap installation.\n");
       }
     } else {
-      console.log(
-        "  No supported package manager found. Install nmap manually:",
+      process.stdout.write(
+        "  No supported package manager found. Install nmap manually:\n",
       );
-      console.log("    https://nmap.org/download.html");
+      process.stdout.write("    https://nmap.org/download.html\n");
     }
-    console.log();
+    process.stdout.write("\n");
   }
 }

--- a/src/core/findings/registry.ts
+++ b/src/core/findings/registry.ts
@@ -368,10 +368,6 @@ export class FindingsRegistry {
 
     const files = readdirSync(findingsPath).filter((f) => f.endsWith(".json"));
 
-    console.log(
-      `[FindingsRegistry.fromDirectory] path=${findingsPath}, jsonFiles=${files.length}`,
-    );
-
     for (const file of files) {
       try {
         const raw = readFileSync(join(findingsPath, file), "utf-8");
@@ -382,24 +378,11 @@ export class FindingsRegistry {
           typeof finding.endpoint === "string"
         ) {
           registry.indexFinding(finding);
-          console.log(
-            `[FindingsRegistry.fromDirectory]   indexed: "${finding.title}" endpoint="${finding.endpoint}" (file=${file})`,
-          );
-        } else {
-          console.log(
-            `[FindingsRegistry.fromDirectory]   skipped (missing title/endpoint): file=${file}`,
-          );
         }
       } catch {
-        console.log(
-          `[FindingsRegistry.fromDirectory]   skipped (malformed): file=${file}`,
-        );
+        // Malformed finding file — skip silently
       }
     }
-
-    console.log(
-      `[FindingsRegistry.fromDirectory] Registry initialized: ${registry.size} findings indexed`,
-    );
 
     return registry;
   }
@@ -467,30 +450,17 @@ export class FindingsRegistry {
    * **not** added to the registry.
    */
   async register(finding: Finding): Promise<DuplicateCheckResult> {
-    console.log(
-      `[FindingsRegistry.register] Checking: "${finding.title}" endpoint="${finding.endpoint}"`,
-    );
-
     // -- Fast path: Tier 1+2 inside the mutex ----------------------------
     const fastResult = await new Promise<DuplicateCheckResult | null>(
       (resolve) => {
         this.mutex = this.mutex.then(() => {
           const check = this.isDuplicate(finding);
           if (check.duplicate) {
-            console.log(
-              `[FindingsRegistry.register] DUPLICATE (${check.matchType}): "${finding.title}" matched="${check.matchedFinding?.title}"`,
-            );
             resolve(check);
           } else if (!this.model || this.findings.length === 0) {
             this.indexFinding(finding);
-            console.log(
-              `[FindingsRegistry.register] UNIQUE (Tier 1+2, no LLM needed): "${finding.title}" — registry size=${this.size}`,
-            );
             resolve({ duplicate: false });
           } else {
-            console.log(
-              `[FindingsRegistry.register] Tier 1+2 pass — proceeding to Tier 3 LLM check for "${finding.title}"`,
-            );
             resolve(null);
           }
         });
@@ -506,15 +476,10 @@ export class FindingsRegistry {
     try {
       semanticResult = await this.semanticDedup(finding, snapshot);
     } catch {
-      console.log(
-        `[FindingsRegistry.register] Tier 3 LLM error for "${finding.title}" — falling back to Tier 1+2 only`,
-      );
+      // Tier 3 LLM error — fall back to Tier 1+2 only
     }
 
     if (semanticResult.duplicate) {
-      console.log(
-        `[FindingsRegistry.register] DUPLICATE (semantic/Tier 3): "${finding.title}" matched="${semanticResult.matchedFinding?.title}"`,
-      );
       return semanticResult;
     }
 
@@ -523,15 +488,9 @@ export class FindingsRegistry {
       this.mutex = this.mutex.then(() => {
         const recheck = this.isDuplicate(finding);
         if (recheck.duplicate) {
-          console.log(
-            `[FindingsRegistry.register] DUPLICATE (race re-check, ${recheck.matchType}): "${finding.title}" matched="${recheck.matchedFinding?.title}"`,
-          );
           resolve(recheck);
         } else {
           this.indexFinding(finding);
-          console.log(
-            `[FindingsRegistry.register] UNIQUE (all tiers passed): "${finding.title}" — registry size=${this.size}`,
-          );
           resolve({ duplicate: false });
         }
       });
@@ -630,9 +589,6 @@ export class FindingsRegistry {
         abortSignal: this.abortSignal,
       });
     } catch {
-      console.log(
-        `[FindingsRegistry.groupByRootCause] LLM error — skipping root-cause grouping`,
-      );
       return [];
     }
 

--- a/src/core/integrations/wandb/client.ts
+++ b/src/core/integrations/wandb/client.ts
@@ -6,6 +6,7 @@
  */
 
 import type { TraceRecord } from "../../agents/offSecAgent";
+import { writeErrorLog } from "../../logger";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -47,8 +48,9 @@ async function initWeave(
 
   if (weaveReady) {
     if (cachedConfigKey && cachedConfigKey !== configKey) {
-      console.warn(
-        `[wandb] initWeave called with ${configKey} but already initialized with ${cachedConfigKey}. Weave supports one project per process.`,
+      writeErrorLog(
+        `initWeave called with ${configKey} but already initialized with ${cachedConfigKey}. Weave supports one project per process.`,
+        "WANDB",
       );
     }
     return weaveReady;
@@ -74,7 +76,7 @@ async function initWeave(
       await weave.init(configKey);
       return weave;
     } catch (e) {
-      console.error("[wandb] Weave init failed:", e);
+      writeErrorLog(e, "WANDB");
       weaveReady = null;
       cachedConfigKey = null;
       return null;
@@ -129,10 +131,7 @@ export async function createWeaveTracer(config: WandbConfig): Promise<{
     logRecord: (record: TraceRecord, sessionId: string) => {
       logTraceRecord({ record, sessionId }).catch((e) => {
         if (!logErrorLogged) {
-          console.error(
-            "[wandb] Record upload failed (suppressing future warnings):",
-            e,
-          );
+          writeErrorLog(e, "WANDB_UPLOAD");
           logErrorLogged = true;
         }
       });
@@ -145,8 +144,9 @@ export async function createWeaveTracer(config: WandbConfig): Promise<{
           }
         ).getGlobalClient;
         if (!getClient) {
-          console.warn(
-            "[wandb] getGlobalClient not found — flush skipped. Check weave SDK version.",
+          writeErrorLog(
+            "getGlobalClient not found — flush skipped. Check weave SDK version.",
+            "WANDB",
           );
           return;
         }
@@ -155,7 +155,7 @@ export async function createWeaveTracer(config: WandbConfig): Promise<{
           await (client.waitForBatchProcessing as () => Promise<void>)();
         }
       } catch (e) {
-        console.error("[wandb] Flush failed:", e);
+        writeErrorLog(e, "WANDB_FLUSH");
       }
     },
   };

--- a/src/core/logger/index.ts
+++ b/src/core/logger/index.ts
@@ -10,11 +10,10 @@ import path from "path";
 import { type SessionInfo, sessions } from "../session";
 
 export enum LogLevel {
-  INFO = "INFO",
-  ERROR = "ERROR",
   DEBUG = "DEBUG",
+  INFO = "INFO",
   WARN = "WARN",
-  LOG = "LOG",
+  ERROR = "ERROR",
 }
 
 const ERROR_LOG_PATH = path.join(os.homedir(), ".pensar", "error.log");
@@ -111,55 +110,34 @@ export class Logger {
     try {
       appendFileSync(this.logFilePath, logEntry, "utf8");
     } catch (error) {
-      console.error(`Failed to write to log file: ${error}`);
+      writeErrorLog(error, "LOGGER");
     }
   }
 
-  /**
-   * Log a general message
-   */
   public log(message: string): void {
-    this.writeLog(LogLevel.LOG, message);
+    this.writeLog(LogLevel.INFO, message);
   }
 
-  /**
-   * Log an info message
-   */
   public info(message: string): void {
     this.writeLog(LogLevel.INFO, message);
   }
 
-  /**
-   * Log an error message
-   */
   public error(message: string): void {
     this.writeLog(LogLevel.ERROR, message);
   }
 
-  /**
-   * Log a debug message
-   */
   public debug(message: string): void {
     this.writeLog(LogLevel.DEBUG, message);
   }
 
-  /**
-   * Log a warning message
-   */
   public warn(message: string): void {
     this.writeLog(LogLevel.WARN, message);
   }
 
-  /**
-   * Get the current log file path
-   */
   public getLogFilePath(): string {
     return this.logFilePath;
   }
 
-  /**
-   * Get the session associated with this logger
-   */
   public getSession(): SessionInfo {
     return this.session;
   }

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -4,11 +4,11 @@ import os from "os";
 import path from "path";
 import z from "zod";
 import { generateRandomName, generateSessionName } from "../../util/name";
-import { writeErrorLog } from "../logger";
 import type { AIAuthConfig, AIModel } from "../ai";
 import { CredentialManager } from "../credentials";
 import * as Identifier from "../id/id";
 import { getCurrentVersion } from "../installation";
+import { writeErrorLog } from "../logger";
 import type { Message } from "../messages/types";
 import { RateLimiter } from "../services/rateLimiter";
 import * as Storage from "../storage";
@@ -320,7 +320,6 @@ async function createSessionDirs(input: CreateExecutionInput): Promise<void> {
   // Write README.md
   const readme = generateSessionReadme(session);
   await Storage.writeRaw(["sessions", session.id, "README.md"], readme);
-
 }
 
 /**

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -4,6 +4,7 @@ import os from "os";
 import path from "path";
 import z from "zod";
 import { generateRandomName, generateSessionName } from "../../util/name";
+import { writeErrorLog } from "../logger";
 import type { AIAuthConfig, AIModel } from "../ai";
 import { CredentialManager } from "../credentials";
 import * as Identifier from "../id/id";
@@ -320,7 +321,6 @@ async function createSessionDirs(input: CreateExecutionInput): Promise<void> {
   const readme = generateSessionReadme(session);
   await Storage.writeRaw(["sessions", session.id, "README.md"], readme);
 
-  console.info("created session", session.id);
 }
 
 /**
@@ -600,7 +600,7 @@ const remove = async (input: z.output<typeof RemoveInput>) => {
     const fsp = await import("fs/promises");
     await fsp.rm(sessionDir, { recursive: true, force: true });
   } catch (e) {
-    console.error(e);
+    writeErrorLog(e, "SESSION_REMOVE");
   }
 };
 
@@ -704,7 +704,7 @@ export async function loadOperatorState(
 
     return parsed as PersistedOperatorState;
   } catch (error) {
-    console.error("Error loading operator state:", error);
+    writeErrorLog(error, "OPERATOR_STATE");
     return null;
   }
 }

--- a/src/core/session/loader.ts
+++ b/src/core/session/loader.ts
@@ -10,6 +10,7 @@
 
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
+import { writeErrorLog } from "../logger";
 import { REPORT_FILENAME_MD } from "../report";
 import type { SessionInfo } from "./index";
 import { loadSubagents, type UIMessage, type UISubagent } from "./persistence";
@@ -58,7 +59,7 @@ export function loadAttackSurfaceResults(
   try {
     return JSON.parse(readFileSync(resultsPath, "utf-8"));
   } catch (e) {
-    console.error("Failed to load attack surface results:", e);
+    writeErrorLog(e, "SESSION_LOADER");
     return null;
   }
 }
@@ -135,7 +136,7 @@ function createDiscoveryFromLogs(
       status: "completed",
     };
   } catch (e) {
-    console.error("Failed to parse logs:", e);
+    writeErrorLog(e, "SESSION_LOADER");
     return null;
   }
 }

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -15,6 +15,7 @@ import {
   writeFileSync,
 } from "fs";
 import { join } from "path";
+import { writeErrorLog } from "../logger";
 import type { SessionInfo } from "./index";
 
 export type { SessionInfo };
@@ -614,7 +615,7 @@ export function loadSubagents(rootPath: string): UISubagent[] {
           status,
         });
       } catch (e) {
-        console.error(`Failed to load subagent file ${file}:`, e);
+        writeErrorLog(e, "PERSISTENCE");
       }
     }
 
@@ -696,7 +697,7 @@ export function loadSubagents(rootPath: string): UISubagent[] {
         }
       }
     } catch (e) {
-      console.error("Failed to load agent manifest:", e);
+      writeErrorLog(e, "PERSISTENCE");
     }
   }
 

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -52,6 +52,7 @@ import {
   updateManifestEntryStatus,
   writeAgentManifest,
 } from "../session/persistence";
+import { writeErrorLog } from "../logger";
 import { runWithBoundedConcurrency } from "../utils/concurrency";
 import { createThreatModelPrompt } from "../utils/prompt";
 import {
@@ -273,9 +274,7 @@ export async function runPentestSwarm(
           await planAgent.consume();
         } catch (planErr) {
           // Plan phase failure is non-fatal — execution agent proceeds without plan
-          console.error(
-            `[pentest-swarm] Plan phase failed for ${subagentId}: ${planErr}`,
-          );
+          writeErrorLog(planErr, "PENTEST_SWARM");
         }
       }
 

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -28,6 +28,7 @@ import type {
 } from "../ai";
 import type { AgentEventBus } from "../eventBus";
 import { FindingsRegistry } from "../findings/registry";
+import { writeErrorLog } from "../logger";
 import {
   buildPentestReport,
   REPORT_FILENAME_JSON,
@@ -52,7 +53,6 @@ import {
   updateManifestEntryStatus,
   writeAgentManifest,
 } from "../session/persistence";
-import { writeErrorLog } from "../logger";
 import { runWithBoundedConcurrency } from "../utils/concurrency";
 import { createThreatModelPrompt } from "../utils/prompt";
 import {

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -34,8 +34,8 @@ import type {
   OpenAIReasoningEffort,
 } from "../ai";
 import type { AgentEventBus } from "../eventBus";
-import { writeErrorLog } from "../logger";
 import { mapAppWithSurface } from "../integrations/surface";
+import { writeErrorLog } from "../logger";
 import type { SessionInfo } from "../session";
 import { runWithBoundedConcurrency } from "../utils/concurrency";
 
@@ -360,10 +360,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
         parentSubagentId: appNodeId,
       });
     } catch (error) {
-      writeErrorLog(
-        error instanceof Error ? error : String(error),
-        "WHITEBOX",
-      );
+      writeErrorLog(error instanceof Error ? error : String(error), "WHITEBOX");
 
       appAnyTaskFailed.set(app.name, true);
       eventBus?.emit("subagent-complete", {
@@ -576,9 +573,7 @@ function readAppsFromAssetsDirectory(
   for (const entry of entries) {
     const entryPath = join(assetsPath, entry);
     if (!statSync(entryPath).isDirectory()) {
-      process.stderr.write(
-        `[readAssets] Skipping non-directory: ${entry}\n`,
-      );
+      process.stderr.write(`[readAssets] Skipping non-directory: ${entry}\n`);
       continue;
     }
 

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -34,6 +34,7 @@ import type {
   OpenAIReasoningEffort,
 } from "../ai";
 import type { AgentEventBus } from "../eventBus";
+import { writeErrorLog } from "../logger";
 import { mapAppWithSurface } from "../integrations/surface";
 import type { SessionInfo } from "../session";
 import { runWithBoundedConcurrency } from "../utils/concurrency";
@@ -191,8 +192,8 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     excludeTools: ["document_endpoint"],
   });
 
-  console.log(
-    `[whitebox-workflow] Phase 1: discovering apps in ${codebasePath}${domains?.length ? ` (${domains.length} known domains)` : ""}`,
+  process.stderr.write(
+    `[whitebox-workflow] Phase 1: discovering apps in ${codebasePath}${domains?.length ? ` (${domains.length} known domains)` : ""}\n`,
   );
 
   // Held open until Phase 2 finishes so per-app synthetic nodes can nest under it.
@@ -206,17 +207,18 @@ export async function runWhiteboxAttackSurfaceWorkflow(
 
   const appsResult = await appsAgent.consume();
 
-  console.log(
+  process.stderr.write(
     `[whitebox-workflow] Phase 1 complete: ${appsResult?.apps.length ?? 0} apps discovered` +
       (appsResult
         ? ` (repoType=${appsResult.repoType}, packageManager=${appsResult.packageManager})`
-        : " (no result returned)"),
+        : " (no result returned)") +
+      "\n",
   );
 
   if (appsResult?.apps.length) {
     for (const app of appsResult.apps) {
-      console.log(
-        `[whitebox-workflow]   app: "${app.name}" type=${app.type} framework="${app.framework}" location="${app.location}"`,
+      process.stderr.write(
+        `[whitebox-workflow]   app: "${app.name}" type=${app.type} framework="${app.framework}" location="${app.location}"\n`,
       );
     }
   }
@@ -268,8 +270,8 @@ export async function runWhiteboxAttackSurfaceWorkflow(
   //          is HTTP-route-focused and doesn't enumerate cloud assets.
   // =========================================================================
 
-  console.log(
-    `[whitebox-workflow] Phase 2: surfaceIntegrationEnabled=${surfaceIntegrationEnabled}`,
+  process.stderr.write(
+    `[whitebox-workflow] Phase 2: surfaceIntegrationEnabled=${surfaceIntegrationEnabled}\n`,
   );
 
   const NON_SERVICE_TYPES = ["cloud_resource", "storage", "database"];
@@ -280,8 +282,8 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     NON_SERVICE_TYPES.includes(app.type),
   );
 
-  console.log(
-    `[whitebox-workflow] Phase 2: ${serviceApps.length} service apps (surface or fallback per app), ${cloudApps.length} cloud resources → ${appsResult.apps.length} total apps`,
+  process.stderr.write(
+    `[whitebox-workflow] Phase 2: ${serviceApps.length} service apps (surface or fallback per app), ${cloudApps.length} cloud resources → ${appsResult.apps.length} total apps\n`,
   );
 
   const totalApps = appsResult.apps.length;
@@ -315,8 +317,8 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     const subagentId = `${type}-${app.name}`;
     const appNodeId = appNodeIdFor(app.name);
 
-    console.log(
-      `[whitebox-workflow] Phase 2: spawning agent id="${subagentId}" parent="${appNodeId}" (app="${app.name}", type=${type}, appType=${app.type})`,
+    process.stderr.write(
+      `[whitebox-workflow] Phase 2: spawning agent id="${subagentId}" parent="${appNodeId}" (app="${app.name}", type=${type}, appType=${app.type})\n`,
     );
 
     eventBus?.emit("subagent-spawn", {
@@ -348,8 +350,8 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     try {
       await agent.consume();
 
-      console.log(
-        `[whitebox-workflow] Phase 2: agent "${subagentId}" completed`,
+      process.stderr.write(
+        `[whitebox-workflow] Phase 2: agent "${subagentId}" completed\n`,
       );
 
       eventBus?.emit("subagent-complete", {
@@ -358,9 +360,9 @@ export async function runWhiteboxAttackSurfaceWorkflow(
         parentSubagentId: appNodeId,
       });
     } catch (error) {
-      console.error(
-        `[whitebox-workflow] Phase 2: agent "${subagentId}" FAILED:`,
-        error instanceof Error ? error.message : String(error),
+      writeErrorLog(
+        error instanceof Error ? error : String(error),
+        "WHITEBOX",
       );
 
       appAnyTaskFailed.set(app.name, true);
@@ -403,8 +405,8 @@ export async function runWhiteboxAttackSurfaceWorkflow(
           // Cloud resources: surface doesn't enumerate these — always fallback.
           await spawnCloudResourceAgent(app);
         } else if (!surfaceIntegrationEnabled) {
-          console.log(
-            `[whitebox] ${app.name}: legacy (surfaceIntegrationEnabled=false)`,
+          process.stderr.write(
+            `[whitebox] ${app.name}: legacy (surfaceIntegrationEnabled=false)\n`,
           );
           await Promise.all([
             spawnPagesAgent(app),
@@ -417,8 +419,8 @@ export async function runWhiteboxAttackSurfaceWorkflow(
             { isSingleAppRepo: serviceApps.length === 1 },
           );
           if (surfaceResult.mode === "surface") {
-            console.log(
-              `[whitebox] ${app.name}: surface-driven (${surfaceResult.endpoints.length} endpoints, frameworks=${surfaceResult.frameworks.join(",")})`,
+            process.stderr.write(
+              `[whitebox] ${app.name}: surface-driven (${surfaceResult.endpoints.length} endpoints, frameworks=${surfaceResult.frameworks.join(",")})\n`,
             );
 
             await runAppEndpointDocumentation({
@@ -439,8 +441,8 @@ export async function runWhiteboxAttackSurfaceWorkflow(
               parentSubagentId: appNodeId,
             });
           } else {
-            console.log(
-              `[whitebox] ${app.name}: fallback (${surfaceResult.reason})`,
+            process.stderr.write(
+              `[whitebox] ${app.name}: fallback (${surfaceResult.reason})\n`,
             );
             await Promise.all([
               spawnPagesAgent(app),
@@ -480,7 +482,9 @@ export async function runWhiteboxAttackSurfaceWorkflow(
   // Phase 3: Read assets directory to build endpoint data
   // =========================================================================
 
-  console.log(`[whitebox-workflow] Phase 3: reading assets from ${assetsPath}`);
+  process.stderr.write(
+    `[whitebox-workflow] Phase 3: reading assets from ${assetsPath}\n`,
+  );
 
   const {
     apps: parsedApps,
@@ -489,8 +493,8 @@ export async function runWhiteboxAttackSurfaceWorkflow(
   } = readAppsFromAssetsDirectory(assetsPath, appsResult);
 
   for (const app of parsedApps) {
-    console.log(
-      `[whitebox-workflow] Phase 3: "${app.name}" → ${app.pages.length} pages, ${app.apiEndpoints.length} API endpoints`,
+    process.stderr.write(
+      `[whitebox-workflow] Phase 3: "${app.name}" → ${app.pages.length} pages, ${app.apiEndpoints.length} API endpoints\n`,
     );
   }
 
@@ -557,20 +561,24 @@ function readAppsFromAssetsDirectory(
   const packageManager = appsDiscovery?.packageManager ?? "unknown";
 
   if (!existsSync(assetsPath)) {
-    console.log(`[readAssets] Assets directory does not exist: ${assetsPath}`);
+    process.stderr.write(
+      `[readAssets] Assets directory does not exist: ${assetsPath}\n`,
+    );
     return { apps: [], repoType, packageManager };
   }
 
   const entries = readdirSync(assetsPath);
-  console.log(
-    `[readAssets] Found ${entries.length} entries in ${assetsPath}: [${entries.join(", ")}]`,
+  process.stderr.write(
+    `[readAssets] Found ${entries.length} entries in ${assetsPath}: [${entries.join(", ")}]\n`,
   );
   const apps: App[] = [];
 
   for (const entry of entries) {
     const entryPath = join(assetsPath, entry);
     if (!statSync(entryPath).isDirectory()) {
-      console.log(`[readAssets] Skipping non-directory: ${entry}`);
+      process.stderr.write(
+        `[readAssets] Skipping non-directory: ${entry}\n`,
+      );
       continue;
     }
 
@@ -583,13 +591,16 @@ function readAppsFromAssetsDirectory(
           readFileSync(appJsonPath, "utf-8"),
         ) as AppMetadata;
       } catch {
-        console.warn(
+        writeErrorLog(
           `[readAssets] Skipping app folder with unreadable app.json: ${entry}`,
+          "WHITEBOX",
         );
         continue;
       }
     } else {
-      console.log(`[readAssets] Skipping folder without app.json: ${entry}`);
+      process.stderr.write(
+        `[readAssets] Skipping folder without app.json: ${entry}\n`,
+      );
       continue;
     }
 
@@ -600,8 +611,8 @@ function readAppsFromAssetsDirectory(
       (f) => f.endsWith(".json") && f !== "app.json",
     );
 
-    console.log(
-      `[readAssets] App "${metadata.name}" (${entry}): ${assetFiles.length} asset files`,
+    process.stderr.write(
+      `[readAssets] App "${metadata.name}" (${entry}): ${assetFiles.length} asset files\n`,
     );
 
     let parseFailed = 0;
@@ -612,8 +623,8 @@ function readAppsFromAssetsDirectory(
 
         const endpoint = assetRecordToEndpoint(data);
         if (!endpoint) {
-          console.log(
-            `[readAssets]   ${file}: failed schema validation (assetRecordToEndpoint returned null)`,
+          process.stderr.write(
+            `[readAssets]   ${file}: failed schema validation (assetRecordToEndpoint returned null)\n`,
           );
           parseFailed++;
           continue;
@@ -625,15 +636,16 @@ function readAppsFromAssetsDirectory(
           apiEndpoints.push(endpoint);
         }
       } catch {
-        console.warn(
+        writeErrorLog(
           `[readAssets] Skipping unreadable asset file: ${entry}/${file}`,
+          "WHITEBOX",
         );
         parseFailed++;
       }
     }
 
-    console.log(
-      `[readAssets] App "${metadata.name}": ${pages.length} pages, ${apiEndpoints.length} API endpoints, ${parseFailed} failed`,
+    process.stderr.write(
+      `[readAssets] App "${metadata.name}": ${pages.length} pages, ${apiEndpoints.length} API endpoints, ${parseFailed} failed\n`,
     );
 
     apps.push({
@@ -1041,10 +1053,7 @@ export async function runIncrementalWhiteboxAttackSurfaceWorkflow(
     );
     writeFileSync(diffPath, diff, "utf-8");
   } catch (error) {
-    console.error(
-      "Failed to generate git diff, falling back to full recon:",
-      error,
-    );
+    writeErrorLog(error, "WHITEBOX");
     return runWhiteboxAttackSurfaceWorkflow(input);
   }
 
@@ -1109,8 +1118,8 @@ export async function runIncrementalWhiteboxAttackSurfaceWorkflow(
     }
   }
 
-  console.log(
-    `Incremental recon: wrote ${preloadedCount} existing endpoint assets to ${assetsPath}`,
+  process.stderr.write(
+    `Incremental recon: wrote ${preloadedCount} existing endpoint assets to ${assetsPath}\n`,
   );
 
   // =========================================================================
@@ -1161,8 +1170,8 @@ export async function runIncrementalWhiteboxAttackSurfaceWorkflow(
 
   const agentResult = await agent.consume();
 
-  console.log(
-    `Incremental agent finished: ${agentResult?.summary ?? "no summary"}`,
+  process.stderr.write(
+    `Incremental agent finished: ${agentResult?.summary ?? "no summary"}\n`,
   );
 
   // =========================================================================

--- a/src/tui/components/chat/loading-indicator.tsx
+++ b/src/tui/components/chat/loading-indicator.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useEffect, useRef, useState } from "react";
+import { writeErrorLog } from "../../../core/logger";
 import { INTERNAL_ID_PATTERN } from "../../../core/operator";
 import { useTheme } from "../../theme";
 
@@ -78,8 +79,9 @@ export function LoadingIndicator({
           !warnedIdsRef.current.has(action)
         ) {
           warnedIdsRef.current.add(action);
-          console.warn(
-            `[LoadingIndicator] internal correlation ID leaked into action prop: ${action}`,
+          writeErrorLog(
+            `internal correlation ID leaked into action prop: ${action}`,
+            "LOADING_INDICATOR",
           );
         }
         if (toolName) {

--- a/src/tui/components/commands/sessions-display.tsx
+++ b/src/tui/components/commands/sessions-display.tsx
@@ -1,6 +1,7 @@
 import type { ScrollBoxRenderable } from "@opentui/core";
 import { useKeyboard } from "@opentui/react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { writeErrorLog } from "../../../core/logger";
 import { REPORT_FILENAME_MD } from "../../../core/report";
 import { sessions } from "../../../core/session";
 import { Dialog } from "../../context/dialog";
@@ -103,7 +104,7 @@ export default function SessionsDisplay({ onClose }: SessionsDisplayProps) {
       toast("Session deleted");
       // selectedIndex clamping handled by the useEffect above after re-render
     } catch (error) {
-      console.error("Error deleting session:", error);
+      writeErrorLog(error, "SESSION_DISPLAY");
       toast("Error deleting session", "error");
     }
   }

--- a/src/tui/components/error-boundary.tsx
+++ b/src/tui/components/error-boundary.tsx
@@ -31,7 +31,6 @@ class ErrorBoundaryInner extends React.Component<
   }
 
   override componentDidCatch(error: Error) {
-    console.error("[ErrorBoundary]", error);
     writeErrorLog(error, "TUI");
     this.props.onError(error.message);
 

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -38,6 +38,7 @@ import {
   modelSupportsThinking,
 } from "../../../core/ai";
 import { runOffensiveSecurityAgent } from "../../../core/api";
+import { writeErrorLog } from "../../../core/logger";
 import { attachWandbToEventBus } from "../../../core/integrations/wandb/upload";
 import type { OperatorMode, PendingApproval } from "../../../core/operator";
 import {
@@ -1004,7 +1005,7 @@ export default function OperatorDashboard({
           subagentHelpers.appendText(d.subagentId, `\nError: ${errMsg}\n`);
           return;
         }
-        console.error("Agent error:", d.error);
+        writeErrorLog(d.error, "OPERATOR");
         // Clear pending-questions state so an error after the tool-call event
         // doesn't leave the questions form stuck over a failed conversation.
         pendingToolCallIdRef.current = null;
@@ -1196,7 +1197,7 @@ export default function OperatorDashboard({
         if (wandbCleanup) return;
         const cleanup = await attachWandbToEventBus(s, eventBus).catch(
           (e: unknown) => {
-            console.error("[wandb] Attach failed:", e);
+            writeErrorLog(e, "WANDB_ATTACH");
             return null;
           },
         );
@@ -1360,7 +1361,7 @@ export default function OperatorDashboard({
         if (wandbCleanup) {
           const fn = wandbCleanup as () => Promise<void>;
           await fn().catch((e: unknown) =>
-            console.error("[wandb] Flush failed:", e),
+            writeErrorLog(e, "WANDB_FLUSH"),
           );
         }
         if (gen === generationRef.current) {
@@ -1909,7 +1910,7 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
     if (sid) {
       sessions
         .updateOperatorSettings(sid, { initialMode: next })
-        .catch((e) => console.error("[operator] Failed to persist mode:", e));
+        .catch((e) => writeErrorLog(e, "OPERATOR_PERSIST"));
     }
   }, []);
 

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -38,8 +38,8 @@ import {
   modelSupportsThinking,
 } from "../../../core/ai";
 import { runOffensiveSecurityAgent } from "../../../core/api";
-import { writeErrorLog } from "../../../core/logger";
 import { attachWandbToEventBus } from "../../../core/integrations/wandb/upload";
+import { writeErrorLog } from "../../../core/logger";
 import type { OperatorMode, PendingApproval } from "../../../core/operator";
 import {
   ApprovalGate,
@@ -1360,9 +1360,7 @@ export default function OperatorDashboard({
 
         if (wandbCleanup) {
           const fn = wandbCleanup as () => Promise<void>;
-          await fn().catch((e: unknown) =>
-            writeErrorLog(e, "WANDB_FLUSH"),
-          );
+          await fn().catch((e: unknown) => writeErrorLog(e, "WANDB_FLUSH"));
         }
         if (gen === generationRef.current) {
           setStatus(pendingToolCallIdRef.current ? "waiting" : "idle");

--- a/src/tui/context/route.tsx
+++ b/src/tui/context/route.tsx
@@ -97,7 +97,6 @@ export function RouteProvider({ children }: RouteProviderProps) {
     () => ({
       data: route,
       navigate: (newRoute: Route) => {
-        console.log("navigating to:", newRoute);
         setRoute(newRoute);
       },
     }),

--- a/src/tui/context/session.tsx
+++ b/src/tui/context/session.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { writeErrorLog } from "../../core/logger";
 import { type SessionInfo, sessions } from "../../core/session";
 
 type SessionContext = {
@@ -34,8 +35,7 @@ export function SessionProvider({ children, session }: SessionProviderProps) {
           setActiveSession(_session);
           return _session;
         } catch (e) {
-          // TODO: display error to user
-          console.error("Error loading session", e);
+          writeErrorLog(e, "SESSION_CONTEXT");
           return null;
         }
       },

--- a/src/tui/hooks/use-sessions-list.ts
+++ b/src/tui/hooks/use-sessions-list.ts
@@ -6,6 +6,7 @@
 import { existsSync, readdirSync } from "fs";
 import { join } from "path";
 import { useCallback, useEffect, useState } from "react";
+import { writeErrorLog } from "../../core/logger";
 import { REPORT_FILENAME_MD } from "../../core/report";
 import {
   list as listSessions,
@@ -77,7 +78,7 @@ export function useSessionsList() {
       enriched.sort((a, b) => b.time.updated - a.time.updated);
       setAllSessions(enriched);
     } catch (error) {
-      console.error("Error loading sessions:", error);
+      writeErrorLog(error, "SESSION_LIST");
     } finally {
       setLoading(false);
     }

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -702,7 +702,9 @@ async function main() {
   process.on("uncaughtException", (err) => {
     cleanupTerminalFocusMode();
     renderer.destroy();
-    process.stderr.write(`Uncaught exception: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+    process.stderr.write(
+      `Uncaught exception: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+    );
     writeErrorLog(err, "UNCAUGHT");
     process.exit(1);
   });
@@ -710,7 +712,9 @@ async function main() {
   process.on("unhandledRejection", (reason) => {
     cleanupTerminalFocusMode();
     renderer.destroy();
-    process.stderr.write(`Unhandled rejection: ${reason instanceof Error ? reason.stack ?? reason.message : String(reason)}\n`);
+    process.stderr.write(
+      `Unhandled rejection: ${reason instanceof Error ? (reason.stack ?? reason.message) : String(reason)}\n`,
+    );
     writeErrorLog(reason, "UNHANDLED_REJECTION");
     process.exit(1);
   });

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -702,7 +702,7 @@ async function main() {
   process.on("uncaughtException", (err) => {
     cleanupTerminalFocusMode();
     renderer.destroy();
-    console.error("Uncaught exception:", err);
+    process.stderr.write(`Uncaught exception: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
     writeErrorLog(err, "UNCAUGHT");
     process.exit(1);
   });
@@ -710,7 +710,7 @@ async function main() {
   process.on("unhandledRejection", (reason) => {
     cleanupTerminalFocusMode();
     renderer.destroy();
-    console.error("Unhandled rejection:", reason);
+    process.stderr.write(`Unhandled rejection: ${reason instanceof Error ? reason.stack ?? reason.message : String(reason)}\n`);
     writeErrorLog(reason, "UNHANDLED_REJECTION");
     process.exit(1);
   });

--- a/src/tui/terminal-focus.ts
+++ b/src/tui/terminal-focus.ts
@@ -11,6 +11,7 @@
  */
 
 import type { CliRenderer } from "@opentui/core";
+import { writeErrorLog } from "../core/logger";
 
 export interface TerminalFocusOptions {
   /** Callback to re-focus the prompt input when terminal regains focus */
@@ -36,7 +37,7 @@ export function setupTerminalFocusHandling(
   const { onTerminalFocus, debug = false } = options;
 
   const log = (...args: unknown[]) => {
-    if (debug) console.error("[TerminalFocus]", ...args);
+    if (debug) writeErrorLog(args.map(String).join(" "), "TERMINAL_FOCUS");
   };
 
   // Enable bracketed focus mode

--- a/src/tui/theme/registry.ts
+++ b/src/tui/theme/registry.ts
@@ -19,7 +19,10 @@ export function registerTheme(theme: ThemeDefinition): void {
 export function getTheme(name: string): ThemeDefinition {
   const theme = themes.get(name);
   if (!theme) {
-    writeErrorLog(`Theme "${name}" not found, falling back to default`, "THEME");
+    writeErrorLog(
+      `Theme "${name}" not found, falling back to default`,
+      "THEME",
+    );
     return themes.get(DEFAULT_THEME_NAME)!;
   }
   return theme;

--- a/src/tui/theme/registry.ts
+++ b/src/tui/theme/registry.ts
@@ -5,6 +5,7 @@
  * Both built-in and custom themes are registered here.
  */
 
+import { writeErrorLog } from "../../core/logger";
 import type { ThemeDefinition } from "./types";
 
 const themes = new Map<string, ThemeDefinition>();
@@ -18,7 +19,7 @@ export function registerTheme(theme: ThemeDefinition): void {
 export function getTheme(name: string): ThemeDefinition {
   const theme = themes.get(name);
   if (!theme) {
-    console.warn(`Theme "${name}" not found, falling back to default`);
+    writeErrorLog(`Theme "${name}" not found, falling back to default`, "THEME");
     return themes.get(DEFAULT_THEME_NAME)!;
   }
   return theme;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Prevents debug `console.log` from shipping to production by enabling Biome's `noConsole` lint rule for all of `src/`. All 510 violations across ~60 files have been resolved.

**Biome config changes:**
- Added `suspicious/noConsole: "error"` to `biome.jsonc`
- Exempted test files (`*.test.ts`, `*.test.tsx`, `*.test-*.ts`) via override
- Exempted non-src files (scripts, root-level demos) via override

**How console.* calls were replaced:**

| Category | Replacement | Files affected |
|----------|------------|----------------|
| CLI user-facing output (`src/cli/`, `src/cli.ts`) | `process.stdout.write` / `process.stderr.write` | 9 files |
| Headless API output (`src/core/api/`) | `process.stdout.write` / `process.stderr.write` | 6 files |
| Diagnostic tool (`src/core/doctor.ts`) | `process.stdout.write` | 1 file |
| Benchmark orchestration | `process.stderr.write` (progress) + `writeErrorLog` (errors) | 6 files |
| Workflow progress | `process.stderr.write` (progress) + `writeErrorLog` (errors) | 2 files |
| Error handling (TUI, core, agents) | `writeErrorLog(error, "SOURCE_TAG")` | ~20 files |
| Debug traces (agent tools, findings registry) | Removed entirely | ~8 files |

**Logger audit:**
- Removed redundant `LogLevel.LOG` (was identical to `LogLevel.INFO`; not a standard level). `Logger.log()` now writes at INFO level.
- Reordered `LogLevel` enum to ascending severity: `DEBUG → INFO → WARN → ERROR`.
- Removed approval gate per-tool-call traces from `offensiveSecurityAgent.ts` — operational debug traces that shouldn't pollute `~/.pensar/error.log`.
- Removed informational session-creation log that was misclassified as an error-level entry.
- Removed verbose findings registry dedup traces (14 `console.log` calls) — development-time debug logging.
- Removed debug delegation traces from `delegateAuth.ts` that logged credential information.
- Cleaned up verbose JSDoc comments from Logger methods — the method signatures are self-documenting.

**Behavior unchanged:** All `process.stdout.write` / `process.stderr.write` calls produce the same output as the original `console.log` / `console.error` calls. Error logging now goes to `~/.pensar/error.log` via `writeErrorLog` instead of stderr, which is a strict improvement for the TUI (stderr output interferes with nothing, but error.log is persistent and searchable).

### How did you verify your code works?

- `bun run lint` — passes with 0 errors (pre-existing warnings only)
- `bun run tsc` — passes with 0 type errors
- `bun run test` — all 1029 tests pass (7 test files skipped = pre-existing integration test skips)
- Verified 0 `noConsole` violations remain via `biome lint src/ --max-diagnostics=2000`
- Verified all remaining `console.*` references in src/ are in JSDoc comments, string literals, or commented-out code (not actual calls)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a091bed9-3d1a-4355-9c6e-607bc19593c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a091bed9-3d1a-4355-9c6e-607bc19593c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

