### PR TITLE
feat(models): add Kimi K2.7 Code, MiniMax M3, and GLM 5.2 to OpenRouter

### DIFF
--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -156,5 +156,16 @@ function lookupOutputBudgetByPattern(modelId: string): number {
     return 8_192;
   }
 
+  // MiniMax M3: match our top-tier Opus output budget (128K) rather than the
+  // model's advertised 512K max, keeping ample input headroom for agentic work.
+  if (modelId.includes("minimax-m3")) {
+    return 128_000;
+  }
+
+  // GLM 5.2 ships a 131.1K (128Ki) max-output window over its 1M context.
+  if (modelId.includes("glm-5.2")) {
+    return 131_072;
+  }
+
   return 4_096;
 }

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -39,6 +39,16 @@ describe("getMaxOutputTokens", () => {
     }
   });
 
+  it("pins MiniMax M3 to the top-tier Opus output budget", () => {
+    // M3 matches our flagship Opus 128K output rather than its advertised
+    // 512K max, leaving input headroom within the 512Ki context window.
+    expect(getMaxOutputTokens("minimax/minimax-m3")).toBe(128_000);
+  });
+
+  it("recognizes GLM 5.2's 131.1K max-output window", () => {
+    expect(getMaxOutputTokens("z-ai/glm-5.2")).toBe(131_072);
+  });
+
   it("recognizes Claude tier-specific budgets", () => {
     expect(getMaxOutputTokens("claude-sonnet-4-5-20250929")).toBe(64_000);
     expect(getMaxOutputTokens("claude-opus-4-5-20250101")).toBe(64_000);

--- a/src/core/ai/models/openrouter.ts
+++ b/src/core/ai/models/openrouter.ts
@@ -124,6 +124,12 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
     contextLength: 262144,
   },
   {
+    id: "moonshotai/kimi-k2.7-code",
+    name: "Kimi K2.7 Code",
+    provider: "openrouter",
+    contextLength: 262144,
+  },
+  {
     id: "moonshot/kimi-k2-turbo",
     name: "Kimi K2 Turbo",
     provider: "openrouter",
@@ -140,6 +146,12 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
     name: "MiniMax M2",
     provider: "openrouter",
     contextLength: 204800,
+  },
+  {
+    id: "minimax/minimax-m3",
+    name: "MiniMax M3",
+    provider: "openrouter",
+    contextLength: 524288,
   },
   {
     id: "qwen/qwen3-8b",
@@ -206,5 +218,11 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
     name: "GLM 4.7 Flash",
     provider: "openrouter",
     contextLength: 200000,
+  },
+  {
+    id: "z-ai/glm-5.2",
+    name: "GLM 5.2",
+    provider: "openrouter",
+    contextLength: 1000000,
   },
 ];


### PR DESCRIPTION
## Summary

Registers three new OpenRouter models in the curated model registry (`src/core/ai/models/openrouter.ts`):

| Model | ID | Context | Max output |
|-------|----|---------|------------|
| Kimi K2.7 Code | `moonshotai/kimi-k2.7-code` | 256Ki (262,144) | default |
| MiniMax M3 | `minimax/minimax-m3` | 512Ki (524,288) | 128K |
| GLM 5.2 | `z-ai/glm-5.2` | 1M (1,000,000) | 131.1K (131,072) |

Without a registry entry, an unlisted model string falls through `getModelInfo` to `provider: "local"` and gets routed to the local model endpoint rather than OpenRouter — so these entries are what actually enables OpenRouter routing for the models.

## Output budgets (`lookupOutputBudgetByPattern`)

- **MiniMax M3 → 128K.** M3 advertises a 512K max, but we pin it to our top-tier Opus budget (`claude-opus-4-6/4-7/4-8`) instead. Context is capped at 512Ki for now since not every provider serves M3's full 1M window yet; 128K output leaves ~396K of input headroom and stays clear of the `getMaxOutputTokens` half-window clamp.
- **GLM 5.2 → 131.1K (128Ki).** Matches the model's documented max-output window over its 1M context.
- Kimi K2.7 Code uses the default budget (no special pattern needed).

Each non-default budget has a regression test in `models.test.ts`.

## Test plan

- [x] `vitest run src/core/ai/models/models.test.ts` — 16 passed
- [x] `biome check` clean on all touched files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry and output-budget metadata only; no auth, routing logic, or streaming behavior changes beyond correct OpenRouter routing and token limits for the new IDs.
> 
> **Overview**
> Registers **Kimi K2.7 Code**, **MiniMax M3**, and **GLM 5.2** in the OpenRouter model list with `provider: "openrouter"` and documented context lengths (262K, 512K, and 1M respectively), so these IDs route through OpenRouter instead of falling through to `local`.
> 
> Extends `lookupOutputBudgetByPattern` with model-specific max-output caps: **MiniMax M3** is pinned to **128K** (aligned with top-tier Opus, not the advertised 512K max), and **GLM 5.2** to **131,072** tokens. Kimi K2.7 Code keeps the default 4,096 output budget. Regression tests lock in the M3 and GLM budgets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 134c1f677dc8bd7b76daae292abd1ec3f5dbcfe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->