### PR TITLE
fix(tui): drop sharp dependency from screenshot modal

### DIFF
--- a/src/tui/components/screenshot-modal.tsx
+++ b/src/tui/components/screenshot-modal.tsx
@@ -1,6 +1,6 @@
+import { open } from "node:fs/promises";
 import { useKeyboard } from "@opentui/react";
 import { useEffect, useState } from "react";
-import sharp from "sharp";
 import { useDimensions } from "../context/dimensions";
 import { useTheme } from "../theme";
 import {
@@ -18,6 +18,28 @@ import { isToolMessage } from "./shared/type-guards";
 // structure (header bar ~3-4 rows; input area + status bar ~6 rows).
 const HEADER_ROWS = 4;
 const FOOTER_ROWS = 6;
+
+// Browser screenshots are PNG. Read width/height from the IHDR chunk
+// (BE uint32 at byte offsets 16 and 20) instead of pulling in `sharp`,
+// whose native addon can't be embedded by `bun build --compile`.
+async function readPngDimensions(
+  path: string,
+): Promise<{ width: number; height: number }> {
+  const fh = await open(path, "r");
+  try {
+    const buf = Buffer.alloc(24);
+    await fh.read(buf, 0, 24, 0);
+    if (
+      buf.readUInt32BE(0) !== 0x89504e47 ||
+      buf.readUInt32BE(4) !== 0x0d0a1a0a
+    ) {
+      throw new Error("not a PNG");
+    }
+    return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+  } finally {
+    await fh.close();
+  }
+}
 
 interface Props {
   /** Chronological list (oldest -> newest). */
@@ -89,9 +111,7 @@ export function ScreenshotModal({ screenshots, initialIndex, onClose }: Props) {
     const id = nextImageId();
     (async () => {
       try {
-        const meta = await sharp(path).metadata();
-        const w = meta.width ?? 1;
-        const h = meta.height ?? 1;
+        const { width: w, height: h } = await readPngDimensions(path);
         // Available cell box inside the chat region (reserve header /
         // footer so they stay visible). Cells are ~1:2 on screen, so
         // image cell-aspect = (h/w) / 2.


### PR DESCRIPTION
## Summary
- Standalone binaries (`bun build --compile` — Quick Install / Homebrew / Windows) crash on launch with `Could not load the "sharp" module` because sharp's native `.node` addon can't be embedded in the single-file binary. Reported in #838.
- `screenshot-modal.tsx` was the only runtime importer of `sharp` and used it solely for `sharp(path).metadata()` to read PNG width/height. Replaced with a 24-byte read of the PNG IHDR chunk (BE uint32 width/height at offsets 16/20) — zero behavior change, no native dep.
- `sharp` stays as a build-time dep for `scripts/generate-ascii-art.ts`; verified the runtime bundle contains zero `sharp` / `@img/sharp-*` imports after this change.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `bun build src/cli.ts` bundle contains zero `sharp` / `@img/sharp-*` references
- [x] `bun run build:binary` produces a standalone `pensar` binary that launches without the sharp error
- [x] Manual: open a chat with a `browser_screenshot` tool result and verify the screenshot modal still renders + centers the image at the correct aspect ratio
- [ ] Manual: confirm Homebrew / curl / Windows install paths work after a release ships

Closes #838