### PR TITLE
fix(offsec): don't require source for blackbox endpoint threat model

### DIFF
--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.test.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ToolContext } from "./types";
+import {
+  buildThreatModelPrompt,
+  generateThreatModelForEndpoint,
+  threatModelExcludeTools,
+  type GenerateThreatModelInput,
+} from "./threatModelGenerator";
+
+// Capture what the (real entry point) hands to the CodeAgent constructor, and
+// stub the LLM call — the one thing that genuinely needs cloud creds.
+const captured = vi.hoisted(() => ({ opts: [] as Array<Record<string, any>> }));
+
+vi.mock("../../specialized/codeAgent/agent", async (importActual) => {
+  const actual =
+    await importActual<typeof import("../../specialized/codeAgent/agent")>();
+  return {
+    ...actual,
+    CodeAgent: class {
+      constructor(opts: Record<string, any>) {
+        captured.opts.push(opts);
+      }
+      async consume() {
+        return {
+          businessLogic: "bl",
+          threatModel: "tm",
+          exposure: 3,
+          dataSensitivity: 2,
+          functionCriticality: 1,
+          securityIndicators: 0,
+          riskScoreJustification: "because",
+          pentestObjectives: [
+            {
+              title: "t",
+              hypothesis: "h",
+              prerequisites: "None.",
+              setup: "No setup.",
+              procedure: "do x",
+              successSignal: "200",
+              priority: "p1",
+            },
+          ],
+        };
+      }
+    },
+  };
+});
+
+const input: GenerateThreatModelInput = {
+  appName: "shop",
+  routePath: "/api/orders/:id",
+  method: "GET",
+  description: "Returns a single order by id.",
+};
+
+describe("threatModelExcludeTools", () => {
+  it("only excludes the document tools when source is available (whitebox)", () => {
+    const excluded = threatModelExcludeTools(true);
+    expect(excluded).toEqual(["document_endpoint", "document_app"]);
+    // Whitebox keeps source-reading tools.
+    expect(excluded).not.toContain("read_file");
+    expect(excluded).not.toContain("grep");
+  });
+
+  it("also excludes source-reading tools when source is unavailable (blackbox)", () => {
+    const excluded = threatModelExcludeTools(false);
+    expect(excluded).toContain("document_endpoint");
+    for (const t of ["read_file", "list_files", "grep", "execute_command"]) {
+      expect(excluded).toContain(t);
+    }
+    // Live HTTP + research stay available so it can work from description/HTTP.
+    for (const t of ["http_request", "web_search", "get_page"]) {
+      expect(excluded).not.toContain(t);
+    }
+  });
+});
+
+describe("buildThreatModelPrompt", () => {
+  it("tells the agent to read the source file in whitebox mode", () => {
+    const prompt = buildThreatModelPrompt(input, undefined, true);
+    expect(prompt).toContain("Read the source file");
+    expect(prompt).not.toContain("blackbox");
+  });
+
+  it("does not push source reading in blackbox mode", () => {
+    const prompt = buildThreatModelPrompt(input, undefined, false);
+    expect(prompt).not.toContain("Read the source file");
+    expect(prompt).toContain("blackbox");
+    expect(prompt).toContain("source-unavailable mode");
+    // Caps priority and forbids fabricated citations.
+    expect(prompt).toContain("p1");
+    expect(prompt).toContain("never fabricate");
+  });
+
+  it("defaults to whitebox behavior when the flag is omitted", () => {
+    expect(buildThreatModelPrompt(input)).toContain("Read the source file");
+  });
+});
+
+// End-to-end through the real entry point: only the LLM agent is stubbed.
+// Reproduces the blackbox scenario from issue #842 and asserts the spawned
+// agent is built source-free with the blackbox prompt — the structural reason
+// it can no longer flail on missing source / loop on `response`.
+describe("generateThreatModelForEndpoint (blackbox vs whitebox wiring)", () => {
+  function makeCtx(agentCwd: string): ToolContext {
+    return {
+      session: {
+        id: "ses_test",
+        rootPath: "/sessions/ses_test",
+        targets: ["https://example.com"],
+        config: {},
+      },
+      agentCwd,
+      model: "test-model",
+    } as unknown as ToolContext;
+  }
+
+  it("blackbox (agentCwd === session.rootPath): source-free agent + blackbox prompt", async () => {
+    captured.opts.length = 0;
+    const out = await generateThreatModelForEndpoint(
+      makeCtx("/sessions/ses_test"),
+      input,
+    );
+
+    expect(captured.opts).toHaveLength(1);
+    const opts = captured.opts[0];
+    expect(opts.excludeTools).toContain("read_file");
+    expect(opts.excludeTools).toContain("grep");
+    expect(opts.objective).toContain("blackbox");
+    expect(opts.objective).not.toContain("Read the source file");
+
+    // Real flattening/score wiring still produces a usable result.
+    expect(out?.riskScore.score).toBe(6);
+    expect(out?.pentestObjectives[0]).toContain("[P1] t");
+  });
+
+  it("whitebox (agentCwd !== session.rootPath): source-first agent + read-the-code prompt", async () => {
+    captured.opts.length = 0;
+    const out = await generateThreatModelForEndpoint(
+      makeCtx("/repo/checkout"),
+      input,
+    );
+
+    expect(captured.opts).toHaveLength(1);
+    const opts = captured.opts[0];
+    expect(opts.excludeTools).not.toContain("read_file");
+    expect(opts.excludeTools).toEqual(["document_endpoint", "document_app"]);
+    expect(opts.objective).toContain("Read the source file");
+    expect(out?.riskScore.score).toBe(6);
+  });
+
+  it("returns null (heuristic fallback) when no model is configured", async () => {
+    const ctx = makeCtx("/sessions/ses_test");
+    (ctx as { model?: unknown }).model = undefined;
+    expect(await generateThreatModelForEndpoint(ctx, input)).toBeNull();
+  });
+});

--- a/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
+++ b/src/core/agents/offSecAgent/tools/threatModelGenerator.ts
@@ -282,6 +282,41 @@ export interface ThreatModelOutput {
   pentestObjectives: string[];
 }
 
+// Source-reading / whitebox tools. Dropped from the per-endpoint threat-model
+// agent in blackbox runs (no checked-out source), so it can't burn turns
+// failing reads of files that don't exist — the failure mode that lets it loop
+// on its `response` tool under the Bedrock wedge (issue #842).
+const SOURCE_TOOLS = [
+  "read_file",
+  "list_files",
+  "grep",
+  "execute_command",
+  "profile_codebase",
+  "query_whitebox_catalog",
+  "run_code_query",
+  "run_whitebox_scan",
+  "create_whitebox_candidate",
+  "update_whitebox_candidate",
+  "list_whitebox_candidates",
+  "start_whitebox_job",
+  "poll_whitebox_job",
+  "stop_whitebox_job",
+  "read_whitebox_artifact",
+];
+
+/**
+ * Tools to exclude from the spawned threat-model CodeAgent.
+ *
+ * `document_endpoint` / `document_app` are always excluded (the agent analyzes,
+ * it doesn't re-document). When source is unavailable (blackbox), the
+ * source-reading tools are dropped too so the agent works from the endpoint
+ * description + live HTTP instead of flailing on a non-existent codebase.
+ */
+export function threatModelExcludeTools(sourceAvailable: boolean): string[] {
+  const base = ["document_endpoint", "document_app"];
+  return sourceAvailable ? base : [...base, ...SOURCE_TOOLS];
+}
+
 /**
  * Spawn a dedicated CodeAgent to produce a business-logic model, threat model,
  * quantitative risk score, and adversarial test plan for a single endpoint.
@@ -298,6 +333,12 @@ export async function generateThreatModelForEndpoint(
 ): Promise<ThreatModelOutput | null> {
   if (!ctx.model) return null;
   const model = ctx.model;
+
+  // Blackbox / sandbox runs have no checked-out source: the agent's working
+  // dir falls back to the session root (mirrors the `sandboxMode` check in
+  // offensiveSecurityAgent.ts / prompt.ts). In that case the threat-model agent
+  // must not be a source-first CodeAgent.
+  const sourceAvailable = ctx.agentCwd !== ctx.session.rootPath;
 
   return threatModelLimiter(async () => {
     if (ctx.abortSignal?.aborted) return null;
@@ -316,7 +357,11 @@ export async function generateThreatModelForEndpoint(
     const localBus = new AgentEventBus();
     AgentEventBus.attachChild(localBus, ctx.eventBus, subagentId);
 
-    const prompt = buildThreatModelPrompt(input, ctx.projectThreatModel);
+    const prompt = buildThreatModelPrompt(
+      input,
+      ctx.projectThreatModel,
+      sourceAvailable,
+    );
 
     const agent = new CodeAgent<ThreatModelResult>({
       codebasePath: ctx.agentCwd,
@@ -329,7 +374,7 @@ export async function generateThreatModelForEndpoint(
       eventBus: localBus,
       subagentId,
       responseSchema: ThreatModelResultSchema,
-      excludeTools: ["document_endpoint", "document_app"],
+      excludeTools: threatModelExcludeTools(sourceAvailable),
     });
 
     try {
@@ -383,9 +428,10 @@ export async function generateThreatModelForEndpoint(
 // Prompt construction
 // ---------------------------------------------------------------------------
 
-function buildThreatModelPrompt(
+export function buildThreatModelPrompt(
   input: GenerateThreatModelInput,
   projectThreatModel?: string,
+  sourceAvailable: boolean = true,
 ): string {
   const lineRange = input.line ? `around line ${input.line}` : "";
   const authInfo = input.authRequired
@@ -394,6 +440,25 @@ function buildThreatModelPrompt(
   const methodStr = Array.isArray(input.method)
     ? input.method.join(", ")
     : (input.method ?? "unknown");
+
+  const readingSection = sourceAvailable
+    ? `## Reading the code
+
+1. Read the source file at \`${input.file ?? "(unknown)"}\` ${lineRange ? `(${lineRange})` : ""} to understand the implementation.
+2. Trace into anything the handler depends on that affects security: auth middleware, repositories, validators, ORM models, external SDK calls, shared helpers. Do not stop at the handler function body.
+3. If a dependency is out of scope or you chose not to trace it, record that under \`analysisGaps\` in Part 1 — do not silently assume.
+4. **Source-unavailable mode.** If the handler source isn't reachable in your environment at all — not just out of scope, but actually unavailable (not checked out, missing from the sandbox, only the route table or OpenAPI spec is present) — record this once in \`analysisGaps\` and continue. In this mode the \`Cite file:line\` requirements below loosen to "cite the grounding source you actually read" (the endpoint description, route table entry, OpenAPI spec, README, or other upstream artifact). Each emitted threat-model vector and pentest objective must be tagged \`[unverified: source unavailable]\` in its title, and pentest objectives derived only from a description are capped at priority \`p1\` (never \`p0\`) because the vector hasn't been confirmed reachable in this implementation. Never fabricate file:line citations or invent code paths.`
+    : `## No source code — blackbox / source-unavailable mode
+
+This is a **blackbox** engagement: the application's source code is **not** checked out and there is no codebase to read. Do not attempt to read source files (you have no filesystem tools for it), and never fabricate \`file:line\` citations or invent code paths. Record once in \`analysisGaps\` that this is blackbox source-unavailable analysis.
+
+Work entirely from what you can actually observe:
+- the endpoint metadata above (method, path, auth, description),
+- any route table / OpenAPI / README detail referenced in the description,
+- live HTTP behavior via the \`http_request\` tool against the running target, and
+- public framework/library documentation via \`web_search\` / \`get_page\` when researching a known behavior.
+
+Operate in **source-unavailable mode** for every field below: instead of \`file:line\`, cite the grounding source you actually read (the endpoint description, route data, or a concrete live HTTP response). Tag each threat-model vector and pentest objective \`[unverified: source unavailable]\` in its title. Set **Security Indicators** to \`0\` unless a live response reveals a concrete issue — do not infer code-level patterns you cannot see. Cap every pentest objective at priority \`p1\` (never \`p0\`), since no vector can be confirmed reachable in the implementation.`;
 
   let prompt = `# Endpoint Analysis
 
@@ -406,12 +471,7 @@ function buildThreatModelPrompt(
 - **Auth**: ${authInfo}
 - **Description**: ${input.description}
 
-## Reading the code
-
-1. Read the source file at \`${input.file ?? "(unknown)"}\` ${lineRange ? `(${lineRange})` : ""} to understand the implementation.
-2. Trace into anything the handler depends on that affects security: auth middleware, repositories, validators, ORM models, external SDK calls, shared helpers. Do not stop at the handler function body.
-3. If a dependency is out of scope or you chose not to trace it, record that under \`analysisGaps\` in Part 1 — do not silently assume.
-4. **Source-unavailable mode.** If the handler source isn't reachable in your environment at all — not just out of scope, but actually unavailable (not checked out, missing from the sandbox, only the route table or OpenAPI spec is present) — record this once in \`analysisGaps\` and continue. In this mode the \`Cite file:line\` requirements below loosen to "cite the grounding source you actually read" (the endpoint description, route table entry, OpenAPI spec, README, or other upstream artifact). Each emitted threat-model vector and pentest objective must be tagged \`[unverified: source unavailable]\` in its title, and pentest objectives derived only from a description are capped at priority \`p1\` (never \`p0\`) because the vector hasn't been confirmed reachable in this implementation. Never fabricate file:line citations or invent code paths.
+${readingSection}
 
 Work Parts 1 → 4 in order. Do not start Part 2 until Part 1 is complete. Do not write Part 4 until Part 2 is complete.
 

--- a/src/core/agents/specialized/codeAgent/agent.test.ts
+++ b/src/core/agents/specialized/codeAgent/agent.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { threatModelExcludeTools } from "../../offSecAgent/tools/threatModelGenerator";
+import { CODE_AGENT_DEFAULT_TOOLS, resolveCodeAgentTools } from "./agent";
+
+// Proves the full chain a blackbox threat-model agent is built through:
+//   sourceAvailable=false → threatModelExcludeTools → resolveCodeAgentTools →
+//   the agent's actual active tool set. Issue #842: that set must contain no
+//   source-reading tools, so the agent physically cannot try to read missing
+//   source and loop on its `response` tool.
+describe("resolveCodeAgentTools", () => {
+  it("appends `response` only when a schema is present", () => {
+    expect(resolveCodeAgentTools([], false)).not.toContain("response");
+    expect(resolveCodeAgentTools([], true)).toContain("response");
+  });
+
+  it("a blackbox threat-model agent gets NO source-reading tools", () => {
+    const tools = resolveCodeAgentTools(threatModelExcludeTools(false), true);
+    for (const t of ["read_file", "list_files", "grep", "execute_command"]) {
+      expect(tools).not.toContain(t);
+    }
+    // It can still observe the live target and capture structured output.
+    expect(tools).toContain("http_request");
+    expect(tools).toContain("response");
+  });
+
+  it("a whitebox threat-model agent keeps source-reading tools", () => {
+    const tools = resolveCodeAgentTools(threatModelExcludeTools(true), true);
+    expect(tools).toContain("read_file");
+    expect(tools).toContain("grep");
+    // document tools are always excluded (the agent analyzes, doesn't document).
+    expect(tools).not.toContain("document_endpoint");
+  });
+
+  it("only ever excludes tools that exist in the default set", () => {
+    for (const t of threatModelExcludeTools(false)) {
+      if (t === "document_endpoint" || t === "document_app") continue;
+      expect(CODE_AGENT_DEFAULT_TOOLS).toContain(t);
+    }
+  });
+});

--- a/src/core/agents/specialized/codeAgent/agent.ts
+++ b/src/core/agents/specialized/codeAgent/agent.ts
@@ -61,6 +61,47 @@ export interface CodeAgentInput<TResult = void> extends SpecializedAgentInput {
  * });
  * ```
  */
+/** The full default CodeAgent toolset, before any exclusions. */
+export const CODE_AGENT_DEFAULT_TOOLS: readonly string[] = [
+  "read_file",
+  "list_files",
+  "grep",
+  "execute_command",
+  "profile_codebase",
+  "query_whitebox_catalog",
+  "run_code_query",
+  "run_whitebox_scan",
+  "create_whitebox_candidate",
+  "update_whitebox_candidate",
+  "list_whitebox_candidates",
+  "start_whitebox_job",
+  "poll_whitebox_job",
+  "stop_whitebox_job",
+  "read_whitebox_artifact",
+  "http_request",
+  "document_app",
+  "document_endpoint",
+  // Web search tools — research vulnerable library versions, look up API docs
+  "web_search",
+  "get_page",
+];
+
+/**
+ * Resolve the active tool list for a CodeAgent: the default toolset minus any
+ * excluded tools, plus `response` when a structured-output schema is supplied.
+ * Pure so callers (and tests) can see exactly which tools an agent will get —
+ * e.g. that a blackbox threat-model agent ends up with no source-reading tools.
+ */
+export function resolveCodeAgentTools(
+  excludeTools?: string[],
+  hasResponseSchema = false,
+): string[] {
+  const excluded = new Set(excludeTools ?? []);
+  const tools = CODE_AGENT_DEFAULT_TOOLS.filter((t) => !excluded.has(t));
+  if (hasResponseSchema) tools.push("response");
+  return tools;
+}
+
 export class CodeAgent<TResult = void> extends OffensiveSecurityAgent<TResult> {
   constructor(opts: CodeAgentInput<TResult>) {
     const {
@@ -84,38 +125,7 @@ export class CodeAgent<TResult = void> extends OffensiveSecurityAgent<TResult> {
       projectThreatModel,
     } = opts;
 
-    let activeTools: string[] = [
-      "read_file",
-      "list_files",
-      "grep",
-      "execute_command",
-      "profile_codebase",
-      "query_whitebox_catalog",
-      "run_code_query",
-      "run_whitebox_scan",
-      "create_whitebox_candidate",
-      "update_whitebox_candidate",
-      "list_whitebox_candidates",
-      "start_whitebox_job",
-      "poll_whitebox_job",
-      "stop_whitebox_job",
-      "read_whitebox_artifact",
-      "http_request",
-      "document_app",
-      "document_endpoint",
-      // Web search tools — research vulnerable library versions, look up API docs
-      "web_search",
-      "get_page",
-    ];
-
-    if (excludeTools?.length) {
-      const excluded = new Set(excludeTools);
-      activeTools = activeTools.filter((t) => !excluded.has(t));
-    }
-
-    if (responseSchema) {
-      activeTools.push("response");
-    }
+    const activeTools = resolveCodeAgentTools(excludeTools, !!responseSchema);
 
     super({
       system: system ?? CODE_AGENT_SYSTEM_PROMPT,


### PR DESCRIPTION
## What

The `document_endpoint` tool spawns a per-endpoint threat-model subagent (`generateThreatModelForEndpoint` → `CodeAgent`) that is built source-first — it gets `read_file`/`grep` and a "read the source file" prompt. In a **blackbox** pentest there's no checked-out source, so it flailed on failed reads and looped on its `response` tool under the Bedrock wedge.

## Change

When source is unavailable (`agentCwd === session.rootPath`, the existing `sandboxMode` signal):
- Drop the source-reading tools so the agent physically can't attempt missing-file reads — removing the loop trigger.
- Swap in a blackbox prompt that works from the endpoint description + live HTTP, caps objectives at `p1`, and forbids fabricated `file:line`.

Whitebox behavior is unchanged. `document_endpoint` already falls back to the heuristic risk score when the subagent returns null, so nothing downstream breaks.

Also extracted `resolveCodeAgentTools()` from the `CodeAgent` constructor so the resolved tool set is testable.

## Verification

- Unit tests for tool exclusion + prompt branching.
- Chain test: `threatModelExcludeTools(false)` → `resolveCodeAgentTools` yields **zero** source tools (keeps `http_request`/`response`).
- Integration test through the real `generateThreatModelForEndpoint` (only the LLM stubbed) for blackbox + whitebox + no-model fallback.
- Full agent suite: 273 passed; `tsc` clean.
- Not covered: a live blackbox run on Bedrock (needs cloud creds + target).

Fixes #842