### PR TITLE
fix: address Bugbot review findings in custom HTTP headers subsystem

### DIFF
--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -208,15 +208,15 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
       const cmdHosts = extractHostsFromCommand(command);
       const inject = applyHeadersToShellCommand(command, ctx.session, cmdHosts);
       if (inject.status === "unknown-tool" && !allow_unprotected) {
-        // Only block when there are actually headers to apply for the
-        // hosts on this command line. `applyHeadersToShellCommand`
-        // returns `unknown-tool` even when no headers are configured.
-        const sampleHost = cmdHosts.find((h) => h.length > 0);
-        const probeUrl = sampleHost ? `https://${sampleHost}` : "";
-        const resolved = probeUrl
-          ? resolveEffectiveHeaders(ctx.session, probeUrl)
-          : null;
-        const hasHeaders = resolved ? Object.keys(resolved).length > 0 : false;
+        // Only block when there are actually headers to apply for at
+        // least one in-scope host on this command line. Check every host
+        // — not just the first — so an out-of-scope host appearing
+        // before an in-scope one doesn't bypass the guard.
+        const hasHeaders = cmdHosts.some((h) => {
+          if (!h) return false;
+          const r = resolveEffectiveHeaders(ctx.session, `https://${h}`);
+          return Object.keys(r).length > 0;
+        });
         if (hasHeaders) {
           const msg =
             "Command rejected: configured custom HTTP headers cannot be injected because the tool is unrecognized or the command is pipelined. " +

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import { z } from "zod";
 import {
   resolveEffectiveHeaders,
+  shellQuote,
   targetFetch,
 } from "../../../http/targetHeaders";
 import { assertUrlInScope, ScopeViolationError } from "./scopeGuard";
@@ -278,7 +279,7 @@ async function executeSandboxHttpRequest(
     // as the `request` layer (wins over global/session/credential).
     const mergedHeaders = resolveEffectiveHeaders(ctx.session, url, headers);
     for (const [key, value] of Object.entries(mergedHeaders)) {
-      curlCommand += ` -H "${key}: ${value}"`;
+      curlCommand += ` -H "${shellQuote(`${key}: ${value}`)}"`;
     }
 
     if (body && ["POST", "PUT", "PATCH"].includes(method)) {

--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -75,11 +75,19 @@ export function redactSecretsInHistoryEntry(entry: string): string {
     if (colon === -1) return entry;
     return `${entry.slice(0, entry.length - payload.length)}${payload.slice(0, colon)}: <redacted>`;
   }
-  return entry.replace(
-    /(--header(?:s-from)?[=\s]+)("?)([^"\s]+:)\s*[^"\s]+("?)/gi,
-    (_, prefix, openQuote, namePart, closeQuote) =>
-      `${prefix}${openQuote}${namePart} <redacted>${closeQuote}`,
-  );
+  return entry
+    .replace(
+      /(--header(?:s-from)?[=\s]+)"([^":]+:)\s*[^"]*"/gi,
+      (_, prefix, namePart) => `${prefix}"${namePart} <redacted>"`,
+    )
+    .replace(
+      /(--header(?:s-from)?[=\s]+)'([^':]+:)\s*[^']*'/gi,
+      (_, prefix, namePart) => `${prefix}'${namePart} <redacted>'`,
+    )
+    .replace(
+      /(--header(?:s-from)?[=\s]+)([^"'\s]+:)\s*\S*/gi,
+      (_, prefix, namePart) => `${prefix}${namePart} <redacted>`,
+    );
 }
 
 /**

--- a/src/core/http/headers.contract.test.ts
+++ b/src/core/http/headers.contract.test.ts
@@ -241,6 +241,33 @@ describe("targetFetch", () => {
 
     spy.mockRestore();
   });
+
+  it("preserves caller-provided headers for out-of-scope URLs", async () => {
+    const session = makeSession({
+      config: { headers: { Authorization: "Bearer secret" } },
+    });
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok"));
+
+    await targetFetch(session, "https://attacker.example.net/page", {
+      headers: {
+        Accept: "text/html",
+        "Accept-Language": "en-US",
+      },
+    });
+
+    const init = spy.mock.calls[0][1] as RequestInit;
+    expect(init.headers).toEqual({
+      Accept: "text/html",
+      "Accept-Language": "en-US",
+    });
+    expect(
+      (init.headers as Record<string, string>)["Authorization"],
+    ).toBeUndefined();
+
+    spy.mockRestore();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -323,7 +350,7 @@ describe("redactSecretsInHistoryEntry", () => {
     const r = redactSecretsInHistoryEntry(
       `pensar pentest --target https://example.com --header "Authorization: Bearer xyz"`,
     );
-    expect(r).not.toContain("Bearer xyz");
+    expect(r).not.toContain("xyz");
     expect(r).toContain("Authorization: <redacted>");
   });
 

--- a/src/core/http/targetHeaders.ts
+++ b/src/core/http/targetHeaders.ts
@@ -134,7 +134,10 @@ export function resolveEffectiveHeaders(
   requestOverrides?: HeaderRecord,
 ): HeaderRecord {
   if (!isUrlInSessionScope(url, session)) {
-    return {};
+    // INV-scope-bound: never leak session/credential headers to
+    // out-of-scope hosts, but preserve the caller's own overrides so
+    // targetFetch behaves like a bare fetch for non-target URLs.
+    return requestOverrides ? { ...requestOverrides } : {};
   }
 
   // Session layer is the only persisted set today; global defaults are
@@ -247,7 +250,7 @@ type ShellInjector = (command: string, headers: HeaderRecord) => string;
  * Escapes `"`, `\`, `$`, and `` ` ``. The caller wraps the result in
  * double quotes itself.
  */
-function shellQuote(value: string): string {
+export function shellQuote(value: string): string {
   return value
     .replace(/\\/g, "\\\\")
     .replace(/"/g, '\\"')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes the five bugs identified by Cursor Bugbot in PR #790 (`enhancement/robust-custom-http-headers`).

#### Fixes

1. **Resolver drops caller-provided headers for out-of-scope URLs** (Medium) — `resolveEffectiveHeaders` now returns `requestOverrides` (if any) for out-of-scope URLs instead of `{}`. This preserves caller-provided `Accept` and `Accept-Language` headers in `getPage` when fetching research URLs (CVE writeups, vendor docs), making the docstring claim "behaves exactly like a bare fetch" correct.

2. **Sandbox curl path lacks shell quoting for headers** (Medium) — The sandbox `curl` path in `executeSandboxHttpRequest` now uses `shellQuote` (exported from `targetHeaders.ts`) to escape header values, preventing shell injection when values contain `"`, `$`, or backticks.

3. **History redaction leaks secret after space in value** (High) — The `--header` redaction regex has been rewritten into three separate passes (double-quoted, single-quoted, unquoted) to correctly match the full value portion. Previously, `--header "Authorization: Bearer xyz"` only redacted `Bearer`, leaking the actual token `xyz`. The test assertion was also tightened from `not.toContain("Bearer xyz")` to `not.toContain("xyz")`.

4. **Fail-closed bypass uses wrong host for probe** (Medium) — The fail-closed guard in `executeCommand` now checks ALL command hosts against the resolver (via `.some()`) instead of only the first non-empty host. Previously, an out-of-scope host appearing before an in-scope host would cause `resolveEffectiveHeaders` to return `{}`, bypassing the guard.

5. **TypeError: `.entries` on plain object** (High) — Already fixed in commit ce69fbf3 (uses `Object.keys(resolved).length > 0`).

#### Testing

- `bun run tsc` — passes
- `bun run lint` — passes (no new warnings)
- `bun run format:check` — passes
- `bun run test` — all 1066 tests pass (1 new contract test added)

### Base

This branch is based on `enhancement/robust-custom-http-headers` (commit ce69fbf3) from PR #790.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d05eb35-9d59-4c88-ac4b-c76a553cbdbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d05eb35-9d59-4c88-ac4b-c76a553cbdbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

