### PR TITLE
Add operator HAR capture and IDOR diff skill

### DIFF
--- a/scripts/compare-results.ts
+++ b/scripts/compare-results.ts
@@ -12,17 +12,17 @@
  *   bun run scripts/compare-results.ts --benchmark-ids XBEN-001-24 XBEN-002-24
  */
 
-import { createAnthropic } from "@ai-sdk/anthropic";
-import { generateText, Output } from "ai";
 import {
   existsSync,
   readdirSync,
   readFileSync,
   statSync,
   writeFileSync,
-} from "fs";
+} from "node:fs";
+import path from "node:path";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { generateText, Output } from "ai";
 import pLimit from "p-limit";
-import path from "path";
 import { z } from "zod";
 
 // Schema for the AI comparison response
@@ -150,8 +150,8 @@ function extractBenchmarkId(dirName: string, isPace?: boolean): string | null {
 
     for (const pattern of pacePatterns) {
       const match = dirName.match(pattern);
-      if (match) {
-        return match[1]!;
+      if (match?.[1]) {
+        return match[1];
       }
     }
   } else {
@@ -164,8 +164,8 @@ function extractBenchmarkId(dirName: string, isPace?: boolean): string | null {
 
     for (const pattern of xbenPatterns) {
       const match = dirName.match(pattern);
-      if (match) {
-        return match[1]!;
+      if (match?.[1]) {
+        return match[1];
       }
     }
   }
@@ -287,8 +287,7 @@ async function compareWithClaude(
 
   // Prepare findings summary
   let findingsText = "";
-  for (let i = 0; i < findings.length; i++) {
-    const f = findings[i]!;
+  for (const [i, f] of findings.entries()) {
     findingsText += `
 Finding ${i + 1}:
 - Title: ${f.title}
@@ -348,7 +347,10 @@ Determine whether the agent identified the correct vulnerability TYPE in the cor
       temperature: 0,
     });
 
-    return output!;
+    if (!output) {
+      throw new Error("Claude returned an empty comparison response");
+    }
+    return output;
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error(`Error calling Claude API:`, errorMessage);
@@ -485,8 +487,12 @@ async function compareBenchmark(
   }
 
   // Use the first expected result as the primary one for backward compatibility
-  const primaryExpected = expectedResults[0]!;
-  const comparison = bestComparison!;
+  const primaryExpected = expectedResults[0];
+  const comparison = bestComparison;
+  if (!primaryExpected || !comparison) {
+    console.error(`Warning: No comparison result produced for ${benchmarkId}`);
+    return null;
+  }
 
   // For multi-vuln benchmarks, vulnerability_found is true if ANY expected vuln was found
   const anyVulnFound = multiVulnDetails.some((d) => d.found);
@@ -568,12 +574,18 @@ function generateTextReport(results: ComparisonResult[]): string {
   lines.push("");
 
   // Show multi-vuln details for PACEbench benchmarks
-  const multiVulnResults = results.filter((r) => r.multi_vuln);
+  const multiVulnResults = results.filter(
+    (
+      r,
+    ): r is ComparisonResult & {
+      multi_vuln: NonNullable<ComparisonResult["multi_vuln"]>;
+    } => Boolean(r.multi_vuln),
+  );
   if (multiVulnResults.length > 0) {
     lines.push("MULTI-VULNERABILITY DETAILS (PACEbench)");
     lines.push("─".repeat(width));
     for (const r of multiVulnResults) {
-      const mv = r.multi_vuln!;
+      const mv = r.multi_vuln;
       lines.push(
         `  ${r.benchmark_id}: ${mv.found}/${mv.total_expected} vulnerabilities found`,
       );
@@ -588,12 +600,18 @@ function generateTextReport(results: ComparisonResult[]): string {
   }
 
   // Show multi-flag details for PACEbench benchmarks
-  const multiFlagResults = results.filter((r) => r.multi_flag);
+  const multiFlagResults = results.filter(
+    (
+      r,
+    ): r is ComparisonResult & {
+      multi_flag: NonNullable<ComparisonResult["multi_flag"]>;
+    } => Boolean(r.multi_flag),
+  );
   if (multiFlagResults.length > 0) {
     lines.push("MULTI-FLAG DETAILS (PACEbench)");
     lines.push("─".repeat(width));
     for (const r of multiFlagResults) {
-      const mf = r.multi_flag!;
+      const mf = r.multi_flag;
       lines.push(`  ${r.benchmark_id}: ${mf.found}/${mf.total} flags captured`);
       for (const detail of mf.details) {
         const status = detail.detected ? "✓" : "✗";
@@ -650,7 +668,7 @@ function generateTextReport(results: ComparisonResult[]): string {
   for (const [vulnClass, stats] of sortedClasses) {
     const rate =
       stats.total > 0
-        ? ((stats.flagged / stats.total) * 100).toFixed(0) + "%"
+        ? `${((stats.flagged / stats.total) * 100).toFixed(0)}%`
         : "0%";
     const miniBar =
       "█".repeat(Math.round((stats.flagged / stats.total) * 8)) +
@@ -798,26 +816,34 @@ async function main(): Promise<void> {
       printUsage();
       process.exit(0);
     } else if (arg === "--executions-dir" && args[i + 1]) {
-      executionsDir = args[++i]!;
+      i++;
+      executionsDir = args[i] ?? executionsDir;
     } else if (arg === "--benchmarks-dir" && args[i + 1]) {
-      benchmarksDir = args[++i]!;
+      i++;
+      benchmarksDir = args[i] ?? benchmarksDir;
     } else if (arg === "--execution-path" && args[i + 1]) {
-      executionPath = args[++i]!;
+      i++;
+      executionPath = args[i] ?? executionPath;
     } else if (arg === "--benchmark-ids") {
       benchmarkIds = [];
-      while (args[i + 1] && !args[i + 1]!.startsWith("-")) {
-        benchmarkIds.push(args[++i]!);
+      while (args[i + 1] && !args[i + 1]?.startsWith("-")) {
+        i++;
+        const benchmarkId = args[i];
+        if (benchmarkId) benchmarkIds.push(benchmarkId);
       }
     } else if (arg === "--prefix" && args[i + 1]) {
-      prefix = args[++i]!;
+      i++;
+      prefix = args[i] ?? prefix;
     } else if (arg === "--pace") {
       isPace = true;
     } else if (arg === "--latest-only") {
       latestOnly = true;
     } else if (arg === "--format" && args[i + 1]) {
-      outputFormat = args[++i]!;
+      i++;
+      outputFormat = args[i] ?? outputFormat;
     } else if (arg === "--output" && args[i + 1]) {
-      outputPath = args[++i]!;
+      i++;
+      outputPath = args[i] ?? outputPath;
     } else if (arg === "--show-missed") {
       printMissed = true;
     } else if (arg === "--dry") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -396,7 +396,7 @@ async function runThreatModel() {
 
   const { runThreatModelWorkflow } = await import("./core/api/threatModel");
   const { config: appConfig } = await import("./core/config");
-  const path = await import("path");
+  const path = await import("node:path");
 
   const pensarConfig = await appConfig.get();
   const model = await resolveCliModel();
@@ -446,9 +446,9 @@ async function runOperator() {
     "./core/agents/offSecAgent"
   );
   const { config: appConfig } = await import("./core/config");
-  const { createInterface } = await import("readline");
-  const { readFileSync, existsSync } = await import("fs");
-  const path = await import("path");
+  const { createInterface } = await import("node:readline");
+  const { readFileSync, existsSync } = await import("node:fs");
+  const path = await import("node:path");
   const { stepCountIs } = await import("ai");
   type ModelMessage = import("ai").ModelMessage;
 

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -12,11 +12,11 @@
  *   pensar uninstall --force      Uninstall without confirmation prompt
  */
 
-import { spawnSync } from "child_process";
-import fs from "fs/promises";
-import os from "os";
-import path from "path";
-import * as readline from "readline";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import * as readline from "node:readline";
 import {
   detectInstallMethod,
   type InstallMethod,
@@ -51,7 +51,7 @@ function findBinaryPath(): string | null {
       ?.replace(/\.exe$/, "") ?? "";
   const isCompiledBinary =
     execName !== "bun" && execName !== "node" && execName !== "bun-debug";
-  if (isCompiledBinary && require("fs").existsSync(process.execPath)) {
+  if (isCompiledBinary && require("node:fs").existsSync(process.execPath)) {
     return process.execPath;
   }
 
@@ -64,7 +64,7 @@ function findBinaryPath(): string | null {
   }
   const defaultPath = path.join(os.homedir(), ".local", "bin", "pensar");
   try {
-    const stat = require("fs").statSync(defaultPath);
+    const stat = require("node:fs").statSync(defaultPath);
     if (stat) return defaultPath;
   } catch {
     // not found
@@ -128,7 +128,7 @@ function removeBinary(method: InstallMethod): {
         };
       }
       try {
-        require("fs").unlinkSync(binPath);
+        require("node:fs").unlinkSync(binPath);
         return { success: true, message: `Removed binary at ${binPath}` };
       } catch (err) {
         return {

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -6,9 +6,9 @@ import type {
   ToolSet,
 } from "ai";
 import { hasToolCall } from "ai";
-import { existsSync, mkdirSync } from "fs";
-import { writeFile } from "fs/promises";
-import { join } from "path";
+import { existsSync, mkdirSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { streamResponse } from "../../ai";
 import { AgentEventBus } from "../../eventBus";
 import {

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -1,3 +1,6 @@
+import { existsSync, mkdirSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import type {
   ModelMessage,
   StopCondition,
@@ -6,9 +9,6 @@ import type {
   ToolSet,
 } from "ai";
 import { hasToolCall } from "ai";
-import { existsSync, mkdirSync } from "node:fs";
-import { writeFile } from "node:fs/promises";
-import { join } from "node:path";
 import { streamResponse } from "../../ai";
 import { AgentEventBus } from "../../eventBus";
 import {

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -238,6 +238,7 @@ export class OffensiveSecurityAgent<TResult = void> {
       model: input.model,
       authConfig: input.authConfig,
       eventBus: this.eventBus,
+      approvalGate: input.approvalGate,
       sandbox: input.sandbox,
       findingsRegistry: input.findingsRegistry,
       attackSurfaceRegistry: input.attackSurfaceRegistry,
@@ -502,6 +503,11 @@ export class OffensiveSecurityAgent<TResult = void> {
         bus.emitStreamPart(chunk, sid);
       }
     } finally {
+      await this.browserSession
+        ?.flushActiveHarCaptures(
+          join(this._session.rootPath, "evidence", "har"),
+        )
+        .catch(() => {});
       this.persistentShell?.dispose();
     }
 

--- a/src/core/agents/offSecAgent/tools/authenticateSession.ts
+++ b/src/core/agents/offSecAgent/tools/authenticateSession.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import { writeFileSync } from "fs";
-import { join } from "path";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 import { targetFetch } from "../../../http/targetHeaders";
 import { resolverSessionFromCtx } from "./scopeGuard";

--- a/src/core/agents/offSecAgent/tools/authenticateSession.ts
+++ b/src/core/agents/offSecAgent/tools/authenticateSession.ts
@@ -1,6 +1,6 @@
-import { tool } from "ai";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import { targetFetch } from "../../../http/targetHeaders";
 import { resolverSessionFromCtx } from "./scopeGuard";

--- a/src/core/agents/offSecAgent/tools/browserTools.ts
+++ b/src/core/agents/offSecAgent/tools/browserTools.ts
@@ -18,7 +18,7 @@
  */
 
 import { tool } from "ai";
-import { join } from "path";
+import { join } from "node:path";
 import { z } from "zod";
 import { createBrowserTools } from "./playwrightMcp";
 import { createSandboxBrowserTools } from "./sandboxPlaywright";

--- a/src/core/agents/offSecAgent/tools/browserTools.ts
+++ b/src/core/agents/offSecAgent/tools/browserTools.ts
@@ -17,8 +17,8 @@
  * in their `activeTools` array.
  */
 
-import { tool } from "ai";
 import { join } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import { createBrowserTools } from "./playwrightMcp";
 import { createSandboxBrowserTools } from "./sandboxPlaywright";

--- a/src/core/agents/offSecAgent/tools/completeAuthentication.ts
+++ b/src/core/agents/offSecAgent/tools/completeAuthentication.ts
@@ -1,6 +1,6 @@
-import { tool } from "ai";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/completeAuthentication.ts
+++ b/src/core/agents/offSecAgent/tools/completeAuthentication.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
-import { join } from "path";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/createAttackSurfaceReport.ts
+++ b/src/core/agents/offSecAgent/tools/createAttackSurfaceReport.ts
@@ -1,6 +1,6 @@
-import { tool } from "ai";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/createAttackSurfaceReport.ts
+++ b/src/core/agents/offSecAgent/tools/createAttackSurfaceReport.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import { writeFileSync } from "fs";
-import { join } from "path";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/createFile.ts
+++ b/src/core/agents/offSecAgent/tools/createFile.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
-import { existsSync } from "fs";
-import { mkdir, writeFile } from "fs/promises";
-import { dirname, isAbsolute, resolve } from "path";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, resolve } from "node:path";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/createFile.ts
+++ b/src/core/agents/offSecAgent/tools/createFile.ts
@@ -1,7 +1,7 @@
-import { tool } from "ai";
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, resolve } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -1,6 +1,6 @@
-import { tool } from "ai";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import { CredentialManager } from "../../../credentials";
 import { AgentEventBus } from "../../../eventBus";

--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import { writeFileSync } from "fs";
-import { join } from "path";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 import { CredentialManager } from "../../../credentials";
 import { AgentEventBus } from "../../../eventBus";

--- a/src/core/agents/offSecAgent/tools/documentApp.ts
+++ b/src/core/agents/offSecAgent/tools/documentApp.ts
@@ -1,6 +1,6 @@
-import { tool } from "ai";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/documentApp.ts
+++ b/src/core/agents/offSecAgent/tools/documentApp.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
-import { join } from "path";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/documentEndpoint.ts
+++ b/src/core/agents/offSecAgent/tools/documentEndpoint.ts
@@ -1,6 +1,6 @@
-import { tool } from "ai";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import { computeBlackboxRiskScore } from "../../specialized/attackSurface/blackboxRiskScoring";
 import { generateThreatModelForEndpoint } from "./threatModelGenerator";

--- a/src/core/agents/offSecAgent/tools/documentEndpoint.ts
+++ b/src/core/agents/offSecAgent/tools/documentEndpoint.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
-import { join } from "path";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 import { computeBlackboxRiskScore } from "../../specialized/attackSurface/blackboxRiskScoring";
 import { generateThreatModelForEndpoint } from "./threatModelGenerator";

--- a/src/core/agents/offSecAgent/tools/documentFinding.test.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.test.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { judgeFinding } from "../../specialized/findingJudge";
 import {

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import { spawn } from "child_process";
+import { spawn } from "node:child_process";
 import {
   appendFileSync,
   chmodSync,
@@ -7,8 +7,8 @@ import {
   mkdirSync,
   unlinkSync,
   writeFileSync,
-} from "fs";
-import { join } from "path";
+} from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 import { hasCanonicalName } from "../../../../lib/cwe/types";
 import type { EvidenceFileEntry } from "../../../../lib/evidence/types";

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -1,4 +1,3 @@
-import { tool } from "ai";
 import { spawn } from "node:child_process";
 import {
   appendFileSync,
@@ -9,6 +8,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import { hasCanonicalName } from "../../../../lib/cwe/types";
 import type { EvidenceFileEntry } from "../../../../lib/evidence/types";

--- a/src/core/agents/offSecAgent/tools/email/sendEmail.ts
+++ b/src/core/agents/offSecAgent/tools/email/sendEmail.ts
@@ -1,8 +1,8 @@
 import { tool } from "ai";
-import { readFile } from "fs/promises";
+import { readFile } from "node:fs/promises";
 import { lookup } from "mime-types";
 import { createTransport } from "nodemailer";
-import { basename } from "path";
+import { basename } from "node:path";
 import { z } from "zod";
 import type { ToolContext } from "../types";
 

--- a/src/core/agents/offSecAgent/tools/email/sendEmail.ts
+++ b/src/core/agents/offSecAgent/tools/email/sendEmail.ts
@@ -1,8 +1,8 @@
-import { tool } from "ai";
 import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { tool } from "ai";
 import { lookup } from "mime-types";
 import { createTransport } from "nodemailer";
-import { basename } from "node:path";
 import { z } from "zod";
 import type { ToolContext } from "../types";
 

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -1,6 +1,6 @@
-import { tool } from "ai";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import { applyHeadersToShellCommand } from "../../../http/targetHeaders";
 import {

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
-import { join } from "path";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 import { applyHeadersToShellCommand } from "../../../http/targetHeaders";
 import {

--- a/src/core/agents/offSecAgent/tools/grep.ts
+++ b/src/core/agents/offSecAgent/tools/grep.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import { spawn } from "child_process";
+import { spawn } from "node:child_process";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/grep.ts
+++ b/src/core/agents/offSecAgent/tools/grep.ts
@@ -1,5 +1,5 @@
-import { tool } from "ai";
 import { spawn } from "node:child_process";
+import { tool } from "ai";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/harRecorderScript.ts
+++ b/src/core/agents/offSecAgent/tools/harRecorderScript.ts
@@ -1,0 +1,224 @@
+export function buildBeginHarCaptureScript(opts: {
+  captureId: string;
+  name: string;
+}): string {
+  const captureId = JSON.stringify(opts.captureId);
+  const name = JSON.stringify(opts.name);
+
+  return `async (page) => {
+    const ctx = page.context();
+    ctx.__apexHarCaptures = ctx.__apexHarCaptures || new Map();
+
+    const captureId = ${captureId};
+    const name = ${name};
+    if (ctx.__apexHarCaptures.has(captureId)) {
+      return { ok: false, error: "Capture already exists: " + captureId };
+    }
+
+    const entries = [];
+    const pending = new Map();
+    const bodyReads = [];
+
+    const headersArray = (headers) =>
+      Object.entries(headers || {}).map(([name, value]) => ({
+        name,
+        value: String(value),
+      }));
+
+    const queryArray = (url) => {
+      try {
+        return Array.from(new URL(url).searchParams.entries()).map(([name, value]) => ({
+          name,
+          value,
+        }));
+      } catch {
+        return [];
+      }
+    };
+
+    const requestBody = (request) => {
+      try {
+        const text = request.postData();
+        if (!text) return undefined;
+        return {
+          mimeType: request.headers()["content-type"] || "application/octet-stream",
+          text,
+          _bodySize: Buffer.byteLength(text),
+        };
+      } catch {
+        return undefined;
+      }
+    };
+
+    const onRequest = (request) => {
+      const startedAt = Date.now();
+      const body = requestBody(request);
+      pending.set(request, {
+        id: captureId + "-" + (entries.length + pending.size + 1),
+        startedAt,
+        startedDateTime: new Date(startedAt).toISOString(),
+        method: request.method(),
+        url: request.url(),
+        headers: headersArray(request.headers()),
+        queryString: queryArray(request.url()),
+        postData: body,
+      });
+    };
+
+    const addEntryForResponse = async (response) => {
+      const request = response.request();
+      const meta = pending.get(request);
+      pending.delete(request);
+      if (!meta) return;
+
+      let bodyBase64 = "";
+      let bodySize = 0;
+      let mimeType = response.headers()["content-type"] || "application/octet-stream";
+      try {
+        const body = await response.body();
+        bodySize = body.length;
+        bodyBase64 = Buffer.from(body).toString("base64");
+      } catch {
+        bodyBase64 = "";
+      }
+
+      entries.push({
+        _id: meta.id,
+        _started: meta.startedAt,
+        startedDateTime: meta.startedDateTime,
+        time: Math.max(0, Date.now() - meta.startedAt),
+        request: {
+          method: meta.method,
+          url: meta.url,
+          httpVersion: "HTTP/1.1",
+          headers: meta.headers,
+          queryString: meta.queryString,
+          ...(meta.postData
+            ? {
+                postData: {
+                  mimeType: meta.postData.mimeType,
+                  text: meta.postData.text,
+                },
+              }
+            : {}),
+          headersSize: -1,
+          bodySize: meta.postData?._bodySize ?? 0,
+        },
+        response: {
+          status: response.status(),
+          statusText: response.statusText(),
+          httpVersion: "HTTP/1.1",
+          headers: headersArray(await response.allHeaders().catch(() => response.headers())),
+          content: {
+            size: bodySize,
+            mimeType,
+            text: bodyBase64,
+            encoding: "base64",
+          },
+          redirectURL: "",
+          headersSize: -1,
+          bodySize,
+        },
+        timings: { wait: Math.max(0, Date.now() - meta.startedAt) },
+      });
+    };
+
+    const onResponse = (response) => {
+      const read = addEntryForResponse(response);
+      bodyReads.push(read);
+      read.finally(() => {
+        const i = bodyReads.indexOf(read);
+        if (i >= 0) bodyReads.splice(i, 1);
+      });
+    };
+
+    const onRequestFailed = (request) => {
+      const meta = pending.get(request);
+      pending.delete(request);
+      if (!meta) return;
+      entries.push({
+        _id: meta.id,
+        _started: meta.startedAt,
+        startedDateTime: meta.startedDateTime,
+        time: Math.max(0, Date.now() - meta.startedAt),
+        request: {
+          method: meta.method,
+          url: meta.url,
+          httpVersion: "HTTP/1.1",
+          headers: meta.headers,
+          queryString: meta.queryString,
+          ...(meta.postData
+            ? {
+                postData: {
+                  mimeType: meta.postData.mimeType,
+                  text: meta.postData.text,
+                },
+              }
+            : {}),
+          headersSize: -1,
+          bodySize: meta.postData?._bodySize ?? 0,
+        },
+        response: {
+          status: 0,
+          statusText: request.failure()?.errorText || "Request failed",
+          httpVersion: "HTTP/1.1",
+          headers: [],
+          content: { size: 0, mimeType: "text/plain", text: "" },
+          redirectURL: "",
+          headersSize: -1,
+          bodySize: 0,
+        },
+        timings: { wait: Math.max(0, Date.now() - meta.startedAt) },
+      });
+    };
+
+    try {
+      ctx.on("request", onRequest);
+      ctx.on("response", onResponse);
+      ctx.on("requestfailed", onRequestFailed);
+      ctx.__apexHarCaptures.set(captureId, {
+        name,
+        entries,
+        bodyReads,
+        onRequest,
+        onResponse,
+        onRequestFailed,
+        startedAt: new Date().toISOString(),
+      });
+      return { ok: true, captureId };
+    } catch (error) {
+      try { ctx.off("request", onRequest); } catch {}
+      try { ctx.off("response", onResponse); } catch {}
+      try { ctx.off("requestfailed", onRequestFailed); } catch {}
+      ctx.__apexHarCaptures.delete(captureId);
+      return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  }`;
+}
+
+export function buildEndHarCaptureScript(captureId: string): string {
+  const id = JSON.stringify(captureId);
+
+  return `async (page) => {
+    const ctx = page.context();
+    const captures = ctx.__apexHarCaptures;
+    if (!captures || !captures.has(${id})) {
+      return { ok: false, error: "Unknown HAR capture: " + ${id} };
+    }
+
+    const capture = captures.get(${id});
+    ctx.off("request", capture.onRequest);
+    ctx.off("response", capture.onResponse);
+    ctx.off("requestfailed", capture.onRequestFailed);
+    captures.delete(${id});
+
+    await Promise.allSettled(capture.bodyReads || []);
+    return {
+      ok: true,
+      captureId: ${id},
+      name: capture.name,
+      startedAt: capture.startedAt,
+      entries: capture.entries,
+    };
+  }`;
+}

--- a/src/core/agents/offSecAgent/tools/harTools.ts
+++ b/src/core/agents/offSecAgent/tools/harTools.ts
@@ -6,7 +6,12 @@ import { z } from "zod";
 import { diffHarEntries } from "../../../har/diff";
 import { filterHarByScope } from "../../../har/scope";
 import { type HarEntry, type HarHeader, parseHar } from "../../../har/types";
-import { assertUrlInScope, ScopeViolationError } from "./scopeGuard";
+import { targetFetch } from "../../../http/targetHeaders";
+import {
+  assertUrlInScope,
+  resolverSessionFromCtx,
+  ScopeViolationError,
+} from "./scopeGuard";
 import type { ToolContext } from "./types";
 
 const BODY_PREVIEW_BYTES = 5_000;
@@ -171,7 +176,7 @@ export function harReplay(ctx: ToolContext) {
           );
         }
 
-        const response = await fetchWithTimeout(replay, timeout);
+        const response = await fetchWithTimeout(ctx, replay, timeout);
         const body = await response.text();
         const bodyInfo = saveReplayBody(ctx, body);
         return {
@@ -422,6 +427,7 @@ function requiresReplayApproval(
 }
 
 async function fetchWithTimeout(
+  ctx: ToolContext,
   replay: {
     url: string;
     method: string;
@@ -433,7 +439,7 @@ async function fetchWithTimeout(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeout);
   try {
-    return await fetch(replay.url, {
+    return await targetFetch(resolverSessionFromCtx(ctx), replay.url, {
       method: replay.method,
       headers: replay.headers,
       body: replay.body,

--- a/src/core/agents/offSecAgent/tools/harTools.ts
+++ b/src/core/agents/offSecAgent/tools/harTools.ts
@@ -1,0 +1,461 @@
+import { tool } from "ai";
+import { randomBytes } from "crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { z } from "zod";
+import { diffHarEntries } from "../../../har/diff";
+import { filterHarByScope } from "../../../har/scope";
+import { type HarEntry, type HarHeader, parseHar } from "../../../har/types";
+import { assertUrlInScope, ScopeViolationError } from "./scopeGuard";
+import type { ToolContext } from "./types";
+
+const BODY_PREVIEW_BYTES = 5_000;
+
+const HarFilterSchema = z.object({
+  host: z.string().optional(),
+  method: z.string().optional(),
+  status: z.number().optional(),
+  pathRegex: z.string().optional(),
+  hasAuth: z.boolean().optional(),
+});
+
+const ReplayMutationsSchema = z
+  .object({
+    headers: z.record(z.string()).optional(),
+    queryParams: z.record(z.string()).optional(),
+    body: z.string().optional(),
+    credentialId: z.string().optional(),
+  })
+  .optional();
+
+export function startHarCapture(ctx: ToolContext) {
+  return tool({
+    description:
+      "Start a named HAR capture for the current browser session. Call this before the flow you want to record.",
+    inputSchema: z.object({
+      name: z
+        .string()
+        .describe("Short capture name, e.g. account-a-profile-flow"),
+      toolCallDescription: z
+        .string()
+        .describe("Why this browser flow should be captured as HAR"),
+    }),
+    execute: async ({ name }) => {
+      if (!ctx.browserSession) {
+        return { success: false, error: "Browser session is not available" };
+      }
+      try {
+        const result = await ctx.browserSession.beginHarCapture(name);
+        return { success: true, ...result };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  });
+}
+
+export function stopHarCapture(ctx: ToolContext) {
+  return tool({
+    description:
+      "Stop an active HAR capture and write it to the session evidence directory.",
+    inputSchema: z.object({
+      captureId: z
+        .string()
+        .describe("Capture ID returned by start_har_capture"),
+      toolCallDescription: z
+        .string()
+        .describe("Why this HAR capture is complete"),
+    }),
+    execute: async ({ captureId }) => {
+      if (!ctx.browserSession) {
+        return { success: false, error: "Browser session is not available" };
+      }
+      try {
+        const result = await ctx.browserSession.endHarCapture(
+          captureId,
+          harEvidenceDir(ctx),
+        );
+        return { success: true, ...result };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  });
+}
+
+export function getHarSummary(ctx: ToolContext) {
+  return tool({
+    description:
+      "Summarize a captured HAR file. Returns scoped in-scope entries with auth/cookie headers preserved for pentesting.",
+    inputSchema: z.object({
+      harPath: z
+        .string()
+        .describe("Absolute path to a HAR file in this session"),
+      filter: HarFilterSchema.optional(),
+      limit: z.number().default(50).describe("Maximum entries to return"),
+      toolCallDescription: z
+        .string()
+        .describe("Why this HAR summary is needed"),
+    }),
+    execute: async ({ harPath, filter, limit }) => {
+      try {
+        const entries = loadScopedEntries(ctx, harPath);
+        const selected = applyHarFilter(entries, filter).slice(0, limit);
+        return {
+          success: true,
+          harPath,
+          totalEntries: entries.length,
+          returnedEntries: selected.length,
+          byHost: countBy(entries, (entry) => new URL(entry.request.url).host),
+          byMethod: countBy(entries, (entry) => entry.request.method),
+          byStatus: countBy(entries, (entry) => String(entry.response.status)),
+          entries: selected.map(summarizeEntry),
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  });
+}
+
+export function harReplay(ctx: ToolContext) {
+  return tool({
+    description:
+      "Replay one request from a captured HAR, optionally mutating headers, query parameters, body, or credential. Enforces target scope before sending.",
+    inputSchema: z.object({
+      harPath: z
+        .string()
+        .describe("Absolute path to a HAR file in this session"),
+      entryId: z.string().describe("HAR entry _id from get_har_summary"),
+      mutations: ReplayMutationsSchema,
+      timeout: z.number().default(10000),
+      toolCallDescription: z
+        .string()
+        .describe("Why this captured request should be replayed"),
+    }),
+    execute: async ({ harPath, entryId, mutations, timeout }) => {
+      try {
+        const entries = loadScopedEntries(ctx, harPath);
+        const entry = entries.find((candidate) => candidate._id === entryId);
+        if (!entry) {
+          return { success: false, error: `Unknown HAR entry: ${entryId}` };
+        }
+
+        const replay = buildReplayRequest(ctx, entry, mutations);
+        assertUrlInScope(replay.url, ctx);
+
+        if (requiresReplayApproval(entry.request.method, mutations)) {
+          if (!ctx.approvalGate) {
+            return {
+              success: false,
+              error: "Approval gate is required for sensitive HAR replay",
+            };
+          }
+          await ctx.approvalGate.requireApproval(
+            "har_replay",
+            `tc_${Date.now()}_${randomBytes(4).toString("hex")}`,
+            {
+              url: replay.url,
+              method: replay.method,
+              mutations,
+            },
+          );
+        }
+
+        const response = await fetchWithTimeout(replay, timeout);
+        const body = await response.text();
+        const bodyInfo = saveReplayBody(ctx, body);
+        return {
+          success: true,
+          url: response.url,
+          method: replay.method,
+          status: response.status,
+          statusText: response.statusText,
+          headers: responseHeadersToRecord(response.headers),
+          body: bodyInfo.preview,
+          bodyPath: bodyInfo.path,
+        };
+      } catch (error) {
+        if (error instanceof ScopeViolationError) {
+          return { success: false, error: error.message };
+        }
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  });
+}
+
+export function harDiff(ctx: ToolContext) {
+  return tool({
+    description:
+      "Compare two captured HAR files for IDOR and broken authorization candidates. Preserves auth/cookie values for in-scope hosts.",
+    inputSchema: z.object({
+      accountAHarPath: z
+        .string()
+        .describe("Absolute path to the HAR captured as account A"),
+      accountBHarPath: z
+        .string()
+        .describe("Absolute path to the HAR captured as account B"),
+      outputPath: z
+        .string()
+        .optional()
+        .describe("Optional session-local path for the JSON diff report"),
+      toolCallDescription: z
+        .string()
+        .describe("Why these HAR files should be compared"),
+    }),
+    execute: async ({ accountAHarPath, accountBHarPath, outputPath }) => {
+      try {
+        const accountAEntries = loadScopedEntries(ctx, accountAHarPath);
+        const accountBEntries = loadScopedEntries(ctx, accountBHarPath);
+        const report = diffHarEntries(accountAEntries, accountBEntries);
+        const path =
+          outputPath ?? join(harEvidenceDir(ctx), `idor-diff-${Date.now()}.json`);
+        const resolvedOutput = assertSessionOutputPath(ctx, path);
+        mkdirSync(dirname(resolvedOutput), { recursive: true });
+        writeFileSync(resolvedOutput, JSON.stringify(report, null, 2));
+        return { success: true, path: resolvedOutput, ...report };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  });
+}
+
+function harEvidenceDir(ctx: ToolContext): string {
+  return join(ctx.session.rootPath, "evidence", "har");
+}
+
+function assertSessionPath(ctx: ToolContext, path: string): string {
+  const resolved = resolve(path);
+  const sessionRoot = resolve(ctx.session.rootPath);
+  if (resolved !== sessionRoot && !resolved.startsWith(`${sessionRoot}/`)) {
+    throw new Error(`HAR path is outside this session: ${path}`);
+  }
+  if (!existsSync(resolved)) {
+    throw new Error(`HAR file not found: ${path}`);
+  }
+  return resolved;
+}
+
+function assertSessionOutputPath(ctx: ToolContext, path: string): string {
+  const resolved = resolve(path);
+  const sessionRoot = resolve(ctx.session.rootPath);
+  if (resolved !== sessionRoot && !resolved.startsWith(`${sessionRoot}/`)) {
+    throw new Error(`HAR output path is outside this session: ${path}`);
+  }
+  return resolved;
+}
+
+function loadScopedEntries(ctx: ToolContext, harPath: string): HarEntry[] {
+  const resolved = assertSessionPath(ctx, harPath);
+  const har = parseHar(readFileSync(resolved, "utf-8"));
+  return filterHarByScope(har.log.entries, ctx);
+}
+
+function applyHarFilter(
+  entries: HarEntry[],
+  filter: z.infer<typeof HarFilterSchema> | undefined,
+): HarEntry[] {
+  if (!filter) return entries;
+  const pathPattern = filter.pathRegex ? new RegExp(filter.pathRegex) : null;
+  return entries.filter((entry) => {
+    const url = new URL(entry.request.url);
+    if (filter.host && url.host !== filter.host) return false;
+    if (filter.method && entry.request.method !== filter.method) return false;
+    if (filter.status && entry.response.status !== filter.status) return false;
+    if (pathPattern && !pathPattern.test(url.pathname)) return false;
+    if (filter.hasAuth !== undefined && hasAuth(entry) !== filter.hasAuth)
+      return false;
+    return true;
+  });
+}
+
+function summarizeEntry(entry: HarEntry) {
+  return {
+    id: entry._id,
+    method: entry.request.method,
+    url: entry.request.url,
+    status: entry.response.status,
+    contentType: headerValue(entry.response.headers, "content-type"),
+    sizeBytes: entry.response.content.size,
+    hasAuth: hasAuth(entry),
+    authHeaders: pickHeaders(entry.request.headers, [
+      "authorization",
+      "cookie",
+    ]),
+    setCookieHeaders: pickHeaders(entry.response.headers, ["set-cookie"]),
+  };
+}
+
+function countBy(
+  entries: HarEntry[],
+  keyFn: (entry: HarEntry) => string,
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const entry of entries) {
+    const key = keyFn(entry);
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function headersToRecord(headers: HarHeader[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const header of headers) {
+    result[header.name] = header.value;
+  }
+  return result;
+}
+
+function responseHeadersToRecord(headers: Headers): Record<string, string> {
+  const result: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
+}
+
+function headerValue(headers: HarHeader[], name: string): string | undefined {
+  const lower = name.toLowerCase();
+  return headers.find((header) => header.name.toLowerCase() === lower)?.value;
+}
+
+function pickHeaders(
+  headers: HarHeader[],
+  names: string[],
+): Record<string, string> {
+  const wanted = new Set(names.map((name) => name.toLowerCase()));
+  const result: Record<string, string> = {};
+  for (const header of headers) {
+    if (wanted.has(header.name.toLowerCase())) {
+      result[header.name] = header.value;
+    }
+  }
+  return result;
+}
+
+function hasAuth(entry: HarEntry): boolean {
+  return Boolean(
+    headerValue(entry.request.headers, "authorization") ||
+      headerValue(entry.request.headers, "cookie"),
+  );
+}
+
+function buildReplayRequest(
+  ctx: ToolContext,
+  entry: HarEntry,
+  mutations: z.infer<typeof ReplayMutationsSchema>,
+): {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: string;
+} {
+  const url = new URL(entry.request.url);
+  const headers = headersToRecord(entry.request.headers);
+  let body =
+    entry.request.postData?.encoding === "base64" && entry.request.postData.text
+      ? Buffer.from(entry.request.postData.text, "base64").toString("utf-8")
+      : entry.request.postData?.text;
+
+  if (mutations?.headers) {
+    Object.assign(headers, mutations.headers);
+  }
+  if (mutations?.queryParams) {
+    for (const [key, value] of Object.entries(mutations.queryParams)) {
+      url.searchParams.set(key, value);
+    }
+  }
+  if (mutations?.body !== undefined) {
+    body = mutations.body;
+  }
+  if (mutations?.credentialId) {
+    const credential = ctx.credentialManager?.resolve(mutations.credentialId);
+    if (!credential) {
+      throw new Error(`Unknown credential ID: ${mutations.credentialId}`);
+    }
+    if (credential.tokens?.bearerToken) {
+      headers.Authorization = `Bearer ${credential.tokens.bearerToken}`;
+    }
+    if (credential.tokens?.cookies) {
+      headers.Cookie = credential.tokens.cookies;
+    }
+    if (credential.tokens?.customHeaders) {
+      Object.assign(headers, credential.tokens.customHeaders);
+    }
+  }
+
+  return {
+    url: url.toString(),
+    method: entry.request.method,
+    headers,
+    body: ["GET", "HEAD"].includes(entry.request.method) ? undefined : body,
+  };
+}
+
+function requiresReplayApproval(
+  method: string,
+  mutations: z.infer<typeof ReplayMutationsSchema>,
+): boolean {
+  if (["DELETE", "PUT", "PATCH"].includes(method.toUpperCase())) return true;
+  if (mutations?.credentialId) return true;
+  return Object.keys(mutations?.headers ?? {}).some((name) =>
+    ["authorization", "cookie"].includes(name.toLowerCase()),
+  );
+}
+
+async function fetchWithTimeout(
+  replay: {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body?: string;
+  },
+  timeout: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  try {
+    return await fetch(replay.url, {
+      method: replay.method,
+      headers: replay.headers,
+      body: replay.body,
+      redirect: "manual",
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function saveReplayBody(
+  ctx: ToolContext,
+  body: string,
+): { preview: string; path?: string } {
+  if (body.length <= BODY_PREVIEW_BYTES) return { preview: body };
+  const outputDir = join(ctx.session.logsPath, "har-replay-responses");
+  mkdirSync(outputDir, { recursive: true });
+  const path = join(outputDir, `response-${Date.now()}.txt`);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, body);
+  return {
+    preview: `${body.slice(0, BODY_PREVIEW_BYTES)}...\n\n(truncated — full response saved to ${path})`,
+    path,
+  };
+}

--- a/src/core/agents/offSecAgent/tools/harTools.ts
+++ b/src/core/agents/offSecAgent/tools/harTools.ts
@@ -35,8 +35,7 @@ const ReplayMutationsSchema = z
 
 export function startHarCapture(ctx: ToolContext) {
   return tool({
-    description:
-      "Start a named HAR capture for the current browser session. Call this before the flow you want to record.",
+    description: "Start a named HAR capture for the current browser session.",
     inputSchema: z.object({
       name: z
         .string()
@@ -96,8 +95,7 @@ export function stopHarCapture(ctx: ToolContext) {
 
 export function getHarSummary(ctx: ToolContext) {
   return tool({
-    description:
-      "Summarize a captured HAR file. Returns scoped in-scope entries with auth/cookie headers preserved for pentesting.",
+    description: "Summarize scoped entries from a captured HAR file.",
     inputSchema: z.object({
       harPath: z
         .string()
@@ -205,7 +203,7 @@ export function harReplay(ctx: ToolContext) {
 export function harDiff(ctx: ToolContext) {
   return tool({
     description:
-      "Compare two captured HAR files for IDOR and broken authorization candidates. Preserves auth/cookie values for in-scope hosts.",
+      "Diff two session HARs and write a JSON report of authorization candidates.",
     inputSchema: z.object({
       accountAHarPath: z
         .string()

--- a/src/core/agents/offSecAgent/tools/harTools.ts
+++ b/src/core/agents/offSecAgent/tools/harTools.ts
@@ -1,7 +1,7 @@
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { tool } from "ai";
-import { randomBytes } from "crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { dirname, join, resolve } from "path";
 import { z } from "zod";
 import { diffHarEntries } from "../../../har/diff";
 import { filterHarByScope } from "../../../har/scope";
@@ -222,7 +222,8 @@ export function harDiff(ctx: ToolContext) {
         const accountBEntries = loadScopedEntries(ctx, accountBHarPath);
         const report = diffHarEntries(accountAEntries, accountBEntries);
         const path =
-          outputPath ?? join(harEvidenceDir(ctx), `idor-diff-${Date.now()}.json`);
+          outputPath ??
+          join(harEvidenceDir(ctx), `idor-diff-${Date.now()}.json`);
         const resolvedOutput = assertSessionOutputPath(ctx, path);
         mkdirSync(dirname(resolvedOutput), { recursive: true });
         writeFileSync(resolvedOutput, JSON.stringify(report, null, 2));

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
-import { join } from "path";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 import {
   resolveEffectiveHeaders,

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -1,6 +1,6 @@
-import { tool } from "ai";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import {
   resolveEffectiveHeaders,

--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -37,6 +37,13 @@ export { extractJsEndpoints } from "./extractJsEndpoints";
 export { getMemory } from "./getMemory";
 export { getPage } from "./getPage";
 export { grep } from "./grep";
+export {
+  harDiff,
+  getHarSummary,
+  harReplay,
+  startHarCapture,
+  stopHarCapture,
+} from "./harTools";
 export { httpRequest } from "./httpRequest";
 export { listFiles } from "./listFiles";
 export { listMemories } from "./listMemories";
@@ -170,6 +177,13 @@ import { extractJsEndpoints } from "./extractJsEndpoints";
 import { getMemory } from "./getMemory";
 import { getPage } from "./getPage";
 import { grep } from "./grep";
+import {
+  harDiff,
+  getHarSummary,
+  harReplay,
+  startHarCapture,
+  stopHarCapture,
+} from "./harTools";
 import { httpRequest } from "./httpRequest";
 import { listFiles } from "./listFiles";
 import { listMemories } from "./listMemories";
@@ -225,6 +239,11 @@ export function createAllTools(ctx: ToolContext) {
     // Core pentest tools
     execute_command: executeCommand(ctx),
     http_request: httpRequest(ctx),
+    start_har_capture: startHarCapture(ctx),
+    stop_har_capture: stopHarCapture(ctx),
+    get_har_summary: getHarSummary(ctx),
+    har_diff: harDiff(ctx),
+    har_replay: harReplay(ctx),
     document_vulnerability: documentVulnerability(ctx),
 
     // Filesystem / search tools
@@ -328,6 +347,11 @@ export const ALL_TOOL_NAMES: ToolName[] = [
   // Core pentest
   "execute_command",
   "http_request",
+  "start_har_capture",
+  "stop_har_capture",
+  "get_har_summary",
+  "har_diff",
+  "har_replay",
   "document_vulnerability",
   // Filesystem / search
   "read_file",

--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -38,8 +38,8 @@ export { getMemory } from "./getMemory";
 export { getPage } from "./getPage";
 export { grep } from "./grep";
 export {
-  harDiff,
   getHarSummary,
+  harDiff,
   harReplay,
   startHarCapture,
   stopHarCapture,
@@ -178,8 +178,8 @@ import { getMemory } from "./getMemory";
 import { getPage } from "./getPage";
 import { grep } from "./grep";
 import {
-  harDiff,
   getHarSummary,
+  harDiff,
   harReplay,
   startHarCapture,
   stopHarCapture,

--- a/src/core/agents/offSecAgent/tools/listFiles.ts
+++ b/src/core/agents/offSecAgent/tools/listFiles.ts
@@ -1,6 +1,6 @@
-import { tool } from "ai";
 import { readdir, stat } from "node:fs/promises";
 import { isAbsolute, join, relative, resolve } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/listFiles.ts
+++ b/src/core/agents/offSecAgent/tools/listFiles.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import { readdir, stat } from "fs/promises";
-import { isAbsolute, join, relative, resolve } from "path";
+import { readdir, stat } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 
@@ -44,7 +44,7 @@ async function listRecursive(
   let total = 0;
 
   async function walk(current: string) {
-    let entries: import("fs").Dirent[];
+    let entries: import("node:fs").Dirent[];
     try {
       entries = await readdir(current, { withFileTypes: true });
     } catch {

--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -1,5 +1,5 @@
-import { spawnSync } from "child_process";
-import { existsSync, readdirSync } from "fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -110,7 +110,7 @@ describe("PersistentShell — long-running stability", () => {
 
     await new Promise((r) => setTimeout(r, 1_500));
 
-    const { spawnSync } = await import("child_process");
+    const { spawnSync } = await import("node:child_process");
     const out = spawnSync(
       "ps",
       ["--ppid", String(bashPid), "-o", "pid=,comm="],

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -1,5 +1,5 @@
-import { type ChildProcess, spawn, spawnSync } from "child_process";
-import { randomBytes } from "crypto";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import {
   closeSync,
   mkdirSync,
@@ -8,9 +8,9 @@ import {
   readSync,
   statSync,
   unlinkSync,
-} from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const MAX_BUFFER = 5_000_000;
 

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
@@ -1,6 +1,6 @@
-import { mkdtempSync, rmSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createBrowserTools,

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -11,11 +11,17 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { tool } from "ai";
+import { createHash, randomUUID } from "crypto";
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { createRequire } from "module";
 import { dirname, join } from "path";
 import { z } from "zod";
+import { type HarEntry, HarFileSchema } from "../../../har/types";
 import type { Logger } from "../../../logger";
+import {
+  buildBeginHarCaptureScript,
+  buildEndHarCaptureScript,
+} from "./harRecorderScript";
 
 /**
  * Playwright `BrowserContext.storageState()` shape — the JSON-serialisable
@@ -37,6 +43,29 @@ export interface BrowserStorageState {
     origin: string;
     localStorage: Array<{ name: string; value: string }>;
   }>;
+}
+
+export interface HarCaptureResult {
+  captureId: string;
+  name: string;
+  path: string;
+  entryCount: number;
+  sizeBytes: number;
+}
+
+interface ActiveHarCapture {
+  id: string;
+  name: string;
+  startedAt: string;
+}
+
+interface BrowserHarCaptureResponse {
+  ok: boolean;
+  captureId?: string;
+  name?: string;
+  startedAt?: string;
+  entries?: HarEntry[];
+  error?: string;
 }
 
 // Types for tool results
@@ -365,6 +394,7 @@ export class PlaywrightMcpSession {
   private readonly userAgent: string | undefined;
   private readonly viewportSize: string | undefined;
   private readonly extraHttpHeaders: Record<string, string> | undefined;
+  private readonly activeHarCaptures = new Map<string, ActiveHarCapture>();
   /** Temp config file written for MCP launch — deleted on disconnect. */
   private mcpConfigPath: string | null = null;
 
@@ -595,6 +625,78 @@ export class PlaywrightMcpSession {
     return this.mcpClient !== null;
   }
 
+  async beginHarCapture(name: string): Promise<{ captureId: string }> {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      throw new Error("HAR capture name is required");
+    }
+    for (const capture of this.activeHarCaptures.values()) {
+      if (capture.name === trimmedName) {
+        throw new Error(`HAR capture "${trimmedName}" is already active`);
+      }
+    }
+
+    const captureId = randomUUID();
+    const result = (await this.callTool("browser_run_code", {
+      code: buildBeginHarCaptureScript({ captureId, name: trimmedName }),
+    })) as BrowserHarCaptureResponse;
+
+    if (!result?.ok || result.captureId !== captureId) {
+      throw new Error(result?.error ?? "Failed to start HAR capture");
+    }
+
+    this.activeHarCaptures.set(captureId, {
+      id: captureId,
+      name: trimmedName,
+      startedAt: new Date().toISOString(),
+    });
+    return { captureId };
+  }
+
+  async endHarCapture(
+    captureId: string,
+    outputDir: string,
+  ): Promise<HarCaptureResult> {
+    const active = this.activeHarCaptures.get(captureId);
+    if (!active) {
+      throw new Error(`Unknown HAR capture: ${captureId}`);
+    }
+
+    let result: BrowserHarCaptureResponse | undefined;
+    try {
+      result = (await this.callTool("browser_run_code", {
+        code: buildEndHarCaptureScript(captureId),
+      })) as BrowserHarCaptureResponse;
+    } finally {
+      this.activeHarCaptures.delete(captureId);
+    }
+
+    if (!result?.ok || !result.entries) {
+      throw new Error(result?.error ?? "Failed to stop HAR capture");
+    }
+
+    return writeHarCapture({
+      outputDir,
+      captureId,
+      name: active.name,
+      entries: result.entries,
+    });
+  }
+
+  async flushActiveHarCaptures(outputDir: string): Promise<HarCaptureResult[]> {
+    const captureIds = Array.from(this.activeHarCaptures.keys());
+    const results: HarCaptureResult[] = [];
+    for (const captureId of captureIds) {
+      try {
+        results.push(await this.endHarCapture(captureId, outputDir));
+      } catch {
+        // Best-effort teardown: listener removal is attempted by endHarCapture,
+        // but teardown must not mask the original agent completion/abort.
+      }
+    }
+    return results;
+  }
+
   /**
    * Snapshot this session's full Playwright storage state (cookies + per-origin
    * localStorage) by invoking `BrowserContext.storageState()` through the
@@ -773,6 +875,76 @@ export class PlaywrightMcpSession {
       abortCleanup?.();
     }
   }
+}
+
+const HAR_INLINE_BODY_BYTES = 16 * 1024;
+
+function sanitizeCaptureName(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 80) || "capture"
+  );
+}
+
+function writeHarCapture(opts: {
+  outputDir: string;
+  captureId: string;
+  name: string;
+  entries: HarEntry[];
+}): HarCaptureResult {
+  mkdirSync(opts.outputDir, { recursive: true });
+  const bodiesDir = join(opts.outputDir, "_bodies");
+  mkdirSync(bodiesDir, { recursive: true });
+
+  const entries = opts.entries.map((entry) => {
+    const text = entry.response.content.text;
+    if (entry.response.content.encoding === "base64" && text) {
+      const body = Buffer.from(text, "base64");
+      if (body.length > HAR_INLINE_BODY_BYTES) {
+        const sha = createHash("sha256").update(body).digest("hex");
+        const bodyPath = join(bodiesDir, sha);
+        writeFileSync(bodyPath, body);
+        return {
+          ...entry,
+          response: {
+            ...entry.response,
+            content: {
+              ...entry.response.content,
+              text: undefined,
+              encoding: undefined,
+              _attachedSha: sha,
+              _attachedPath: bodyPath,
+            },
+          },
+        };
+      }
+    }
+    return entry;
+  });
+
+  const har = HarFileSchema.parse({
+    log: {
+      version: "1.2",
+      creator: { name: "Pensar Apex", version: "1.0" },
+      entries,
+    },
+  });
+
+  const filename = `${sanitizeCaptureName(opts.name)}-${opts.captureId}.har`;
+  const path = join(opts.outputDir, filename);
+  const serialized = JSON.stringify(har, null, 2);
+  writeFileSync(path, serialized);
+
+  return {
+    captureId: opts.captureId,
+    name: opts.name,
+    path,
+    entryCount: entries.length,
+    sizeBytes: Buffer.byteLength(serialized),
+  };
 }
 
 // Mode-specific descriptions

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -11,10 +11,10 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { tool } from "ai";
-import { createHash, randomUUID } from "crypto";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
-import { createRequire } from "module";
-import { dirname, join } from "path";
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import { z } from "zod";
 import { type HarEntry, HarFileSchema } from "../../../har/types";
 import type { Logger } from "../../../logger";
@@ -387,7 +387,7 @@ export interface PlaywrightMcpSessionOptions {
 export class PlaywrightMcpSession {
   private mcpClient: Client | null = null;
   private mcpTransport: StdioClientTransport | null = null;
-  private mcpProcess: import("child_process").ChildProcess | null = null;
+  private mcpProcess: import("node:child_process").ChildProcess | null = null;
   private connectionPromise: Promise<Client> | null = null;
   private disconnecting = false;
   private readonly headless: boolean;
@@ -497,8 +497,8 @@ export class PlaywrightMcpSession {
         // Pass extraHTTPHeaders via a temp @playwright/mcp config file
         // so every Chromium request includes them.
         if (this.extraHttpHeaders) {
-          const os = await import("os");
-          const fsp = await import("fs/promises");
+          const os = await import("node:os");
+          const fsp = await import("node:fs/promises");
           const cfg = {
             browser: {
               contextOptions: { extraHTTPHeaders: this.extraHttpHeaders },
@@ -538,7 +538,7 @@ export class PlaywrightMcpSession {
           this.mcpProcess =
             (
               transport as unknown as {
-                _process?: import("child_process").ChildProcess;
+                _process?: import("node:child_process").ChildProcess;
               }
             )._process ?? null;
         };
@@ -609,7 +609,7 @@ export class PlaywrightMcpSession {
       this.mcpConfigPath = null;
       void (async () => {
         try {
-          const fsp = await import("fs/promises");
+          const fsp = await import("node:fs/promises");
           await fsp.unlink(configPath);
         } catch {
           // best-effort; already-deleted is fine

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -8,13 +8,13 @@
  * - "operator": User-driven operator mode - SPA reconnaissance, authenticated flows, attack surface mapping
  */
 
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { tool } from "ai";
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { tool } from "ai";
 import { z } from "zod";
 import { type HarEntry, HarFileSchema } from "../../../har/types";
 import type { Logger } from "../../../logger";

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -690,8 +690,7 @@ export class PlaywrightMcpSession {
       try {
         results.push(await this.endHarCapture(captureId, outputDir));
       } catch {
-        // Best-effort teardown: listener removal is attempted by endHarCapture,
-        // but teardown must not mask the original agent completion/abort.
+        // Best-effort teardown.
       }
     }
     return results;

--- a/src/core/agents/offSecAgent/tools/provideComparisonResults.ts
+++ b/src/core/agents/offSecAgent/tools/provideComparisonResults.ts
@@ -1,6 +1,6 @@
-import { tool } from "ai";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/provideComparisonResults.ts
+++ b/src/core/agents/offSecAgent/tools/provideComparisonResults.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import { writeFileSync } from "fs";
-import { join } from "path";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/readFile.ts
+++ b/src/core/agents/offSecAgent/tools/readFile.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import { readFile as fsReadFile } from "fs/promises";
-import { isAbsolute, resolve } from "path";
+import { readFile as fsReadFile } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/readFile.ts
+++ b/src/core/agents/offSecAgent/tools/readFile.ts
@@ -1,6 +1,6 @@
-import { tool } from "ai";
 import { readFile as fsReadFile } from "node:fs/promises";
 import { isAbsolute, resolve } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -18,9 +18,9 @@
  * because the Chromium process stays alive between connections.
  */
 
-import { tool } from "ai";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import {
   resolveEffectiveHeaders,

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -19,8 +19,8 @@
  */
 
 import { tool } from "ai";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
-import { dirname, join } from "path";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { z } from "zod";
 import {
   resolveEffectiveHeaders,
@@ -242,7 +242,7 @@ async function runPlaywrightScript(
       : "null";
   const script = `
 const { chromium } = require('playwright');
-const fs = require('fs');
+const fs = require('node:fs');
 
 (async () => {
   function resolve(value) {
@@ -290,7 +290,7 @@ const fs = require('fs');
   } finally {
     if (__consoleMessages.length > 0) {
       try {
-        const fs = require('fs');
+        const fs = require('node:fs');
         let existing = [];
         try { existing = JSON.parse(fs.readFileSync('${SANDBOX_CONSOLE_FILE}', 'utf-8')); } catch {}
         existing.push(...__consoleMessages);
@@ -479,7 +479,7 @@ Target base URL: ${targetUrl}`,
           `
     await page.goto(${JSON.stringify(url)}, { waitUntil: 'domcontentloaded', timeout: 30000 });
     // Persist current URL so subsequent tool calls can restore the page
-    require('fs').writeFileSync('${SANDBOX_URL_FILE}', page.url());
+    require('node:fs').writeFileSync('${SANDBOX_URL_FILE}', page.url());
     const title = await page.title();
 
     resolve({ success: true, url: page.url(), title });
@@ -516,8 +516,8 @@ Use this to document:
           `
     const buf = await page.screenshot({ fullPage: false });
     const b64 = buf.toString('base64');
-    require('fs').mkdirSync(${JSON.stringify(SANDBOX_EVIDENCE_DIR)}, { recursive: true });
-    require('fs').writeFileSync(${JSON.stringify(sandboxPath)}, buf);
+    require('node:fs').mkdirSync(${JSON.stringify(SANDBOX_EVIDENCE_DIR)}, { recursive: true });
+    require('node:fs').writeFileSync(${JSON.stringify(sandboxPath)}, buf);
     resolve({ success: true, data: b64, sandboxPath: ${JSON.stringify(sandboxPath)} });
           `,
           30,
@@ -656,7 +656,7 @@ Example workflow:
     }
 
     const text = formatNode(treeData, 0);
-    require('fs').writeFileSync(${JSON.stringify(SANDBOX_REFS_FILE)}, JSON.stringify(refMap));
+    require('node:fs').writeFileSync(${JSON.stringify(SANDBOX_REFS_FILE)}, JSON.stringify(refMap));
     resolve({ success: true, snapshot: text });
           `,
           30,
@@ -703,7 +703,7 @@ IMPORTANT: For reliable clicking, first call browser_snapshot to get element ref
 
     if (ref) {
       try {
-        const refData = JSON.parse(require('fs').readFileSync(${JSON.stringify(SANDBOX_REFS_FILE)}, 'utf-8'));
+        const refData = JSON.parse(require('node:fs').readFileSync(${JSON.stringify(SANDBOX_REFS_FILE)}, 'utf-8'));
         const info = refData[ref];
         if (info && info.role && info.name) {
           const role = TAG_TO_ROLE[info.role] || info.role;
@@ -781,7 +781,7 @@ IMPORTANT: For reliable form filling, first call browser_snapshot to get element
 
     if (ref) {
       try {
-        const refData = JSON.parse(require('fs').readFileSync(${JSON.stringify(SANDBOX_REFS_FILE)}, 'utf-8'));
+        const refData = JSON.parse(require('node:fs').readFileSync(${JSON.stringify(SANDBOX_REFS_FILE)}, 'utf-8'));
         const info = refData[ref];
         if (info && info.role && info.name) {
           const role = TAG_TO_ROLE[info.role] || info.role;
@@ -886,7 +886,7 @@ Use this to check for:
         await setup();
         const result = (await runScript(
           `
-    const fs = require('fs');
+    const fs = require('node:fs');
     let persisted = [];
     try { persisted = JSON.parse(fs.readFileSync('${SANDBOX_CONSOLE_FILE}', 'utf-8')); } catch {}
     const allMessages = [...persisted, ...__consoleMessages];

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -3,6 +3,7 @@ import type { CredentialManager } from "../../../credentials";
 import type { AgentEventBus } from "../../../eventBus";
 import type { AttackSurfaceRegistry } from "../../../findings/attackSurfaceRegistry";
 import type { FindingsRegistry } from "../../../findings/registry";
+import type { ApprovalGate } from "../../../operator";
 import type { SessionInfo } from "../../../session";
 import type { SkillsRegistry } from "../../../skills/registry";
 import type { StepTraceWriter } from "../trace";
@@ -38,6 +39,9 @@ export type ToolContext = {
 
   /** Event bus for streaming agent output and subagent lifecycle events */
   eventBus?: AgentEventBus;
+
+  /** Operator approval gate for tools that require approval internally. */
+  approvalGate?: ApprovalGate;
 
   /**
    * When set, tools like execute_command / http_request / document_vulnerability

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -40,7 +40,6 @@ export type ToolContext = {
   /** Event bus for streaming agent output and subagent lifecycle events */
   eventBus?: AgentEventBus;
 
-  /** Operator approval gate for tools that require approval internally. */
   approvalGate?: ApprovalGate;
 
   /**

--- a/src/core/agents/offSecAgent/tools/updateFile.ts
+++ b/src/core/agents/offSecAgent/tools/updateFile.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import { readFile, writeFile } from "fs/promises";
-import { isAbsolute, resolve } from "path";
+import { readFile, writeFile } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/updateFile.ts
+++ b/src/core/agents/offSecAgent/tools/updateFile.ts
@@ -1,6 +1,6 @@
-import { tool } from "ai";
 import { readFile, writeFile } from "node:fs/promises";
 import { isAbsolute, resolve } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import type { ToolContext } from "./types";
 

--- a/src/core/agents/offSecAgent/tools/writePlan.ts
+++ b/src/core/agents/offSecAgent/tools/writePlan.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
-import { mkdirSync } from "fs";
-import { writeFile } from "fs/promises";
-import { dirname } from "path";
+import { mkdirSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import { z } from "zod";
 import { planFilePath } from "../../../plan";
 import type { ToolContext } from "./types";

--- a/src/core/agents/offSecAgent/tools/writePlan.ts
+++ b/src/core/agents/offSecAgent/tools/writePlan.ts
@@ -1,7 +1,7 @@
-import { tool } from "ai";
 import { mkdirSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
+import { tool } from "ai";
 import { z } from "zod";
 import { planFilePath } from "../../../plan";
 import type { ToolContext } from "./types";

--- a/src/core/agents/offSecAgent/trace.test.ts
+++ b/src/core/agents/offSecAgent/trace.test.ts
@@ -1,7 +1,7 @@
 import type { ModelMessage } from "ai";
-import { mkdtempSync, readFileSync, rmSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AgentEventBus } from "../../eventBus";
 import {

--- a/src/core/agents/offSecAgent/trace.test.ts
+++ b/src/core/agents/offSecAgent/trace.test.ts
@@ -1,7 +1,7 @@
-import type { ModelMessage } from "ai";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ModelMessage } from "ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AgentEventBus } from "../../eventBus";
 import {

--- a/src/core/agents/offSecAgent/trace.ts
+++ b/src/core/agents/offSecAgent/trace.ts
@@ -9,10 +9,10 @@
  * metrics pipeline (step-level cost analysis), post-training data curation.
  */
 
-import type { ModelMessage } from "ai";
 import { createHash } from "node:crypto";
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import type { ModelMessage } from "ai";
 import type { AgentEventBus } from "../../eventBus";
 
 // ---------------------------------------------------------------------------

--- a/src/core/agents/offSecAgent/trace.ts
+++ b/src/core/agents/offSecAgent/trace.ts
@@ -10,9 +10,9 @@
  */
 
 import type { ModelMessage } from "ai";
-import { createHash } from "crypto";
-import { appendFileSync, mkdirSync } from "fs";
-import { dirname } from "path";
+import { createHash } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
 import type { AgentEventBus } from "../../eventBus";
 
 // ---------------------------------------------------------------------------

--- a/src/core/agents/specialized/attackSurface/blackboxAgent.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxAgent.ts
@@ -1,6 +1,6 @@
 import { hasToolCall, stepCountIs } from "ai";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
-import { join } from "path";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type { SessionInfo } from "../../../session";
 import {
   OffensiveSecurityAgent,

--- a/src/core/agents/specialized/attackSurface/blackboxAgent.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxAgent.ts
@@ -1,6 +1,6 @@
-import { hasToolCall, stepCountIs } from "ai";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { hasToolCall, stepCountIs } from "ai";
 import type { SessionInfo } from "../../../session";
 import {
   OffensiveSecurityAgent,

--- a/src/core/agents/specialized/attackSurface/types.ts
+++ b/src/core/agents/specialized/attackSurface/types.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 
 /**
  * Type definitions for Attack Surface Analysis results

--- a/src/core/agents/specialized/authenticationAgent/agent.ts
+++ b/src/core/agents/specialized/authenticationAgent/agent.ts
@@ -1,7 +1,7 @@
-import type { StreamTextOnStepFinishCallback, ToolSet } from "ai";
-import { hasToolCall } from "ai";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import type { StreamTextOnStepFinishCallback, ToolSet } from "ai";
+import { hasToolCall } from "ai";
 import type { AIAuthConfig, AIModel, OpenAIReasoningEffort } from "../../../ai";
 import type { AgentEventBus } from "../../../eventBus";
 import type { SessionInfo } from "../../../session";

--- a/src/core/agents/specialized/authenticationAgent/agent.ts
+++ b/src/core/agents/specialized/authenticationAgent/agent.ts
@@ -1,7 +1,7 @@
 import type { StreamTextOnStepFinishCallback, ToolSet } from "ai";
 import { hasToolCall } from "ai";
-import { existsSync, readFileSync } from "fs";
-import { join } from "path";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { AIAuthConfig, AIModel, OpenAIReasoningEffort } from "../../../ai";
 import type { AgentEventBus } from "../../../eventBus";
 import type { SessionInfo } from "../../../session";

--- a/src/core/agents/specialized/authenticationAgent/prompts.ts
+++ b/src/core/agents/specialized/authenticationAgent/prompts.ts
@@ -189,13 +189,14 @@ function buildAuthUserPrompt(input: {
     captchaDetected?: boolean;
   };
 }): string {
+  const credentialTokens = input.credentials?.tokens;
   const hasTokens =
-    input.credentials?.tokens &&
-    (input.credentials.tokens.bearerToken ||
-      input.credentials.tokens.cookies ||
-      input.credentials.tokens.sessionToken ||
-      (input.credentials.tokens.customHeaders &&
-        Object.keys(input.credentials.tokens.customHeaders).length > 0));
+    credentialTokens &&
+    (credentialTokens.bearerToken ||
+      credentialTokens.cookies ||
+      credentialTokens.sessionToken ||
+      (credentialTokens.customHeaders &&
+        Object.keys(credentialTokens.customHeaders).length > 0));
 
   let prompt = `# Authentication Task
 
@@ -244,7 +245,7 @@ The following credentials are configured for this domain:
   }
 
   // If pre-existing tokens are provided, prioritize them
-  if (hasTokens) {
+  if (hasTokens && credentialTokens) {
     prompt += `## Pre-existing Tokens (VERIFY THESE FIRST)
 **Mode: Token Verification** - Your goal is to verify these tokens grant access.
 
@@ -257,7 +258,7 @@ The following credentials are configured for this domain:
       prompt += `- Context: ${input.credentials!.context}
 `;
     }
-    const tokens = input.credentials!.tokens!;
+    const tokens = credentialTokens;
     if (tokens.bearerToken) {
       prompt += `- Bearer Token: ${tokens.bearerToken}
   Use as: Authorization: Bearer <token>

--- a/src/core/agents/specialized/benchmark/comparisonAgent.ts
+++ b/src/core/agents/specialized/benchmark/comparisonAgent.ts
@@ -1,6 +1,6 @@
-import { stepCountIs, tool } from "ai";
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { stepCountIs, tool } from "ai";
 import { z } from "zod";
 import { type AIModel, streamResponse } from "../../../ai";
 import type { ComparisonResult } from "./types";

--- a/src/core/agents/specialized/benchmark/comparisonAgent.ts
+++ b/src/core/agents/specialized/benchmark/comparisonAgent.ts
@@ -1,6 +1,6 @@
 import { stepCountIs, tool } from "ai";
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 import { type AIModel, streamResponse } from "../../../ai";
 import type { ComparisonResult } from "./types";

--- a/src/core/agents/specialized/benchmark/docker-utils.ts
+++ b/src/core/agents/specialized/benchmark/docker-utils.ts
@@ -1,7 +1,7 @@
-import { exec as nodeExec } from "child_process";
-import { existsSync, readFileSync, writeFileSync } from "fs";
-import path from "path";
-import { promisify } from "util";
+import { exec as nodeExec } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
 import yaml from "yaml";
 
 const exec = promisify(nodeExec);

--- a/src/core/agents/specialized/benchmark/flag-detector.ts
+++ b/src/core/agents/specialized/benchmark/flag-detector.ts
@@ -1,8 +1,8 @@
-import crypto from "crypto";
-import { existsSync } from "fs";
-import fs from "fs/promises";
+import crypto from "node:crypto";
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
 import { glob } from "glob";
-import path from "path";
+import path from "node:path";
 import yaml from "yaml";
 import type { FlagDetectionResult, FlagLocation } from "./types";
 

--- a/src/core/agents/specialized/benchmark/flag-detector.ts
+++ b/src/core/agents/specialized/benchmark/flag-detector.ts
@@ -1,8 +1,8 @@
 import crypto from "node:crypto";
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
-import { glob } from "glob";
 import path from "node:path";
+import { glob } from "glob";
 import yaml from "yaml";
 import type { FlagDetectionResult, FlagLocation } from "./types";
 

--- a/src/core/agents/specialized/benchmark/remote/daytona-wrapper.ts
+++ b/src/core/agents/specialized/benchmark/remote/daytona-wrapper.ts
@@ -1,7 +1,7 @@
-import { Daytona, type Sandbox } from "@daytonaio/sdk";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import pLimit from "p-limit";
 import path from "node:path";
+import { Daytona, type Sandbox } from "@daytonaio/sdk";
+import pLimit from "p-limit";
 import type { AIModel } from "../../../../ai";
 import { CircuitBreaker } from "./circuit-breaker";
 

--- a/src/core/agents/specialized/benchmark/remote/daytona-wrapper.ts
+++ b/src/core/agents/specialized/benchmark/remote/daytona-wrapper.ts
@@ -1,7 +1,7 @@
 import { Daytona, type Sandbox } from "@daytonaio/sdk";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import pLimit from "p-limit";
-import path from "path";
+import path from "node:path";
 import type { AIModel } from "../../../../ai";
 import { CircuitBreaker } from "./circuit-breaker";
 
@@ -723,7 +723,7 @@ async function downloadResults(
   let findingsCount = 0;
   if (existsSync(findingsDir)) {
     try {
-      const findingFiles = await import("fs/promises").then((fs) =>
+      const findingFiles = await import("node:fs/promises").then((fs) =>
         fs.readdir(findingsDir),
       );
       findingsCount = findingFiles.filter((f) => f.endsWith(".json")).length;

--- a/src/core/agents/specialized/benchmarkComparisonAgent.ts
+++ b/src/core/agents/specialized/benchmarkComparisonAgent.ts
@@ -1,7 +1,7 @@
-import type { StreamTextOnStepFinishCallback, ToolSet } from "ai";
-import { hasToolCall, stepCountIs } from "ai";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import type { StreamTextOnStepFinishCallback, ToolSet } from "ai";
+import { hasToolCall, stepCountIs } from "ai";
 import type { AIAuthConfig, AIModel, OpenAIReasoningEffort } from "../../ai";
 import type { SessionInfo } from "../../session";
 import { OffensiveSecurityAgent } from "../offSecAgent";

--- a/src/core/agents/specialized/benchmarkComparisonAgent.ts
+++ b/src/core/agents/specialized/benchmarkComparisonAgent.ts
@@ -1,7 +1,7 @@
 import type { StreamTextOnStepFinishCallback, ToolSet } from "ai";
 import { hasToolCall, stepCountIs } from "ai";
-import { existsSync, readdirSync, readFileSync } from "fs";
-import { join } from "path";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { AIAuthConfig, AIModel, OpenAIReasoningEffort } from "../../ai";
 import type { SessionInfo } from "../../session";
 import { OffensiveSecurityAgent } from "../offSecAgent";

--- a/src/core/agents/specialized/patching/agent.ts
+++ b/src/core/agents/specialized/patching/agent.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
-import { join } from "path";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { OffensiveSecurityAgent } from "../../offSecAgent";
 import { buildPatchingPrompt, buildSystemPrompt } from "./prompts";
 import {

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -1,5 +1,5 @@
-import { existsSync, readdirSync, readFileSync } from "fs";
-import { join } from "path";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 import type { FindingsRegistry } from "../../../findings/registry";
 import { readPlan } from "../../../plan";

--- a/src/core/agents/specialized/utils.ts
+++ b/src/core/agents/specialized/utils.ts
@@ -1,5 +1,5 @@
-import { execSync } from "child_process";
-import { existsSync, readFileSync } from "fs";
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { getBundledWordlists } from "../../assets/wordlists";
 
 type DetectedEnvironment = {

--- a/src/core/ai/contextManagement.test.ts
+++ b/src/core/ai/contextManagement.test.ts
@@ -1,7 +1,7 @@
 import type { ModelMessage, ToolSet } from "ai";
-import { mkdtempSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import {
@@ -231,9 +231,11 @@ describe("applyToolResultBudget", () => {
       }
     ).value;
     expect(pass1Value).toMatch(/truncated 48000 chars/);
-    const pass1FilePath = pass1Value.match(
+    const pass1FileMatch = pass1Value.match(
       /full output saved to (.+?)\]$/,
-    )![1]!;
+    );
+    expect(pass1FileMatch?.[1]).toBeDefined();
+    const pass1FilePath = pass1FileMatch?.[1] ?? "";
 
     const afterPass2 = applyToolResultBudget(afterPass1, {
       sessionPath,

--- a/src/core/ai/contextManagement.test.ts
+++ b/src/core/ai/contextManagement.test.ts
@@ -1,7 +1,7 @@
-import type { ModelMessage, ToolSet } from "ai";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ModelMessage, ToolSet } from "ai";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import {
@@ -231,9 +231,7 @@ describe("applyToolResultBudget", () => {
       }
     ).value;
     expect(pass1Value).toMatch(/truncated 48000 chars/);
-    const pass1FileMatch = pass1Value.match(
-      /full output saved to (.+?)\]$/,
-    );
+    const pass1FileMatch = pass1Value.match(/full output saved to (.+?)\]$/);
     expect(pass1FileMatch?.[1]).toBeDefined();
     const pass1FilePath = pass1FileMatch?.[1] ?? "";
 

--- a/src/core/ai/contextManagement.ts
+++ b/src/core/ai/contextManagement.ts
@@ -7,8 +7,8 @@
  */
 
 import type { ModelMessage, ToolSet } from "ai";
-import { mkdirSync, writeFileSync } from "fs";
-import { join } from "path";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 /**
  * Truncate `text` so the returned string fits in **at most** `max` chars,

--- a/src/core/ai/contextManagement.ts
+++ b/src/core/ai/contextManagement.ts
@@ -6,9 +6,9 @@
  * token budget so callers can compact proactively, not only on error.
  */
 
-import type { ModelMessage, ToolSet } from "ai";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { ModelMessage, ToolSet } from "ai";
 
 /**
  * Truncate `text` so the returned string fits in **at most** `max` chars,

--- a/src/core/assets/wordlists.test.ts
+++ b/src/core/assets/wordlists.test.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, statSync } from "fs";
-import { isAbsolute } from "path";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { isAbsolute } from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   _resetBundledWordlistsCacheForTests,

--- a/src/core/assets/wordlists.ts
+++ b/src/core/assets/wordlists.ts
@@ -1,6 +1,6 @@
-import { existsSync, readFileSync, statSync } from "fs";
-import { dirname, join, resolve } from "path";
-import { fileURLToPath } from "url";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /**
  * Absolute paths to the wordlists bundled inside the published package.

--- a/src/core/auth/signing.ts
+++ b/src/core/auth/signing.ts
@@ -1,4 +1,4 @@
-import { createHash, createHmac, randomUUID } from "crypto";
+import { createHash, createHmac, randomUUID } from "node:crypto";
 
 /**
  * Sign an inference request for the Pensar Gateway.

--- a/src/core/benchmark/runner.ts
+++ b/src/core/benchmark/runner.ts
@@ -1,7 +1,7 @@
-import { exec as nodeExec } from "child_process";
-import { existsSync, readFileSync, writeFileSync } from "fs";
-import path from "path";
-import { promisify } from "util";
+import { exec as nodeExec } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
 
 import {
   detectFlagInArtifacts,

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -1,6 +1,6 @@
-import fs from "fs/promises";
-import os from "os";
-import path from "path";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { getCurrentVersion } from "../installation";
 
 const DEFAULT_CONFIG: Config = {

--- a/src/core/credentials/manager.ts
+++ b/src/core/credentials/manager.ts
@@ -6,7 +6,7 @@
  * secrets are resolved at tool-execution time via {@link resolve}.
  */
 
-import { randomBytes } from "crypto";
+import { randomBytes } from "node:crypto";
 import type { AuthCredentials } from "../session";
 import type {
   CredentialReference,

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -1,5 +1,5 @@
-import { execSync, spawnSync } from "child_process";
-import readline from "readline";
+import { execSync, spawnSync } from "node:child_process";
+import readline from "node:readline";
 import { toolExists } from "./agents/specialized/utils.js";
 
 function detectPackageManager(): { name: string; installCmd: string } | null {

--- a/src/core/eventBus.test.ts
+++ b/src/core/eventBus.test.ts
@@ -1,6 +1,6 @@
-import { mkdtempSync, rmSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { StepTraceWriter, type TraceRecord } from "./agents/offSecAgent/trace";
 import { AgentEventBus } from "./eventBus";

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -1,5 +1,5 @@
-import type { TextStreamPart, ToolSet } from "ai";
 import { EventEmitter } from "node:events";
+import type { TextStreamPart, ToolSet } from "ai";
 
 /**
  * Typed event map for the agent event bus.

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -1,5 +1,5 @@
 import type { TextStreamPart, ToolSet } from "ai";
-import { EventEmitter } from "events";
+import { EventEmitter } from "node:events";
 
 /**
  * Typed event map for the agent event bus.

--- a/src/core/findings/attackSurfaceRegistry.ts
+++ b/src/core/findings/attackSurfaceRegistry.ts
@@ -1,5 +1,5 @@
-import { existsSync, readdirSync, readFileSync } from "fs";
-import { join } from "path";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 
 // ---------------------------------------------------------------------------
 // Fingerprinting helpers

--- a/src/core/findings/registry.test.ts
+++ b/src/core/findings/registry.test.ts
@@ -788,10 +788,10 @@ describe("FindingsRegistry", () => {
   // -------------------------------------------------------------------------
 
   describe("fromDirectory", () => {
-    let mockedFs: typeof import("fs");
+    let mockedFs: typeof import("node:fs");
 
     beforeEach(async () => {
-      mockedFs = await import("fs");
+      mockedFs = await import("node:fs");
     });
 
     afterEach(() => {

--- a/src/core/findings/registry.ts
+++ b/src/core/findings/registry.ts
@@ -1,5 +1,5 @@
-import { existsSync, readdirSync, readFileSync } from "fs";
-import { join } from "path";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 import type { Finding } from "../agents/offSecAgent";
 import { type AIAuthConfig, type AIModel, generateObjectResponse } from "../ai";

--- a/src/core/har/diff.test.ts
+++ b/src/core/har/diff.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { diffHarEntries } from "./diff";
+import type { HarEntry } from "./types";
+
+function entry(id: string, url: string, body: string, status = 200): HarEntry {
+  return {
+    _id: id,
+    startedDateTime: new Date().toISOString(),
+    time: 1,
+    request: {
+      method: "GET",
+      url,
+      headers: [{ name: "Cookie", value: `sid=${id}` }],
+      queryString: [],
+    },
+    response: {
+      status,
+      headers: [{ name: "Content-Type", value: "application/json" }],
+      content: { size: body.length, text: body },
+    },
+  };
+}
+
+describe("diffHarEntries", () => {
+  it("preserves auth context and buckets same-response candidates", () => {
+    const report = diffHarEntries(
+      [entry("a1", "https://app.example.com/api/users/1", '{"id":1}')],
+      [entry("b1", "https://app.example.com/api/users/1", '{"id":1}')],
+    );
+
+    expect(report.candidates[0]).toMatchObject({
+      bucket: "same-response",
+      score: 80,
+      accountA: {
+        requestAuth: { cookie: "sid=a1" },
+      },
+      accountB: {
+        requestAuth: { cookie: "sid=b1" },
+      },
+    });
+  });
+
+  it("records unique entries from both accounts", () => {
+    const report = diffHarEntries(
+      [entry("a1", "https://app.example.com/api/a", "a")],
+      [entry("b1", "https://app.example.com/api/b", "b")],
+    );
+
+    expect(report.candidates.map((candidate) => candidate.bucket)).toEqual([
+      "unique-to-a",
+      "unique-to-b",
+    ]);
+  });
+});

--- a/src/core/har/diff.ts
+++ b/src/core/har/diff.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 import type { HarEntry, HarHeader } from "./types";
 
 export type HarDiffBucket =
@@ -8,7 +8,7 @@ export type HarDiffBucket =
   | "unique-to-a"
   | "unique-to-b";
 
-export interface HarDiffCandidate {
+interface HarDiffCandidate {
   bucket: HarDiffBucket;
   score: number;
   key: string;
@@ -16,7 +16,7 @@ export interface HarDiffCandidate {
   accountB?: CompactHarEntry;
 }
 
-export interface CompactHarEntry {
+interface CompactHarEntry {
   id?: string;
   method: string;
   url: string;

--- a/src/core/har/diff.ts
+++ b/src/core/har/diff.ts
@@ -1,0 +1,186 @@
+import { createHash } from "crypto";
+import type { HarEntry, HarHeader } from "./types";
+
+export type HarDiffBucket =
+  | "same-response"
+  | "different-but-200"
+  | "403-vs-200"
+  | "unique-to-a"
+  | "unique-to-b";
+
+export interface HarDiffCandidate {
+  bucket: HarDiffBucket;
+  score: number;
+  key: string;
+  accountA?: CompactHarEntry;
+  accountB?: CompactHarEntry;
+}
+
+export interface CompactHarEntry {
+  id?: string;
+  method: string;
+  url: string;
+  requestAuth: {
+    authorization?: string;
+    cookie?: string;
+  };
+  response: {
+    status: number;
+    contentType?: string;
+    setCookie?: string;
+    size: number;
+    bodySha: string;
+  };
+}
+
+export interface HarDiffReport {
+  generatedAt: string;
+  counts: {
+    accountAEntries: number;
+    accountBEntries: number;
+    candidates: number;
+  };
+  candidates: HarDiffCandidate[];
+}
+
+export function diffHarEntries(
+  accountAEntries: HarEntry[],
+  accountBEntries: HarEntry[],
+): HarDiffReport {
+  const byKeyB = new Map(
+    accountBEntries.map((entry) => [canonicalKey(entry), entry]),
+  );
+  const seenB = new Set<string>();
+  const candidates: HarDiffCandidate[] = [];
+
+  for (const accountA of accountAEntries) {
+    const key = canonicalKey(accountA);
+    const accountB = byKeyB.get(key);
+    if (!accountB) {
+      candidates.push({
+        bucket: "unique-to-a",
+        score: suspicionScore("unique-to-a"),
+        key,
+        accountA: compactHarEntry(accountA),
+      });
+      continue;
+    }
+
+    seenB.add(key);
+    const bucket = bucketPair(accountA, accountB);
+    candidates.push({
+      bucket,
+      score: suspicionScore(bucket),
+      key,
+      accountA: compactHarEntry(accountA),
+      accountB: compactHarEntry(accountB),
+    });
+  }
+
+  for (const accountB of accountBEntries) {
+    const key = canonicalKey(accountB);
+    if (seenB.has(key)) continue;
+    candidates.push({
+      bucket: "unique-to-b",
+      score: suspicionScore("unique-to-b"),
+      key,
+      accountB: compactHarEntry(accountB),
+    });
+  }
+
+  candidates.sort((a, b) => b.score - a.score);
+  return {
+    generatedAt: new Date().toISOString(),
+    counts: {
+      accountAEntries: accountAEntries.length,
+      accountBEntries: accountBEntries.length,
+      candidates: candidates.length,
+    },
+    candidates,
+  };
+}
+
+function canonicalKey(entry: HarEntry): string {
+  const url = new URL(entry.request.url);
+  const params = Array.from(url.searchParams.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+  const body = entry.request.postData?.text ?? "";
+  const bodyHash = body
+    ? createHash("sha256").update(body).digest("hex").slice(0, 12)
+    : "";
+  return [
+    entry.request.method.toUpperCase(),
+    url.host,
+    url.pathname,
+    params,
+    bodyHash,
+  ].join(" ");
+}
+
+function responseHash(entry: HarEntry): string {
+  const content = entry.response.content;
+  return createHash("sha256")
+    .update(
+      `${entry.response.status}:${content.size}:${content.text ?? content._attachedSha ?? ""}`,
+    )
+    .digest("hex");
+}
+
+function headerValue(headers: HarHeader[], name: string): string | undefined {
+  const lower = name.toLowerCase();
+  return headers.find((header) => header.name.toLowerCase() === lower)?.value;
+}
+
+function compactHarEntry(entry: HarEntry): CompactHarEntry {
+  return {
+    id: entry._id,
+    method: entry.request.method,
+    url: entry.request.url,
+    requestAuth: {
+      authorization: headerValue(entry.request.headers, "authorization"),
+      cookie: headerValue(entry.request.headers, "cookie"),
+    },
+    response: {
+      status: entry.response.status,
+      contentType: headerValue(entry.response.headers, "content-type"),
+      setCookie: headerValue(entry.response.headers, "set-cookie"),
+      size: entry.response.content.size,
+      bodySha: entry.response.content._attachedSha ?? responseHash(entry),
+    },
+  };
+}
+
+function bucketPair(accountA: HarEntry, accountB: HarEntry): HarDiffBucket {
+  if (
+    (accountA.response.status === 403 &&
+      accountB.response.status >= 200 &&
+      accountB.response.status < 300) ||
+    (accountB.response.status === 403 &&
+      accountA.response.status >= 200 &&
+      accountA.response.status < 300)
+  ) {
+    return "403-vs-200";
+  }
+  if (
+    accountA.response.status >= 200 &&
+    accountA.response.status < 300 &&
+    accountB.response.status >= 200 &&
+    accountB.response.status < 300
+  ) {
+    return responseHash(accountA) === responseHash(accountB)
+      ? "same-response"
+      : "different-but-200";
+  }
+  return responseHash(accountA) === responseHash(accountB)
+    ? "same-response"
+    : "different-but-200";
+}
+
+function suspicionScore(bucket: HarDiffBucket): number {
+  if (bucket === "same-response") return 80;
+  if (bucket === "different-but-200") return 55;
+  if (bucket === "403-vs-200") return 45;
+  return 30;
+}

--- a/src/core/har/scope.test.ts
+++ b/src/core/har/scope.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { ToolContext } from "../agents/offSecAgent/tools";
+import { filterHarByScope } from "./scope";
+import type { HarEntry } from "./types";
+
+function entry(url: string): HarEntry {
+  return {
+    _id: url,
+    startedDateTime: new Date().toISOString(),
+    time: 1,
+    request: {
+      method: "GET",
+      url,
+      headers: [],
+      queryString: [],
+    },
+    response: {
+      status: 200,
+      headers: [],
+      content: { size: 0, text: "" },
+    },
+  };
+}
+
+describe("filterHarByScope", () => {
+  it("keeps target registrable-domain entries and drops third-party hosts", () => {
+    const ctx = {
+      target: "https://app.example.com",
+      session: {
+        targets: ["https://app.example.com"],
+        config: {},
+      },
+    } as ToolContext;
+
+    const filtered = filterHarByScope(
+      [
+        entry("https://app.example.com/api/me"),
+        entry("https://api.example.com/api/me"),
+        entry("https://analytics.example.net/beacon"),
+      ],
+      ctx,
+    );
+
+    expect(filtered.map((item) => item.request.url)).toEqual([
+      "https://app.example.com/api/me",
+      "https://api.example.com/api/me",
+    ]);
+  });
+});

--- a/src/core/har/scope.ts
+++ b/src/core/har/scope.ts
@@ -1,0 +1,29 @@
+import {
+  getAllowedHosts,
+  isHostAllowed,
+} from "../agents/offSecAgent/tools/scopeGuard";
+import type { ToolContext } from "../agents/offSecAgent/tools/types";
+import type { HarEntry } from "./types";
+
+export function filterHarEntriesByAllowedHosts(
+  entries: HarEntry[],
+  allowedHosts: string[],
+): HarEntry[] {
+  if (allowedHosts.length === 0) return entries;
+
+  return entries.filter((entry) => {
+    try {
+      const hostname = new URL(entry.request.url).hostname.toLowerCase();
+      return isHostAllowed(hostname, allowedHosts);
+    } catch {
+      return false;
+    }
+  });
+}
+
+export function filterHarByScope(
+  entries: HarEntry[],
+  ctx: ToolContext,
+): HarEntry[] {
+  return filterHarEntriesByAllowedHosts(entries, getAllowedHosts(ctx));
+}

--- a/src/core/har/scope.ts
+++ b/src/core/har/scope.ts
@@ -5,7 +5,7 @@ import {
 import type { ToolContext } from "../agents/offSecAgent/tools/types";
 import type { HarEntry } from "./types";
 
-export function filterHarEntriesByAllowedHosts(
+function filterHarEntriesByAllowedHosts(
   entries: HarEntry[],
   allowedHosts: string[],
 ): HarEntry[] {

--- a/src/core/har/types.test.ts
+++ b/src/core/har/types.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseHar } from "./types";
+
+describe("parseHar", () => {
+  it("parses the HAR subset Apex emits", () => {
+    const har = parseHar({
+      log: {
+        version: "1.2",
+        entries: [
+          {
+            _id: "entry-1",
+            startedDateTime: new Date().toISOString(),
+            time: 12,
+            request: {
+              method: "GET",
+              url: "https://app.example.com/api/me",
+              headers: [{ name: "Cookie", value: "sid=abc" }],
+              queryString: [],
+            },
+            response: {
+              status: 200,
+              headers: [{ name: "Content-Type", value: "application/json" }],
+              content: {
+                size: 2,
+                mimeType: "application/json",
+                text: "{}",
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(har.log.entries[0].request.headers[0].value).toBe("sid=abc");
+  });
+});

--- a/src/core/har/types.ts
+++ b/src/core/har/types.ts
@@ -7,14 +7,14 @@ export const HarHeaderSchema = z
   })
   .passthrough();
 
-export const HarPostDataSchema = z
+const HarPostDataSchema = z
   .object({
     mimeType: z.string().optional(),
     text: z.string().optional(),
   })
   .passthrough();
 
-export const HarRequestSchema = z
+const HarRequestSchema = z
   .object({
     method: z.string(),
     url: z.string(),
@@ -27,7 +27,7 @@ export const HarRequestSchema = z
   })
   .passthrough();
 
-export const HarContentSchema = z
+const HarContentSchema = z
   .object({
     size: z.number(),
     mimeType: z.string().optional(),
@@ -38,7 +38,7 @@ export const HarContentSchema = z
   })
   .passthrough();
 
-export const HarResponseSchema = z
+const HarResponseSchema = z
   .object({
     status: z.number(),
     statusText: z.string().optional(),
@@ -82,8 +82,6 @@ export const HarFileSchema = z
   .passthrough();
 
 export type HarHeader = z.infer<typeof HarHeaderSchema>;
-export type HarRequest = z.infer<typeof HarRequestSchema>;
-export type HarResponse = z.infer<typeof HarResponseSchema>;
 export type HarEntry = z.infer<typeof HarEntrySchema>;
 export type HarFile = z.infer<typeof HarFileSchema>;
 

--- a/src/core/har/types.ts
+++ b/src/core/har/types.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+
+export const HarHeaderSchema = z
+  .object({
+    name: z.string(),
+    value: z.string(),
+  })
+  .passthrough();
+
+export const HarPostDataSchema = z
+  .object({
+    mimeType: z.string().optional(),
+    text: z.string().optional(),
+  })
+  .passthrough();
+
+export const HarRequestSchema = z
+  .object({
+    method: z.string(),
+    url: z.string(),
+    httpVersion: z.string().optional(),
+    headers: z.array(HarHeaderSchema).default([]),
+    queryString: z.array(HarHeaderSchema).default([]),
+    postData: HarPostDataSchema.optional(),
+    headersSize: z.number().optional(),
+    bodySize: z.number().optional(),
+  })
+  .passthrough();
+
+export const HarContentSchema = z
+  .object({
+    size: z.number(),
+    mimeType: z.string().optional(),
+    text: z.string().optional(),
+    encoding: z.string().optional(),
+    _attachedSha: z.string().optional(),
+    _attachedPath: z.string().optional(),
+  })
+  .passthrough();
+
+export const HarResponseSchema = z
+  .object({
+    status: z.number(),
+    statusText: z.string().optional(),
+    httpVersion: z.string().optional(),
+    headers: z.array(HarHeaderSchema).default([]),
+    content: HarContentSchema,
+    redirectURL: z.string().optional(),
+    headersSize: z.number().optional(),
+    bodySize: z.number().optional(),
+  })
+  .passthrough();
+
+export const HarEntrySchema = z
+  .object({
+    _id: z.string().optional(),
+    _started: z.number().optional(),
+    startedDateTime: z.string(),
+    time: z.number(),
+    request: HarRequestSchema,
+    response: HarResponseSchema,
+    timings: z.record(z.number()).optional(),
+    pageref: z.string().optional(),
+  })
+  .passthrough();
+
+export const HarFileSchema = z
+  .object({
+    log: z
+      .object({
+        version: z.string(),
+        creator: z
+          .object({
+            name: z.string(),
+            version: z.string(),
+          })
+          .optional(),
+        entries: z.array(HarEntrySchema),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+export type HarHeader = z.infer<typeof HarHeaderSchema>;
+export type HarRequest = z.infer<typeof HarRequestSchema>;
+export type HarResponse = z.infer<typeof HarResponseSchema>;
+export type HarEntry = z.infer<typeof HarEntrySchema>;
+export type HarFile = z.infer<typeof HarFileSchema>;
+
+export function parseHar(input: unknown): HarFile {
+  const value = typeof input === "string" ? JSON.parse(input) : input;
+  return HarFileSchema.parse(value);
+}

--- a/src/core/http/headers.contract.test.ts
+++ b/src/core/http/headers.contract.test.ts
@@ -1,10 +1,10 @@
 // Contract tests for the custom-headers subsystem: resolver layering/scope,
 // `targetFetch`, shell injection, history redaction, parser errors.
 
-import { mkdtempSync, rmSync } from "fs";
-import { writeFile } from "fs/promises";
-import { tmpdir } from "os";
-import { join } from "path";
+import { mkdtempSync, rmSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { redactSecretsInHistoryEntry } from "../history";
 import {

--- a/src/core/http/parse.ts
+++ b/src/core/http/parse.ts
@@ -164,7 +164,7 @@ function parseHeaderRecord(
 export async function parseHeadersFromFile(
   filePath: string,
 ): Promise<Result<HeaderEntry[], ParseError[]>> {
-  const fs = await import("fs/promises");
+  const fs = await import("node:fs/promises");
   let raw: string;
   try {
     raw = await fs.readFile(filePath, "utf-8");

--- a/src/core/id/id.ts
+++ b/src/core/id/id.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "crypto";
+import { randomBytes } from "node:crypto";
 import z from "zod";
 
 const prefixes = {

--- a/src/core/installation/index.ts
+++ b/src/core/installation/index.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "child_process";
+import { spawnSync } from "node:child_process";
 import packageJson from "../../../package.json";
 
 export type InstallMethod = "npm" | "homebrew" | "binary";

--- a/src/core/installation/installation.test.ts
+++ b/src/core/installation/installation.test.ts
@@ -183,7 +183,7 @@ describe("detectInstallMethod", () => {
     });
     process.argv[1] = "/usr/local/bin/pensar";
 
-    const { spawnSync } = await import("child_process");
+    const { spawnSync } = await import("node:child_process");
     const mockedSpawnSync = vi.mocked(spawnSync);
     mockedSpawnSync.mockReturnValue({
       status: 0,
@@ -209,7 +209,7 @@ describe("detectInstallMethod", () => {
     });
     process.argv[1] = "/usr/local/bin/pensar";
 
-    const { spawnSync } = await import("child_process");
+    const { spawnSync } = await import("node:child_process");
     const mockedSpawnSync = vi.mocked(spawnSync);
     mockedSpawnSync.mockReturnValue({
       status: 1,
@@ -230,7 +230,7 @@ describe("detectInstallMethod", () => {
     });
     process.argv[1] = "upgrade";
 
-    const { spawnSync } = await import("child_process");
+    const { spawnSync } = await import("node:child_process");
     const mockedSpawnSync = vi.mocked(spawnSync);
     mockedSpawnSync.mockReturnValue({
       status: 0,
@@ -361,7 +361,7 @@ describe("upgrade", () => {
       new Response(JSON.stringify({ version: "99.99.99" }), { status: 200 }),
     );
 
-    const { spawnSync } = await import("child_process");
+    const { spawnSync } = await import("node:child_process");
     const mockedSpawnSync = vi.mocked(spawnSync);
     mockedSpawnSync.mockReturnValue({
       status: 0,
@@ -384,7 +384,7 @@ describe("upgrade", () => {
       new Response(JSON.stringify({ version: "99.99.99" }), { status: 200 }),
     );
 
-    const { spawnSync } = await import("child_process");
+    const { spawnSync } = await import("node:child_process");
     const mockedSpawnSync = vi.mocked(spawnSync);
     mockedSpawnSync.mockReturnValue({
       status: 0,
@@ -409,7 +409,7 @@ describe("upgrade", () => {
       new Response(JSON.stringify({ version: "99.99.99" }), { status: 200 }),
     );
 
-    const { spawnSync } = await import("child_process");
+    const { spawnSync } = await import("node:child_process");
     const mockedSpawnSync = vi.mocked(spawnSync);
     mockedSpawnSync.mockReturnValue({
       status: 0,
@@ -434,7 +434,7 @@ describe("upgrade", () => {
       new Response(JSON.stringify({ version: "99.99.99" }), { status: 200 }),
     );
 
-    const { spawnSync } = await import("child_process");
+    const { spawnSync } = await import("node:child_process");
     const mockedSpawnSync = vi.mocked(spawnSync);
     mockedSpawnSync.mockReturnValue({
       status: 1,

--- a/src/core/integrations/wandb/upload.test.ts
+++ b/src/core/integrations/wandb/upload.test.ts
@@ -1,7 +1,7 @@
-import type { ModelMessage } from "ai";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ModelMessage } from "ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   StepTraceWriter,

--- a/src/core/integrations/wandb/upload.test.ts
+++ b/src/core/integrations/wandb/upload.test.ts
@@ -1,7 +1,7 @@
 import type { ModelMessage } from "ai";
-import { mkdtempSync, readFileSync, rmSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   StepTraceWriter,

--- a/src/core/logger/index.ts
+++ b/src/core/logger/index.ts
@@ -4,9 +4,9 @@ import {
   mkdirSync,
   readFileSync,
   writeFileSync,
-} from "fs";
-import os from "os";
-import path from "path";
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { type SessionInfo, sessions } from "../session";
 
 export enum LogLevel {

--- a/src/core/memory/memory.test.ts
+++ b/src/core/memory/memory.test.ts
@@ -1,7 +1,7 @@
-import { mkdtempSync, rmSync } from "fs";
-import fs from "fs/promises";
-import { tmpdir } from "os";
-import path from "path";
+import { mkdtempSync, rmSync } from "node:fs";
+import fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {

--- a/src/core/operator/approvalGate.ts
+++ b/src/core/operator/approvalGate.ts
@@ -90,6 +90,19 @@ export class ApprovalGate extends EventEmitter {
     return this.requestApproval(toolName, toolCallId, args);
   }
 
+  /**
+   * Require an explicit operator decision regardless of the current
+   * auto/manual mode. Used by tools for high-impact actions where the
+   * approval requirement is part of the tool's own safety contract.
+   */
+  async requireApproval(
+    toolName: string,
+    toolCallId: string,
+    args: Record<string, unknown>,
+  ): Promise<ApprovalDecision> {
+    return this.requestApproval(toolName, toolCallId, args);
+  }
+
   private requestApproval(
     toolName: string,
     toolCallId: string,

--- a/src/core/operator/approvalGate.ts
+++ b/src/core/operator/approvalGate.ts
@@ -1,5 +1,5 @@
-import { randomBytes } from "crypto";
-import { EventEmitter } from "events";
+import { randomBytes } from "node:crypto";
+import { EventEmitter } from "node:events";
 import type {
   ActionHistoryEntry,
   ApprovalDecision,

--- a/src/core/operator/approvalGate.ts
+++ b/src/core/operator/approvalGate.ts
@@ -90,11 +90,7 @@ export class ApprovalGate extends EventEmitter {
     return this.requestApproval(toolName, toolCallId, args);
   }
 
-  /**
-   * Require an explicit operator decision regardless of the current
-   * auto/manual mode. Used by tools for high-impact actions where the
-   * approval requirement is part of the tool's own safety contract.
-   */
+  /** Always prompt the operator, ignoring auto-approve mode. */
   async requireApproval(
     toolName: string,
     toolCallId: string,

--- a/src/core/plan/index.ts
+++ b/src/core/plan/index.ts
@@ -9,8 +9,8 @@
  * multiple plan agents run concurrently.
  */
 
-import { existsSync, readFileSync } from "fs";
-import { join } from "path";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 
 const PLAN_FILENAME = "plan.md";
 

--- a/src/core/session/execution-metrics.ts
+++ b/src/core/session/execution-metrics.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 const EXECUTION_METRICS_FILENAME = "execution-metrics.json";
 

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -1,7 +1,7 @@
-import type { ModelMessage } from "ai";
 import { existsSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { ModelMessage } from "ai";
 import z from "zod";
 import { generateRandomName, generateSessionName } from "../../util/name";
 import type { AIAuthConfig, AIModel } from "../ai";

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -1,7 +1,7 @@
 import type { ModelMessage } from "ai";
-import { existsSync, readFileSync } from "fs";
-import os from "os";
-import path from "path";
+import { existsSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import z from "zod";
 import { generateRandomName, generateSessionName } from "../../util/name";
 import type { AIAuthConfig, AIModel } from "../ai";
@@ -615,9 +615,9 @@ async function update(id: string, editor: (session: SessionInfo) => void) {
 
 export async function* list() {
   const sessionsDir = getSessionsDir();
-  let entries: import("fs").Dirent[];
+  let entries: import("node:fs").Dirent[];
   try {
-    entries = await import("fs/promises").then((fsp) =>
+    entries = await import("node:fs/promises").then((fsp) =>
       fsp.readdir(sessionsDir, { withFileTypes: true }),
     );
   } catch {
@@ -645,7 +645,7 @@ const remove = async (input: z.output<typeof RemoveInput>) => {
   try {
     // Remove the entire session directory (metadata + artifacts)
     const sessionDir = getSessionRoot(input.sessionId);
-    const fsp = await import("fs/promises");
+    const fsp = await import("node:fs/promises");
     await fsp.rm(sessionDir, { recursive: true, force: true });
   } catch (e) {
     console.error(e);

--- a/src/core/session/loader.ts
+++ b/src/core/session/loader.ts
@@ -8,8 +8,8 @@
  * This file orchestrates the higher-level session state assembly.
  */
 
-import { existsSync, readFileSync } from "fs";
-import { join } from "path";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { REPORT_FILENAME_MD } from "../report";
 import type { SessionInfo } from "./index";
 import { loadSubagents, type UIMessage, type UISubagent } from "./persistence";

--- a/src/core/session/persistence.test.ts
+++ b/src/core/session/persistence.test.ts
@@ -1,4 +1,3 @@
-import type { ModelMessage } from "ai";
 import {
   existsSync,
   mkdirSync,
@@ -9,6 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ModelMessage } from "ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getResumeMessages, normalizeMessages } from "./index";
 import {

--- a/src/core/session/persistence.test.ts
+++ b/src/core/session/persistence.test.ts
@@ -6,9 +6,9 @@ import {
   readFileSync,
   rmSync,
   writeFileSync,
-} from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getResumeMessages, normalizeMessages } from "./index";
 import {
@@ -220,7 +220,7 @@ describe("saveSubagentData + loadSubagents roundtrip", () => {
     });
 
     // Verify the raw JSON has the correct findingsCount
-    const files = require("fs").readdirSync(join(tmpDir, "subagents"));
+    const files = require("node:fs").readdirSync(join(tmpDir, "subagents"));
     const data = JSON.parse(
       readFileSync(join(tmpDir, "subagents", files[0]), "utf-8"),
     );

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -13,8 +13,8 @@ import {
   readFileSync,
   statSync,
   writeFileSync,
-} from "fs";
-import { join } from "path";
+} from "node:fs";
+import { join } from "node:path";
 import type { SessionInfo } from "./index";
 
 export type { SessionInfo };

--- a/src/core/skills/builtins/idorHarDiff.ts
+++ b/src/core/skills/builtins/idorHarDiff.ts
@@ -28,45 +28,27 @@ export const idorHarDiffSkill: BuiltInSkill = {
   },
   instructions: `# IDOR HAR Diff
 
-Use this skill when the operator asks for IDOR / broken authorization testing, or when two comparable user accounts are available and you need to compare what each account can see.
-
-This skill encodes a known pentester workflow: perform the same browser flow as Account A and Account B, compare the captured traffic, then actively confirm any cross-account access with replay. The HARs intentionally include \`Authorization\`, \`Cookie\`, and \`Set-Cookie\` values for in-scope hosts because replay and session-management analysis need them.
+Use this skill for IDOR / broken authorization testing when two comparable accounts are available. Captured HARs keep in-scope auth headers so candidates can be replayed.
 
 ## Workflow
 
-1. Start Account A capture:
-   - Call \`start_har_capture\` with a descriptive name such as \`account-a-profile\`.
-   - Log in or switch to Account A.
-   - Navigate through the requested flow or seed URLs.
-   - Call \`stop_har_capture\` and keep the returned \`path\`.
-
-2. Start Account B capture:
-   - Call \`start_har_capture\` with a descriptive name such as \`account-b-profile\`.
-   - Log out / switch accounts if needed.
-   - Perform the same flow as Account B.
-   - Call \`stop_har_capture\` and keep the returned \`path\`.
-
-3. Compare the HARs:
-   - Call \`har_diff\` with \`accountAHarPath\` and \`accountBHarPath\`.
-   - Keep the returned \`path\` to the generated JSON report.
-
-4. Confirm candidates:
-   - Review the \`har_diff\` candidates.
-   - For each high-suspicion candidate, call \`har_replay\` against the relevant captured entry.
-   - A diff alone is not a vulnerability. Only document a finding after replay confirms Account B can access Account A's resource or data.
+1. Capture the same flow as Account A with \`start_har_capture\` / \`stop_har_capture\`; keep the returned \`path\`.
+2. Capture the same flow as Account B; keep the returned \`path\`.
+3. Compare both files with \`har_diff\`.
+4. Replay high-suspicion entries with \`har_replay\`. A diff alone is not a vulnerability; document only confirmed cross-account access.
 
 ## How to read the diff
 
-- \`same-response\`: both accounts received very similar 2xx responses for the same request shape. Investigate when the response contains user-specific data.
-- \`different-but-200\`: both accounts received 2xx, but the bodies differ. Often expected; inspect IDs, owner fields, tenant IDs, and object counts.
-- \`403-vs-200\`: one account is blocked and the other succeeds. This is often correct authorization, but can reveal which request carries the authorization boundary.
-- \`unique-to-a\` / \`unique-to-b\`: one flow made a request the other never made. Often UI/role driven; inspect before replay.
+- \`same-response\`: most suspicious when user-specific data is present.
+- \`different-but-200\`: inspect IDs, owners, tenant IDs, and object counts.
+- \`403-vs-200\`: often correct authorization; useful for locating the boundary.
+- \`unique-to-a\` / \`unique-to-b\`: often role/UI driven; inspect before replay.
 
 ## Rules
 
 - Do not report IDOR if the endpoint is unauthenticated for everyone. That is missing authentication, not IDOR.
-- Do not replay out-of-scope hosts. The \`har_replay\` tool enforces scope, but you should avoid selecting those candidates.
-- Do not call destructive methods unless necessary. \`har_replay\` will require operator approval for \`DELETE\`, \`PUT\`, \`PATCH\`, credential swaps, and auth-header overrides.
+- Avoid replaying out-of-scope hosts.
+- Do not call destructive methods unless necessary.
 - Prefer confirming read-only access first (\`GET\` / safe \`POST\`) before attempting mutations.
 `,
 };

--- a/src/core/skills/builtins/idorHarDiff.ts
+++ b/src/core/skills/builtins/idorHarDiff.ts
@@ -1,0 +1,71 @@
+import type { BuiltInSkill } from "../types";
+
+export const idorHarDiffSkill: BuiltInSkill = {
+  slug: "idor-har-diff",
+  manifest: {
+    name: "IDOR HAR Diff",
+    description:
+      "Capture two authenticated browser flows and compare their HARs to find IDOR and broken authorization candidates",
+    tags: ["security", "authz", "idor"],
+    inputs: [
+      {
+        name: "credentialIdA",
+        description: "First account credential ID or account label",
+        required: true,
+      },
+      {
+        name: "credentialIdB",
+        description: "Second account credential ID or account label",
+        required: true,
+      },
+      {
+        name: "seedUrls",
+        description: "Optional URLs or browser flow to capture under both accounts",
+        required: false,
+      },
+    ],
+  },
+  instructions: `# IDOR HAR Diff
+
+Use this skill when the operator asks for IDOR / broken authorization testing, or when two comparable user accounts are available and you need to compare what each account can see.
+
+This skill encodes a known pentester workflow: perform the same browser flow as Account A and Account B, compare the captured traffic, then actively confirm any cross-account access with replay. The HARs intentionally include \`Authorization\`, \`Cookie\`, and \`Set-Cookie\` values for in-scope hosts because replay and session-management analysis need them.
+
+## Workflow
+
+1. Start Account A capture:
+   - Call \`start_har_capture\` with a descriptive name such as \`account-a-profile\`.
+   - Log in or switch to Account A.
+   - Navigate through the requested flow or seed URLs.
+   - Call \`stop_har_capture\` and keep the returned \`path\`.
+
+2. Start Account B capture:
+   - Call \`start_har_capture\` with a descriptive name such as \`account-b-profile\`.
+   - Log out / switch accounts if needed.
+   - Perform the same flow as Account B.
+   - Call \`stop_har_capture\` and keep the returned \`path\`.
+
+3. Compare the HARs:
+   - Call \`har_diff\` with \`accountAHarPath\` and \`accountBHarPath\`.
+   - Keep the returned \`path\` to the generated JSON report.
+
+4. Confirm candidates:
+   - Review the \`har_diff\` candidates.
+   - For each high-suspicion candidate, call \`har_replay\` against the relevant captured entry.
+   - A diff alone is not a vulnerability. Only document a finding after replay confirms Account B can access Account A's resource or data.
+
+## How to read the diff
+
+- \`same-response\`: both accounts received very similar 2xx responses for the same request shape. Investigate when the response contains user-specific data.
+- \`different-but-200\`: both accounts received 2xx, but the bodies differ. Often expected; inspect IDs, owner fields, tenant IDs, and object counts.
+- \`403-vs-200\`: one account is blocked and the other succeeds. This is often correct authorization, but can reveal which request carries the authorization boundary.
+- \`unique-to-a\` / \`unique-to-b\`: one flow made a request the other never made. Often UI/role driven; inspect before replay.
+
+## Rules
+
+- Do not report IDOR if the endpoint is unauthenticated for everyone. That is missing authentication, not IDOR.
+- Do not replay out-of-scope hosts. The \`har_replay\` tool enforces scope, but you should avoid selecting those candidates.
+- Do not call destructive methods unless necessary. \`har_replay\` will require operator approval for \`DELETE\`, \`PUT\`, \`PATCH\`, credential swaps, and auth-header overrides.
+- Prefer confirming read-only access first (\`GET\` / safe \`POST\`) before attempting mutations.
+`,
+};

--- a/src/core/skills/builtins/idorHarDiff.ts
+++ b/src/core/skills/builtins/idorHarDiff.ts
@@ -20,7 +20,8 @@ export const idorHarDiffSkill: BuiltInSkill = {
       },
       {
         name: "seedUrls",
-        description: "Optional URLs or browser flow to capture under both accounts",
+        description:
+          "Optional URLs or browser flow to capture under both accounts",
         required: false,
       },
     ],

--- a/src/core/skills/builtins/index.ts
+++ b/src/core/skills/builtins/index.ts
@@ -1,4 +1,5 @@
 import type { BuiltInSkill } from "../types";
+import { idorHarDiffSkill } from "./idorHarDiff";
 import { pentestSkill } from "./pentest";
 import { threatModelSkill } from "./threatModel";
 
@@ -13,4 +14,8 @@ export { buildThreatModelPrompt } from "./threatModel";
  *
  * To add a built-in skill, push a BuiltInSkill object into this array.
  */
-export const BUILTIN_SKILLS: BuiltInSkill[] = [pentestSkill, threatModelSkill];
+export const BUILTIN_SKILLS: BuiltInSkill[] = [
+  pentestSkill,
+  threatModelSkill,
+  idorHarDiffSkill,
+];

--- a/src/core/skills/registry.test.ts
+++ b/src/core/skills/registry.test.ts
@@ -1,6 +1,6 @@
-import fs from "fs/promises";
-import os from "os";
-import path from "path";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { BUILTIN_SKILLS } from "./builtins";
 import { SkillsRegistry } from "./registry";

--- a/src/core/skills/registry.ts
+++ b/src/core/skills/registry.ts
@@ -1,4 +1,4 @@
-import fs from "fs/promises";
+import fs from "node:fs/promises";
 import { BUILTIN_SKILLS } from "./builtins";
 import { parseSkillMd } from "./parser";
 import { scanSkillRoots } from "./scanner";

--- a/src/core/skills/scanner.test.ts
+++ b/src/core/skills/scanner.test.ts
@@ -1,6 +1,6 @@
-import fs from "fs/promises";
-import os from "os";
-import path from "path";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { scanSkillRoots } from "./scanner";
 

--- a/src/core/skills/scanner.ts
+++ b/src/core/skills/scanner.ts
@@ -1,6 +1,6 @@
-import type { Dirent } from "fs";
-import fs from "fs/promises";
-import path from "path";
+import type { Dirent } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { parseSkillMd } from "./parser";
 import type { SkillEntry, SkillScript, SkillSource } from "./types";
 import {

--- a/src/core/skills/utils.ts
+++ b/src/core/skills/utils.ts
@@ -1,5 +1,5 @@
-import os from "os";
-import path from "path";
+import os from "node:os";
+import path from "node:path";
 
 /** Global skills directory: ~/.pensar/skills/ */
 export const SKILLS_DIR = path.join(os.homedir(), ".pensar", "skills");

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -1,6 +1,6 @@
-import fs, { readdir } from "fs/promises";
-import os from "os";
-import path from "path";
+import fs, { readdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import z from "zod";
 import { NamedError } from "../../util/errors";

--- a/src/core/tasks/index.ts
+++ b/src/core/tasks/index.ts
@@ -13,8 +13,8 @@
  * - High water mark for ID generation (prevents reuse after deletion)
  */
 
-import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -1,7 +1,7 @@
-import type { ModelMessage, StreamTextOnStepFinishCallback, ToolSet } from "ai";
-import { hasToolCall } from "ai";
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { ModelMessage, StreamTextOnStepFinishCallback, ToolSet } from "ai";
+import { hasToolCall } from "ai";
 import type { Finding } from "../agents/offSecAgent";
 import {
   OffensiveSecurityAgent,

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -1,7 +1,7 @@
 import type { ModelMessage, StreamTextOnStepFinishCallback, ToolSet } from "ai";
 import { hasToolCall } from "ai";
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type { Finding } from "../agents/offSecAgent";
 import {
   OffensiveSecurityAgent,

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -1,6 +1,6 @@
 import type { StreamTextOnStepFinishCallback, ToolSet } from "ai";
-import { execFileSync } from "child_process";
-import { createHash } from "crypto";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
@@ -8,8 +8,8 @@ import {
   readFileSync,
   statSync,
   writeFileSync,
-} from "fs";
-import { join } from "path";
+} from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 import type { DocumentedEndpointRecord } from "../agents/specialized/attackSurface/schemas";
 import { CodeAgent } from "../agents/specialized/codeAgent/agent";

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -1,4 +1,3 @@
-import type { StreamTextOnStepFinishCallback, ToolSet } from "ai";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
@@ -10,6 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import type { StreamTextOnStepFinishCallback, ToolSet } from "ai";
 import { z } from "zod";
 import type { DocumentedEndpointRecord } from "../agents/specialized/attackSurface/schemas";
 import { CodeAgent } from "../agents/specialized/codeAgent/agent";

--- a/src/tests/authPentestHandoff.test.ts
+++ b/src/tests/authPentestHandoff.test.ts
@@ -10,9 +10,9 @@
  * No mocking — both agents actually run against staging.
  */
 
-import { config } from "dotenv";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { config } from "dotenv";
 import { describe, expect, it } from "vitest";
 import { TargetedPentestAgent } from "../core/agents/specialized/pentest/agent";
 import { runAuthenticationAgent } from "../core/api/authentication";

--- a/src/tests/authPentestHandoff.test.ts
+++ b/src/tests/authPentestHandoff.test.ts
@@ -11,8 +11,8 @@
  */
 
 import { config } from "dotenv";
-import { existsSync, readFileSync } from "fs";
-import { join } from "path";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { TargetedPentestAgent } from "../core/agents/specialized/pentest/agent";
 import { runAuthenticationAgent } from "../core/api/authentication";

--- a/src/tui/components/footer.tsx
+++ b/src/tui/components/footer.tsx
@@ -1,5 +1,5 @@
 import type { RGBA } from "@opentui/core";
-import os from "os";
+import os from "node:os";
 import { useAgent } from "../context/agent";
 import { useDimensions } from "../context/dimensions";
 import { useInput } from "../context/input";

--- a/src/tui/components/footer.tsx
+++ b/src/tui/components/footer.tsx
@@ -1,5 +1,5 @@
-import type { RGBA } from "@opentui/core";
 import os from "node:os";
+import type { RGBA } from "@opentui/core";
 import { useAgent } from "../context/agent";
 import { useDimensions } from "../context/dimensions";
 import { useInput } from "../context/input";

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -8,8 +8,8 @@
 
 import { useKeyboard } from "@opentui/react";
 import { hasToolCall, type ModelMessage, stepCountIs } from "ai";
-import { existsSync, readFileSync, writeFileSync } from "fs";
-import { isAbsolute, join, resolve } from "path";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
 import {
   useCallback,
   useEffect,

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -6,10 +6,10 @@
  * Reuses MessageList and InputArea from the shared/chat components.
  */
 
-import { useKeyboard } from "@opentui/react";
-import { hasToolCall, type ModelMessage, stepCountIs } from "ai";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
+import { useKeyboard } from "@opentui/react";
+import { hasToolCall, type ModelMessage, stepCountIs } from "ai";
 import {
   useCallback,
   useEffect,

--- a/src/tui/components/shared/syntax-highlight.ts
+++ b/src/tui/components/shared/syntax-highlight.ts
@@ -8,9 +8,9 @@
  * with dark/light variants via ThemeColors tokens.
  */
 
+import { extname } from "node:path";
 import { type RGBA, StyledText, type TextChunk } from "@opentui/core";
 import hljs from "highlight.js";
-import { extname } from "node:path";
 import type { ThemeColors } from "../../theme";
 
 // ---------------------------------------------------------------------------

--- a/src/tui/components/shared/syntax-highlight.ts
+++ b/src/tui/components/shared/syntax-highlight.ts
@@ -10,7 +10,7 @@
 
 import { type RGBA, StyledText, type TextChunk } from "@opentui/core";
 import hljs from "highlight.js";
-import { extname } from "path";
+import { extname } from "node:path";
 import type { ThemeColors } from "../../theme";
 
 // ---------------------------------------------------------------------------

--- a/src/tui/hooks/use-sessions-list.ts
+++ b/src/tui/hooks/use-sessions-list.ts
@@ -3,8 +3,8 @@
  * Used by SessionsDisplay.
  */
 
-import { existsSync, readdirSync } from "fs";
-import { join } from "path";
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import { useCallback, useEffect, useState } from "react";
 import { REPORT_FILENAME_MD } from "../../core/report";
 import {

--- a/src/tui/utils/command-flags.test.ts
+++ b/src/tui/utils/command-flags.test.ts
@@ -1,6 +1,6 @@
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildSwarmSessionConfig,

--- a/src/tui/utils/command-flags.ts
+++ b/src/tui/utils/command-flags.ts
@@ -5,8 +5,8 @@
  * Supports: --flag value, --flag=value, --boolean-flag
  */
 
-import { readFileSync } from "fs";
-import { isAbsolute, resolve } from "path";
+import { readFileSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
 import { formatParseError, parseHeaderLine } from "../../core/http/parse";
 import type { OperatorMode } from "../../core/operator";
 import type { SessionConfig } from "../../core/session";


### PR DESCRIPTION
## Summary
- Add operator tools for on-demand HAR capture, scoped HAR summaries, deterministic HAR diffing, and guarded request replay.
- Add a built-in `idor-har-diff` skill that ships with Apex and guides agents through the two-account capture/diff/replay workflow.
- Add typed HAR parsing, scope filtering, and tests for parsing, scope filtering, and diff bucketing.

## Test plan
- `bun run test src/core/har src/core/skills/registry.test.ts`
- `NODE_OPTIONS=\"--max-old-space-size=8192\" bun run tsc`
- `bun run test`
- `bun run build`

Note: plain `bun run tsc` hit a local Node heap OOM; rerunning with an 8GB heap passed.

Made with [Cursor](https://cursor.com)