### PR TITLE
Support Shift+Enter newlines in operator input

### DIFF
--- a/src/tui/components/chat/input-area.test.ts
+++ b/src/tui/components/chat/input-area.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  chatKeyBindings,
+  redirectKeyBindings,
+} from "../shared/text-input-keybindings";
+
+function actionFor(
+  bindings: typeof chatKeyBindings,
+  name: string,
+  shift = false,
+) {
+  return bindings.find(
+    (binding) => binding.name === name && !!binding.shift === shift,
+  )?.action;
+}
+
+describe("operator input keybindings", () => {
+  it("submits on Enter and inserts a newline on Shift+Enter in the normal prompt", () => {
+    expect(actionFor(chatKeyBindings, "return")).toBe("submit");
+    expect(actionFor(chatKeyBindings, "enter")).toBe("submit");
+    expect(actionFor(chatKeyBindings, "return", true)).toBe("newline");
+    expect(actionFor(chatKeyBindings, "enter", true)).toBe("newline");
+  });
+
+  it("submits on Enter and inserts a newline on Shift+Enter in approval redirect input", () => {
+    expect(actionFor(redirectKeyBindings, "return")).toBe("submit");
+    expect(actionFor(redirectKeyBindings, "enter")).toBe("submit");
+    expect(actionFor(redirectKeyBindings, "return", true)).toBe("newline");
+    expect(actionFor(redirectKeyBindings, "enter", true)).toBe("newline");
+  });
+});

--- a/src/tui/components/chat/input-area.tsx
+++ b/src/tui/components/chat/input-area.tsx
@@ -7,6 +7,7 @@
  * - Mode and status awareness
  */
 
+import type { TextareaRenderable } from "@opentui/core";
 import { useKeyboard } from "@opentui/react";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
@@ -17,8 +18,11 @@ import { useDialog } from "../../context/dialog";
 import { useDimensions } from "../../context/dimensions";
 import { InputProvider, useInput } from "../../context/input";
 import { useTheme } from "../../theme";
-import { getPasteText } from "../../utils/paste";
-import { PromptInput, type PromptInputRef } from "../shared";
+import {
+  PromptInput,
+  type PromptInputRef,
+  redirectKeyBindings,
+} from "../shared";
 
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   anthropic: "Anthropic",
@@ -391,6 +395,18 @@ function ApprovalInputArea({
   const { colors } = useTheme();
   const { setExternalDialogOpen } = useDialog();
   const [focusedElement, setFocusedElement] = useState(0); // 0=Yes, 1=Auto, 2=Input
+  const textareaRef = useRef<TextareaRenderable | null>(null);
+  const redirectInputRef = useRef(redirectInput);
+  const onRedirectRef = useRef(onRedirect);
+
+  redirectInputRef.current = redirectInput;
+  onRedirectRef.current = onRedirect;
+
+  useEffect(() => {
+    if (textareaRef.current?.plainText !== redirectInput) {
+      textareaRef.current?.setText(redirectInput);
+    }
+  }, [redirectInput]);
 
   // Signal to dashboard that redirect input is focused so it skips Y/A shortcuts
   useEffect(() => {
@@ -414,13 +430,13 @@ function ApprovalInputArea({
     }
 
     // Enter to select
-    if (key.name === "return") {
+    if ((key.name === "return" || key.name === "enter") && !key.shift) {
       if (focusedElement === 0) {
         onApprove();
       } else if (focusedElement === 1) {
         onAutoApprove();
-      } else if (focusedElement === 2 && redirectInput.trim()) {
-        onRedirect(redirectInput);
+      } else if (focusedElement === 2 && redirectInputRef.current.trim()) {
+        onRedirectRef.current(redirectInputRef.current);
       }
       return;
     }
@@ -479,13 +495,20 @@ function ApprovalInputArea({
           content={focusedElement === 2 ? ">" : " "}
         />
         <text fg={colors.primary} content=">" />
-        <input
+        <textarea
+          ref={textareaRef}
           width="100%"
-          value={redirectInput}
-          onInput={setRedirectInput}
-          onPaste={(event) => {
-            const cleaned = getPasteText(event).replace(/\r?\n/g, " ");
-            setRedirectInput(cleaned);
+          minHeight={1}
+          maxHeight={3}
+          initialValue={redirectInput}
+          keyBindings={redirectKeyBindings}
+          onContentChange={() => {
+            setRedirectInput(textareaRef.current?.plainText ?? "");
+          }}
+          onSubmit={() => {
+            if (redirectInputRef.current.trim()) {
+              onRedirectRef.current(redirectInputRef.current);
+            }
           }}
           focused={focusedElement === 2}
           placeholder="Or type to redirect agent..."

--- a/src/tui/components/chat/input-area.tsx
+++ b/src/tui/components/chat/input-area.tsx
@@ -435,8 +435,6 @@ function ApprovalInputArea({
         onApprove();
       } else if (focusedElement === 1) {
         onAutoApprove();
-      } else if (focusedElement === 2 && redirectInputRef.current.trim()) {
-        onRedirectRef.current(redirectInputRef.current);
       }
       return;
     }

--- a/src/tui/components/shared/index.ts
+++ b/src/tui/components/shared/index.ts
@@ -25,12 +25,13 @@ export {
   getStableMessageKey,
   tryParsePartialJson,
 } from "./message-utils";
-// Input components
 export {
   type AutocompleteOption,
   PromptInput,
   type PromptInputRef,
 } from "./prompt-input";
+// Input components
+export { chatKeyBindings, redirectKeyBindings } from "./text-input-keybindings";
 // Registries
 export {
   getArgsPreview,

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -1,9 +1,4 @@
-import {
-  type RGBA,
-  SyntaxStyle,
-  type KeyBinding as TextareaKeyBinding,
-  type TextareaRenderable,
-} from "@opentui/core";
+import { type RGBA, SyntaxStyle, type TextareaRenderable } from "@opentui/core";
 import { useKeyboard, useTerminalDimensions } from "@opentui/react";
 import {
   forwardRef,
@@ -36,6 +31,7 @@ import {
   type InlineSlashContext,
   shouldResetHistory,
 } from "./prompt-input-logic";
+import { chatKeyBindings } from "./text-input-keybindings";
 import { usePasteExtmarks } from "./use-paste-extmarks";
 
 /** Word-wrap text and return at most `maxLines` lines, adding ellipsis if truncated. */
@@ -90,20 +86,6 @@ export interface AutocompleteOption {
   label: string;
   description?: string;
 }
-
-/**
- * Chat-style keybindings: Enter submits, Shift+Enter / Ctrl+J inserts newline.
- * Overrides @opentui defaults (return=newline, Cmd+return=submit).
- *
- * Both "return" (\r) and "linefeed" (\n) need shift variants because
- * @opentui matches modifiers exactly (Kitty protocol reports shift explicitly).
- */
-const chatKeyBindings: TextareaKeyBinding[] = [
-  { name: "return", action: "submit" },
-  { name: "linefeed", action: "newline" },
-  { name: "return", shift: true, action: "newline" },
-  { name: "linefeed", shift: true, action: "newline" },
-];
 
 // Highlight ref ID for slash command highlighting (stable across renders)
 const SLASH_HL_REF = 99;

--- a/src/tui/components/shared/text-input-keybindings.ts
+++ b/src/tui/components/shared/text-input-keybindings.ts
@@ -1,0 +1,19 @@
+import type { KeyBinding as TextareaKeyBinding } from "@opentui/core";
+
+/**
+ * Chat-style keybindings: Enter submits, Shift+Enter / Ctrl+J inserts newline.
+ * Overrides @opentui defaults (return=newline, Cmd+return=submit).
+ *
+ * Both "return" (\r) and "linefeed" (\n) need shift variants because
+ * @opentui matches modifiers exactly (Kitty protocol reports shift explicitly).
+ */
+export const chatKeyBindings: TextareaKeyBinding[] = [
+  { name: "return", action: "submit" },
+  { name: "enter", action: "submit" },
+  { name: "linefeed", action: "newline" },
+  { name: "return", shift: true, action: "newline" },
+  { name: "enter", shift: true, action: "newline" },
+  { name: "linefeed", shift: true, action: "newline" },
+];
+
+export const redirectKeyBindings: TextareaKeyBinding[] = [...chatKeyBindings];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Adds shared textarea keybindings for operator text inputs so Enter submits while Shift+Enter inserts a newline, including terminals that report the key as either `return` or `enter`. The approval redirect input now uses a multiline textarea with the same keybinding contract instead of a single-line input that stripped newlines.

### How did you verify your code works?

- `bun test src/tui/components/chat/input-area.test.ts`
- `bun run tsc`
- `bun run test`
- `bun run lint`
- `bun run format:check`
- Manual TUI check in operator mode: sent `alpha`, explicit Kitty `Shift+Enter` sequence (`Esc [ 13 ; 2 u`), then `beta`; the operator input displayed a two-line draft without submitting.

<a href="https://cursor.com/agents/bc-32c63b61-3223-4076-ac54-7d5740f2327f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foperator_shift_enter_multiline_input.mp4"><img src="https://cursor.com/artifacts/c/art-b3e04fe8-0446-43a8-85cc-e3025b1dbd90" alt="operator_shift_enter_multiline_input.mp4" /></a>

![Operator Shift+Enter multiline input](https://cursor.com/artifacts/c/art-06100eb0-1ae2-4139-80c9-08a98ff86d07)

Capture: `/opt/cursor/artifacts/operator_shift_enter_terminal_capture.txt`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32c63b61-3223-4076-ac54-7d5740f2327f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32c63b61-3223-4076-ac54-7d5740f2327f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

