### PR TITLE
fix: prevent persistentShell from orphaning background subshells

### DIFF
--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -467,6 +467,11 @@ describe("PersistentShell — long-running stability", () => {
 
     await shell.execute("sleep 10 | cat", 2);
 
+    await shell.execute(
+      "kill $(jobs -p) 2>/dev/null; wait 2>/dev/null; true",
+      3,
+    );
+
     const start = Date.now();
     const final = await shell.execute("echo final", 5);
     const elapsed = Date.now() - start;

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -557,43 +557,39 @@ export class PersistentShell {
     }
 
     if (this.proc) {
-      try {
-        this.proc.stdin?.write("exit\n");
-      } catch {
-        // ignore
-      }
-
       const p = this.proc;
       const pid = p.pid;
+
+      // Kill the process group synchronously so backgrounded subshells
+      // die even if the runner process is killed before timers fire.
+      if (pid && process.platform !== "win32") {
+        try {
+          process.kill(-pid, "SIGTERM");
+        } catch {
+          // already gone
+        }
+      }
+      try {
+        p.kill("SIGTERM");
+      } catch {
+        // already dead
+      }
+
+      // SIGKILL escalation on a timer — only needed if SIGTERM is ignored.
       setTimeout(() => {
-        // Kill the whole process group so detached children die too.
         if (pid && process.platform !== "win32") {
           try {
-            process.kill(-pid, "SIGTERM");
+            process.kill(-pid, "SIGKILL");
           } catch {
             // already gone
           }
         }
         try {
-          p.kill("SIGTERM");
+          p.kill("SIGKILL");
         } catch {
           // already dead
         }
-        setTimeout(() => {
-          if (pid && process.platform !== "win32") {
-            try {
-              process.kill(-pid, "SIGKILL");
-            } catch {
-              // already gone
-            }
-          }
-          try {
-            p.kill("SIGKILL");
-          } catch {
-            // already dead
-          }
-        }, 2_000);
-      }, 1_000);
+      }, 2_000);
     }
 
     this.alive = false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes the issue where the backgrounded `while :; do echo s-$RANDOM; done &` from `persistentShell.test.ts` (the "stays responsive after a mixed workload" test) could survive its test run, get orphaned, and spin at ~98% CPU writing to a growing temp file indefinitely.

Two gaps lined up to cause this:

1. That test never killed its background job — the similar spam-loop test at line 131 does `kill $(jobs -p)`, but this one relied entirely on `afterEach → dispose()`.
2. `dispose()` wrote `exit\n` and deferred the process-group SIGTERM behind a `setTimeout`. But `exit` only terminates the main shell (backgrounded subshells survive it), and if the runner process exits — or is hard-killed mid-suite — before the timer fires, the group-kill never happens.

**Changes (belt and suspenders):**

1. **Test fix:** The "stays responsive after a mixed workload" test now explicitly kills its background echo loop (`kill $(jobs -p)`) before relying on `dispose()`, matching the pattern already used by the background-leak test at line 131.

2. **`dispose()` fix:** Send SIGTERM to the process group synchronously instead of deferring it behind a `setTimeout`. If the runner process is killed mid-suite (e.g. `kill -9` on vitest), timers never fire and backgrounded subshells survive `exit`. The SIGKILL escalation stays on a timer since it's only needed when SIGTERM is ignored — if the runner dies before that timer fires, the SIGTERM has already taken out the group.

### How did you verify your code works?

- All 1084 tests pass (36 persistentShell tests specifically), including the modified "stays responsive after a mixed workload" test
- TypeScript type check passes (`bun run tsc`)
- Lint passes (`bun run lint`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8804b447-7fef-492e-9877-53e3a4b67701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8804b447-7fef-492e-9877-53e3a4b67701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

