### PR TITLE
Operator CLI verbosity (--show-output) and clearer command approvals

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,18 +90,91 @@ function getAllArgs(flag: string, argv = args): string[] {
   return values;
 }
 
-function attachCliAgentStreamListeners(bus: AgentEventBus): void {
+/**
+ * Render a tool call's arguments for verbose output. For shell commands the
+ * full command is shown (un-truncated) so an operator running with approvals
+ * off can still see — and a report can still capture — exactly what ran.
+ * Other tools get a compact single-line JSON of their meaningful args.
+ */
+function formatToolCallArgs(toolName: string, args: unknown): string {
+  if (args && typeof args === "object") {
+    const record = args as Record<string, unknown>;
+    if (toolName === "execute_command" && typeof record.command === "string") {
+      return record.command
+        .split("\n")
+        .map((line) => `    ${line}`)
+        .join("\n");
+    }
+    const meaningful = Object.fromEntries(
+      Object.entries(record).filter(
+        ([k]) => k !== "toolCallId" && k !== "toolCallDescription",
+      ),
+    );
+    if (Object.keys(meaningful).length === 0) return "";
+    return `    ${JSON.stringify(meaningful)}`;
+  }
+  return args !== undefined ? `    ${JSON.stringify(args)}` : "";
+}
+
+/** Render a tool result for verbose output, indenting and capping size. */
+function formatToolResult(result: unknown): string {
+  const MAX = 20_000;
+  const indent = (text: string) =>
+    text
+      .split("\n")
+      .map((line) => `    ${line}`)
+      .join("\n");
+
+  if (result && typeof result === "object") {
+    const r = result as Record<string, unknown>;
+    const parts: string[] = [];
+    if (typeof r.stdout === "string" && r.stdout.length > 0) {
+      parts.push(indent(r.stdout));
+    }
+    if (typeof r.stderr === "string" && r.stderr.length > 0) {
+      parts.push(indent(`[stderr] ${r.stderr}`));
+    }
+    if (typeof r.outputFile === "string" && r.outputFile.length > 0) {
+      parts.push(`    (full output saved to ${r.outputFile})`);
+    }
+    if (parts.length > 0) return parts.join("\n").slice(0, MAX);
+  }
+
+  if (typeof result === "string") return indent(result).slice(0, MAX);
+  if (result === undefined || result === null) return "";
+  return indent(JSON.stringify(result)).slice(0, MAX);
+}
+
+function attachCliAgentStreamListeners(
+  bus: AgentEventBus,
+  opts: { verbose?: boolean } = {},
+): void {
   bus.on("text-delta", (d) => process.stdout.write(d.text));
-  bus.on("tool-call-complete", (d) => console.log(`\n→ ${d.toolName}`));
-  bus.on("tool-result", (d) => console.log(`✓ ${d.toolName} completed`));
+  bus.on("tool-call-complete", (d) => {
+    console.log(`\n→ ${d.toolName}`);
+    if (opts.verbose) {
+      const detail = formatToolCallArgs(d.toolName, d.args);
+      if (detail) console.log(detail);
+    }
+  });
+  bus.on("tool-result", (d) => {
+    if (opts.verbose) {
+      const detail = formatToolResult(d.result);
+      console.log(`✓ ${d.toolName}`);
+      if (detail) console.log(detail);
+    } else {
+      console.log(`✓ ${d.toolName} completed`);
+    }
+  });
   bus.on("error", (d) => console.error("Error:", d.error));
 }
 
 async function createInstrumentedBus(
   session: SessionInfo,
+  opts: { verbose?: boolean } = {},
 ): Promise<{ bus: AgentEventBus; cleanup: () => Promise<void> }> {
   const bus = new AgentEventBus();
-  attachCliAgentStreamListeners(bus);
+  attachCliAgentStreamListeners(bus, opts);
   const { attachWandbToEventBus } = await import(
     "./core/integrations/wandb/upload"
   );
@@ -222,6 +295,7 @@ Usage:
 operator options (-p):
   -p, --prompt <text|@file>  (required) Prompt for the operator agent
   -s, --system <text|@file>  Override the default system prompt
+  --show-output              Echo full commands and tool output as they run
   --target <url>             Target URL / domain / IP
   --model <model>            AI model (default: auto-selected from configured provider)
   --header "Name: Value"     Custom HTTP header (repeatable)
@@ -497,6 +571,7 @@ async function runOperator() {
   const systemRaw = getArg("-s") ?? getArg("--system");
   const systemPrompt = systemRaw ? resolveFlagValue(systemRaw) : undefined;
   const target = getArg("--target");
+  const showOutput = hasFlag("--show-output");
   const pensarConfig = await appConfig.get();
   const model = await resolveCliModel();
 
@@ -504,7 +579,9 @@ async function runOperator() {
   console.log(`${sep}
 OPERATOR SESSION
 ${sep}
-Model:   ${model}${target ? `\nTarget:  ${target}` : ""}
+Model:   ${model}${target ? `\nTarget:  ${target}` : ""}${
+    showOutput ? "\nShow output: on" : ""
+  }
 ${sep}\n`);
 
   const headers = await resolveCliHeaders();
@@ -523,7 +600,9 @@ ${sep}\n`);
     },
   });
 
-  const { bus, cleanup: wandbCleanup } = await createInstrumentedBus(session);
+  const { bus, cleanup: wandbCleanup } = await createInstrumentedBus(session, {
+    verbose: showOutput,
+  });
 
   let currentPrompt = prompt;
   let messages: ModelMessage[] | undefined;

--- a/src/tui/components/shared/tool-registry.ts
+++ b/src/tui/components/shared/tool-registry.ts
@@ -7,6 +7,8 @@
  * Inspired by OpenCode's extensible tool display pattern.
  */
 
+import { stripEnvAssignmentPrefix } from "../../../util/shell-command";
+
 type ToolSummaryFn = (args: Record<string, unknown>) => string;
 
 /**
@@ -23,7 +25,11 @@ const TOOL_SUMMARY_MAP: Record<string, ToolSummaryFn> = {
 
   // Shell/Command tools
   execute_command: (args) => {
-    const cmd = String(args.command || "").split("\n")[0];
+    // Strip leading `export PATH=…`/`VAR=…` setup so the operator sees the
+    // real command rather than environment plumbing in the approval prompt.
+    const cmd = stripEnvAssignmentPrefix(String(args.command || "")).split(
+      "\n",
+    )[0];
     return cmd.length > 80 ? `$ ${cmd.slice(0, 80)}…` : `$ ${cmd}`;
   },
 

--- a/src/util/shell-command.test.ts
+++ b/src/util/shell-command.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { stripEnvAssignmentPrefix } from "./shell-command";
+
+describe("stripEnvAssignmentPrefix", () => {
+  it("strips a single export prefix joined with &&", () => {
+    expect(
+      stripEnvAssignmentPrefix(
+        'export PATH="/opt/tools/bin:$PATH" && nmap -sV target',
+      ),
+    ).toBe("nmap -sV target");
+  });
+
+  it("strips chained export prefixes", () => {
+    expect(
+      stripEnvAssignmentPrefix(
+        'export BUN_INSTALL="$HOME/.bun" && export PATH="$BUN_INSTALL/bin:$PATH" && bun install',
+      ),
+    ).toBe("bun install");
+  });
+
+  it("strips inline space-separated assignments without export", () => {
+    expect(
+      stripEnvAssignmentPrefix("FOO=bar BAR=baz ./scanner --target x"),
+    ).toBe("./scanner --target x");
+  });
+
+  it("strips assignments separated by semicolons", () => {
+    expect(stripEnvAssignmentPrefix("FOO=bar; nmap target")).toBe(
+      "nmap target",
+    );
+  });
+
+  it("leaves a plain command untouched", () => {
+    expect(stripEnvAssignmentPrefix("nmap -sV target")).toBe("nmap -sV target");
+  });
+
+  it("does not treat a command's own flags as assignments", () => {
+    expect(stripEnvAssignmentPrefix('curl -H "X-Test: y" http://host')).toBe(
+      'curl -H "X-Test: y" http://host',
+    );
+  });
+
+  it("falls back to the original when only assignments are present", () => {
+    expect(stripEnvAssignmentPrefix("FOO=bar")).toBe("FOO=bar");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(stripEnvAssignmentPrefix("  export A=1 && id  ")).toBe("id");
+  });
+});

--- a/src/util/shell-command.ts
+++ b/src/util/shell-command.ts
@@ -1,0 +1,39 @@
+/**
+ * Shell command display helpers.
+ *
+ * Agents frequently prefix commands with environment setup so that tools
+ * installed outside the default distro PATH resolve, e.g.
+ *
+ *   export PATH="/opt/tools/bin:$PATH" && nmap -sV target
+ *   FOO=bar BAR=baz ./scanner --target host
+ *
+ * When such a command is summarized for an operator approval prompt the
+ * leading `export …`/`VAR=…` noise can push the meaningful command past the
+ * truncation window, leaving the operator approving a command they cannot
+ * see. {@link stripEnvAssignmentPrefix} drops those leading assignments so the
+ * actual command surfaces. It is display-only and never used to rewrite a
+ * command that is executed.
+ */
+
+// One leading assignment, optionally `export`-prefixed, optionally followed by
+// a command separator (`&&`, `;`, `||`). The value is a quoted string or a run
+// of non-whitespace characters (covers `$VAR`, `:`, paths, etc.).
+const LEADING_ASSIGNMENT =
+  /^(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S+)\s*(?:(?:&&|\|\||;)\s*)?/;
+
+/**
+ * Strip leading environment-variable assignments / `export` statements from a
+ * shell command, returning the first meaningful command. Falls back to the
+ * original (trimmed) command if stripping would leave nothing behind.
+ */
+export function stripEnvAssignmentPrefix(command: string): string {
+  let rest = command.trim();
+
+  for (;;) {
+    const stripped = rest.replace(LEADING_ASSIGNMENT, "");
+    if (stripped === rest) break;
+    rest = stripped;
+  }
+
+  return rest.length > 0 ? rest : command.trim();
+}


### PR DESCRIPTION
### Summary

Allows operator mode users in TUI and CLI interface to view all commands and output via `--show-output`.

The commands were already passing thru the event bus, they just weren't being used.
All I did was capture those commands via the event bus if the user wants them.

For command approval, there is a regex match that tries to identify and split
when the agent is sanity-checking $PATH as part of a CLI tool that isn't
shipped with the OS. Prior to this PR, approval prompts could hide the actual command 
behind PATH/env modifications, meaning the user had no clue what they were
actually approving.

### Verification

Ran all tests requested in CONTRIBUTING.md
Wrote 8 unit tests for the new command parsing and stripping util
