### PR TITLE
ci: add advisory slop-scan stage (non-blocking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ jobs:
     uses: ./.github/workflows/knip.yml
 
   slop-scan:
+    # Granted here on the caller; the reusable workflow inherits these. A
+    # called workflow cannot request more than the caller holds, so the
+    # neutral check + comment need write scopes set at this level.
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/slop-scan.yml
 
   typecheck:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,7 @@ jobs:
     uses: ./.github/workflows/knip.yml
 
   slop-scan:
-    # Granted here on the caller; the reusable workflow inherits these. A
-    # called workflow cannot request more than the caller holds, so the
-    # neutral check + comment need write scopes set at this level.
+    # Granted on the caller so the reusable workflow inherits them (it can't request more).
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
   dead-code:
     uses: ./.github/workflows/knip.yml
 
+  slop-scan:
+    uses: ./.github/workflows/slop-scan.yml
+
   typecheck:
     uses: ./.github/workflows/typecheck.yml
 

--- a/.github/workflows/slop-scan.yml
+++ b/.github/workflows/slop-scan.yml
@@ -46,9 +46,11 @@ jobs:
         continue-on-error: true
         run: bun run scripts/slop-report.ts slop-delta.json > slop-comment.md
 
-      # always(): post the neutral check even if an earlier step failed.
+      # always() so it posts even after an earlier failure; continue-on-error so
+      # a GitHub API failure (e.g. read-only token on fork PRs) can't red the job.
       - name: Publish neutral check + sticky comment
         if: always()
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -56,8 +58,10 @@ jobs:
             const marker = '<!-- slop-scan-report -->';
 
             let summary = {};
+            let deltaOk = false;
             try {
               summary = JSON.parse(fs.readFileSync('slop-delta.json', 'utf8')).summary ?? {};
+              deltaOk = true;
             } catch (err) {
               core.warning(`slop-scan delta unavailable: ${err}`);
             }
@@ -72,9 +76,12 @@ jobs:
             // Neutral check — visible in the checks list, never blocks merge.
             const { owner, repo } = context.repo;
             const head_sha = context.payload.pull_request.head.sha;
-            const conclusionText = added + worsened > 0
-              ? `${added} new, ${worsened} worsened, ${resolved} resolved`
-              : `No new slop (${resolved} resolved)`;
+            // Don't claim "No new slop" when the scan never produced a delta.
+            const conclusionText = !deltaOk
+              ? '⚠️ Could not produce slop report'
+              : added + worsened > 0
+                ? `${added} new, ${worsened} worsened, ${resolved} resolved`
+                : `No new slop (${resolved} resolved)`;
             const checkOutput = {
               status: 'completed',
               conclusion: 'neutral',

--- a/.github/workflows/slop-scan.yml
+++ b/.github/workflows/slop-scan.yml
@@ -1,0 +1,113 @@
+# Advisory AI-slop workflow (powered by slop-scan).
+# Diffs a PR against its base and reports new/worsened slop as a neutral check
+# plus a sticky comment — never blocks. Promote to a gate later via --fail-on.
+
+name: Slop Scan
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  slop-scan:
+    runs-on: ubuntu-latest
+    # A delta needs a base to compare against, which only exists on PRs.
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout head
+        uses: actions/checkout@v4
+
+      - name: Checkout base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .slop-base
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Scan both sides with the same config so config edits don't read as deltas.
+      - name: Align base config
+        run: cp slop-scan.config.json .slop-base/slop-scan.config.json
+
+      # No --fail-on + continue-on-error: a scan crash must never red the PR.
+      - name: Slop Scan (delta)
+        continue-on-error: true
+        run: bun run slop-scan delta --base .slop-base --head . --json > slop-delta.json
+
+      - name: Build report
+        continue-on-error: true
+        run: bun run scripts/slop-report.ts slop-delta.json > slop-comment.md
+
+      # always(): post the neutral check even if an earlier step failed.
+      - name: Publish neutral check + sticky comment
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- slop-scan-report -->';
+
+            let summary = {};
+            try {
+              summary = JSON.parse(fs.readFileSync('slop-delta.json', 'utf8')).summary ?? {};
+            } catch (err) {
+              core.warning(`slop-scan delta unavailable: ${err}`);
+            }
+            const added = summary.addedCount ?? 0;
+            const worsened = summary.worsenedCount ?? 0;
+            const resolved = summary.resolvedCount ?? 0;
+
+            const body = fs.existsSync('slop-comment.md')
+              ? fs.readFileSync('slop-comment.md', 'utf8')
+              : `${marker}\n## 🩹 Slop Scan\n\n⚠️ slop-scan could not produce a report for this PR.`;
+
+            // Neutral check — visible in the checks list, never blocks merge.
+            const { owner, repo } = context.repo;
+            const head_sha = context.payload.pull_request.head.sha;
+            const conclusionText = added + worsened > 0
+              ? `${added} new, ${worsened} worsened, ${resolved} resolved`
+              : `No new slop (${resolved} resolved)`;
+            const checkOutput = {
+              status: 'completed',
+              conclusion: 'neutral',
+              output: { title: conclusionText, summary: body },
+            };
+            // Update an existing check on this SHA rather than stacking a new
+            // one on every re-run.
+            const existingChecks = await github.rest.checks.listForRef({
+              owner, repo, ref: head_sha, check_name: 'Slop Scan', per_page: 1,
+            });
+            const priorCheck = existingChecks.data.check_runs[0];
+            if (priorCheck) {
+              await github.rest.checks.update({ owner, repo, check_run_id: priorCheck.id, ...checkOutput });
+            } else {
+              await github.rest.checks.create({ owner, repo, name: 'Slop Scan', head_sha, ...checkOutput });
+            }
+
+            // Sticky comment — create once, then update in place on each push.
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find((c) => c.body?.includes(marker));
+
+            // Don't spam clean PRs that never had a comment; otherwise keep the
+            // existing comment in sync (so it flips to "clean" once fixed).
+            if (!existing && added + worsened === 0) return;
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/slop-scan.yml
+++ b/.github/workflows/slop-scan.yml
@@ -7,9 +7,7 @@ name: Slop Scan
 on:
   workflow_call:
 
-# Permissions (contents:read, checks:write, pull-requests:write) are granted by
-# the caller's job in ci.yml — a reusable workflow inherits the caller's token
-# scopes, and declaring more here than the caller holds fails the run at startup.
+# Permissions are granted by the caller job in ci.yml (reusable workflows inherit them).
 
 jobs:
   slop-scan:
@@ -69,7 +67,7 @@ jobs:
 
             const body = fs.existsSync('slop-comment.md')
               ? fs.readFileSync('slop-comment.md', 'utf8')
-              : `${marker}\n## 🩹 Slop Scan\n\n⚠️ slop-scan could not produce a report for this PR.`;
+              : `${marker}\n## Slop Scan\n\n⚠️ slop-scan could not produce a report for this PR.`;
 
             // Neutral check — visible in the checks list, never blocks merge.
             const { owner, repo } = context.repo;

--- a/.github/workflows/slop-scan.yml
+++ b/.github/workflows/slop-scan.yml
@@ -7,10 +7,9 @@ name: Slop Scan
 on:
   workflow_call:
 
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
+# Permissions (contents:read, checks:write, pull-requests:write) are granted by
+# the caller's job in ci.yml — a reusable workflow inherits the caller's token
+# scopes, and declaring more here than the caller holds fails the run at startup.
 
 jobs:
   slop-scan:

--- a/.github/workflows/slop-scan.yml
+++ b/.github/workflows/slop-scan.yml
@@ -56,6 +56,8 @@ jobs:
           script: |
             const fs = require('fs');
             const marker = '<!-- slop-scan-report -->';
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
 
             let summary = {};
             let deltaOk = false;
@@ -68,50 +70,46 @@ jobs:
             const added = summary.addedCount ?? 0;
             const worsened = summary.worsenedCount ?? 0;
             const resolved = summary.resolvedCount ?? 0;
-
             const body = fs.existsSync('slop-comment.md')
               ? fs.readFileSync('slop-comment.md', 'utf8')
               : `${marker}\n## Slop Scan\n\n⚠️ slop-scan could not produce a report for this PR.`;
+            core.info(`slop-scan: deltaOk=${deltaOk} added=${added} worsened=${worsened} resolved=${resolved}`);
 
             // Neutral check — visible in the checks list, never blocks merge.
-            const { owner, repo } = context.repo;
-            const head_sha = context.payload.pull_request.head.sha;
             // Don't claim "No new slop" when the scan never produced a delta.
-            const conclusionText = !deltaOk
+            const title = !deltaOk
               ? '⚠️ Could not produce slop report'
               : added + worsened > 0
                 ? `${added} new, ${worsened} worsened, ${resolved} resolved`
                 : `No new slop (${resolved} resolved)`;
-            const checkOutput = {
-              status: 'completed',
-              conclusion: 'neutral',
-              output: { title: conclusionText, summary: body },
-            };
-            // Update an existing check on this SHA rather than stacking a new
-            // one on every re-run.
-            const existingChecks = await github.rest.checks.listForRef({
-              owner, repo, ref: head_sha, check_name: 'Slop Scan', per_page: 1,
-            });
-            const priorCheck = existingChecks.data.check_runs[0];
-            if (priorCheck) {
-              await github.rest.checks.update({ owner, repo, check_run_id: priorCheck.id, ...checkOutput });
-            } else {
-              await github.rest.checks.create({ owner, repo, name: 'Slop Scan', head_sha, ...checkOutput });
+            try {
+              const out = { status: 'completed', conclusion: 'neutral', output: { title, summary: body } };
+              // Update an existing check on this SHA rather than stacking a new one per re-run.
+              const prior = (await github.rest.checks.listForRef({
+                owner, repo, ref: pr.head.sha, check_name: 'Slop Scan', per_page: 1,
+              })).data.check_runs[0];
+              if (prior) await github.rest.checks.update({ owner, repo, check_run_id: prior.id, ...out });
+              else await github.rest.checks.create({ owner, repo, name: 'Slop Scan', head_sha: pr.head.sha, ...out });
+              core.info('slop-scan: neutral check posted');
+            } catch (err) {
+              core.warning(`slop-scan: could not post neutral check: ${err}`);
             }
 
-            // Sticky comment — create once, then update in place on each push.
-            const issue_number = context.payload.pull_request.number;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number, per_page: 100,
-            });
-            const existing = comments.find((c) => c.body?.includes(marker));
-
-            // Don't spam clean PRs that never had a comment; otherwise keep the
-            // existing comment in sync (so it flips to "clean" once fixed).
-            if (!existing && added + worsened === 0) return;
-
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            // Sticky comment — created once, then updated in place on each push.
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: pr.number, per_page: 100,
+              });
+              const existing = comments.find((c) => c.body?.includes(marker));
+              if (!existing && added + worsened === 0) {
+                core.info('slop-scan: clean PR with no prior comment — nothing to post');
+              } else if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+                core.info('slop-scan: sticky comment updated');
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
+                core.info('slop-scan: sticky comment created');
+              }
+            } catch (err) {
+              core.warning(`slop-scan: could not post comment: ${err}`);
             }

--- a/.github/workflows/slop-scan.yml
+++ b/.github/workflows/slop-scan.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            // Keep in sync with COMMENT_MARKER in scripts/slop-report.ts.
             const marker = '<!-- slop-scan-report -->';
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
@@ -101,7 +102,8 @@ jobs:
                 owner, repo, issue_number: pr.number, per_page: 100,
               });
               const existing = comments.find((c) => c.body?.includes(marker));
-              if (!existing && added + worsened === 0) {
+              // Skip only a genuinely clean PR; a failed scan (!deltaOk) still posts its notice.
+              if (!existing && deltaOk && added + worsened === 0) {
                 core.info('slop-scan: clean PR with no prior comment — nothing to post');
               } else if (existing) {
                 await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
         "dotenv": "^17.2.3",
         "knip": "^6.12.0",
         "prettier": "^3.8.1",
+        "slop-scan": "^0.3.0",
         "vitest": "^2.1.8",
       },
       "optionalDependencies": {
@@ -525,6 +526,8 @@
 
     "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "^5.0.3", "selderee": "^0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
 
+    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+
     "@smithy/abort-controller": ["@smithy/abort-controller@4.2.7", "", { "dependencies": { "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw=="],
 
     "@smithy/chunked-blob-reader": ["@smithy/chunked-blob-reader@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WmU0TnhEAJLWvfSeMxBNe5xtbselEO8+4wG0NtZeL8oR21WgH1xiO37El+/Y+H/Ie4SCwBy3MxYWmOYaGgZueA=="],
@@ -911,6 +914,8 @@
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "globby": ["globby@16.2.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "fast-glob": "^3.3.3", "ignore": "^7.0.5", "is-path-inside": "^4.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.4.0" } }, "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q=="],
+
     "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
@@ -947,6 +952,8 @@
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
     "image-q": ["image-q@4.0.0", "", { "dependencies": { "@types/node": "16.9.1" } }, "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw=="],
 
     "imapflow": ["imapflow@1.3.3", "", { "dependencies": { "@zone-eu/mailsplit": "5.4.9", "encoding-japanese": "2.2.0", "iconv-lite": "0.7.2", "libbase64": "1.3.0", "libmime": "5.3.8", "libqp": "2.1.1", "nodemailer": "8.0.7", "pino": "10.3.1", "socks": "2.8.8" } }, "sha512-lx7nWcUDfNgITEKYYfunUDqJ3LT6ImuiA1ReqJepVEA2nqBQNUqa3ppF7Yz5CNjuDYG95pmzsCcNqRjMrwh/Vg=="],
@@ -968,6 +975,8 @@
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-path-inside": ["is-path-inside@4.0.0", "", {}, "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
@@ -1219,6 +1228,10 @@
 
     "simple-xml-to-json": ["simple-xml-to-json@1.2.3", "", {}, "sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA=="],
 
+    "slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
+
+    "slop-scan": ["slop-scan@0.3.0", "", { "dependencies": { "globby": "^16.2.0", "typescript": "^5.8.3" }, "bin": { "slop-scan": "bin/slop-scan.js" } }, "sha512-uviaHdntkRX5+4RZhzk/N3wYzoW9FMe9XrA4uCuNUslTt8GxbXc8B99YE9map78hJ9/FbXDpmn3phG/EsD7TZQ=="],
+
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
@@ -1300,6 +1313,8 @@
     "unbash": ["unbash@3.0.0", "", {}, "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "dotenv": "^17.2.3",
     "knip": "^6.12.0",
     "prettier": "^3.8.1",
+    "slop-scan": "^0.3.0",
     "vitest": "^2.1.8"
   },
   "engines": {
@@ -106,6 +107,7 @@
     "local-benchmark": "bun run scripts/local-benchmark.ts",
     "pensar": "node bin/pensar.js",
     "prepublishOnly": "npm run build",
+    "slop-scan": "slop-scan",
     "start": "bun run src/tui/index.tsx",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/slop-report.test.ts
+++ b/scripts/slop-report.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { COMMENT_MARKER, renderReport } from "./slop-report";
+
+// ---------------------------------------------------------------------------
+// renderReport turns a slop-scan `delta --json` payload into the Markdown body
+// of an advisory PR comment. It is pure and must never throw — the workflow
+// posts whatever it returns as a neutral, non-blocking check.
+// ---------------------------------------------------------------------------
+
+/** Build a single "added"/"worsened" change as slop-scan emits it. */
+function change(
+  status: "added" | "worsened" | "resolved",
+  ruleId: string,
+  severity: string,
+  message: string,
+  line?: number,
+) {
+  return {
+    status,
+    ruleId,
+    head: { severity, message, primaryLocation: line ? { line } : undefined },
+  };
+}
+
+describe("renderReport", () => {
+  it("reports a clean PR when nothing was added or worsened", () => {
+    const body = renderReport({
+      summary: { addedCount: 0, worsenedCount: 0, resolvedCount: 0 },
+    });
+    expect(body).toContain(COMMENT_MARKER);
+    expect(body).toContain("No new slop introduced");
+    expect(body).toContain("never blocks merge");
+    expect(body).not.toContain("| Location |");
+  });
+
+  it("calls out resolved findings on an otherwise-clean PR", () => {
+    const body = renderReport({
+      summary: { addedCount: 0, worsenedCount: 0, resolvedCount: 3 },
+    });
+    expect(body).toContain("resolves 3");
+  });
+
+  it("renders a table of added/worsened findings with severity icons and locations", () => {
+    const body = renderReport({
+      summary: { addedCount: 1, worsenedCount: 1, resolvedCount: 0 },
+      paths: [
+        {
+          path: "src/a.ts",
+          changes: [
+            change(
+              "added",
+              "defensive.empty-catch",
+              "strong",
+              "Found 1 empty catch block",
+              42,
+            ),
+          ],
+        },
+        {
+          path: "src/b.ts",
+          changes: [
+            change(
+              "worsened",
+              "defensive.error-obscuring",
+              "medium",
+              "Obscures error",
+              7,
+            ),
+          ],
+        },
+      ],
+    });
+    expect(body).toContain("**1** new");
+    expect(body).toContain("**1** worsened");
+    expect(body).toContain("🔴"); // strong
+    expect(body).toContain("🟡"); // medium
+    expect(body).toContain("`src/a.ts:42`");
+    expect(body).toContain("`src/b.ts:7` _(worsened)_");
+    expect(body).toContain("`defensive.empty-catch`");
+  });
+
+  it("ignores resolved/unchanged occurrences in the table", () => {
+    const body = renderReport({
+      summary: { addedCount: 0, worsenedCount: 0, resolvedCount: 1 },
+      paths: [
+        {
+          path: "src/a.ts",
+          changes: [
+            change("resolved", "defensive.empty-catch", "strong", "gone", 1),
+          ],
+        },
+      ],
+    });
+    // resolved-only with no adds/worsens takes the clean path, not the table.
+    expect(body).not.toContain("| Location |");
+    expect(body).toContain("resolves 1");
+  });
+
+  it("escapes pipes and collapses newlines so the table cannot break", () => {
+    const body = renderReport({
+      summary: { addedCount: 1, worsenedCount: 0, resolvedCount: 0 },
+      paths: [
+        {
+          path: "src/a.ts",
+          changes: [
+            change("added", "x.rule", "strong", "a | b\nsecond line", 1),
+          ],
+        },
+      ],
+    });
+    const row = body.split("\n").find((l) => l.includes("`src/a.ts:1`")) ?? "";
+    expect(row).toContain("a \\| b second line"); // pipe escaped, newline collapsed
+    expect(row).not.toMatch(/\n/);
+    // The escaped pipe is the only literal `|`-with-backslash; the row's
+    // own column separators stay intact.
+    expect(row.startsWith("|")).toBe(true);
+  });
+
+  it("falls back gracefully when the location has no line number", () => {
+    const body = renderReport({
+      summary: { addedCount: 1, worsenedCount: 0, resolvedCount: 0 },
+      paths: [
+        {
+          path: "src/dir",
+          changes: [change("added", "structure.x", "medium", "dir issue")],
+        },
+      ],
+    });
+    expect(body).toContain("`src/dir`");
+    expect(body).not.toContain("`src/dir:`");
+  });
+
+  it("tolerates a missing summary without throwing", () => {
+    expect(() => renderReport({})).not.toThrow();
+    expect(renderReport({})).toContain("No new slop introduced");
+  });
+});

--- a/scripts/slop-report.test.ts
+++ b/scripts/slop-report.test.ts
@@ -135,6 +135,38 @@ describe("renderReport", () => {
     expect(body).not.toContain("baseline=1.00");
   });
 
+  it("omits the 'new' segment for a worsened-only delta (no '0 new')", () => {
+    const body = renderReport({
+      summary: { addedCount: 0, worsenedCount: 1, resolvedCount: 0 },
+      paths: [
+        {
+          path: "src/a.ts",
+          changes: [
+            change(
+              "worsened",
+              "defensive.empty-catch",
+              "strong",
+              "Found 2 empty catch blocks",
+              5,
+            ),
+          ],
+        },
+      ],
+    });
+    expect(body).toContain("**1** worsened finding");
+    expect(body).not.toContain("new");
+  });
+
+  it("counts added/worsened from the rendered rows, not summary (no header-only table)", () => {
+    // summary claims a finding, but no matching path change exists → treat as clean, no empty table.
+    const body = renderReport({
+      summary: { addedCount: 1, worsenedCount: 0, resolvedCount: 0 },
+      paths: [],
+    });
+    expect(body).toContain("No new slop introduced");
+    expect(body).not.toContain("| Location |");
+  });
+
   it("ignores resolved/unchanged occurrences in the table", () => {
     const body = renderReport({
       summary: { addedCount: 0, worsenedCount: 0, resolvedCount: 1 },

--- a/scripts/slop-report.test.ts
+++ b/scripts/slop-report.test.ts
@@ -29,8 +29,8 @@ describe("renderReport", () => {
     });
     expect(body).toContain(COMMENT_MARKER);
     expect(body).toContain("No new slop introduced");
-    expect(body).toContain("never blocks merge");
     expect(body).not.toContain("| Location |");
+    expect(body).not.toContain("🩹");
   });
 
   it("calls out resolved findings on an otherwise-clean PR", () => {
@@ -40,7 +40,7 @@ describe("renderReport", () => {
     expect(body).toContain("resolves 3");
   });
 
-  it("renders a table of added/worsened findings with severity icons and locations", () => {
+  it("renders a table of added/worsened findings with severity, location, and an actionable fix", () => {
     const body = renderReport({
       summary: { addedCount: 1, worsenedCount: 1, resolvedCount: 0 },
       paths: [
@@ -76,7 +76,36 @@ describe("renderReport", () => {
     expect(body).toContain("🟡"); // medium
     expect(body).toContain("`src/a.ts:42`");
     expect(body).toContain("`src/b.ts:7` _(worsened)_");
-    expect(body).toContain("`defensive.empty-catch`");
+    expect(body).toContain("Suggested fix");
+    // Actionable: each row carries a concrete remediation, not just the rule id.
+    expect(body).toContain("Handle or log the error");
+    expect(body).toContain("Preserve the original error");
+  });
+
+  it("surfaces specific evidence over the generic message and falls back to a default fix", () => {
+    const body = renderReport({
+      summary: { addedCount: 1, worsenedCount: 0, resolvedCount: 0 },
+      paths: [
+        {
+          path: "src/a.ts",
+          changes: [
+            {
+              status: "added",
+              ruleId: "some.unknown-rule",
+              head: {
+                severity: "strong",
+                message: "Generic message",
+                evidence: ["line 42: empty catch, boundary=config"],
+                primaryLocation: { line: 42 },
+              },
+            },
+          ],
+        },
+      ],
+    });
+    expect(body).toContain("empty catch, boundary=config"); // evidence, line-prefix stripped
+    expect(body).not.toContain("line 42: empty catch"); // prefix removed
+    expect(body).toContain("tune the rule in `slop-scan.config.json`"); // default fix
   });
 
   it("ignores resolved/unchanged occurrences in the table", () => {

--- a/scripts/slop-report.test.ts
+++ b/scripts/slop-report.test.ts
@@ -82,7 +82,7 @@ describe("renderReport", () => {
     expect(body).toContain("Preserve the original error");
   });
 
-  it("surfaces specific evidence over the generic message and falls back to a default fix", () => {
+  it("uses the descriptive message and appends the boundary tag, with a default fix for unknown rules", () => {
     const body = renderReport({
       summary: { addedCount: 1, worsenedCount: 0, resolvedCount: 0 },
       paths: [
@@ -94,8 +94,8 @@ describe("renderReport", () => {
               ruleId: "some.unknown-rule",
               head: {
                 severity: "strong",
-                message: "Generic message",
-                evidence: ["line 42: empty catch, boundary=config"],
+                message: "Found 1 empty catch block",
+                evidence: ["line 42: empty catch, boundary=network"],
                 primaryLocation: { line: 42 },
               },
             },
@@ -103,9 +103,36 @@ describe("renderReport", () => {
         },
       ],
     });
-    expect(body).toContain("empty catch, boundary=config"); // evidence, line-prefix stripped
-    expect(body).not.toContain("line 42: empty catch"); // prefix removed
+    expect(body).toContain("Found 1 empty catch block (boundary=network)"); // message + boundary
+    expect(body).not.toContain("baseline="); // never surface the raw numeric evidence
     expect(body).toContain("tune the rule in `slop-scan.config.json`"); // default fix
+  });
+
+  it("renders only the message when evidence has no boundary tag (e.g. structural rules)", () => {
+    const body = renderReport({
+      summary: { addedCount: 1, worsenedCount: 0, resolvedCount: 0 },
+      paths: [
+        {
+          path: "scripts",
+          changes: [
+            {
+              status: "added",
+              ruleId: "structure.directory-fanout-hotspot",
+              head: {
+                severity: "medium",
+                message:
+                  "Directory fan-out is a repo hotspot (16 files vs baseline 1.0)",
+                evidence: ["baseline=1.00", "threshold=6", "fileCount=16"],
+              },
+            },
+          ],
+        },
+      ],
+    });
+    expect(body).toContain(
+      "Directory fan-out is a repo hotspot (16 files vs baseline 1.0)",
+    );
+    expect(body).not.toContain("baseline=1.00");
   });
 
   it("ignores resolved/unchanged occurrences in the table", () => {

--- a/scripts/slop-report.ts
+++ b/scripts/slop-report.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env bun
+// Render a slop-scan `delta --json` report as a Markdown PR comment body.
+// Usage: `bun run scripts/slop-report.ts <delta.json>`
+import { readFileSync } from "node:fs";
+
+/** Stable marker so the workflow can find-and-update its own comment. */
+export const COMMENT_MARKER = "<!-- slop-scan-report -->";
+
+interface OccurrenceSide {
+  message?: string;
+  severity?: string;
+  primaryLocation?: { line?: number };
+}
+interface Occurrence {
+  status: "added" | "worsened" | "resolved" | "improved" | "unchanged";
+  ruleId: string;
+  severity?: string;
+  head?: OccurrenceSide | null;
+  base?: OccurrenceSide | null;
+}
+interface DeltaPath {
+  path: string;
+  changes?: Occurrence[];
+}
+interface Delta {
+  summary?: {
+    addedCount?: number;
+    worsenedCount?: number;
+    resolvedCount?: number;
+    improvedCount?: number;
+    headFindingCount?: number;
+  };
+  paths?: DeltaPath[];
+}
+
+const SEVERITY_ICON: Record<string, string> = {
+  strong: "🔴",
+  medium: "🟡",
+  weak: "⚪",
+};
+
+export function renderReport(delta: Delta): string {
+  const s = delta.summary ?? {};
+  const added = s.addedCount ?? 0;
+  const worsened = s.worsenedCount ?? 0;
+  const resolved = s.resolvedCount ?? 0;
+
+  const lines: string[] = [COMMENT_MARKER, "## 🩹 Slop Scan", ""];
+
+  if (added === 0 && worsened === 0) {
+    lines.push(
+      resolved > 0
+        ? `✅ No new slop introduced — and this PR **resolves ${resolved}** existing finding${resolved === 1 ? "" : "s"}. Nice.`
+        : "✅ No new slop introduced by this PR.",
+    );
+    lines.push("", "_Advisory only — this check never blocks merge._");
+    return lines.join("\n");
+  }
+
+  const summaryBits = [`**${added}** new`];
+  if (worsened > 0) summaryBits.push(`**${worsened}** worsened`);
+  if (resolved > 0) summaryBits.push(`${resolved} resolved`);
+  lines.push(
+    `${summaryBits.join(" · ")} finding${added + worsened === 1 ? "" : "s"} vs. the base branch.`,
+    "",
+  );
+  lines.push("| | Location | Rule | Detail |", "| - | - | - | - |");
+
+  for (const p of delta.paths ?? []) {
+    for (const c of p.changes ?? []) {
+      if (c.status !== "added" && c.status !== "worsened") continue;
+      const severity = c.head?.severity ?? c.base?.severity ?? c.severity ?? "";
+      const icon = SEVERITY_ICON[severity] ?? "•";
+      const line = c.head?.primaryLocation?.line;
+      const loc = line ? `\`${p.path}:${line}\`` : `\`${p.path}\``;
+      const tag = c.status === "worsened" ? " _(worsened)_" : "";
+      // Collapse newlines (would break the table row) and escape pipes.
+      const detail = (c.head?.message ?? "")
+        .replace(/\s*\n\s*/g, " ")
+        .replace(/\|/g, "\\|");
+      lines.push(`| ${icon} | ${loc}${tag} | \`${c.ruleId}\` | ${detail} |`);
+    }
+  }
+
+  lines.push(
+    "",
+    "_Advisory only — this check never blocks merge. If a finding is a false positive or an accepted pattern, you can ignore it; persistently noisy rules will be tuned out in `slop-scan.config.json`._",
+  );
+  return lines.join("\n");
+}
+
+// Run directly (not when imported by a test).
+if (import.meta.main) {
+  const path = process.argv[2];
+  if (!path) {
+    console.error("usage: bun run scripts/slop-report.ts <delta.json>");
+    process.exit(2);
+  }
+  let delta: Delta;
+  try {
+    delta = JSON.parse(readFileSync(path, "utf8")) as Delta;
+  } catch (err) {
+    // Advisory: bad/missing input must never fail CI — degrade and exit 0.
+    const reason = err instanceof Error ? err.message : String(err);
+    process.stdout.write(
+      `${COMMENT_MARKER}\n## 🩹 Slop Scan\n\n⚠️ slop-scan did not produce a usable delta report (${reason}). No slop verdict for this PR.\n\n_Advisory only — this check never blocks merge._\n`,
+    );
+    process.exit(0);
+  }
+  process.stdout.write(`${renderReport(delta)}\n`);
+}

--- a/scripts/slop-report.ts
+++ b/scripts/slop-report.ts
@@ -3,7 +3,11 @@
 // Usage: `bun run scripts/slop-report.ts <delta.json>`
 import { readFileSync } from "node:fs";
 
-/** Stable marker so the workflow can find-and-update its own comment. */
+/**
+ * Stable marker so the workflow can find-and-update its own comment.
+ * Keep in sync with the `marker` literal in .github/workflows/slop-scan.yml —
+ * if they drift, the workflow stops matching its comment and posts a new one per push.
+ */
 export const COMMENT_MARKER = "<!-- slop-scan-report -->";
 
 interface OccurrenceSide {
@@ -75,18 +79,36 @@ function describe(side?: OccurrenceSide | null): string {
   const message = side?.message?.trim();
   const boundary = side?.evidence?.join(" ").match(/boundary=\S+/)?.[0];
   if (message && boundary) return `${message} (${boundary})`;
-  return message || side?.evidence?.[0] || "issue";
+  return (
+    message || side?.evidence?.[0]?.replace(/^line\s+\d+:\s*/i, "") || "issue"
+  );
 }
 
 export function renderReport(delta: Delta): string {
-  const s = delta.summary ?? {};
-  const added = s.addedCount ?? 0;
-  const worsened = s.worsenedCount ?? 0;
-  const resolved = s.resolvedCount ?? 0;
-
+  // Build the rows first; added/worsened are counted from the rows we actually
+  // render, so the gate, the summary line, and the table can't disagree.
+  const rows: string[] = [];
+  let added = 0;
+  let worsened = 0;
+  for (const p of delta.paths ?? []) {
+    for (const c of p.changes ?? []) {
+      if (c.status !== "added" && c.status !== "worsened") continue;
+      if (c.status === "added") added++;
+      else worsened++;
+      const severity = c.head?.severity ?? c.base?.severity ?? c.severity ?? "";
+      const icon = SEVERITY_ICON[severity] ?? "•";
+      const line = c.head?.primaryLocation?.line;
+      const loc = line ? `\`${p.path}:${line}\`` : `\`${p.path}\``;
+      const tag = c.status === "worsened" ? " _(worsened)_" : "";
+      const issue = `${cell(describe(c.head))} (\`${c.ruleId}\`)`;
+      const fix = cell(FIX_HINTS[c.ruleId] ?? DEFAULT_FIX);
+      rows.push(`| ${icon} | ${loc}${tag} | ${issue} | ${fix} |`);
+    }
+  }
+  const resolved = delta.summary?.resolvedCount ?? 0;
   const lines: string[] = [COMMENT_MARKER, "## Slop Scan", ""];
 
-  if (added === 0 && worsened === 0) {
+  if (rows.length === 0) {
     lines.push(
       resolved > 0
         ? `No new slop introduced — and this PR resolves ${resolved} existing finding${resolved === 1 ? "" : "s"}.`
@@ -95,29 +117,17 @@ export function renderReport(delta: Delta): string {
     return lines.join("\n");
   }
 
-  const summaryBits = [`**${added}** new`];
+  const summaryBits: string[] = [];
+  if (added > 0) summaryBits.push(`**${added}** new`);
   if (worsened > 0) summaryBits.push(`**${worsened}** worsened`);
   if (resolved > 0) summaryBits.push(`${resolved} resolved`);
   lines.push(
     `${summaryBits.join(" · ")} finding${added + worsened === 1 ? "" : "s"} vs. the base branch.`,
     "",
+    "| | Location | Issue | Suggested fix |",
+    "| - | - | - | - |",
+    ...rows,
   );
-  lines.push("| | Location | Issue | Suggested fix |", "| - | - | - | - |");
-
-  for (const p of delta.paths ?? []) {
-    for (const c of p.changes ?? []) {
-      if (c.status !== "added" && c.status !== "worsened") continue;
-      const severity = c.head?.severity ?? c.base?.severity ?? c.severity ?? "";
-      const icon = SEVERITY_ICON[severity] ?? "•";
-      const line = c.head?.primaryLocation?.line;
-      const loc = line ? `\`${p.path}:${line}\`` : `\`${p.path}\``;
-      const tag = c.status === "worsened" ? " _(worsened)_" : "";
-      const issue = `${cell(describe(c.head))} (\`${c.ruleId}\`)`;
-      const fix = cell(FIX_HINTS[c.ruleId] ?? DEFAULT_FIX);
-      lines.push(`| ${icon} | ${loc}${tag} | ${issue} | ${fix} |`);
-    }
-  }
-
   return lines.join("\n");
 }
 

--- a/scripts/slop-report.ts
+++ b/scripts/slop-report.ts
@@ -9,6 +9,7 @@ export const COMMENT_MARKER = "<!-- slop-scan-report -->";
 interface OccurrenceSide {
   message?: string;
   severity?: string;
+  evidence?: string[];
   primaryLocation?: { line?: number };
 }
 interface Occurrence {
@@ -39,21 +40,56 @@ const SEVERITY_ICON: Record<string, string> = {
   weak: "⚪",
 };
 
+// Concrete remediation per rule — a finding is only useful if it says what to do.
+const FIX_HINTS: Record<string, string> = {
+  "defensive.empty-catch":
+    "Handle or log the error, or comment why it's safe to swallow.",
+  "defensive.error-obscuring":
+    "Preserve the original error (e.g. `cause`) instead of replacing it.",
+  "defensive.error-swallowing":
+    "Don't log-and-continue if the caller needs to know it failed.",
+  "defensive.async-noise":
+    "Await the promise or handle rejection; avoid fire-and-forget.",
+  "structure.pass-through-wrappers":
+    "Inline the wrapper or give it behavior of its own.",
+  "structure.duplicate-function-signatures":
+    "Extract a shared helper/type for the repeated signature.",
+  "structure.barrel-density":
+    "Drop the barrel; import the underlying files directly.",
+  "structure.directory-fanout-hotspot":
+    "Group related files into a cohesive submodule.",
+  "structure.over-fragmentation": "Consolidate the over-split modules.",
+  "comments.placeholder-comments":
+    "Remove the placeholder comment or implement what it describes.",
+  "tests.duplicate-mock-setup":
+    "Extract the repeated mock/setup into a shared fixture.",
+};
+const DEFAULT_FIX =
+  "Address it, or tune the rule in `slop-scan.config.json` if it's noise.";
+
+/** Newlines break table rows and pipes break columns — neutralize both. */
+const cell = (s: string) => s.replace(/\s*\n\s*/g, " ").replace(/\|/g, "\\|");
+
+/** Prefer the specific evidence ("empty catch, boundary=config") over the generic message. */
+function describe(side?: OccurrenceSide | null): string {
+  const evidence = side?.evidence?.[0]?.replace(/^line\s+\d+:\s*/i, "");
+  return evidence || side?.message || "issue";
+}
+
 export function renderReport(delta: Delta): string {
   const s = delta.summary ?? {};
   const added = s.addedCount ?? 0;
   const worsened = s.worsenedCount ?? 0;
   const resolved = s.resolvedCount ?? 0;
 
-  const lines: string[] = [COMMENT_MARKER, "## 🩹 Slop Scan", ""];
+  const lines: string[] = [COMMENT_MARKER, "## Slop Scan", ""];
 
   if (added === 0 && worsened === 0) {
     lines.push(
       resolved > 0
-        ? `✅ No new slop introduced — and this PR **resolves ${resolved}** existing finding${resolved === 1 ? "" : "s"}. Nice.`
-        : "✅ No new slop introduced by this PR.",
+        ? `No new slop introduced — and this PR resolves ${resolved} existing finding${resolved === 1 ? "" : "s"}.`
+        : "No new slop introduced by this PR.",
     );
-    lines.push("", "_Advisory only — this check never blocks merge._");
     return lines.join("\n");
   }
 
@@ -64,7 +100,7 @@ export function renderReport(delta: Delta): string {
     `${summaryBits.join(" · ")} finding${added + worsened === 1 ? "" : "s"} vs. the base branch.`,
     "",
   );
-  lines.push("| | Location | Rule | Detail |", "| - | - | - | - |");
+  lines.push("| | Location | Issue | Suggested fix |", "| - | - | - | - |");
 
   for (const p of delta.paths ?? []) {
     for (const c of p.changes ?? []) {
@@ -74,18 +110,12 @@ export function renderReport(delta: Delta): string {
       const line = c.head?.primaryLocation?.line;
       const loc = line ? `\`${p.path}:${line}\`` : `\`${p.path}\``;
       const tag = c.status === "worsened" ? " _(worsened)_" : "";
-      // Collapse newlines (would break the table row) and escape pipes.
-      const detail = (c.head?.message ?? "")
-        .replace(/\s*\n\s*/g, " ")
-        .replace(/\|/g, "\\|");
-      lines.push(`| ${icon} | ${loc}${tag} | \`${c.ruleId}\` | ${detail} |`);
+      const issue = `${cell(describe(c.head))} (\`${c.ruleId}\`)`;
+      const fix = cell(FIX_HINTS[c.ruleId] ?? DEFAULT_FIX);
+      lines.push(`| ${icon} | ${loc}${tag} | ${issue} | ${fix} |`);
     }
   }
 
-  lines.push(
-    "",
-    "_Advisory only — this check never blocks merge. If a finding is a false positive or an accepted pattern, you can ignore it; persistently noisy rules will be tuned out in `slop-scan.config.json`._",
-  );
   return lines.join("\n");
 }
 
@@ -103,7 +133,7 @@ if (import.meta.main) {
     // Advisory: bad/missing input must never fail CI — degrade and exit 0.
     const reason = err instanceof Error ? err.message : String(err);
     process.stdout.write(
-      `${COMMENT_MARKER}\n## 🩹 Slop Scan\n\n⚠️ slop-scan did not produce a usable delta report (${reason}). No slop verdict for this PR.\n\n_Advisory only — this check never blocks merge._\n`,
+      `${COMMENT_MARKER}\n## Slop Scan\n\n⚠️ slop-scan could not produce a delta report (${reason}). No slop verdict for this PR.\n`,
     );
     process.exit(0);
   }

--- a/scripts/slop-report.ts
+++ b/scripts/slop-report.ts
@@ -70,10 +70,12 @@ const DEFAULT_FIX =
 /** Newlines break table rows and pipes break columns — neutralize both. */
 const cell = (s: string) => s.replace(/\s*\n\s*/g, " ").replace(/\|/g, "\\|");
 
-/** Prefer the specific evidence ("empty catch, boundary=config") over the generic message. */
+/** The message is the human-readable summary; append the boundary tag from evidence when present (it tells you what kind of catch/edge a defensive finding guards). */
 function describe(side?: OccurrenceSide | null): string {
-  const evidence = side?.evidence?.[0]?.replace(/^line\s+\d+:\s*/i, "");
-  return evidence || side?.message || "issue";
+  const message = side?.message?.trim();
+  const boundary = side?.evidence?.join(" ").match(/boundary=\S+/)?.[0];
+  if (message && boundary) return `${message} (${boundary})`;
+  return message || side?.evidence?.[0] || "issue";
 }
 
 export function renderReport(delta: Delta): string {

--- a/slop-scan.config.json
+++ b/slop-scan.config.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://unpkg.com/slop-scan@0/schema.json",
+  "ignores": [
+    "**/node_modules/**",
+    "**/.git/**",
+    "build/**",
+    "dist/**",
+    "bin/**",
+    "container/**",
+    "fern/**",
+    "benchmarks/**",
+    "assets/**",
+    "**/coverage/**",
+    "**/*.generated.*",
+    "loader-demo.tsx",
+    ".slop-base/**"
+  ],
+  "_comment": "overrides: empty catches in test teardown/cleanup are benign and high-frequency; suppress so advisory comments stay signal-rich.",
+  "overrides": [
+    {
+      "files": ["**/*.test.ts", "**/*.test.tsx"],
+      "rules": {
+        "defensive.empty-catch": { "enabled": false }
+      }
+    }
+  ]
+}

--- a/slop-scan.config.json
+++ b/slop-scan.config.json
@@ -15,7 +15,11 @@
     "loader-demo.tsx",
     ".slop-base/**"
   ],
-  "_comment": "overrides: empty catches in test teardown/cleanup are benign and high-frequency; suppress so advisory comments stay signal-rich.",
+  "_comment": "directory-fanout/barrel rules are convention noise (non-actionable, fire on file-per-thing layouts); test-teardown empty catches are benign and high-frequency.",
+  "rules": {
+    "structure.directory-fanout-hotspot": { "enabled": false },
+    "structure.barrel-density": { "enabled": false }
+  },
   "overrides": [
     {
       "files": ["**/*.test.ts", "**/*.test.tsx"],


### PR DESCRIPTION
## Why

We ship fast and lean heavily on AI-assisted coding, and that quietly accumulates **slop** — the stuff that passes lint, types, and tests but rots the codebase: empty `catch {}` blocks that swallow errors, error-obscuring catches that hide the real cause, log-and-continue swallowing, copy-paste duplication, pass-through wrappers that add nothing.

We already have **knip** guarding one slice of code health — dead/unused code. But knip only sees what's *unused*; live, wired-up code can still be full of design smells, and nothing in CI looks for those today. `slop-scan` is the complement: it watches the code that *is* in use for those smells, on every PR — so keeping the code clean becomes a default, not a periodic cleanup project. It's **advisory**: it nudges, it never blocks.

## What

A Bug Bot-style `slop-scan` CI stage (powered by [slop-scan](https://github.com/benvinegar/slop-scan)), sitting alongside knip as the second code-health check. On every push to a PR it diffs the branch against its base and reports **newly added / worsened** slop as:

1. a **neutral check** (grey, never red), and
2. a **sticky PR comment** — a table of `severity · file:line · what's wrong · suggested fix`, updated in place each push.

You decide whether to fix or ignore. Nothing is ever blocked.

## How it behaves

- **Per push**, like Bug Bot — re-scans on every `synchronize`.
- **Never reds CI** — scan/report/publish steps all degrade gracefully; worst case is a check saying "couldn't produce a report."
- **Actionable** — each finding names the specific issue and a concrete fix, not just a rule id.
- **Self-cleaning** — the comment flips to "No new slop" once findings are resolved.

## Why advisory first (not a hard gate)

The repo has ~100 pre-existing findings and several rules are judgment calls. A hard gate would either block forever or force noisy suppressions. Advisory mode surfaces signal without friction and doubles as the data-gathering phase for tuning the ruleset — once a rule earns trust, promoting it to a real gate is a one-line `--fail-on` change.

## Files

- `slop-scan.config.json` — ignores build/vendored dirs; disables proven-noisy convention rules (`directory-fanout-hotspot`, `barrel-density`); suppresses benign test-teardown `empty-catch`.
- `scripts/slop-report.ts` (+ tests) — pure `delta.json → markdown` formatter; degrades to a fallback and exits 0 on bad input so a scan crash can't red CI.
- `.github/workflows/slop-scan.yml` — delta + neutral check (update-or-create) + sticky comment.
- `ci.yml`, `package.json`, `bun.lock` — wiring + pinned devDependency.

## Notes

- **Permissions**: scoped to this one job. `pull-requests: write` already has precedent (`auto-assign.yml`); `checks: write` is the only new scope, used solely for the neutral check.
- **Fork PRs**: the check/comment no-op on forks (read-only token by design — no `pull_request_target`). Same-repo branches work fully.