### PR TITLE
fix: stop bash kill messages leaking into sibling command stderr

### DIFF
--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -78,6 +78,12 @@ interface PendingCommand {
   cutoverSeen: boolean;
   cutoverMarker: string;
   stderr: string;
+  // Mirror of the stdout cutover fence for stderr. A command's real stderr is
+  // `cat`'d to bash's stderr only after this marker is emitted on fd2; anything
+  // before it is bash's own job-control noise (e.g. "Terminated"/"Killed" from
+  // a prior killed sibling) and must not leak into this command's stderr.
+  stderrCutoverSeen: boolean;
+  stderrPreCutover: string;
   stdoutTruncated: boolean;
   exitMarkerPrefix: string;
   onData?: (chunk: string) => void;
@@ -335,7 +341,37 @@ export class PersistentShell {
     const cmd = this.current;
     if (!cmd) return;
 
-    cmd.stderr += data.toString();
+    let chunk = data.toString();
+
+    if (!cmd.stderrCutoverSeen) {
+      // Discard everything up to and including this command's stderr cutover
+      // marker. The command's own stderr is `cat`'d only after the marker, so
+      // pre-marker bytes are bash diagnostics (job-control kill messages) that
+      // would otherwise be misattributed to this command.
+      cmd.stderrPreCutover += chunk;
+      const cutIdx = cmd.stderrPreCutover.indexOf(cmd.cutoverMarker);
+      if (cutIdx === -1) {
+        // Keep only a marker-length tail so a marker straddling chunks is still
+        // found; bounded so unexpected pre-cutover output can't grow unbounded.
+        if (cmd.stderrPreCutover.length > cmd.cutoverMarker.length) {
+          cmd.stderrPreCutover = cmd.stderrPreCutover.substring(
+            cmd.stderrPreCutover.length - cmd.cutoverMarker.length,
+          );
+        }
+        return;
+      }
+      const postMarker = cmd.stderrPreCutover.substring(
+        cutIdx + cmd.cutoverMarker.length,
+      );
+      cmd.stderrCutoverSeen = true;
+      cmd.stderrPreCutover = "";
+      chunk = postMarker.startsWith("\n")
+        ? postMarker.substring(1)
+        : postMarker;
+      if (chunk.length === 0) return;
+    }
+
+    cmd.stderr += chunk;
     if (cmd.stderr.length > MAX_BUFFER) {
       cmd.stderr =
         cmd.stderr.substring(0, MAX_BUFFER) + "...\n(stderr truncated)";
@@ -391,6 +427,8 @@ export class PersistentShell {
           cutoverSeen: false,
           cutoverMarker,
           stderr: "",
+          stderrCutoverSeen: false,
+          stderrPreCutover: "",
           stdoutTruncated: false,
           exitMarkerPrefix,
           onData,
@@ -475,6 +513,10 @@ export class PersistentShell {
           `wait "$__APEX_TAIL" 2>/dev/null`,
           `printf '%s\\n' "${cutoverMarker}"`,
           `cat "$__APEX_OUT"`,
+          // Stderr cutover fence: marks the boundary between bash's own
+          // diagnostics (job-control kill messages from a killed sibling) and
+          // this command's real stderr, so the former can't leak into it.
+          `printf '%s\\n' "${cutoverMarker}" >&2`,
           `cat "$__APEX_ERR" >&2`,
           // Node owns tempfile cleanup so kill paths can read before unlink.
           `echo "${exitMarkerPrefix}$__APEX_EC"`,


### PR DESCRIPTION
## Summary

Fixes a flaky failure in `PersistentShell` where a timed-out/aborted command's bash job-control kill message (`Terminated` / `Killed`) leaked into the **next** command's stderr.

When a command times out or is aborted, its foreground child is SIGTERM'd and bash prints a job-control message to its **own** stderr (fd2). That message is asynchronous — it can arrive after the timed-out command has already resolved (via the disk-read salvage timer) and `this.current` has advanced to the next command, so it gets misattributed to the surviving sibling.

stdout was already protected: each command delimits its authoritative output with a per-command cutover marker, so stale stdout from a killed sibling is fenced off. stderr had no equivalent fence.

## Fix

Symmetric stderr fence:
- Emit the cutover marker on fd2 (`printf '%s\n' "$cutoverMarker" >&2`) right before `cat`'ing the command's real stderr.
- In `onStderrData`, discard everything received before that marker. A command's real stderr is only `cat`'d after the marker, so any pre-marker bytes are bash's own diagnostics and must not leak across commands.

The salvage/close paths read stderr from the per-command tempfile on disk, so they are unaffected.

## Test plan

- [x] `bunx vitest run src/core/agents/offSecAgent/tools/persistentShell.test.ts` — 35 passed / 1 skipped
- [x] Ran the previously-flaky `isolates parallel-call timeouts (no marker or kill-message leakage)` test repeatedly — consistently green
- [x] `bun run tsc` clean
- [x] `bun run lint` clean (no new diagnostics)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to shell output parsing in the off-sec agent tool; no auth, data, or API surface changes, with existing tests covering parallel timeout isolation.
> 
> **Overview**
> Fixes flaky mis-attribution of bash job-control messages (`Terminated` / `Killed`) to the **next** command's stderr when a prior command times out or is aborted and resolves before those bytes arrive on fd2.
> 
> **PersistentShell** now mirrors the existing stdout cutover fence on stderr: the wrapper prints the per-command cutover marker on fd2 immediately before `cat`'ing the command's real stderr from its tempfile. **`onStderrData`** buffers until that marker (with a bounded tail for split chunks), drops everything before it, and only then accumulates stderr for the active command.
> 
> Timeout/abort salvage paths that read stderr from disk are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9a28c100757874fda839e3a7767b845d1d499c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->