### PR TITLE
operator: teach the agent about its own pensar CLI

### DIFF
--- a/src/core/agents/offSecAgent/prompt.ts
+++ b/src/core/agents/offSecAgent/prompt.ts
@@ -219,6 +219,17 @@ You can perform the full lifecycle of a penetration test and support a wide rang
 - **spawn_pentest_swarm** — Fan out targeted pentest agents in parallel across multiple endpoints/objectives.
 - **spawn_coding_agent** — Spawn parallel code analysis agents for source-code tasks.
 
+## Pensar CLI (workspace & attack surface)
+
+You run inside Pensar Apex, and the \`pensar\` CLI is available on this machine. Invoke it through \`execute_command\` to perform Console/workspace operations your other tools don't cover — most importantly managing the **attack surface** and triaging results. These commands act on the workspace the user connected with \`pensar login\` and print JSON to stdout, so you can parse and chain them.
+
+- **Attack surface (apps & endpoints)** — \`pensar apps\` (list), \`apps get <appId>\`, \`apps create\`, \`apps update <appId>\`, \`apps delete <appId>\`; endpoints via \`apps endpoints <appId>\`, \`apps endpoint <endpointId>\`, \`apps endpoint-create <appId>\`, \`apps endpoint-update <endpointId>\`, \`apps endpoint-delete <endpointId>\`; and \`apps search <query>\` / \`apps search-endpoints <query>\`.
+- **Issues & fixes** — \`pensar issues [--status --severity --scan --branch]\`, \`issues get <id>\`, \`issues update <id>\`; \`pensar fixes <issueId>\`, \`fixes get <fixId>\`.
+- **Scans** — \`pensar pentests\`, \`pentests get <id>\`, \`pentests dispatch [--branch --level]\`.
+- **Agent logs** — \`pensar logs <issueId>\`, \`logs search <issueId> <query>\`.
+
+Run \`pensar --help\` or \`pensar <command> --help\` for exact flags — the CLI is the source of truth. These commands require the user to be logged in; if one reports it is not authenticated, tell the user to run \`pensar login\` rather than attempting the device flow yourself. Confirm with the user before any mutating command (\`create\`/\`update\`/\`delete\`, \`endpoint-*\`, \`pentests dispatch\`, \`issues update\`). Do NOT launch nested engagements from here (\`pensar pentest\`, \`pensar targeted-pentest\`, \`pensar operator\`, or \`pensar -p\`) — use your own tools for testing.
+
 # How to Work
 
 1. **Execute what the user asks.** If they say "scan this target", scan it. If they say "test this endpoint for SQLi", test it. Carry out the requested task using your tools and present the results.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In operator mode, the offensive-security agent had no awareness that it can drive the **`pensar` CLI itself** (via `execute_command`) to perform Console/workspace operations. So when a user wants the operator to work in their workspace — manage the **attack surface** (apps & endpoints), triage issues, view fixes, list/dispatch scans, or read agent logs — the agent didn't know those commands exist.

## Approach

Add a compact **"Pensar CLI (workspace & attack surface)"** subsection to the base operator system prompt (`buildBaseSystemPrompt` in `src/core/agents/offSecAgent/prompt.ts`).

Why the base prompt rather than a built-in skill / the skills catalog:
- `buildBaseSystemPrompt` feeds **both** operator paths — the interactive TUI operator (`buildOperatorSystemPrompt`) and the headless `pensar -p` operator (`OffensiveSecurityAgent`).
- The headless path does **not** wire up the `SkillsRegistry` or inject the `<available_skills>` catalog, so a skill-based approach wouldn't surface there. `read_skill` also returns "Skills not available" in that path.
- Knowing about its own CLI is core self-knowledge, so it belongs in the base persona.

The section is intentionally compact to avoid per-turn context bloat:
- Lists the workspace command groups (apps/endpoints, issues/fixes, scans, logs).
- Points at `pensar <command> --help` as the **source of truth** instead of duplicating full flag docs.
- Notes workspace commands require `pensar login` (and to tell the user to log in rather than attempting the device flow itself).
- Requires user confirmation before mutating commands (`create`/`update`/`delete`, `endpoint-*`, `pentests dispatch`, `issues update`).
- Forbids launching nested engagements (`pensar pentest` / `targeted-pentest` / `operator` / `-p`) so the agent uses its own tools for testing instead of recursing.

This complements the [`pensar-security` skill update in `pensarai/skills`](https://github.com/pensarai/skills/pull/3), which documents the same CLI surface for external agents.

## Verification

- `bun run test src/tests/agentWorkingDirectory.test.ts` — base-prompt tests pass
- `bun run test src/core/agents/offSecAgent/ src/tui/components/operator-dashboard/logic.test.ts` — 306 passed / 6 skipped
- `bun run tsc` — clean
- `bun run lint` — passes (only pre-existing repo-wide warnings)
- `biome format` — clean on the changed file

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cb7b931-d93a-4aee-921b-aa10a19a6afb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cb7b931-d93a-4aee-921b-aa10a19a6afb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

