### PR TITLE
Calibrate finding judge against low-signal findings

### DIFF
--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           repository: pensarai/console
           token: ${{ secrets.CONSOLE_REPO_TOKEN }}
+          submodules: recursive
           path: console
 
       - name: Update apex submodule to current ref
@@ -41,10 +42,6 @@ jobs:
           fi
 
           echo "Found apex submodule at: $SUBMODULE_PATH"
-
-          # Only initialize the Apex submodule. Console may have other private
-          # submodules that are unrelated to this downstream compatibility check.
-          git submodule update --init --depth=1 "$SUBMODULE_PATH"
 
           # Point the submodule at the local apex checkout and update
           cd "$SUBMODULE_PATH"

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -51,6 +51,21 @@ jobs:
           git fetch "$GITHUB_WORKSPACE/apex" "$GITHUB_SHA"
           git checkout "$GITHUB_SHA"
 
+      - name: Remove unrelated missing workspaces
+        working-directory: console
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+          const pkgPath = "package.json";
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+          const workspaces = Array.isArray(pkg.workspaces) ? pkg.workspaces : [];
+          pkg.workspaces = workspaces.filter((workspace) => {
+            if (!workspace.includes("design-system")) return true;
+            return fs.existsSync(workspace);
+          });
+          fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+          NODE
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -51,21 +51,6 @@ jobs:
           git fetch "$GITHUB_WORKSPACE/apex" "$GITHUB_SHA"
           git checkout "$GITHUB_SHA"
 
-      - name: Remove unrelated missing workspaces
-        working-directory: console
-        run: |
-          node <<'NODE'
-          const fs = require("node:fs");
-          const pkgPath = "package.json";
-          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
-          const workspaces = Array.isArray(pkg.workspaces) ? pkg.workspaces : [];
-          pkg.workspaces = workspaces.filter((workspace) => {
-            if (!workspace.includes("design-system")) return true;
-            return fs.existsSync(workspace);
-          });
-          fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
-          NODE
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           repository: pensarai/console
           token: ${{ secrets.CONSOLE_REPO_TOKEN }}
-          submodules: recursive
           path: console
 
       - name: Update apex submodule to current ref
@@ -42,6 +41,10 @@ jobs:
           fi
 
           echo "Found apex submodule at: $SUBMODULE_PATH"
+
+          # Only initialize the Apex submodule. Console may have other private
+          # submodules that are unrelated to this downstream compatibility check.
+          git submodule update --init --depth=1 "$SUBMODULE_PATH"
 
           # Point the submodule at the local apex checkout and update
           cd "$SUBMODULE_PATH"

--- a/src/core/agents/specialized/findingJudge/index.test.ts
+++ b/src/core/agents/specialized/findingJudge/index.test.ts
@@ -98,15 +98,15 @@ describe("judgeFinding", () => {
     );
   });
 
-  it("preserves the finding with low confidence when the judge agent fails", async () => {
+  it("rejects the finding as unverified when the judge agent fails", async () => {
     mocks.consume.mockRejectedValue(new Error("provider overloaded"));
 
     const result = await judgeFinding(makeInput(), makeContext());
 
-    expect(result.valid).toBe(true);
-    expect(result.findingType).toBe("vulnerability");
+    expect(result.valid).toBe(false);
+    expect(result.findingType).toBe("informational");
     expect(result.confidence).toBe(0.4);
-    expect(result.reasoning).toContain("Preserving");
+    expect(result.reasoning).toContain("Rejecting");
     expect(result.concerns).toEqual(
       expect.arrayContaining([
         expect.stringContaining("infrastructure failed"),
@@ -115,13 +115,13 @@ describe("judgeFinding", () => {
     expect(result.error?.message).toBe("provider overloaded");
   });
 
-  it("creates explicit degraded preservation diagnostics", () => {
+  it("creates explicit unverified rejection diagnostics", () => {
     const result = createJudgeFailureResult(
       Object.assign(new Error("rate limited"), { status: 429 }),
       "test-model",
     );
 
-    expect(result.valid).toBe(true);
+    expect(result.valid).toBe(false);
     expect(result.confidence).toBeLessThan(0.5);
     expect(result.error?.message).toContain("[status=429]");
     expect(result.limitations?.[0]).toContain("No independent judge");

--- a/src/core/agents/specialized/findingJudge/index.ts
+++ b/src/core/agents/specialized/findingJudge/index.ts
@@ -38,8 +38,8 @@ export type FindingJudgeRuntimeContext = Pick<
 /**
  * Validate a vulnerability finding by running a bounded verifier agent.
  *
- * Infrastructure failures intentionally preserve the already-successful
- * POC-backed finding with low confidence and explicit unverified metadata.
+ * Infrastructure failures reject the finding as unverified rather than
+ * preserving it as a vulnerability.
  */
 export async function judgeFinding(
   input: FindingJudgeInput,
@@ -114,13 +114,13 @@ export function createJudgeFailureResult(
   const diagnostic = `${type}${statusStr}: ${message.substring(0, 200)}`;
 
   return {
-    valid: true,
-    findingType: "vulnerability",
+    valid: false,
+    findingType: "informational",
     confidence,
-    reasoning: `Agentic finding judge could not complete (${diagnostic}). Preserving the successfully executed PoC-backed finding as unverified with low confidence so it is not lost.`,
+    reasoning: `Agentic finding judge could not complete (${diagnostic}). Rejecting the finding as unverified so unavailable judge infrastructure does not preserve false positives as vulnerabilities.`,
     concerns: [
       "Agentic judge infrastructure failed before producing a completed verification judgment.",
-      "Finding is preserved because the submitted PoC already executed successfully, but the judge did not independently verify the claim.",
+      "The submitted PoC may have executed successfully, but the judge did not independently verify that it proves a material vulnerability.",
     ],
     verificationSteps: [],
     toolEvidence: [],

--- a/src/core/agents/specialized/findingJudge/prompts.ts
+++ b/src/core/agents/specialized/findingJudge/prompts.ts
@@ -28,11 +28,11 @@ You are the last line of defense against false positives, hallucinated findings,
 ## Evaluation Criteria
 
 ### Materiality
-- A finding is a vulnerability only when the observed behavior creates a concrete security impact for the assessed target and threat model.
+- A finding is a vulnerability only when the observed behavior is exploitable now in a way that creates a concrete security risk for the assessed target and threat model.
 - Do not reward theoretical "missing control" findings unless the PoC shows a realistic abuse path, affected security boundary, and material consequence.
 - Evaluate behavior in context: application purpose, deployment model, data sensitivity, exposed trust boundaries, and whether the observed behavior is intended for that environment. Expected, documented, demo, sandbox, or training behavior is usually expected-behavior or informational unless the claim demonstrates impact outside that intended use.
-- CVSS 0.0, "LOW", or "best practice" observations should usually be rejected or downgraded unless the evidence shows a real exploit chain or sensitive-data impact.
-- If a PoC only proves that input is accepted, an error is returned, a public endpoint is reachable, or a control is absent, reject or downgrade when the impact is negligible.
+- Reject CVSS 0.0 findings rather than downgrading them. A non-zero LOW severity can still be valid when the PoC demonstrates real exploitability and security risk.
+- If a PoC only proves that input is accepted, an error is returned, a public endpoint is reachable, or a control is absent, reject when it does not show an exploitable security risk.
 
 ### Correctness
 - SQL injection: output should show inaccessible data, query errors, or behavioral differences indicating injection success.
@@ -46,7 +46,7 @@ You are the last line of defense against false positives, hallucinated findings,
 - Missing rate limiting / anti-automation: fewer than 50 requests is insufficient. Evidence must state exact request count, timing/distribution, and observed statuses.
 
 ### Common Low-Signal Patterns
-Reject or downgrade these unless the submitted evidence demonstrates concrete harm:
+Reject these unless the submitted evidence demonstrates concrete harm:
 - Missing rate limiting on non-sensitive, low-value, intentionally public, or low-abuse-potential endpoints.
 - Verbose errors, stack traces, framework versions, or internal paths without secrets, protected data, or a working exploit chain.
 - Missing input validation that only permits nulls, empty strings, negative values, long text, type coercion, or malformed JSON with no security boundary crossed.
@@ -64,15 +64,15 @@ Reject or lower confidence when:
 - Evidence text does not match live responses or the claimed endpoint.
 
 ### Severity and Classification
-- Accept as vulnerability when real target interaction demonstrates unintended, exploitable behavior.
-- Accept as informational when the observation is real but low-risk, common default behavior, or plausibly intentional.
-- Accept as expected-behavior when the behavior is clearly by design.
+- Accept as vulnerability only when real target interaction demonstrates unintended, exploitable behavior that creates security risk.
+- Classify as informational when the observation is real but not currently exploitable or not security-impacting.
+- Classify as expected-behavior when the behavior is clearly by design.
 - Reject when the PoC fabricates evidence, does not demonstrate the claim, or the demonstrated impact fundamentally mismatches the finding.
 
 ## Response Requirements
 
 Call the response tool exactly once. Include:
-- valid: true only when the finding should be persisted.
+- valid: true only when the finding should be persisted as an exploitable vulnerability. Use valid: false for informational, expected-behavior, CVSS 0.0, non-exploitable, or merely best-practice observations.
 - findingType: vulnerability, informational, or expected-behavior.
 - confidence: calibrated 0.0 to 1.0. Below 0.7 requires concerns.
 - reasoning: concise explanation grounded in concrete observations.

--- a/src/core/agents/specialized/findingJudge/prompts.ts
+++ b/src/core/agents/specialized/findingJudge/prompts.ts
@@ -30,7 +30,7 @@ You are the last line of defense against false positives, hallucinated findings,
 ### Materiality
 - A finding is a vulnerability only when the observed behavior creates a concrete security impact for the assessed target and threat model.
 - Do not reward theoretical "missing control" findings unless the PoC shows a realistic abuse path, affected security boundary, and material consequence.
-- Treat deliberately vulnerable CTF/training applications differently from production applications. Expected challenge mechanics, public challenge metadata, challenge-solution exposure, and intentionally weak controls are usually expected-behavior or informational unless the claim demonstrates impact outside the exercise design.
+- Evaluate behavior in context: application purpose, deployment model, data sensitivity, exposed trust boundaries, and whether the observed behavior is intended for that environment. Expected, documented, demo, sandbox, or training behavior is usually expected-behavior or informational unless the claim demonstrates impact outside that intended use.
 - CVSS 0.0, "LOW", or "best practice" observations should usually be rejected or downgraded unless the evidence shows a real exploit chain or sensitive-data impact.
 - If a PoC only proves that input is accepted, an error is returned, a public endpoint is reachable, or a control is absent, reject or downgrade when the impact is negligible.
 
@@ -47,10 +47,10 @@ You are the last line of defense against false positives, hallucinated findings,
 
 ### Common Low-Signal Patterns
 Reject or downgrade these unless the submitted evidence demonstrates concrete harm:
-- Missing rate limiting on non-sensitive, low-value, or CTF-only endpoints.
+- Missing rate limiting on non-sensitive, low-value, intentionally public, or low-abuse-potential endpoints.
 - Verbose errors, stack traces, framework versions, or internal paths without secrets, protected data, or a working exploit chain.
 - Missing input validation that only permits nulls, empty strings, negative values, long text, type coercion, or malformed JSON with no security boundary crossed.
-- Missing authentication on public, non-sensitive, catalog, challenge-list, listener, metadata, or training endpoints.
+- Missing authentication on public, non-sensitive, catalog, status, listener, metadata, demo, or intentionally unauthenticated endpoints.
 - Client-side validation bypasses where direct API calls produce no server-side security impact.
 - User enumeration, timing differences, weak pseudonymization, and email masking weaknesses without credible account takeover, sensitive data exposure, or targeting impact.
 - Unhandled type errors, method confusion, and 500 responses that only prove fragile error handling.

--- a/src/core/agents/specialized/findingJudge/prompts.ts
+++ b/src/core/agents/specialized/findingJudge/prompts.ts
@@ -27,6 +27,13 @@ You are the last line of defense against false positives, hallucinated findings,
 
 ## Evaluation Criteria
 
+### Materiality
+- A finding is a vulnerability only when the observed behavior creates a concrete security impact for the assessed target and threat model.
+- Do not reward theoretical "missing control" findings unless the PoC shows a realistic abuse path, affected security boundary, and material consequence.
+- Treat deliberately vulnerable CTF/training applications differently from production applications. Expected challenge mechanics, public challenge metadata, challenge-solution exposure, and intentionally weak controls are usually expected-behavior or informational unless the claim demonstrates impact outside the exercise design.
+- CVSS 0.0, "LOW", or "best practice" observations should usually be rejected or downgraded unless the evidence shows a real exploit chain or sensitive-data impact.
+- If a PoC only proves that input is accepted, an error is returned, a public endpoint is reachable, or a control is absent, reject or downgrade when the impact is negligible.
+
 ### Correctness
 - SQL injection: output should show inaccessible data, query errors, or behavioral differences indicating injection success.
 - XSS: output should show payload reflection/execution in a browser-executable context.
@@ -37,6 +44,16 @@ You are the last line of defense against false positives, hallucinated findings,
 - Authentication bypass: output should show protected access without valid credentials.
 - Email/HTML injection: ideally verify delivery and rendering. If only server acceptance is shown, confidence must stay below 0.7 and limitations must state rendering was not independently verified.
 - Missing rate limiting / anti-automation: fewer than 50 requests is insufficient. Evidence must state exact request count, timing/distribution, and observed statuses.
+
+### Common Low-Signal Patterns
+Reject or downgrade these unless the submitted evidence demonstrates concrete harm:
+- Missing rate limiting on non-sensitive, low-value, or CTF-only endpoints.
+- Verbose errors, stack traces, framework versions, or internal paths without secrets, protected data, or a working exploit chain.
+- Missing input validation that only permits nulls, empty strings, negative values, long text, type coercion, or malformed JSON with no security boundary crossed.
+- Missing authentication on public, non-sensitive, catalog, challenge-list, listener, metadata, or training endpoints.
+- Client-side validation bypasses where direct API calls produce no server-side security impact.
+- User enumeration, timing differences, weak pseudonymization, and email masking weaknesses without credible account takeover, sensitive data exposure, or targeting impact.
+- Unhandled type errors, method confusion, and 500 responses that only prove fragile error handling.
 
 ### Hallucination and Hardcoding
 Reject or lower confidence when:

--- a/src/core/agents/specialized/findingJudge/types.ts
+++ b/src/core/agents/specialized/findingJudge/types.ts
@@ -48,7 +48,7 @@ interface FindingJudgeVerificationDetails {
 }
 
 export interface FindingJudgeResult extends FindingJudgeVerificationDetails {
-  /** Whether the finding is legitimate and well-demonstrated */
+  /** Whether the finding should be persisted as an exploitable vulnerability */
   valid: boolean;
   /** Classification of the finding */
   findingType: FindingType;
@@ -71,7 +71,7 @@ export const FindingJudgeOutputSchema = z.object({
   valid: z
     .boolean()
     .describe(
-      "Whether the POC legitimately demonstrates the claimed vulnerability",
+      "Whether the POC demonstrates a currently exploitable vulnerability that should be persisted",
     ),
   findingType: z
     .enum(FINDING_TYPES)
@@ -93,7 +93,7 @@ export const FindingJudgeOutputSchema = z.object({
   concerns: z
     .array(z.string())
     .describe(
-      "Specific concerns identified. Empty array only when the finding is valid and high-confidence.",
+      "Specific concerns identified. Empty array only when the finding is a valid high-confidence vulnerability.",
     ),
   verificationSteps: z
     .array(z.string())


### PR DESCRIPTION
## Summary
- Add finding-judge prompt guidance for material exploitability, CTF/training-app context, and common low-signal false-positive patterns.
- Fail closed when the judge cannot complete, so infrastructure failures do not preserve unverified findings as vulnerabilities.
- Update focused judge tests for the new unverified rejection behavior.

## Test plan
- `bun run tsc`
- `bun run test src/core/agents/specialized/findingJudge/index.test.ts src/core/agents/offSecAgent/tools/documentFinding.test.ts`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Infrastructure failures now block persistence of PoC-backed findings that previously survived as unverified vulnerabilities, which may drop legitimate findings during outages but reduces false positives in the verification gate.
> 
> **Overview**
> Tightens the **finding judge** so only materially exploitable issues count as vulnerabilities, and **fails closed** when the judge cannot run.
> 
> The judge system prompt now requires **material exploitability** (real abuse path and security impact), evaluates findings in **deployment/training context**, rejects **CVSS 0.0** claims instead of downgrading them, and lists **common low-signal patterns** to reject (e.g. missing rate limits on public endpoints, verbose errors without exploit chains, missing auth on intentionally public APIs). Response rules and Zod/schema comments now define **`valid`** as permission to persist an **exploitable vulnerability**, not merely a well-formed PoC.
> 
> When judge **infrastructure fails** (`createJudgeFailureResult`), the fallback changes from preserving the PoC-backed finding as a low-confidence vulnerability to **`valid: false`** with **`findingType: informational`** and explicit rejection messaging—so outages do not surface unverified items as vulnerabilities (aligned with `documentFinding` rejecting `!valid`).
> 
> Tests in `findingJudge/index.test.ts` are updated for the new rejection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de64146f7136af8bdb00b984bbd45c5f8709adeb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->