### PR TITLE
fix(tui): harden echo guard against parent clears and queue-edit

### DIFF
--- a/src/tui/components/chat/input-area.tsx
+++ b/src/tui/components/chat/input-area.tsx
@@ -222,11 +222,29 @@ function NormalInputAreaInner({
     prevValueRef.current = value;
     if (value === prevValue) return;
 
+    // Parent-driven clears (submit, Ctrl+C, queue-block) always apply.
+    // An empty-string echo is harmless (no caret to jump in an empty
+    // input), so we never skip it. Flush the FIFO so stale emissions
+    // can't shadow the next external set (e.g. queue-edit after submit).
+    if (value === "") {
+      emittedRef.current = [];
+      if (value !== inputValue) {
+        isExternalUpdate.current = true;
+        setInputValue(value);
+        promptRef.current?.setValue(value);
+      }
+      return;
+    }
+
     const echoIdx = emittedRef.current.indexOf(value);
     if (echoIdx !== -1) {
       emittedRef.current.splice(0, echoIdx + 1);
       return;
     }
+
+    // Genuine external update (queue-edit, history load, etc.) — flush
+    // stale echoes so they can't shadow future external sets.
+    emittedRef.current = [];
     if (value !== inputValue) {
       isExternalUpdate.current = true;
       setInputValue(value);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes two bugs in the `NormalInputAreaInner` echo guard identified by Bugbot on #846:

**1. Echo guard blocks parent clears (High)**
After the user ever emitted an empty string (e.g. backspacing to empty), `""` lingered in `emittedRef`. Parent-driven clears (`value=""` on submit, Ctrl+C, queue-block) matched the stale `""` and were skipped as echoes, leaving the textarea populated when the parent had already cleared.

**Fix:** Always apply empty-string values from the parent — clears are always intentional, and echoing an empty input is harmless (no caret to jump in an empty textarea). Flush the entire FIFO on empty so stale emissions can't shadow the next external set.

**2. Echo guard skips queue edit (Medium)**
Queue-edit sets the parent `value` to queued message text that the user had previously typed. If those emissions were still in `emittedRef`, the guard consumed them as echoes and skipped `setValue`, so the prompt kept a stale `inputValue`.

**Fix:** Flush the FIFO when a genuine external update is detected (value not found in the FIFO). This prevents old emissions from shadowing future external sets like queue-edit. Combined with fix 1, the common flow (type → submit → queue-edit) always works because submit's clear flushes the FIFO before queue-edit arrives.

### How did you verify your code works?

- `tsc` clean
- `bun run lint` clean
- `bun run test` — all 1122 tests pass, 15 skipped (integration tests requiring live services)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04beb7c3-c0a6-4127-b590-0f09a724423d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04beb7c3-c0a6-4127-b590-0f09a724423d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

