### PR TITLE
fix(tui): count subagent tokens in operator session totals

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -820,31 +820,44 @@ export default function OperatorDashboard({
         nextMessages = conversationRef.current;
       }
 
+      // Shared sink for orchestrator + subagent token usage.
+      const recordTokenUsage = (
+        inputTokens: number,
+        outputTokens: number,
+        cacheReadTokens = 0,
+        cacheWriteTokens = 0,
+      ) => {
+        const nextUsage = accumulateTokenUsage(
+          tokenUsageRef.current,
+          inputTokens,
+          outputTokens,
+        );
+        if (nextUsage) {
+          tokenUsageRef.current = nextUsage;
+          addTokenUsage(inputTokens, outputTokens);
+          if (session) {
+            try {
+              writeExecutionMetrics({
+                sessionRootPath: session.rootPath,
+                tokenUsage: nextUsage,
+              });
+            } catch {
+              // Best effort: token metrics should not interrupt operator runs.
+            }
+          }
+        }
+        if (cacheReadTokens > 0 || cacheWriteTokens > 0) {
+          addCacheUsage(cacheReadTokens, cacheWriteTokens);
+        }
+      };
+
       const onStepFinish = (event: {
         usage?: { inputTokens?: number; outputTokens?: number };
       }) => {
-        const nextUsage = accumulateTokenUsage(
-          tokenUsageRef.current,
+        recordTokenUsage(
           event.usage?.inputTokens ?? 0,
           event.usage?.outputTokens ?? 0,
         );
-        if (!nextUsage) return;
-        tokenUsageRef.current = nextUsage;
-
-        addTokenUsage(
-          event.usage?.inputTokens ?? 0,
-          event.usage?.outputTokens ?? 0,
-        );
-        if (session) {
-          try {
-            writeExecutionMetrics({
-              sessionRootPath: session.rootPath,
-              tokenUsage: nextUsage,
-            });
-          } catch {
-            // Best effort: token metrics should not interrupt operator runs.
-          }
-        }
       };
 
       const eventBus = new AgentEventBus();
@@ -1188,6 +1201,23 @@ export default function OperatorDashboard({
         earlyBuffer?.push(e);
       };
       eventBus.on("trace-record", earlyBufferHandler);
+
+      // Subagent steps (orchestrator ones lack subagentId, counted above).
+      // Key dedupes the W&B early-buffer replay.
+      const countedSubagentSteps = new Set<string>();
+      eventBus.on("trace-record", ({ record, subagentId }) => {
+        if (gen !== generationRef.current) return;
+        if (!subagentId || record.type !== "step") return;
+        const key = `${subagentId}:${record.stepIndex}:${record.timestamp}`;
+        if (countedSubagentSteps.has(key)) return;
+        countedSubagentSteps.add(key);
+        recordTokenUsage(
+          record.usage.inputTokens,
+          record.usage.outputTokens,
+          record.usage.cacheReadTokens ?? 0,
+          record.usage.cacheWriteTokens ?? 0,
+        );
+      });
 
       const tryAttachWandb = async (s: SessionInfo) => {
         if (wandbCleanup) return;


### PR DESCRIPTION
## Problem

The operator dashboard's token counter only summed the **orchestrator's** steps via `onStepFinish`. Every subagent — threat-model generators, finding judges, the pentest swarm — runs its own agent loop and never touched the dashboard's accumulator, so its tokens were dropped from the footer total (`↓in ↑out ⚡cache Σtotal`) and from the persisted execution metrics.

The undercount is large in practice. On a real subagent-heavy session the footer reported **1.8M** input tokens; the actual total across the orchestrator plus its five subagents was **~2.8M** — roughly **55% higher**. The gap was entirely the subagent fan-out.

## What changes

`src/tui/components/operator-dashboard/index.tsx`:

- **Extract `recordTokenUsage`** — a single sink that updates the live context (`addTokenUsage`), the persistence ref (`tokenUsageRef`), the on-disk metrics (`writeExecutionMetrics`), and cache counters (`addCacheUsage`) together. `onStepFinish` now just calls it.
- **Add a `trace-record` handler for subagent steps.** Subagents already emit per-step `trace-record` events that bubble up to the orchestrator bus with `subagentId` stamped on them by `attachChild`. The handler routes any step record carrying a `subagentId` through `recordTokenUsage`. Orchestrator records have no `subagentId` and stay on the `onStepFinish` path, so there's no double-counting between the two.

## How it works

- **No double-count of input/output:** subagents never call the orchestrator's `onStepFinish`, and orchestrator trace-records carry no `subagentId` (skipped by the new handler). Each step is counted exactly once.
- **No double-count of cache:** `onCacheMetrics` is only invoked by the top-level agent in `offensiveSecurityAgent.ts`; the subagent spawn tools don't propagate it, so subagent cache reaches the dashboard solely through the new handler.
- **Replay-safe:** the W&B early-buffer logic re-emits buffered `trace-record` events on the same bus. The handler dedupes by a stable `subagentId:stepIndex:timestamp` key, so replays are idempotent. Distinct invocations of the same subagent (e.g. a finding judge that runs several times) differ by timestamp and are counted separately — fixing an undercount that affected even the subagent's own `cumulativeUsage` field.
- **Nested subagents** keep working: `attachChild` preserves the innermost `subagentId`, so deeper agents are still counted.

This also picks up subagent **cache** tokens, which previously had no path into the dashboard at all. The footer and persisted metrics now reflect the whole agent tree, live and after resume.

## Test plan

- [x] `vitest run src/tui/components/operator-dashboard/logic.test.ts src/core/eventBus.test.ts` — 80/80 pass, incl. the eventBus contract test confirming `trace-record` forwards with `subagentId` injected
- [x] `tsc --noEmit` — clean on the touched file
- [x] Run a subagent-heavy operator session and confirm the footer total matches the sum of the orchestrator's `cumulativeUsage` plus the per-step usage across all `subagents/*.trace.jsonl`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only metrics aggregation with explicit dedup; no auth, billing, or agent execution path changes.
> 
> **Overview**
> The operator dashboard **footer token totals and persisted execution metrics** now include subagent usage, not just the orchestrator’s `onStepFinish` steps.
> 
> **`recordTokenUsage`** centralizes updates to the live accumulator, `tokenUsageRef`, `writeExecutionMetrics`, and **`addCacheUsage`**. The orchestrator still reports through **`onStepFinish`**; a new **`trace-record`** listener adds **step** records that carry a **`subagentId`** (including cache read/write from the trace), with **dedup** on `subagentId:stepIndex:timestamp` so W&B early-buffer replays do not double-count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9703acc4fc55b9bf8bb059a4db58a6756fe5f7fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->