### PR TITLE
feat(tui): honor terminal transparency

### DIFF
--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -30,6 +30,8 @@ export interface Config {
   // Theme preferences
   theme?: string;
   themeMode?: "dark" | "light" | "auto";
+  // Use the terminal's default background so a transparent terminal shows through.
+  transparentBackground?: boolean;
   // Model preference
   selectedModelId?: string | null;
   // Extended thinking / reasoning

--- a/src/tui/components/commands/theme-picker.tsx
+++ b/src/tui/components/commands/theme-picker.tsx
@@ -28,6 +28,8 @@ export default function ThemePicker({ onClose }: ThemePickerProps) {
     setTheme,
     toggleMode,
     setMode,
+    transparent,
+    toggleTransparent,
   } = useTheme();
 
   const [selectedIndex, setSelectedIndex] = useState(() =>
@@ -92,6 +94,12 @@ export default function ThemePicker({ onClose }: ThemePickerProps) {
       config.update({ themeMode: newMode });
       return;
     }
+
+    if (evt.name === "b") {
+      toggleTransparent();
+      config.update({ transparentBackground: !transparent });
+      return;
+    }
   });
 
   const panelWidth = Math.min(50, dimensions.width - 4);
@@ -122,11 +130,14 @@ export default function ThemePicker({ onClose }: ThemePickerProps) {
         footerActions={[
           { key: "Enter", label: "select", variant: "primary" },
           { key: "M", label: "toggle mode" },
+          { key: "B", label: "transparency" },
         ]}
       >
         {/* Mode indicator */}
         <box marginBottom={1}>
-          <text fg={colors.textMuted}>mode: {mode}</text>
+          <text fg={colors.textMuted}>
+            mode: {mode} · transparent: {transparent ? "on" : "off"}
+          </text>
         </box>
 
         {/* Separator */}

--- a/src/tui/components/commands/theme-picker.tsx
+++ b/src/tui/components/commands/theme-picker.tsx
@@ -37,22 +37,24 @@ export default function ThemePicker({ onClose }: ThemePickerProps) {
   );
   const originalThemeRef = useRef(theme.name);
   const originalModeRef = useRef(mode);
+  const originalTransparentRef = useRef(transparent);
 
   const handleClose = useCallback(() => {
-    // Revert to original theme
+    // Revert previews to their state when the dialog opened
     setTheme(originalThemeRef.current);
     setMode(originalModeRef.current);
+    if (transparent !== originalTransparentRef.current) toggleTransparent();
     onClose();
-  }, [setTheme, setMode, onClose]);
+  }, [setTheme, setMode, transparent, toggleTransparent, onClose]);
 
   const handleConfirm = useCallback(async () => {
-    // Persist the current theme and mode
     const currentThemeName = availableThemes[selectedIndex];
     if (currentThemeName) {
       await config.update({ theme: currentThemeName });
     }
+    await config.update({ transparentBackground: transparent });
     onClose();
-  }, [availableThemes, selectedIndex, onClose]);
+  }, [availableThemes, selectedIndex, transparent, onClose]);
 
   useKeyboard((evt) => {
     // Modal dialog — consume all keystrokes to prevent leaking to components underneath
@@ -97,7 +99,6 @@ export default function ThemePicker({ onClose }: ThemePickerProps) {
 
     if (evt.name === "b") {
       toggleTransparent();
-      config.update({ transparentBackground: !transparent });
       return;
     }
   });

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -683,7 +683,11 @@ async function main() {
   }
 
   const transparent = appConfig.transparentBackground ?? false;
-  const themeColors = resolveThemeColors(getTheme(themeName), mode, transparent);
+  const themeColors = resolveThemeColors(
+    getTheme(themeName),
+    mode,
+    transparent,
+  );
   overlayThemeRef.current = themeColors;
 
   const renderer = await createCliRenderer({

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -1,4 +1,4 @@
-import { createCliRenderer, FrameBufferRenderable } from "@opentui/core";
+import { createCliRenderer, FrameBufferRenderable, RGBA } from "@opentui/core";
 import { createRoot, extend } from "@opentui/react";
 import { useEffect, useState } from "react";
 import { config } from "../core/config";
@@ -682,12 +682,15 @@ async function main() {
     mode = await detectTerminalMode();
   }
 
-  const themeColors = resolveThemeColors(getTheme(themeName), mode);
+  const transparent = appConfig.transparentBackground ?? false;
+  const themeColors = resolveThemeColors(getTheme(themeName), mode, transparent);
   overlayThemeRef.current = themeColors;
 
   const renderer = await createCliRenderer({
     exitOnCtrlC: false,
     consoleOptions: buildConsoleOptions(themeColors),
+    // Opaque themes paint over this; transparent mode leaves it showing through.
+    backgroundColor: RGBA.defaultBackground(),
   });
 
   const { copyToClipboard } = createClipboardManager(renderer);
@@ -721,7 +724,11 @@ async function main() {
 
   createRoot(renderer).render(
     <ObfuscationProvider initialEnabled={obfuscateEnabled}>
-      <ThemeProvider initialTheme={themeName} initialMode={mode}>
+      <ThemeProvider
+        initialTheme={themeName}
+        initialMode={mode}
+        initialTransparent={transparent}
+      >
         <ConsoleThemeSync />
         <TerminalDimensionsProvider>
           <ToastProvider>

--- a/src/tui/theme/context.tsx
+++ b/src/tui/theme/context.tsx
@@ -5,7 +5,7 @@
  * mode, resolving per-token { dark, light } values to flat RGBA colors.
  */
 
-import type { RGBA } from "@opentui/core";
+import { RGBA } from "@opentui/core";
 import {
   createContext,
   type ReactNode,
@@ -37,6 +37,10 @@ interface ThemeContextValue {
   toggleMode: () => void;
   /** Set a specific mode */
   setMode: (mode: ColorMode) => void;
+  /** Whether the terminal's default (transparent) background is used */
+  transparent: boolean;
+  /** Toggle terminal-transparent background on/off */
+  toggleTransparent: () => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
@@ -51,32 +55,40 @@ function resolveColor(value: ThemeColorValue, mode: ColorMode): RGBA {
 export function resolveThemeColors(
   theme: ThemeDefinition,
   mode: ColorMode,
+  transparent = false,
 ): ThemeColors {
   const entries = Object.entries(theme.colors) as [string, ThemeColorValue][];
   const resolved: Record<string, RGBA> = {};
   for (const [key, value] of entries) {
     resolved[key] = resolveColor(value, mode);
   }
+  if (transparent) resolved.background = RGBA.defaultBackground();
   return resolved as unknown as ThemeColors;
 }
 
 interface ThemeProviderProps {
   initialTheme?: string;
   initialMode?: ColorMode;
+  initialTransparent?: boolean;
   children: ReactNode;
 }
 
 export function ThemeProvider({
   initialTheme,
   initialMode = "dark",
+  initialTransparent = false,
   children,
 }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<ThemeDefinition>(() =>
     getTheme(initialTheme ?? DEFAULT_THEME_NAME),
   );
   const [mode, setModeState] = useState<ColorMode>(initialMode);
+  const [transparent, setTransparent] = useState(initialTransparent);
 
-  const colors = useMemo(() => resolveThemeColors(theme, mode), [theme, mode]);
+  const colors = useMemo(
+    () => resolveThemeColors(theme, mode, transparent),
+    [theme, mode, transparent],
+  );
 
   const setTheme = useCallback((name: string) => {
     const newTheme = getTheme(name);
@@ -91,6 +103,8 @@ export function ThemeProvider({
     setModeState(m);
   }, []);
 
+  const toggleTransparent = useCallback(() => setTransparent((p) => !p), []);
+
   return (
     <ThemeContext.Provider
       value={{
@@ -101,6 +115,8 @@ export function ThemeProvider({
         setTheme,
         toggleMode,
         setMode,
+        transparent,
+        toggleTransparent,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- Apex painted an opaque page background over the whole terminal, so a partially transparent terminal (e.g. ghostty with `background-opacity`) looked broken — the transparency was covered up.
- The renderer now clears to the terminal's **default** background (`RGBA.defaultBackground()`, which emits the ANSI reset-bg). Opaque themes paint over it as before, so there's zero visual change by default; transparent mode leaves it showing through.
- Added a persisted `transparentBackground` config flag (defaults `false`). When on, `resolveThemeColors` swaps the page `background` for the terminal default — panels and text keep their own colors.
- Live toggle in `/themes` with **B**; state persists to config like theme/mode.

## Behavior
- Default off → identical to today for everyone.
- On + transparent terminal → terminal/wallpaper shows through.
- On + opaque terminal → inherits the terminal's solid background (still fully readable). Apex defers to the terminal; it can't make an opaque terminal transparent.

## Test plan
- [x] `tsc --noEmit` clean on touched files
- [x] Manual: ghostty with `background-opacity` < 1, toggle `B` in `/themes`, confirm transparency shows through
- [x] Manual: opaque terminal, confirm default (off) is unchanged and toggling on inherits terminal bg
- [x] Manual: confirm setting persists across restart

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only rendering and theme preference changes; default behavior stays unchanged when the flag is off.
> 
> **Overview**
> Adds optional **transparent background** support so terminals with partial opacity (e.g. Ghostty) are not covered by an opaque page fill.
> 
> The CLI renderer now clears with `RGBA.defaultBackground()` (ANSI reset background). **`transparentBackground`** in config (default **off**) drives `resolveThemeColors` to swap the page `background` token for the terminal default while panels and text keep theme colors. **`ThemeProvider`** exposes `transparent` / `toggleTransparent`; startup reads config and passes `initialTransparent`.
> 
> The **`/themes`** picker previews transparency with **B**, reverts on cancel, and persists the flag on confirm alongside theme selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e1f91914cb7d6e346ebc98f76d4c63b19f8140b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->