### PR TITLE
feat(memory): add memoryEnabled config knob

### DIFF
--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { z } from "zod";
 import type { FindingsRegistry } from "../../../findings/registry";
+import { isMemoryEnabled } from "../../../memory";
 import { readPlan } from "../../../plan";
 import {
   type Finding,
@@ -902,28 +903,30 @@ const SHARED_PENTEST_TOOLS = [
  *   `list_tasks`. Workers do NOT get `spawn_pentest_agent` — this prevents
  *   unbounded recursive fan-out.
  */
+const MEMORY_TOOL_NAMES = ["add_memory", "list_memories", "get_memory"];
+
 export function buildPentestActiveTools(
   role: PentestAgentRole,
   session: { config?: { taskDriven?: boolean } },
 ): string[] {
-  if (role === "orchestrator") {
-    return [
-      ...WORKER_RECON_TOOLS,
-      ...SHARED_PENTEST_TOOLS,
-      "spawn_pentest_agent",
-    ];
-  }
+  const tools =
+    role === "orchestrator"
+      ? [...WORKER_RECON_TOOLS, ...SHARED_PENTEST_TOOLS, "spawn_pentest_agent"]
+      : [
+          ...WORKER_RECON_TOOLS,
+          "document_vulnerability",
+          ...SHARED_PENTEST_TOOLS,
+          // Task decomposition tools — only active when taskDriven is enabled
+          // (tools are conditionally created by the base class based on tasksDir).
+          ...(session.config?.taskDriven
+            ? ["create_task", "update_task", "list_tasks"]
+            : []),
+        ];
 
-  return [
-    ...WORKER_RECON_TOOLS,
-    "document_vulnerability",
-    ...SHARED_PENTEST_TOOLS,
-    // Task decomposition tools — only active when taskDriven is enabled
-    // (tools are conditionally created by the base class based on tasksDir).
-    ...(session.config?.taskDriven
-      ? ["create_task", "update_task", "list_tasks"]
-      : []),
-  ];
+  if (!isMemoryEnabled()) {
+    return tools.filter((t) => !MEMORY_TOOL_NAMES.includes(t));
+  }
+  return tools;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/memory/index.ts
+++ b/src/core/memory/index.ts
@@ -26,6 +26,12 @@ export interface Memory {
 
 const MEMORIES_PREFIX = "memories";
 
+/** Disabled via the `PENSAR_MEMORY_ENABLED` env var; enabled when unset. */
+export function isMemoryEnabled(): boolean {
+  const v = process.env.PENSAR_MEMORY_ENABLED?.trim().toLowerCase();
+  return !(v === "false" || v === "0" || v === "off" || v === "no");
+}
+
 function storageKey(category: MemoryCategory, id: string): string[] {
   return [MEMORIES_PREFIX, category, id];
 }
@@ -79,6 +85,9 @@ export async function addMemory(input: {
     updatedAt: now,
   };
 
+  // Disabled: no-op write.
+  if (!isMemoryEnabled()) return memory;
+
   await Storage.write(storageKey(category, id), memory);
   return memory;
 }
@@ -97,6 +106,19 @@ export async function addMemoryWithId(input: {
   validateId(input.id);
   const category: MemoryCategory = input.category ?? "general";
   const now = new Date().toISOString();
+
+  // Disabled: no-op write.
+  if (!isMemoryEnabled()) {
+    return {
+      id: input.id,
+      category,
+      title: input.title,
+      content: input.content,
+      tags: input.tags ?? [],
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
 
   // Preserve createdAt if this is an update
   let createdAt = now;
@@ -129,6 +151,7 @@ export async function deleteMemory(
   category: MemoryCategory,
   id: string,
 ): Promise<boolean> {
+  if (!isMemoryEnabled()) return false;
   validateId(id);
   // Check existence first — Storage.remove silently succeeds on missing files
   const existing = await getMemory(category, id);
@@ -145,6 +168,7 @@ export async function getMemory(
   category: MemoryCategory,
   id: string,
 ): Promise<Memory | null> {
+  if (!isMemoryEnabled()) return null;
   validateId(id);
   try {
     return await Storage.read<Memory>(storageKey(category, id));
@@ -172,6 +196,7 @@ export async function listMemories(opts?: {
   category?: MemoryCategory;
   tag?: string;
 }): Promise<MemorySummary[]> {
+  if (!isMemoryEnabled()) return [];
   const prefix = opts?.category
     ? [MEMORIES_PREFIX, opts.category]
     : [MEMORIES_PREFIX];


### PR DESCRIPTION
Adds a `memoryEnabled` config knob (env: `PENSAR_MEMORY_ENABLED`, default on), mirroring `surfaceIntegrationEnabled`.

When disabled:
- Storage layer no-ops — reads return empty, writes persist nothing.
- `buildPentestActiveTools` drops the memory tools from the agent's active set.

`bun run tsc` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Feature-flag style behavior change with safe defaults; only affects optional cross-session memory, not auth or findings.
> 
> **Overview**
> Adds a **`memoryEnabled`** setting (config + **`PENSAR_MEMORY_ENABLED`**, default **on** when unset), following the same pattern as **`surfaceIntegrationEnabled`**.
> 
> When memory is off, the **memory module** short-circuits: reads return empty/null, writes/deletes do not touch disk (add APIs still return in-memory-shaped objects). **`buildPentestActiveTools`** also removes **`add_memory`**, **`list_memories`**, and **`get_memory`** when the env flag disables memory (pentest gating is env-only, not **`config.json`**).
> 
> **`buildPentestActiveTools`** is refactored slightly (shared tool list + filter) with no intended change to orchestrator vs worker tool sets beyond the memory filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4810696b97c883cc61fc5c2670712ce9abee570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->