### PR TITLE
Cursor/fix browser session leak 8c88

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentui/core": "^0.1.107",
     "@opentui/react": "^0.1.107",
-    "@pensar/surface": "0.2.1",
+    "@pensar/surface": "0.2.2",
     "@playwright/mcp": "^0.0.54",
     "ai": "^6.0.105",
     "glob": "^13.0.0",

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -76,6 +76,8 @@ function buildStubAgent(overrides: {
   persistentShell?: { dispose: () => void };
   abortSignal?: AbortSignal;
   resolveResult?: (sr: unknown) => unknown;
+  browserSession?: { disconnect: () => Promise<void> };
+  ownsBrowserSession?: boolean;
 }): OffensiveSecurityAgent<unknown> {
   const agent = Object.create(
     OffensiveSecurityAgent.prototype,
@@ -97,6 +99,12 @@ function buildStubAgent(overrides: {
   });
   Object.defineProperty(agent, "resolveResult", {
     value: overrides.resolveResult,
+  });
+  Object.defineProperty(agent, "browserSession", {
+    value: overrides.browserSession,
+  });
+  Object.defineProperty(agent, "ownsBrowserSession", {
+    value: overrides.ownsBrowserSession ?? false,
   });
 
   return agent;
@@ -170,6 +178,57 @@ describe("OffensiveSecurityAgent.consume()", () => {
 
       await expect(agent.consume()).rejects.toThrow("bus emit failed");
       expect(dispose).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("browser session teardown on completion (Chromium leak fix)", () => {
+    it("disconnects the owned browser session after a successful stream", async () => {
+      const disconnect = vi.fn().mockResolvedValue(undefined);
+      const agent = buildStubAgent({
+        fullStream: yieldChunks([textDelta]),
+        browserSession: { disconnect },
+        ownsBrowserSession: true,
+      });
+
+      await agent.consume();
+      expect(disconnect).toHaveBeenCalledOnce();
+    });
+
+    it("disconnects the owned browser session when the stream throws", async () => {
+      const disconnect = vi.fn().mockResolvedValue(undefined);
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow([textDelta], new Error("stream exploded")),
+        browserSession: { disconnect },
+        ownsBrowserSession: true,
+      });
+
+      await expect(agent.consume()).rejects.toThrow("stream exploded");
+      expect(disconnect).toHaveBeenCalledOnce();
+    });
+
+    it("does NOT disconnect an inherited (not-owned) browser session", async () => {
+      const disconnect = vi.fn().mockResolvedValue(undefined);
+      const agent = buildStubAgent({
+        fullStream: yieldChunks([textDelta]),
+        browserSession: { disconnect },
+        ownsBrowserSession: false,
+      });
+
+      await agent.consume();
+      expect(disconnect).not.toHaveBeenCalled();
+    });
+
+    it("swallows a disconnect failure so it never masks the run result", async () => {
+      const disconnect = vi.fn().mockRejectedValue(new Error("kill failed"));
+      const agent = buildStubAgent({
+        fullStream: yieldChunks([textDelta]),
+        browserSession: { disconnect },
+        ownsBrowserSession: true,
+        resolveResult: () => "ok",
+      });
+
+      await expect(agent.consume()).resolves.toBe("ok");
+      expect(disconnect).toHaveBeenCalledOnce();
     });
   });
 

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -117,6 +117,15 @@ export class OffensiveSecurityAgent<TResult = void> {
    */
   public readonly browserSession?: PlaywrightMcpSession;
 
+  /**
+   * True when this agent constructed its own {@link browserSession} (no
+   * `browserSession` was passed in). Only the owner disconnects it on
+   * `consume()` completion — an inherited session is torn down by whoever
+   * created it (e.g. `spawn_pentest_agent` for worker clones), so we must
+   * never disconnect a session we don't own.
+   */
+  private readonly ownsBrowserSession: boolean;
+
   private readonly abortSignal?: AbortSignal;
 
   /** The user-facing prompt passed to the model. */
@@ -193,11 +202,14 @@ export class OffensiveSecurityAgent<TResult = void> {
       const sessionHeaders = input.target
         ? resolveEffectiveHeaders(input.session, input.target)
         : input.session.config?.headers;
+      this.ownsBrowserSession = !input.browserSession;
       this.browserSession =
         input.browserSession ??
         new PlaywrightMcpSession({
           extraHttpHeaders: stripBrowserManagedHeaders(sessionHeaders),
         });
+    } else {
+      this.ownsBrowserSession = false;
     }
 
     // -- Step trace (trace.jsonl) ---------------------------------------------
@@ -527,6 +539,14 @@ export class OffensiveSecurityAgent<TResult = void> {
         }
       } finally {
         this.persistentShell?.dispose();
+        // Tear down the Chromium child process we own. Without this, a
+        // naturally-finishing agent leaks its Playwright MCP browser — over a
+        // long single-process scan (many endpoints) the leaked Chromium
+        // processes exhaust memory and OOM the run. disconnect() force-kills
+        // and never hangs, so awaiting here is safe.
+        if (this.ownsBrowserSession && this.browserSession) {
+          await this.browserSession.disconnect().catch(() => {});
+        }
       }
 
       if (this.abortSignal?.aborted) {


### PR DESCRIPTION
### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent lifecycle teardown for local browser automation; incorrect ownership logic could disconnect shared sessions or leave leaks, but behavior is scoped to non-sandbox mode with explicit ownership checks and tests.
> 
> **Overview**
> Fixes a **Chromium leak** when offensive-security agents finish without tearing down their Playwright MCP session. Long scans with many endpoints could accumulate orphaned browser processes and OOM the run.
> 
> `OffensiveSecurityAgent` now tracks **`ownsBrowserSession`**: only agents that created their own `PlaywrightMcpSession` (not inherited from a parent/spawn tool) call **`disconnect()`** in the `consume()` `finally` block, alongside existing shell disposal. Inherited sessions are left alone so workers don’t kill a parent’s browser. Disconnect errors are swallowed so teardown never masks the real run outcome.
> 
> Unit tests cover success, stream failure, non-owned sessions, and failed disconnect. **`@pensar/surface`** is bumped **0.2.1 → 0.2.2** in `package.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c2a3d8a9787941852560e1bf24c160c94241001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->