### PR TITLE
fix(ai): omit sampling params for Opus 4.7/4.8

### DIFF
--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -586,6 +586,27 @@ export function modelSupportsThinking(modelId: string): boolean {
   );
 }
 
+/**
+ * Whether a model accepts sampling parameters (`temperature`, `top_p`,
+ * `top_k`).
+ *
+ * Claude Opus 4.7 and 4.8 reject any non-default sampling value with a 400 —
+ * they expose only adaptive thinking and the `effort` control, so behavior
+ * must be steered via prompting rather than sampling. Returns `false` for
+ * those models and `true` for everything else. Matches native
+ * (`claude-opus-4-8`), Bedrock (`…anthropic.claude-opus-4-8…`), and OpenRouter
+ * (`anthropic/claude-opus-4.8`) id forms.
+ */
+export function modelSupportsSamplingParams(modelId: string): boolean {
+  // Normalize OpenRouter's dotted version numbers (4.8 → 4-8) so all id
+  // forms hit the same dashed patterns.
+  const normalized = modelId.replace(/(\d)\.(\d)/g, "$1-$2");
+  return !(
+    normalized.includes("claude-opus-4-7") ||
+    normalized.includes("claude-opus-4-8")
+  );
+}
+
 export function modelSupportsOpenAIReasoning(modelId: string): boolean {
   const { provider } = getModelInfo(modelId);
   if (provider !== "openai") return false;
@@ -1112,6 +1133,11 @@ export async function generateObjectResponse<T extends z.ZodType>(
     model,
     openAIReasoningEffort,
   );
+  // Opus 4.7/4.8 reject sampling params with a 400 — omit temperature for
+  // them and let prompting steer behavior. Other models keep it.
+  const effectiveTemperature = modelSupportsSamplingParams(model)
+    ? temperature
+    : undefined;
 
   let lastError: unknown;
 
@@ -1126,7 +1152,7 @@ export async function generateObjectResponse<T extends z.ZodType>(
         prompt,
         system,
         maxOutputTokens: maxTokens,
-        temperature,
+        temperature: effectiveTemperature,
         providerOptions: normalizedOpenAIEffort
           ? {
               openai: {

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_OPENAI_REASONING_EFFORT,
   modelSupportsOpenAIReasoning,
+  modelSupportsSamplingParams,
   normalizeOpenAIReasoningEffort,
 } from "../ai";
 import { AVAILABLE_MODELS, getMaxOutputTokens, getModelInfo } from "./index";
@@ -161,5 +162,33 @@ describe("OpenAI reasoning effort support", () => {
     expect(normalizeOpenAIReasoningEffort("gpt-5.5")).toBe(
       DEFAULT_OPENAI_REASONING_EFFORT,
     );
+  });
+});
+
+describe("modelSupportsSamplingParams", () => {
+  it("rejects sampling params for Opus 4.7 and 4.8 across id forms", () => {
+    // Native Anthropic ids
+    expect(modelSupportsSamplingParams("claude-opus-4-7")).toBe(false);
+    expect(modelSupportsSamplingParams("claude-opus-4-8")).toBe(false);
+    // Bedrock-prefixed ids
+    expect(modelSupportsSamplingParams("us.anthropic.claude-opus-4-8")).toBe(
+      false,
+    );
+    // OpenRouter dotted ids
+    expect(modelSupportsSamplingParams("anthropic/claude-opus-4.8")).toBe(
+      false,
+    );
+    expect(modelSupportsSamplingParams("anthropic/claude-opus-4.7")).toBe(
+      false,
+    );
+  });
+
+  it("allows sampling params for older Opus and all other Claude tiers", () => {
+    expect(modelSupportsSamplingParams("claude-opus-4-6")).toBe(true);
+    expect(modelSupportsSamplingParams("claude-opus-4-5")).toBe(true);
+    expect(modelSupportsSamplingParams("claude-opus-4-1")).toBe(true);
+    expect(modelSupportsSamplingParams("claude-sonnet-4-8")).toBe(true);
+    expect(modelSupportsSamplingParams("claude-haiku-4-5")).toBe(true);
+    expect(modelSupportsSamplingParams("gpt-5.5")).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

Claude Opus 4.7 and 4.8 reject any non-default sampling parameter (`temperature`, `top_p`, `top_k`) with a **400 error** — they expose only adaptive thinking and the `effort` control. Behavior must be steered via prompting.

`generateObjectResponse` (`src/core/ai/ai.ts`) forwards a `temperature`, and `generateSessionName` (`src/util/name.ts`) calls it with `temperature: 0.7`. On Opus 4.7/4.8 that 400s — and since the error is swallowed by the surrounding `try/catch`, **AI session-name generation silently fell back to the placeholder name** on those models.

## Fix

- Add `modelSupportsSamplingParams(modelId)` — returns `false` for Opus 4.7/4.8, matching native (`claude-opus-4-8`), Bedrock (`…anthropic.claude-opus-4-8`), and OpenRouter (`anthropic/claude-opus-4.8`) id forms.
- Apply it centrally in `generateObjectResponse` so it omits `temperature` for those models — protecting every current and future caller. Temperature still applies on every other model (Sonnet, Haiku, older Opus, GPT).
- Scoped to Opus 4.7/4.8 exactly, per the API docs ("same as on Claude Opus 4.7"). Older models' behavior is untouched.

## Already correct (no change)

Adaptive thinking: both `streamResponse` and the Pensar/Bedrock formatter (`pensarFormatters.ts`) emit `{ type: "adaptive" }` and never `budget_tokens`, so Opus 4.8 thinking was already handled correctly.

## Tests

Added coverage in `models.test.ts` for the id-form matching. All 157 AI/findings tests pass; biome clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly CI, documentation, and static assets; build smoke tests add coverage but do not alter runtime auth or pentest logic in the diff shown.
> 
> **Overview**
> This PR is mostly **tooling, CI, docs, and packaged assets**—not the Opus 4.7/4.8 sampling fix described in the PR text (that logic is not in the diff shown).
> 
> **CI and quality gates:** Lint is documented and wired for **Biome** (plus Prettier for Markdown/YAML). A reusable **knip** dead-code job is added to the main CI pipeline. **Build** smoke tests expand to cover global npm install under **Node** and **Bun**, TUI behavior when Bun is missing, and the **compiled binary**. A new **`fern check`** workflow runs on PRs and `canary` pushes. **Integration CI** pins Bun 1.3.10 and runs console install/SST/typecheck via `bun` instead of `npm`/`npx`.
> 
> **Agent skills:** Adds the team-shared **`/create-skill`** skill (`.agents/skills/create-skill/`), a `.claude/skills` symlink, and `.gitignore` whitelists so only that skill is committed by default.
> 
> **Bundled wordlists:** Ships **`assets/wordlists/`** (`tiny`, `common`, `large`, SecLists license/README) so dir-bruteforce tools have portable `-w` paths off Kali.
> 
> **Contributor and product docs:** **`AGENTS.md`** gains working principles, closing-the-loop guidance, UI/UX and barrel-file conventions, and expanded command/CI notes. **`README.md`** is restructured (use cases, install table, headless CLI flags, W&B Weave, OpenTelemetry). **VS Code** defaults to Biome on save.
> 
> **Misc:** Removes root **`.prettierignore`** (format scope shifts with Biome). Ignores **`sst-env.d.ts`** and local Claude settings under skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 136fe5a16403d7c1b7f41b631205eec9628cad18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->