### PR TITLE
fix(agents): nest Finding Judge under the invoking subagent in log hi…

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentFinding.test.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.test.ts
@@ -2,7 +2,11 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { judgeFinding } from "../../specialized/findingJudge";
+import { AgentEventBus, type AgentEventMap } from "../../../eventBus";
+import {
+  type FindingJudgeResult,
+  judgeFinding,
+} from "../../specialized/findingJudge";
 import {
   documentVulnerability,
   validatePocPortability,
@@ -191,6 +195,169 @@ describe("documentVulnerability judge handling", () => {
     expect(existsSync(join(ctx.session.pocsPath, "poc_admin_data.sh"))).toBe(
       true,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding Judge subagent lifecycle (regression for the judge rendering as a
+// top-level sibling instead of nested under the invoking worker).
+// ---------------------------------------------------------------------------
+
+function makeAcceptedJudgeResult(): FindingJudgeResult {
+  return {
+    valid: true,
+    findingType: "vulnerability",
+    confidence: 0.95,
+    reasoning: "Reproduced the PoC and confirmed the data exposure.",
+    concerns: [],
+    verificationSteps: ["Reran the PoC."],
+    toolEvidence: ["stdout contained the leaked admin data."],
+    reproducedPoc: true,
+    webResearchUsed: false,
+    limitations: [],
+  };
+}
+
+describe("documentVulnerability finding-judge subagent lifecycle", () => {
+  let rootPath: string;
+
+  beforeEach(() => {
+    rootPath = mkdtempSync(join(tmpdir(), "apex-document-finding-"));
+    mockedJudgeFinding.mockReset();
+  });
+
+  afterEach(() => {
+    rmSync(rootPath, { recursive: true, force: true });
+  });
+
+  it("nests the judge under the invoking worker via lifecycle events and a child bus", async () => {
+    const parentBus = new AgentEventBus();
+    const spawns: AgentEventMap["subagent-spawn"][] = [];
+    const completes: AgentEventMap["subagent-complete"][] = [];
+    const textDeltas: AgentEventMap["text-delta"][] = [];
+    parentBus.on("subagent-spawn", (e) => spawns.push(e));
+    parentBus.on("subagent-complete", (e) => completes.push(e));
+    parentBus.on("text-delta", (e) => textDeltas.push(e));
+
+    let judgeCtx: Parameters<typeof judgeFinding>[1] | undefined;
+    mockedJudgeFinding.mockImplementation(async (_input, ctx) => {
+      judgeCtx = ctx;
+      // Simulate the judge agent streaming on the bus it was handed.
+      ctx.eventBus?.emit("text-delta", { text: "verifying finding" });
+      return makeAcceptedJudgeResult();
+    });
+
+    const ctx = {
+      ...makeToolContext(rootPath),
+      eventBus: parentBus,
+      subagentId: "pentest-agent-worker-1",
+    };
+    const tool = documentVulnerability(ctx);
+    const result = (await tool.execute!(makeDocumentInput(), {
+      toolCallId: "test",
+      messages: [],
+    })) as DocumentToolResult;
+
+    expect(result.success).toBe(true);
+
+    // Lifecycle: one spawn + one complete, anchored to the worker.
+    expect(spawns).toHaveLength(1);
+    expect(spawns[0].name).toBe("Finding Judge");
+    expect(spawns[0].subagentId).toMatch(
+      /^pentest-agent-worker-1-finding-judge-\d+$/,
+    );
+    expect(spawns[0].parentSubagentId).toBe("pentest-agent-worker-1");
+
+    expect(completes).toHaveLength(1);
+    expect(completes[0].subagentId).toBe(spawns[0].subagentId);
+    expect(completes[0].status).toBe("completed");
+    expect(completes[0].parentSubagentId).toBe("pentest-agent-worker-1");
+
+    // The judge ran on a child bus with the same id the spawn announced,
+    // and its untagged events reach the parent tagged with that id.
+    expect(judgeCtx?.subagentId).toBe(spawns[0].subagentId);
+    expect(judgeCtx?.eventBus).toBeDefined();
+    expect(judgeCtx?.eventBus).not.toBe(parentBus);
+    expect(textDeltas).toHaveLength(1);
+    expect(textDeltas[0].subagentId).toBe(spawns[0].subagentId);
+  });
+
+  it("allocates a fresh judge subagent id per invocation", async () => {
+    const parentBus = new AgentEventBus();
+    const spawns: AgentEventMap["subagent-spawn"][] = [];
+    parentBus.on("subagent-spawn", (e) => spawns.push(e));
+    mockedJudgeFinding.mockResolvedValue(makeAcceptedJudgeResult());
+
+    const ctx = {
+      ...makeToolContext(rootPath),
+      eventBus: parentBus,
+      subagentId: "pentest-agent-worker-2",
+    };
+    const tool = documentVulnerability(ctx);
+    await tool.execute!(makeDocumentInput(), {
+      toolCallId: "t1",
+      messages: [],
+    });
+    await tool.execute!(
+      { ...makeDocumentInput(), title: "Second Finding" },
+      { toolCallId: "t2", messages: [] },
+    );
+
+    expect(spawns).toHaveLength(2);
+    expect(spawns[0].subagentId).not.toBe(spawns[1].subagentId);
+  });
+
+  it("spawns the judge top-level (no parentSubagentId) when the documenting agent has none", async () => {
+    const parentBus = new AgentEventBus();
+    const spawns: AgentEventMap["subagent-spawn"][] = [];
+    parentBus.on("subagent-spawn", (e) => spawns.push(e));
+    mockedJudgeFinding.mockResolvedValue(makeAcceptedJudgeResult());
+
+    const ctx = { ...makeToolContext(rootPath), eventBus: parentBus };
+    const tool = documentVulnerability(ctx);
+    await tool.execute!(makeDocumentInput(), {
+      toolCallId: "test",
+      messages: [],
+    });
+
+    expect(spawns).toHaveLength(1);
+    expect(spawns[0].subagentId).toMatch(/^finding-judge-\d+$/);
+    expect(spawns[0].parentSubagentId).toBeUndefined();
+  });
+
+  it("marks the judge subagent failed when the judge falls back on infrastructure failure", async () => {
+    const parentBus = new AgentEventBus();
+    const completes: AgentEventMap["subagent-complete"][] = [];
+    parentBus.on("subagent-complete", (e) => completes.push(e));
+
+    mockedJudgeFinding.mockResolvedValue({
+      valid: false,
+      findingType: "informational",
+      confidence: 0.4,
+      reasoning: "Agentic finding judge could not complete.",
+      concerns: ["Judge infrastructure failed."],
+      verificationSteps: [],
+      toolEvidence: [],
+      reproducedPoc: false,
+      webResearchUsed: false,
+      limitations: [],
+      error: { message: "provider overloaded", type: "Error", model: "m" },
+    });
+
+    const ctx = {
+      ...makeToolContext(rootPath),
+      eventBus: parentBus,
+      subagentId: "pentest-agent-worker-3",
+    };
+    const tool = documentVulnerability(ctx);
+    await tool.execute!(makeDocumentInput(), {
+      toolCallId: "test",
+      messages: [],
+    });
+
+    expect(completes).toHaveLength(1);
+    expect(completes[0].status).toBe("failed");
+    expect(completes[0].parentSubagentId).toBe("pentest-agent-worker-3");
   });
 });
 

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -12,6 +12,7 @@ import { join } from "path";
 import { z } from "zod";
 import { hasCanonicalName } from "../../../../lib/cwe/types";
 import type { EvidenceFileEntry } from "../../../../lib/evidence/types";
+import { AgentEventBus } from "../../../eventBus";
 import {
   type CVSSScorerInput,
   type CVSSScorerResult,
@@ -19,6 +20,7 @@ import {
 } from "../../specialized/cvssScorer";
 import {
   type FindingJudgeInput,
+  type FindingJudgeResult,
   judgeFinding,
 } from "../../specialized/findingJudge";
 import type { Finding } from "../types";
@@ -232,16 +234,52 @@ CRITICAL RULES — READ BEFORE CALLING:
           },
         };
 
-        const judgeResult = await judgeFinding(judgeInput, {
-          model: ctx.model!,
-          session: ctx.session,
-          authConfig: ctx.authConfig,
-          abortSignal: ctx.abortSignal,
-          eventBus: ctx.eventBus,
-          sandbox: ctx.sandbox,
-          target: ctx.target,
-          enableThinking: ctx.enableThinking,
-          openAIReasoningEffort: ctx.openAIReasoningEffort,
+        // Run the judge as a proper nested subagent: explicit lifecycle
+        // events (with parentSubagentId) plus a child bus, mirroring
+        // spawn_pentest_agent / spawn_coding_agent. Without this the judge's
+        // stream renders as a top-level sibling instead of nested under the
+        // worker that invoked document_vulnerability.
+        const judgeSubagentId = nextJudgeSubagentId(ctx.subagentId);
+
+        ctx.eventBus?.emit("subagent-spawn", {
+          subagentId: judgeSubagentId,
+          name: "Finding Judge",
+          input: { title: input.title, endpoint: input.endpoint },
+          parentSubagentId: ctx.subagentId,
+        });
+
+        const judgeBus = new AgentEventBus();
+        AgentEventBus.attachChild(judgeBus, ctx.eventBus, judgeSubagentId);
+
+        let judgeResult: FindingJudgeResult;
+        try {
+          judgeResult = await judgeFinding(judgeInput, {
+            model: ctx.model!,
+            session: ctx.session,
+            authConfig: ctx.authConfig,
+            abortSignal: ctx.abortSignal,
+            eventBus: judgeBus,
+            subagentId: judgeSubagentId,
+            sandbox: ctx.sandbox,
+            target: ctx.target,
+            enableThinking: ctx.enableThinking,
+            openAIReasoningEffort: ctx.openAIReasoningEffort,
+          });
+        } catch (error) {
+          ctx.eventBus?.emit("subagent-complete", {
+            subagentId: judgeSubagentId,
+            status: "failed",
+            parentSubagentId: ctx.subagentId,
+          });
+          throw error;
+        }
+
+        ctx.eventBus?.emit("subagent-complete", {
+          subagentId: judgeSubagentId,
+          // `error` is only set by the infrastructure-failure fallback —
+          // a judge that completed and rejected the finding still "completed".
+          status: judgeResult.error ? "failed" : "completed",
+          parentSubagentId: ctx.subagentId,
         });
 
         if (!judgeResult.valid) {
@@ -599,6 +637,23 @@ ${finding.references ? `## References\n\n${finding.references}` : ""}
       }
     },
   });
+}
+
+// ---------------------------------------------------------------------------
+// Finding Judge subagent ids
+// ---------------------------------------------------------------------------
+
+// Per-parent counter so repeated/concurrent judge runs within the same
+// parent stream get unique subagent ids (mirrors spawn_pentest_agent's
+// child-id allocation). Keyed by parent subagentId ("" for top-level).
+const judgeCounters = new Map<string, number>();
+
+function nextJudgeSubagentId(parentSubagentId: string | undefined): string {
+  const key = parentSubagentId ?? "";
+  const next = (judgeCounters.get(key) ?? 0) + 1;
+  judgeCounters.set(key, next);
+  const prefix = parentSubagentId ? `${parentSubagentId}-` : "";
+  return `${prefix}finding-judge-${next}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/agents/specialized/findingJudge/agent.ts
+++ b/src/core/agents/specialized/findingJudge/agent.ts
@@ -23,6 +23,8 @@ export interface FindingJudgeAgentInput {
   authConfig?: AIAuthConfig;
   abortSignal?: AbortSignal;
   eventBus?: AgentEventBus;
+  /** Id used to tag the judge's stream events. Defaults to "finding-judge". */
+  subagentId?: string;
   sandbox?: UnifiedSandbox;
   target?: string;
   enableThinking?: boolean;
@@ -57,7 +59,7 @@ export class FindingJudgeAgent extends OffensiveSecurityAgent<FindingJudgeAgentO
       sandbox: opts.sandbox,
       enableThinking: opts.enableThinking,
       openAIReasoningEffort: opts.openAIReasoningEffort,
-      subagentId: "finding-judge",
+      subagentId: opts.subagentId ?? "finding-judge",
       activeTools: [...FINDING_JUDGE_ACTIVE_TOOLS],
       responseSchema: FindingJudgeOutputSchema,
       stopWhen: stepCountIs(60),

--- a/src/core/agents/specialized/findingJudge/index.test.ts
+++ b/src/core/agents/specialized/findingJudge/index.test.ts
@@ -98,6 +98,32 @@ describe("judgeFinding", () => {
     );
   });
 
+  it("forwards the caller-provided subagentId to the judge agent", async () => {
+    mocks.consume.mockResolvedValue({
+      valid: true,
+      findingType: "vulnerability",
+      confidence: 0.9,
+      reasoning: "ok",
+      concerns: [],
+      verificationSteps: [],
+      toolEvidence: [],
+      reproducedPoc: true,
+      webResearchUsed: false,
+      limitations: [],
+    });
+
+    await judgeFinding(makeInput(), {
+      ...makeContext(),
+      subagentId: "pentest-agent-worker-1-finding-judge-1",
+    });
+
+    expect(mocks.constructorArgs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subagentId: "pentest-agent-worker-1-finding-judge-1",
+      }),
+    );
+  });
+
   it("rejects the finding as unverified when the judge agent fails", async () => {
     mocks.consume.mockRejectedValue(new Error("provider overloaded"));
 

--- a/src/core/agents/specialized/findingJudge/index.ts
+++ b/src/core/agents/specialized/findingJudge/index.ts
@@ -33,6 +33,13 @@ export type FindingJudgeRuntimeContext = Pick<
   | "openAIReasoningEffort"
 > & {
   model: AIModel;
+  /**
+   * Subagent id used to tag the judge's own stream events. Callers that
+   * spawn the judge as a nested subagent must pass the same id they
+   * emitted in the `subagent-spawn` lifecycle event so the live UI and
+   * persisted logs line up. Defaults to `"finding-judge"`.
+   */
+  subagentId?: string;
 };
 
 /**
@@ -56,6 +63,7 @@ export async function judgeFinding(
       authConfig: ctx.authConfig,
       abortSignal: ctx.abortSignal,
       eventBus: ctx.eventBus,
+      subagentId: ctx.subagentId,
       sandbox: ctx.sandbox,
       target: input.target ?? ctx.target ?? ctx.session.targets[0],
       enableThinking: ctx.enableThinking,

--- a/src/core/eventBus.test.ts
+++ b/src/core/eventBus.test.ts
@@ -66,6 +66,59 @@ describe("AgentEventBus.attachChild — child→parent forwarding contract", () 
     expect(received).toHaveLength(0);
   });
 
+  // Lifecycle hierarchy: a subagent-spawn emitted on a child bus without an
+  // explicit parent must arrive at the parent bus anchored to the child's
+  // subagentId. This is what nests e.g. the Finding Judge under the pentest
+  // worker that invoked document_vulnerability.
+  it("injects parentSubagentId on lifecycle events crossing the child→parent boundary", () => {
+    const parent = new AgentEventBus();
+    const child = new AgentEventBus();
+    AgentEventBus.attachChild(child, parent, "pentest-agent-worker-1");
+
+    const spawns: { subagentId: string; parentSubagentId?: string }[] = [];
+    const completes: { subagentId: string; parentSubagentId?: string }[] = [];
+    parent.on("subagent-spawn", (e) => spawns.push(e));
+    parent.on("subagent-complete", (e) => completes.push(e));
+
+    child.emit("subagent-spawn", {
+      subagentId: "finding-judge-1",
+      name: "Finding Judge",
+      input: null,
+    });
+    child.emit("subagent-complete", {
+      subagentId: "finding-judge-1",
+      status: "completed",
+    });
+
+    expect(spawns).toHaveLength(1);
+    expect(spawns[0].parentSubagentId).toBe("pentest-agent-worker-1");
+    expect(completes).toHaveLength(1);
+    expect(completes[0].parentSubagentId).toBe("pentest-agent-worker-1");
+  });
+
+  // Lifecycle hierarchy across nested hops: once a parent has been assigned
+  // (explicitly or by the first attachChild hop), outer hops must not
+  // overwrite it — otherwise deep nesting flattens to the outermost agent.
+  it("preserves an existing parentSubagentId on lifecycle events across nested hops", () => {
+    const root = new AgentEventBus();
+    const mid = new AgentEventBus();
+    const leaf = new AgentEventBus();
+    AgentEventBus.attachChild(mid, root, "outer");
+    AgentEventBus.attachChild(leaf, mid, "inner");
+
+    const spawns: { subagentId: string; parentSubagentId?: string }[] = [];
+    root.on("subagent-spawn", (e) => spawns.push(e));
+
+    leaf.emit("subagent-spawn", {
+      subagentId: "inner-finding-judge-1",
+      name: "Finding Judge",
+      input: null,
+    });
+
+    expect(spawns).toHaveLength(1);
+    expect(spawns[0].parentSubagentId).toBe("inner");
+  });
+
   // INV-7: nested attachChild (grandchild → child → root) must preserve the
   // innermost subagentId on the root bus. StepTraceWriter self-tags every
   // record with its own agentId, so the W&B grouping convention relies on


### PR DESCRIPTION
…erarchy

The Finding Judge ran on the caller's event bus with a fixed global subagentId and no subagent-spawn/subagent-complete lifecycle events, so the Console log UI (which builds the hierarchy from parentSubagentId on lifecycle events) rendered it as a top-level sibling instead of nested under the pentest worker that invoked document_vulnerability.

document_vulnerability now spawns the judge like other nested agents (spawn_pentest_agent / spawn_coding_agent): it emits subagent-spawn with parentSubagentId, runs the judge on a child AgentEventBus attached via AgentEventBus.attachChild, and emits subagent-complete (failed when the judge falls back on infrastructure failure). Judge subagent ids are allocated per parent so repeated runs in one stream don't collide.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily observability and event routing around an existing judge call path; finding validation semantics are unchanged aside from clearer failed lifecycle when the judge errors.
> 
> **Overview**
> Fixes the console log hierarchy so **Finding Judge** appears nested under the pentest worker that called `document_vulnerability`, instead of as a top-level sibling.
> 
> `document_vulnerability` now treats the judge like other nested agents (`spawn_pentest_agent` / `spawn_coding_agent`): it emits **`subagent-spawn`** with **`parentSubagentId`**, runs **`judgeFinding`** on a dedicated child **`AgentEventBus`** via **`attachChild`**, and emits **`subagent-complete`** (`failed` on thrown errors or when the judge result carries infrastructure **`error`**). Per-parent **`nextJudgeSubagentId`** avoids id collisions across repeated runs in one stream.
> 
> **`judgeFinding`** / **`FindingJudgeAgent`** accept an optional **`subagentId`** so streamed events match the spawn announcement. New tests cover lifecycle wiring in **`documentFinding`** and **`attachChild`** lifecycle **`parentSubagentId`** behavior (including not overwriting an existing parent across nested hops).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71b32b34f700327394a1578010c24b20e2d9d68d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->