### PR TITLE
Send client_id on legacy device auth code and token requests

### DIFF
--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -153,6 +153,7 @@ async function login(): Promise<void> {
       deviceCode: deviceInfo.deviceCode,
       interval: deviceInfo.interval,
       expiresIn: deviceInfo.expiresIn,
+      clientId: flowInfo.clientId,
     });
 
     const apiKey = data.apiKey;

--- a/src/core/auth/device-flow.ts
+++ b/src/core/auth/device-flow.ts
@@ -22,6 +22,7 @@ export async function startDeviceFlow(
   apiUrl?: string,
 ): Promise<DeviceFlowInfo> {
   const url = apiUrl ?? getPensarApiUrl();
+  let workosClientId: string | undefined;
 
   // Try WorkOS first
   try {
@@ -30,6 +31,7 @@ export async function startDeviceFlow(
       const cliConfig = (await configResponse.json()) as {
         workosClientId: string;
       };
+      workosClientId = cliConfig.workosClientId;
 
       const response = await fetch(
         "https://api.workos.com/user_management/authorize/device",
@@ -53,10 +55,14 @@ export async function startDeviceFlow(
     // Fall through to legacy
   }
 
-  // Legacy flow
+  // Legacy flow. Newer backends require client identification (RFC 8628
+  // §3.1); older backends ignore the extra field.
   const response = await fetch(`${url}/auth/device/code`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(
+      workosClientId ? { client_id: workosClientId } : {},
+    ),
   });
 
   if (!response.ok) {
@@ -64,7 +70,7 @@ export async function startDeviceFlow(
   }
 
   const deviceInfo = (await response.json()) as LegacyDeviceCodeResponse;
-  return { mode: "legacy", deviceInfo };
+  return { mode: "legacy", clientId: workosClientId, deviceInfo };
 }
 
 /**
@@ -147,9 +153,10 @@ export async function pollLegacyToken(params: {
   deviceCode: string;
   interval: number;
   expiresIn: number;
+  clientId?: string;
   signal?: AbortSignal;
 }): Promise<LegacyTokenResponse> {
-  const { apiUrl, deviceCode, interval, expiresIn, signal } = params;
+  const { apiUrl, deviceCode, interval, expiresIn, clientId, signal } = params;
   const deadline = Date.now() + expiresIn * 1000;
 
   while (Date.now() < deadline) {
@@ -163,7 +170,9 @@ export async function pollLegacyToken(params: {
       const response = await fetch(`${apiUrl}/auth/device/token`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ deviceCode }),
+        body: JSON.stringify(
+          clientId ? { deviceCode, client_id: clientId } : { deviceCode },
+        ),
       });
 
       if (!response.ok) continue;

--- a/src/core/auth/device-flow.ts
+++ b/src/core/auth/device-flow.ts
@@ -60,9 +60,7 @@ export async function startDeviceFlow(
   const response = await fetch(`${url}/auth/device/code`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(
-      workosClientId ? { client_id: workosClientId } : {},
-    ),
+    body: JSON.stringify(workosClientId ? { client_id: workosClientId } : {}),
   });
 
   if (!response.ok) {

--- a/src/core/auth/types.ts
+++ b/src/core/auth/types.ts
@@ -78,6 +78,7 @@ export type DeviceFlowInfo =
     }
   | {
       mode: "legacy";
+      clientId?: string;
       deviceInfo: LegacyDeviceCodeResponse;
     };
 

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -200,6 +200,7 @@ export default function AuthFlow({ onClose, hideEsc }: AuthFlowProps) {
         deviceCode: info.deviceInfo.deviceCode,
         interval: info.deviceInfo.interval,
         expiresIn: info.deviceInfo.expiresIn,
+        clientId: info.clientId,
         signal: ac.signal,
       });
 


### PR DESCRIPTION
### What does this PR do?

Companion to console PR #1765. The console legacy device-auth endpoints (POST /auth/device/code and /auth/device/token) now require a client_id matching the stage's registered WorkOS client (RFC 8628 §3.1). This change makes the CLI's legacy fallback flow send client_id (sourced from GET /api/cli/config) on both the code request and each token poll. Older backends ignore the extra field, so it's backward-compatible.

### How did you verify your code works?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches login/device-auth request payloads across CLI and TUI; incorrect client_id could break legacy login on updated backends, but the change is backward-compatible when client_id is omitted.
> 
> **Overview**
> Updates the **legacy device-authorization fallback** so it satisfies newer Pensar Console requirements (RFC 8628 §3.1): when `GET /api/cli/config` returns a WorkOS `workosClientId`, that value is sent as **`client_id`** on **`POST /auth/device/code`** and on each **`POST /auth/device/token`** poll.
> 
> `startDeviceFlow` now retains `workosClientId` from the config fetch even when the WorkOS path is not used, includes optional **`clientId`** on legacy `DeviceFlowInfo`, and **`pollLegacyToken`** accepts optional **`clientId`** in the JSON body. **CLI** (`pensar login`) and **TUI** auth flows pass **`flowInfo.clientId`** into legacy polling. If config was never fetched, behavior stays the same (no `client_id`), which older backends tolerate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c320e57bb80d0d085dceee0e6618e78bf819338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->