### PR TITLE
fix(tui): stop prompt caret jumping to front while typing

### DIFF
--- a/src/tui/components/chat/input-area.tsx
+++ b/src/tui/components/chat/input-area.tsx
@@ -225,7 +225,11 @@ function NormalInputAreaInner({
     const echoIdx = emittedRef.current.indexOf(value);
     if (echoIdx !== -1) {
       emittedRef.current.splice(0, echoIdx + 1);
-      return;
+      if (value !== "" || emittedRef.current.length > 0) {
+        return;
+      }
+    } else {
+      emittedRef.current.length = 0;
     }
     if (value !== inputValue) {
       isExternalUpdate.current = true;

--- a/src/tui/components/chat/input-area.tsx
+++ b/src/tui/components/chat/input-area.tsx
@@ -212,16 +212,22 @@ function NormalInputAreaInner({
   const promptRef = useRef<PromptInputRef>(null);
   const isExternalUpdate = useRef(false);
   const prevValueRef = useRef(value);
+  const emittedRef = useRef<string[]>([]);
 
-  // Sync external value prop to context when the parent explicitly changes it.
-  // Only sync when the value prop itself changed between renders (not just a
-  // re-render with stale value), to avoid resetting user input during typing.
+  // Sync external value prop down — but ignore our own keystrokes echoing back.
+  // During fast typing the parent's value lags behind; without this guard a
+  // stale echo calls setValue() and resets the caret to the front.
   useEffect(() => {
     const prevValue = prevValueRef.current;
     prevValueRef.current = value;
+    if (value === prevValue) return;
 
-    // Only sync if the parent's value prop actually changed from the previous render
-    if (value !== prevValue && value !== inputValue) {
+    const echoIdx = emittedRef.current.indexOf(value);
+    if (echoIdx !== -1) {
+      emittedRef.current.splice(0, echoIdx + 1);
+      return;
+    }
+    if (value !== inputValue) {
       isExternalUpdate.current = true;
       setInputValue(value);
       promptRef.current?.setValue(value);
@@ -235,6 +241,7 @@ function NormalInputAreaInner({
       return;
     }
     if (inputValue !== value) {
+      emittedRef.current.push(inputValue);
       onChange(inputValue);
     }
   }, [inputValue, value, onChange]);

--- a/src/tui/components/shared/prompt-input.tsx
+++ b/src/tui/components/shared/prompt-input.tsx
@@ -334,7 +334,9 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       },
       setValue: (value: string) => {
         setInputValue(value);
-        textareaRef.current?.setText(value);
+        const ta = textareaRef.current;
+        ta?.setText(value);
+        if (ta) ta.cursorOffset = value.length;
         clearPaste();
       },
       getValue: () => inputValue,


### PR DESCRIPTION
## What
Typing in the prompt would intermittently snap the caret back to the start of the input (and silently drop the latest keystroke). It's a race in the input state bridge, not random.

The prompt mirrors its value across three layers: the `@opentui` `<textarea>` (source of truth), the inner `InputProvider` context, and the parent `operator-dashboard`'s own `inputValue`. `NormalInputAreaInner` echoes every keystroke up via `onChange` and syncs the parent's `value` back down via `promptRef.setValue()`.

During fast typing the parent's `value` prop lags a keystroke or two behind the context. The down-sync guard then passes with a *stale* echo and calls `setValue()`, which ran `textarea.setText()` **without restoring the cursor** — `@opentui`'s `setText()` resets the caret to offset 0. `setValue` was the only `setText` caller in the file that forgot to restore the caret (history nav, obfuscation, and inline completion all do).

## Change
- `prompt-input.tsx` `setValue`: restore `cursorOffset = value.length` after `setText`, matching the convention used by every other `setText` caller.
- `input-area.tsx`: track values emitted to the parent in a FIFO ref and consume our own round-tripped echoes in the down-sync, so a lagged echo never clobbers live input. Genuinely external sets (clear-on-submit, queue-edit) still apply.

## Verification
- `tsc` clean on both files.
- Type rapidly in the operator prompt — caret stays at the end, no jump, no dropped characters.
- Submit clears the input; queue-edit (`e`) and history (Up/Down) load text with the caret at the end.

No automated test: this is a TUI timing race that can't be reproduced deterministically without a harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI input bridging and caret handling with no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a race where fast typing in the operator prompt could snap the caret to the start and drop characters when the dashboard’s `value` echoed back one or two keystrokes behind live input.
> 
> **`input-area.tsx`** records each `onChange` payload in a FIFO `emittedRef` and treats matching parent `value` updates as echoes (skipping `setValue`), while still applying real external updates such as submit clear and queue edit. Parent-driven **empty** clears are not blocked by the echo guard, and non-matching parent values reset the FIFO so stale entries cannot block a genuine clear.
> 
> **`prompt-input.tsx`** sets `cursorOffset` to the end of the string after `setText` in `setValue`, aligning with other programmatic `setText` paths so a down-sync no longer leaves the caret at offset 0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aac8c023408fed41df17305929a961697a9c1032. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->