### PR TITLE
Add Vue recon benchmark fixtures

### DIFF
--- a/benchmarks/vue-recon/README.md
+++ b/benchmarks/vue-recon/README.md
@@ -1,0 +1,39 @@
+# Vue Recon Benchmarks
+
+This suite measures Apex recon coverage against buildable Vue-style applications
+before Vue-specific recon improvements are made.
+
+The fixtures are intentionally small and include a machine-readable endpoint
+oracle. They are designed for evalgate-style consumers and for local baseline
+runs through:
+
+```bash
+bun run benchmark:vue-recon
+```
+
+## Fixtures
+
+- `vue-vite-router` — Vue 3 + Vite + Vue Router page routes, dynamic routes,
+  nested routes, and lazy-loaded route chunks.
+- `vue-vite-api-calls` — Vue 3 + Vite API calls through `fetch`, axios-style
+  clients, environment-derived API bases, and relative paths.
+- `nuxt-routes-api` — Nuxt-style pages, dynamic pages, `server/api` routes, and
+  `$fetch` / `useFetch` calls.
+
+Each app has:
+
+- source files under `apps/<id>/`
+- a static production-like build under `apps/<id>/static-build/`
+- an expected endpoint manifest under `expected/<id>.json`
+
+## Baseline metric sources
+
+The current local baseline script does not run model-backed recon. It measures
+the deterministic pieces Apex already has locally:
+
+- blackbox JavaScript extraction via `extractJavascriptEndpoints`
+- whitebox deterministic route mapping via `mapAppWithSurface`
+
+This keeps the benchmark repeatable without API keys and gives evalgate an
+endpoint oracle to compare against when running full `pensar pentest` or
+attack-surface sessions.

--- a/benchmarks/vue-recon/README.md
+++ b/benchmarks/vue-recon/README.md
@@ -19,6 +19,8 @@ bun run benchmark:vue-recon
   clients, environment-derived API bases, and relative paths.
 - `nuxt-routes-api` — Nuxt-style pages, dynamic pages, `server/api` routes, and
   `$fetch` / `useFetch` calls.
+- `vue-enterprise-mock` — Runnable local Vue-style SPA plus Bun API server used
+  for full Apex pentest comparison.
 
 Each app has:
 
@@ -37,3 +39,12 @@ the deterministic pieces Apex already has locally:
 This keeps the benchmark repeatable without API keys and gives evalgate an
 endpoint oracle to compare against when running full `pensar pentest` or
 attack-surface sessions.
+
+## Full Apex pentest result
+
+`vue-enterprise-mock` was also exercised through the full Apex CLI pentest
+workflow. That run discovered all known first-party endpoints through persisted
+`document_endpoint` assets. See:
+
+- `results/vue-enterprise-mock-pentest.md`
+- `results/vue-enterprise-mock-pentest.json`

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/app.vue
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
+</template>

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/nuxt.config.ts
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/nuxt.config.ts
@@ -1,0 +1,7 @@
+export default defineNuxtConfig({
+  devtools: { enabled: false },
+  routeRules: {
+    "/admin": { ssr: false },
+    "/blog/**": { swr: true },
+  },
+});

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/package.json
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nuxt-routes-api-recon-fixture",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "nuxt build",
+    "dev": "nuxt dev --host 0.0.0.0"
+  },
+  "dependencies": {
+    "nuxt": "^4.2.2",
+    "vue": "^3.5.25"
+  },
+  "devDependencies": {}
+}

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/pages/admin.vue
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/pages/admin.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+const audit = await $fetch("/api/admin/audit-log");
+</script>
+
+<template><main>{{ audit }}</main></template>

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/pages/blog/[slug].vue
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/pages/blog/[slug].vue
@@ -1,0 +1,6 @@
+<script setup lang="ts">
+const route = useRoute();
+const post = await $fetch(`/api/blog/posts/${route.params.slug}`);
+</script>
+
+<template><main>{{ post }}</main></template>

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/pages/blog/index.vue
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/pages/blog/index.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+const posts = await useFetch("/api/blog/posts");
+</script>
+
+<template><main>{{ posts }}</main></template>

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/pages/index.vue
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/pages/index.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+const { data } = await useFetch("/api/me");
+</script>
+
+<template><main>{{ data }}</main></template>

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/pages/profile/settings.vue
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/pages/profile/settings.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+const settings = await useFetch("/api/profile/settings");
+</script>
+
+<template><main>{{ settings }}</main></template>

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/server/api/admin/audit-log.get.ts
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/server/api/admin/audit-log.get.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => [{ action: "login" }]);

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/server/api/blog/posts.get.ts
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/server/api/blog/posts.get.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => [{ slug: "hello-vue" }]);

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/server/api/blog/posts/[slug].get.ts
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/server/api/blog/posts/[slug].get.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler((event) => ({
+  slug: getRouterParam(event, "slug"),
+}));

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/server/api/me.get.ts
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/server/api/me.get.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => ({ id: "user_demo" }));

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/server/api/profile/settings.get.ts
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/server/api/profile/settings.get.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => ({ theme: "dark" }));

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/static-build/_nuxt/app-nuxt-r4t5y6.js
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/static-build/_nuxt/app-nuxt-r4t5y6.js
@@ -1,0 +1,18 @@
+const pages = [
+  "/",
+  "/admin",
+  "/blog",
+  "/blog/:slug",
+  "/profile/settings",
+];
+
+useFetch("/api/me");
+$fetch("/api/admin/audit-log");
+useFetch("/api/blog/posts");
+$fetch(`/api/blog/posts/${window.__BLOG_SLUG__ || "hello-vue"}`);
+useFetch("/api/profile/settings");
+
+window.__NUXT__ = {
+  routes: pages,
+  config: { public: { apiBase: "/api" } },
+};

--- a/benchmarks/vue-recon/apps/nuxt-routes-api/static-build/index.html
+++ b/benchmarks/vue-recon/apps/nuxt-routes-api/static-build/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nuxt Routes API Recon Fixture</title>
+    <script type="module" crossorigin src="/_nuxt/app-nuxt-r4t5y6.js"></script>
+  </head>
+  <body>
+    <div id="__nuxt"></div>
+  </body>
+</html>

--- a/benchmarks/vue-recon/apps/vue-enterprise-mock/package.json
+++ b/benchmarks/vue-recon/apps/vue-enterprise-mock/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "vue-enterprise-recon-mock",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "serve": "bun run server.ts"
+  },
+  "dependencies": {
+    "@vitejs/plugin-vue": "^6.0.3",
+    "vite": "^7.2.7",
+    "vue": "^3.5.25",
+    "vue-router": "^4.6.4"
+  },
+  "devDependencies": {}
+}

--- a/benchmarks/vue-recon/apps/vue-enterprise-mock/public/assets/app.css
+++ b/benchmarks/vue-recon/apps/vue-enterprise-mock/public/assets/app.css
@@ -1,0 +1,29 @@
+body {
+  background: #101827;
+  color: #f8fafc;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  margin: 0;
+}
+
+header,
+main {
+  margin: 0 auto;
+  max-width: 920px;
+  padding: 24px;
+}
+
+nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+a {
+  color: #93c5fd;
+}
+
+form {
+  display: grid;
+  gap: 12px;
+  max-width: 360px;
+}

--- a/benchmarks/vue-recon/apps/vue-enterprise-mock/public/assets/vue-enterprise-app.js
+++ b/benchmarks/vue-recon/apps/vue-enterprise-mock/public/assets/vue-enterprise-app.js
@@ -1,0 +1,55 @@
+const routes = [
+  { path: "/", name: "home" },
+  { path: "/login", name: "login" },
+  { path: "/dashboard", name: "dashboard" },
+  { path: "/projects", name: "projects" },
+  { path: "/projects/:projectId", name: "project-detail" },
+  { path: "/admin/users", name: "admin-users", meta: { requiresAdmin: true } },
+  { path: "/settings/profile", name: "profile-settings" },
+];
+
+const apiBase = import.meta.env?.VITE_API_URL || "/api";
+
+const http = {
+  get(path) {
+    return fetch(`${apiBase}${path}`).then((response) => response.json());
+  },
+  post(path, body) {
+    return fetch(`${apiBase}${path}`, {
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }).then((response) => response.json());
+  },
+};
+
+async function boot() {
+  await fetch("/api/session");
+  await http.get("/dashboard/summary");
+  await http.get("/projects");
+  await fetch(`/api/projects/${window.__PROJECT_ID__ || "alpha"}`);
+  await http.get("/admin/users");
+  await http.get("/settings/profile");
+
+  // External telemetry should be ignored as third-party infrastructure.
+  navigator.sendBeacon?.("https://telemetry.example.invalid/vue-enterprise");
+}
+
+document.querySelector("#login-form")?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  void http.post("/login", {
+    email: "analyst@example.test",
+    password: "password123",
+  });
+});
+
+window.__VUE_ROUTER__ = {
+  getRoutes: () => routes,
+  options: { routes },
+};
+
+window.__VUE_APP_CONFIG__ = {
+  apiBase,
+};
+
+void boot();

--- a/benchmarks/vue-recon/apps/vue-enterprise-mock/public/index.html
+++ b/benchmarks/vue-recon/apps/vue-enterprise-mock/public/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vue Enterprise Recon Mock</title>
+    <link rel="stylesheet" href="/assets/app.css" />
+    <script type="module" src="/assets/vue-enterprise-app.js"></script>
+  </head>
+  <body>
+    <div id="app">
+      <header>
+        <h1>Vue Enterprise Portal</h1>
+        <nav aria-label="Primary navigation">
+          <a href="/">Home</a>
+          <a href="/login">Login</a>
+          <a href="/dashboard">Dashboard</a>
+          <a href="/projects">Projects</a>
+          <a href="/projects/alpha">Alpha project</a>
+          <a href="/admin/users">Admin users</a>
+          <a href="/settings/profile">Profile</a>
+        </nav>
+      </header>
+      <main>
+        <section data-route="/">
+          <h2>Home</h2>
+          <p>Mock Vue app for attack-surface endpoint discovery.</p>
+        </section>
+        <form id="login-form" action="/api/login" method="post">
+          <label>
+            Email
+            <input name="email" value="analyst@example.test" />
+          </label>
+          <label>
+            Password
+            <input name="password" type="password" value="password123" />
+          </label>
+          <button type="submit">Sign in</button>
+        </form>
+      </main>
+    </div>
+  </body>
+</html>

--- a/benchmarks/vue-recon/apps/vue-enterprise-mock/server.ts
+++ b/benchmarks/vue-recon/apps/vue-enterprise-mock/server.ts
@@ -1,0 +1,118 @@
+import { existsSync } from "node:fs";
+import { extname, join, resolve } from "node:path";
+
+const publicRoot = resolve(import.meta.dir, "public");
+
+const projects = [
+  { id: "alpha", name: "Alpha Migration", owner: "alice@example.test" },
+  { id: "bravo", name: "Bravo Launch", owner: "bob@example.test" },
+];
+
+const users = [
+  { id: "u_1", email: "admin@example.test", role: "admin" },
+  { id: "u_2", email: "analyst@example.test", role: "analyst" },
+];
+
+const profile = {
+  email: "analyst@example.test",
+  displayName: "Vue Analyst",
+  mfaEnabled: true,
+};
+
+const MIME_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+};
+
+function json(data: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(data, null, 2), {
+    ...init,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...init?.headers,
+    },
+  });
+}
+
+function readBody(request: Request): Promise<unknown> {
+  return request.text().then((body) => {
+    if (!body) return {};
+    try {
+      return JSON.parse(body);
+    } catch {
+      return {};
+    }
+  });
+}
+
+function staticResponse(pathname: string): Response {
+  const relativePath = pathname === "/" ? "index.html" : pathname.slice(1);
+  const filePath = resolve(publicRoot, relativePath);
+
+  if (!(filePath === publicRoot || filePath.startsWith(`${publicRoot}/`))) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  if (existsSync(filePath)) {
+    return new Response(Bun.file(filePath), {
+      headers: {
+        "content-type": MIME_TYPES[extname(filePath)] ?? "text/plain",
+      },
+    });
+  }
+
+  return new Response(Bun.file(join(publicRoot, "index.html")), {
+    headers: { "content-type": MIME_TYPES[".html"] },
+  });
+}
+
+const server = Bun.serve({
+  port: Number(process.env.PORT ?? 4173),
+  async fetch(request) {
+    const url = new URL(request.url);
+    const { pathname } = url;
+
+    if (pathname === "/api/session" && request.method === "GET") {
+      return json({ authenticated: true, user: profile });
+    }
+
+    if (pathname === "/api/login" && request.method === "POST") {
+      const body = await readBody(request);
+      return json({ ok: true, received: body });
+    }
+
+    if (pathname === "/api/dashboard/summary" && request.method === "GET") {
+      return json({ activeProjects: projects.length, openRisks: 3 });
+    }
+
+    if (pathname === "/api/projects" && request.method === "GET") {
+      return json(projects);
+    }
+
+    const projectMatch = pathname.match(/^\/api\/projects\/([^/]+)$/);
+    if (projectMatch && request.method === "GET") {
+      const project = projects.find((item) => item.id === projectMatch[1]);
+      return project
+        ? json(project)
+        : json({ error: "not_found" }, { status: 404 });
+    }
+
+    if (pathname === "/api/admin/users" && request.method === "GET") {
+      return json(users);
+    }
+
+    if (pathname === "/api/settings/profile" && request.method === "GET") {
+      return json(profile);
+    }
+
+    if (pathname.startsWith("/api/")) {
+      return json({ error: "not_found" }, { status: 404 });
+    }
+
+    return staticResponse(pathname);
+  },
+});
+
+console.log(`Vue enterprise mock listening on http://127.0.0.1:${server.port}`);

--- a/benchmarks/vue-recon/apps/vue-vite-api-calls/index.html
+++ b/benchmarks/vue-recon/apps/vue-vite-api-calls/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vue Vite API Calls Recon Fixture</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/benchmarks/vue-recon/apps/vue-vite-api-calls/package.json
+++ b/benchmarks/vue-recon/apps/vue-vite-api-calls/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "vue-vite-api-calls-recon-fixture",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite --host 0.0.0.0"
+  },
+  "dependencies": {
+    "@vitejs/plugin-vue": "^6.0.3",
+    "axios": "^1.13.2",
+    "vite": "^7.2.7",
+    "vue": "^3.5.25",
+    "vue-router": "^4.6.4"
+  },
+  "devDependencies": {}
+}

--- a/benchmarks/vue-recon/apps/vue-vite-api-calls/src/App.vue
+++ b/benchmarks/vue-recon/apps/vue-vite-api-calls/src/App.vue
@@ -1,0 +1,7 @@
+<template>
+  <nav>
+    <RouterLink to="/account">Account</RouterLink>
+    <RouterLink to="/billing">Billing</RouterLink>
+  </nav>
+  <RouterView />
+</template>

--- a/benchmarks/vue-recon/apps/vue-vite-api-calls/src/main.ts
+++ b/benchmarks/vue-recon/apps/vue-vite-api-calls/src/main.ts
@@ -1,0 +1,19 @@
+import { createApp } from "vue";
+import { createRouter, createWebHistory } from "vue-router";
+import App from "./App.vue";
+import AccountView from "./views/AccountView.vue";
+import BillingView from "./views/BillingView.vue";
+import { loadAccount } from "./services/account";
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: "/", component: AccountView },
+    { path: "/account", component: AccountView },
+    { path: "/billing", component: BillingView },
+  ],
+});
+
+void loadAccount();
+
+createApp(App).use(router).mount("#app");

--- a/benchmarks/vue-recon/apps/vue-vite-api-calls/src/services/account.ts
+++ b/benchmarks/vue-recon/apps/vue-vite-api-calls/src/services/account.ts
@@ -1,0 +1,20 @@
+import axios from "axios";
+
+const apiBase = import.meta.env.VITE_API_URL || "/api";
+
+const client = axios.create({
+  baseURL: apiBase,
+  headers: { "x-client": "vue-recon-fixture" },
+});
+
+export async function loadAccount() {
+  return client.get("/account");
+}
+
+export async function loadFeatureFlags() {
+  return fetch(`${apiBase}/feature-flags`).then((res) => res.json());
+}
+
+export async function searchAccounts(query: string) {
+  return fetch(`/api/search?q=${encodeURIComponent(query)}`);
+}

--- a/benchmarks/vue-recon/apps/vue-vite-api-calls/src/services/billing.ts
+++ b/benchmarks/vue-recon/apps/vue-vite-api-calls/src/services/billing.ts
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+export async function listInvoices() {
+  return axios.get("/api/billing/invoices");
+}
+
+export async function loadInvoice(invoiceId: string) {
+  return axios.get(`/api/billing/invoices/${invoiceId}`);
+}

--- a/benchmarks/vue-recon/apps/vue-vite-api-calls/src/views/AccountView.vue
+++ b/benchmarks/vue-recon/apps/vue-vite-api-calls/src/views/AccountView.vue
@@ -1,0 +1,1 @@
+<template><main>Account</main></template>

--- a/benchmarks/vue-recon/apps/vue-vite-api-calls/src/views/BillingView.vue
+++ b/benchmarks/vue-recon/apps/vue-vite-api-calls/src/views/BillingView.vue
@@ -1,0 +1,1 @@
+<template><main>Billing</main></template>

--- a/benchmarks/vue-recon/apps/vue-vite-api-calls/static-build/assets/app-api-q1w2e3.js
+++ b/benchmarks/vue-recon/apps/vue-vite-api-calls/static-build/assets/app-api-q1w2e3.js
@@ -1,0 +1,19 @@
+const apiBase = import.meta.env.VITE_API_URL || "/api";
+const client = {
+  get: (path) => fetch(`${apiBase}${path}`),
+};
+
+client.get("/account");
+fetch(`${apiBase}/feature-flags`);
+fetch(`/api/search?q=${encodeURIComponent("demo")}`);
+fetch("/api/billing/invoices");
+fetch(`/api/billing/invoices/${window.__INVOICE_ID__ || "inv_demo"}`);
+fetch("https://analytics.example.invalid/collect", { method: "POST" });
+
+window.__VUE_ROUTER__ = {
+  getRoutes: () => [
+    { path: "/" },
+    { path: "/account" },
+    { path: "/billing" },
+  ],
+};

--- a/benchmarks/vue-recon/apps/vue-vite-api-calls/static-build/index.html
+++ b/benchmarks/vue-recon/apps/vue-vite-api-calls/static-build/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vue Vite API Calls Recon Fixture</title>
+    <script type="module" crossorigin src="/assets/app-api-q1w2e3.js"></script>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/benchmarks/vue-recon/apps/vue-vite-router/index.html
+++ b/benchmarks/vue-recon/apps/vue-vite-router/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vue Vite Router Recon Fixture</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/benchmarks/vue-recon/apps/vue-vite-router/package.json
+++ b/benchmarks/vue-recon/apps/vue-vite-router/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "vue-vite-router-recon-fixture",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite --host 0.0.0.0"
+  },
+  "dependencies": {
+    "@vitejs/plugin-vue": "^6.0.3",
+    "vite": "^7.2.7",
+    "vue": "^3.5.25",
+    "vue-router": "^4.6.4"
+  },
+  "devDependencies": {}
+}

--- a/benchmarks/vue-recon/apps/vue-vite-router/src/App.vue
+++ b/benchmarks/vue-recon/apps/vue-vite-router/src/App.vue
@@ -1,0 +1,9 @@
+<template>
+  <nav>
+    <RouterLink to="/">Home</RouterLink>
+    <RouterLink to="/dashboard">Dashboard</RouterLink>
+    <RouterLink to="/projects">Projects</RouterLink>
+    <RouterLink to="/settings/profile">Profile</RouterLink>
+  </nav>
+  <RouterView />
+</template>

--- a/benchmarks/vue-recon/apps/vue-vite-router/src/main.ts
+++ b/benchmarks/vue-recon/apps/vue-vite-router/src/main.ts
@@ -1,0 +1,14 @@
+import { createApp } from "vue";
+import { createRouter, createWebHistory } from "vue-router";
+import App from "./App.vue";
+import { loadSession } from "./services/api";
+import { routes } from "./router";
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+});
+
+void loadSession();
+
+createApp(App).use(router).mount("#app");

--- a/benchmarks/vue-recon/apps/vue-vite-router/src/router.ts
+++ b/benchmarks/vue-recon/apps/vue-vite-router/src/router.ts
@@ -1,0 +1,26 @@
+import type { RouteRecordRaw } from "vue-router";
+import HomeView from "./views/HomeView.vue";
+import ProjectsView from "./views/ProjectsView.vue";
+
+export const routes: RouteRecordRaw[] = [
+  { path: "/", component: HomeView },
+  {
+    path: "/dashboard",
+    component: () => import("./views/DashboardView.vue"),
+    children: [
+      {
+        path: "reports",
+        component: () => import("./views/ReportsView.vue"),
+      },
+    ],
+  },
+  { path: "/projects", component: ProjectsView },
+  {
+    path: "/projects/:projectId",
+    component: () => import("./views/ProjectDetailView.vue"),
+  },
+  {
+    path: "/settings/profile",
+    component: () => import("./views/ProfileSettingsView.vue"),
+  },
+];

--- a/benchmarks/vue-recon/apps/vue-vite-router/src/services/api.ts
+++ b/benchmarks/vue-recon/apps/vue-vite-router/src/services/api.ts
@@ -1,0 +1,15 @@
+export async function loadSession() {
+  return fetch("/api/session").then((res) => res.json());
+}
+
+export async function listProjects() {
+  return fetch("/api/projects").then((res) => res.json());
+}
+
+export async function loadProject(projectId: string) {
+  return fetch(`/api/projects/${projectId}`).then((res) => res.json());
+}
+
+export async function loadMonthlyReport() {
+  return fetch("/api/reports/monthly").then((res) => res.json());
+}

--- a/benchmarks/vue-recon/apps/vue-vite-router/src/views/DashboardView.vue
+++ b/benchmarks/vue-recon/apps/vue-vite-router/src/views/DashboardView.vue
@@ -1,0 +1,6 @@
+<template>
+  <main>
+    Dashboard
+    <RouterView />
+  </main>
+</template>

--- a/benchmarks/vue-recon/apps/vue-vite-router/src/views/HomeView.vue
+++ b/benchmarks/vue-recon/apps/vue-vite-router/src/views/HomeView.vue
@@ -1,0 +1,1 @@
+<template><main>Home</main></template>

--- a/benchmarks/vue-recon/apps/vue-vite-router/src/views/ProfileSettingsView.vue
+++ b/benchmarks/vue-recon/apps/vue-vite-router/src/views/ProfileSettingsView.vue
@@ -1,0 +1,1 @@
+<template><main>Profile settings</main></template>

--- a/benchmarks/vue-recon/apps/vue-vite-router/src/views/ProjectDetailView.vue
+++ b/benchmarks/vue-recon/apps/vue-vite-router/src/views/ProjectDetailView.vue
@@ -1,0 +1,1 @@
+<template><main>Project detail</main></template>

--- a/benchmarks/vue-recon/apps/vue-vite-router/src/views/ProjectsView.vue
+++ b/benchmarks/vue-recon/apps/vue-vite-router/src/views/ProjectsView.vue
@@ -1,0 +1,1 @@
+<template><main>Projects</main></template>

--- a/benchmarks/vue-recon/apps/vue-vite-router/src/views/ReportsView.vue
+++ b/benchmarks/vue-recon/apps/vue-vite-router/src/views/ReportsView.vue
@@ -1,0 +1,1 @@
+<template><section>Reports</section></template>

--- a/benchmarks/vue-recon/apps/vue-vite-router/static-build/assets/app-router-a1b2c3.js
+++ b/benchmarks/vue-recon/apps/vue-vite-router/static-build/assets/app-router-a1b2c3.js
@@ -1,0 +1,18 @@
+const routes = [
+  { path: "/", component: "HomeView" },
+  { path: "/dashboard", component: () => import("./dashboard-d4e5f6.js") },
+  { path: "/dashboard/reports", component: () => import("./reports-f7g8h9.js") },
+  { path: "/projects", component: "ProjectsView" },
+  { path: "/projects/:projectId", component: () => import("./project-j1k2l3.js") },
+  { path: "/settings/profile", component: () => import("./profile-m4n5o6.js") },
+];
+
+fetch("/api/session");
+fetch("/api/projects");
+fetch(`/api/projects/${window.__PROJECT_ID__ || "demo"}`);
+fetch("/api/reports/monthly");
+
+window.__VUE_ROUTER__ = {
+  getRoutes: () => routes,
+  options: { routes },
+};

--- a/benchmarks/vue-recon/apps/vue-vite-router/static-build/index.html
+++ b/benchmarks/vue-recon/apps/vue-vite-router/static-build/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vue Vite Router Recon Fixture</title>
+    <script type="module" crossorigin src="/assets/app-router-a1b2c3.js"></script>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/benchmarks/vue-recon/expected/nuxt-routes-api.json
+++ b/benchmarks/vue-recon/expected/nuxt-routes-api.json
@@ -1,0 +1,26 @@
+{
+  "id": "nuxt-routes-api",
+  "name": "Nuxt Routes API",
+  "framework": "nuxt",
+  "appPath": "benchmarks/vue-recon/apps/nuxt-routes-api",
+  "staticBuildPath": "benchmarks/vue-recon/apps/nuxt-routes-api/static-build",
+  "expected": {
+    "pages": [
+      "/",
+      "/admin",
+      "/blog",
+      "/blog/:slug",
+      "/profile/settings"
+    ],
+    "apiEndpoints": [
+      "/api/admin/audit-log",
+      "/api/blog/posts",
+      "/api/blog/posts/:slug",
+      "/api/me",
+      "/api/profile/settings"
+    ],
+    "ignoredExternal": [
+      "https://images.example.invalid/avatar.png"
+    ]
+  }
+}

--- a/benchmarks/vue-recon/expected/vue-enterprise-mock.json
+++ b/benchmarks/vue-recon/expected/vue-enterprise-mock.json
@@ -1,0 +1,30 @@
+{
+  "id": "vue-enterprise-mock",
+  "name": "Vue Enterprise Mock",
+  "framework": "vue-vite",
+  "appPath": "benchmarks/vue-recon/apps/vue-enterprise-mock",
+  "staticBuildPath": "benchmarks/vue-recon/apps/vue-enterprise-mock/public",
+  "expected": {
+    "pages": [
+      "/",
+      "/login",
+      "/dashboard",
+      "/projects",
+      "/projects/:projectId",
+      "/admin/users",
+      "/settings/profile"
+    ],
+    "apiEndpoints": [
+      "/api/session",
+      "/api/login",
+      "/api/dashboard/summary",
+      "/api/projects",
+      "/api/projects/:projectId",
+      "/api/admin/users",
+      "/api/settings/profile"
+    ],
+    "ignoredExternal": [
+      "https://telemetry.example.invalid/vue-enterprise"
+    ]
+  }
+}

--- a/benchmarks/vue-recon/expected/vue-vite-api-calls.json
+++ b/benchmarks/vue-recon/expected/vue-vite-api-calls.json
@@ -1,0 +1,24 @@
+{
+  "id": "vue-vite-api-calls",
+  "name": "Vue Vite API Calls",
+  "framework": "vue-vite",
+  "appPath": "benchmarks/vue-recon/apps/vue-vite-api-calls",
+  "staticBuildPath": "benchmarks/vue-recon/apps/vue-vite-api-calls/static-build",
+  "expected": {
+    "pages": [
+      "/",
+      "/account",
+      "/billing"
+    ],
+    "apiEndpoints": [
+      "/api/account",
+      "/api/billing/invoices",
+      "/api/billing/invoices/:invoiceId",
+      "/api/feature-flags",
+      "/api/search"
+    ],
+    "ignoredExternal": [
+      "https://analytics.example.invalid/collect"
+    ]
+  }
+}

--- a/benchmarks/vue-recon/expected/vue-vite-router.json
+++ b/benchmarks/vue-recon/expected/vue-vite-router.json
@@ -1,0 +1,26 @@
+{
+  "id": "vue-vite-router",
+  "name": "Vue Vite Router",
+  "framework": "vue-vite",
+  "appPath": "benchmarks/vue-recon/apps/vue-vite-router",
+  "staticBuildPath": "benchmarks/vue-recon/apps/vue-vite-router/static-build",
+  "expected": {
+    "pages": [
+      "/",
+      "/dashboard",
+      "/dashboard/reports",
+      "/projects",
+      "/projects/:projectId",
+      "/settings/profile"
+    ],
+    "apiEndpoints": [
+      "/api/session",
+      "/api/projects",
+      "/api/projects/:projectId",
+      "/api/reports/monthly"
+    ],
+    "ignoredExternal": [
+      "https://cdn.example.invalid/vue-devtools.js"
+    ]
+  }
+}

--- a/benchmarks/vue-recon/results/baseline-current.json
+++ b/benchmarks/vue-recon/results/baseline-current.json
@@ -1,11 +1,11 @@
 {
-  "generatedAt": "2026-06-08T21:34:36.093Z",
+  "generatedAt": "2026-06-08T22:33:55.265Z",
   "metricSources": [
     "extractJavascriptEndpoints",
     "mapAppWithSurface"
   ],
   "summary": {
-    "fixtures": 3,
+    "fixtures": 4,
     "pageRouteRecall": 0,
     "apiEndpointRecall": 0,
     "dynamicRouteRecall": 0,
@@ -81,6 +81,89 @@
           "missed": [
             "/api/blog/posts/:slug",
             "/blog/:slug"
+          ],
+          "falsePositives": [],
+          "recall": 0
+        }
+      }
+    },
+    {
+      "id": "vue-enterprise-mock",
+      "name": "Vue Enterprise Mock",
+      "framework": "vue-vite",
+      "blackbox": {
+        "jsEndpoints": [],
+        "externalJSFiles": [
+          "/assets/vue-enterprise-app.js"
+        ],
+        "filesAnalyzed": 2,
+        "message": "Found 0 unique endpoints in JavaScript (0 total calls)."
+      },
+      "whitebox": {
+        "mode": "fallback",
+        "reason": "no frameworks detected",
+        "frameworks": [],
+        "endpoints": []
+      },
+      "coverage": {
+        "pages": {
+          "expected": [
+            "/",
+            "/login",
+            "/dashboard",
+            "/projects",
+            "/projects/:projectId",
+            "/admin/users",
+            "/settings/profile"
+          ],
+          "discovered": [],
+          "matched": [],
+          "missed": [
+            "/",
+            "/admin/users",
+            "/dashboard",
+            "/login",
+            "/projects",
+            "/projects/:projectId",
+            "/settings/profile"
+          ],
+          "falsePositives": [],
+          "recall": 0
+        },
+        "apiEndpoints": {
+          "expected": [
+            "/api/session",
+            "/api/login",
+            "/api/dashboard/summary",
+            "/api/projects",
+            "/api/projects/:projectId",
+            "/api/admin/users",
+            "/api/settings/profile"
+          ],
+          "discovered": [],
+          "matched": [],
+          "missed": [
+            "/api/admin/users",
+            "/api/dashboard/summary",
+            "/api/login",
+            "/api/projects",
+            "/api/projects/:projectId",
+            "/api/session",
+            "/api/settings/profile"
+          ],
+          "falsePositives": [],
+          "recall": 0
+        },
+        "dynamicRoutes": {
+          "expected": [
+            "/projects/:projectId",
+            "/api/projects/:projectId"
+          ],
+          "discovered": [],
+          "matched": [],
+          "missed": [
+            "/api/projects/:projectId",
+            "/projects/:projectId"
           ],
           "falsePositives": [],
           "recall": 0

--- a/benchmarks/vue-recon/results/baseline-current.json
+++ b/benchmarks/vue-recon/results/baseline-current.json
@@ -1,0 +1,235 @@
+{
+  "generatedAt": "2026-06-08T21:34:36.093Z",
+  "metricSources": [
+    "extractJavascriptEndpoints",
+    "mapAppWithSurface"
+  ],
+  "summary": {
+    "fixtures": 3,
+    "pageRouteRecall": 0,
+    "apiEndpointRecall": 0,
+    "dynamicRouteRecall": 0,
+    "totalFalsePositives": 0
+  },
+  "results": [
+    {
+      "id": "nuxt-routes-api",
+      "name": "Nuxt Routes API",
+      "framework": "nuxt",
+      "blackbox": {
+        "jsEndpoints": [],
+        "externalJSFiles": [
+          "/_nuxt/app-nuxt-r4t5y6.js"
+        ],
+        "filesAnalyzed": 2,
+        "message": "Found 0 unique endpoints in JavaScript (0 total calls)."
+      },
+      "whitebox": {
+        "mode": "fallback",
+        "reason": "no frameworks detected",
+        "frameworks": [],
+        "endpoints": []
+      },
+      "coverage": {
+        "pages": {
+          "expected": [
+            "/",
+            "/admin",
+            "/blog",
+            "/blog/:slug",
+            "/profile/settings"
+          ],
+          "discovered": [],
+          "matched": [],
+          "missed": [
+            "/",
+            "/admin",
+            "/blog",
+            "/blog/:slug",
+            "/profile/settings"
+          ],
+          "falsePositives": [],
+          "recall": 0
+        },
+        "apiEndpoints": {
+          "expected": [
+            "/api/admin/audit-log",
+            "/api/blog/posts",
+            "/api/blog/posts/:slug",
+            "/api/me",
+            "/api/profile/settings"
+          ],
+          "discovered": [],
+          "matched": [],
+          "missed": [
+            "/api/admin/audit-log",
+            "/api/blog/posts",
+            "/api/blog/posts/:slug",
+            "/api/me",
+            "/api/profile/settings"
+          ],
+          "falsePositives": [],
+          "recall": 0
+        },
+        "dynamicRoutes": {
+          "expected": [
+            "/blog/:slug",
+            "/api/blog/posts/:slug"
+          ],
+          "discovered": [],
+          "matched": [],
+          "missed": [
+            "/api/blog/posts/:slug",
+            "/blog/:slug"
+          ],
+          "falsePositives": [],
+          "recall": 0
+        }
+      }
+    },
+    {
+      "id": "vue-vite-api-calls",
+      "name": "Vue Vite API Calls",
+      "framework": "vue-vite",
+      "blackbox": {
+        "jsEndpoints": [],
+        "externalJSFiles": [
+          "/assets/app-api-q1w2e3.js"
+        ],
+        "filesAnalyzed": 2,
+        "message": "Found 0 unique endpoints in JavaScript (0 total calls)."
+      },
+      "whitebox": {
+        "mode": "fallback",
+        "reason": "no frameworks detected",
+        "frameworks": [],
+        "endpoints": []
+      },
+      "coverage": {
+        "pages": {
+          "expected": [
+            "/",
+            "/account",
+            "/billing"
+          ],
+          "discovered": [],
+          "matched": [],
+          "missed": [
+            "/",
+            "/account",
+            "/billing"
+          ],
+          "falsePositives": [],
+          "recall": 0
+        },
+        "apiEndpoints": {
+          "expected": [
+            "/api/account",
+            "/api/billing/invoices",
+            "/api/billing/invoices/:invoiceId",
+            "/api/feature-flags",
+            "/api/search"
+          ],
+          "discovered": [],
+          "matched": [],
+          "missed": [
+            "/api/account",
+            "/api/billing/invoices",
+            "/api/billing/invoices/:invoiceId",
+            "/api/feature-flags",
+            "/api/search"
+          ],
+          "falsePositives": [],
+          "recall": 0
+        },
+        "dynamicRoutes": {
+          "expected": [
+            "/api/billing/invoices/:invoiceId"
+          ],
+          "discovered": [],
+          "matched": [],
+          "missed": [
+            "/api/billing/invoices/:invoiceId"
+          ],
+          "falsePositives": [],
+          "recall": 0
+        }
+      }
+    },
+    {
+      "id": "vue-vite-router",
+      "name": "Vue Vite Router",
+      "framework": "vue-vite",
+      "blackbox": {
+        "jsEndpoints": [],
+        "externalJSFiles": [
+          "/assets/app-router-a1b2c3.js"
+        ],
+        "filesAnalyzed": 2,
+        "message": "Found 0 unique endpoints in JavaScript (0 total calls)."
+      },
+      "whitebox": {
+        "mode": "fallback",
+        "reason": "no frameworks detected",
+        "frameworks": [],
+        "endpoints": []
+      },
+      "coverage": {
+        "pages": {
+          "expected": [
+            "/",
+            "/dashboard",
+            "/dashboard/reports",
+            "/projects",
+            "/projects/:projectId",
+            "/settings/profile"
+          ],
+          "discovered": [],
+          "matched": [],
+          "missed": [
+            "/",
+            "/dashboard",
+            "/dashboard/reports",
+            "/projects",
+            "/projects/:projectId",
+            "/settings/profile"
+          ],
+          "falsePositives": [],
+          "recall": 0
+        },
+        "apiEndpoints": {
+          "expected": [
+            "/api/session",
+            "/api/projects",
+            "/api/projects/:projectId",
+            "/api/reports/monthly"
+          ],
+          "discovered": [],
+          "matched": [],
+          "missed": [
+            "/api/projects",
+            "/api/projects/:projectId",
+            "/api/reports/monthly",
+            "/api/session"
+          ],
+          "falsePositives": [],
+          "recall": 0
+        },
+        "dynamicRoutes": {
+          "expected": [
+            "/projects/:projectId",
+            "/api/projects/:projectId"
+          ],
+          "discovered": [],
+          "matched": [],
+          "missed": [
+            "/api/projects/:projectId",
+            "/projects/:projectId"
+          ],
+          "falsePositives": [],
+          "recall": 0
+        }
+      }
+    }
+  ]
+}

--- a/benchmarks/vue-recon/results/current-stocktake.md
+++ b/benchmarks/vue-recon/results/current-stocktake.md
@@ -1,0 +1,47 @@
+# Vue Recon Baseline Stocktake
+
+Baseline command:
+
+```bash
+bun run benchmark:vue-recon
+```
+
+## Result
+
+| Metric               | Current baseline |
+| -------------------- | ---------------: |
+| Fixtures             |                3 |
+| Page route recall    |             0.0% |
+| API endpoint recall  |             0.0% |
+| Dynamic route recall |             0.0% |
+| False positives      |                0 |
+
+## What current recon saw
+
+- `extractJavascriptEndpoints` found each app's external production bundle:
+  - `/_nuxt/app-nuxt-r4t5y6.js`
+  - `/assets/app-api-q1w2e3.js`
+  - `/assets/app-router-a1b2c3.js`
+- It did not analyze those external bundles, so it reported zero endpoints.
+- `mapAppWithSurface` returned `fallback` for all three apps with reason
+  `no frameworks detected`.
+
+## Coverage gaps proven by the benchmark
+
+- Vue Router page routes are not deterministically extracted.
+- Vite hashed external chunks are not parsed by the current JS extractor.
+- Nuxt file-based pages and `server/api` routes are not covered by the current
+  surface integration.
+- `$fetch`, `useFetch`, axios instances, `import.meta.env` API bases, and
+  template-literal dynamic API paths are not covered by the deterministic
+  baseline.
+
+## Build priorities implied by the data
+
+1. Fetch and analyze same-origin external JS bundles in `jsExtraction.ts`.
+2. Add route/API patterns for Vue Router, Nuxt `$fetch` / `useFetch`, axios
+   instances, and `import.meta.env` API bases.
+3. Add Vue/Nuxt whitebox coverage through `@pensar/surface` or an Apex fallback
+   extractor.
+4. Feed this endpoint-oracle format into evalgate/full attack-surface runs so
+   LLM-driven browser exploration can be scored against the same manifests.

--- a/benchmarks/vue-recon/results/current-stocktake.md
+++ b/benchmarks/vue-recon/results/current-stocktake.md
@@ -10,7 +10,7 @@ bun run benchmark:vue-recon
 
 | Metric               | Current baseline |
 | -------------------- | ---------------: |
-| Fixtures             |                3 |
+| Fixtures             |                4 |
 | Page route recall    |             0.0% |
 | API endpoint recall  |             0.0% |
 | Dynamic route recall |             0.0% |
@@ -45,3 +45,10 @@ bun run benchmark:vue-recon
    extractor.
 4. Feed this endpoint-oracle format into evalgate/full attack-surface runs so
    LLM-driven browser exploration can be scored against the same manifests.
+
+## Full pentest contrast
+
+The full Apex CLI pentest run against `vue-enterprise-mock` discovered 100% of
+the known endpoints through persisted `document_endpoint` assets. This confirms
+the agentic browser/shell workflow can cover Vue when it thoroughly executes,
+even though deterministic helpers still miss Vue/Vite/Nuxt endpoints.

--- a/benchmarks/vue-recon/results/vue-enterprise-mock-pentest.json
+++ b/benchmarks/vue-recon/results/vue-enterprise-mock-pentest.json
@@ -1,0 +1,56 @@
+{
+  "fixtureId": "vue-enterprise-mock",
+  "sessionId": "ses_156b1dc70ffeveGajKKUoMCeQM",
+  "target": "http://127.0.0.1:4173",
+  "source": "apex pentest persisted document_endpoint assets",
+  "status": {
+    "endpointAssetsComplete": true,
+    "attackSurfaceResultsJsonPresent": false
+  },
+  "expected": {
+    "pages": [
+      "/",
+      "/login",
+      "/dashboard",
+      "/projects",
+      "/projects/:projectId",
+      "/admin/users",
+      "/settings/profile"
+    ],
+    "apiEndpoints": [
+      "/api/session",
+      "/api/login",
+      "/api/dashboard/summary",
+      "/api/projects",
+      "/api/projects/:projectId",
+      "/api/admin/users",
+      "/api/settings/profile"
+    ]
+  },
+  "discovered": {
+    "pages": [
+      "/",
+      "/login",
+      "/dashboard",
+      "/projects",
+      "/projects/:projectId",
+      "/admin/users",
+      "/settings/profile"
+    ],
+    "apiEndpoints": [
+      "/api/session",
+      "/api/login",
+      "/api/dashboard/summary",
+      "/api/projects",
+      "/api/projects/:projectId",
+      "/api/admin/users",
+      "/api/settings/profile"
+    ]
+  },
+  "metrics": {
+    "pageRouteRecall": 1,
+    "apiEndpointRecall": 1,
+    "dynamicRouteRecall": 1,
+    "falsePositives": 0
+  }
+}

--- a/benchmarks/vue-recon/results/vue-enterprise-mock-pentest.md
+++ b/benchmarks/vue-recon/results/vue-enterprise-mock-pentest.md
@@ -1,0 +1,89 @@
+# Vue Enterprise Mock Apex Pentest Result
+
+Command:
+
+```bash
+bun run src/cli.ts pentest --target http://127.0.0.1:4173 --model claude-haiku-4-5 --prompt "This is an authorized local benchmark against a Vue.js mock app. Focus on attack-surface recon and endpoint discovery. Stay in scope on http://127.0.0.1:4173 only. Do not attempt destructive actions."
+```
+
+Session:
+
+- `ses_156b1dc70ffeveGajKKUoMCeQM`
+- `/home/ubuntu/.pensar/sessions/ses_156b1dc70ffeveGajKKUoMCeQM`
+
+At comparison time, Apex had persisted `document_endpoint` assets for all known
+mock endpoints. The CLI had not yet emitted `attack-surface-results.json`, so
+this report compares the durable endpoint asset records in `assets/`.
+
+## Oracle
+
+The app defines 14 known first-party endpoints:
+
+- 7 page routes
+- 7 API endpoints
+- 1 ignored third-party telemetry endpoint:
+  `https://telemetry.example.invalid/vue-enterprise`
+
+## Coverage
+
+| Metric | Result |
+| --- | ---: |
+| Page routes expected | 7 |
+| Page routes discovered | 7 |
+| Page route recall | 100.0% |
+| API endpoints expected | 7 |
+| API endpoints discovered | 7 |
+| API endpoint recall | 100.0% |
+| Dynamic routes expected | 2 |
+| Dynamic routes discovered | 2 |
+| Dynamic route recall | 100.0% |
+| False positives in persisted endpoint assets | 0 |
+
+## Expected vs discovered
+
+### Page routes
+
+| Endpoint | Result |
+| --- | --- |
+| `/` | found |
+| `/login` | found |
+| `/dashboard` | found |
+| `/projects` | found |
+| `/projects/:projectId` | found |
+| `/admin/users` | found |
+| `/settings/profile` | found |
+
+### API endpoints
+
+| Endpoint | Result |
+| --- | --- |
+| `/api/session` | found |
+| `/api/login` | found |
+| `/api/dashboard/summary` | found |
+| `/api/projects` | found |
+| `/api/projects/:projectId` | found |
+| `/api/admin/users` | found |
+| `/api/settings/profile` | found |
+
+## What this says about Apex on Vue
+
+Apex's full LLM/browser/shell-driven pentest workflow did well on this runnable
+Vue mock app. It:
+
+- recognized the Vue app and visible navigation routes
+- inspected the JavaScript bundle
+- probed the APIs with HTTP requests
+- documented both Vue page routes and backend API endpoints
+- normalized dynamic routes like `/projects/:projectId` and
+  `/api/projects/:projectId`
+
+This is materially better than the deterministic baseline, which still misses
+Vue/Vite/Nuxt endpoints because it does not parse external bundles and
+`@pensar/surface` falls back on Vue/Nuxt apps.
+
+## Caveat
+
+This successful result depends on the full agentic pentest workflow. The
+deterministic recon helpers remain weak for Vue apps, so Vue coverage is good
+when the model/browser workflow executes thoroughly, but not yet guaranteed by
+static or deterministic extraction alone.

--- a/benchmarks/vue-recon/results/vue-enterprise-mock-pentest.md
+++ b/benchmarks/vue-recon/results/vue-enterprise-mock-pentest.md
@@ -26,44 +26,44 @@ The app defines 14 known first-party endpoints:
 
 ## Coverage
 
-| Metric | Result |
-| --- | ---: |
-| Page routes expected | 7 |
-| Page routes discovered | 7 |
-| Page route recall | 100.0% |
-| API endpoints expected | 7 |
-| API endpoints discovered | 7 |
-| API endpoint recall | 100.0% |
-| Dynamic routes expected | 2 |
-| Dynamic routes discovered | 2 |
-| Dynamic route recall | 100.0% |
-| False positives in persisted endpoint assets | 0 |
+| Metric                                       | Result |
+| -------------------------------------------- | -----: |
+| Page routes expected                         |      7 |
+| Page routes discovered                       |      7 |
+| Page route recall                            | 100.0% |
+| API endpoints expected                       |      7 |
+| API endpoints discovered                     |      7 |
+| API endpoint recall                          | 100.0% |
+| Dynamic routes expected                      |      2 |
+| Dynamic routes discovered                    |      2 |
+| Dynamic route recall                         | 100.0% |
+| False positives in persisted endpoint assets |      0 |
 
 ## Expected vs discovered
 
 ### Page routes
 
-| Endpoint | Result |
-| --- | --- |
-| `/` | found |
-| `/login` | found |
-| `/dashboard` | found |
-| `/projects` | found |
-| `/projects/:projectId` | found |
-| `/admin/users` | found |
-| `/settings/profile` | found |
+| Endpoint               | Result |
+| ---------------------- | ------ |
+| `/`                    | found  |
+| `/login`               | found  |
+| `/dashboard`           | found  |
+| `/projects`            | found  |
+| `/projects/:projectId` | found  |
+| `/admin/users`         | found  |
+| `/settings/profile`    | found  |
 
 ### API endpoints
 
-| Endpoint | Result |
-| --- | --- |
-| `/api/session` | found |
-| `/api/login` | found |
-| `/api/dashboard/summary` | found |
-| `/api/projects` | found |
-| `/api/projects/:projectId` | found |
-| `/api/admin/users` | found |
-| `/api/settings/profile` | found |
+| Endpoint                   | Result |
+| -------------------------- | ------ |
+| `/api/session`             | found  |
+| `/api/login`               | found  |
+| `/api/dashboard/summary`   | found  |
+| `/api/projects`            | found  |
+| `/api/projects/:projectId` | found  |
+| `/api/admin/users`         | found  |
+| `/api/settings/profile`    | found  |
 
 ## What this says about Apex on Vue
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "build:binary:linux-x64": "bun build src/cli.ts --compile --target=bun-linux-x64 --outfile dist/pensar-linux-x64",
     "build:binary:macos-arm64": "bun build src/cli.ts --compile --target=bun-darwin-arm64 --outfile dist/pensar-darwin-arm64",
     "build:binary:macos-x64": "bun build src/cli.ts --compile --target=bun-darwin-x64 --outfile dist/pensar-darwin-x64",
+    "benchmark:vue-recon": "bun run scripts/benchmark-vue-recon.ts",
     "check": "biome check --write",
     "check:ci": "biome check",
     "daytona-benchmark": "bun run scripts/daytona-benchmark.ts",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "url": "https://github.com/pensarai/apex.git"
   },
   "scripts": {
+    "benchmark:vue-recon": "bun run scripts/benchmark-vue-recon.ts",
     "build": "bun build src/cli.ts --outdir build --target node --format esm --splitting --external @opentui/core --external @opentui/react --external @opentui/react/* --external react --external react/jsx-runtime --external react/jsx-dev-runtime --external react-reconciler --external weave",
     "build:binaries": "bun run generate:ascii && mkdir -p dist && bun run build:binary:macos-arm64 && bun run build:binary:macos-x64 && bun run build:binary:linux-x64 && bun run build:binary:linux-arm64",
     "build:binary": "bun run generate:ascii && bun build src/cli.ts --compile --outfile pensar",
@@ -91,7 +92,6 @@
     "build:binary:linux-x64": "bun build src/cli.ts --compile --target=bun-linux-x64 --outfile dist/pensar-linux-x64",
     "build:binary:macos-arm64": "bun build src/cli.ts --compile --target=bun-darwin-arm64 --outfile dist/pensar-darwin-arm64",
     "build:binary:macos-x64": "bun build src/cli.ts --compile --target=bun-darwin-x64 --outfile dist/pensar-darwin-x64",
-    "benchmark:vue-recon": "bun run scripts/benchmark-vue-recon.ts",
     "check": "biome check --write",
     "check:ci": "biome check",
     "daytona-benchmark": "bun run scripts/daytona-benchmark.ts",

--- a/scripts/benchmark-vue-recon.ts
+++ b/scripts/benchmark-vue-recon.ts
@@ -1,7 +1,13 @@
 #!/usr/bin/env bun
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync } from "fs";
-import { extname, join, resolve } from "path";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import { extname, join, resolve } from "node:path";
 import { extractJavascriptEndpoints } from "../src/core/agents/specialized/attackSurface/jsExtraction";
 import { mapAppWithSurface } from "../src/core/integrations/surface";
 
@@ -51,7 +57,9 @@ interface FixtureResult {
 }
 
 const MANIFEST_DIR = resolve("benchmarks/vue-recon/expected");
-const OUTPUT_PATH = resolve("benchmarks/vue-recon/results/baseline-current.json");
+const OUTPUT_PATH = resolve(
+  "benchmarks/vue-recon/results/baseline-current.json",
+);
 
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
@@ -130,8 +138,13 @@ function matchesExpected(actual: string, expected: string): boolean {
   return false;
 }
 
-function compareCoverage(expected: string[], discoveredRaw: string[]): CoverageResult {
-  const discovered = Array.from(new Set(discoveredRaw.map(normalizePath))).sort();
+function compareCoverage(
+  expected: string[],
+  discoveredRaw: string[],
+): CoverageResult {
+  const discovered = Array.from(
+    new Set(discoveredRaw.map(normalizePath)),
+  ).sort();
   const matched = expected
     .filter((expectedPath) =>
       discovered.some((actual) => matchesExpected(actual, expectedPath)),
@@ -172,7 +185,8 @@ async function runFixture(manifest: EndpointManifest): Promise<FixtureResult> {
       includeExternalJS: true,
     });
 
-    const jsEndpoints = jsResult.endpoints?.map((endpoint) => endpoint.endpoint) ?? [];
+    const jsEndpoints =
+      jsResult.endpoints?.map((endpoint) => endpoint.endpoint) ?? [];
     const surfaceResult = mapAppWithSurface(appPath, appPath, {
       isSingleAppRepo: true,
     });
@@ -255,10 +269,7 @@ async function main(): Promise<void> {
 
   const report = {
     generatedAt: new Date().toISOString(),
-    metricSources: [
-      "extractJavascriptEndpoints",
-      "mapAppWithSurface",
-    ],
+    metricSources: ["extractJavascriptEndpoints", "mapAppWithSurface"],
     summary: {
       fixtures: results.length,
       pageRouteRecall: average(results.map((r) => r.coverage.pages.recall)),

--- a/scripts/benchmark-vue-recon.ts
+++ b/scripts/benchmark-vue-recon.ts
@@ -1,0 +1,304 @@
+#!/usr/bin/env bun
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync } from "fs";
+import { extname, join, resolve } from "path";
+import { extractJavascriptEndpoints } from "../src/core/agents/specialized/attackSurface/jsExtraction";
+import { mapAppWithSurface } from "../src/core/integrations/surface";
+
+interface EndpointManifest {
+  id: string;
+  name: string;
+  framework: string;
+  appPath: string;
+  staticBuildPath: string;
+  expected: {
+    pages: string[];
+    apiEndpoints: string[];
+    ignoredExternal: string[];
+  };
+}
+
+interface CoverageResult {
+  expected: string[];
+  discovered: string[];
+  matched: string[];
+  missed: string[];
+  falsePositives: string[];
+  recall: number;
+}
+
+interface FixtureResult {
+  id: string;
+  name: string;
+  framework: string;
+  blackbox: {
+    jsEndpoints: string[];
+    externalJSFiles: string[];
+    filesAnalyzed: number;
+    message: string;
+  };
+  whitebox: {
+    mode: "surface" | "fallback";
+    reason?: string;
+    frameworks: string[];
+    endpoints: string[];
+  };
+  coverage: {
+    pages: CoverageResult;
+    apiEndpoints: CoverageResult;
+    dynamicRoutes: CoverageResult;
+  };
+}
+
+const MANIFEST_DIR = resolve("benchmarks/vue-recon/expected");
+const OUTPUT_PATH = resolve("benchmarks/vue-recon/results/baseline-current.json");
+
+const MIME_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+};
+
+function loadManifests(): EndpointManifest[] {
+  return readdirSync(MANIFEST_DIR)
+    .filter((file) => file.endsWith(".json"))
+    .sort()
+    .map((file) => {
+      const fullPath = join(MANIFEST_DIR, file);
+      return JSON.parse(readFileSync(fullPath, "utf-8")) as EndpointManifest;
+    });
+}
+
+function startStaticServer(root: string): { url: string; stop: () => void } {
+  const staticRoot = resolve(root);
+  const server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      const requestUrl = new URL(request.url);
+      const pathname = decodeURIComponent(requestUrl.pathname);
+      const relativePath = pathname === "/" ? "index.html" : pathname.slice(1);
+      const filePath = resolve(staticRoot, relativePath);
+
+      if (!(filePath === staticRoot || filePath.startsWith(`${staticRoot}/`))) {
+        return new Response("Forbidden", { status: 403 });
+      }
+
+      if (existsSync(filePath) && statSync(filePath).isFile()) {
+        return new Response(Bun.file(filePath), {
+          headers: {
+            "content-type":
+              MIME_TYPES[extname(filePath)] ?? "application/octet-stream",
+          },
+        });
+      }
+
+      const fallbackPath = join(staticRoot, "index.html");
+      return new Response(Bun.file(fallbackPath), {
+        headers: { "content-type": MIME_TYPES[".html"] },
+      });
+    },
+  });
+
+  return {
+    url: `http://127.0.0.1:${server.port}`,
+    stop: () => server.stop(true),
+  };
+}
+
+function normalizePath(value: string): string {
+  try {
+    const parsed = new URL(value, "http://fixture.local");
+    return parsed.pathname.replace(/\/$/, "") || "/";
+  } catch {
+    return value.split(/[?#]/, 1)[0]?.replace(/\/$/, "") || "/";
+  }
+}
+
+function expectedPatternToRegex(pattern: string): RegExp {
+  const escaped = pattern
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/:[^/]+/g, "[^/]+");
+  return new RegExp(`^${escaped}$`);
+}
+
+function matchesExpected(actual: string, expected: string): boolean {
+  if (actual === expected) return true;
+  if (expected.includes(":")) {
+    return expectedPatternToRegex(expected).test(actual);
+  }
+  return false;
+}
+
+function compareCoverage(expected: string[], discoveredRaw: string[]): CoverageResult {
+  const discovered = Array.from(new Set(discoveredRaw.map(normalizePath))).sort();
+  const matched = expected
+    .filter((expectedPath) =>
+      discovered.some((actual) => matchesExpected(actual, expectedPath)),
+    )
+    .sort();
+  const missed = expected
+    .filter((expectedPath) => !matched.includes(expectedPath))
+    .sort();
+  const falsePositives = discovered
+    .filter(
+      (actual) =>
+        !expected.some((expectedPath) => matchesExpected(actual, expectedPath)),
+    )
+    .sort();
+
+  return {
+    expected,
+    discovered,
+    matched,
+    missed,
+    falsePositives,
+    recall: expected.length === 0 ? 1 : matched.length / expected.length,
+  };
+}
+
+function dynamicOnly(paths: string[]): string[] {
+  return paths.filter((path) => path.includes(":"));
+}
+
+async function runFixture(manifest: EndpointManifest): Promise<FixtureResult> {
+  const appPath = resolve(manifest.appPath);
+  const staticBuildPath = resolve(manifest.staticBuildPath);
+  const server = startStaticServer(staticBuildPath);
+
+  try {
+    const jsResult = await extractJavascriptEndpoints({
+      url: server.url,
+      includeExternalJS: true,
+    });
+
+    const jsEndpoints = jsResult.endpoints?.map((endpoint) => endpoint.endpoint) ?? [];
+    const surfaceResult = mapAppWithSurface(appPath, appPath, {
+      isSingleAppRepo: true,
+    });
+
+    const surfaceEndpoints =
+      surfaceResult.mode === "surface" ? surfaceResult.endpoints : [];
+    const surfacePages = surfaceEndpoints
+      .filter((endpoint) => endpoint.kind === "page")
+      .map((endpoint) => endpoint.path);
+    const surfaceApiEndpoints = surfaceEndpoints
+      .filter((endpoint) => endpoint.kind === "api")
+      .map((endpoint) => endpoint.path);
+
+    const discoveredPages = jsEndpoints
+      .filter((endpoint) => !normalizePath(endpoint).startsWith("/api"))
+      .concat(surfacePages);
+    const discoveredApiEndpoints = jsEndpoints
+      .filter((endpoint) => normalizePath(endpoint).startsWith("/api"))
+      .concat(surfaceApiEndpoints);
+
+    return {
+      id: manifest.id,
+      name: manifest.name,
+      framework: manifest.framework,
+      blackbox: {
+        jsEndpoints: Array.from(new Set(jsEndpoints.map(normalizePath))).sort(),
+        externalJSFiles: jsResult.externalJSFiles ?? [],
+        filesAnalyzed: jsResult.filesAnalyzed ?? 0,
+        message: jsResult.message,
+      },
+      whitebox:
+        surfaceResult.mode === "surface"
+          ? {
+              mode: "surface",
+              frameworks: surfaceResult.frameworks,
+              endpoints: surfaceResult.endpoints
+                .map((endpoint) => endpoint.path)
+                .sort(),
+            }
+          : {
+              mode: "fallback",
+              reason: surfaceResult.reason,
+              frameworks: [],
+              endpoints: [],
+            },
+      coverage: {
+        pages: compareCoverage(manifest.expected.pages, discoveredPages),
+        apiEndpoints: compareCoverage(
+          manifest.expected.apiEndpoints,
+          discoveredApiEndpoints,
+        ),
+        dynamicRoutes: compareCoverage(
+          dynamicOnly([
+            ...manifest.expected.pages,
+            ...manifest.expected.apiEndpoints,
+          ]),
+          [...discoveredPages, ...discoveredApiEndpoints],
+        ),
+      },
+    };
+  } finally {
+    server.stop();
+  }
+}
+
+function average(values: number[]): number {
+  return values.length === 0
+    ? 0
+    : values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+async function main(): Promise<void> {
+  const manifests = loadManifests();
+  const results: FixtureResult[] = [];
+
+  for (const manifest of manifests) {
+    console.log(`Running Vue recon benchmark: ${manifest.id}`);
+    results.push(await runFixture(manifest));
+  }
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    metricSources: [
+      "extractJavascriptEndpoints",
+      "mapAppWithSurface",
+    ],
+    summary: {
+      fixtures: results.length,
+      pageRouteRecall: average(results.map((r) => r.coverage.pages.recall)),
+      apiEndpointRecall: average(
+        results.map((r) => r.coverage.apiEndpoints.recall),
+      ),
+      dynamicRouteRecall: average(
+        results.map((r) => r.coverage.dynamicRoutes.recall),
+      ),
+      totalFalsePositives: results.reduce(
+        (sum, result) =>
+          sum +
+          result.coverage.pages.falsePositives.length +
+          result.coverage.apiEndpoints.falsePositives.length,
+        0,
+      ),
+    },
+    results,
+  };
+
+  mkdirSync(resolve("benchmarks/vue-recon/results"), { recursive: true });
+  await Bun.write(OUTPUT_PATH, `${JSON.stringify(report, null, 2)}\n`);
+
+  console.log("");
+  console.log("Vue recon baseline summary");
+  console.log(`Fixtures: ${report.summary.fixtures}`);
+  console.log(
+    `Page route recall: ${(report.summary.pageRouteRecall * 100).toFixed(1)}%`,
+  );
+  console.log(
+    `API endpoint recall: ${(report.summary.apiEndpointRecall * 100).toFixed(1)}%`,
+  );
+  console.log(
+    `Dynamic route recall: ${(report.summary.dynamicRouteRecall * 100).toFixed(1)}%`,
+  );
+  console.log(`False positives: ${report.summary.totalFalsePositives}`);
+  console.log(`Report: ${OUTPUT_PATH}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
-  }
+  },
+  "exclude": ["benchmarks/vue-recon/apps/**"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Adds a benchmark-first Vue recon suite with buildable Vue/Vite/Nuxt fixtures, endpoint oracle manifests, static production-like builds, and a local `bun run benchmark:vue-recon` command to measure current deterministic recon coverage before implementing Vue-specific support.

It also adds a runnable `vue-enterprise-mock` app and records a real Apex CLI pentest comparison in `benchmarks/vue-recon/results/vue-enterprise-mock-pentest.md` / `.json`.

Current deterministic baseline:

| Metric | Result |
| --- | ---: |
| Fixtures | 4 |
| Page route recall | 0.0% |
| API endpoint recall | 0.0% |
| Dynamic route recall | 0.0% |
| False positives | 0 |

Full Apex pentest on `vue-enterprise-mock`:

| Metric | Result |
| --- | ---: |
| Page route recall | 100.0% |
| API endpoint recall | 100.0% |
| Dynamic route recall | 100.0% |
| False positives in persisted endpoint assets | 0 |

### How did you verify your code works?

- `curl` probes against `http://127.0.0.1:4173/`, `/api/admin/users`, and `/api/settings/profile`
- `bun run src/cli.ts pentest --target http://127.0.0.1:4173 --model claude-haiku-4-5 --prompt "This is an authorized local benchmark against a Vue.js mock app. Focus on attack-surface recon and endpoint discovery. Stay in scope on http://127.0.0.1:4173 only. Do not attempt destructive actions."`
- `bun run benchmark:vue-recon`
- `bun run tsc`
- `bun run lint`
- `bun run test`
- `bunx prettier --check "benchmarks/vue-recon/**/*.md"`

Note: full `bun run format:check` is blocked by existing unrelated Biome diagnostics in scripts such as `scripts/compare-results.ts`; touched benchmark markdown is formatted and the standard `bun run lint` target passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bab9c27-c4f3-4a5b-9a24-71b8ebd4df16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bab9c27-c4f3-4a5b-9a24-71b8ebd4df16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

