### PR TITLE
fix(ai): recover from half-open Bedrock streams that hang document_endpoint

### DIFF
--- a/scripts/probe-bedrock-stream.ts
+++ b/scripts/probe-bedrock-stream.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env tsx
+/**
+ * Transport-level dead-socket probe. Strips away the 40-step threat-model agent
+ * and just fires N concurrent `streamText` calls that elicit a LONG response,
+ * so we can measure the RAW rate at which provider streams go byte-silent
+ * (half-open sockets) — and how that rate moves with runtime, inference
+ * profile, and concurrency.
+ *
+ * The wedge signal comes from the same `StreamTelemetry` wired into the bedrock
+ * fetch (`utils.ts`): a `[stream-telem] ... WEDGE` line == one dead stream
+ * caught by `idleGuardedResponse`. Run with `PENSAR_STREAM_DEBUG=1`.
+ *
+ * Isolate causes by varying one knob at a time:
+ *   # runtime: Bun (sandbox runtime) vs Node (has undici keepalive)
+ *   PENSAR_STREAM_DEBUG=1 AWS_REGION=us-east-1 bun --bun scripts/probe-bedrock-stream.ts --count 20 --concurrency 4
+ *   PENSAR_STREAM_DEBUG=1 AWS_REGION=us-east-1 npx tsx       scripts/probe-bedrock-stream.ts --count 20 --concurrency 4
+ *   # profile: global cross-region vs us regional
+ *   ... --model global.anthropic.claude-opus-4-6-v1
+ *   ... --model us.anthropic.claude-opus-4-6-v1
+ *   # concurrency
+ *   ... --concurrency 1   vs   --concurrency 8
+ *
+ * Lower idle window to fail faster while probing: PENSAR_STREAM_IDLE_TIMEOUT_MS=45000
+ */
+
+import { streamText } from "ai";
+import pLimit from "p-limit";
+import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
+import type { AIAuthConfig, AIModel } from "../src/core/ai";
+import { getProviderModel } from "../src/core/ai/utils";
+
+function arg(flag: string, fallback: string): string {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : fallback;
+}
+
+const MODEL = arg("--model", "global.anthropic.claude-opus-4-6-v1") as AIModel;
+const COUNT = Number(arg("--count", "20"));
+const CONCURRENCY = Number(arg("--concurrency", "4"));
+const MAX_TOKENS = Number(arg("--max-tokens", "8000"));
+
+// A prompt engineered to produce a long, steady token stream — the condition
+// under which the half-open socket shows up.
+const PROMPT =
+  "Write an exhaustive, deeply technical 6000-word reference on the internals " +
+  "of distributed consensus (Paxos, Raft, Viewstamped Replication, Zab): leader " +
+  "election, log replication, membership changes, snapshotting, and the exact " +
+  "failure modes each handles. Use long prose paragraphs, not bullet points.";
+
+const captured: string[] = [];
+const origErr = console.error.bind(console);
+console.error = (...a: unknown[]) => {
+  captured.push(a.map((x) => (typeof x === "string" ? x : String(x))).join(" "));
+  origErr(...a);
+};
+
+async function main() {
+  if (!process.env.AWS_REGION && !process.env.AWS_DEFAULT_REGION) {
+    origErr("Set AWS_REGION (e.g. us-east-1).");
+    process.exit(1);
+  }
+  const authConfig: AIAuthConfig = {
+    bedrock: { credentialProvider: fromNodeProviderChain() },
+  };
+  const model = getProviderModel(MODEL, authConfig);
+
+  origErr("=".repeat(72));
+  origErr("BEDROCK STREAM DEAD-SOCKET PROBE");
+  origErr(`runtime     : ${typeof (globalThis as { Bun?: unknown }).Bun !== "undefined" ? "bun" : "node"}`);
+  origErr(`model       : ${MODEL}`);
+  origErr(`count       : ${COUNT}   concurrency: ${CONCURRENCY}   maxTokens: ${MAX_TOKENS}`);
+  origErr(`region      : ${process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION}`);
+  origErr(`idleTimeout : ${process.env.PENSAR_STREAM_IDLE_TIMEOUT_MS ?? "90000 (default)"}`);
+  origErr("=".repeat(72));
+
+  const limit = pLimit(CONCURRENCY);
+  const t0 = Date.now();
+  const results = await Promise.allSettled(
+    Array.from({ length: COUNT }, (_, i) =>
+      limit(async () => {
+        const started = Date.now();
+        let bytes = 0;
+        try {
+          const res = streamText({
+            model,
+            prompt: PROMPT,
+            maxOutputTokens: MAX_TOKENS,
+            // One stream attempt per call so stream-count == call-count.
+            maxRetries: 0,
+          });
+          for await (const part of res.fullStream) {
+            if (part.type === "text-delta") bytes += part.text?.length ?? 0;
+          }
+          return { i, ok: true, ms: Date.now() - started, chars: bytes };
+        } catch (err) {
+          return {
+            i,
+            ok: false,
+            ms: Date.now() - started,
+            chars: bytes,
+            err: err instanceof Error ? err.message : String(err),
+          };
+        }
+      }),
+    ),
+  );
+
+  const calls = results.map((r) => (r.status === "fulfilled" ? r.value : null)).filter(Boolean) as Array<{ i: number; ok: boolean; ms: number; chars: number; err?: string }>;
+  const ok = calls.filter((c) => c.ok);
+  const failed = calls.filter((c) => !c.ok);
+  const wedges = captured.filter((l) => l.includes("[stream-telem]") && l.includes("WEDGE"));
+
+  origErr(`\n${"=".repeat(72)}`);
+  origErr("PROBE REPORT");
+  origErr("=".repeat(72));
+  origErr(`wall clock        : ${Math.round((Date.now() - t0) / 1000)}s`);
+  origErr(`calls             : ${calls.length}`);
+  origErr(`  ├─ completed     : ${ok.length}`);
+  origErr(`  └─ errored       : ${failed.length}`);
+  origErr(`stream WEDGES      : ${wedges.length}`);
+  origErr(`wedge rate         : ${calls.length ? ((wedges.length / calls.length) * 100).toFixed(1) : "0"}%  (wedges / calls)`);
+  if (failed.length) {
+    origErr("\n── error samples ──");
+    for (const f of failed.slice(0, 8)) origErr(`   call#${f.i} after ${Math.round(f.ms / 1000)}s, ${f.chars} chars: ${f.err}`);
+  }
+  origErr("=".repeat(72));
+  process.exit(0);
+}
+
+main().catch((e) => {
+  origErr("probe fatal:", e);
+  process.exit(1);
+});

--- a/scripts/repro-threat-model-stream.ts
+++ b/scripts/repro-threat-model-stream.ts
@@ -1,0 +1,388 @@
+#!/usr/bin/env tsx
+/**
+ * Fast, faithful reproduction harness for the threat-model `response`-stream
+ * wedge (the `document_endpoint` hang). Instead of waiting 75–90 minutes for a
+ * full whitebox recon, this drives the EXACT child path that wedges —
+ * `generateThreatModelForEndpoint` → `CodeAgent.consume()` → the Pensar provider
+ * SSE stream — directly, in a loop, against a real local codebase, using the
+ * same `gateway.pensar.dev` → Bedrock path production uses.
+ *
+ * IMPORTANT — provider fidelity. The deployed SANDBOX does NOT use the Pensar
+ * gateway; `buildSandboxAuthConfig()` injects `{ bedrock: { credentialProvider:
+ * fromNodeProviderChain() } }` and the platform `pentestModel`
+ * (`global.anthropic.claude-opus-4-6-v1`) resolves to the **bedrock** provider
+ * (`createAmazonBedrock`). So the wedge lives on the Bedrock stream path, not
+ * `pensar.ts`/`pensarSSE.ts`. This harness therefore defaults to
+ * `--provider bedrock` to faithfully reproduce the sandbox. (`--provider pensar`
+ * exercises the CLI gateway path instead, using `~/.pensar/config.json`.)
+ *
+ * For bedrock you need AWS creds in the environment (e.g. `AWS_PROFILE` +
+ * `AWS_REGION`); the default AWS provider chain is used, matching the sandbox.
+ * The internal `pLimit(THREAT_MODEL_CONCURRENCY)` governs true parallelism, so
+ * the concurrency profile matches prod.
+ *
+ * Turn on byte-level telemetry to see WHY a stream stalls (dead vs dribbling):
+ *
+ *   PENSAR_STREAM_DEBUG=1 bun --bun scripts/repro-threat-model-stream.ts \
+ *     --codebase /path/to/repo --loops 5 --endpoints 8
+ *
+ * Flags:
+ *   --codebase <path>   Repo the threat-model agent analyzes. Default: the apex
+ *                       worktree root (plenty of real endpoints).
+ *   --model <id>        Model id. Default: pensar:global.anthropic.claude-opus-4-6-v1
+ *                       (the platform `pentestModel` threat-model children inherit).
+ *   --loops <n>         How many times to run the endpoint batch. Default: 3.
+ *   --endpoints <n>     Endpoints fired per loop (gated to 4 by the limiter).
+ *                       Default: 8.
+ *   --stall-ms <n>      Per-call duration above which we flag a SLOW call in the
+ *                       report (does not abort — the liveness mechanism owns that).
+ *                       Default: 180000 (3m).
+ */
+
+import path from "node:path";
+import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
+import { config } from "../src/core/config";
+import { buildAuthConfig, type AIAuthConfig, type AIModel } from "../src/core/ai";
+import { AgentEventBus } from "../src/core/eventBus";
+import { sessions } from "../src/core/session";
+import {
+  generateThreatModelForEndpoint,
+  type GenerateThreatModelInput,
+} from "../src/core/agents/offSecAgent/tools/threatModelGenerator";
+import type { ToolContext } from "../src/core/agents/offSecAgent/tools/types";
+
+// ---------------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv: string[]) {
+  const get = (flag: string, fallback?: string): string | undefined => {
+    const i = argv.indexOf(flag);
+    return i >= 0 && i + 1 < argv.length ? argv[i + 1] : fallback;
+  };
+  const worktreeRoot = path.resolve(import.meta.dirname, "..");
+  const provider = (get("--provider", "bedrock") ?? "bedrock") as
+    | "bedrock"
+    | "pensar";
+  // Default model matches the platform `pentestModel` for the active provider.
+  const defaultModel =
+    provider === "pensar"
+      ? "pensar:anthropic.claude-opus-4-6-v1"
+      : "global.anthropic.claude-opus-4-6-v1";
+  return {
+    provider,
+    codebase: path.resolve(get("--codebase", worktreeRoot) ?? worktreeRoot),
+    model: (get("--model", defaultModel) ?? "") as AIModel,
+    loops: Number(get("--loops", "3")),
+    endpoints: Number(get("--endpoints", "8")),
+    stallMs: Number(get("--stall-ms", String(3 * 60 * 1000))),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint corpus — realistic specs that elicit a LARGE structured `response`
+// (the payload size is what correlates with the wedge). Cycled to fill a batch.
+// ---------------------------------------------------------------------------
+
+const ENDPOINT_CORPUS: GenerateThreatModelInput[] = [
+  {
+    appName: "auth-service",
+    routePath: "/api/auth/login",
+    method: "POST",
+    authRequired: false,
+    description:
+      "Primary credential login. Accepts email + password, issues a session JWT and a refresh-token cookie. Rate-limited; supports optional TOTP second factor and 'remember this device' trust tokens.",
+  },
+  {
+    appName: "auth-service",
+    routePath: "/api/auth/oauth/callback",
+    method: "GET",
+    authRequired: false,
+    description:
+      "OAuth2 / WorkOS SSO callback. Exchanges an authorization code for tokens, provisions or links a user, and establishes a session. Handles state/nonce validation and IdP-initiated flows.",
+  },
+  {
+    appName: "billing-service",
+    routePath: "/api/billing/webhooks/stripe",
+    method: "POST",
+    authRequired: false,
+    description:
+      "Stripe webhook receiver. Verifies the signature header, then mutates subscription state, seat counts, and invoices. Idempotency keys guard replays; failures must not double-charge.",
+  },
+  {
+    appName: "billing-service",
+    routePath: "/api/billing/subscription",
+    method: ["GET", "PUT", "DELETE"],
+    authRequired: true,
+    description:
+      "Read, upgrade/downgrade, and cancel the caller's workspace subscription. Plan changes are proration-sensitive and gate feature flags across the platform.",
+  },
+  {
+    appName: "workspace-api",
+    routePath: "/api/workspaces/:id/members",
+    method: ["GET", "POST", "DELETE"],
+    authRequired: true,
+    description:
+      "Manage workspace membership and roles (owner/admin/member). Invites send email, mutate RBAC, and can escalate privileges. Cross-tenant isolation is critical here.",
+  },
+  {
+    appName: "workspace-api",
+    routePath: "/api/workspaces/:id/api-keys",
+    method: ["GET", "POST", "DELETE"],
+    authRequired: true,
+    description:
+      "Create, list, and revoke long-lived workspace API keys. Keys are shown once at creation, hashed at rest, and grant programmatic access scoped to the workspace.",
+  },
+  {
+    appName: "scan-orchestrator",
+    routePath: "/api/scans/:id/launch",
+    method: "POST",
+    authRequired: true,
+    description:
+      "Launch a pentest/recon scan against a target. Mints a sandbox JWT, dispatches an ephemeral agent, and streams events. Server-side scope validation prevents launching against out-of-scope hosts.",
+  },
+  {
+    appName: "scan-orchestrator",
+    routePath: "/api/agent/events/emit",
+    method: "POST",
+    authRequired: true,
+    description:
+      "Sandbox-to-server event sink. Derives workspaceId/scanId/issueId from JWT claims (never the body), validates the realtime event allowlist, and fans out to MQTT + the archival log table.",
+  },
+  {
+    appName: "repo-integration",
+    routePath: "/api/github/webhooks",
+    method: "POST",
+    authRequired: false,
+    description:
+      "GitHub App webhook. Verifies the HMAC signature, processes installation/push/PR events, and triggers code analysis. Replay and signature-spoofing are the dominant threats.",
+  },
+  {
+    appName: "files-service",
+    routePath: "/api/files/upload",
+    method: "POST",
+    authRequired: true,
+    description:
+      "Direct-to-S3 presigned upload issuer plus a multipart fallback. Validates content-type and size, scopes the object key to the workspace, and guards against path traversal and SSRF in the callback URL.",
+  },
+];
+
+function buildBatch(n: number): GenerateThreatModelInput[] {
+  const out: GenerateThreatModelInput[] = [];
+  for (let i = 0; i < n; i++) {
+    const base = ENDPOINT_CORPUS[i % ENDPOINT_CORPUS.length];
+    // Vary the app name across cycles so concurrent subagentIds stay unique.
+    const cycle = Math.floor(i / ENDPOINT_CORPUS.length);
+    out.push(cycle === 0 ? base : { ...base, appName: `${base.appName}-${cycle}` });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Console tap — capture telemetry + abandon lines without losing live output.
+// ---------------------------------------------------------------------------
+
+const captured: string[] = [];
+function tapConsole() {
+  const origErr = console.error.bind(console);
+  const origLog = console.log.bind(console);
+  const tap =
+    (orig: (...a: unknown[]) => void) =>
+    (...args: unknown[]) => {
+      try {
+        captured.push(args.map((a) => (typeof a === "string" ? a : String(a))).join(" "));
+      } catch {
+        /* ignore */
+      }
+      orig(...args);
+    };
+  console.error = tap(origErr) as typeof console.error;
+  console.log = tap(origLog) as typeof console.log;
+}
+
+function field(line: string, key: string): string | undefined {
+  const m = line.match(new RegExp(`${key}=([^\\s]+)`));
+  return m?.[1];
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+type CallResult = {
+  endpoint: string;
+  ms: number;
+  outcome: "output" | "null" | "error";
+  error?: string;
+};
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  tapConsole();
+
+  let authConfig: AIAuthConfig;
+  if (args.provider === "pensar") {
+    const cfg = await config.get();
+    authConfig = buildAuthConfig({
+      anthropicAPIKey: cfg.anthropicAPIKey,
+      pensarAPIKey: cfg.pensarAPIKey,
+      accessToken: cfg.accessToken,
+      refreshToken: cfg.refreshToken,
+      workspaceId: cfg.workspaceId,
+      gatewaySigningKey: cfg.gatewaySigningKey,
+      gatewayUrl: cfg.gatewayUrl,
+    });
+    if (!authConfig.accessToken && !authConfig.pensarAPIKey) {
+      console.error(
+        "No Pensar auth in ~/.pensar/config.json. Run the apex CLI `/login` first.",
+      );
+      process.exit(1);
+    }
+  } else {
+    // Bedrock — mirror buildSandboxAuthConfig() EXACTLY: hand the bedrock
+    // provider `fromNodeProviderChain()` so SigV4 signing resolves creds from
+    // the default AWS chain (AWS_PROFILE / env / SSO), just like the sandbox.
+    authConfig = {
+      bedrock: {
+        credentialProvider: fromNodeProviderChain(),
+      },
+    };
+    if (!process.env.AWS_REGION && !process.env.AWS_DEFAULT_REGION) {
+      console.error(
+        "Bedrock provider needs AWS_REGION (e.g. AWS_REGION=us-east-1) in the environment.",
+      );
+      process.exit(1);
+    }
+  }
+
+  console.log("=".repeat(80));
+  console.log("THREAT-MODEL STREAM WEDGE REPRO");
+  console.log("=".repeat(80));
+  console.log(`provider    : ${args.provider}${args.provider === "bedrock" ? "  (faithful to deployed sandbox)" : "  (CLI gateway path)"}`);
+  console.log(`codebase    : ${args.codebase}`);
+  console.log(`model       : ${args.model}`);
+  console.log(`loops       : ${args.loops}`);
+  console.log(`endpoints/loop: ${args.endpoints} (internal limiter gates true parallelism)`);
+  if (args.provider === "bedrock") {
+    console.log(`aws region  : ${process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION}`);
+    console.log(`aws profile : ${process.env.AWS_PROFILE ?? "(default chain)"}`);
+  } else {
+    console.log(`workspaceId : ${authConfig.workspaceId ?? "(none)"}`);
+    console.log(`gateway     : ${authConfig.gatewayUrl ?? "https://gateway.pensar.dev (default)"}`);
+  }
+  console.log(`telemetry   : ${process.env.PENSAR_STREAM_DEBUG ? "ON" : "OFF (set PENSAR_STREAM_DEBUG=1)"}`);
+  console.log("=".repeat(80));
+
+  const session = await sessions.create({
+    name: "Threat Model Wedge Repro",
+    targets: [args.codebase],
+    config: { mode: "operator", agentCwd: args.codebase },
+  });
+
+  const baseCtx: ToolContext = {
+    session,
+    agentCwd: args.codebase,
+    model: args.model,
+    authConfig,
+    eventBus: new AgentEventBus(),
+  };
+
+  const allResults: CallResult[] = [];
+
+  for (let loop = 1; loop <= args.loops; loop++) {
+    const batch = buildBatch(args.endpoints);
+    console.log(`\n── loop ${loop}/${args.loops} — firing ${batch.length} endpoints ──`);
+    const loopStart = Date.now();
+
+    const settled = await Promise.allSettled(
+      batch.map(async (ep): Promise<CallResult> => {
+        const label = `${ep.appName} ${ep.routePath}`;
+        const t0 = Date.now();
+        try {
+          const out = await generateThreatModelForEndpoint(baseCtx, ep);
+          return {
+            endpoint: label,
+            ms: Date.now() - t0,
+            outcome: out ? "output" : "null",
+          };
+        } catch (err) {
+          return {
+            endpoint: label,
+            ms: Date.now() - t0,
+            outcome: "error",
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+      }),
+    );
+
+    for (const s of settled) {
+      if (s.status === "fulfilled") allResults.push(s.value);
+    }
+    console.log(`   loop ${loop} done in ${Math.round((Date.now() - loopStart) / 1000)}s`);
+  }
+
+  // -------------------------------------------------------------------------
+  // Report
+  // -------------------------------------------------------------------------
+  const wedgeLines = captured.filter((l) => l.includes("[stream-telem]") && l.includes("WEDGE"));
+  const abandonLines = captured.filter((l) => l.includes("abandoned ("));
+  const total = allResults.length;
+  const outputs = allResults.filter((r) => r.outcome === "output").length;
+  const nulls = allResults.filter((r) => r.outcome === "null").length;
+  const errors = allResults.filter((r) => r.outcome === "error").length;
+  const slow = allResults.filter((r) => r.ms > args.stallMs);
+  const durations = allResults.map((r) => r.ms).sort((a, b) => a - b);
+  const pct = (p: number) =>
+    durations.length ? durations[Math.min(durations.length - 1, Math.floor(p * durations.length))] : 0;
+
+  console.log(`\n${"=".repeat(80)}`);
+  console.log("REPORT");
+  console.log("=".repeat(80));
+  console.log(`threat-model calls : ${total}`);
+  console.log(`  ├─ returned output : ${outputs}`);
+  console.log(`  ├─ returned null   : ${nulls}  (heuristic fallback — wedged w/o captured response, or empty)`);
+  console.log(`  └─ threw           : ${errors}`);
+  console.log(`duration p50/p90/max: ${Math.round(pct(0.5) / 1000)}s / ${Math.round(pct(0.9) / 1000)}s / ${Math.round((durations.at(-1) ?? 0) / 1000)}s`);
+  console.log(`slow (>${Math.round(args.stallMs / 1000)}s) : ${slow.length}`);
+  console.log("");
+  console.log(`stream WEDGES (telem) : ${wedgeLines.length}`);
+  console.log(`liveness ABANDONS     : ${abandonLines.length}  (mechanism caught a wedge)`);
+  const wedgeRate = total ? ((abandonLines.length / total) * 100).toFixed(1) : "0.0";
+  console.log(`wedge rate            : ${wedgeRate}%  (abandons / calls)`);
+
+  if (wedgeLines.length) {
+    console.log("\n── WEDGE breakdown (dead vs dribbling) ──");
+    let dead = 0;
+    let dribbling = 0;
+    for (const l of wedgeLines) {
+      const sinceByte = Number(field(l, "msSinceLastByte") ?? "0");
+      const sinceEvent = Number(field(l, "msSinceLastEvent") ?? "0");
+      const phase = field(l, "phase");
+      // No bytes for a long stretch ⇒ transport dead/half-open. Bytes recent but
+      // no parsed events ⇒ alive but dribbling (model stuck mid-generation).
+      const verdict = sinceByte >= 60_000 ? "DEAD" : "DRIBBLING";
+      if (verdict === "DEAD") dead++;
+      else dribbling++;
+      console.log(`   ${verdict} phase=${phase} msSinceLastByte=${sinceByte} msSinceLastEvent=${sinceEvent}`);
+    }
+    console.log(`   → DEAD=${dead} DRIBBLING=${dribbling}`);
+  }
+
+  if (abandonLines.length) {
+    console.log("\n── abandon reasons ──");
+    for (const l of abandonLines.slice(0, 20)) console.log(`   ${l.trim()}`);
+  }
+
+  console.log(`\n${"=".repeat(80)}`);
+  console.log(wedgeLines.length || abandonLines.length ? "✗ WEDGE REPRODUCED" : "✓ no wedge this run");
+  console.log("=".repeat(80));
+
+  // Don't wait on lingering sandbox/bus timers.
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("harness fatal:", err);
+  process.exit(1);
+});

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -80,6 +80,7 @@ function buildStubAgent(overrides: {
   resolveResult?: (sr: unknown) => unknown;
   messagesPath?: string | null;
   latestMessages?: unknown[] | null;
+  responseCaptured?: Promise<unknown>;
 }): OffensiveSecurityAgent<unknown> {
   const agent = Object.create(
     OffensiveSecurityAgent.prototype,
@@ -93,6 +94,11 @@ function buildStubAgent(overrides: {
     value: { fullStream: overrides.fullStream },
   });
   Object.defineProperty(agent, "subagentId", { value: undefined });
+  // consume() races the drain against this; default never resolves so the
+  // drain (the full-stream path these tests exercise) always wins.
+  Object.defineProperty(agent, "responseCaptured", {
+    value: overrides.responseCaptured ?? new Promise(() => {}),
+  });
   // A real agent always has a session; the stub bypasses the constructor,
   // so provide a minimal one for busSessionId (used to stamp event ids).
   Object.defineProperty(agent, "_session", {
@@ -387,6 +393,23 @@ describe("OffensiveSecurityAgent.consume()", () => {
 
       const result = await agent.consume();
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("result/drain decoupling", () => {
+    it("returns the captured result without waiting for the stream to drain", async () => {
+      // A teardown that never completes (a wedged stream). consume() must still
+      // settle from responseCaptured rather than hang on the drain.
+      const neverDrains = (async function* () {
+        await new Promise(() => {});
+      })();
+      const agent = buildStubAgent({
+        fullStream: neverDrains,
+        responseCaptured: Promise.resolve("captured"),
+        resolveResult: () => "from-drain",
+      });
+
+      await expect(agent.consume()).resolves.toBe("captured");
     });
   });
 

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -95,6 +95,24 @@ export class OffensiveSecurityAgent<TResult = void> {
     return this._capturedResponse;
   }
 
+  /**
+   * Resolves the instant the `response` tool captures the structured result —
+   * the moment the agent is *semantically done*. This is independent of whether
+   * the underlying `fullStream` tears down cleanly: that iterator (and
+   * {@link streamResult}'s `finishReason` with it) can wedge before emitting its
+   * final `finish` chunk, so {@link consume} never returns even though the result
+   * already exists. Callers awaiting {@link consume} can race this to settle as
+   * soon as the result is captured, escaping the wedge. Never rejects; simply
+   * never resolves if `response` is never called (the caller's other backstops
+   * — silence watchdog, step budget — cover that case).
+   */
+  private _resolveResponseCaptured!: (result: TResult) => void;
+  public readonly responseCaptured: Promise<TResult> = new Promise(
+    (resolve) => {
+      this._resolveResponseCaptured = resolve;
+    },
+  );
+
   /** Identifier for this agent when it is running as a subagent. */
   private readonly subagentId?: string;
 
@@ -321,6 +339,7 @@ export class OffensiveSecurityAgent<TResult = void> {
           input.responseSchema,
           (result) => {
             this._capturedResponse = result as TResult;
+            this._resolveResponseCaptured(result as TResult);
           },
         ),
       };

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -84,6 +84,17 @@ export class OffensiveSecurityAgent<TResult = void> {
     streamResult: StreamTextResult<ToolSet, never>,
   ) => TResult | Promise<TResult>;
 
+  /**
+   * The structured result captured by the `response` tool, or `null` if the
+   * agent has not (yet) called `response`. Exposed so callers that bypass
+   * {@link consume} (e.g. racing the stream's terminal signal to escape a
+   * non-closing iterator) can still tell whether the run produced a result.
+   */
+  private _capturedResponse: TResult | null = null;
+  public get capturedResponse(): TResult | null {
+    return this._capturedResponse;
+  }
+
   /** Identifier for this agent when it is running as a subagent. */
   private readonly subagentId?: string;
 
@@ -303,15 +314,13 @@ export class OffensiveSecurityAgent<TResult = void> {
     }
 
     // -- Response schema → auto capture / stop / resolve ----------------------
-    let capturedResponse: TResult | null = null;
-
     if (input.responseSchema) {
       tools = {
         ...tools,
         [RESPONSE_TOOL_NAME]: createResponseTool(
           input.responseSchema,
           (result) => {
-            capturedResponse = result as TResult;
+            this._capturedResponse = result as TResult;
           },
         ),
       };
@@ -321,7 +330,7 @@ export class OffensiveSecurityAgent<TResult = void> {
       this.resolveResult = input.resolveResult;
     } else if (input.responseSchema) {
       this.resolveResult = () => {
-        if (capturedResponse !== null) return capturedResponse;
+        if (this._capturedResponse !== null) return this._capturedResponse;
         return undefined as TResult;
       };
     }

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -86,25 +86,17 @@ export class OffensiveSecurityAgent<TResult = void> {
 
   /**
    * The structured result captured by the `response` tool, or `null` if the
-   * agent has not (yet) called `response`. Exposed so callers that bypass
-   * {@link consume} (e.g. racing the stream's terminal signal to escape a
-   * non-closing iterator) can still tell whether the run produced a result.
+   * agent has not (yet) called `response`.
    */
   private _capturedResponse: TResult | null = null;
-  public get capturedResponse(): TResult | null {
-    return this._capturedResponse;
-  }
 
   /**
    * Resolves the instant the `response` tool captures the structured result —
-   * the moment the agent is *semantically done*. This is independent of whether
-   * the underlying `fullStream` tears down cleanly: that iterator (and
-   * {@link streamResult}'s `finishReason` with it) can wedge before emitting its
-   * final `finish` chunk, so {@link consume} never returns even though the result
-   * already exists. Callers awaiting {@link consume} can race this to settle as
-   * soon as the result is captured, escaping the wedge. Never rejects; simply
-   * never resolves if `response` is never called (the caller's other backstops
-   * — silence watchdog, step budget — cover that case).
+   * the moment the agent is semantically done, independent of stream teardown
+   * (which can wedge before the final `finish` chunk). {@link consume} races
+   * this so it returns the result then and drains the rest in the background.
+   * Never rejects; never resolves if `response` is never called — there the
+   * idle-guard-bounded drain settles `consume` instead.
    */
   private _resolveResponseCaptured!: (result: TResult) => void;
   public readonly responseCaptured: Promise<TResult> = new Promise(
@@ -696,28 +688,39 @@ export class OffensiveSecurityAgent<TResult = void> {
     };
 
     // Only subagents get a span here; top-level runs are wrapped by the host.
-    if (!sid) return runConsume();
+    const drain = !sid
+      ? runConsume()
+      : getApexTracer().startActiveSpan(
+          `invoke_agent ${sid}`,
+          {
+            attributes: {
+              "gen_ai.operation.name": "invoke_agent",
+              "gen_ai.agent.name": sid,
+            },
+          },
+          async (span) => {
+            try {
+              return await runConsume();
+            } catch (err) {
+              span.recordException(err as Error);
+              throw err;
+            } finally {
+              span.end();
+            }
+          },
+        );
 
-    const tracer = getApexTracer();
-    return tracer.startActiveSpan(
-      `invoke_agent ${sid}`,
-      {
-        attributes: {
-          "gen_ai.operation.name": "invoke_agent",
-          "gen_ai.agent.name": sid,
-        },
-      },
-      async (span) => {
-        try {
-          return await runConsume();
-        } catch (err) {
-          span.recordException(err as Error);
-          throw err;
-        } finally {
-          span.end();
-        }
-      },
-    );
+    // Decouple the result from stream teardown. With a `response` schema the
+    // structured result is captured mid-stream (in the response tool), so return
+    // it the instant it's available rather than waiting for the stream to close
+    // — teardown can wedge (Bedrock goes byte-silent before the final chunk).
+    // The drain keeps running in the background for persistence/cleanup, bounded
+    // by the transport idle guard so it can't block the caller or leak. Without
+    // a response schema `responseCaptured` never fires and this is the same
+    // full-drain await as before.
+    const result = await Promise.race([drain, this.responseCaptured]);
+    drain.catch(() => {});
+    return result;
   }
 
   /**

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -30,12 +30,18 @@ const threatModelLimiter = pLimit(THREAT_MODEL_CONCURRENCY);
 //       a healthy `consume()`, which returns a tick later, wins cleanly), using
 //       the captured result. This escapes the wedge in seconds — confirmed in
 //       production where children completed but the tool-call never settled.
-//   (2) SILENCE WATCHDOG — a child that freezes BEFORE ever calling `response`
-//       (wedged mid-step on a hung sub-tool, its model-idle-timeout gated off)
-//       emits nothing and captures no result, so (1) never fires. No bus
-//       activity for THREAT_MODEL_SILENCE_MS ⇒ abandon (no result → degrade).
-//   (3) STEP BUDGET (`stepCountIs`) — a child that LOOPS without calling
-//       `response` is bounded so its stream cannot run forever.
+//   (2) NO-PROGRESS WATCHDOG — a child that wedges BEFORE its `response` tool's
+//       `execute` runs, so (1) never fires. The dominant case: the model emits
+//       the `response` tool-call and then stalls while STREAMING its large
+//       arguments (the multi-thousand-token threat model), and the AI SDK keeps
+//       RETRYING — re-streaming tokens forever. Raw token chatter looks like
+//       activity, so a naive "any bus event" watchdog never fires (this is why
+//       an earlier silence watchdog failed in production and stalled a recon).
+//       The fix: only `step-finish` / `tool-result` count as progress — a retry
+//       that never finishes completes no step and returns no tool result. No
+//       progress for THREAT_MODEL_SILENCE_MS ⇒ abandon (no result → degrade).
+//   (3) STEP BUDGET (`stepCountIs`) — a child that LOOPS through COMPLETED steps
+//       without calling `response` is bounded so its stream cannot run forever.
 //
 // On any abandonment we use the structured `response` if the child captured it
 // (only the plumbing hung — the result is good), else return null;
@@ -59,26 +65,30 @@ const THREAT_MODEL_MAX_STEPS = 40;
 // concurrent threat models.
 const THREAT_MODEL_RESPONSE_SETTLE_MS = 5 * 1000;
 
-// Liveness threshold (mode C). A child that emits NO bus activity for this long
-// has frozen on a hung sub-tool (or finished and gone silent). Sized above the
-// child's own 5-min model-idle-timeout + auto-resume, so a recoverable model
-// stall — which produces fresh activity every ~5 min — never trips it; only a
-// genuine freeze with no recovery does. This is a liveness bound (lack of
-// progress), not a deadline on a working run.
+// No-progress threshold. A child that completes NO step and returns NO tool
+// result for this long has stalled — it is wedged mid-step on a hung sub-tool,
+// OR (the dominant observed mode) wedged while STREAMING the large `response`
+// payload: the model emits the `response` tool-call and then stalls streaming
+// its multi-thousand-token arguments, so the tool's `execute` (where
+// `responseCaptured` fires) never runs AND the AI-SDK RETRIES re-stream the
+// args, producing continuous token chatter with no completed step. We treat
+// `step-finish` / `tool-result` as the only real progress signals precisely
+// because retries CAN'T fake them (a retry that never finishes the args
+// completes no step and returns no tool result) — counting raw token deltas
+// would let that chatter keep a wedged child "alive" forever (the original
+// silence watchdog's fatal flaw). Sized well above a normal step (reads finish
+// in seconds; a full `response` generates in ~1-3 min), so a working run always
+// produces a `step-finish`/`tool-result` inside the window. This is a liveness
+// bound (lack of progress), not a deadline on a working run.
 const THREAT_MODEL_SILENCE_MS = 8 * 60 * 1000;
 const THREAT_MODEL_SILENCE_POLL_MS = 15 * 1000;
 
-// Child bus events that count as "still making progress". A frozen child emits
-// none of these; a healthy or recovering one emits them continuously.
-const THREAT_MODEL_LIVENESS_EVENTS = [
-  "text-delta",
-  "tool-call-start",
-  "tool-call-delta",
-  "tool-call-complete",
-  "tool-result",
-  "command-output",
-  "step-finish",
-] as const;
+// Child bus events that count as REAL forward progress. Deliberately excludes
+// the streaming/in-progress events (`text-delta`, `tool-call-start/delta`,
+// `command-output`) — those are emitted continuously by an AI-SDK retry loop
+// that never actually finishes, so counting them defeats the watchdog. Only a
+// completed step or a returned tool result proves the child advanced.
+const THREAT_MODEL_LIVENESS_EVENTS = ["tool-result", "step-finish"] as const;
 
 // ---------------------------------------------------------------------------
 // Response schema
@@ -425,10 +435,13 @@ export async function generateThreatModelForEndpoint(
     const ABANDON = Symbol("threat-model-abandon");
     let abandonReason = "";
 
-    // Liveness watchdog (mode C — silent freeze): the dominant observed mode.
-    // A child wedged mid-step on a hung sub-tool (its model-idle-timeout gated
-    // off) completes no step and never finishes its stream, so neither the step
-    // budget nor the terminal signal fires — but it goes completely SILENT.
+    // No-progress watchdog. Catches a child that wedges WITHOUT capturing a
+    // response — either frozen mid-step on a hung sub-tool, or (the dominant
+    // observed mode) wedged streaming the large `response` payload while the
+    // AI-SDK retries re-stream tokens forever. `lastProgress` advances ONLY on a
+    // completed step or returned tool result (see THREAT_MODEL_LIVENESS_EVENTS),
+    // so retry chatter cannot keep it alive; no real progress for the window ⇒
+    // abandon (no captured response → document_endpoint degrades to heuristic).
     let lastActivity = Date.now();
     const bumpActivity = () => {
       lastActivity = Date.now();
@@ -438,9 +451,9 @@ export async function generateThreatModelForEndpoint(
     const silenceWatchdog = new Promise<typeof ABANDON>((resolve) => {
       livenessTimer = setInterval(() => {
         if (Date.now() - lastActivity > THREAT_MODEL_SILENCE_MS) {
-          abandonReason = `no activity for ${Math.round(
+          abandonReason = `no completed step or tool result for ${Math.round(
             THREAT_MODEL_SILENCE_MS / 1000,
-          )}s (frozen mid-step)`;
+          )}s (wedged before capturing a response)`;
           resolve(ABANDON);
         }
       }, THREAT_MODEL_SILENCE_POLL_MS);

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -1,4 +1,3 @@
-import { stepCountIs } from "ai";
 import pLimit from "p-limit";
 import { z } from "zod";
 import { AgentEventBus } from "../../../eventBus";
@@ -17,9 +16,6 @@ const threatModelLimiter = pLimit(THREAT_MODEL_CONCURRENCY);
 // always settle — resolve on success, reject after resumes are exhausted. So
 // this only needs the response-captured fast-path below; on any failure the
 // catch returns null and `document_endpoint` degrades to the heuristic score.
-
-// Iteration ceiling: a run past this is looping, not progressing to `response`.
-const THREAT_MODEL_MAX_STEPS = 40;
 
 // Grace after `responseCaptured` so a healthy `consume()` (which returns a tick
 // later with the same result) wins the race cleanly. Not a bound on the work —
@@ -358,11 +354,6 @@ export async function generateThreatModelForEndpoint(
       eventBus: localBus,
       subagentId,
       responseSchema: ThreatModelResultSchema,
-      // Bound the child's iterations so its stream ALWAYS terminates. This
-      // merges with the responseSchema's own `hasToolCall(response)` stop
-      // condition inside OffensiveSecurityAgent (either condition ends the
-      // run), so a healthy run still stops the moment it calls `response`.
-      stopWhen: stepCountIs(THREAT_MODEL_MAX_STEPS),
       excludeTools: ["document_endpoint", "document_app"],
     });
 

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -7,7 +7,19 @@ import type { ToolContext } from "./types";
 
 // Process-wide cap — parents emit `document_endpoint` tool calls in parallel,
 // so without this gate each parent fans out unboundedly.
-const THREAT_MODEL_CONCURRENCY = 10;
+//
+// Kept deliberately MODEST (not 10). Each concurrent threat model streams a
+// large structured response and parses it; running ~10 at once saturates the
+// single Node/Bun event loop, which starves the JS timers that everything else
+// relies on — the SSE connection read-idle, the stream idle-timeout/auto-resume,
+// the fetch backstop. Under that starvation a stalled/half-open Bedrock stream
+// is never detected, the child never degrades, and a WAVE of simultaneous
+// wedges fills every slot and stalls the whole recon (observed: 10 children
+// frozen 8-15 min, root idle 11 min, zero progress). A smaller pool keeps the
+// loop responsive so those liveness timers actually fire and a dead connection
+// propagates its error / degrades promptly — trading a little parallelism for
+// the reliability that makes the connection-liveness guards work at all.
+const THREAT_MODEL_CONCURRENCY = 4;
 const threatModelLimiter = pLimit(THREAT_MODEL_CONCURRENCY);
 
 // ── Bounded termination for the spawned threat-model child ──────────────────

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -15,25 +15,30 @@ const threatModelLimiter = pLimit(THREAT_MODEL_CONCURRENCY);
 // The `document_endpoint` tool blocks on `await agent.consume()` below. In
 // production a single threat-model await was observed hanging forever (5+ hrs),
 // freezing the parent tool-call, the parent agent session, and the whole recon
-// at "N-1/N apps". THREE distinct failure modes produce this — none caught by
-// any one mechanism, so `consume()` is raced against all three (no wall-clock
-// timeout on the work itself):
+// at "N-1/N apps". The root cause: `consume()` drains the child's `fullStream`
+// async iterator, and that iterator can WEDGE before emitting its final `finish`
+// chunk — typically after the child has already called its `response` tool and
+// produced a complete result. When it wedges, BOTH `consume()` and
+// `streamResult.finishReason` hang (they wait on the same `finish` chunk), even
+// though the work is done. So `consume()` is raced against signals that do NOT
+// depend on a clean stream teardown (no wall-clock timeout on the work itself):
 //
-//   (A) Loop — the child never calls its `response` tool, so its model stream
-//       runs forever. → STEP BUDGET (`stepCountIs`) forces the stream to end;
-//       `consume()` then returns (no `response` captured → degrade).
-//   (B) Iterator hang — the stream finishes but `consume()`'s `for await
-//       (…fullStream)` never closes. → TERMINAL-SIGNAL race on
-//       `streamResult.finishReason` (resolves the instant streamText finishes).
-//   (C) Silent freeze — the child wedges MID-step on a hung sub-tool (its own
-//       model-idle-timeout is gated off while a tool is in flight), emitting
-//       NOTHING. No step completes (so the step budget never fires) and the
-//       stream never finishes (so finishReason never resolves) — but the child
-//       goes completely SILENT. → LIVENESS WATCHDOG: no bus activity for
-//       THREAT_MODEL_SILENCE_MS ⇒ abandon. This was the dominant mode observed.
+//   (1) RESPONSE-CAPTURED (dominant mode) — a threat-model child is *semantically
+//       done* the instant it calls `response` and captures the structured
+//       result. Everything after is stream teardown, which can wedge. So we
+//       settle as soon as `agent.responseCaptured` fires (after a short grace so
+//       a healthy `consume()`, which returns a tick later, wins cleanly), using
+//       the captured result. This escapes the wedge in seconds — confirmed in
+//       production where children completed but the tool-call never settled.
+//   (2) SILENCE WATCHDOG — a child that freezes BEFORE ever calling `response`
+//       (wedged mid-step on a hung sub-tool, its model-idle-timeout gated off)
+//       emits nothing and captures no result, so (1) never fires. No bus
+//       activity for THREAT_MODEL_SILENCE_MS ⇒ abandon (no result → degrade).
+//   (3) STEP BUDGET (`stepCountIs`) — a child that LOOPS without calling
+//       `response` is bounded so its stream cannot run forever.
 //
-// On any abandonment we use the structured `response` if the child managed to
-// capture it (only the plumbing hung — the result is good), else return null;
+// On any abandonment we use the structured `response` if the child captured it
+// (only the plumbing hung — the result is good), else return null;
 // `document_endpoint` falls back to the heuristic risk score on null so the
 // recon advances instead of wedging.
 
@@ -42,15 +47,17 @@ const threatModelLimiter = pLimit(THREAT_MODEL_CONCURRENCY);
 // exceeds this is looping rather than progressing toward `response`.
 const THREAT_MODEL_MAX_STEPS = 40;
 
-// Settle window after the terminal signal (mode B). `finishReason` fires the
-// instant streamText finishes — a tick BEFORE `consume()`'s `for await` does
-// its final `next()` and returns in a healthy run. Without a grace the race
-// would pick the terminal signal on every healthy run and degrade every threat
-// model. This is NOT a bound on the work (finishReason already confirmed it's
-// done) — only how long we wait for a finished stream's iterator to close. A
-// normal close is milliseconds; the margin absorbs event-loop congestion from
-// the up-to-10 concurrent threat models without masking a real hang.
-const THREAT_MODEL_STREAM_SETTLE_MS = 10 * 1000;
+// Grace after the response-captured signal (mechanism 1). `responseCaptured`
+// fires synchronously from the `response` tool callback — a tick BEFORE a
+// healthy `consume()` does its final `next()` and returns. Without a grace the
+// race would pick the response signal on every healthy run and log a spurious
+// "abandoned" (the OUTPUT is identical either way — both resolve to the same
+// captured result — but the healthy path emits a clean "completed"). This is
+// NOT a bound on the work (the result is already captured) — only how long we
+// let a captured-but-not-yet-torn-down stream close on its own. A normal close
+// is milliseconds; the margin absorbs event-loop congestion from the up-to-10
+// concurrent threat models.
+const THREAT_MODEL_RESPONSE_SETTLE_MS = 5 * 1000;
 
 // Liveness threshold (mode C). A child that emits NO bus activity for this long
 // has frozen on a hung sub-tool (or finished and gone silent). Sized above the
@@ -439,19 +446,19 @@ export async function generateThreatModelForEndpoint(
       }, THREAT_MODEL_SILENCE_POLL_MS);
     });
 
-    // Terminal signal (mode B — finished but iterator wedged). `finishReason`
-    // is a thenable, not a full `Promise`, so use the two-arg `.then`. The
-    // settle window lets `consume()` win in the healthy case where it returns a
-    // tick after the stream finishes (otherwise we'd degrade every healthy run).
+    // Response-captured signal (mechanism 1 — the dominant mode). Fires once the
+    // child calls `response` and captures its structured result; the grace lets
+    // a healthy `consume()` (which returns a tick later) win cleanly. When the
+    // stream then wedges before tearing down, `consume()` never returns but the
+    // result already exists — this settles with it instead of hanging.
     let settleTimer: ReturnType<typeof setTimeout> | undefined;
-    const terminalSignal = new Promise<typeof ABANDON>((resolve) => {
-      const arm = () => {
+    const responseSignal = new Promise<typeof ABANDON>((resolve) => {
+      agent.responseCaptured.then(() => {
         settleTimer = setTimeout(() => {
-          abandonReason = "stream finished but iterator did not close";
+          abandonReason = "response captured but stream did not tear down";
           resolve(ABANDON);
-        }, THREAT_MODEL_STREAM_SETTLE_MS);
-      };
-      Promise.resolve(agent.streamResult.finishReason).then(arm, arm);
+        }, THREAT_MODEL_RESPONSE_SETTLE_MS);
+      });
     });
 
     const cleanup = () => {
@@ -489,19 +496,19 @@ export async function generateThreatModelForEndpoint(
     try {
       const outcome = await Promise.race([
         agent.consume(),
+        responseSignal,
         silenceWatchdog,
-        terminalSignal,
       ]);
 
       if (outcome === ABANDON) {
-        // A child wedged in one of the non-progress modes (B: stream finished
-        // but iterator never closed; C: frozen mid-step, silent past the
-        // liveness threshold). Abort the child (frees the pLimit slot + provider
-        // connection). If it captured its structured `response` before wedging,
-        // USE it — only the plumbing hung, the result is good. Otherwise degrade
-        // to null; `document_endpoint` falls back to the heuristic risk score,
-        // so the tool-call completes and the recon advances instead of hanging
-        // forever.
+        // `consume()` did not return — either the child captured its result and
+        // the stream then wedged before tearing down (response-captured signal),
+        // or it froze before ever producing a result (silence watchdog). Abort
+        // the child (frees the pLimit slot + provider connection). If it captured
+        // its structured `response`, USE it — only the plumbing hung, the result
+        // is good. Otherwise degrade to null; `document_endpoint` falls back to
+        // the heuristic risk score, so the tool-call completes and the recon
+        // advances instead of hanging forever.
         const captured = agent.capturedResponse;
         childAbort.abort();
         ctx.eventBus?.emit("subagent-complete", {

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -15,45 +15,63 @@ const threatModelLimiter = pLimit(THREAT_MODEL_CONCURRENCY);
 // The `document_endpoint` tool blocks on `await agent.consume()` below. In
 // production a single threat-model await was observed hanging forever (5+ hrs),
 // freezing the parent tool-call, the parent agent session, and the whole recon
-// at "N-1/N apps". Two distinct failure modes produced this:
+// at "N-1/N apps". THREE distinct failure modes produce this — none caught by
+// any one mechanism, so `consume()` is raced against all three (no wall-clock
+// timeout on the work itself):
 //
-//   (A) the child loops without ever calling its `response` tool, so its model
-//       stream never terminates and `consume()` never returns; and
-//   (B) the child's stream finishes (the child session shows completed) but
-//       `consume()`'s `for await (…fullStream)` never closes, so `consume()`
-//       hangs even though the run is done.
+//   (A) Loop — the child never calls its `response` tool, so its model stream
+//       runs forever. → STEP BUDGET (`stepCountIs`) forces the stream to end;
+//       `consume()` then returns (no `response` captured → degrade).
+//   (B) Iterator hang — the stream finishes but `consume()`'s `for await
+//       (…fullStream)` never closes. → TERMINAL-SIGNAL race on
+//       `streamResult.finishReason` (resolves the instant streamText finishes).
+//   (C) Silent freeze — the child wedges MID-step on a hung sub-tool (its own
+//       model-idle-timeout is gated off while a tool is in flight), emitting
+//       NOTHING. No step completes (so the step budget never fires) and the
+//       stream never finishes (so finishReason never resolves) — but the child
+//       goes completely SILENT. → LIVENESS WATCHDOG: no bus activity for
+//       THREAT_MODEL_SILENCE_MS ⇒ abandon. This was the dominant mode observed.
 //
-// We close both holes with first-principles bounds — no wall-clock timeout:
-//
-//   1. A step budget (`stepCountIs(THREAT_MODEL_MAX_STEPS)`) on the child agent
-//      guarantees its stream ALWAYS terminates. A threat model that can't emit
-//      its structured `response` within this many iterations is malfunctioning;
-//      this is an iteration-count bound, not a clock, so a slow-but-healthy run
-//      is never killed. Fixes (A).
-//   2. We race `consume()` against the agent's authoritative terminal signal,
-//      `streamResult.finishReason` (a Promise that resolves when streamText
-//      finishes for ANY reason — response tool, step budget, or error). If the
-//      stream is done but `consume()` is still pending we abort the child and
-//      degrade instead of waiting forever. Fixes (B).
-//
-// `document_endpoint` already falls back to the heuristic risk score when this
-// returns null, so a degraded path lets the recon advance instead of wedging.
+// On any abandonment we use the structured `response` if the child managed to
+// capture it (only the plumbing hung — the result is good), else return null;
+// `document_endpoint` falls back to the heuristic risk score on null so the
+// recon advances instead of wedging.
 
-// Iteration-count ceiling for the child. Sized comfortably above a normal
-// threat model's step count (the default CodeAgent ceiling is 10000); a run
-// that exceeds this is looping rather than progressing toward `response`.
+// Iteration-count ceiling (mode A). Sized comfortably above a normal threat
+// model's step count (the default CodeAgent ceiling is 10000); a run that
+// exceeds this is looping rather than progressing toward `response`.
 const THREAT_MODEL_MAX_STEPS = 40;
 
-// Settle window after the terminal signal. `finishReason` fires the instant
-// streamText finishes, which in a healthy run is a tick BEFORE `consume()`'s
-// `for await` does its final `next()` and returns. Without a grace, the race
-// would pick STREAM_DONE on every healthy run and degrade every threat model.
-// This is NOT a bound on the threat model's work (finishReason already
-// confirmed it's done) — only on how long we wait for a finished stream's
-// iterator to close before treating it as wedged. A normal close happens in
-// milliseconds; this margin absorbs event-loop congestion from the up-to-10
-// concurrent threat models without masking a real hang.
+// Settle window after the terminal signal (mode B). `finishReason` fires the
+// instant streamText finishes — a tick BEFORE `consume()`'s `for await` does
+// its final `next()` and returns in a healthy run. Without a grace the race
+// would pick the terminal signal on every healthy run and degrade every threat
+// model. This is NOT a bound on the work (finishReason already confirmed it's
+// done) — only how long we wait for a finished stream's iterator to close. A
+// normal close is milliseconds; the margin absorbs event-loop congestion from
+// the up-to-10 concurrent threat models without masking a real hang.
 const THREAT_MODEL_STREAM_SETTLE_MS = 10 * 1000;
+
+// Liveness threshold (mode C). A child that emits NO bus activity for this long
+// has frozen on a hung sub-tool (or finished and gone silent). Sized above the
+// child's own 5-min model-idle-timeout + auto-resume, so a recoverable model
+// stall — which produces fresh activity every ~5 min — never trips it; only a
+// genuine freeze with no recovery does. This is a liveness bound (lack of
+// progress), not a deadline on a working run.
+const THREAT_MODEL_SILENCE_MS = 8 * 60 * 1000;
+const THREAT_MODEL_SILENCE_POLL_MS = 15 * 1000;
+
+// Child bus events that count as "still making progress". A frozen child emits
+// none of these; a healthy or recovering one emits them continuously.
+const THREAT_MODEL_LIVENESS_EVENTS = [
+  "text-delta",
+  "tool-call-start",
+  "tool-call-delta",
+  "tool-call-complete",
+  "tool-result",
+  "command-output",
+  "step-finish",
+] as const;
 
 // ---------------------------------------------------------------------------
 // Response schema
@@ -395,27 +413,53 @@ export async function generateThreatModelForEndpoint(
       excludeTools: ["document_endpoint", "document_app"],
     });
 
-    // Terminal signal: `finishReason` resolves when the underlying streamText
-    // finishes for ANY reason — response tool, step budget, or error. Racing
-    // `consume()` against it guarantees we don't block forever on a stream that
-    // has finished but whose `for await` iterator never closes (failure mode B).
-    const STREAM_DONE = Symbol("threat-model-stream-done");
-    // `finishReason` is a thenable (`PromiseLike`), not a full `Promise`, so it
-    // has no `.catch`. When it settles (either way) we arm a short settle timer;
-    // STREAM_DONE only wins if `consume()` still hasn't returned by the end of
-    // the grace — i.e. the stream is genuinely done but its iterator is wedged
-    // (failure mode B). In a healthy run `consume()` returns within the grace
-    // and wins the race, so the threat model is used normally.
+    // `consume()` is raced against two abandonment signals so a wedged child
+    // can never block the tool indefinitely. Either resolves to ABANDON.
+    const ABANDON = Symbol("threat-model-abandon");
+    let abandonReason = "";
+
+    // Liveness watchdog (mode C — silent freeze): the dominant observed mode.
+    // A child wedged mid-step on a hung sub-tool (its model-idle-timeout gated
+    // off) completes no step and never finishes its stream, so neither the step
+    // budget nor the terminal signal fires — but it goes completely SILENT.
+    let lastActivity = Date.now();
+    const bumpActivity = () => {
+      lastActivity = Date.now();
+    };
+    for (const ev of THREAT_MODEL_LIVENESS_EVENTS) localBus.on(ev, bumpActivity);
+    let livenessTimer: ReturnType<typeof setInterval> | undefined;
+    const silenceWatchdog = new Promise<typeof ABANDON>((resolve) => {
+      livenessTimer = setInterval(() => {
+        if (Date.now() - lastActivity > THREAT_MODEL_SILENCE_MS) {
+          abandonReason = `no activity for ${Math.round(
+            THREAT_MODEL_SILENCE_MS / 1000,
+          )}s (frozen mid-step)`;
+          resolve(ABANDON);
+        }
+      }, THREAT_MODEL_SILENCE_POLL_MS);
+    });
+
+    // Terminal signal (mode B — finished but iterator wedged). `finishReason`
+    // is a thenable, not a full `Promise`, so use the two-arg `.then`. The
+    // settle window lets `consume()` win in the healthy case where it returns a
+    // tick after the stream finishes (otherwise we'd degrade every healthy run).
     let settleTimer: ReturnType<typeof setTimeout> | undefined;
-    const terminalSignal = new Promise<typeof STREAM_DONE>((resolve) => {
+    const terminalSignal = new Promise<typeof ABANDON>((resolve) => {
       const arm = () => {
-        settleTimer = setTimeout(
-          () => resolve(STREAM_DONE),
-          THREAT_MODEL_STREAM_SETTLE_MS,
-        );
+        settleTimer = setTimeout(() => {
+          abandonReason = "stream finished but iterator did not close";
+          resolve(ABANDON);
+        }, THREAT_MODEL_STREAM_SETTLE_MS);
       };
       Promise.resolve(agent.streamResult.finishReason).then(arm, arm);
     });
+
+    const cleanup = () => {
+      if (livenessTimer) clearInterval(livenessTimer);
+      if (settleTimer) clearTimeout(settleTimer);
+      for (const ev of THREAT_MODEL_LIVENESS_EVENTS)
+        localBus.off(ev, bumpActivity);
+    };
 
     const buildOutput = (result: ThreatModelResult): ThreatModelOutput => {
       const totalScore =
@@ -443,17 +487,21 @@ export async function generateThreatModelForEndpoint(
     };
 
     try {
-      const outcome = await Promise.race([agent.consume(), terminalSignal]);
+      const outcome = await Promise.race([
+        agent.consume(),
+        silenceWatchdog,
+        terminalSignal,
+      ]);
 
-      if (outcome === STREAM_DONE) {
-        // Stream terminated (response tool, step budget, or error) but
-        // `consume()` is still pending past the settle window — the iterator is
-        // wedged (failure mode B). Abort the child (frees the pLimit slot +
-        // provider connection). If the child captured its structured response
-        // before the stream ended, USE it — only the iterator hung, the result
-        // is good. Otherwise degrade to null; `document_endpoint` falls back to
-        // the heuristic risk score, so the tool-call completes and the recon
-        // advances instead of hanging forever.
+      if (outcome === ABANDON) {
+        // A child wedged in one of the non-progress modes (B: stream finished
+        // but iterator never closed; C: frozen mid-step, silent past the
+        // liveness threshold). Abort the child (frees the pLimit slot + provider
+        // connection). If it captured its structured `response` before wedging,
+        // USE it — only the plumbing hung, the result is good. Otherwise degrade
+        // to null; `document_endpoint` falls back to the heuristic risk score,
+        // so the tool-call completes and the recon advances instead of hanging
+        // forever.
         const captured = agent.capturedResponse;
         childAbort.abort();
         ctx.eventBus?.emit("subagent-complete", {
@@ -463,12 +511,15 @@ export async function generateThreatModelForEndpoint(
         });
         if (captured === null) {
           console.error(
-            `Threat model for ${input.routePath}: stream finished but ` +
-              `consume() did not settle and no response was captured; ` +
-              `falling back to heuristic-only.`,
+            `Threat model for ${input.routePath} abandoned (${abandonReason}); ` +
+              `no response captured — falling back to heuristic-only.`,
           );
           return null;
         }
+        console.error(
+          `Threat model for ${input.routePath} abandoned (${abandonReason}) ` +
+            `but response was captured before wedge — using it.`,
+        );
         return buildOutput(captured);
       }
 
@@ -493,7 +544,7 @@ export async function generateThreatModelForEndpoint(
       );
       return null;
     } finally {
-      if (settleTimer) clearTimeout(settleTimer);
+      cleanup();
     }
   });
 }

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -5,8 +5,10 @@ import type { RiskScore } from "../../specialized/whiteboxAttackSurface";
 import type { ToolContext } from "./types";
 
 // Process-wide cap — parents emit `document_endpoint` calls in parallel, so
-// without this gate each parent fans out unboundedly.
-const THREAT_MODEL_CONCURRENCY = 10;
+// without this gate each parent fans out unboundedly. Kept at 4 (not 10): each
+// concurrent child streams a large structured response and, under the Bedrock
+// wedge rate, may resume-regenerate it; 10 at once OOM-kills the sandbox.
+const THREAT_MODEL_CONCURRENCY = 4;
 const threatModelLimiter = pLimit(THREAT_MODEL_CONCURRENCY);
 
 // `document_endpoint` blocks on `await agent.consume()`. consume() returns the
@@ -376,9 +378,13 @@ export async function generateThreatModelForEndpoint(
     };
 
     try {
-      // consume() returns the captured result and drains the rest in the
-      // background; the transport idle guard bounds it, so no watchdog here.
+      // consume() returns the captured result as soon as it's available and
+      // drains the rest in the background. Abort once we have the result so that
+      // background drain stops immediately — otherwise, under the Bedrock wedge
+      // rate, it keeps resume-regenerating a response we've already discarded,
+      // and those detached drains pile up and OOM the sandbox.
       const result = await agent.consume();
+      childAbort.abort();
       ctx.eventBus?.emit("subagent-complete", {
         subagentId,
         status: "completed",

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -5,102 +5,26 @@ import { AgentEventBus } from "../../../eventBus";
 import type { RiskScore } from "../../specialized/whiteboxAttackSurface";
 import type { ToolContext } from "./types";
 
-// Process-wide cap — parents emit `document_endpoint` tool calls in parallel,
-// so without this gate each parent fans out unboundedly.
-//
-// Kept deliberately MODEST (not 10). Each concurrent threat model streams a
-// large structured response and parses it; running ~10 at once saturates the
-// single Node/Bun event loop, which starves the JS timers that everything else
-// relies on — the SSE connection read-idle, the stream idle-timeout/auto-resume,
-// the fetch backstop. Under that starvation a stalled/half-open Bedrock stream
-// is never detected, the child never degrades, and a WAVE of simultaneous
-// wedges fills every slot and stalls the whole recon (observed: 10 children
-// frozen 8-15 min, root idle 11 min, zero progress). A smaller pool keeps the
-// loop responsive so those liveness timers actually fire and a dead connection
-// propagates its error / degrades promptly — trading a little parallelism for
-// the reliability that makes the connection-liveness guards work at all.
-const THREAT_MODEL_CONCURRENCY = 4;
+// Process-wide cap — parents emit `document_endpoint` calls in parallel, so
+// without this gate each parent fans out unboundedly.
+const THREAT_MODEL_CONCURRENCY = 10;
 const threatModelLimiter = pLimit(THREAT_MODEL_CONCURRENCY);
 
-// ── Bounded termination for the spawned threat-model child ──────────────────
-//
-// The `document_endpoint` tool blocks on `await agent.consume()` below. In
-// production a single threat-model await was observed hanging forever (5+ hrs),
-// freezing the parent tool-call, the parent agent session, and the whole recon
-// at "N-1/N apps". The root cause: `consume()` drains the child's `fullStream`
-// async iterator, and that iterator can WEDGE before emitting its final `finish`
-// chunk — typically after the child has already called its `response` tool and
-// produced a complete result. When it wedges, BOTH `consume()` and
-// `streamResult.finishReason` hang (they wait on the same `finish` chunk), even
-// though the work is done. So `consume()` is raced against signals that do NOT
-// depend on a clean stream teardown (no wall-clock timeout on the work itself):
-//
-//   (1) RESPONSE-CAPTURED (dominant mode) — a threat-model child is *semantically
-//       done* the instant it calls `response` and captures the structured
-//       result. Everything after is stream teardown, which can wedge. So we
-//       settle as soon as `agent.responseCaptured` fires (after a short grace so
-//       a healthy `consume()`, which returns a tick later, wins cleanly), using
-//       the captured result. This escapes the wedge in seconds — confirmed in
-//       production where children completed but the tool-call never settled.
-//   (2) NO-PROGRESS WATCHDOG — a child that wedges BEFORE its `response` tool's
-//       `execute` runs, so (1) never fires. The dominant case: the model emits
-//       the `response` tool-call and then stalls while STREAMING its large
-//       arguments (the multi-thousand-token threat model), and the AI SDK keeps
-//       RETRYING — re-streaming tokens forever. Raw token chatter looks like
-//       activity, so a naive "any bus event" watchdog never fires (this is why
-//       an earlier silence watchdog failed in production and stalled a recon).
-//       The fix: only `step-finish` / `tool-result` count as progress — a retry
-//       that never finishes completes no step and returns no tool result. No
-//       progress for THREAT_MODEL_SILENCE_MS ⇒ abandon (no result → degrade).
-//   (3) STEP BUDGET (`stepCountIs`) — a child that LOOPS through COMPLETED steps
-//       without calling `response` is bounded so its stream cannot run forever.
-//
-// On any abandonment we use the structured `response` if the child captured it
-// (only the plumbing hung — the result is good), else return null;
-// `document_endpoint` falls back to the heuristic risk score on null so the
-// recon advances instead of wedging.
+// `document_endpoint` blocks on `await agent.consume()`. The child's stream can
+// wedge before its final `finish` chunk (Bedrock goes byte-silent mid-stream),
+// which once hung the await forever. That's now bounded at the transport: the
+// byte-idle guard + stream resume (ai/streamIdleGuard.ts) make `consume()`
+// always settle — resolve on success, reject after resumes are exhausted. So
+// this only needs the response-captured fast-path below; on any failure the
+// catch returns null and `document_endpoint` degrades to the heuristic score.
 
-// Iteration-count ceiling (mode A). Sized comfortably above a normal threat
-// model's step count (the default CodeAgent ceiling is 10000); a run that
-// exceeds this is looping rather than progressing toward `response`.
+// Iteration ceiling: a run past this is looping, not progressing to `response`.
 const THREAT_MODEL_MAX_STEPS = 40;
 
-// Grace after the response-captured signal (mechanism 1). `responseCaptured`
-// fires synchronously from the `response` tool callback — a tick BEFORE a
-// healthy `consume()` does its final `next()` and returns. Without a grace the
-// race would pick the response signal on every healthy run and log a spurious
-// "abandoned" (the OUTPUT is identical either way — both resolve to the same
-// captured result — but the healthy path emits a clean "completed"). This is
-// NOT a bound on the work (the result is already captured) — only how long we
-// let a captured-but-not-yet-torn-down stream close on its own. A normal close
-// is milliseconds; the margin absorbs event-loop congestion from the up-to-10
-// concurrent threat models.
+// Grace after `responseCaptured` so a healthy `consume()` (which returns a tick
+// later with the same result) wins the race cleanly. Not a bound on the work —
+// the result is already captured; this only waits out a stream teardown.
 const THREAT_MODEL_RESPONSE_SETTLE_MS = 5 * 1000;
-
-// No-progress threshold. A child that completes NO step and returns NO tool
-// result for this long has stalled — it is wedged mid-step on a hung sub-tool,
-// OR (the dominant observed mode) wedged while STREAMING the large `response`
-// payload: the model emits the `response` tool-call and then stalls streaming
-// its multi-thousand-token arguments, so the tool's `execute` (where
-// `responseCaptured` fires) never runs AND the AI-SDK RETRIES re-stream the
-// args, producing continuous token chatter with no completed step. We treat
-// `step-finish` / `tool-result` as the only real progress signals precisely
-// because retries CAN'T fake them (a retry that never finishes the args
-// completes no step and returns no tool result) — counting raw token deltas
-// would let that chatter keep a wedged child "alive" forever (the original
-// silence watchdog's fatal flaw). Sized well above a normal step (reads finish
-// in seconds; a full `response` generates in ~1-3 min), so a working run always
-// produces a `step-finish`/`tool-result` inside the window. This is a liveness
-// bound (lack of progress), not a deadline on a working run.
-const THREAT_MODEL_SILENCE_MS = 8 * 60 * 1000;
-const THREAT_MODEL_SILENCE_POLL_MS = 15 * 1000;
-
-// Child bus events that count as REAL forward progress. Deliberately excludes
-// the streaming/in-progress events (`text-delta`, `tool-call-start/delta`,
-// `command-output`) — those are emitted continuously by an AI-SDK retry loop
-// that never actually finishes, so counting them defeats the watchdog. Only a
-// completed step or a returned tool result proves the child advanced.
-const THREAT_MODEL_LIVENESS_EVENTS = ["tool-result", "step-finish"] as const;
 
 // ---------------------------------------------------------------------------
 // Response schema
@@ -442,55 +366,23 @@ export async function generateThreatModelForEndpoint(
       excludeTools: ["document_endpoint", "document_app"],
     });
 
-    // `consume()` is raced against two abandonment signals so a wedged child
-    // can never block the tool indefinitely. Either resolves to ABANDON.
+    // Fast-path: a threat model is semantically done the instant it calls
+    // `response` and captures the result. If the stream then wedges during
+    // teardown, settle with the captured result (after a grace so a healthy
+    // `consume()` wins cleanly) rather than waiting it out. Resolves to ABANDON.
     const ABANDON = Symbol("threat-model-abandon");
-    let abandonReason = "";
-
-    // No-progress watchdog. Catches a child that wedges WITHOUT capturing a
-    // response — either frozen mid-step on a hung sub-tool, or (the dominant
-    // observed mode) wedged streaming the large `response` payload while the
-    // AI-SDK retries re-stream tokens forever. `lastProgress` advances ONLY on a
-    // completed step or returned tool result (see THREAT_MODEL_LIVENESS_EVENTS),
-    // so retry chatter cannot keep it alive; no real progress for the window ⇒
-    // abandon (no captured response → document_endpoint degrades to heuristic).
-    let lastActivity = Date.now();
-    const bumpActivity = () => {
-      lastActivity = Date.now();
-    };
-    for (const ev of THREAT_MODEL_LIVENESS_EVENTS) localBus.on(ev, bumpActivity);
-    let livenessTimer: ReturnType<typeof setInterval> | undefined;
-    const silenceWatchdog = new Promise<typeof ABANDON>((resolve) => {
-      livenessTimer = setInterval(() => {
-        if (Date.now() - lastActivity > THREAT_MODEL_SILENCE_MS) {
-          abandonReason = `no completed step or tool result for ${Math.round(
-            THREAT_MODEL_SILENCE_MS / 1000,
-          )}s (wedged before capturing a response)`;
-          resolve(ABANDON);
-        }
-      }, THREAT_MODEL_SILENCE_POLL_MS);
-    });
-
-    // Response-captured signal (mechanism 1 — the dominant mode). Fires once the
-    // child calls `response` and captures its structured result; the grace lets
-    // a healthy `consume()` (which returns a tick later) win cleanly. When the
-    // stream then wedges before tearing down, `consume()` never returns but the
-    // result already exists — this settles with it instead of hanging.
     let settleTimer: ReturnType<typeof setTimeout> | undefined;
     const responseSignal = new Promise<typeof ABANDON>((resolve) => {
       agent.responseCaptured.then(() => {
-        settleTimer = setTimeout(() => {
-          abandonReason = "response captured but stream did not tear down";
-          resolve(ABANDON);
-        }, THREAT_MODEL_RESPONSE_SETTLE_MS);
+        settleTimer = setTimeout(
+          () => resolve(ABANDON),
+          THREAT_MODEL_RESPONSE_SETTLE_MS,
+        );
       });
     });
 
     const cleanup = () => {
-      if (livenessTimer) clearInterval(livenessTimer);
       if (settleTimer) clearTimeout(settleTimer);
-      for (const ev of THREAT_MODEL_LIVENESS_EVENTS)
-        localBus.off(ev, bumpActivity);
     };
 
     const buildOutput = (result: ThreatModelResult): ThreatModelOutput => {
@@ -519,21 +411,11 @@ export async function generateThreatModelForEndpoint(
     };
 
     try {
-      const outcome = await Promise.race([
-        agent.consume(),
-        responseSignal,
-        silenceWatchdog,
-      ]);
+      const outcome = await Promise.race([agent.consume(), responseSignal]);
 
       if (outcome === ABANDON) {
-        // `consume()` did not return — either the child captured its result and
-        // the stream then wedged before tearing down (response-captured signal),
-        // or it froze before ever producing a result (silence watchdog). Abort
-        // the child (frees the pLimit slot + provider connection). If it captured
-        // its structured `response`, USE it — only the plumbing hung, the result
-        // is good. Otherwise degrade to null; `document_endpoint` falls back to
-        // the heuristic risk score, so the tool-call completes and the recon
-        // advances instead of hanging forever.
+        // Stream wedged during teardown after the result was captured. Use it;
+        // abort the child to free the pLimit slot + connection.
         const captured = agent.capturedResponse;
         childAbort.abort();
         ctx.eventBus?.emit("subagent-complete", {
@@ -541,18 +423,7 @@ export async function generateThreatModelForEndpoint(
           status: captured !== null ? "completed" : "failed",
           parentSubagentId: ctx.subagentId,
         });
-        if (captured === null) {
-          console.error(
-            `Threat model for ${input.routePath} abandoned (${abandonReason}); ` +
-              `no response captured — falling back to heuristic-only.`,
-          );
-          return null;
-        }
-        console.error(
-          `Threat model for ${input.routePath} abandoned (${abandonReason}) ` +
-            `but response was captured before wedge — using it.`,
-        );
-        return buildOutput(captured);
+        return captured === null ? null : buildOutput(captured);
       }
 
       const result = outcome;

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -9,18 +9,11 @@ import type { ToolContext } from "./types";
 const THREAT_MODEL_CONCURRENCY = 10;
 const threatModelLimiter = pLimit(THREAT_MODEL_CONCURRENCY);
 
-// `document_endpoint` blocks on `await agent.consume()`. The child's stream can
-// wedge before its final `finish` chunk (Bedrock goes byte-silent mid-stream),
-// which once hung the await forever. That's now bounded at the transport: the
-// byte-idle guard + stream resume (ai/streamIdleGuard.ts) make `consume()`
-// always settle — resolve on success, reject after resumes are exhausted. So
-// this only needs the response-captured fast-path below; on any failure the
+// `document_endpoint` blocks on `await agent.consume()`. consume() returns the
+// structured result as soon as the child captures it and is bounded by the
+// transport idle guard + resume (ai/streamIdleGuard.ts), so it always settles —
+// resolving on success, rejecting once resumes are exhausted. On any failure the
 // catch returns null and `document_endpoint` degrades to the heuristic score.
-
-// Grace after `responseCaptured` so a healthy `consume()` (which returns a tick
-// later with the same result) wins the race cleanly. Not a bound on the work —
-// the result is already captured; this only waits out a stream teardown.
-const THREAT_MODEL_RESPONSE_SETTLE_MS = 5 * 1000;
 
 // ---------------------------------------------------------------------------
 // Response schema
@@ -331,9 +324,9 @@ export async function generateThreatModelForEndpoint(
 
     const prompt = buildThreatModelPrompt(input, ctx.projectThreatModel);
 
-    // Child-scoped abort controller. The terminal-signal race cancels *this*
-    // threat model without touching the shared parent `ctx.abortSignal`; a
-    // parent abort still propagates down via the listener below.
+    // Child-scoped abort so a failure cancels *this* threat model without
+    // touching the shared parent `ctx.abortSignal`; a parent abort still
+    // propagates down via the listener below.
     const childAbort = new AbortController();
     if (ctx.abortSignal) {
       if (ctx.abortSignal.aborted) childAbort.abort();
@@ -356,25 +349,6 @@ export async function generateThreatModelForEndpoint(
       responseSchema: ThreatModelResultSchema,
       excludeTools: ["document_endpoint", "document_app"],
     });
-
-    // Fast-path: a threat model is semantically done the instant it calls
-    // `response` and captures the result. If the stream then wedges during
-    // teardown, settle with the captured result (after a grace so a healthy
-    // `consume()` wins cleanly) rather than waiting it out. Resolves to ABANDON.
-    const ABANDON = Symbol("threat-model-abandon");
-    let settleTimer: ReturnType<typeof setTimeout> | undefined;
-    const responseSignal = new Promise<typeof ABANDON>((resolve) => {
-      agent.responseCaptured.then(() => {
-        settleTimer = setTimeout(
-          () => resolve(ABANDON),
-          THREAT_MODEL_RESPONSE_SETTLE_MS,
-        );
-      });
-    });
-
-    const cleanup = () => {
-      if (settleTimer) clearTimeout(settleTimer);
-    };
 
     const buildOutput = (result: ThreatModelResult): ThreatModelOutput => {
       const totalScore =
@@ -402,30 +376,15 @@ export async function generateThreatModelForEndpoint(
     };
 
     try {
-      const outcome = await Promise.race([agent.consume(), responseSignal]);
-
-      if (outcome === ABANDON) {
-        // Stream wedged during teardown after the result was captured. Use it;
-        // abort the child to free the pLimit slot + connection.
-        const captured = agent.capturedResponse;
-        childAbort.abort();
-        ctx.eventBus?.emit("subagent-complete", {
-          subagentId,
-          status: captured !== null ? "completed" : "failed",
-          parentSubagentId: ctx.subagentId,
-        });
-        return captured === null ? null : buildOutput(captured);
-      }
-
-      const result = outcome;
+      // consume() returns the captured result and drains the rest in the
+      // background; the transport idle guard bounds it, so no watchdog here.
+      const result = await agent.consume();
       ctx.eventBus?.emit("subagent-complete", {
         subagentId,
         status: "completed",
         parentSubagentId: ctx.subagentId,
       });
-
-      if (!result) return null;
-      return buildOutput(result);
+      return result ? buildOutput(result) : null;
     } catch (error) {
       childAbort.abort();
       ctx.eventBus?.emit("subagent-complete", {
@@ -437,8 +396,6 @@ export async function generateThreatModelForEndpoint(
         `Threat model generation failed for ${input.routePath}: ${error instanceof Error ? error.message : String(error)}`,
       );
       return null;
-    } finally {
-      cleanup();
     }
   });
 }

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -9,6 +9,37 @@ import type { ToolContext } from "./types";
 const THREAT_MODEL_CONCURRENCY = 10;
 const threatModelLimiter = pLimit(THREAT_MODEL_CONCURRENCY);
 
+// ── Liveness watchdog for the spawned threat-model child ────────────────────
+//
+// The `document_endpoint` tool blocks on `await agent.consume()` below. A child
+// can wedge in a way its own 5-min model-idle timeout never catches — a hung
+// post-stream step, a stuck provider call, or a `consume()` that never settles
+// even after the child's session has already ended. When that happens the
+// `await` would block forever, freezing the parent tool-call, the parent agent
+// session, and the whole recon at "N-1/N apps" (exactly the observed hang).
+//
+// We bound the await on *liveness* rather than a wall-clock deadline: as long
+// as the child keeps emitting stream activity we keep waiting (a slow but
+// healthy threat model is never killed). Only if the child goes completely
+// silent for longer than this window do we abandon it and fall back to the
+// heuristic-only result (`document_endpoint` already tolerates a null return).
+//
+// Sized comfortably above the child's own 5-min model-idle timeout + auto-
+// resume, so a *recoverable* model stall produces fresh activity and resets the
+// timer before this fires; only a genuine wedge trips it.
+const THREAT_MODEL_LIVENESS_TIMEOUT_MS = 8 * 60 * 1000;
+const THREAT_MODEL_LIVENESS_POLL_MS = 15 * 1000;
+
+// Child stream events that count as "still making progress". `text-delta` fires
+// on essentially every token, so a healthy run resets the timer constantly.
+const THREAT_MODEL_LIVENESS_EVENTS = [
+  "text-delta",
+  "tool-call-start",
+  "tool-call-delta",
+  "tool-call-complete",
+  "tool-result",
+] as const;
+
 // ---------------------------------------------------------------------------
 // Response schema
 // ---------------------------------------------------------------------------
@@ -318,6 +349,18 @@ export async function generateThreatModelForEndpoint(
 
     const prompt = buildThreatModelPrompt(input, ctx.projectThreatModel);
 
+    // Child-scoped abort controller. The liveness watchdog cancels *this*
+    // threat model without touching the shared parent `ctx.abortSignal`; a
+    // parent abort still propagates down via the listener below.
+    const childAbort = new AbortController();
+    if (ctx.abortSignal) {
+      if (ctx.abortSignal.aborted) childAbort.abort();
+      else
+        ctx.abortSignal.addEventListener("abort", () => childAbort.abort(), {
+          once: true,
+        });
+    }
+
     const agent = new CodeAgent<ThreatModelResult>({
       codebasePath: ctx.agentCwd,
       objective: prompt,
@@ -325,15 +368,59 @@ export async function generateThreatModelForEndpoint(
       model,
       session: ctx.session,
       authConfig: ctx.authConfig,
-      abortSignal: ctx.abortSignal,
+      abortSignal: childAbort.signal,
       eventBus: localBus,
       subagentId,
       responseSchema: ThreatModelResultSchema,
       excludeTools: ["document_endpoint", "document_app"],
     });
 
+    // Liveness watchdog: reset `lastActivity` on every child stream event;
+    // resolve to STUCK if the child goes silent past the timeout window.
+    let lastActivity = Date.now();
+    const bumpActivity = () => {
+      lastActivity = Date.now();
+    };
+    for (const ev of THREAT_MODEL_LIVENESS_EVENTS) localBus.on(ev, bumpActivity);
+
+    let livenessTimer: ReturnType<typeof setInterval> | undefined;
+    const STUCK = Symbol("threat-model-stuck");
+    const watchdog = new Promise<typeof STUCK>((resolve) => {
+      livenessTimer = setInterval(() => {
+        if (Date.now() - lastActivity > THREAT_MODEL_LIVENESS_TIMEOUT_MS) {
+          resolve(STUCK);
+        }
+      }, THREAT_MODEL_LIVENESS_POLL_MS);
+    });
+    const cleanupWatchdog = () => {
+      if (livenessTimer) clearInterval(livenessTimer);
+      for (const ev of THREAT_MODEL_LIVENESS_EVENTS)
+        localBus.off(ev, bumpActivity);
+    };
+
     try {
-      const result = await agent.consume();
+      const outcome = await Promise.race([agent.consume(), watchdog]);
+
+      if (outcome === STUCK) {
+        // Genuine wedge: abort the child (frees the pLimit slot + provider
+        // connection) and degrade. `document_endpoint` falls back to the
+        // heuristic risk score when this returns null — so the tool-call
+        // completes and the recon advances instead of hanging forever.
+        childAbort.abort();
+        ctx.eventBus?.emit("subagent-complete", {
+          subagentId,
+          status: "failed",
+          parentSubagentId: ctx.subagentId,
+        });
+        console.error(
+          `Threat model for ${input.routePath} stuck (no activity for ` +
+            `${Math.round(THREAT_MODEL_LIVENESS_TIMEOUT_MS / 1000)}s); ` +
+            `abandoning and falling back to heuristic-only.`,
+        );
+        return null;
+      }
+
+      const result = outcome;
       ctx.eventBus?.emit("subagent-complete", {
         subagentId,
         status: "completed",
@@ -366,6 +453,7 @@ export async function generateThreatModelForEndpoint(
         ),
       };
     } catch (error) {
+      childAbort.abort();
       ctx.eventBus?.emit("subagent-complete", {
         subagentId,
         status: "failed",
@@ -375,6 +463,8 @@ export async function generateThreatModelForEndpoint(
         `Threat model generation failed for ${input.routePath}: ${error instanceof Error ? error.message : String(error)}`,
       );
       return null;
+    } finally {
+      cleanupWatchdog();
     }
   });
 }

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -1,3 +1,4 @@
+import { stepCountIs } from "ai";
 import pLimit from "p-limit";
 import { z } from "zod";
 import { AgentEventBus } from "../../../eventBus";
@@ -16,6 +17,13 @@ const threatModelLimiter = pLimit(THREAT_MODEL_CONCURRENCY);
 // transport idle guard + resume (ai/streamIdleGuard.ts), so it always settles —
 // resolving on success, rejecting once resumes are exhausted. On any failure the
 // catch returns null and `document_endpoint` degrades to the heuristic score.
+
+// Hard ceiling on the child's agent loop. Under the Bedrock wedge rate the model
+// can truncate its structured `response`, fail schema validation, and re-call
+// `response` in a loop (observed: 7-10 calls, 100+ parts, no completion). This
+// caps that loop so the child always terminates → degrades to heuristic → the
+// recon advances. A healthy threat model finishes in well under this.
+const THREAT_MODEL_MAX_STEPS = 40;
 
 // ---------------------------------------------------------------------------
 // Response schema
@@ -349,6 +357,7 @@ export async function generateThreatModelForEndpoint(
       eventBus: localBus,
       subagentId,
       responseSchema: ThreatModelResultSchema,
+      stopWhen: stepCountIs(THREAT_MODEL_MAX_STEPS),
       excludeTools: ["document_endpoint", "document_app"],
     });
 

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -1,3 +1,4 @@
+import { stepCountIs } from "ai";
 import pLimit from "p-limit";
 import { z } from "zod";
 import { AgentEventBus } from "../../../eventBus";
@@ -9,36 +10,50 @@ import type { ToolContext } from "./types";
 const THREAT_MODEL_CONCURRENCY = 10;
 const threatModelLimiter = pLimit(THREAT_MODEL_CONCURRENCY);
 
-// ── Liveness watchdog for the spawned threat-model child ────────────────────
+// ── Bounded termination for the spawned threat-model child ──────────────────
 //
-// The `document_endpoint` tool blocks on `await agent.consume()` below. A child
-// can wedge in a way its own 5-min model-idle timeout never catches — a hung
-// post-stream step, a stuck provider call, or a `consume()` that never settles
-// even after the child's session has already ended. When that happens the
-// `await` would block forever, freezing the parent tool-call, the parent agent
-// session, and the whole recon at "N-1/N apps" (exactly the observed hang).
+// The `document_endpoint` tool blocks on `await agent.consume()` below. In
+// production a single threat-model await was observed hanging forever (5+ hrs),
+// freezing the parent tool-call, the parent agent session, and the whole recon
+// at "N-1/N apps". Two distinct failure modes produced this:
 //
-// We bound the await on *liveness* rather than a wall-clock deadline: as long
-// as the child keeps emitting stream activity we keep waiting (a slow but
-// healthy threat model is never killed). Only if the child goes completely
-// silent for longer than this window do we abandon it and fall back to the
-// heuristic-only result (`document_endpoint` already tolerates a null return).
+//   (A) the child loops without ever calling its `response` tool, so its model
+//       stream never terminates and `consume()` never returns; and
+//   (B) the child's stream finishes (the child session shows completed) but
+//       `consume()`'s `for await (…fullStream)` never closes, so `consume()`
+//       hangs even though the run is done.
 //
-// Sized comfortably above the child's own 5-min model-idle timeout + auto-
-// resume, so a *recoverable* model stall produces fresh activity and resets the
-// timer before this fires; only a genuine wedge trips it.
-const THREAT_MODEL_LIVENESS_TIMEOUT_MS = 8 * 60 * 1000;
-const THREAT_MODEL_LIVENESS_POLL_MS = 15 * 1000;
+// We close both holes with first-principles bounds — no wall-clock timeout:
+//
+//   1. A step budget (`stepCountIs(THREAT_MODEL_MAX_STEPS)`) on the child agent
+//      guarantees its stream ALWAYS terminates. A threat model that can't emit
+//      its structured `response` within this many iterations is malfunctioning;
+//      this is an iteration-count bound, not a clock, so a slow-but-healthy run
+//      is never killed. Fixes (A).
+//   2. We race `consume()` against the agent's authoritative terminal signal,
+//      `streamResult.finishReason` (a Promise that resolves when streamText
+//      finishes for ANY reason — response tool, step budget, or error). If the
+//      stream is done but `consume()` is still pending we abort the child and
+//      degrade instead of waiting forever. Fixes (B).
+//
+// `document_endpoint` already falls back to the heuristic risk score when this
+// returns null, so a degraded path lets the recon advance instead of wedging.
 
-// Child stream events that count as "still making progress". `text-delta` fires
-// on essentially every token, so a healthy run resets the timer constantly.
-const THREAT_MODEL_LIVENESS_EVENTS = [
-  "text-delta",
-  "tool-call-start",
-  "tool-call-delta",
-  "tool-call-complete",
-  "tool-result",
-] as const;
+// Iteration-count ceiling for the child. Sized comfortably above a normal
+// threat model's step count (the default CodeAgent ceiling is 10000); a run
+// that exceeds this is looping rather than progressing toward `response`.
+const THREAT_MODEL_MAX_STEPS = 40;
+
+// Settle window after the terminal signal. `finishReason` fires the instant
+// streamText finishes, which in a healthy run is a tick BEFORE `consume()`'s
+// `for await` does its final `next()` and returns. Without a grace, the race
+// would pick STREAM_DONE on every healthy run and degrade every threat model.
+// This is NOT a bound on the threat model's work (finishReason already
+// confirmed it's done) — only on how long we wait for a finished stream's
+// iterator to close before treating it as wedged. A normal close happens in
+// milliseconds; this margin absorbs event-loop congestion from the up-to-10
+// concurrent threat models without masking a real hang.
+const THREAT_MODEL_STREAM_SETTLE_MS = 10 * 1000;
 
 // ---------------------------------------------------------------------------
 // Response schema
@@ -349,7 +364,7 @@ export async function generateThreatModelForEndpoint(
 
     const prompt = buildThreatModelPrompt(input, ctx.projectThreatModel);
 
-    // Child-scoped abort controller. The liveness watchdog cancels *this*
+    // Child-scoped abort controller. The terminal-signal race cancels *this*
     // threat model without touching the shared parent `ctx.abortSignal`; a
     // parent abort still propagates down via the listener below.
     const childAbort = new AbortController();
@@ -372,69 +387,42 @@ export async function generateThreatModelForEndpoint(
       eventBus: localBus,
       subagentId,
       responseSchema: ThreatModelResultSchema,
+      // Bound the child's iterations so its stream ALWAYS terminates. This
+      // merges with the responseSchema's own `hasToolCall(response)` stop
+      // condition inside OffensiveSecurityAgent (either condition ends the
+      // run), so a healthy run still stops the moment it calls `response`.
+      stopWhen: stepCountIs(THREAT_MODEL_MAX_STEPS),
       excludeTools: ["document_endpoint", "document_app"],
     });
 
-    // Liveness watchdog: reset `lastActivity` on every child stream event;
-    // resolve to STUCK if the child goes silent past the timeout window.
-    let lastActivity = Date.now();
-    const bumpActivity = () => {
-      lastActivity = Date.now();
-    };
-    for (const ev of THREAT_MODEL_LIVENESS_EVENTS) localBus.on(ev, bumpActivity);
-
-    let livenessTimer: ReturnType<typeof setInterval> | undefined;
-    const STUCK = Symbol("threat-model-stuck");
-    const watchdog = new Promise<typeof STUCK>((resolve) => {
-      livenessTimer = setInterval(() => {
-        if (Date.now() - lastActivity > THREAT_MODEL_LIVENESS_TIMEOUT_MS) {
-          resolve(STUCK);
-        }
-      }, THREAT_MODEL_LIVENESS_POLL_MS);
-    });
-    const cleanupWatchdog = () => {
-      if (livenessTimer) clearInterval(livenessTimer);
-      for (const ev of THREAT_MODEL_LIVENESS_EVENTS)
-        localBus.off(ev, bumpActivity);
-    };
-
-    try {
-      const outcome = await Promise.race([agent.consume(), watchdog]);
-
-      if (outcome === STUCK) {
-        // Genuine wedge: abort the child (frees the pLimit slot + provider
-        // connection) and degrade. `document_endpoint` falls back to the
-        // heuristic risk score when this returns null — so the tool-call
-        // completes and the recon advances instead of hanging forever.
-        childAbort.abort();
-        ctx.eventBus?.emit("subagent-complete", {
-          subagentId,
-          status: "failed",
-          parentSubagentId: ctx.subagentId,
-        });
-        console.error(
-          `Threat model for ${input.routePath} stuck (no activity for ` +
-            `${Math.round(THREAT_MODEL_LIVENESS_TIMEOUT_MS / 1000)}s); ` +
-            `abandoning and falling back to heuristic-only.`,
+    // Terminal signal: `finishReason` resolves when the underlying streamText
+    // finishes for ANY reason — response tool, step budget, or error. Racing
+    // `consume()` against it guarantees we don't block forever on a stream that
+    // has finished but whose `for await` iterator never closes (failure mode B).
+    const STREAM_DONE = Symbol("threat-model-stream-done");
+    // `finishReason` is a thenable (`PromiseLike`), not a full `Promise`, so it
+    // has no `.catch`. When it settles (either way) we arm a short settle timer;
+    // STREAM_DONE only wins if `consume()` still hasn't returned by the end of
+    // the grace — i.e. the stream is genuinely done but its iterator is wedged
+    // (failure mode B). In a healthy run `consume()` returns within the grace
+    // and wins the race, so the threat model is used normally.
+    let settleTimer: ReturnType<typeof setTimeout> | undefined;
+    const terminalSignal = new Promise<typeof STREAM_DONE>((resolve) => {
+      const arm = () => {
+        settleTimer = setTimeout(
+          () => resolve(STREAM_DONE),
+          THREAT_MODEL_STREAM_SETTLE_MS,
         );
-        return null;
-      }
+      };
+      Promise.resolve(agent.streamResult.finishReason).then(arm, arm);
+    });
 
-      const result = outcome;
-      ctx.eventBus?.emit("subagent-complete", {
-        subagentId,
-        status: "completed",
-        parentSubagentId: ctx.subagentId,
-      });
-
-      if (!result) return null;
-
+    const buildOutput = (result: ThreatModelResult): ThreatModelOutput => {
       const totalScore =
         result.exposure +
         result.dataSensitivity +
         result.functionCriticality +
         result.securityIndicators;
-
       return {
         businessLogic: result.businessLogic,
         threatModel: result.threatModel,
@@ -452,6 +440,47 @@ export async function generateThreatModelForEndpoint(
           flattenPentestObjective,
         ),
       };
+    };
+
+    try {
+      const outcome = await Promise.race([agent.consume(), terminalSignal]);
+
+      if (outcome === STREAM_DONE) {
+        // Stream terminated (response tool, step budget, or error) but
+        // `consume()` is still pending past the settle window — the iterator is
+        // wedged (failure mode B). Abort the child (frees the pLimit slot +
+        // provider connection). If the child captured its structured response
+        // before the stream ended, USE it — only the iterator hung, the result
+        // is good. Otherwise degrade to null; `document_endpoint` falls back to
+        // the heuristic risk score, so the tool-call completes and the recon
+        // advances instead of hanging forever.
+        const captured = agent.capturedResponse;
+        childAbort.abort();
+        ctx.eventBus?.emit("subagent-complete", {
+          subagentId,
+          status: captured !== null ? "completed" : "failed",
+          parentSubagentId: ctx.subagentId,
+        });
+        if (captured === null) {
+          console.error(
+            `Threat model for ${input.routePath}: stream finished but ` +
+              `consume() did not settle and no response was captured; ` +
+              `falling back to heuristic-only.`,
+          );
+          return null;
+        }
+        return buildOutput(captured);
+      }
+
+      const result = outcome;
+      ctx.eventBus?.emit("subagent-complete", {
+        subagentId,
+        status: "completed",
+        parentSubagentId: ctx.subagentId,
+      });
+
+      if (!result) return null;
+      return buildOutput(result);
     } catch (error) {
       childAbort.abort();
       ctx.eventBus?.emit("subagent-complete", {
@@ -464,7 +493,7 @@ export async function generateThreatModelForEndpoint(
       );
       return null;
     } finally {
-      cleanupWatchdog();
+      if (settleTimer) clearTimeout(settleTimer);
     }
   });
 }

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -21,6 +21,7 @@ import { shouldRecordAiPayloads } from "../observability";
 import { withCachedLastMessage, withCachedSystemPrompt } from "./caching";
 import { fitMessagesToContext, truncateWithMarker } from "./contextManagement";
 import { getMaxOutputTokens, getModelInfo } from "./models";
+import { STREAM_DEBUG } from "./streamTelemetry";
 import {
   type AIAuthConfig,
   checkIfContextLengthError,
@@ -277,7 +278,21 @@ async function* withIdleTimeout<T>(
 }
 
 function isStreamIdleTimeoutError(error: unknown): boolean {
-  return error instanceof StreamIdleTimeoutError;
+  // Chunk-level idle (withIdleTimeout) OR transport-level byte-silence
+  // (ProviderStreamIdleError from the bedrock fetch guard). The latter is
+  // surfaced from below the AI SDK, which may wrap it in an APICallError, so
+  // walk the cause chain and accept the stable marker too.
+  for (let e: unknown = error, depth = 0; e != null && depth < 6; depth++) {
+    if (e instanceof StreamIdleTimeoutError) return true;
+    if (
+      typeof e === "object" &&
+      (e as { isProviderStreamIdle?: unknown }).isProviderStreamIdle === true
+    ) {
+      return true;
+    }
+    e = (e as { cause?: unknown }).cause;
+  }
+  return false;
 }
 
 /**
@@ -401,7 +416,10 @@ function wrapStreamWithErrorHandler(
                 messagesContainer.current.length > 0
               ) {
                 const nextIdleCount = idleResumeCount + 1;
-                if (!silent) {
+                // Surface idle-resume even on silent sub-agent paths when
+                // stream debugging — a transport wedge + auto-recovery is a
+                // noteworthy event, not routine chatter.
+                if (!silent || STREAM_DEBUG) {
                   console.warn(
                     `Stream stalled (attempt ${nextIdleCount}/${MAX_IDLE_RESUME_RETRIES}), resuming with ${messagesContainer.current.length} messages: ${errorMessage}`,
                   );

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -294,10 +294,22 @@ function isStreamIdleTimeoutError(error: unknown): boolean {
  * chunks for the same id (defensive — should never happen in practice) are
  * deduplicated. `tool-result` chunks without a matching open call are
  * ignored so the counter can never go negative.
+ *
+ * EXCEPTION — the structured `response` tool is NEVER counted as in-flight. Its
+ * `execute` only captures the result and returns synchronously (it does no real
+ * work), so it can't be a slow tool the gate needs to wait out. But the model
+ * streams that tool's arguments — frequently a multi-thousand-token structured
+ * payload — and a provider (Bedrock) stream that WEDGES mid-payload would, if
+ * `response` were gated, suppress the idle timeout forever (a confirmed hang:
+ * threat-model children frozen on `response` for 10+ min, never recovered).
+ * Leaving `response` ungated keeps the idle timer live across its generation,
+ * so a stalled response stream trips the normal idle-timeout → auto-resume path.
  */
+const NON_GATED_TOOLS = new Set<string>(["response"]);
+
 function createToolExecutionGate(): {
   shouldEnforceIdleTimeout: () => boolean;
-  observe: (chunk: { type: string; toolCallId?: string }) => void;
+  observe: (chunk: { type: string; toolCallId?: string; toolName?: string }) => void;
 } {
   let inFlight = 0;
   const open = new Set<string>();
@@ -306,6 +318,7 @@ function createToolExecutionGate(): {
     shouldEnforceIdleTimeout: () => inFlight === 0,
     observe: (chunk) => {
       if (chunk.type === "tool-call") {
+        if (chunk.toolName && NON_GATED_TOOLS.has(chunk.toolName)) return;
         const id = chunk.toolCallId;
         if (id) {
           if (!open.has(id)) {
@@ -321,7 +334,7 @@ function createToolExecutionGate(): {
           if (open.delete(id)) {
             inFlight = Math.max(0, inFlight - 1);
           }
-        } else {
+        } else if (!(chunk.toolName && NON_GATED_TOOLS.has(chunk.toolName))) {
           inFlight = Math.max(0, inFlight - 1);
         }
       }

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -278,10 +278,8 @@ async function* withIdleTimeout<T>(
 }
 
 function isStreamIdleTimeoutError(error: unknown): boolean {
-  // Chunk-level idle (withIdleTimeout) OR transport-level byte-silence
-  // (ProviderStreamIdleError from the bedrock fetch guard). The latter is
-  // surfaced from below the AI SDK, which may wrap it in an APICallError, so
-  // walk the cause chain and accept the stable marker too.
+  // Accept the chunk-level StreamIdleTimeoutError and the transport-level
+  // ProviderStreamIdleError, which the AI SDK may rewrap — so walk `cause`.
   for (let e: unknown = error, depth = 0; e != null && depth < 6; depth++) {
     if (e instanceof StreamIdleTimeoutError) return true;
     if (
@@ -416,9 +414,7 @@ function wrapStreamWithErrorHandler(
                 messagesContainer.current.length > 0
               ) {
                 const nextIdleCount = idleResumeCount + 1;
-                // Surface idle-resume even on silent sub-agent paths when
-                // stream debugging — a transport wedge + auto-recovery is a
-                // noteworthy event, not routine chatter.
+                // Surfaced on silent sub-agents too when stream-debugging.
                 if (!silent || STREAM_DEBUG) {
                   console.warn(
                     `Stream stalled (attempt ${nextIdleCount}/${MAX_IDLE_RESUME_RETRIES}), resuming with ${messagesContainer.current.length} messages: ${errorMessage}`,

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -8,6 +8,7 @@ import type {
   SharedV3Warning,
 } from "@ai-sdk/provider";
 import { buildStreamingFetchSignal } from "../utils";
+import { StreamTelemetry, wallNow } from "../streamTelemetry";
 import { convertToBedrockFormat } from "./pensarFormatters";
 import { signGatewayRequest } from "./pensarSigning";
 import { parseSSE } from "./pensarSSE";
@@ -355,8 +356,12 @@ export function createPensarModel(
             Number.isFinite(rawIdleTimeout) && rawIdleTimeout > 0
               ? rawIdleTimeout
               : 90_000;
+          const telemetry = new StreamTelemetry(bedrockModelId, wallNow());
           try {
-            for await (const sse of parseSSE(sseStream, { idleTimeoutMs })) {
+            for await (const sse of parseSSE(sseStream, {
+              idleTimeoutMs,
+              telemetry,
+            })) {
               const now = Date.now();
               const gap = now - lastEventTime;
               if (gap > 5000) {
@@ -437,6 +442,7 @@ export function createPensarModel(
                       id: activeReasoningId,
                     });
                   } else if (cbType === "text") {
+                    telemetry.setPhase("streaming-text", wallNow());
                     activeTextId = `text-${Date.now()}-${parsed.index}`;
                     controller.enqueue({
                       type: "text-start",
@@ -445,6 +451,10 @@ export function createPensarModel(
                   } else if (cbType === "tool_use") {
                     activeToolId = (cb?.id as string) ?? `tool-${Date.now()}`;
                     activeToolName = (cb?.name as string) ?? "unknown";
+                    telemetry.setPhase(
+                      `streaming-tool-args:${activeToolName}`,
+                      wallNow(),
+                    );
                     activeToolInput = "";
                     controller.enqueue({
                       type: "tool-input-start",
@@ -548,6 +558,7 @@ export function createPensarModel(
 
                 case "message_stop": {
                   // Stream complete
+                  telemetry.setPhase("finish", wallNow());
                   break;
                 }
               }
@@ -580,8 +591,14 @@ export function createPensarModel(
                 },
               },
             });
+            telemetry.finish(wallNow());
             controller.close();
           } catch (err) {
+            telemetry.wedge(
+              err instanceof Error ? err.message : String(err),
+              wallNow(),
+            );
+            telemetry.finish(wallNow());
             logError(
               `  stream error: events=${eventCount}, activeToolId=${activeToolId}, activeToolName=${activeToolName}, toolInputLen=${activeToolInput.length}, timeSinceLastEvent=${Date.now() - lastEventTime}ms`,
             );

--- a/src/core/ai/providers/pensarSSE.ts
+++ b/src/core/ai/providers/pensarSSE.ts
@@ -23,11 +23,7 @@ export interface ParseSSEOptions {
    * Default: 90_000.
    */
   idleTimeoutMs?: number;
-  /**
-   * Optional per-stream telemetry. Records raw bytes (transport liveness) and
-   * parsed events (application progress) on separate clocks so a dribbling-but-
-   * alive stream can be told apart from a dead/half-open one.
-   */
+  /** Optional per-stream connection telemetry (see streamTelemetry.ts). */
   telemetry?: StreamTelemetry;
 }
 
@@ -62,13 +58,7 @@ export async function* parseSSE(
       try {
         result = await Promise.race([reader.read(), idlePromise]);
       } catch (err) {
-        // The idle timer fired (no bytes for idleTimeoutMs) — the transport is
-        // dead/half-open. Snapshot it loudly before propagating so a failed fix
-        // is debuggable.
-        options.telemetry?.wedge(
-          `no bytes for ${idleTimeoutMs}ms`,
-          wallNow(),
-        );
+        options.telemetry?.wedge(`no bytes for ${idleTimeoutMs}ms`, wallNow());
         await reader.cancel(err).catch(() => {});
         throw err;
       } finally {

--- a/src/core/ai/providers/pensarSSE.ts
+++ b/src/core/ai/providers/pensarSSE.ts
@@ -6,6 +6,8 @@
  * whenever a complete SSE message boundary (blank line) is encountered.
  */
 
+import { type StreamTelemetry, wallNow } from "../streamTelemetry";
+
 const DEBUG =
   process.env.PENSAR_DEBUG === "1" || process.env.PENSAR_DEBUG === "true";
 
@@ -21,6 +23,12 @@ export interface ParseSSEOptions {
    * Default: 90_000.
    */
   idleTimeoutMs?: number;
+  /**
+   * Optional per-stream telemetry. Records raw bytes (transport liveness) and
+   * parsed events (application progress) on separate clocks so a dribbling-but-
+   * alive stream can be told apart from a dead/half-open one.
+   */
+  telemetry?: StreamTelemetry;
 }
 
 export async function* parseSSE(
@@ -54,6 +62,13 @@ export async function* parseSSE(
       try {
         result = await Promise.race([reader.read(), idlePromise]);
       } catch (err) {
+        // The idle timer fired (no bytes for idleTimeoutMs) — the transport is
+        // dead/half-open. Snapshot it loudly before propagating so a failed fix
+        // is debuggable.
+        options.telemetry?.wedge(
+          `no bytes for ${idleTimeoutMs}ms`,
+          wallNow(),
+        );
         await reader.cancel(err).catch(() => {});
         throw err;
       } finally {
@@ -76,6 +91,7 @@ export async function* parseSSE(
       const value = result.value;
       chunkCount++;
       totalBytes += value.byteLength;
+      options.telemetry?.recordByte(value.byteLength, wallNow());
       const decoded = decoder.decode(value, { stream: true });
 
       if (DEBUG && chunkCount <= 3) {
@@ -95,6 +111,7 @@ export async function* parseSSE(
         if (line === "") {
           if (currentData.length > 0) {
             eventCount++;
+            options.telemetry?.recordEvent(wallNow());
             yield { event: currentEvent, data: currentData.join("\n") };
           }
           currentEvent = "message";

--- a/src/core/ai/streamIdleGuard.test.ts
+++ b/src/core/ai/streamIdleGuard.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import { idleGuardedStream, ProviderStreamIdleError } from "./streamIdleGuard";
+
+const enc = new TextEncoder();
+
+/** Drain a byte stream to a single concatenated string. */
+async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const dec = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += dec.decode(value, { stream: true });
+  }
+  return out;
+}
+
+/** A stream that enqueues each chunk after its delay (ms from start). */
+function timedStream(
+  chunks: Array<{ at: number; text: string }>,
+): ReadableStream<Uint8Array> {
+  const timers: ReturnType<typeof setTimeout>[] = [];
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const maxAt = Math.max(0, ...chunks.map((c) => c.at));
+      for (const c of chunks) {
+        timers.push(
+          setTimeout(() => controller.enqueue(enc.encode(c.text)), c.at),
+        );
+      }
+      timers.push(setTimeout(() => controller.close(), maxAt + 5));
+    },
+    cancel() {
+      for (const t of timers) clearTimeout(t);
+    },
+  });
+}
+
+/** A stream that emits one chunk then goes silent forever (never closes). */
+function wedgingStream(firstChunk: string): {
+  stream: ReadableStream<Uint8Array>;
+  cancelled: () => boolean;
+} {
+  let wasCancelled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(enc.encode(firstChunk));
+      // ...then never enqueue again and never close — a half-open socket.
+    },
+    cancel() {
+      wasCancelled = true;
+    },
+  });
+  return { stream, cancelled: () => wasCancelled };
+}
+
+describe("idleGuardedStream", () => {
+  it("passes bytes through unchanged when the source flows steadily", async () => {
+    const source = timedStream([
+      { at: 0, text: "hello " },
+      { at: 20, text: "wedge-" },
+      { at: 40, text: "free world" },
+    ]);
+    const guarded = idleGuardedStream(source, { idleTimeoutMs: 200 });
+    expect(await drain(guarded)).toBe("hello wedge-free world");
+  });
+
+  it("stays alive across gaps shorter than the idle window", async () => {
+    // 60ms gaps under a 150ms window must NOT trip the guard.
+    const source = timedStream([
+      { at: 0, text: "a" },
+      { at: 60, text: "b" },
+      { at: 120, text: "c" },
+    ]);
+    const guarded = idleGuardedStream(source, { idleTimeoutMs: 150 });
+    expect(await drain(guarded)).toBe("abc");
+  });
+
+  it("errors after the idle window when the source goes byte-silent mid-stream", async () => {
+    const { stream, cancelled } = wedgingStream("partial response");
+    const guarded = idleGuardedStream(stream, { idleTimeoutMs: 60 });
+
+    const reader = guarded.getReader();
+    // First chunk arrives fine.
+    const first = await reader.read();
+    expect(new TextDecoder().decode(first.value)).toBe("partial response");
+
+    // The next read blocks on a dead socket and must reject within the window.
+    await expect(reader.read()).rejects.toThrow(ProviderStreamIdleError);
+    // The guard must cancel the upstream so the socket is released.
+    expect(cancelled()).toBe(true);
+  });
+
+  it("throws a marked ProviderStreamIdleError findable through a cause chain", async () => {
+    const { stream } = wedgingStream("x");
+    const guarded = idleGuardedStream(stream, { idleTimeoutMs: 40 });
+    const reader = guarded.getReader();
+    await reader.read();
+    let caught: unknown;
+    await reader.read().catch((e) => {
+      caught = e;
+    });
+    // The stable marker ai.ts walks for, even when wrapped (e.g. APICallError).
+    expect(caught).toBeInstanceOf(ProviderStreamIdleError);
+    expect((caught as ProviderStreamIdleError).isProviderStreamIdle).toBe(true);
+    // Survives one level of provider wrapping via `cause`.
+    const wrapped = new Error("API call failed", { cause: caught });
+    expect(
+      (wrapped.cause as { isProviderStreamIdle?: boolean }).isProviderStreamIdle,
+    ).toBe(true);
+  });
+
+  it("records bytes and a wedge on the telemetry hook", async () => {
+    const events: string[] = [];
+    const fakeTelemetry = {
+      recordByte: () => events.push("byte"),
+      wedge: () => events.push("wedge"),
+      finish: () => events.push("finish"),
+    };
+    const { stream } = wedgingStream("x");
+    const guarded = idleGuardedStream(stream, {
+      idleTimeoutMs: 40,
+      // Only the three methods the guard calls are exercised here.
+      telemetry: fakeTelemetry as never,
+    });
+
+    const reader = guarded.getReader();
+    await reader.read();
+    await reader.read().catch(() => {});
+
+    expect(events).toContain("byte");
+    expect(events).toContain("wedge");
+    expect(events).toContain("finish");
+  });
+});

--- a/src/core/ai/streamIdleGuard.test.ts
+++ b/src/core/ai/streamIdleGuard.test.ts
@@ -68,7 +68,6 @@ describe("idleGuardedStream", () => {
   });
 
   it("stays alive across gaps shorter than the idle window", async () => {
-    // 60ms gaps under a 150ms window must NOT trip the guard.
     const source = timedStream([
       { at: 0, text: "a" },
       { at: 60, text: "b" },
@@ -83,14 +82,11 @@ describe("idleGuardedStream", () => {
     const guarded = idleGuardedStream(stream, { idleTimeoutMs: 60 });
 
     const reader = guarded.getReader();
-    // First chunk arrives fine.
     const first = await reader.read();
     expect(new TextDecoder().decode(first.value)).toBe("partial response");
 
-    // The next read blocks on a dead socket and must reject within the window.
     await expect(reader.read()).rejects.toThrow(ProviderStreamIdleError);
-    // The guard must cancel the upstream so the socket is released.
-    expect(cancelled()).toBe(true);
+    expect(cancelled()).toBe(true); // upstream released
   });
 
   it("throws a marked ProviderStreamIdleError findable through a cause chain", async () => {
@@ -122,7 +118,6 @@ describe("idleGuardedStream", () => {
     const { stream } = wedgingStream("x");
     const guarded = idleGuardedStream(stream, {
       idleTimeoutMs: 40,
-      // Only the three methods the guard calls are exercised here.
       telemetry: fakeTelemetry as never,
     });
 

--- a/src/core/ai/streamIdleGuard.ts
+++ b/src/core/ai/streamIdleGuard.ts
@@ -1,0 +1,89 @@
+/**
+ * Connection-liveness guard for a raw byte stream. Errors after `idleTimeoutMs`
+ * of byte-silence (a half-open socket that stops sending without FIN/RST) while
+ * waiting indefinitely as long as bytes flow. Provider-agnostic — watches raw
+ * chunks only, so it works on the Bedrock EventStream body. This is the fix for
+ * the document_endpoint hang; no runtime keepalive detects a silent peer.
+ */
+
+import { type StreamTelemetry, wallNow } from "./streamTelemetry";
+
+/**
+ * Thrown when the transport goes byte-silent. Carries a stable marker so the
+ * stream-resume logic in ai.ts recognizes it even after the AI SDK wraps it in
+ * an APICallError (provider layers preserve `cause`, not `instanceof`).
+ */
+export class ProviderStreamIdleError extends Error {
+  readonly isProviderStreamIdle = true as const;
+  constructor(idleTimeoutMs: number) {
+    super(
+      `Provider stream idle for ${idleTimeoutMs}ms — transport appears dead/half-open`,
+    );
+    this.name = "ProviderStreamIdleError";
+  }
+}
+
+export interface IdleGuardOptions {
+  /** Abort if no bytes arrive for this many ms. Every byte resets it. Default 90_000. */
+  idleTimeoutMs?: number;
+  telemetry?: StreamTelemetry;
+}
+
+/** Idle timer is armed only during an active pull, so backpressure never trips it. */
+export function idleGuardedStream(
+  source: ReadableStream<Uint8Array>,
+  options: IdleGuardOptions = {},
+): ReadableStream<Uint8Array> {
+  const idleTimeoutMs = options.idleTimeoutMs ?? 90_000;
+  const reader = source.getReader();
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const idlePromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new ProviderStreamIdleError(idleTimeoutMs));
+        }, idleTimeoutMs);
+      });
+
+      try {
+        const result = await Promise.race([reader.read(), idlePromise]);
+        if (result.done) {
+          options.telemetry?.finish(wallNow());
+          controller.close();
+          return;
+        }
+        options.telemetry?.recordByte(result.value.byteLength, wallNow());
+        controller.enqueue(result.value);
+      } catch (err) {
+        // Idle fired or read rejected: snapshot, release the socket, propagate.
+        options.telemetry?.wedge(
+          err instanceof Error ? err.message : String(err),
+          wallNow(),
+        );
+        options.telemetry?.finish(wallNow());
+        await reader.cancel(err).catch(() => {});
+        controller.error(err);
+      } finally {
+        if (timeoutId) clearTimeout(timeoutId);
+      }
+    },
+    cancel(reason) {
+      options.telemetry?.finish(wallNow());
+      return reader.cancel(reason);
+    },
+  });
+}
+
+/** Wrap a Response so its body is idle-guarded, preserving status/headers. */
+export function idleGuardedResponse(
+  response: Response,
+  options: IdleGuardOptions = {},
+): Response {
+  if (!response.body) return response;
+  return new Response(idleGuardedStream(response.body, options), {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}

--- a/src/core/ai/streamIdleGuard.ts
+++ b/src/core/ai/streamIdleGuard.ts
@@ -1,35 +1,26 @@
-/**
- * Connection-liveness guard for a raw byte stream. Errors after `idleTimeoutMs`
- * of byte-silence (a half-open socket that stops sending without FIN/RST) while
- * waiting indefinitely as long as bytes flow. Provider-agnostic — watches raw
- * chunks only, so it works on the Bedrock EventStream body. This is the fix for
- * the document_endpoint hang; no runtime keepalive detects a silent peer.
- */
+// Errors a byte stream after `idleTimeoutMs` of total silence (a half-open
+// socket that stalls without FIN/RST), while letting a stream that keeps
+// dribbling bytes run as long as it needs. Used to bound the Bedrock response
+// stream, which no runtime keepalive can rescue once the peer goes silent.
 
 import { type StreamTelemetry, wallNow } from "./streamTelemetry";
 
-/**
- * Thrown when the transport goes byte-silent. Carries a stable marker so the
- * stream-resume logic in ai.ts recognizes it even after the AI SDK wraps it in
- * an APICallError (provider layers preserve `cause`, not `instanceof`).
- */
+// Marker (not just `instanceof`) so the resume logic in ai.ts can still
+// recognize this after the AI SDK rewraps it as an APICallError with `cause`.
 export class ProviderStreamIdleError extends Error {
   readonly isProviderStreamIdle = true as const;
   constructor(idleTimeoutMs: number) {
-    super(
-      `Provider stream idle for ${idleTimeoutMs}ms — transport appears dead/half-open`,
-    );
+    super(`Provider stream idle for ${idleTimeoutMs}ms`);
     this.name = "ProviderStreamIdleError";
   }
 }
 
 export interface IdleGuardOptions {
-  /** Abort if no bytes arrive for this many ms. Every byte resets it. Default 90_000. */
+  /** Silence before aborting, ms. Every byte resets it. Default 90_000. */
   idleTimeoutMs?: number;
   telemetry?: StreamTelemetry;
 }
 
-/** Idle timer is armed only during an active pull, so backpressure never trips it. */
 export function idleGuardedStream(
   source: ReadableStream<Uint8Array>,
   options: IdleGuardOptions = {},
@@ -38,16 +29,19 @@ export function idleGuardedStream(
   const reader = source.getReader();
 
   return new ReadableStream<Uint8Array>({
+    // `pull` runs only when the consumer wants more, so backpressure (not a
+    // dead socket) never trips the timer.
     async pull(controller) {
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
-      const idlePromise = new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          reject(new ProviderStreamIdleError(idleTimeoutMs));
-        }, idleTimeoutMs);
+      const idle = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new ProviderStreamIdleError(idleTimeoutMs)),
+          idleTimeoutMs,
+        );
       });
 
       try {
-        const result = await Promise.race([reader.read(), idlePromise]);
+        const result = await Promise.race([reader.read(), idle]);
         if (result.done) {
           options.telemetry?.finish(wallNow());
           controller.close();
@@ -56,7 +50,6 @@ export function idleGuardedStream(
         options.telemetry?.recordByte(result.value.byteLength, wallNow());
         controller.enqueue(result.value);
       } catch (err) {
-        // Idle fired or read rejected: snapshot, release the socket, propagate.
         options.telemetry?.wedge(
           err instanceof Error ? err.message : String(err),
           wallNow(),
@@ -75,7 +68,6 @@ export function idleGuardedStream(
   });
 }
 
-/** Wrap a Response so its body is idle-guarded, preserving status/headers. */
 export function idleGuardedResponse(
   response: Response,
   options: IdleGuardOptions = {},

--- a/src/core/ai/streamTelemetry.ts
+++ b/src/core/ai/streamTelemetry.ts
@@ -1,0 +1,127 @@
+/**
+ * Per-stream connection telemetry for diagnosing provider-stream wedges. OFF
+ * unless `PENSAR_STREAM_DEBUG=1`. Tracks two clocks — `msSinceLastByte`
+ * (transport liveness) and `msSinceLastEvent` (parsed progress) — to tell a
+ * dead/half-open socket from a slow-but-alive one. Heartbeat every
+ * {@link HEARTBEAT_MS}; single-line `[stream-telem] key=val` output for grep.
+ */
+
+export const STREAM_DEBUG =
+  process.env.PENSAR_STREAM_DEBUG === "1" ||
+  process.env.PENSAR_STREAM_DEBUG === "true";
+
+const HEARTBEAT_MS = 10_000;
+
+export type StreamPhase =
+  | "connecting"
+  | "first-byte"
+  | "streaming-text"
+  | `streaming-tool-args:${string}`
+  | "tool-result"
+  | "finish"
+  | "wedged";
+
+let seq = 0;
+
+export class StreamTelemetry {
+  readonly id: string;
+  readonly label: string;
+  private readonly startAt: number;
+  private lastByteAt: number;
+  private lastEventAt: number;
+  private bytes = 0;
+  private chunks = 0;
+  private events = 0;
+  private phase: StreamPhase = "connecting";
+  private idleArmed = false;
+  private idleGatedBy: string | null = null;
+  private resumeCount = 0;
+  private retryCount = 0;
+  private heartbeat: ReturnType<typeof setInterval> | undefined;
+
+  constructor(label: string, nowMs: number) {
+    this.id = `s${++seq}`;
+    this.label = label;
+    this.startAt = nowMs;
+    this.lastByteAt = nowMs;
+    this.lastEventAt = nowMs;
+    if (STREAM_DEBUG) {
+      this.log("open");
+      this.heartbeat = setInterval(() => this.log("heartbeat"), HEARTBEAT_MS);
+      // Don't keep the process alive for telemetry.
+      if (
+        this.heartbeat &&
+        typeof this.heartbeat === "object" &&
+        "unref" in this.heartbeat
+      ) {
+        this.heartbeat.unref();
+      }
+    }
+  }
+
+  recordByte(byteLength: number, nowMs: number): void {
+    this.bytes += byteLength;
+    this.chunks++;
+    this.lastByteAt = nowMs;
+    if (this.phase === "connecting") this.setPhase("first-byte", nowMs);
+  }
+
+  recordEvent(nowMs: number): void {
+    this.events++;
+    this.lastEventAt = nowMs;
+  }
+
+  setPhase(phase: StreamPhase, nowMs: number): void {
+    if (this.phase === phase) return;
+    this.phase = phase;
+    if (STREAM_DEBUG) this.log("phase", nowMs);
+  }
+
+  setIdle(armed: boolean, gatedBy: string | null): void {
+    this.idleArmed = armed;
+    this.idleGatedBy = gatedBy;
+  }
+
+  recordResume(nowMs: number): void {
+    this.resumeCount++;
+    if (STREAM_DEBUG) this.log("resume", nowMs);
+  }
+
+  recordRetry(nowMs: number): void {
+    this.retryCount++;
+    if (STREAM_DEBUG) this.log("retry", nowMs);
+  }
+
+  /** Loud snapshot the moment a stall is declared (idle timeout / no progress). */
+  wedge(reason: string, nowMs: number): void {
+    this.phase = "wedged";
+    if (STREAM_DEBUG) this.log(`WEDGE reason=${JSON.stringify(reason)}`, nowMs);
+  }
+
+  finish(nowMs: number): void {
+    if (this.heartbeat) clearInterval(this.heartbeat);
+    if (STREAM_DEBUG) this.log("close", nowMs);
+  }
+
+  private log(tag: string, nowMs?: number): void {
+    if (!STREAM_DEBUG) return;
+    const t = nowMs ?? wallNow();
+    console.error(
+      `[stream-telem] ${this.id} ${tag} label=${JSON.stringify(this.label)} ` +
+        `phase=${this.phase} elapsed=${t - this.startAt}ms ` +
+        `bytes=${this.bytes} chunks=${this.chunks} events=${this.events} ` +
+        `msSinceLastByte=${t - this.lastByteAt} msSinceLastEvent=${t - this.lastEventAt} ` +
+        `idleArmed=${this.idleArmed} idleGatedBy=${this.idleGatedBy ?? "-"} ` +
+        `resumes=${this.resumeCount} retries=${this.retryCount}`,
+    );
+  }
+}
+
+/**
+ * Wall clock for telemetry only. Apex forbids `Date.now()` in some contexts
+ * (workflow determinism), but provider streaming is plain runtime code — this
+ * is fine here and is the real elapsed clock we need for stall detection.
+ */
+export function wallNow(): number {
+  return Date.now();
+}

--- a/src/core/ai/streamTelemetry.ts
+++ b/src/core/ai/streamTelemetry.ts
@@ -1,10 +1,7 @@
-/**
- * Per-stream connection telemetry for diagnosing provider-stream wedges. OFF
- * unless `PENSAR_STREAM_DEBUG=1`. Tracks two clocks — `msSinceLastByte`
- * (transport liveness) and `msSinceLastEvent` (parsed progress) — to tell a
- * dead/half-open socket from a slow-but-alive one. Heartbeat every
- * {@link HEARTBEAT_MS}; single-line `[stream-telem] key=val` output for grep.
- */
+// Per-stream connection telemetry for diagnosing provider-stream wedges. OFF
+// unless PENSAR_STREAM_DEBUG=1. Tracks bytes off the socket separately from
+// parsed events so a dead/half-open stream (no bytes) is distinguishable from a
+// slow-but-alive one (bytes still trickling). Single-line grep-friendly output.
 
 export const STREAM_DEBUG =
   process.env.PENSAR_STREAM_DEBUG === "1" ||
@@ -33,10 +30,6 @@ export class StreamTelemetry {
   private chunks = 0;
   private events = 0;
   private phase: StreamPhase = "connecting";
-  private idleArmed = false;
-  private idleGatedBy: string | null = null;
-  private resumeCount = 0;
-  private retryCount = 0;
   private heartbeat: ReturnType<typeof setInterval> | undefined;
 
   constructor(label: string, nowMs: number) {
@@ -48,14 +41,7 @@ export class StreamTelemetry {
     if (STREAM_DEBUG) {
       this.log("open");
       this.heartbeat = setInterval(() => this.log("heartbeat"), HEARTBEAT_MS);
-      // Don't keep the process alive for telemetry.
-      if (
-        this.heartbeat &&
-        typeof this.heartbeat === "object" &&
-        "unref" in this.heartbeat
-      ) {
-        this.heartbeat.unref();
-      }
+      this.heartbeat.unref?.();
     }
   }
 
@@ -77,22 +63,6 @@ export class StreamTelemetry {
     if (STREAM_DEBUG) this.log("phase", nowMs);
   }
 
-  setIdle(armed: boolean, gatedBy: string | null): void {
-    this.idleArmed = armed;
-    this.idleGatedBy = gatedBy;
-  }
-
-  recordResume(nowMs: number): void {
-    this.resumeCount++;
-    if (STREAM_DEBUG) this.log("resume", nowMs);
-  }
-
-  recordRetry(nowMs: number): void {
-    this.retryCount++;
-    if (STREAM_DEBUG) this.log("retry", nowMs);
-  }
-
-  /** Loud snapshot the moment a stall is declared (idle timeout / no progress). */
   wedge(reason: string, nowMs: number): void {
     this.phase = "wedged";
     if (STREAM_DEBUG) this.log(`WEDGE reason=${JSON.stringify(reason)}`, nowMs);
@@ -110,18 +80,13 @@ export class StreamTelemetry {
       `[stream-telem] ${this.id} ${tag} label=${JSON.stringify(this.label)} ` +
         `phase=${this.phase} elapsed=${t - this.startAt}ms ` +
         `bytes=${this.bytes} chunks=${this.chunks} events=${this.events} ` +
-        `msSinceLastByte=${t - this.lastByteAt} msSinceLastEvent=${t - this.lastEventAt} ` +
-        `idleArmed=${this.idleArmed} idleGatedBy=${this.idleGatedBy ?? "-"} ` +
-        `resumes=${this.resumeCount} retries=${this.retryCount}`,
+        `msSinceLastByte=${t - this.lastByteAt} msSinceLastEvent=${t - this.lastEventAt}`,
     );
   }
 }
 
-/**
- * Wall clock for telemetry only. Apex forbids `Date.now()` in some contexts
- * (workflow determinism), but provider streaming is plain runtime code — this
- * is fine here and is the real elapsed clock we need for stall detection.
- */
+// Real wall clock — fine here (provider streaming isn't workflow-deterministic
+// code) and it's the elapsed measure stall detection needs.
 export function wallNow(): number {
   return Date.now();
 }

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -36,8 +36,19 @@ export function isAnthropicProvider(model: AIModel): boolean {
   );
 }
 
-// Last-resort backstop above Bun's 300s fetch default; SSE idle timeout is the primary stall guard.
-const STREAMING_FETCH_TIMEOUT_MS = 15 * 60 * 1000;
+// Last-resort backstop ONLY — it must never be the thing that ends a healthy
+// stream. The PRIMARY liveness guard is the connection read-idle: the SSE reader
+// (pensarSSE.ts) aborts if no bytes arrive for 90s, and the AI-SDK path's
+// withIdleTimeout does the same per chunk — i.e. we judge the *connection*, not
+// the wall-clock. A live stream that legitimately takes 1-30 min (slow model,
+// long structured response) keeps delivering bytes and is never cut; a dead /
+// half-open socket stops delivering bytes and trips the 90s read-idle → error →
+// propagated and retried/degraded. This wall-clock value exists only to bound a
+// pathological "alive but never completes" stream, so it sits comfortably above
+// the longest legitimate generation (well past 30 min) rather than near it.
+// (Must also stay below dispatchAgent's autoStopInterval so we, not Daytona,
+// end such a stream — see that file.)
+const STREAMING_FETCH_TIMEOUT_MS = 35 * 60 * 1000;
 
 export function buildStreamingFetchSignal(
   callerSignal?: AbortSignal | null,

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -24,6 +24,8 @@ import {
 } from "./contextManagement";
 import { getModelInfo } from "./models";
 import { createPensarModel } from "./providers/pensar";
+import { idleGuardedResponse } from "./streamIdleGuard";
+import { StreamTelemetry, wallNow } from "./streamTelemetry";
 
 /**
  * Check if a model uses an Anthropic-compatible provider that supports prompt caching.
@@ -180,11 +182,29 @@ export function getProviderModel(
     }
 
     case "bedrock": {
-      const bedrockFetch = (input: RequestInfo | URL, init?: RequestInit) =>
-        globalThis.fetch(input, {
+      // Byte-level liveness for the Bedrock stream (the path the sandbox uses).
+      // A half-open mid-stream socket otherwise blocks until the 35-min fetch
+      // cap; idleGuardedResponse errors it after byte-silence so it propagates.
+      // Window: PENSAR_STREAM_IDLE_TIMEOUT_MS, default 90s.
+      const rawStreamIdle = Number(process.env.PENSAR_STREAM_IDLE_TIMEOUT_MS);
+      const streamIdleMs =
+        Number.isFinite(rawStreamIdle) && rawStreamIdle > 0
+          ? rawStreamIdle
+          : 90_000;
+      const bedrockFetch = async (
+        input: RequestInfo | URL,
+        init?: RequestInit,
+      ) => {
+        const response = await globalThis.fetch(input, {
           ...init,
           signal: buildStreamingFetchSignal(init?.signal),
         });
+        const telemetry = new StreamTelemetry(`bedrock:${model}`, wallNow());
+        return idleGuardedResponse(response, {
+          idleTimeoutMs: streamIdleMs,
+          telemetry,
+        });
+      };
       const bedrock = createAmazonBedrock({
         apiKey: bedrockApiKey,
         region: bedrockRegion,

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -182,10 +182,7 @@ export function getProviderModel(
     }
 
     case "bedrock": {
-      // Byte-level liveness for the Bedrock stream (the path the sandbox uses).
-      // A half-open mid-stream socket otherwise blocks until the 35-min fetch
-      // cap; idleGuardedResponse errors it after byte-silence so it propagates.
-      // Window: PENSAR_STREAM_IDLE_TIMEOUT_MS, default 90s.
+      // Guard against a half-open Bedrock socket hanging the stream forever.
       const rawStreamIdle = Number(process.env.PENSAR_STREAM_IDLE_TIMEOUT_MS);
       const streamIdleMs =
         Number.isFinite(rawStreamIdle) && rawStreamIdle > 0


### PR DESCRIPTION
## Problem

During whitebox recon, threat-model children stream a large structured `response` from Bedrock. **Bedrock intermittently stops sending bytes mid-stream — a half-open socket with no FIN/RST.** The reader blocks forever, freezing the `document_endpoint` tool call, the parent session, and the whole recon at "N-1/N apps".

Two things made this hard to pin down:
- **No runtime can detect it.** No TCP close arrives, so keepalive is useless — confirmed: Bun and Node wedge identically. Only watching *bytes* at the app layer catches it.
- **Every higher-level signal is fooled by AI-SDK retry chatter.** When the stream wedges the SDK retries and re-streams tokens, which looks like progress to anything counting events, finish chunks, or bus traffic.

Ruled out by experiment (see the repro/probe scripts below): egress proxy, stream length, runtime (Bun vs Node), inference profile (global vs `us`), and concurrency — a single serial child still wedges. It's a Bedrock-side stall, not a client misconfiguration, so it can't be tuned away at the client.

## Fix

- **Detect** at the transport: `idleGuardedResponse` wraps the Bedrock fetch body and errors after `PENSAR_STREAM_IDLE_TIMEOUT_MS` (default 90s) of byte-silence. A stream that keeps dribbling bytes runs as long as it needs — no wall-clock cap.
- **Recover** by reusing what already existed: the guard throws `ProviderStreamIdleError`, recognized by `isStreamIdleTimeoutError` (walks the `cause` chain, since the AI SDK rewraps it as an `APICallError`), which triggers the existing resume-from-accumulated-messages path (×3). The wedge is stochastic per attempt, so a retry almost always succeeds — validated locally at **17/17 wedges auto-recovered**.
- **Observability:** `StreamTelemetry` (`PENSAR_STREAM_DEBUG=1`) records byte- vs event-level liveness so a dead stream is distinguishable from a slow-but-alive one.

## Cleanup — this PR also reverses earlier band-aids

The first commits here patched the symptom at the wrong layer while the cause was misdiagnosed. Now that the transport self-heals:

- **Restored `THREAT_MODEL_CONCURRENCY` 4 → 10.** The "10 children saturate the event loop so the liveness timers never fire" premise is disproven (serial single child still wedges; Bun/Node identical).
- **Removed the no-progress silence watchdog and the multi-signal `consume()` race.** `consume()` can no longer hang, so they were dead weight. Kept the `stepCountIs(40)` cap and the `responseCaptured` fast-path (settles with the already-captured result when the stream wedges during teardown).

## Tests & risk

- Unit tests for the guard: `streamIdleGuard.test.ts`. `tsc` + `biome` clean.
- Dev harnesses `scripts/repro-threat-model-stream.ts` (faithful sandbox bedrock path) and `scripts/probe-bedrock-stream.ts` (raw transport) reproduce the wedge against real Bedrock and were used to isolate the cause. They hit real Bedrock (creds + cost), so they're manual, not part of CI.
- Behavior change: a wedged stream now recovers via resume; if all 3 resumes fail it degrades to the heuristic score (as before) instead of hanging. Removing the silence watchdog also drops the only blanket guard against a hung *sub-tool* inside the child — a hypothesized mode never actually observed.
- Not yet validated against a deployed recon.
