### PR TITLE
fix(observability): route trace context through agent fan-out

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -42,8 +42,8 @@ import type { CreateAgentInput, OffensiveSecurityAgentInput } from "./types";
  * the session context, and specific agents select which ones to activate
  * via the `activeTools` array (passed through to the AI SDK).
  *
- * The stream starts **immediately on construction** — no need to call a
- * separate `.run()` method.
+ * The stream is created lazily on first consumption (see {@link streamResult}),
+ * so the AI SDK telemetry nests under this agent's span — no separate `.run()`.
  *
  * @typeParam TResult - The type returned by {@link consume}. When the input
  *   includes a `resolveResult` function, `consume()` awaits it after the
@@ -71,8 +71,11 @@ import type { CreateAgentInput, OffensiveSecurityAgentInput } from "./types";
  * ```
  */
 export class OffensiveSecurityAgent<TResult = void> {
-  /** The underlying Vercel AI SDK stream result — escape hatch for advanced use. */
-  public readonly streamResult: StreamTextResult<ToolSet, never>;
+  /** Cached stream result, populated on first {@link streamResult} access. */
+  private _streamResult: StreamTextResult<ToolSet, never> | null = null;
+
+  /** Builds the underlying stream; invoked lazily by {@link streamResult}. */
+  private readonly createStream: () => StreamTextResult<ToolSet, never>;
 
   /** The event bus for this agent's streaming output. */
   public readonly eventBus: AgentEventBus;
@@ -390,73 +393,94 @@ export class OffensiveSecurityAgent<TResult = void> {
       cacheWriteTokens: number;
     } | null = null;
 
-    this.streamResult = streamResponse({
-      prompt: input.prompt,
-      system: systemPrompt,
-      model: input.model,
-      messages: input.messages,
-      tools,
-      activeTools,
-      stopWhen,
-      toolChoice: "auto",
-      sessionPath: input.session.rootPath,
-      onStepFinish: async (event) => {
-        latestMessages = [
-          ...initialMessagesRef.current,
-          ...event.response.messages,
-        ];
-        schedulePersist();
-        traceWriter.recordStep(event.response.messages as ModelMessage[], {
-          inputTokens: event.usage.inputTokens ?? 0,
-          outputTokens: event.usage.outputTokens ?? 0,
-          ...lastCacheMetrics,
-        });
-        lastCacheMetrics = null;
-        this.eventBus.emit("step-finish", {
-          messages: event.response.messages,
-          subagentId: this.subagentId,
-        });
-        await input.onStepFinish?.(event);
-      },
-      onSummarized: () => {
-        // Context was reset by summarization — discard the old history so
-        // subsequent onStepFinish writes only persist post-summary messages.
-        initialMessagesRef.current = [];
-        traceWriter.markSummarized();
-      },
-      onFinish: async (event) => {
-        // Flush any pending persistence before finishing
-        if (persistTimer) {
-          clearTimeout(persistTimer);
-          persistTimer = null;
-        }
-        const finalMessages = latestMessages ?? [
-          ...initialMessagesRef.current,
-          ...event.response.messages,
-        ];
-        await writeFile(messagesPath, JSON.stringify(finalMessages)).catch(
-          () => {},
-        );
-        await input.onFinish?.(event);
-      },
-      abortSignal: input.abortSignal,
-      authConfig: input.authConfig,
-      onCacheMetrics: (metrics) => {
-        lastCacheMetrics = {
-          cacheReadTokens: metrics.cacheReadInputTokens,
-          cacheWriteTokens: metrics.cacheCreationInputTokens,
-        };
-        input.onCacheMetrics?.(metrics);
-      },
-      enableThinking: input.enableThinking,
-      openAIReasoningEffort: input.openAIReasoningEffort,
-      silent: true,
-    });
+    // Stream creation is deferred (see the `streamResult` getter) so the AI
+    // SDK telemetry spans are emitted under this agent's `invoke_agent` span
+    // (entered in `consume()`), not under whatever context was active at
+    // construction. That is what keeps a subagent's gen_ai spans nested under
+    // its own agent span rather than orphaned in the trace.
+    this.createStream = () =>
+      streamResponse({
+        prompt: input.prompt,
+        system: systemPrompt,
+        model: input.model,
+        messages: input.messages,
+        tools,
+        activeTools,
+        stopWhen,
+        toolChoice: "auto",
+        sessionPath: input.session.rootPath,
+        onStepFinish: async (event) => {
+          latestMessages = [
+            ...initialMessagesRef.current,
+            ...event.response.messages,
+          ];
+          schedulePersist();
+          traceWriter.recordStep(event.response.messages as ModelMessage[], {
+            inputTokens: event.usage.inputTokens ?? 0,
+            outputTokens: event.usage.outputTokens ?? 0,
+            ...lastCacheMetrics,
+          });
+          lastCacheMetrics = null;
+          this.eventBus.emit("step-finish", {
+            messages: event.response.messages,
+            subagentId: this.subagentId,
+          });
+          await input.onStepFinish?.(event);
+        },
+        onSummarized: () => {
+          // Context was reset by summarization — discard the old history so
+          // subsequent onStepFinish writes only persist post-summary messages.
+          initialMessagesRef.current = [];
+          traceWriter.markSummarized();
+        },
+        onFinish: async (event) => {
+          // Flush any pending persistence before finishing
+          if (persistTimer) {
+            clearTimeout(persistTimer);
+            persistTimer = null;
+          }
+          const finalMessages = latestMessages ?? [
+            ...initialMessagesRef.current,
+            ...event.response.messages,
+          ];
+          await writeFile(messagesPath, JSON.stringify(finalMessages)).catch(
+            () => {},
+          );
+          await input.onFinish?.(event);
+        },
+        abortSignal: input.abortSignal,
+        authConfig: input.authConfig,
+        onCacheMetrics: (metrics) => {
+          lastCacheMetrics = {
+            cacheReadTokens: metrics.cacheReadInputTokens,
+            cacheWriteTokens: metrics.cacheCreationInputTokens,
+          };
+          input.onCacheMetrics?.(metrics);
+        },
+        enableThinking: input.enableThinking,
+        openAIReasoningEffort: input.openAIReasoningEffort,
+        silent: true,
+      });
   }
 
   // ---------------------------------------------------------------------------
   // Stream access
   // ---------------------------------------------------------------------------
+
+  /**
+   * The underlying Vercel AI SDK stream result — escape hatch for advanced use.
+   *
+   * Created lazily and cached on first access so the AI SDK telemetry spans are
+   * emitted under whatever OTel span is active at first consumption — this
+   * agent's `invoke_agent` span in {@link consume} — rather than the
+   * construction-time context.
+   */
+  get streamResult(): StreamTextResult<ToolSet, never> {
+    if (this._streamResult === null) {
+      this._streamResult = this.createStream();
+    }
+    return this._streamResult;
+  }
 
   /**
    * The raw async-iterable stream of chunks.

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -393,11 +393,8 @@ export class OffensiveSecurityAgent<TResult = void> {
       cacheWriteTokens: number;
     } | null = null;
 
-    // Stream creation is deferred (see the `streamResult` getter) so the AI
-    // SDK telemetry spans are emitted under this agent's `invoke_agent` span
-    // (entered in `consume()`), not under whatever context was active at
-    // construction. That is what keeps a subagent's gen_ai spans nested under
-    // its own agent span rather than orphaned in the trace.
+    // Deferred so the AI SDK telemetry binds to this agent's span (entered in
+    // consume()) rather than the construction-time context. See `streamResult`.
     this.createStream = () =>
       streamResponse({
         prompt: input.prompt,
@@ -469,11 +466,8 @@ export class OffensiveSecurityAgent<TResult = void> {
 
   /**
    * The underlying Vercel AI SDK stream result — escape hatch for advanced use.
-   *
-   * Created lazily and cached on first access so the AI SDK telemetry spans are
-   * emitted under whatever OTel span is active at first consumption — this
-   * agent's `invoke_agent` span in {@link consume} — rather than the
-   * construction-time context.
+   * Created lazily so its telemetry binds to the span active at first
+   * consumption (this agent's `invoke_agent` span), not the construction context.
    */
   get streamResult(): StreamTextResult<ToolSet, never> {
     if (this._streamResult === null) {

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -98,10 +98,8 @@ Returns an array of results with the text output from each agent.`,
 
       const total = validatedTasks.length;
 
-      // Fan out through the shared bounded-concurrency primitive so each coding
-      // sub-agent inherits this tool call's OTel context (keeping its spans
-      // parented). Errors are caught per task and returned inline, so the
-      // helper never yields a null.
+      // Shared primitive so each sub-agent inherits the OTel context. Errors
+      // are caught per task and returned inline, so results never contain null.
       const settled = await runWithBoundedConcurrency(
         validatedTasks,
         DEFAULT_CONCURRENCY,
@@ -128,7 +126,6 @@ Returns an array of results with the text output from each agent.`,
             };
           }
         },
-        ctx.abortSignal,
       );
 
       const results = settled.filter(

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { AgentEventBus } from "../../../eventBus";
+import { runWithBoundedConcurrency } from "../../../utils/concurrency";
 import {
   resolvePathWithinCodebaseRoot,
   resolveWhiteboxCodebaseRoot,
@@ -95,62 +96,51 @@ Returns an array of results with the text output from each agent.`,
         }
       }
 
-      const concurrency = DEFAULT_CONCURRENCY;
       const total = validatedTasks.length;
 
-      const results: Array<{
-        codebasePath: string;
-        objective: string;
-        output: string;
-        error?: string;
-      }> = [];
-
-      let active = 0;
-      let idx = 0;
-      const queue = validatedTasks.map((t, i) => ({ ...t, index: i }));
-
-      await new Promise<void>((resolve) => {
-        function next() {
-          if (results.length === total) {
-            resolve();
-            return;
-          }
-
-          while (active < concurrency && idx < queue.length) {
-            const item = queue[idx++];
-            active++;
-
-            runSingleCodingAgent(
+      // Fan out through the shared bounded-concurrency primitive so each coding
+      // sub-agent inherits this tool call's OTel context (keeping its spans
+      // parented). Errors are caught per task and returned inline, so the
+      // helper never yields a null.
+      const settled = await runWithBoundedConcurrency(
+        validatedTasks,
+        DEFAULT_CONCURRENCY,
+        async (item, i) => {
+          try {
+            const output = await runSingleCodingAgent(
               ctx,
               item.codebasePath,
               item.objective,
-              item.index + 1,
+              i + 1,
               item.name,
-            )
-              .then((output) => {
-                results.push({
-                  codebasePath: item.codebasePath,
-                  objective: item.objective,
-                  output,
-                });
-              })
-              .catch((err) => {
-                results.push({
-                  codebasePath: item.codebasePath,
-                  objective: item.objective,
-                  output: "",
-                  error: err.message,
-                });
-              })
-              .finally(() => {
-                active--;
-                next();
-              });
+            );
+            return {
+              codebasePath: item.codebasePath,
+              objective: item.objective,
+              output,
+            };
+          } catch (err) {
+            return {
+              codebasePath: item.codebasePath,
+              objective: item.objective,
+              output: "",
+              error: err instanceof Error ? err.message : String(err),
+            };
           }
-        }
+        },
+        ctx.abortSignal,
+      );
 
-        next();
-      });
+      const results = settled.filter(
+        (
+          r,
+        ): r is {
+          codebasePath: string;
+          objective: string;
+          output: string;
+          error?: string;
+        } => r !== null,
+      );
 
       const failedTasks = results.filter((r) => r.error);
 

--- a/src/core/utils/concurrency.test.ts
+++ b/src/core/utils/concurrency.test.ts
@@ -1,5 +1,54 @@
-import { describe, expect, it } from "vitest";
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  type Context,
+  type ContextManager,
+  context,
+  createContextKey,
+  ROOT_CONTEXT,
+} from "@opentelemetry/api";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { runWithBoundedConcurrency } from "./concurrency";
+
+/**
+ * Minimal AsyncLocalStorage-backed OTel context manager for tests. Apex depends
+ * only on `@opentelemetry/api` (no SDK), so without registering a manager
+ * `context.active()` is always ROOT and propagation can't be observed. This
+ * mirrors what the host's Sentry/OTel SDK installs in production.
+ */
+class TestContextManager implements ContextManager {
+  private readonly als = new AsyncLocalStorage<Context>();
+  active(): Context {
+    return this.als.getStore() ?? ROOT_CONTEXT;
+  }
+  with<A extends unknown[], F extends (...args: A) => ReturnType<F>>(
+    ctx: Context,
+    fn: F,
+    thisArg?: ThisParameterType<F>,
+    ...args: A
+  ): ReturnType<F> {
+    return this.als.run(ctx, () =>
+      fn.apply(thisArg as ThisParameterType<F>, args),
+    );
+  }
+  bind<T>(ctx: Context, target: T): T {
+    if (typeof target === "function") {
+      const self = this;
+      return function (this: unknown, ...args: unknown[]) {
+        return self.with(ctx, () =>
+          (target as (...a: unknown[]) => unknown).apply(this, args),
+        );
+      } as T;
+    }
+    return target;
+  }
+  enable(): this {
+    return this;
+  }
+  disable(): this {
+    this.als.disable();
+    return this;
+  }
+}
 
 describe("runWithBoundedConcurrency", () => {
   it("respects concurrency limit", async () => {
@@ -128,6 +177,33 @@ describe("runWithBoundedConcurrency", () => {
 
       // Task 1 completes, launches task 2, task 2 aborts — task 3 should never start
       expect(launchCount).toBe(2);
+    });
+  });
+
+  describe("trace context propagation", () => {
+    beforeAll(() => {
+      context.setGlobalContextManager(new TestContextManager());
+    });
+    afterAll(() => {
+      context.disable();
+    });
+
+    it("runs every task under the context active at call time, including continuation-launched tasks", async () => {
+      const KEY = createContextKey("test-trace-id");
+      const seen: (unknown | undefined)[] = [];
+
+      // concurrency=1 forces tasks 1..3 to launch from the `.finally()`
+      // continuation — the exact boundary that previously dropped the active
+      // context and orphaned agent spans.
+      await context.with(ROOT_CONTEXT.setValue(KEY, "parent"), async () => {
+        await runWithBoundedConcurrency([0, 1, 2, 3], 1, async (i) => {
+          await new Promise((r) => setTimeout(r, 1));
+          seen[i] = context.active().getValue(KEY);
+          return i;
+        });
+      });
+
+      expect(seen).toEqual(["parent", "parent", "parent", "parent"]);
     });
   });
 });

--- a/src/core/utils/concurrency.test.ts
+++ b/src/core/utils/concurrency.test.ts
@@ -9,12 +9,8 @@ import {
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { runWithBoundedConcurrency } from "./concurrency";
 
-/**
- * Minimal AsyncLocalStorage-backed OTel context manager for tests. Apex depends
- * only on `@opentelemetry/api` (no SDK), so without registering a manager
- * `context.active()` is always ROOT and propagation can't be observed. This
- * mirrors what the host's Sentry/OTel SDK installs in production.
- */
+// Minimal AsyncLocalStorage context manager — apex ships only @opentelemetry/api,
+// so a manager must be registered for context propagation to be observable here.
 class TestContextManager implements ContextManager {
   private readonly als = new AsyncLocalStorage<Context>();
   active(): Context {
@@ -192,9 +188,8 @@ describe("runWithBoundedConcurrency", () => {
       const KEY = createContextKey("test-trace-id");
       const seen: (unknown | undefined)[] = [];
 
-      // concurrency=1 forces tasks 1..3 to launch from the `.finally()`
-      // continuation — the exact boundary that previously dropped the active
-      // context and orphaned agent spans.
+      // concurrency=1 makes tasks 1..3 launch from the `.finally()` continuation,
+      // the boundary that drops context without the explicit binding.
       await context.with(ROOT_CONTEXT.setValue(KEY, "parent"), async () => {
         await runWithBoundedConcurrency([0, 1, 2, 3], 1, async (i) => {
           await new Promise((r) => setTimeout(r, 1));

--- a/src/core/utils/concurrency.ts
+++ b/src/core/utils/concurrency.ts
@@ -10,15 +10,10 @@ import { context } from "@opentelemetry/api";
  * orphaned promises where agents finish their work but persistence
  * (saveSubagentData, manifest updates) never executes.
  *
- * Trace context: this is the seam where a code workflow fans out into agent
- * work, so it must carry the caller's OTel context into every task. Tasks are
- * launched from a `new Promise` executor and re-scheduled from `.finally()`
- * continuations, neither of which inherits the active context on its own — so
- * each `fn` invocation is explicitly run under the context that was active when
- * this helper was called. Without this, spans created inside `fn` (agent
- * `invoke_agent` spans and their gen_ai children) detach from the parent span
- * and never join the trace. Route all agent fan-out through this helper so the
- * routing can't be forgotten.
+ * Each task runs under the OTel context active when this helper was called —
+ * the `new Promise` executor and `.finally()` continuations don't carry it on
+ * their own, so spans created inside `fn` would otherwise detach from the
+ * caller's trace. Route agent fan-out through here so context propagates.
  */
 export async function runWithBoundedConcurrency<T, R>(
   items: T[],

--- a/src/core/utils/concurrency.ts
+++ b/src/core/utils/concurrency.ts
@@ -1,3 +1,5 @@
+import { context } from "@opentelemetry/api";
+
 /**
  * Run tasks with bounded concurrency.
  * Returns an array of results in the same order as items.
@@ -7,6 +9,16 @@
  * currently-running tasks are awaited to completion. This prevents
  * orphaned promises where agents finish their work but persistence
  * (saveSubagentData, manifest updates) never executes.
+ *
+ * Trace context: this is the seam where a code workflow fans out into agent
+ * work, so it must carry the caller's OTel context into every task. Tasks are
+ * launched from a `new Promise` executor and re-scheduled from `.finally()`
+ * continuations, neither of which inherits the active context on its own — so
+ * each `fn` invocation is explicitly run under the context that was active when
+ * this helper was called. Without this, spans created inside `fn` (agent
+ * `invoke_agent` spans and their gen_ai children) detach from the parent span
+ * and never join the trace. Route all agent fan-out through this helper so the
+ * routing can't be forgotten.
  */
 export async function runWithBoundedConcurrency<T, R>(
   items: T[],
@@ -15,6 +27,7 @@ export async function runWithBoundedConcurrency<T, R>(
   abortSignal?: AbortSignal,
 ): Promise<(R | null)[]> {
   const results: (R | null)[] = new Array(items.length).fill(null);
+  const parentContext = context.active();
   let nextIdx = 0;
   let completed = 0;
 
@@ -44,7 +57,8 @@ export async function runWithBoundedConcurrency<T, R>(
         const idx = nextIdx++;
         active++;
 
-        fn(items[idx]!, idx)
+        context
+          .with(parentContext, () => fn(items[idx]!, idx))
           .then((r) => {
             results[idx] = r;
           })


### PR DESCRIPTION
## Problem

Agent fan-out dropped the active OpenTelemetry context, so spans created inside concurrent agents detached from the host's `invoke_agent` span and never joined the trace. Concretely, a multi-app whitebox recon's per-app discovery agents (and `spawn_coding_agent` sub-agents) produced `gen_ai` spans that were orphaned from the recon's root span — the delivered trace was a bare `invoke_agent` root with no children, while a single-agent flow (e.g. the threat-model questionnaire) nested its 25+ children correctly.

Two compounding causes:

1. **Lost context across the fan-out seam.** Bounded-concurrency helpers launch work from a `new Promise` executor and re-schedule from `.finally()` continuations. The active context wasn't explicitly carried into each task, so agent spans created inside `fn` parented off a detached root. The same pool pattern was *duplicated* in `spawn_coding_agent`, so the routing had to be remembered in two places — and was missed.
2. **Telemetry emitted before the agent's span existed.** `OffensiveSecurityAgent` kicked off `streamResponse()` (which emits the AI SDK `gen_ai` spans) in its **constructor**, before `consume()` opened the agent's `invoke_agent` span. So even when context was intact, the agent's own spans couldn't nest under its span.

## Changes

- **`runWithBoundedConcurrency`** binds each task to the context active when the helper is called — making it the single seam that carries trace context from a code workflow into agent work, including continuation-launched tasks. Adds a regression test using a minimal `AsyncLocalStorage`-backed context manager (keeps apex on `@opentelemetry/api`-only).
- **`spawn_coding_agent`** now fans out through `runWithBoundedConcurrency` instead of its own bespoke promise pool, inheriting the context routing (and deleting the duplicate that previously had to be fixed independently).
- **`OffensiveSecurityAgent`** creates its stream lazily (on first `streamResult` access) so the AI SDK telemetry is emitted under the agent's own `invoke_agent` span entered in `consume()`, nesting the `gen_ai` spans correctly.

## Design intent

The routing is centralized so it can't be silently forgotten again: all agent fan-out goes through the one bounded-concurrency primitive (which propagates context), and every agent self-instruments its own span around its own stream. New fan-out code and new agents get correct tracing for free.

## Tests

- `bun test src/core/utils/concurrency.test.ts` — incl. the new context-propagation test.
- Broader sweep: 233 passing across `offSecAgent`, `codeAgent`, `utils`.
- `biome check` + `tsc --noEmit` clean.

Status: **draft** — pending end-to-end verification that a real multi-app recon now produces a nested trace on the consuming stage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent streaming and all bounded fan-out paths; behavior is observability-only but wrong nesting would still mislead production debugging until verified end-to-end.
> 
> **Overview**
> Fixes **orphaned OpenTelemetry traces** when multiple agents run in parallel or when sub-agents stream LLM work.
> 
> **`OffensiveSecurityAgent`** no longer starts `streamResponse()` in the constructor. The stream is built on first access to `streamResult`, so Vercel AI SDK `gen_ai` spans are created under the active **`invoke_agent`** span opened in `consume()` instead of at construction time.
> 
> **`runWithBoundedConcurrency`** now runs each task inside `context.with(parentContext, …)`, preserving the caller’s trace across promise-pool scheduling and `.finally()` continuations. A regression test verifies propagation for continuation-launched tasks.
> 
> **`spawn_coding_agent`** drops its hand-rolled concurrency pool and fans out through **`runWithBoundedConcurrency`**, so coding sub-agents inherit the same trace context as other agent fan-out paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67b7e3f888a7af0504555c0e817de7d3bd42cc3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->