### PR TITLE
feat(login): move multi-workspace selection to the browser

### DIFF
--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -16,14 +16,15 @@
 
 import * as readline from "node:readline";
 import { getPensarApiUrl, getPensarConsoleUrl } from "../core/api";
-import type { WorkspaceInfo } from "../core/auth";
 import {
+  createWorkspaceSelection,
   disconnect,
   fetchWorkspaces,
   isConnected,
   pollForWorkspaceCreation,
   pollLegacyToken,
   pollWorkOSToken,
+  pollWorkspaceSelection,
   selectWorkspace,
   startDeviceFlow,
 } from "../core/auth";
@@ -65,30 +66,26 @@ function prompt(question: string): Promise<string> {
   });
 }
 
-async function promptWorkspaceSelection(
-  workspaces: WorkspaceInfo[],
-): Promise<WorkspaceInfo> {
-  console.log("\nSelect a workspace:\n");
-  workspaces.forEach((ws, i) => {
-    console.log(
-      `  ${i + 1}. ${ws.name} (${ws.slug}) — $${ws.balance.toFixed(2)}`,
-    );
-  });
+/**
+ * Resolve a workspace when the user has more than one, by handing selection off
+ * to the browser. The CLI opens a Console page, the user picks there, and we
+ * poll until the choice comes back — so login never blocks on a terminal prompt.
+ *
+ * Returns the chosen workspace id.
+ */
+async function selectWorkspaceInBrowser(
+  apiUrl: string,
+  accessToken: string,
+): Promise<string> {
+  const selection = await createWorkspaceSelection(apiUrl, accessToken);
 
-  const answer = await prompt(`\nEnter number (1-${workspaces.length}): `);
-  const index = parseInt(answer, 10) - 1;
+  openUrl(selection.selectionUrl);
 
-  if (Number.isNaN(index) || index < 0 || index >= workspaces.length) {
-    console.error("Invalid selection.");
-    process.exit(1);
-  }
+  console.log(
+    `\nYou have multiple workspaces. Choose one in your browser to continue.\nIf the browser didn't open, visit:\n  ${selection.selectionUrl}\n\nWaiting for workspace selection...`,
+  );
 
-  const workspace = workspaces[index];
-  if (!workspace) {
-    console.error("Invalid selection.");
-    process.exit(1);
-  }
-  return workspace;
+  return pollWorkspaceSelection(apiUrl, accessToken, selection.selectionId);
 }
 
 // ---------------------------------------------------------------------------
@@ -204,18 +201,19 @@ async function handleWorkspaces(
     workspaces = await pollForWorkspaceCreation(apiUrl, accessToken);
   }
 
-  let workspace: WorkspaceInfo;
+  let workspaceId: string;
   if (workspaces.length === 1) {
     const onlyWorkspace = workspaces[0];
     if (!onlyWorkspace) {
       throw new Error("No workspace available after workspace lookup");
     }
-    workspace = onlyWorkspace;
+    workspaceId = onlyWorkspace.id;
   } else {
-    workspace = await promptWorkspaceSelection(workspaces);
+    workspaceId = await selectWorkspaceInBrowser(apiUrl, accessToken);
   }
 
-  const result = await selectWorkspace(apiUrl, accessToken, workspace.id);
+  const result = await selectWorkspace(apiUrl, accessToken, workspaceId);
+  const workspace = result.workspace;
 
   await config.update({
     workspaceId: workspace.id,

--- a/src/core/auth/index.ts
+++ b/src/core/auth/index.ts
@@ -9,6 +9,7 @@ export { validateGateway } from "./gateway";
 export { signGatewayRequest } from "./signing";
 export { ensureValidToken, isTokenExpired } from "./token";
 export type {
+  CreateWorkspaceSelectionResponse,
   DeviceFlowInfo,
   FetchWorkspacesResponse,
   LegacyDeviceCodeResponse,
@@ -17,9 +18,12 @@ export type {
   ValidToken,
   WorkOSDeviceResponse,
   WorkspaceInfo,
+  WorkspaceSelectionStatusResponse,
 } from "./types";
 export {
+  createWorkspaceSelection,
   fetchWorkspaces,
   pollForWorkspaceCreation,
+  pollWorkspaceSelection,
   selectWorkspace,
 } from "./workspaces";

--- a/src/core/auth/types.ts
+++ b/src/core/auth/types.ts
@@ -57,6 +57,20 @@ export interface FetchWorkspacesResponse {
   consoleUrl?: string;
 }
 
+// Browser-based workspace selection rendezvous (WorkOS flow). The CLI creates a
+// pending selection, opens `selectionUrl` in the browser, and polls until the
+// user picks a workspace there — so login never prompts in the terminal.
+export interface CreateWorkspaceSelectionResponse {
+  selectionId: string;
+  selectionUrl: string;
+  expiresIn: number;
+}
+
+export interface WorkspaceSelectionStatusResponse {
+  status: "pending" | "complete" | "expired";
+  workspaceId?: string;
+}
+
 export interface SelectWorkspaceResponse {
   confirmed: boolean;
   workspace: { id: string; name: string; slug: string };

--- a/src/core/auth/workspaces.ts
+++ b/src/core/auth/workspaces.ts
@@ -1,7 +1,9 @@
 import type {
+  CreateWorkspaceSelectionResponse,
   FetchWorkspacesResponse,
   SelectWorkspaceResponse,
   WorkspaceInfo,
+  WorkspaceSelectionStatusResponse,
 } from "./types";
 
 function sleep(ms: number): Promise<void> {
@@ -103,4 +105,88 @@ export async function selectWorkspace(
   }
 
   return (await response.json()) as SelectWorkspaceResponse;
+}
+
+/**
+ * Open a browser-based workspace selection rendezvous on the Console.
+ *
+ * Returns the selection id and the URL the user should open to pick a
+ * workspace in the browser, keeping `pensar login` non-interactive.
+ */
+export async function createWorkspaceSelection(
+  apiUrl: string,
+  accessToken: string,
+): Promise<CreateWorkspaceSelectionResponse> {
+  const response = await fetch(`${apiUrl}/api/cli/workspace-selection`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to start workspace selection");
+  }
+
+  return (await response.json()) as CreateWorkspaceSelectionResponse;
+}
+
+/**
+ * Poll the Console until the user selects a workspace in the browser.
+ *
+ * Resolves with the chosen workspace id. Rejects on expiry, timeout, or
+ * cancellation via the optional `AbortSignal`.
+ */
+export async function pollWorkspaceSelection(
+  apiUrl: string,
+  accessToken: string,
+  selectionId: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const POLL_INTERVAL = 3000;
+  const TIMEOUT = 10 * 60 * 1000;
+  const deadline = Date.now() + TIMEOUT;
+
+  while (Date.now() < deadline) {
+    if (signal?.aborted) throw new Error("Cancelled");
+
+    await sleep(POLL_INTERVAL);
+
+    if (signal?.aborted) throw new Error("Cancelled");
+
+    try {
+      const response = await fetch(
+        `${apiUrl}/api/cli/workspace-selection?id=${encodeURIComponent(selectionId)}`,
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        },
+      );
+
+      if (!response.ok) continue;
+
+      const data = (await response.json()) as WorkspaceSelectionStatusResponse;
+
+      if (data.status === "complete" && data.workspaceId) {
+        return data.workspaceId;
+      }
+
+      if (data.status === "expired") {
+        throw new Error(
+          "Workspace selection expired. Please run `pensar login` again.",
+        );
+      }
+    } catch (err) {
+      if (signal?.aborted) throw new Error("Cancelled");
+      if (err instanceof Error && err.message.includes("Please try again")) {
+        throw err;
+      }
+      if (err instanceof Error && err.message.includes("expired")) {
+        throw err;
+      }
+      // Network glitch — retry
+    }
+  }
+
+  throw new Error("Workspace selection timed out. Please try again.");
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Makes `pensar login` non-interactive for the multi-workspace case by moving workspace selection from a terminal prompt to the browser. This is the CLI-side half of the change; the Console-side endpoints/page live in [pensarai/console](https://github.com/pensarai/console).

**Problem:** In the WorkOS device flow, after browser auth the CLI fetches the user's workspaces and, when there's more than one, prompts on stdin (`promptWorkspaceSelection`). That stdin prompt blocks agent-driven logins — an agent running `pensar login` has no way to answer it.

**Change:** When the user has multiple workspaces, the CLI now:
1. Calls `POST /api/cli/workspace-selection` to open a browser rendezvous.
2. Opens the returned Console URL and prints it as a fallback.
3. Polls `GET /api/cli/workspace-selection` until the user picks a workspace in the browser, then continues through the existing `selectWorkspace` path (signing key + billing checks) unchanged.

The terminal prompt (`promptWorkspaceSelection`) is removed. Single-workspace (auto-select) and zero-workspace (browser create-workspace + poll) flows are unchanged, as is the legacy API-key device flow.

**Files:**
- `src/core/auth/workspaces.ts` — new `createWorkspaceSelection` + `pollWorkspaceSelection`.
- `src/core/auth/types.ts`, `src/core/auth/index.ts` — types + barrel exports.
- `src/cli/auth.ts` — `selectWorkspaceInBrowser` helper; `handleWorkspaces` uses it and now derives the final workspace from the `selectWorkspace` response.

This requires the companion Console PR to be deployed (the new endpoints). Until then, users on an older backend hit the legacy device flow path, which is unaffected.

### How did you verify your code works?

- `bun run tsc` — passes.
- `bun run lint` (Biome) — passes for changed files; repo-wide warnings/infos are pre-existing.
- `bun run test` — full suite passes (1122 passed, 15 skipped).
- End-to-end against a live stage requires the companion Console PR deployed; recommend a manual run with a 2+ workspace account to confirm the browser hand-off and that the terminal never prompts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ee1a2e0-f54d-4cf5-8303-5e6c34a882a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ee1a2e0-f54d-4cf5-8303-5e6c34a882a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

