### PR TITLE
feat: native session/message/part IDs + Console rehydration

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -7,6 +7,8 @@
  * Heavy transitive dependencies (tools, AI SDK, zod) are stubbed so
  * the test loads cleanly without external provider keys.
  */
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -76,6 +78,8 @@ function buildStubAgent(overrides: {
   persistentShell?: { dispose: () => void };
   abortSignal?: AbortSignal;
   resolveResult?: (sr: unknown) => unknown;
+  messagesPath?: string | null;
+  latestMessages?: unknown[] | null;
 }): OffensiveSecurityAgent<unknown> {
   const agent = Object.create(
     OffensiveSecurityAgent.prototype,
@@ -106,6 +110,16 @@ function buildStubAgent(overrides: {
   });
   Object.defineProperty(agent, "resolveResult", {
     value: overrides.resolveResult,
+  });
+  Object.defineProperty(agent, "latestMessages", {
+    value: overrides.latestMessages ?? null,
+    writable: true,
+  });
+  Object.defineProperty(agent, "messagesPath", {
+    value: overrides.messagesPath ?? null,
+  });
+  Object.defineProperty(agent, "cancelPersistTimer", {
+    value: () => {},
   });
 
   return agent;
@@ -243,6 +257,118 @@ describe("OffensiveSecurityAgent.consume()", () => {
     });
   });
 
+  describe("synthetic tool-result on stream abort/error", () => {
+    const toolCallChunk = {
+      type: "tool-call",
+      toolCallId: "tc1",
+      toolName: "execute_command",
+    };
+    const otherToolCallChunk = {
+      type: "tool-call",
+      toolCallId: "tc2",
+      toolName: "read_file",
+    };
+    const toolResultChunk = {
+      type: "tool-result",
+      toolCallId: "tc1",
+      result: { type: "text", value: "done" },
+    };
+
+    it("emits synthetic tool-result for an in-flight tool when stream throws", async () => {
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow(
+          [toolCallChunk],
+          new Error("connection reset"),
+        ),
+      });
+
+      const emittedResults: Array<{
+        toolCallId: string;
+        result: unknown;
+      }> = [];
+      agent.eventBus.on("tool-result", (e) => {
+        emittedResults.push({ toolCallId: e.toolCallId, result: e.result });
+      });
+
+      await expect(agent.consume()).rejects.toThrow("connection reset");
+
+      expect(emittedResults).toHaveLength(1);
+      expect(emittedResults[0].toolCallId).toBe("tc1");
+      expect(emittedResults[0].result).toMatchObject({
+        type: "error-text",
+        value: expect.stringContaining("connection reset"),
+      });
+    });
+
+    it("does not emit a synthetic result when the matching tool-result already streamed", async () => {
+      const agent = buildStubAgent({
+        fullStream: yieldChunks([toolCallChunk, toolResultChunk]),
+      });
+
+      const emittedResults: unknown[] = [];
+      agent.eventBus.on("tool-result", (e) => emittedResults.push(e));
+
+      await agent.consume();
+
+      expect(emittedResults).toHaveLength(0);
+    });
+
+    it("emits one synthetic per in-flight tool when multiple are open at abort", async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow(
+          [toolCallChunk, otherToolCallChunk],
+          new DOMException("Aborted", "AbortError"),
+        ),
+        abortSignal: controller.signal,
+      });
+
+      const emittedResults: Array<{ toolCallId: string; result: unknown }> = [];
+      agent.eventBus.on("tool-result", (e) => {
+        emittedResults.push({ toolCallId: e.toolCallId, result: e.result });
+      });
+
+      await expect(agent.consume()).rejects.toBeInstanceOf(DOMException);
+
+      expect(emittedResults).toHaveLength(2);
+      const ids = emittedResults.map((r) => r.toolCallId).sort();
+      expect(ids).toEqual(["tc1", "tc2"]);
+      for (const r of emittedResults) {
+        expect(r.result).toMatchObject({
+          type: "error-text",
+          value: expect.stringContaining("aborted"),
+        });
+      }
+    });
+
+    it("uses 'Agent aborted by user' as reason when abortSignal is set", async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow(
+          [toolCallChunk],
+          new DOMException("Aborted", "AbortError"),
+        ),
+        abortSignal: controller.signal,
+      });
+
+      const emittedResults: Array<{ result: unknown }> = [];
+      agent.eventBus.on("tool-result", (e) =>
+        emittedResults.push({ result: e.result }),
+      );
+
+      await expect(agent.consume()).rejects.toBeInstanceOf(DOMException);
+
+      expect(emittedResults[0].result).toMatchObject({
+        type: "error-text",
+        value: expect.stringContaining("aborted by user"),
+      });
+    });
+  });
+
   describe("resolveResult", () => {
     it("returns resolved value when resolveResult is provided", async () => {
       const agent = buildStubAgent({
@@ -261,6 +387,354 @@ describe("OffensiveSecurityAgent.consume()", () => {
 
       const result = await agent.consume();
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("synthetic tool-result: persist timer fallback (bugbot fix)", () => {
+    const toolCallChunk = {
+      type: "tool-call",
+      toolCallId: "tc1",
+      toolName: "execute_command",
+    };
+
+    it("reads persisted messages from disk when latestMessages is null", async () => {
+      const tmpDir = join("/tmp", `pensar-test-${Date.now()}-fallback`);
+      mkdirSync(tmpDir, { recursive: true });
+      const messagesPath = join(tmpDir, "messages.json");
+
+      const existingMessages = [
+        { role: "user", content: [{ type: "text", text: "run nmap" }] },
+        { role: "assistant", content: [{ type: "text", text: "Running..." }] },
+      ];
+      writeFileSync(messagesPath, JSON.stringify(existingMessages));
+
+      // latestMessages is null — simulates persist timer having flushed
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow([toolCallChunk], new Error("timeout")),
+        messagesPath,
+        latestMessages: null,
+      });
+
+      try {
+        await agent.consume();
+      } catch {}
+
+      // Wait for async writeFile
+      await new Promise((r) => setTimeout(r, 50));
+
+      const written = JSON.parse(readFileSync(messagesPath, "utf-8"));
+      // original 2 + assistant (tool-call) + tool (synthetic result)
+      expect(written).toHaveLength(4);
+      expect(written[0].role).toBe("user");
+      expect(written[1].role).toBe("assistant");
+      expect(written[2].role).toBe("assistant");
+      expect(written[2].content[0].type).toBe("tool-call");
+      expect(written[2].content[0].toolCallId).toBe("tc1");
+      expect(written[3].role).toBe("tool");
+      expect(written[3].content[0].toolCallId).toBe("tc1");
+      expect(written[3].content[0].output.type).toBe("error-text");
+
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("does not lose history when persist timer nulled latestMessages", async () => {
+      const tmpDir = join("/tmp", `pensar-test-${Date.now()}-noloss`);
+      mkdirSync(tmpDir, { recursive: true });
+      const messagesPath = join(tmpDir, "messages.json");
+
+      const existingMessages = [
+        { role: "user", content: [{ type: "text", text: "scan target" }] },
+      ];
+      writeFileSync(messagesPath, JSON.stringify(existingMessages));
+
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow([toolCallChunk], new Error("network")),
+        messagesPath,
+        latestMessages: null,
+      });
+
+      try {
+        await agent.consume();
+      } catch {}
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const written = JSON.parse(readFileSync(messagesPath, "utf-8"));
+      // Must NOT be just [{ role: "tool" ... }] — must include original messages
+      expect(written.length).toBeGreaterThan(1);
+      expect(written[0].role).toBe("user");
+
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("does not add assistant tool-call msg when base already contains them", async () => {
+      const tmpDir = join("/tmp", `pensar-test-${Date.now()}-nodup`);
+      mkdirSync(tmpDir, { recursive: true });
+      const messagesPath = join(tmpDir, "messages.json");
+
+      // Simulate onStepFinish having already persisted the assistant tool-call
+      const existingMessages = [
+        { role: "user", content: [{ type: "text", text: "scan" }] },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "tc1",
+              toolName: "execute_command",
+              input: {},
+            },
+          ],
+        },
+      ];
+      writeFileSync(messagesPath, JSON.stringify(existingMessages));
+
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow([toolCallChunk], new Error("abort")),
+        messagesPath,
+        latestMessages: null,
+      });
+
+      try {
+        await agent.consume();
+      } catch {}
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const written = JSON.parse(readFileSync(messagesPath, "utf-8"));
+      // Should NOT duplicate the assistant message — just user + assistant + tool
+      expect(written).toHaveLength(3);
+      expect(written[0].role).toBe("user");
+      expect(written[1].role).toBe("assistant");
+      expect(written[2].role).toBe("tool");
+      expect(written[2].content[0].output.type).toBe("error-text");
+
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+  });
+
+  describe("parallel tool abort persists completed tools (bugbot fix)", () => {
+    it("includes completed tool results alongside synthetics on abort", async () => {
+      const tmpDir = join("/tmp", `pensar-test-${Date.now()}-parallel`);
+      mkdirSync(tmpDir, { recursive: true });
+      const messagesPath = join(tmpDir, "messages.json");
+
+      const existingMessages = [
+        { role: "user", content: [{ type: "text", text: "scan" }] },
+      ];
+      writeFileSync(messagesPath, JSON.stringify(existingMessages));
+
+      // Two tools called; tool A completes, tool B is still in-flight on abort.
+      const toolCallA = {
+        type: "tool-call",
+        toolCallId: "tcA",
+        toolName: "read_file",
+      };
+      const toolCallB = {
+        type: "tool-call",
+        toolCallId: "tcB",
+        toolName: "execute_command",
+      };
+      const toolResultA = {
+        type: "tool-result",
+        toolCallId: "tcA",
+        toolName: "read_file",
+        result: { type: "text", value: "file contents" },
+      };
+
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow(
+          [toolCallA, toolCallB, toolResultA],
+          new Error("connection lost"),
+        ),
+        messagesPath,
+        latestMessages: null,
+      });
+
+      try {
+        await agent.consume();
+      } catch {}
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const written = JSON.parse(readFileSync(messagesPath, "utf-8"));
+      // user + assistant (with both tool-calls) + tool (with both results)
+      expect(written).toHaveLength(3);
+      expect(written[0].role).toBe("user");
+      expect(written[1].role).toBe("assistant");
+      expect(written[1].content).toHaveLength(2);
+      const assistantToolIds = written[1].content.map(
+        (c: { toolCallId: string }) => c.toolCallId,
+      );
+      expect(assistantToolIds.sort()).toEqual(["tcA", "tcB"]);
+
+      expect(written[2].role).toBe("tool");
+      expect(written[2].content).toHaveLength(2);
+      const toolResultIds = written[2].content.map(
+        (c: { toolCallId: string }) => c.toolCallId,
+      );
+      expect(toolResultIds.sort()).toEqual(["tcA", "tcB"]);
+
+      // Tool A has real result, Tool B has synthetic error-text
+      const resultA = written[2].content.find(
+        (c: { toolCallId: string }) => c.toolCallId === "tcA",
+      );
+      const resultB = written[2].content.find(
+        (c: { toolCallId: string }) => c.toolCallId === "tcB",
+      );
+      expect(resultA.output.type).toBe("text");
+      expect(resultB.output.type).toBe("error-text");
+
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+  });
+
+  describe("multi-step abort does not duplicate prior steps (bugbot fix)", () => {
+    it("clears completed results at finish-step so earlier steps aren't re-appended", async () => {
+      const tmpDir = join("/tmp", `pensar-test-${Date.now()}-multistep`);
+      mkdirSync(tmpDir, { recursive: true });
+      const messagesPath = join(tmpDir, "messages.json");
+
+      // Step 1 already persisted by onStepFinish: tool A called and resolved.
+      const persistedAfterStep1 = [
+        { role: "user", content: [{ type: "text", text: "scan" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool-call", toolCallId: "tcA", toolName: "read_file" },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "tcA",
+              toolName: "read_file",
+              output: { type: "text", value: "file contents" },
+            },
+          ],
+        },
+      ];
+      writeFileSync(messagesPath, JSON.stringify(persistedAfterStep1));
+
+      // Stream replays step 1's chunks, finishes the step, then opens tool B
+      // in step 2 before erroring.
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow(
+          [
+            { type: "tool-call", toolCallId: "tcA", toolName: "read_file" },
+            {
+              type: "tool-result",
+              toolCallId: "tcA",
+              toolName: "read_file",
+              result: { type: "text", value: "file contents" },
+            },
+            { type: "finish-step" },
+            {
+              type: "tool-call",
+              toolCallId: "tcB",
+              toolName: "execute_command",
+            },
+          ],
+          new Error("connection lost"),
+        ),
+        messagesPath,
+        latestMessages: persistedAfterStep1,
+      });
+
+      try {
+        await agent.consume();
+      } catch {}
+      await new Promise((r) => setTimeout(r, 50));
+
+      const written = JSON.parse(readFileSync(messagesPath, "utf-8"));
+      const toolCallIds = written
+        .filter((m: { role: string }) => m.role === "assistant")
+        .flatMap((m: { content: { toolCallId?: string }[] }) =>
+          m.content.map((c) => c.toolCallId),
+        );
+      // tcA must appear exactly once — the abort snapshot must not re-append it.
+      expect(toolCallIds.filter((id: string) => id === "tcA")).toHaveLength(1);
+      expect(toolCallIds.filter((id: string) => id === "tcB")).toHaveLength(1);
+
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+  });
+
+  describe("failed abort write leaves flag unset (bugbot fix)", () => {
+    const toolCallChunk = {
+      type: "tool-call",
+      toolCallId: "tc1",
+      toolName: "execute_command",
+    };
+
+    it("does not mark synthetics persisted when the write fails", async () => {
+      // A path inside a non-existent directory makes writeFile reject.
+      const messagesPath = join(
+        "/tmp",
+        `pensar-test-${Date.now()}-missing`,
+        "nope",
+        "messages.json",
+      );
+
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow([toolCallChunk], new Error("stream broke")),
+        messagesPath,
+        latestMessages: [
+          { role: "user", content: [{ type: "text", text: "scan" }] },
+        ],
+      });
+
+      try {
+        await agent.consume();
+      } catch {}
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(
+        (agent as unknown as { syntheticsPersisted?: boolean })
+          .syntheticsPersisted,
+      ).toBeFalsy();
+    });
+  });
+
+  describe("emitSyntheticToolResults error does not mask stream error (bugbot fix)", () => {
+    const toolCallChunk = {
+      type: "tool-call",
+      toolCallId: "tc1",
+      toolName: "execute_command",
+    };
+
+    it("propagates original stream error when event listener throws", async () => {
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow(
+          [toolCallChunk],
+          new Error("original stream error"),
+        ),
+      });
+
+      // Make the event listener throw during synthetic emission
+      agent.eventBus.on("tool-result", () => {
+        throw new Error("listener explosion");
+      });
+
+      // The original stream error must propagate, not the listener error
+      await expect(agent.consume()).rejects.toThrow("original stream error");
+    });
+
+    it("still disposes shell when emitSyntheticToolResults throws", async () => {
+      const dispose = vi.fn();
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow([toolCallChunk], new Error("stream broke")),
+        persistentShell: { dispose },
+      });
+
+      agent.eventBus.on("tool-result", () => {
+        throw new Error("listener crash");
+      });
+
+      await expect(agent.consume()).rejects.toThrow("stream broke");
+      expect(dispose).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -89,6 +89,15 @@ function buildStubAgent(overrides: {
     value: { fullStream: overrides.fullStream },
   });
   Object.defineProperty(agent, "subagentId", { value: undefined });
+  // A real agent always has a session; the stub bypasses the constructor,
+  // so provide a minimal one for busSessionId (used to stamp event ids).
+  Object.defineProperty(agent, "_session", {
+    value: { id: "ses_stub" },
+  });
+  Object.defineProperty(agent, "currentMessageId", {
+    value: null,
+    writable: true,
+  });
   Object.defineProperty(agent, "persistentShell", {
     value: overrides.persistentShell,
   });

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -10,11 +10,12 @@ import { existsSync, mkdirSync } from "fs";
 import { writeFile } from "fs/promises";
 import { join } from "path";
 import { streamResponse } from "../../ai";
-import { AgentEventBus } from "../../eventBus";
+import { AgentEventBus, type StreamIdContext } from "../../eventBus";
 import {
   resolveEffectiveHeaders,
   stripBrowserManagedHeaders,
 } from "../../http/targetHeaders";
+import { newMessageId, newPartId } from "../../id/id";
 import { getApexTracer } from "../../observability";
 import type { ApprovalGate } from "../../operator";
 import { ApprovalDeniedError } from "../../operator";
@@ -84,6 +85,14 @@ export class OffensiveSecurityAgent<TResult = void> {
   /** Identifier for this agent when it is running as a subagent. */
   private readonly subagentId?: string;
 
+  /**
+   * The current open assistant message id (`msg_…`) for the in-flight step.
+   * Minted on the `start-step` chunk in {@link consume} and read by
+   * `onStepFinish` so the closing `step-finish` event carries the same id.
+   * `null` between steps.
+   */
+  private currentMessageId: string | null = null;
+
   /** Persistent shell for local-mode command execution; disposed on consume() completion. */
   private readonly persistentShell?: PersistentShell;
 
@@ -146,6 +155,18 @@ export class OffensiveSecurityAgent<TResult = void> {
   /** The session this agent is operating within. */
   get session(): SessionInfo {
     return this._session;
+  }
+
+  /**
+   * This agent's identity on the event bus, as a session id (`ses_…`).
+   *
+   * For a subagent, `subagentId` is the child's own session id (minted by
+   * the spawning tool). For the root agent, it is the root session's id.
+   * Used to stamp `sessionId` (and the legacy `subagentId` alias) onto
+   * every event this agent emits.
+   */
+  private get busSessionId(): string {
+    return this.subagentId ?? this._session.id;
   }
 
   constructor(input: OffensiveSecurityAgentInput<TResult>) {
@@ -415,7 +436,12 @@ export class OffensiveSecurityAgent<TResult = void> {
         this.eventBus.emit("step-finish", {
           messages: event.response.messages,
           subagentId: this.subagentId,
+          sessionId: this.busSessionId,
+          messageId: this.currentMessageId ?? undefined,
         });
+        // The step's message is now closed; the next `start-step` chunk in
+        // consume() mints a fresh one.
+        this.currentMessageId = null;
         await input.onStepFinish?.(event);
       },
       onSummarized: () => {
@@ -499,9 +525,51 @@ export class OffensiveSecurityAgent<TResult = void> {
     const bus = this.eventBus;
 
     const runConsume = async (): Promise<TResult> => {
+      // Per-tool-call part ids: minted on first reference and reused for that
+      // call's complete / result. Cleared each step.
+      let toolParts = new Map<string, string>();
+      const ids: StreamIdContext = {
+        subagentId: this.busSessionId,
+        sessionId: this.busSessionId,
+        messageId: undefined,
+        textPartId: undefined,
+        toolPartId: (toolCallId: string) => {
+          let p = toolParts.get(toolCallId);
+          if (!p) {
+            p = newPartId();
+            toolParts.set(toolCallId, p);
+          }
+          return p;
+        },
+      };
       try {
         for await (const chunk of this.streamResult.fullStream) {
-          bus.emitStreamPart(chunk, sid);
+          switch (chunk.type) {
+            case "start-step":
+              // New step → new assistant message; reset part tracking. Mirror
+              // the id onto the instance so onStepFinish can close it.
+              ids.messageId = newMessageId();
+              this.currentMessageId = ids.messageId;
+              ids.textPartId = undefined;
+              toolParts = new Map();
+              ids.toolPartId = (toolCallId: string) => {
+                let p = toolParts.get(toolCallId);
+                if (!p) {
+                  p = newPartId();
+                  toolParts.set(toolCallId, p);
+                }
+                return p;
+              };
+              break;
+            case "text-start":
+              // Each text run within a step gets its own part id.
+              ids.textPartId = newPartId();
+              break;
+            case "text-end":
+              ids.textPartId = undefined;
+              break;
+          }
+          bus.emitStreamPart(chunk, ids);
         }
       } finally {
         this.persistentShell?.dispose();

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -1,14 +1,16 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import type {
   ModelMessage,
   StopCondition,
   StreamTextResult,
   TextStreamPart,
+  ToolCallPart,
+  ToolResultPart,
   ToolSet,
 } from "ai";
 import { hasToolCall } from "ai";
-import { existsSync, mkdirSync } from "fs";
-import { writeFile } from "fs/promises";
-import { join } from "path";
 import { streamResponse } from "../../ai";
 import { AgentEventBus, type StreamIdContext } from "../../eventBus";
 import {
@@ -126,6 +128,16 @@ export class OffensiveSecurityAgent<TResult = void> {
 
   /** The session this agent is operating within. */
   private readonly _session: SessionInfo;
+
+  /** Latest accumulated messages, shared with `consume()` for abort persistence. */
+  private latestMessages: ModelMessage[] | null = null;
+
+  private messagesPath: string | null = null;
+
+  /** Cancels the debounced persist timer so abort writes don't race it. */
+  private cancelPersistTimer: (() => void) | null = null;
+
+  private syntheticsPersisted = false;
 
   /**
    * Async factory that creates a session when one is not provided,
@@ -350,7 +362,8 @@ export class OffensiveSecurityAgent<TResult = void> {
     if (!existsSync(messagesDir)) {
       mkdirSync(messagesDir, { recursive: true });
     }
-    const messagesPath = join(messagesDir, "messages.json");
+    this.messagesPath = join(messagesDir, "messages.json");
+    const messagesPath = this.messagesPath;
 
     // Mutable so that summarization can clear stale history.
     const initialMessagesRef: { current: ModelMessage[] } = {
@@ -368,18 +381,24 @@ export class OffensiveSecurityAgent<TResult = void> {
     // JSON.stringify on every step when many agents run concurrently.
     const PERSIST_INTERVAL_MS = 15_000;
     let persistTimer: ReturnType<typeof setTimeout> | null = null;
-    let latestMessages: ModelMessage[] | null = null;
 
     const schedulePersist = () => {
       if (persistTimer) return;
       persistTimer = setTimeout(() => {
         persistTimer = null;
-        if (latestMessages) {
-          const toWrite = latestMessages;
-          latestMessages = null;
+        if (this.latestMessages) {
+          const toWrite = this.latestMessages;
+          this.latestMessages = null;
           writeFile(messagesPath, JSON.stringify(toWrite)).catch(() => {});
         }
       }, PERSIST_INTERVAL_MS);
+    };
+
+    this.cancelPersistTimer = () => {
+      if (persistTimer) {
+        clearTimeout(persistTimer);
+        persistTimer = null;
+      }
     };
 
     // -- Init record (trace.jsonl first line) ---------------------------------
@@ -422,7 +441,7 @@ export class OffensiveSecurityAgent<TResult = void> {
       toolChoice: "auto",
       sessionPath: input.session.rootPath,
       onStepFinish: async (event) => {
-        latestMessages = [
+        this.latestMessages = [
           ...initialMessagesRef.current,
           ...event.response.messages,
         ];
@@ -456,13 +475,16 @@ export class OffensiveSecurityAgent<TResult = void> {
           clearTimeout(persistTimer);
           persistTimer = null;
         }
-        const finalMessages = latestMessages ?? [
-          ...initialMessagesRef.current,
-          ...event.response.messages,
-        ];
-        await writeFile(messagesPath, JSON.stringify(finalMessages)).catch(
-          () => {},
-        );
+        // Skip if emitSyntheticToolResults already wrote the abort snapshot.
+        if (!this.syntheticsPersisted) {
+          const finalMessages = this.latestMessages ?? [
+            ...initialMessagesRef.current,
+            ...event.response.messages,
+          ];
+          await writeFile(messagesPath, JSON.stringify(finalMessages)).catch(
+            () => {},
+          );
+        }
         await input.onFinish?.(event);
       },
       abortSignal: input.abortSignal,
@@ -542,6 +564,16 @@ export class OffensiveSecurityAgent<TResult = void> {
           return p;
         },
       };
+
+      // Track the current step so it can be reconstructed on abort (PR #779):
+      // inFlightTools = calls still awaiting a result, completedResults =
+      // results already streamed but not yet persisted by onStepFinish. On
+      // stream end with calls still in flight, `emitSyntheticToolResults`
+      // closes them so no tool-call is ever left without a matching result.
+      const inFlightTools = new Map<string, string>();
+      const completedResults: ToolResultPart[] = [];
+      let streamError: unknown = null;
+
       try {
         for await (const chunk of this.streamResult.fullStream) {
           switch (chunk.type) {
@@ -568,11 +600,61 @@ export class OffensiveSecurityAgent<TResult = void> {
             case "text-end":
               ids.textPartId = undefined;
               break;
+            case "tool-call":
+              inFlightTools.set(chunk.toolCallId, chunk.toolName);
+              break;
+            case "tool-result": {
+              const tc = chunk as {
+                toolCallId: string;
+                toolName: string;
+                result?: unknown;
+                output?: unknown;
+              };
+              inFlightTools.delete(tc.toolCallId);
+              completedResults.push({
+                type: "tool-result",
+                toolCallId: tc.toolCallId,
+                toolName: tc.toolName,
+                output: (tc.result ?? tc.output) as ToolResultPart["output"],
+              });
+              break;
+            }
+            case "finish-step":
+              // onStepFinish has persisted this step; drop its results so a
+              // later abort doesn't re-append already-saved tool calls/results.
+              completedResults.length = 0;
+              break;
           }
           bus.emitStreamPart(chunk, ids);
         }
+        // Completed normally — onStepFinish persists everything.
+        completedResults.length = 0;
+      } catch (err) {
+        streamError = err;
       } finally {
+        // Dispose first — don't block on persistence I/O.
         this.persistentShell?.dispose();
+
+        if (inFlightTools.size > 0) {
+          const reason = this.abortSignal?.aborted
+            ? "Agent aborted by user"
+            : streamError instanceof Error && streamError.message
+              ? streamError.message
+              : "Stream terminated unexpectedly";
+          try {
+            await this.emitSyntheticToolResults(
+              inFlightTools,
+              completedResults,
+              reason,
+            );
+          } catch {
+            // Never mask the original streamError with a listener error.
+          }
+        }
+      }
+
+      if (streamError) {
+        throw streamError;
       }
 
       if (this.abortSignal?.aborted) {
@@ -616,6 +698,113 @@ export class OffensiveSecurityAgent<TResult = void> {
    */
   get response() {
     return this.streamResult.response;
+  }
+
+  private async emitSyntheticToolResults(
+    inFlightTools: Map<string, string>,
+    completedResults: ToolResultPart[],
+    reason: string,
+  ): Promise<void> {
+    const sid = this.subagentId;
+    const output = {
+      type: "error-text" as const,
+      value: `Tool execution aborted: ${reason}`,
+    };
+    const syntheticParts: ToolResultPart[] = [];
+
+    for (const [toolCallId, toolName] of inFlightTools) {
+      this.eventBus.emit("tool-result", {
+        toolCallId,
+        toolName,
+        result: output,
+        // Carry this agent's canonical session id (not just the legacy
+        // subagentId alias) so the execution translator routes the synthetic
+        // result to THIS subagent's session rather than falling back to root.
+        sessionId: this.busSessionId,
+        subagentId: sid,
+      });
+      syntheticParts.push({
+        type: "tool-result",
+        toolCallId,
+        toolName,
+        output,
+      });
+    }
+
+    if (!this.messagesPath) return;
+
+    // Cancel the debounced timer so its writeFile can't race the write below.
+    this.cancelPersistTimer?.();
+
+    // latestMessages is null once the debounced timer has flushed; fall back
+    // to the on-disk snapshot so we don't overwrite history with synthetics.
+    let base: ModelMessage[] = this.latestMessages ?? [];
+    if (base.length === 0 && existsSync(this.messagesPath)) {
+      try {
+        base = JSON.parse(readFileSync(this.messagesPath, "utf-8"));
+      } catch {
+        // Corrupt file → proceed with empty base.
+      }
+    }
+
+    // When onStepFinish hasn't fired, this step's assistant + tool messages
+    // aren't in base yet; reconstruct it so resumed sessions see valid pairs.
+    const allToolCallIds = new Set([
+      ...inFlightTools.keys(),
+      ...completedResults.map((r) => r.toolCallId),
+    ]);
+    const lastMsg = base[base.length - 1];
+    const needsStepReconstruction =
+      !lastMsg ||
+      lastMsg.role !== "assistant" ||
+      !this.baseContainsToolCalls(lastMsg, allToolCallIds);
+
+    const appended: ModelMessage[] = [];
+    if (needsStepReconstruction) {
+      const stepTools: Array<[string, string]> = [
+        ...inFlightTools,
+        ...completedResults.map((r): [string, string] => [
+          r.toolCallId,
+          r.toolName,
+        ]),
+      ];
+      const toolCalls: ToolCallPart[] = stepTools.map(
+        ([toolCallId, toolName]) => ({
+          type: "tool-call" as const,
+          toolCallId,
+          toolName,
+          input: {},
+        }),
+      );
+      appended.push({ role: "assistant", content: toolCalls });
+    }
+    appended.push({
+      role: "tool",
+      content: [...completedResults, ...syntheticParts],
+    });
+
+    const next: ModelMessage[] = [...base, ...appended];
+    this.latestMessages = next;
+    try {
+      await writeFile(this.messagesPath, JSON.stringify(next));
+      // Only suppress onFinish's write once the snapshot is safely on disk.
+      this.syntheticsPersisted = true;
+    } catch {
+      // Write failed — leave the flag false so onFinish still attempts a write.
+    }
+  }
+
+  private baseContainsToolCalls(
+    msg: ModelMessage,
+    toolCallIds: Set<string>,
+  ): boolean {
+    if (!Array.isArray(msg.content)) return false;
+    const contentToolIds = new Set(
+      (msg.content as Array<{ type: string; toolCallId?: string }>)
+        .filter((p) => p.type === "tool-call" && p.toolCallId)
+        .map((p) => p.toolCallId),
+    );
+    return [...toolCallIds].every((id) => contentToolIds.has(id));
   }
 }
 

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -10,7 +10,8 @@ import { existsSync, mkdirSync } from "fs";
 import { writeFile } from "fs/promises";
 import { join } from "path";
 import { streamResponse } from "../../ai";
-import { AgentEventBus } from "../../eventBus";
+import { AgentEventBus, type StreamIdContext } from "../../eventBus";
+import { newMessageId, newPartId } from "../../id/id";
 import type { ApprovalGate } from "../../operator";
 import { ApprovalDeniedError } from "../../operator";
 import { create as createSession, type SessionInfo } from "../../session";
@@ -79,6 +80,14 @@ export class OffensiveSecurityAgent<TResult = void> {
   /** Identifier for this agent when it is running as a subagent. */
   private readonly subagentId?: string;
 
+  /**
+   * The current open assistant message id (`msg_…`) for the in-flight step.
+   * Minted on the `start-step` chunk in {@link consume} and read by
+   * `onStepFinish` so the closing `step-finish` event carries the same id.
+   * `null` between steps.
+   */
+  private currentMessageId: string | null = null;
+
   /** Persistent shell for local-mode command execution; disposed on consume() completion. */
   private readonly persistentShell?: PersistentShell;
 
@@ -141,6 +150,18 @@ export class OffensiveSecurityAgent<TResult = void> {
   /** The session this agent is operating within. */
   get session(): SessionInfo {
     return this._session;
+  }
+
+  /**
+   * This agent's identity on the event bus, as a session id (`ses_…`).
+   *
+   * For a subagent, `subagentId` is the child's own session id (minted by
+   * the spawning tool). For the root agent, it is the root session's id.
+   * Used to stamp `sessionId` (and the legacy `subagentId` alias) onto
+   * every event this agent emits.
+   */
+  private get busSessionId(): string {
+    return this.subagentId ?? this._session.id;
   }
 
   constructor(input: OffensiveSecurityAgentInput<TResult>) {
@@ -400,7 +421,12 @@ export class OffensiveSecurityAgent<TResult = void> {
         this.eventBus.emit("step-finish", {
           messages: event.response.messages,
           subagentId: this.subagentId,
+          sessionId: this.busSessionId,
+          messageId: this.currentMessageId ?? undefined,
         });
+        // The step's message is now closed; the next `start-step` chunk in
+        // consume() mints a fresh one.
+        this.currentMessageId = null;
         await input.onStepFinish?.(event);
       },
       onSummarized: () => {
@@ -479,12 +505,54 @@ export class OffensiveSecurityAgent<TResult = void> {
    * @returns The value produced by `resolveResult`, or `void` if none was provided.
    */
   async consume(): Promise<TResult> {
-    const sid = this.subagentId;
     const bus = this.eventBus;
+
+    // Per-tool-call part ids: minted on first reference (tool-input-start)
+    // and reused for that call's complete / result. Cleared each step.
+    let toolParts = new Map<string, string>();
+    const ids: StreamIdContext = {
+      subagentId: this.busSessionId,
+      sessionId: this.busSessionId,
+      messageId: undefined,
+      textPartId: undefined,
+      toolPartId: (toolCallId: string) => {
+        let p = toolParts.get(toolCallId);
+        if (!p) {
+          p = newPartId();
+          toolParts.set(toolCallId, p);
+        }
+        return p;
+      },
+    };
 
     try {
       for await (const chunk of this.streamResult.fullStream) {
-        bus.emitStreamPart(chunk, sid);
+        switch (chunk.type) {
+          case "start-step":
+            // New step → new assistant message; reset part tracking. Mirror
+            // the id onto the instance so onStepFinish can close it.
+            ids.messageId = newMessageId();
+            this.currentMessageId = ids.messageId;
+            ids.textPartId = undefined;
+            toolParts = new Map();
+            ids.toolPartId = (toolCallId: string) => {
+              let p = toolParts.get(toolCallId);
+              if (!p) {
+                p = newPartId();
+                toolParts.set(toolCallId, p);
+              }
+              return p;
+            };
+            break;
+          case "text-start":
+            // Each text run within a step gets its own part id.
+            ids.textPartId = newPartId();
+            break;
+          case "text-end":
+            ids.textPartId = undefined;
+            break;
+        }
+        bus.emitStreamPart(chunk, ids);
       }
     } finally {
       this.persistentShell?.dispose();

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -5,6 +5,7 @@ import {
   resolvePathWithinCodebaseRoot,
   resolveWhiteboxCodebaseRoot,
 } from "../../../whitebox";
+import { newSessionId } from "../../../id/id";
 import type { ToolContext } from "./types";
 
 /** Default max concurrent coding agents */
@@ -187,13 +188,20 @@ async function runSingleCodingAgent(
   // codeAgent → offensiveSecurityAgent → tools/index → spawnCodingAgent → codeAgent
   const { CodeAgent } = await import("../../specialized/codeAgent/agent");
 
-  const subagentId = `coding-agent-${agentIndex}`;
+  // Native identity: the subagent IS a session. Mint its session id up front
+  // and use it as the bus identity, mirroring spawnPentestAgent. The `name`
+  // field carries the human-readable UI label; the `agentIndex` slot id is no
+  // longer used as the agent's identity.
+  const childSessionId = newSessionId();
+  const subagentId = childSessionId as string;
 
   ctx.eventBus?.emit("subagent-spawn", {
     subagentId,
+    sessionId: childSessionId,
     name,
     input: { codebasePath, objective },
     parentSubagentId: ctx.subagentId,
+    parentSessionId: ctx.subagentId ?? ctx.session.id,
   });
 
   const localBus = new AgentEventBus();
@@ -221,16 +229,20 @@ async function runSingleCodingAgent(
 
     ctx.eventBus?.emit("subagent-complete", {
       subagentId,
+      sessionId: childSessionId,
       status: "completed",
       parentSubagentId: ctx.subagentId,
+      parentSessionId: ctx.subagentId ?? ctx.session.id,
     });
 
     return textOutput;
   } catch (error) {
     ctx.eventBus?.emit("subagent-complete", {
       subagentId,
+      sessionId: childSessionId,
       status: "failed",
       parentSubagentId: ctx.subagentId,
+      parentSessionId: ctx.subagentId ?? ctx.session.id,
     });
     throw error;
   }

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { AgentEventBus } from "../../../eventBus";
+import { newSessionId } from "../../../id/id";
 import type { ToolContext } from "./types";
 
 /** Default max concurrent coding agents */
@@ -156,13 +157,20 @@ async function runSingleCodingAgent(
   // codeAgent → offensiveSecurityAgent → tools/index → spawnCodingAgent → codeAgent
   const { CodeAgent } = await import("../../specialized/codeAgent/agent");
 
-  const subagentId = `coding-agent-${agentIndex}`;
+  // Native identity: the subagent IS a session. Mint its session id up front
+  // and use it as the bus identity, mirroring spawnPentestAgent. The `name`
+  // field carries the human-readable UI label; the `agentIndex` slot id is no
+  // longer used as the agent's identity.
+  const childSessionId = newSessionId();
+  const subagentId = childSessionId as string;
 
   ctx.eventBus?.emit("subagent-spawn", {
     subagentId,
+    sessionId: childSessionId,
     name,
     input: { codebasePath, objective },
     parentSubagentId: ctx.subagentId,
+    parentSessionId: ctx.subagentId ?? ctx.session.id,
   });
 
   const localBus = new AgentEventBus();
@@ -189,16 +197,20 @@ async function runSingleCodingAgent(
 
     ctx.eventBus?.emit("subagent-complete", {
       subagentId,
+      sessionId: childSessionId,
       status: "completed",
       parentSubagentId: ctx.subagentId,
+      parentSessionId: ctx.subagentId ?? ctx.session.id,
     });
 
     return textOutput;
   } catch (error) {
     ctx.eventBus?.emit("subagent-complete", {
       subagentId,
+      sessionId: childSessionId,
       status: "failed",
       parentSubagentId: ctx.subagentId,
+      parentSessionId: ctx.subagentId ?? ctx.session.id,
     });
     throw error;
   }

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -1,11 +1,11 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { AgentEventBus } from "../../../eventBus";
+import { newSessionId } from "../../../id/id";
 import {
   resolvePathWithinCodebaseRoot,
   resolveWhiteboxCodebaseRoot,
 } from "../../../whitebox";
-import { newSessionId } from "../../../id/id";
 import type { ToolContext } from "./types";
 
 /** Default max concurrent coding agents */

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -2,6 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import { AgentEventBus } from "../../../eventBus";
 import { FindingsRegistry } from "../../../findings/registry";
+import { newSessionId } from "../../../id/id";
 import { PlaywrightMcpSession } from "./playwrightMcp";
 import type { ToolContext } from "./types";
 
@@ -97,14 +98,20 @@ Returns the worker's summary, objective results, and finding count — but NOT t
           abortSignal: ctx.abortSignal,
         });
 
-      const childIndex = nextChildIndex(ctx.subagentId);
-      const subagentId = buildChildSubagentId(ctx.subagentId, childIndex);
+      // Native identity: the subagent IS a session. Mint its session id up
+      // front and use it as the on-disk directory key
+      // (subagents/{childSessionId}/) and the bus identity. The human-readable
+      // `name` is carried separately for display.
+      const childSessionId = newSessionId();
+      const subagentId = childSessionId as string;
 
       ctx.eventBus?.emit("subagent-spawn", {
         subagentId,
+        sessionId: childSessionId,
         name,
         input: { target, objectives },
         parentSubagentId: ctx.subagentId,
+        parentSessionId: ctx.subagentId ?? ctx.session.id,
       });
 
       const childBus = new AgentEventBus();
@@ -192,8 +199,10 @@ Returns the worker's summary, objective results, and finding count — but NOT t
 
         ctx.eventBus?.emit("subagent-complete", {
           subagentId,
+          sessionId: childSessionId,
           status: "completed",
           parentSubagentId: ctx.subagentId,
+          parentSessionId: ctx.subagentId ?? ctx.session.id,
         });
 
         return {
@@ -206,8 +215,10 @@ Returns the worker's summary, objective results, and finding count — but NOT t
       } catch (error) {
         ctx.eventBus?.emit("subagent-complete", {
           subagentId,
+          sessionId: childSessionId,
           status: "failed",
           parentSubagentId: ctx.subagentId,
+          parentSessionId: ctx.subagentId ?? ctx.session.id,
         });
 
         const message = error instanceof Error ? error.message : String(error);
@@ -232,28 +243,8 @@ Returns the worker's summary, objective results, and finding count — but NOT t
 }
 
 // ---------------------------------------------------------------------------
-// Internals — child subagent id allocation
+// Internals
 // ---------------------------------------------------------------------------
-
-// Per-parent counter. Ensures unique ids when an orchestrator spawns multiple
-// workers sequentially. Keyed by parent subagentId (or "" for top-level
-// orchestrators) so counters in independent parent runs don't collide.
-const childCounters = new Map<string, number>();
-
-function nextChildIndex(parentSubagentId: string | undefined): number {
-  const key = parentSubagentId ?? "";
-  const next = (childCounters.get(key) ?? 0) + 1;
-  childCounters.set(key, next);
-  return next;
-}
-
-function buildChildSubagentId(
-  parentSubagentId: string | undefined,
-  index: number,
-): string {
-  const prefix = parentSubagentId ?? "pentest-agent";
-  return `${prefix}-worker-${index}`;
-}
 
 /**
  * Inject a "Cloned Browser Session" note at the top of the worker's

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -6,6 +6,7 @@ import {
   resolveEffectiveHeaders,
   stripBrowserManagedHeaders,
 } from "../../../http/targetHeaders";
+import { newSessionId } from "../../../id/id";
 import { PlaywrightMcpSession } from "./playwrightMcp";
 import type { ToolContext } from "./types";
 
@@ -103,14 +104,20 @@ Returns the worker's summary, objective results, and finding count — but NOT t
           abortSignal: ctx.abortSignal,
         });
 
-      const childIndex = nextChildIndex(ctx.subagentId);
-      const subagentId = buildChildSubagentId(ctx.subagentId, childIndex);
+      // Native identity: the subagent IS a session. Mint its session id up
+      // front and use it as the on-disk directory key
+      // (subagents/{childSessionId}/) and the bus identity. The human-readable
+      // `name` is carried separately for display.
+      const childSessionId = newSessionId();
+      const subagentId = childSessionId as string;
 
       ctx.eventBus?.emit("subagent-spawn", {
         subagentId,
+        sessionId: childSessionId,
         name,
         input: { target, objectives },
         parentSubagentId: ctx.subagentId,
+        parentSessionId: ctx.subagentId ?? ctx.session.id,
       });
 
       const childBus = new AgentEventBus();
@@ -210,8 +217,10 @@ Returns the worker's summary, objective results, and finding count — but NOT t
 
         ctx.eventBus?.emit("subagent-complete", {
           subagentId,
+          sessionId: childSessionId,
           status: "completed",
           parentSubagentId: ctx.subagentId,
+          parentSessionId: ctx.subagentId ?? ctx.session.id,
         });
 
         return {
@@ -224,8 +233,10 @@ Returns the worker's summary, objective results, and finding count — but NOT t
       } catch (error) {
         ctx.eventBus?.emit("subagent-complete", {
           subagentId,
+          sessionId: childSessionId,
           status: "failed",
           parentSubagentId: ctx.subagentId,
+          parentSessionId: ctx.subagentId ?? ctx.session.id,
         });
 
         const message = error instanceof Error ? error.message : String(error);
@@ -250,28 +261,8 @@ Returns the worker's summary, objective results, and finding count — but NOT t
 }
 
 // ---------------------------------------------------------------------------
-// Internals — child subagent id allocation
+// Internals
 // ---------------------------------------------------------------------------
-
-// Per-parent counter. Ensures unique ids when an orchestrator spawns multiple
-// workers sequentially. Keyed by parent subagentId (or "" for top-level
-// orchestrators) so counters in independent parent runs don't collide.
-const childCounters = new Map<string, number>();
-
-function nextChildIndex(parentSubagentId: string | undefined): number {
-  const key = parentSubagentId ?? "";
-  const next = (childCounters.get(key) ?? 0) + 1;
-  childCounters.set(key, next);
-  return next;
-}
-
-function buildChildSubagentId(
-  parentSubagentId: string | undefined,
-  index: number,
-): string {
-  const prefix = parentSubagentId ?? "pentest-agent";
-  return `${prefix}-worker-${index}`;
-}
 
 /**
  * Inject a "Cloned Browser Session" note at the top of the worker's

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -1,5 +1,6 @@
 import type { AnthropicMessagesModelId } from "@ai-sdk/anthropic/internal";
 import type { OpenAIChatModelId } from "@ai-sdk/openai/internal";
+import { AsyncLocalStorage } from "node:async_hooks";
 import {
   generateText,
   type LanguageModel,
@@ -28,17 +29,92 @@ import {
 
 export type AIModel = AnthropicMessagesModelId | OpenAIChatModelId | string; // For OpenRouter and Bedrock models
 
+/**
+ * Per-step billing context attached to a usage report.
+ *
+ * Carries the identity of the step that produced the usage so the billing
+ * sink can attribute cost to a specific `(sessionId, stepSeq)` rather than a
+ * whole run. Both fields are optional for backward compatibility — callers
+ * that registered a 3-arg callback continue to work unchanged.
+ */
+export interface UsageStepContext {
+  /** Session id (`ses_…`) that emitted the step, when known. */
+  sessionId?: string;
+  /** Monotonic per-run AI-SDK step index (see {@link runWithStepContext}). */
+  stepSeq?: number;
+}
+
 /** Callback for reporting token usage from AI operations */
 type UsageCallback = (
   model: string,
   inputTokens: number,
   outputTokens: number,
+  ctx?: UsageStepContext,
 ) => void;
 let _usageCallback: UsageCallback | null = null;
 
 /** Register a callback to receive token usage reports from all AI operations */
 export function onUsage(cb: UsageCallback | null): void {
   _usageCallback = cb;
+}
+
+// ---------------------------------------------------------------------------
+// Per-run step counter (for per-step billing attribution)
+// ---------------------------------------------------------------------------
+//
+// Each AI-SDK `streamText` step that reports usage is tagged with a monotonic
+// `stepSeq` scoped to the emitting session. The counter lives in
+// AsyncLocalStorage so concurrent runs (e.g. parallel subagents) never share
+// or race a step index — each `runWithStepContext` call gets its own store.
+//
+// Monotonicity across a resumed run: the caller seeds `nextStepSeq` from the
+// count of rehydrated assistant messages (the best available proxy for "how
+// many steps already happened"). This guarantees monotonic-within-a-run and
+// approximates cross-run monotonicity. It is NOT a strict global sequence —
+// the authoritative per-session step ordering is the DB `stepSeq` on
+// `agent_messages`; this counter only labels live usage reports for billing.
+
+interface StepContext {
+  sessionId?: string;
+  /** Next step index to hand out; mutated in place as steps finish. */
+  next: number;
+}
+
+const stepContextStore = new AsyncLocalStorage<StepContext>();
+
+/**
+ * Run `fn` within a per-run step-counting context. All `streamResponse` steps
+ * executed inside `fn`'s async tree report usage tagged with `sessionId` and a
+ * monotonically increasing `stepSeq` starting at `seedStepSeq` (default 0).
+ *
+ * Pass `seedStepSeq` = number of prior assistant messages on resume so the
+ * counter continues past the rehydrated history.
+ */
+export function runWithStepContext<T>(
+  opts: { sessionId?: string; seedStepSeq?: number },
+  fn: () => T,
+): T {
+  return stepContextStore.run(
+    { sessionId: opts.sessionId, next: opts.seedStepSeq ?? 0 },
+    fn,
+  );
+}
+
+/**
+ * Take (and advance) the next `stepSeq` for the current run, returning the
+ * accompanying billing context. Returns `undefined` when no step context is
+ * active (e.g. one-off `generateText` calls outside a run) so callers stay
+ * backward compatible.
+ *
+ * Exported for testing the per-step counter in isolation; production callers
+ * should not need to call this directly.
+ */
+export function takeStepContext(): UsageStepContext | undefined {
+  const store = stepContextStore.getStore();
+  if (!store) return undefined;
+  const stepSeq = store.next;
+  store.next += 1;
+  return { sessionId: store.sessionId, stepSeq };
 }
 
 export type AIModelProvider =
@@ -638,7 +714,10 @@ export function streamResponse(
     if (_usageCallback) {
       const inp = step.usage?.inputTokens ?? 0;
       const out = step.usage?.outputTokens ?? 0;
-      if (inp > 0 || out > 0) _usageCallback(model, inp, out);
+      // Always advance the step counter once per finished step (even with zero
+      // usage) so `stepSeq` stays aligned with the AI-SDK step index.
+      const stepCtx = takeStepContext();
+      if (inp > 0 || out > 0) _usageCallback(model, inp, out, stepCtx);
     }
   };
   const providerModel = getProviderModel(model, authConfig);
@@ -1034,7 +1113,8 @@ export async function generateObjectResponse<T extends z.ZodType>(
       if (_usageCallback && usage) {
         const inp = usage.inputTokens ?? 0;
         const out = usage.outputTokens ?? 0;
-        if (inp > 0 || out > 0) _usageCallback(model, inp, out);
+        const stepCtx = takeStepContext();
+        if (inp > 0 || out > 0) _usageCallback(model, inp, out, stepCtx);
       }
 
       return output;

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -1,7 +1,7 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { AnthropicMessagesModelId } from "@ai-sdk/anthropic/internal";
 import type { OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
 import type { OpenAIChatModelId } from "@ai-sdk/openai/internal";
-import { AsyncLocalStorage } from "node:async_hooks";
 import {
   generateText,
   type LanguageModel,

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -1,6 +1,7 @@
 import type { AnthropicMessagesModelId } from "@ai-sdk/anthropic/internal";
 import type { OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
 import type { OpenAIChatModelId } from "@ai-sdk/openai/internal";
+import { AsyncLocalStorage } from "node:async_hooks";
 import {
   generateText,
   type LanguageModel,
@@ -56,17 +57,92 @@ const OPENAI_REASONING_MODEL_IDS = new Set([
   "gpt-5.5-2026-04-23",
 ]);
 
+/**
+ * Per-step billing context attached to a usage report.
+ *
+ * Carries the identity of the step that produced the usage so the billing
+ * sink can attribute cost to a specific `(sessionId, stepSeq)` rather than a
+ * whole run. Both fields are optional for backward compatibility — callers
+ * that registered a 3-arg callback continue to work unchanged.
+ */
+export interface UsageStepContext {
+  /** Session id (`ses_…`) that emitted the step, when known. */
+  sessionId?: string;
+  /** Monotonic per-run AI-SDK step index (see {@link runWithStepContext}). */
+  stepSeq?: number;
+}
+
 /** Callback for reporting token usage from AI operations */
 type UsageCallback = (
   model: string,
   inputTokens: number,
   outputTokens: number,
+  ctx?: UsageStepContext,
 ) => void;
 let _usageCallback: UsageCallback | null = null;
 
 /** Register a callback to receive token usage reports from all AI operations */
 export function onUsage(cb: UsageCallback | null): void {
   _usageCallback = cb;
+}
+
+// ---------------------------------------------------------------------------
+// Per-run step counter (for per-step billing attribution)
+// ---------------------------------------------------------------------------
+//
+// Each AI-SDK `streamText` step that reports usage is tagged with a monotonic
+// `stepSeq` scoped to the emitting session. The counter lives in
+// AsyncLocalStorage so concurrent runs (e.g. parallel subagents) never share
+// or race a step index — each `runWithStepContext` call gets its own store.
+//
+// Monotonicity across a resumed run: the caller seeds `nextStepSeq` from the
+// count of rehydrated assistant messages (the best available proxy for "how
+// many steps already happened"). This guarantees monotonic-within-a-run and
+// approximates cross-run monotonicity. It is NOT a strict global sequence —
+// the authoritative per-session step ordering is the DB `stepSeq` on
+// `agent_messages`; this counter only labels live usage reports for billing.
+
+interface StepContext {
+  sessionId?: string;
+  /** Next step index to hand out; mutated in place as steps finish. */
+  next: number;
+}
+
+const stepContextStore = new AsyncLocalStorage<StepContext>();
+
+/**
+ * Run `fn` within a per-run step-counting context. All `streamResponse` steps
+ * executed inside `fn`'s async tree report usage tagged with `sessionId` and a
+ * monotonically increasing `stepSeq` starting at `seedStepSeq` (default 0).
+ *
+ * Pass `seedStepSeq` = number of prior assistant messages on resume so the
+ * counter continues past the rehydrated history.
+ */
+export function runWithStepContext<T>(
+  opts: { sessionId?: string; seedStepSeq?: number },
+  fn: () => T,
+): T {
+  return stepContextStore.run(
+    { sessionId: opts.sessionId, next: opts.seedStepSeq ?? 0 },
+    fn,
+  );
+}
+
+/**
+ * Take (and advance) the next `stepSeq` for the current run, returning the
+ * accompanying billing context. Returns `undefined` when no step context is
+ * active (e.g. one-off `generateText` calls outside a run) so callers stay
+ * backward compatible.
+ *
+ * Exported for testing the per-step counter in isolation; production callers
+ * should not need to call this directly.
+ */
+export function takeStepContext(): UsageStepContext | undefined {
+  const store = stepContextStore.getStore();
+  if (!store) return undefined;
+  const stepSeq = store.next;
+  store.next += 1;
+  return { sessionId: store.sessionId, stepSeq };
 }
 
 export type AIModelProvider =
@@ -697,7 +773,10 @@ export function streamResponse(
     if (_usageCallback) {
       const inp = step.usage?.inputTokens ?? 0;
       const out = step.usage?.outputTokens ?? 0;
-      if (inp > 0 || out > 0) _usageCallback(model, inp, out);
+      // Always advance the step counter once per finished step (even with zero
+      // usage) so `stepSeq` stays aligned with the AI-SDK step index.
+      const stepCtx = takeStepContext();
+      if (inp > 0 || out > 0) _usageCallback(model, inp, out, stepCtx);
     }
   };
   const providerModel = getProviderModel(model, authConfig);
@@ -1151,7 +1230,8 @@ export async function generateObjectResponse<T extends z.ZodType>(
       if (_usageCallback && usage) {
         const inp = usage.inputTokens ?? 0;
         const out = usage.outputTokens ?? 0;
-        if (inp > 0 || out > 0) _usageCallback(model, inp, out);
+        const stepCtx = takeStepContext();
+        if (inp > 0 || out > 0) _usageCallback(model, inp, out, stepCtx);
       }
 
       return output;

--- a/src/core/ai/stepContext.test.ts
+++ b/src/core/ai/stepContext.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { runWithStepContext, takeStepContext } from "./ai";
+
+describe("per-run step counter", () => {
+  it("hands out stepSeq 0..N-1 within a run, tagged with the sessionId", () => {
+    const seqs = runWithStepContext({ sessionId: "ses_root" }, () => {
+      const out: Array<{ sessionId?: string; stepSeq?: number }> = [];
+      for (let i = 0; i < 5; i++) {
+        const ctx = takeStepContext();
+        out.push(ctx!);
+      }
+      return out;
+    });
+
+    expect(seqs.map((c) => c.stepSeq)).toEqual([0, 1, 2, 3, 4]);
+    expect(seqs.every((c) => c.sessionId === "ses_root")).toBe(true);
+  });
+
+  it("continues monotonically across a resumed run via seedStepSeq", () => {
+    // A resumed run with M=3 prior assistant messages seeds the counter at 3.
+    const seqs = runWithStepContext(
+      { sessionId: "ses_resumed", seedStepSeq: 3 },
+      () => {
+        const out: number[] = [];
+        for (let i = 0; i < 3; i++) out.push(takeStepContext()!.stepSeq!);
+        return out;
+      },
+    );
+    expect(seqs).toEqual([3, 4, 5]);
+  });
+
+  it("returns undefined outside any run context (backward compatible)", () => {
+    expect(takeStepContext()).toBeUndefined();
+  });
+
+  it("isolates concurrent runs — each gets its own counter", async () => {
+    const runA = new Promise<number[]>((resolve) => {
+      runWithStepContext({ sessionId: "ses_a" }, async () => {
+        const out: number[] = [];
+        out.push(takeStepContext()!.stepSeq!);
+        await Promise.resolve();
+        out.push(takeStepContext()!.stepSeq!);
+        resolve(out);
+      });
+    });
+    const runB = new Promise<number[]>((resolve) => {
+      runWithStepContext({ sessionId: "ses_b" }, async () => {
+        const out: number[] = [];
+        out.push(takeStepContext()!.stepSeq!);
+        await Promise.resolve();
+        out.push(takeStepContext()!.stepSeq!);
+        resolve(out);
+      });
+    });
+
+    const [a, b] = await Promise.all([runA, runB]);
+    // Both runs count independently from 0 — no cross-contamination.
+    expect(a).toEqual([0, 1]);
+    expect(b).toEqual([0, 1]);
+  });
+});

--- a/src/core/eventBus.test.ts
+++ b/src/core/eventBus.test.ts
@@ -1,9 +1,11 @@
+import type { TextStreamPart, ToolSet } from "ai";
 import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { StepTraceWriter, type TraceRecord } from "./agents/offSecAgent/trace";
-import { AgentEventBus } from "./eventBus";
+import { AgentEventBus, type StreamIdContext } from "./eventBus";
+import { isPartId, newMessageId, newSessionId } from "./id/id";
 
 // ---------------------------------------------------------------------------
 // Regression coverage for issue #707 — trace-record forwarding across
@@ -94,5 +96,187 @@ describe("AgentEventBus.attachChild — child→parent forwarding contract", () 
 
     expect(received).toHaveLength(1);
     expect(received[0].subagentId).toBe("inner");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Native identity threading: emitStreamPart stamps sessionId / messageId /
+// partId, and attachChild injects the child's session id + parentSessionId.
+// ---------------------------------------------------------------------------
+
+describe("emitStreamPart — native id threading", () => {
+  function part(chunk: Partial<TextStreamPart<ToolSet>> & { type: string }) {
+    return chunk as TextStreamPart<ToolSet>;
+  }
+
+  it("stamps sessionId/messageId/partId on text and tool events", () => {
+    const bus = new AgentEventBus();
+    const sessionId = newSessionId();
+    const messageId = newMessageId();
+    const toolPartIds = new Map<string, string>();
+    let nextPart = 0;
+
+    const ids: StreamIdContext = {
+      subagentId: sessionId,
+      sessionId,
+      messageId,
+      textPartId: "prt_textrun",
+      toolPartId: (toolCallId: string) => {
+        let p = toolPartIds.get(toolCallId);
+        if (!p) {
+          p = `prt_tool_${nextPart++}`;
+          toolPartIds.set(toolCallId, p);
+        }
+        return p;
+      },
+    };
+
+    const text: AgentEventMapText[] = [];
+    bus.on("text-delta", (e) => text.push(e));
+    const starts: AgentEventMapToolStart[] = [];
+    bus.on("tool-call-start", (e) => starts.push(e));
+    const completes: AgentEventMapToolComplete[] = [];
+    bus.on("tool-call-complete", (e) => completes.push(e));
+    const results: AgentEventMapToolResult[] = [];
+    bus.on("tool-result", (e) => results.push(e));
+
+    bus.emitStreamPart(part({ type: "text-delta", id: "t1", text: "hi" }), ids);
+    bus.emitStreamPart(
+      part({ type: "tool-input-start", id: "tc-1", toolName: "exec" }),
+      ids,
+    );
+    bus.emitStreamPart(
+      part({
+        type: "tool-call",
+        toolCallId: "tc-1",
+        toolName: "exec",
+        input: { cmd: "ls" },
+      }),
+      ids,
+    );
+    bus.emitStreamPart(
+      part({
+        type: "tool-result",
+        toolCallId: "tc-1",
+        toolName: "exec",
+        output: "ok",
+      }),
+      ids,
+    );
+
+    expect(text[0]).toMatchObject({
+      sessionId,
+      messageId,
+      partId: "prt_textrun",
+    });
+
+    // Tool start mints a part id; complete + result reuse the SAME part id.
+    expect(starts[0]).toMatchObject({ sessionId, messageId });
+    const toolPartId = starts[0].partId;
+    expect(toolPartId).toBeDefined();
+    expect(completes[0].partId).toBe(toolPartId);
+    expect(results[0].partId).toBe(toolPartId);
+  });
+
+  it("accepts a bare subagentId string for backward compatibility", () => {
+    const bus = new AgentEventBus();
+    const received: AgentEventMapText[] = [];
+    bus.on("text-delta", (e) => received.push(e));
+
+    bus.emitStreamPart(
+      part({ type: "text-delta", id: "t1", text: "x" }),
+      "sub-1",
+    );
+
+    expect(received[0].subagentId).toBe("sub-1");
+    expect(received[0].sessionId).toBeUndefined();
+  });
+});
+
+describe("attachChild — session id injection", () => {
+  it("injects the child session id as sessionId + subagentId on forwarded events", () => {
+    const parent = new AgentEventBus();
+    const child = new AgentEventBus();
+    const childSessionId = newSessionId();
+    AgentEventBus.attachChild(child, parent, childSessionId);
+
+    const received: { sessionId?: string; subagentId?: string }[] = [];
+    parent.on("text-delta", (e) => received.push(e));
+
+    child.emit("text-delta", { text: "from child" });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].sessionId).toBe(childSessionId);
+    expect(received[0].subagentId).toBe(childSessionId);
+  });
+
+  it("injects parentSessionId on bubbled lifecycle events", () => {
+    const parent = new AgentEventBus();
+    const child = new AgentEventBus();
+    const childSessionId = newSessionId();
+    AgentEventBus.attachChild(child, parent, childSessionId);
+
+    const received: { parentSessionId?: string; sessionId?: string }[] = [];
+    parent.on("subagent-spawn", (e) => received.push(e));
+
+    const grandchildSessionId = newSessionId();
+    child.emit("subagent-spawn", {
+      subagentId: grandchildSessionId,
+      sessionId: grandchildSessionId,
+      input: {},
+    });
+
+    expect(received).toHaveLength(1);
+    // The grandchild's own session id is preserved...
+    expect(received[0].sessionId).toBe(grandchildSessionId);
+    // ...and the child (this bus's owner) becomes the parent.
+    expect(received[0].parentSessionId).toBe(childSessionId);
+  });
+});
+
+// Local payload aliases so the test bodies stay readable without importing
+// the (intentionally not exported) AgentEventMap.
+type AgentEventMapText = {
+  text: string;
+  sessionId?: string;
+  subagentId?: string;
+  messageId?: string;
+  partId?: string;
+};
+type AgentEventMapToolStart = {
+  toolCallId: string;
+  toolName: string;
+  sessionId?: string;
+  messageId?: string;
+  partId?: string;
+};
+type AgentEventMapToolComplete = AgentEventMapToolStart & { args: unknown };
+type AgentEventMapToolResult = AgentEventMapToolStart & { result: unknown };
+
+// Reference isPartId so the import is exercised as a sanity assertion.
+describe("partId shape", () => {
+  it("minted tool/text part ids are prt_-prefixed", () => {
+    const bus = new AgentEventBus();
+    const got: string[] = [];
+    bus.on("tool-call-start", (e) => {
+      if (e.partId) got.push(e.partId);
+    });
+    let n = 0;
+    bus.emitStreamPart(
+      {
+        type: "tool-input-start",
+        id: "tc-x",
+        toolName: "t",
+      } as TextStreamPart<ToolSet>,
+      {
+        sessionId: newSessionId(),
+        toolPartId: () => {
+          n++;
+          return `prt_x${n}`;
+        },
+      },
+    );
+    expect(got).toHaveLength(1);
+    expect(isPartId(got[0])).toBe(true);
   });
 });

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -4,47 +4,89 @@ import { EventEmitter } from "events";
 /**
  * Typed event map for the agent event bus.
  *
- * Events mirror the AI SDK's `TextStreamPart` types with an added
- * `subagentId` for multi-agent delineation.  Lifecycle events
- * (`subagent-spawn`, `subagent-complete`) and side-channel events
- * (`command-output`, `error`) round out the map.
+ * Events mirror the AI SDK's `TextStreamPart` types and carry native
+ * identity so a downstream translator can route them without inference:
+ *
+ *   - `sessionId`  — the session id (`ses_…`) of the emitting agent (root or
+ *     subagent). This is the canonical multi-agent delineator and supersedes
+ *     the legacy `subagentId` string. For a subagent it is the child's own
+ *     session id; for the root agent it is the root session id.
+ *   - `messageId`  — the assistant message (`msg_…`) the part belongs to,
+ *     minted at step start and closed on `step-finish`.
+ *   - `partId`     — the part (`prt_…`) within that message; minted per text
+ *     run and per tool call (stable across a tool's start/complete/result).
+ *
+ * `subagentId` is retained as a backward-compatible alias of the emitting
+ * agent's identity so the existing consumer surface (W&B uploader,
+ * operator dashboard, persistence) keeps working during the migration.
+ * When a `ses_…` session id is the agent's identity, `subagentId` carries
+ * that same value.
+ *
+ * Lifecycle events (`subagent-spawn`, `subagent-complete`) and side-channel
+ * events (`command-output`, `error`) round out the map.
  */
 export type AgentEventMap = {
-  "text-delta": { text: string; subagentId?: string };
+  "text-delta": {
+    text: string;
+    subagentId?: string;
+    sessionId?: string;
+    messageId?: string;
+    partId?: string;
+  };
   "tool-call-start": {
     toolCallId: string;
     toolName: string;
     subagentId?: string;
+    sessionId?: string;
+    messageId?: string;
+    partId?: string;
   };
   "tool-call-delta": {
     toolCallId: string;
     argsTextDelta: string;
     subagentId?: string;
+    sessionId?: string;
+    messageId?: string;
+    partId?: string;
   };
   "tool-call-complete": {
     toolCallId: string;
     toolName: string;
     args: unknown;
     subagentId?: string;
+    sessionId?: string;
+    messageId?: string;
+    partId?: string;
   };
   "tool-result": {
     toolCallId: string;
     toolName: string;
     result: unknown;
     subagentId?: string;
+    sessionId?: string;
+    messageId?: string;
+    partId?: string;
   };
   "subagent-spawn": {
     subagentId: string;
+    /** The spawned child's own session id (`ses_…`). */
+    sessionId?: string;
     name?: string;
     input: unknown;
     /** Omitted means top-level. Auto-populated by {@link AgentEventBus.attachChild}. */
     parentSubagentId?: string;
+    /** Parent agent's session id (`ses_…`). Auto-populated by {@link AgentEventBus.attachChild}. */
+    parentSessionId?: string;
   };
   "subagent-complete": {
     subagentId: string;
+    /** The completed child's own session id (`ses_…`). */
+    sessionId?: string;
     status: "completed" | "failed";
     /** Omitted means top-level. Auto-populated by {@link AgentEventBus.attachChild}. */
     parentSubagentId?: string;
+    /** Parent agent's session id (`ses_…`). Auto-populated by {@link AgentEventBus.attachChild}. */
+    parentSessionId?: string;
   };
   "workflow-phase-start": {
     phase: "discovery" | "pentesting" | "reporting";
@@ -63,6 +105,9 @@ export type AgentEventMap = {
   "step-finish": {
     messages: unknown[];
     subagentId?: string;
+    sessionId?: string;
+    /** The assistant message (`msg_…`) that just closed this step. */
+    messageId?: string;
   };
   "command-output": { data: string; subagentId?: string };
   error: { error: unknown; subagentId?: string };
@@ -181,19 +226,23 @@ export class AgentEventBus {
 
   /**
    * Forward selected events from a child bus to a parent bus, ensuring
-   * all forwarded payloads carry the given `subagentId`.
+   * all forwarded payloads carry the child's identity.
+   *
+   * `childSessionId` is the spawned subagent's own session id (`ses_…`).
+   * It is injected as both `sessionId` (canonical) and `subagentId`
+   * (legacy alias) on every bubbled event that lacks one, so the
+   * parent's routing logic (subagent store vs main view, downstream
+   * translator) works correctly without inference.
    *
    * Tools running inside a subagent emit side-channel events (e.g.
-   * `command-output`) without `subagentId`. This method injects the
-   * ID so the parent's routing logic (subagent store vs main view)
-   * works correctly. For `subagent-spawn` / `subagent-complete` it
-   * additionally injects `parentSubagentId` to preserve hierarchy
-   * across nested subagents.
+   * `command-output`) without any identity. For `subagent-spawn` /
+   * `subagent-complete` this additionally injects `parentSubagentId`
+   * and `parentSessionId` to preserve hierarchy across nested subagents.
    */
   static attachChild(
     child: AgentEventBus,
     parent: AgentEventBus | undefined,
-    subagentId: string,
+    childSessionId: string,
   ): void {
     if (!parent) return;
     for (const key of CHILD_BUS_FORWARDED_EVENTS) {
@@ -207,25 +256,33 @@ export class AgentEventBus {
           forwardKey === "subagent-spawn" || forwardKey === "subagent-complete";
 
         if (isLifecycle) {
-          if (p.parentSubagentId) {
-            parent.emit(forwardKey, payload as never);
-          } else {
-            parent.emit(forwardKey, {
-              ...p,
-              parentSubagentId: subagentId,
-            } as never);
-          }
+          // The child bus belongs to a NESTED subagent: this lifecycle
+          // event describes a grandchild, so `childSessionId` is the
+          // parent of that grandchild.
+          const next: Record<string, unknown> = { ...p };
+          if (!p.parentSubagentId) next.parentSubagentId = childSessionId;
+          if (!p.parentSessionId) next.parentSessionId = childSessionId;
+          parent.emit(forwardKey, next as never);
           return;
         }
 
-        if (!p.subagentId) {
-          parent.emit(forwardKey, { ...p, subagentId } as never);
-        } else {
-          parent.emit(forwardKey, payload as never);
-        }
+        const next: Record<string, unknown> = { ...p };
+        if (!p.subagentId) next.subagentId = childSessionId;
+        if (!p.sessionId) next.sessionId = childSessionId;
+        parent.emit(forwardKey, next as never);
       });
     }
   }
+
+  /**
+   * Per-stream identity context threaded into {@link emitStreamPart}.
+   *
+   * The emitting agent owns this object and mutates it as the stream
+   * progresses (a new `messageId` at step start, a fresh text `partId`
+   * per text run). It is passed by reference on every chunk so the bus
+   * stamps each event with the right native ids.
+   */
+  // (interface declared at module scope as StreamIdContext)
 
   /**
    * Emit the appropriate bus event for an AI SDK `fullStream` chunk.
@@ -237,17 +294,46 @@ export class AgentEventBus {
    *   tool-call         → tool-call-complete
    *   tool-result       → tool-result
    *   error             → error
+   *
+   * The second argument carries the emitting agent's identity. For
+   * backward compatibility a bare `subagentId` string is still accepted;
+   * callers that have full identity should pass a {@link StreamIdContext}
+   * so events carry `sessionId` / `messageId` / `partId`.
+   *
+   * Part ids:
+   *   - text parts reuse `ids.textPartId` (the agent mints a fresh one at
+   *     the start of each text run and clears it at step boundaries).
+   *   - tool parts are minted on `tool-input-start` keyed by `toolCallId`
+   *     and reused for `tool-call` / `tool-result` of the same call.
    */
-  emitStreamPart(chunk: TextStreamPart<ToolSet>, subagentId?: string): void {
+  emitStreamPart(
+    chunk: TextStreamPart<ToolSet>,
+    ids?: string | StreamIdContext,
+  ): void {
+    const ctx: StreamIdContext =
+      typeof ids === "string" ? { subagentId: ids } : (ids ?? {});
+    const subagentId = ctx.subagentId ?? ctx.sessionId;
+    const sessionId = ctx.sessionId;
+    const messageId = ctx.messageId;
+
     switch (chunk.type) {
       case "text-delta":
-        this.emit("text-delta", { text: chunk.text, subagentId });
+        this.emit("text-delta", {
+          text: chunk.text,
+          subagentId,
+          sessionId,
+          messageId,
+          partId: ctx.textPartId,
+        });
         break;
       case "tool-input-start":
         this.emit("tool-call-start", {
           toolCallId: chunk.id,
           toolName: chunk.toolName,
           subagentId,
+          sessionId,
+          messageId,
+          partId: ctx.toolPartId?.(chunk.id),
         });
         break;
       case "tool-input-delta":
@@ -255,6 +341,9 @@ export class AgentEventBus {
           toolCallId: chunk.id,
           argsTextDelta: chunk.delta,
           subagentId,
+          sessionId,
+          messageId,
+          partId: ctx.toolPartId?.(chunk.id),
         });
         break;
       case "tool-call": {
@@ -269,6 +358,9 @@ export class AgentEventBus {
           toolName: tc.toolName,
           args: tc.args ?? tc.input,
           subagentId,
+          sessionId,
+          messageId,
+          partId: ctx.toolPartId?.(tc.toolCallId),
         });
         break;
       }
@@ -284,6 +376,9 @@ export class AgentEventBus {
           toolName: tr.toolName,
           result: tr.result ?? tr.output,
           subagentId,
+          sessionId,
+          messageId,
+          partId: ctx.toolPartId?.(tr.toolCallId),
         });
         break;
       }
@@ -295,4 +390,24 @@ export class AgentEventBus {
         break;
     }
   }
+}
+
+/**
+ * Identity context the emitting agent threads through
+ * {@link AgentEventBus.emitStreamPart}.
+ */
+export interface StreamIdContext {
+  /** Legacy multi-agent delineator; equals {@link sessionId} when set. */
+  subagentId?: string;
+  /** Emitting agent's session id (`ses_…`). */
+  sessionId?: string;
+  /** Current open assistant message id (`msg_…`) for this step. */
+  messageId?: string;
+  /** Current text part id (`prt_…`); minted per text run by the agent. */
+  textPartId?: string;
+  /**
+   * Resolve a stable part id (`prt_…`) for a tool call, minting on first
+   * call for a given `toolCallId` and returning the same id thereafter.
+   */
+  toolPartId?: (toolCallId: string) => string;
 }

--- a/src/core/id/id.test.ts
+++ b/src/core/id/id.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  isMessageId,
+  isPartId,
+  isSessionId,
+  newMessageId,
+  newPartId,
+  newSessionId,
+} from "./id";
+
+// ---------------------------------------------------------------------------
+// Prefixed-ULID identity: minters, prefixes, uniqueness, and guards.
+// ---------------------------------------------------------------------------
+
+const ITERATIONS = 100_000;
+
+describe("id minters", () => {
+  it("mint correct prefixes", () => {
+    expect(newSessionId()).toMatch(/^ses_/);
+    expect(newMessageId()).toMatch(/^msg_/);
+    expect(newPartId()).toMatch(/^prt_/);
+  });
+
+  it("produce unique session ids over 100k iterations", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < ITERATIONS; i++) seen.add(newSessionId());
+    expect(seen.size).toBe(ITERATIONS);
+  });
+
+  it("produce unique message ids over 100k iterations", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < ITERATIONS; i++) seen.add(newMessageId());
+    expect(seen.size).toBe(ITERATIONS);
+  });
+
+  it("produce unique part ids over 100k iterations", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < ITERATIONS; i++) seen.add(newPartId());
+    expect(seen.size).toBe(ITERATIONS);
+  });
+});
+
+describe("id guards", () => {
+  it("accept their own kind", () => {
+    expect(isSessionId(newSessionId())).toBe(true);
+    expect(isMessageId(newMessageId())).toBe(true);
+    expect(isPartId(newPartId())).toBe(true);
+  });
+
+  it("reject other kinds", () => {
+    const ses = newSessionId();
+    const msg = newMessageId();
+    const prt = newPartId();
+
+    expect(isSessionId(msg)).toBe(false);
+    expect(isSessionId(prt)).toBe(false);
+
+    expect(isMessageId(ses)).toBe(false);
+    expect(isMessageId(prt)).toBe(false);
+
+    expect(isPartId(ses)).toBe(false);
+    expect(isPartId(msg)).toBe(false);
+  });
+
+  it("reject arbitrary strings", () => {
+    expect(isSessionId("pentest-agent-1")).toBe(false);
+    expect(isMessageId("")).toBe(false);
+    expect(isPartId("prt")).toBe(false); // no underscore separator
+  });
+});

--- a/src/core/id/id.ts
+++ b/src/core/id/id.ts
@@ -54,6 +54,39 @@ function randomBase62(length: number): string {
   return result;
 }
 
+// ---------------------------------------------------------------------------
+// Branded identity types + convenience minters / guards
+// ---------------------------------------------------------------------------
+//
+// These give session / message / part ids a nominal type so they can't be
+// accidentally crossed (e.g. passing a messageId where a sessionId is
+// expected). The runtime value is still a plain prefixed-ULID string
+// (`ses_…` / `msg_…` / `prt_…`); the brand exists only at the type level.
+
+/** A session identifier: `ses_<time><random>`. */
+export type SessionID = string & { readonly __brand: "SessionID" };
+/** A message identifier: `msg_<time><random>`. */
+export type MessageID = string & { readonly __brand: "MessageID" };
+/** A part identifier: `prt_<time><random>`. */
+export type PartID = string & { readonly __brand: "PartID" };
+
+/** Mint a fresh, time-descending session id. */
+export const newSessionId = (): SessionID => descending("session") as SessionID;
+/** Mint a fresh, time-descending message id. */
+export const newMessageId = (): MessageID => descending("message") as MessageID;
+/** Mint a fresh, time-descending part id. */
+export const newPartId = (): PartID => descending("part") as PartID;
+
+/** Runtime guard: is this string a session id? */
+export const isSessionId = (s: string): s is SessionID =>
+  s.startsWith(`${prefixes.session}_`);
+/** Runtime guard: is this string a message id? */
+export const isMessageId = (s: string): s is MessageID =>
+  s.startsWith(`${prefixes.message}_`);
+/** Runtime guard: is this string a part id? */
+export const isPartId = (s: string): s is PartID =>
+  s.startsWith(`${prefixes.part}_`);
+
 function create(
   prefix: IdentifierPrefix,
   descending: boolean,

--- a/src/core/session/persistence.test.ts
+++ b/src/core/session/persistence.test.ts
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { newSessionId } from "../id/id";
 import { getResumeMessages, normalizeMessages } from "./index";
 import {
   type AgentManifestEntry,
@@ -515,6 +516,32 @@ describe("loadSubagents directory-only discovery", () => {
 
     const loaded = loadSubagents(tmpDir);
     expect(loaded).toHaveLength(0);
+  });
+
+  it("discovers a session-id-keyed subagent directory (spawn_pentest_agent)", () => {
+    const childSessionId = newSessionId();
+    const subagentsDir = join(tmpDir, "subagents");
+    const dir = join(subagentsDir, childSessionId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "messages.json"),
+      JSON.stringify([
+        { role: "user", content: "Test /api/users for IDOR" },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Probing IDOR..." }],
+        },
+      ]),
+    );
+
+    const loaded = loadSubagents(tmpDir);
+    expect(loaded).toHaveLength(1);
+    // Directory key (and thus the loaded id) IS the child's session id.
+    expect(loaded[0].id).toBe(childSessionId);
+    expect(loaded[0].id.startsWith("ses_")).toBe(true);
+    expect(loaded[0].type).toBe("pentest");
+    expect(loaded[0].name).toBe("Pentest Worker");
+    expect(loaded[0].messages.length).toBeGreaterThan(0);
   });
 
   it("skips directories without messages.json", () => {

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -18,15 +18,17 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  renameSync,
   statSync,
   writeFileSync,
 } from "fs";
 import { join } from "path";
-import type { SessionInfo } from "./index";
+import { getSessionRoot, normalizeMessages, type SessionInfo } from "./index";
 
 export type { SessionInfo };
 
 import type { ModelMessage } from "ai";
+import type { SessionID } from "../id/id";
 import type { AuthenticationInfo } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -725,4 +727,343 @@ export function loadSubagents(rootPath: string): UISubagent[] {
   }
 
   return subagents;
+}
+
+// ---------------------------------------------------------------------------
+// Console rehydration — rebuild on-disk session state from the Console DB
+// ---------------------------------------------------------------------------
+//
+// Apex must stay standalone: it cannot import any `@console/*` package. The
+// Console session tree is therefore supplied through an INJECTED `fetchTree`
+// callback (the parent `runApexAgent` passes the agent-SDK fetcher). This file
+// only knows the *shape* of the data, declared inline below.
+
+/** A persisted agent message row (Console `agent_messages`). */
+export interface ConsoleMessageRow {
+  id: string;
+  sessionId: string;
+  role: "user" | "assistant" | "system";
+  sequence: number;
+  stepSeq: number | null;
+  data: unknown;
+  createdAt: string | Date;
+}
+
+/** A persisted agent part row (Console `agent_parts`). */
+export interface ConsolePartRow {
+  id: string;
+  messageId: string;
+  sessionId: string;
+  index: number;
+  type: "text" | "tool" | "file" | "subagent_ref";
+  toolCallId: string | null;
+  s3Key: string | null;
+  data: unknown;
+  createdAt: string | Date;
+}
+
+/** One session node (root or descendant) of a Console session tree. */
+export interface ConsoleSessionNode {
+  session: {
+    id: string;
+    agentType: string;
+    parentSessionId: string | null;
+    status: string;
+    metadata?: unknown;
+  };
+  messages: ConsoleMessageRow[];
+  parts: ConsolePartRow[];
+}
+
+/**
+ * The full session tree returned by `agentApi.execution.getSessionTree`.
+ * Mirrors the Console shape without importing it.
+ */
+export interface ConsoleSessionTree extends ConsoleSessionNode {
+  descendants: ConsoleSessionNode[];
+}
+
+/** Injected fetcher — resolves a Console session tree by session id. */
+export type FetchConsoleTree = (id: string) => Promise<ConsoleSessionTree>;
+
+/** Result of rehydration: the on-disk root plus in-memory model messages. */
+export interface RehydrateResult {
+  rootPath: string;
+  /** Root-session model messages, ready for the agent constructor. */
+  messages: ModelMessage[];
+  /** childSessionId → that subagent's model messages. */
+  subagentMessages: Map<string, ModelMessage[]>;
+}
+
+// --- Part-data shapes (mirror @pensar/core executionTypes, declared inline) --
+
+interface TextPartData {
+  text: string;
+  preview?: string;
+}
+type ToolOutput = string | { s3Key: string; preview: string };
+interface ToolStatePending {
+  status: "pending" | "running";
+  input: Record<string, unknown>;
+}
+interface ToolStateCompleted {
+  status: "completed";
+  input: Record<string, unknown>;
+  output: ToolOutput;
+}
+interface ToolStateError {
+  status: "error";
+  input: Record<string, unknown>;
+  errorMessage: string;
+}
+type ToolState = ToolStatePending | ToolStateCompleted | ToolStateError;
+interface ToolPartData {
+  toolCallId: string;
+  tool: string;
+  state: ToolState;
+}
+
+/** Resolve a tool output blob to the AI-SDK structured tool-result `output`. */
+function toolOutputToModelOutput(output: ToolOutput): {
+  type: "text";
+  value: string;
+} {
+  if (typeof output === "string") return { type: "text", value: output };
+  // S3-offloaded: inline previews are enough for resume context. Fetching the
+  // full blob from S3 is out of scope here.
+  // TODO(A2): a tool that re-reads its own prior full output would need the S3
+  // blob; resume only needs the preview for conversational context.
+  return { type: "text", value: output.preview };
+}
+
+/**
+ * Convert one Console message + its ordered parts into AI-SDK `ModelMessage`s.
+ *
+ * A single Console assistant message can expand into TWO model messages: the
+ * assistant turn (text + tool-call parts) followed by a `tool` message holding
+ * the matching tool-results. `subagent_ref` parts are spawn markers only — the
+ * child transcript lives in its own `subagents/{childSessionId}/messages.json`,
+ * never inlined here.
+ */
+function consoleMessageToModelMessages(
+  message: ConsoleMessageRow,
+  parts: ConsolePartRow[],
+): ModelMessage[] {
+  const ordered = [...parts].sort((a, b) => a.index - b.index);
+
+  // user / system → plain text content (concatenate text parts).
+  if (message.role === "user" || message.role === "system") {
+    const text = ordered
+      .filter((p) => p.type === "text")
+      .map((p) => (p.data as TextPartData | null)?.text ?? "")
+      .join("");
+    return [{ role: message.role, content: text } as ModelMessage];
+  }
+
+  // assistant → assistant content array (text + tool-call) plus a trailing
+  // tool message for completed tool-results.
+  const assistantContent: Array<Record<string, unknown>> = [];
+  const toolResults: Array<Record<string, unknown>> = [];
+
+  for (const part of ordered) {
+    if (part.type === "text") {
+      const text = (part.data as TextPartData | null)?.text ?? "";
+      if (text) assistantContent.push({ type: "text", text });
+    } else if (part.type === "tool") {
+      const tool = part.data as ToolPartData | null;
+      if (!tool) continue;
+      assistantContent.push({
+        type: "tool-call",
+        toolCallId: tool.toolCallId,
+        toolName: tool.tool,
+        input: tool.state.input ?? {},
+      });
+      if (tool.state.status === "completed") {
+        toolResults.push({
+          type: "tool-result",
+          toolCallId: tool.toolCallId,
+          toolName: tool.tool,
+          output: toolOutputToModelOutput(tool.state.output),
+        });
+      } else if (tool.state.status === "error") {
+        toolResults.push({
+          type: "tool-result",
+          toolCallId: tool.toolCallId,
+          toolName: tool.tool,
+          output: { type: "text", value: `tool failed: ${tool.state.errorMessage}` },
+        });
+      }
+      // pending/running tool-calls are left without a tool-result here; the
+      // open-tool-call repair pass below synthesizes one so the in-memory
+      // message list is valid for the agent constructor.
+    }
+    // `file` and `subagent_ref` parts are not inlined into model messages.
+  }
+
+  const out: ModelMessage[] = [];
+  if (assistantContent.length > 0) {
+    out.push({ role: "assistant", content: assistantContent } as ModelMessage);
+  }
+  if (toolResults.length > 0) {
+    out.push({ role: "tool", content: toolResults } as ModelMessage);
+  }
+  return out;
+}
+
+/** Convert a whole Console session node (root or descendant) to ModelMessages. */
+function nodeToModelMessages(node: ConsoleSessionNode): ModelMessage[] {
+  const partsByMessage = new Map<string, ConsolePartRow[]>();
+  for (const part of node.parts) {
+    const arr = partsByMessage.get(part.messageId);
+    if (arr) arr.push(part);
+    else partsByMessage.set(part.messageId, [part]);
+  }
+
+  const messages = [...node.messages].sort((a, b) => a.sequence - b.sequence);
+  const out: ModelMessage[] = [];
+  for (const message of messages) {
+    out.push(
+      ...consoleMessageToModelMessages(
+        message,
+        partsByMessage.get(message.id) ?? [],
+      ),
+    );
+  }
+  return out;
+}
+
+/**
+ * Repair orphan (open) tool-calls left by a mid-step crash.
+ *
+ * A trailing assistant `tool-call` with no matching `tool` message means the
+ * process died after issuing the call but before persisting a result. The DB
+ * row stays `running` (monotonicity invariant); this repair ONLY mutates the
+ * in-memory message list handed to the agent constructor, so the conversation
+ * is well-formed (every tool-call has a tool-result).
+ *
+ * For each unmatched tool-call we append a synthesized `tool` message with
+ * `output: { type: "text", value: "tool failed: process terminated" }`.
+ */
+export function repairOrphanToolCalls(
+  messages: ModelMessage[],
+): ModelMessage[] {
+  // Collect every toolCallId that already has a tool-result.
+  const resolved = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role !== "tool" || !Array.isArray(msg.content)) continue;
+    for (const part of msg.content as Array<Record<string, unknown>>) {
+      if (part.type === "tool-result" && typeof part.toolCallId === "string") {
+        resolved.add(part.toolCallId);
+      }
+    }
+  }
+
+  const result: ModelMessage[] = [];
+  for (const msg of messages) {
+    result.push(msg);
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+
+    const orphanResults: Array<Record<string, unknown>> = [];
+    for (const part of msg.content as Array<Record<string, unknown>>) {
+      if (
+        part.type === "tool-call" &&
+        typeof part.toolCallId === "string" &&
+        !resolved.has(part.toolCallId)
+      ) {
+        resolved.add(part.toolCallId);
+        orphanResults.push({
+          type: "tool-result",
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          output: { type: "text", value: "tool failed: process terminated" },
+        });
+      }
+    }
+    if (orphanResults.length > 0) {
+      result.push({ role: "tool", content: orphanResults } as ModelMessage);
+    }
+  }
+  return result;
+}
+
+/** Run a message list through the resume normalizer + orphan-tool repair. */
+function finalizeResumeMessages(messages: ModelMessage[]): ModelMessage[] {
+  return normalizeMessages(repairOrphanToolCalls(messages));
+}
+
+/** Atomic JSON write: write to a temp sibling then rename into place. */
+function atomicWriteJson(filePath: string, value: unknown): void {
+  mkdirSync(join(filePath, ".."), { recursive: true });
+  const tmp = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tmp, JSON.stringify(value, null, 2), "utf-8");
+  renameSync(tmp, filePath);
+}
+
+/**
+ * Rebuild a session's on-disk state from an already-fetched Console session
+ * tree. Prefer this over {@link rehydrateFromConsole} when the caller already
+ * holds the tree (avoids a double fetch).
+ *
+ * Writes (atomically):
+ *  - `~/.pensar/sessions/{id}/session.json` — minimal metadata stub
+ *  - `~/.pensar/sessions/{id}/messages.json` — root model messages
+ *  - `~/.pensar/sessions/{id}/subagents/{childSessionId}/messages.json` per
+ *    descendant
+ *
+ * Returns the in-memory root `messages` and a `subagentMessages` map for the
+ * constructor. Open tool-calls are repaired in the returned in-memory messages
+ * only (the DB rows are untouched).
+ */
+export function rehydrateFromConsoleTree(
+  sessionId: SessionID,
+  tree: ConsoleSessionTree,
+): RehydrateResult {
+  const rootPath = getSessionRoot(sessionId);
+
+  // Root.
+  const rootMessages = finalizeResumeMessages(nodeToModelMessages(tree));
+
+  // session.json stub — enough for downstream readers; the live session.json
+  // written by sessions.create() already carries full config, so only refresh
+  // it if it does not already exist (do not clobber richer metadata).
+  const sessionJsonPath = join(rootPath, "session.json");
+  if (!existsSync(sessionJsonPath)) {
+    atomicWriteJson(sessionJsonPath, {
+      id: tree.session.id,
+      agentType: tree.session.agentType,
+      parentSessionId: tree.session.parentSessionId,
+      status: tree.session.status,
+      metadata: tree.session.metadata ?? null,
+    });
+  }
+
+  atomicWriteJson(join(rootPath, "messages.json"), rootMessages);
+
+  // Descendants → subagents/{childSessionId}/messages.json.
+  const subagentMessages = new Map<string, ModelMessage[]>();
+  for (const descendant of tree.descendants) {
+    const childId = descendant.session.id;
+    const childMessages = finalizeResumeMessages(
+      nodeToModelMessages(descendant),
+    );
+    subagentMessages.set(childId, childMessages);
+    atomicWriteJson(
+      join(rootPath, SUBAGENTS_DIR, childId, "messages.json"),
+      childMessages,
+    );
+  }
+
+  return { rootPath, messages: rootMessages, subagentMessages };
+}
+
+/**
+ * Fetch a Console session tree (via the injected `fetchTree`) and rebuild the
+ * session's on-disk state from it. See {@link rehydrateFromConsoleTree}.
+ */
+export async function rehydrateFromConsole(
+  sessionId: SessionID,
+  fetchTree: FetchConsoleTree,
+): Promise<RehydrateResult> {
+  const tree = await fetchTree(sessionId);
+  return rehydrateFromConsoleTree(sessionId, tree);
 }

--- a/src/core/session/persistence.ts
+++ b/src/core/session/persistence.ts
@@ -4,6 +4,13 @@
  * Single source of truth for writing AND reading subagent data.
  * Both saveSubagentData (write) and loadSubagents (read) share the
  * same path constants and filename conventions so they can never drift.
+ *
+ * Directory key — every subagent is stored under
+ * `{rootPath}/subagents/{key}/` where `key` is the subagent's identity. For
+ * subagents spawned via `spawn_pentest_agent` the key IS the child's session
+ * id (`ses_…`), minted before spawn. The swarm path (`spawn_pentest_swarm`)
+ * still uses stable slot ids (`pentest-agent-N`) so its index-based manifest
+ * resume logic keeps working; this layer is agnostic to the key's shape.
  */
 
 import {
@@ -112,17 +119,19 @@ export interface SubagentSaveInput {
   userPrompt?: string;
 }
 
+/**
+ * Read a subagent's persisted messages by directory key.
+ *
+ * `key` is the subagent's identity directory under `subagents/` — a session
+ * id (`ses_…`) for `spawn_pentest_agent` workers, or a slot id
+ * (`pentest-agent-N`) for the swarm.
+ */
 export function loadSubagentMessages(
   session: SessionInfo,
-  agentName: string,
+  key: string,
 ): ModelMessage[] {
   // Primary: base class step persistence (written incrementally, survives aborts)
-  const stepPath = join(
-    session.rootPath,
-    SUBAGENTS_DIR,
-    agentName,
-    "messages.json",
-  );
+  const stepPath = join(session.rootPath, SUBAGENTS_DIR, key, "messages.json");
   if (existsSync(stepPath)) {
     try {
       return JSON.parse(readFileSync(stepPath, "utf-8")) as ModelMessage[];
@@ -131,11 +140,7 @@ export function loadSubagentMessages(
     }
   }
   // Fallback: old snapshot format (pre-split sessions)
-  const snapshotPath = join(
-    session.rootPath,
-    SUBAGENTS_DIR,
-    `${agentName}.json`,
-  );
+  const snapshotPath = join(session.rootPath, SUBAGENTS_DIR, `${key}.json`);
   if (!existsSync(snapshotPath)) return [];
   try {
     const data = JSON.parse(
@@ -196,7 +201,18 @@ export function saveSubagentData(
 // ---------------------------------------------------------------------------
 
 export interface AgentManifestEntry {
+  /**
+   * Directory key / identity for this subagent. Equal to {@link sessionId}
+   * when the subagent's identity is a minted session id (`ses_…`); for the
+   * swarm path this is a stable slot id (`pentest-agent-N`).
+   */
   id: string;
+  /**
+   * The subagent's session id (`ses_…`) when it has one. Mirrors {@link id}
+   * for session-keyed subagents; carried explicitly so downstream consumers
+   * can route by session without re-parsing the directory key.
+   */
+  sessionId?: string;
   name: string;
   target: string;
   vulnerabilityClass: string;
@@ -405,6 +421,14 @@ function parseSubagentFilename(filename: string): {
 
   if (filename.startsWith("orchestrator-")) {
     return { agentType: "pentest", name: "Orchestrator Summary" };
+  }
+
+  // Session-id-keyed subagent (spawn_pentest_agent worker). The
+  // human-readable label lives on the `subagent-spawn` bus event / manifest;
+  // when loading from disk alone we don't have it, so fall back to a generic
+  // pentest worker label rather than surfacing the raw `ses_…` id.
+  if (filename.startsWith("ses_")) {
+    return { agentType: "pentest", name: "Pentest Worker" };
   }
 
   return { agentType: "pentest", name: filename.split("-")[0] || "Unknown" };

--- a/src/core/session/rehydrate.test.ts
+++ b/src/core/session/rehydrate.test.ts
@@ -1,0 +1,421 @@
+import type { ModelMessage } from "ai";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import os from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { newSessionId, type SessionID } from "../id/id";
+import {
+  type ConsolePartRow,
+  type ConsoleSessionNode,
+  type ConsoleSessionTree,
+  rehydrateFromConsole,
+  rehydrateFromConsoleTree,
+  repairOrphanToolCalls,
+} from "./persistence";
+
+// rehydrateFromConsoleTree writes under os.homedir()/.pensar/sessions/{id};
+// point homedir at a throwaway tmp dir so the test never touches the real ~.
+let homeDir: string;
+
+beforeEach(() => {
+  homeDir = mkdtempSync(join(os.tmpdir(), "rehydrate-test-"));
+  vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(homeDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Tree builders
+// ---------------------------------------------------------------------------
+
+function textPart(
+  messageId: string,
+  sessionId: string,
+  index: number,
+  text: string,
+): ConsolePartRow {
+  return {
+    id: `prt_text_${messageId}_${index}`,
+    messageId,
+    sessionId,
+    index,
+    type: "text",
+    toolCallId: null,
+    s3Key: null,
+    data: { text },
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function toolPart(
+  messageId: string,
+  sessionId: string,
+  index: number,
+  toolCallId: string,
+  tool: string,
+  state: ConsolePartRow["data"],
+): ConsolePartRow {
+  return {
+    id: `prt_tool_${toolCallId}`,
+    messageId,
+    sessionId,
+    index,
+    type: "tool",
+    toolCallId,
+    s3Key: null,
+    data: state,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function subagentRefPart(
+  messageId: string,
+  sessionId: string,
+  index: number,
+  childSessionId: string,
+): ConsolePartRow {
+  return {
+    id: `prt_ref_${childSessionId}`,
+    messageId,
+    sessionId,
+    index,
+    type: "subagent_ref",
+    toolCallId: null,
+    s3Key: null,
+    data: { childSessionId, childAgentType: "pentest" },
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function emptyNode(
+  id: string,
+  parentSessionId: string | null,
+): ConsoleSessionNode {
+  return {
+    session: {
+      id,
+      agentType: "pentest",
+      parentSessionId,
+      status: "completed",
+    },
+    messages: [],
+    parts: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// rehydrateFromConsoleTree
+// ---------------------------------------------------------------------------
+
+describe("rehydrateFromConsoleTree", () => {
+  it("writes messages.json + subagents/{child}/messages.json and returns matching ModelMessages", () => {
+    const rootId = newSessionId();
+    const childId = newSessionId();
+
+    const tree: ConsoleSessionTree = {
+      session: {
+        id: rootId,
+        agentType: "pentest",
+        parentSessionId: null,
+        status: "running",
+      },
+      messages: [
+        {
+          id: "msg_u1",
+          sessionId: rootId,
+          role: "user",
+          sequence: 0,
+          stepSeq: null,
+          data: null,
+          createdAt: new Date().toISOString(),
+        },
+        {
+          id: "msg_a1",
+          sessionId: rootId,
+          role: "assistant",
+          sequence: 1,
+          stepSeq: 0,
+          data: null,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      parts: [
+        textPart("msg_u1", rootId, 0, "scan the target"),
+        textPart("msg_a1", rootId, 0, "Running a command"),
+        toolPart("msg_a1", rootId, 1, "tc-1", "execute_command", {
+          toolCallId: "tc-1",
+          tool: "execute_command",
+          state: {
+            status: "completed",
+            input: { cmd: "ls" },
+            output: "file1.txt\nfile2.txt",
+          },
+        }),
+        // spawn marker only — child transcript lives in its own file.
+        subagentRefPart("msg_a1", rootId, 2, childId),
+      ],
+      descendants: [
+        {
+          session: {
+            id: childId,
+            agentType: "pentest",
+            parentSessionId: rootId,
+            status: "completed",
+          },
+          messages: [
+            {
+              id: "msg_cu1",
+              sessionId: childId,
+              role: "user",
+              sequence: 0,
+              stepSeq: null,
+              data: null,
+              createdAt: new Date().toISOString(),
+            },
+            {
+              id: "msg_ca1",
+              sessionId: childId,
+              role: "assistant",
+              sequence: 1,
+              stepSeq: 0,
+              data: null,
+              createdAt: new Date().toISOString(),
+            },
+          ],
+          parts: [
+            textPart("msg_cu1", childId, 0, "test for IDOR"),
+            textPart("msg_ca1", childId, 0, "Probing IDOR"),
+          ],
+        },
+      ],
+    };
+
+    const result = rehydrateFromConsoleTree(rootId as SessionID, tree);
+
+    // --- on-disk files ---
+    const rootMessagesPath = join(result.rootPath, "messages.json");
+    const childMessagesPath = join(
+      result.rootPath,
+      "subagents",
+      childId,
+      "messages.json",
+    );
+    expect(existsSync(rootMessagesPath)).toBe(true);
+    expect(existsSync(childMessagesPath)).toBe(true);
+    expect(existsSync(join(result.rootPath, "session.json"))).toBe(true);
+
+    const diskRoot = JSON.parse(
+      readFileSync(rootMessagesPath, "utf-8"),
+    ) as ModelMessage[];
+    expect(diskRoot).toEqual(result.messages);
+
+    // --- returned root messages ---
+    // user → text content
+    expect(result.messages[0]).toEqual({
+      role: "user",
+      content: "scan the target",
+    });
+    // assistant → text + tool-call
+    const assistant = result.messages[1] as {
+      role: string;
+      content: Array<Record<string, unknown>>;
+    };
+    expect(assistant.role).toBe("assistant");
+    expect(assistant.content[0]).toEqual({
+      type: "text",
+      text: "Running a command",
+    });
+    expect(assistant.content[1]).toMatchObject({
+      type: "tool-call",
+      toolCallId: "tc-1",
+      toolName: "execute_command",
+      input: { cmd: "ls" },
+    });
+    // subagent_ref is NOT inlined
+    expect(
+      assistant.content.some((p) => p.type === "subagent_ref"),
+    ).toBe(false);
+    // completed tool → following tool message with structured output
+    const toolMsg = result.messages[2] as {
+      role: string;
+      content: Array<Record<string, unknown>>;
+    };
+    expect(toolMsg.role).toBe("tool");
+    expect(toolMsg.content[0]).toEqual({
+      type: "tool-result",
+      toolCallId: "tc-1",
+      toolName: "execute_command",
+      output: { type: "text", value: "file1.txt\nfile2.txt" },
+    });
+
+    // --- subagent map + file ---
+    expect(result.subagentMessages.has(childId)).toBe(true);
+    const childMsgs = result.subagentMessages.get(childId)!;
+    expect(childMsgs[0]).toEqual({ role: "user", content: "test for IDOR" });
+    const diskChild = JSON.parse(
+      readFileSync(childMessagesPath, "utf-8"),
+    ) as ModelMessage[];
+    expect(diskChild).toEqual(childMsgs);
+  });
+
+  it("resolves S3-offloaded tool output to its inline preview", () => {
+    const rootId = newSessionId();
+    const tree: ConsoleSessionTree = {
+      ...emptyNode(rootId, null),
+      session: {
+        id: rootId,
+        agentType: "pentest",
+        parentSessionId: null,
+        status: "completed",
+      },
+      messages: [
+        {
+          id: "msg_a1",
+          sessionId: rootId,
+          role: "assistant",
+          sequence: 0,
+          stepSeq: 0,
+          data: null,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      parts: [
+        toolPart("msg_a1", rootId, 0, "tc-big", "read_file", {
+          toolCallId: "tc-big",
+          tool: "read_file",
+          state: {
+            status: "completed",
+            input: { path: "big.txt" },
+            output: { s3Key: "s3://blob", preview: "first 100 bytes…" },
+          },
+        }),
+      ],
+      descendants: [],
+    } as ConsoleSessionTree;
+
+    const result = rehydrateFromConsoleTree(rootId as SessionID, tree);
+    const toolMsg = result.messages.find((m) => m.role === "tool") as {
+      content: Array<Record<string, unknown>>;
+    };
+    expect(toolMsg.content[0].output).toEqual({
+      type: "text",
+      value: "first 100 bytes…",
+    });
+  });
+
+  it("rehydrateFromConsole fetches via the injected fetcher", async () => {
+    const rootId = newSessionId();
+    const tree: ConsoleSessionTree = {
+      session: {
+        id: rootId,
+        agentType: "pentest",
+        parentSessionId: null,
+        status: "running",
+      },
+      messages: [
+        {
+          id: "msg_u1",
+          sessionId: rootId,
+          role: "user",
+          sequence: 0,
+          stepSeq: null,
+          data: null,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      parts: [textPart("msg_u1", rootId, 0, "hello")],
+      descendants: [],
+    };
+    const fetchTree = vi.fn(async () => tree);
+
+    const result = await rehydrateFromConsole(
+      rootId as SessionID,
+      fetchTree,
+    );
+    expect(fetchTree).toHaveBeenCalledWith(rootId);
+    expect(result.messages[0]).toEqual({ role: "user", content: "hello" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Open tool-call repair
+// ---------------------------------------------------------------------------
+
+describe("repairOrphanToolCalls / rehydrate open-tool repair", () => {
+  it("synthesizes a tool-result for a trailing running tool-call so the list is valid", () => {
+    const rootId = newSessionId();
+    const tree: ConsoleSessionTree = {
+      session: {
+        id: rootId,
+        agentType: "pentest",
+        parentSessionId: null,
+        status: "running",
+      },
+      messages: [
+        {
+          id: "msg_a1",
+          sessionId: rootId,
+          role: "assistant",
+          sequence: 0,
+          stepSeq: 0,
+          data: null,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      parts: [
+        textPart("msg_a1", rootId, 0, "kicking off a long scan"),
+        // still running — the process died mid-step.
+        toolPart("msg_a1", rootId, 1, "tc-open", "long_scan", {
+          toolCallId: "tc-open",
+          tool: "long_scan",
+          state: { status: "running", input: { target: "host" } },
+        }),
+      ],
+      descendants: [],
+    };
+
+    const result = rehydrateFromConsoleTree(rootId as SessionID, tree);
+
+    // Every tool-call must have a matching tool-result for the constructor.
+    const toolCallIds = new Set<string>();
+    const toolResultIds = new Set<string>();
+    for (const msg of result.messages) {
+      if (!Array.isArray(msg.content)) continue;
+      for (const part of msg.content as Array<Record<string, unknown>>) {
+        if (part.type === "tool-call") toolCallIds.add(part.toolCallId as string);
+        if (part.type === "tool-result")
+          toolResultIds.add(part.toolCallId as string);
+      }
+    }
+    expect(toolCallIds.has("tc-open")).toBe(true);
+    expect(toolResultIds.has("tc-open")).toBe(true);
+
+    const toolMsg = result.messages.find((m) => m.role === "tool") as {
+      content: Array<Record<string, unknown>>;
+    };
+    expect(toolMsg.content[0].output).toEqual({
+      type: "text",
+      value: "tool failed: process terminated",
+    });
+  });
+
+  it("leaves a fully-resolved conversation untouched", () => {
+    const messages: ModelMessage[] = [
+      { role: "assistant", content: [
+        { type: "tool-call", toolCallId: "tc-1", toolName: "x", input: {} },
+      ] } as ModelMessage,
+      { role: "tool", content: [
+        {
+          type: "tool-result",
+          toolCallId: "tc-1",
+          toolName: "x",
+          output: { type: "text", value: "ok" },
+        },
+      ] } as ModelMessage,
+    ];
+    expect(repairOrphanToolCalls(messages)).toEqual(messages);
+  });
+});


### PR DESCRIPTION
Makes session/message/part identity native and consistent end-to-end.

- Prefixed-ULID IDs (\`ses_\`/\`msg_\`/\`prt_\`): subagent on-disk dirs keyed by child session id; bus events carry \`sessionId\`/\`messageId\`/\`partId\`; open-message + open-tool-part tracking in the agent loop.
- \`Session.rehydrateFromConsole(sessionId, fetchTree)\` — re-materializes on-disk session state (messages/subagents) from injected rows on resume; orphan tool-call repair via \`normalizeMessages\`.
- Per-step billing context: usage callback now carries \`{ sessionId, stepSeq }\` (ALS step counter).

\`tsc --noEmit\` clean; full vitest suite green (1024 passing).