### PR TITLE
fix(ai): improve Bedrock prompt-cache hit rate (tool-result tail + model-gated 1h TTL)

### DIFF
--- a/src/core/ai/providers/pensarFormatters.test.ts
+++ b/src/core/ai/providers/pensarFormatters.test.ts
@@ -1,0 +1,117 @@
+import type { LanguageModelV3CallOptions } from "@ai-sdk/provider";
+import { describe, expect, it } from "vitest";
+import { convertToBedrockFormat } from "./pensarFormatters";
+
+// Opus 4.6 supports ONLY the 5-minute TTL on Bedrock; the 4.5 generation
+// (Opus/Sonnet/Haiku 4.5) additionally supports the extended 1-hour TTL.
+const MODEL_ID = "anthropic.claude-opus-4-6-v1";
+const MODEL_ID_1H = "anthropic.claude-sonnet-4-5-20250929-v1:0";
+const EPHEMERAL = { type: "ephemeral" };
+const EPHEMERAL_1H = { type: "ephemeral", ttl: "1h" };
+const CACHE_OPTS = { anthropic: { cacheControl: { type: "ephemeral" } } };
+
+type Block = Record<string, unknown>;
+type Msg = { role: string; content: string | Block[] };
+
+/** Build a Bedrock request body from a loosely-typed prompt array. */
+function build(
+  prompt: unknown[],
+  modelId: string = MODEL_ID,
+): Record<string, unknown> {
+  return convertToBedrockFormat(modelId, {
+    prompt,
+  } as unknown as LanguageModelV3CallOptions);
+}
+
+function toolResult(toolCallId: string, value: string): Block {
+  return {
+    type: "tool-result",
+    toolCallId,
+    toolName: "http_request",
+    output: { type: "text", value },
+  };
+}
+
+/** Content blocks of the message at `index` (defaults to the last message). */
+function blocksOf(body: Record<string, unknown>, index = -1): Block[] {
+  const messages = body.messages as Msg[];
+  const msg = messages.at(index);
+  return msg?.content as Block[];
+}
+
+describe("convertToBedrockFormat — Anthropic cache_control", () => {
+  it("tags the last tool_result block when the tool message carries cacheControl (fix #1)", () => {
+    // In an agent loop the rolling breakpoint (withCachedLastMessage) lands on
+    // the trailing tool result. Previously the tool branch ignored it, so only
+    // the static system block ever cached.
+    const body = build([
+      {
+        role: "tool",
+        providerOptions: CACHE_OPTS,
+        content: [toolResult("call_1", "RESPONSE BODY")],
+      },
+    ]);
+
+    expect((body.messages as Msg[]).at(-1)?.role).toBe("user");
+    const lastBlock = blocksOf(body).at(-1);
+    expect(lastBlock?.type).toBe("tool_result");
+    expect(lastBlock?.cache_control).toEqual(EPHEMERAL);
+  });
+
+  it("tags only the LAST tool_result block when several are present", () => {
+    const body = build([
+      {
+        role: "tool",
+        providerOptions: CACHE_OPTS,
+        content: [toolResult("a", "first"), toolResult("b", "second")],
+      },
+    ]);
+
+    const blocks = blocksOf(body);
+    expect(blocks.at(0)?.cache_control).toBeUndefined();
+    expect(blocks.at(1)?.cache_control).toEqual(EPHEMERAL);
+  });
+
+  it("does NOT tag tool results when no cacheControl is present (regression guard)", () => {
+    const body = build([
+      {
+        role: "tool",
+        content: [toolResult("call_1", "RESPONSE BODY")],
+      },
+    ]);
+
+    expect(blocksOf(body).at(0)?.cache_control).toBeUndefined();
+  });
+
+  it("applies a 1-hour TTL to the cached system prefix on a model that supports it (fix #3)", () => {
+    const body = build(
+      [
+        {
+          role: "system",
+          content: "SYSTEM PROMPT",
+          providerOptions: CACHE_OPTS,
+        },
+      ],
+      MODEL_ID_1H,
+    );
+
+    expect(body.system).toEqual([
+      { type: "text", text: "SYSTEM PROMPT", cache_control: EPHEMERAL_1H },
+    ]);
+  });
+
+  it("uses 5-minute ephemeral (no ttl) for the system prefix on Opus 4.6, which lacks 1h support", () => {
+    const body = build([
+      { role: "system", content: "SYSTEM PROMPT", providerOptions: CACHE_OPTS },
+    ]);
+
+    expect(body.system).toEqual([
+      { type: "text", text: "SYSTEM PROMPT", cache_control: EPHEMERAL },
+    ]);
+  });
+
+  it("keeps the system prompt a plain string when uncached", () => {
+    const body = build([{ role: "system", content: "SYSTEM PROMPT" }]);
+    expect(body.system).toBe("SYSTEM PROMPT");
+  });
+});

--- a/src/core/ai/providers/pensarFormatters.ts
+++ b/src/core/ai/providers/pensarFormatters.ts
@@ -21,6 +21,34 @@ export function convertToBedrockFormat(
 
 const EPHEMERAL_CACHE_CONTROL = { type: "ephemeral" as const };
 
+// Extended (1-hour) TTL variant for the static system + tools prefix. This
+// prefix is byte-identical across every step of a session and across all
+// parallel workers in a run, so a 1h TTL keeps it warm across slow tool calls
+// (browser automation, multi-minute sub-agents) and rate-limit backoffs that
+// exceed the default 5-minute window, and lets a later worker read the prefix
+// an earlier worker already wrote. Only emitted for models that support it
+// (see supportsExtendedCacheTtl) — Bedrock ignores/refuses ttl on the rest.
+const SYSTEM_CACHE_CONTROL_1H = {
+  type: "ephemeral" as const,
+  ttl: "1h" as const,
+};
+
+// Only a subset of Claude models on Bedrock support the extended 1-hour cache
+// TTL: Opus 4.5, Sonnet 4.5, and Haiku 4.5. Opus 4.6+ and Sonnet 4.6, plus
+// older models (Opus 4, 3.7/3.5 Sonnet), support ONLY the default 5-minute
+// TTL — sending ttl:"1h" to them does not extend the cache. Gate on an explicit
+// allowlist and fall back to plain 5-minute ephemeral everywhere else.
+// https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+function supportsExtendedCacheTtl(modelId: string): boolean {
+  // Normalize dotted version forms (4.5 → 4-5) so all id shapes match.
+  const normalized = modelId.replace(/(\d)\.(\d)/g, "$1-$2");
+  return (
+    normalized.includes("claude-opus-4-5") ||
+    normalized.includes("claude-sonnet-4-5") ||
+    normalized.includes("claude-haiku-4-5")
+  );
+}
+
 function hasCacheControl(part: Record<string, unknown>): boolean {
   const opts = part.providerOptions as
     | Record<string, Record<string, unknown>>
@@ -116,8 +144,11 @@ function convertToAnthropicFormat(
           messages.push({ role: "assistant", content: text });
         }
       } else if (part.role === "tool") {
-        // Tool results get appended as user messages in Anthropic format
-        const toolResults = (
+        // Tool results get appended as user messages in Anthropic format.
+        const partHasCache = hasCacheControl(
+          part as unknown as Record<string, unknown>,
+        );
+        const toolResults: Array<Record<string, unknown>> = (
           part.content as Array<LanguageModelV3ToolResultPart>
         ).map((c: LanguageModelV3ToolResultPart) => {
           let resultContent: string;
@@ -136,6 +167,17 @@ function convertToAnthropicFormat(
             content: resultContent,
           };
         });
+        // The rolling cache breakpoint (withCachedLastMessage) lands on
+        // whatever the last message is — in an agent loop that is almost
+        // always a tool result. Without honoring cacheControl here, the
+        // breakpoint is silently dropped and only the static system block
+        // ever caches, so the entire growing conversation is re-billed as
+        // fresh input every step. Anthropic caches the prefix up to the
+        // block carrying cache_control, so tag the LAST tool_result block.
+        const lastResult = toolResults[toolResults.length - 1];
+        if (partHasCache && lastResult) {
+          lastResult.cache_control = EPHEMERAL_CACHE_CONTROL;
+        }
         messages.push({ role: "user", content: toolResults });
       }
     }
@@ -158,12 +200,19 @@ function convertToAnthropicFormat(
   };
 
   if (systemPrompt) {
+    // 1h TTL only on models that support it; everything else uses 5-minute
+    // ephemeral. The system block precedes messages, satisfying Bedrock's
+    // "longer TTL must appear before shorter TTL" ordering constraint when the
+    // rolling 5-minute tail breakpoint is also present.
+    const systemCacheControl = supportsExtendedCacheTtl(modelId)
+      ? SYSTEM_CACHE_CONTROL_1H
+      : EPHEMERAL_CACHE_CONTROL;
     body.system = systemHasCacheControl
       ? [
           {
             type: "text",
             text: systemPrompt,
-            cache_control: EPHEMERAL_CACHE_CONTROL,
+            cache_control: systemCacheControl,
           },
         ]
       : systemPrompt;


### PR DESCRIPTION
## Problem

On a real Opus 4.6 pentest run, prompt caching was badly underperforming: **~81% of input was uncached (~19% cache-read)**, and cache-read stayed *flat* at roughly the system+tools size regardless of conversation length. That's the fingerprint of **only the static system block caching, with the entire growing conversation re-billed as fresh input every step**.

Root cause: `convertToAnthropicFormat` (the Bedrock request formatter) applied `cache_control` to system and user-text blocks, but the **`tool`-role branch ignored `cacheControl` entirely**. In an agent loop the last message before nearly every model call is a tool result, so the rolling breakpoint that `withCachedLastMessage` places was silently dropped on conversion — leaving only the system breakpoint.

## Changes

**#1 — Honor `cacheControl` on tool-result messages.** Tag the **last** `tool_result` block when the tool part carries `cacheControl`, so the rolling breakpoint survives and the conversation prefix caches incrementally. This is the high-leverage fix.

**#3 — Model-gated 1h cache TTL on the static system/tools prefix.** Per the [Bedrock prompt-caching docs](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html), only **Opus 4.5 / Sonnet 4.5 / Haiku 4.5** support the extended 1-hour TTL. **Opus 4.6+ and older models support only the 5-minute TTL**, so `supportsExtendedCacheTtl()` gates the `ttl:"1h"` emission and everything else falls back to plain ephemeral. The system block precedes messages, satisfying Bedrock's "longer TTL must appear before shorter TTL" ordering constraint when the 5-minute tail breakpoint is also present.

## Impact

- **#1 carries the win** — turns on incremental caching of conversation history. The 5-minute TTL slides (resets on each cache hit), so fast-stepping loops stay warm continuously.
- **#3 is a no-op on Opus 4.6** (already 5-min ephemeral there); it only helps 4.5-generation models. Kept because it's correct and free.

## Tests

New `pensarFormatters.test.ts` (6 cases): tool-result tail tagging, last-of-many tagging, no-cacheControl regression guard, 1h TTL on a supporting model, 5-min ephemeral on Opus 4.6, plain-string system when uncached.

- `bunx vitest run` — 6/6 pass
- `biome check` — clean
- `bun run tsc` — exit 0

## Not included / follow-ups

- **#2 (cache-aware compaction)** — `snipOldSteps`/`applyToolResultBudget` mutate mid-history messages, which invalidates the rolling prefix #1 just enabled. This is the highest-value follow-up to *hold* the gain on long sessions (freeze truncated results + hysteresis + a third breakpoint at the `keepRecent` boundary).
- **#4 (caching the `generateObjectResponse` path)** — investigated and **dropped**: all those system prompts are under Opus 4.6's 4,096-token cache floor and the path is a rounding error in total tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)