### PR TITLE
feat(findings): recalibrate severity, framing & root-cause consolidation

### DIFF
--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -55,6 +55,8 @@ export const ApexFindingObject = z.object({
   cwes: z.array(ValidatedCweEntrySchema.or(CweEntrySchema)).optional(),
   rootCauseGroup: z.string().optional(),
   relatedFindings: z.array(z.string()).optional(),
+  /** True for the single lead finding of a root-cause group (the one that should anchor the consolidated write-up). */
+  rootCauseLead: z.boolean().optional(),
   evidenceFiles: z.array(EvidenceFileEntrySchema).optional(),
 });
 

--- a/src/core/agents/specialized/cvssScorer/index.ts
+++ b/src/core/agents/specialized/cvssScorer/index.ts
@@ -279,6 +279,30 @@ const CVSS_SCORER_SYSTEM_PROMPT = `You are a CVSS 4.0 scoring specialist. Your t
 - If production-like or confirmed unintentional: **E:A**
 - Severity: typically **HIGH-CRITICAL** for real bypasses, **MEDIUM** for intentional test credentials in sandbox
 
+### Denial of Service / Resource Exhaustion (unbounded input, algorithmic complexity, amplification)
+- Typically: **AV:N, AC:L, AT:N, PR** varies (often **L** for authenticated endpoints), **UI:N**
+- **VC:N, VI:N** — DoS has no confidentiality/integrity impact unless separately demonstrated
+- **VA** must reflect what the evidence actually proves, not the worst case it implies:
+  - **VA:L** when a single request degrades performance or ties up one worker temporarily (the typical demonstrated case). A slow response (e.g. several seconds) for one request is **VA:L**, not **VA:H**.
+  - **VA:H** ONLY when the POC demonstrates a *sustained, service-wide* outage — e.g. proven worker-pool exhaustion at realistic concurrency, or the service staying unavailable to other users. Extrapolating "5-10 concurrent requests would exhaust the pool" is theoretical and does NOT justify **VA:H** unless the POC actually showed it.
+- **E:P** when only the resource-consumption gap was demonstrated; **E:A** only if an actual outage was produced and observed during testing.
+- Severity range: typically **LOW-MEDIUM**. Reserve **HIGH** for a demonstrated full outage with no easy mitigation.
+
+### OAuth Flow Weaknesses (missing PKCE, weak/predictable state, state integrity)
+- These findings describe a *missing or weak control* in an auth flow. The impact (account/session takeover) is only realizable when chained with a *separate* capability: an authorization-code interception path (open redirect, referrer leakage, network MITM) or a forgeable/guessable state.
+- **Do NOT credit full VC:H/VI:H on the vulnerable system unless the interception/forgery chain was actually demonstrated end to end.** If only the absence of PKCE (or a missing signature) was shown, the direct impact on the vulnerable system is limited → prefer **VC:L/VI:L or N** and **E:P**, with **AC:H** and/or **AT:P** to reflect the required preconditions.
+- If a state parameter already binds to the initiating user (e.g. a server-side userId check on return), missing PKCE/signing is largely a **defense-in-depth / best-practice** gap → **LOW** (or informational when state is also unguessable and validated).
+- Severity range: typically **LOW** for "missing PKCE / unsigned state" in isolation; elevate only when a working interception or CSRF-via-state-forgery chain is demonstrated.
+
+## Severity Calibration Principles
+
+Apply these across every vulnerability class. They override the worst-case instinct.
+
+- **Score what was demonstrated, not what could theoretically follow.** The CVSS reflects the impact the POC actually proved on the target, not the maximal impact the weakness might enable in a different configuration or when chained with an undiscovered bug.
+- **Chained / conditional exploitation:** when realizing impact depends on a *separate, undemonstrated* vulnerability or attacker-favorable precondition (interception position, a second bug, a guessed identifier), reflect that in the exploitability metrics (**AC:H**, **AT:P**, exploit maturity **E:P/U**) and do NOT assign full **VC:H/VI:H/VA:H** to the vulnerable system. A finding whose impact is entirely contingent on a missing precondition trends **LOW**.
+- **Security-boundary bypass without proven sensitive exposure:** when a test shows an access-control/authorization boundary was bypassed but the data actually returned is non-sensitive or same-tenant/expected-visible, score the *demonstrated* confidentiality impact (often **VC:L** or **VC:N**), not the boundary's theoretical worst case. Note explicitly in the reasoning what data was (and was not) exposed.
+- **Cross-tenant vs same-tenant matters:** confirmed cross-tenant/cross-user exposure of private data justifies **VC:H**; same-tenant data the identity could plausibly already see does not. If tenancy is unproven, say so and score conservatively.
+
 ## Analysis Instructions
 
 1. Read the finding description and evidence carefully
@@ -286,8 +310,8 @@ const CVSS_SCORER_SYSTEM_PROMPT = `You are a CVSS 4.0 scoring specialist. Your t
 3. Assess complexity based on whether special conditions were needed
 4. Determine privileges based on authentication requirements
 5. Evaluate user interaction based on exploit mechanics
-6. Assess impact on both the vulnerable system AND potential subsequent systems
-7. Since a POC exists and confirmed the vulnerability, E should typically be 'A'
+6. Assess impact on both the vulnerable system AND potential subsequent systems — score what the evidence proves, not the worst case it implies (see Severity Calibration Principles)
+7. Exploit Maturity (E): use **A (Attacked)** only when the POC demonstrated the actual security impact (data accessed, outage produced, session taken over). When the POC only proved the *gap* exists — a missing control, a slow response, a boundary bypass without confirmed sensitive exposure — use **P (POC)**. Do not default to **A** merely because a script ran and exited 0.
 
 Always provide brief reasoning explaining your key decisions.
 
@@ -319,6 +343,8 @@ In addition to CVSS metrics, assign one or more CWE identifiers to the finding. 
 | Hardcoded Credentials | CWE-798 | CWE-259 (Hard-coded Password), CWE-321 (Hard-coded Crypto Key) |
 | Captcha Bypass | CWE-804 | CWE-837 (Improper Enforcement of Single Access) |
 | Missing Security Headers | CWE-1021 | CWE-693 (Protection Mechanism Failure), CWE-16 (Configuration) |
+| Denial of Service / Resource Exhaustion | CWE-400 | CWE-770 (Allocation Without Limits), CWE-1333 (Inefficient Regex) |
+| OAuth Flow Weakness (missing PKCE, weak state) | CWE-352 | CWE-345 (Insufficient Verification of Authenticity), CWE-1275 (Sensitive Cookie Weak Attributes) |
 
 ### CWE Assignment Rules
 

--- a/src/core/agents/specialized/findingJudge/prompts.ts
+++ b/src/core/agents/specialized/findingJudge/prompts.ts
@@ -41,6 +41,7 @@ You are the last line of defense against false positives, hallucinated findings,
 - SSRF: output should show responses from internal or otherwise protected services.
 - Path traversal: output should show file contents outside the intended path.
 - IDOR: output should show access to another user's/account's resource while authentication exists.
+- Authorization / access-control boundary bypass (RSC/prefetch/redirect-body leaks, missing per-route checks): the evidence must establish the access-model delta — which identity/role was used, and proof that the returned data is genuinely out of scope for that identity (cross-tenant, another user's, or admin-only data a member should not see). A 200 response, a leaked RSC payload, or a skipped redirect alone does NOT prove sensitive exposure. If the bypass is real but the returned data is non-sensitive or plausibly same-tenant/expected-visible, classify as a valid lower-impact finding and require the claim's impact/severity to match — do NOT accept it as high-confidence sensitive/cross-tenant exposure.
 - Authentication bypass: output should show protected access without valid credentials.
 - Email/HTML injection: ideally verify delivery and rendering. If only server acceptance is shown, confidence must stay below 0.7 and limitations must state rendering was not independently verified.
 - Missing rate limiting / anti-automation: fewer than 50 requests is insufficient. Evidence must state exact request count, timing/distribution, and observed statuses.
@@ -68,6 +69,7 @@ Reject or lower confidence when:
 - Classify as informational when the observation is real but not currently exploitable or not security-impacting.
 - Classify as expected-behavior when the behavior is clearly by design.
 - Reject when the PoC fabricates evidence, does not demonstrate the claim, or the demonstrated impact fundamentally mismatches the finding.
+- Guard against overstated confidentiality impact: when the demonstrated result is weaker than the claimed impact (e.g. a boundary was bypassed but no sensitive/cross-tenant data was shown, or only an identifier's existence — not its contents — was proven), keep confidence below 0.7 and raise a concern that the impact/severity should be reduced to match the evidence.
 
 ## Response Requirements
 

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -350,6 +350,28 @@ const SECTION_CREDENTIAL_DISCOVERY = `Credential & Secret Discovery:
 - When validating an exposed key, verify what access it actually grants. A key that returns 200 on a single endpoint is less severe than a key that provides access to user data, admin functions, or billing APIs.
 - Title findings precisely: "Exposed Backend API Key" is better than "Hardcoded API Keys and AWS Infrastructure Configuration" which conflates secret and non-secret data.`;
 
+const SECTION_FINDING_QUALITY = `Finding Framing, Titles & Remediation:
+
+Lead with the strongest demonstrated impact:
+- The title and the FIRST sentence of the description must state the strongest impact you actually PROVED, not the weakest observable symptom. If your POC reads file/record contents belonging to another tenant, the finding is "unauthorized cross-tenant data access" / IDOR — NOT "enumeration" or "status-code oracle", even if an oracle is how you first noticed it. Frame around the data you accessed, then mention the oracle/mechanism as the technique.
+- Do not bury a high-impact result inside a low-impact framing. If you can access content, your evidence must show the content you accessed (and that the test identity should not have access to it), not merely that an ID exists.
+
+Title hygiene:
+- A title names the vulnerability class + the affected component or root cause (e.g. "Authorization Bypass Leaks Page Content for All /dev Routes via RSC 307 Body"). 
+- When the root cause is systemic (one shared layout, middleware, or helper affecting many routes), title it for the systemic cause, NOT a single example route. Do not title a class-wide issue after one instance like "/dev/colors" when the body says "any /dev page".
+- No editorial asides or comparisons in titles (e.g. drop "(Distinct from the Egnyte Callback)"). The title must be consistent with the scope stated in the description.
+
+Prove the access-model delta (authorization / IDOR / data-exposure findings):
+- Explicitly state the access model: which identity/role you tested as, and what that identity should vs should not be able to see.
+- Prove the boundary was actually crossed: show that the data returned belongs to a DIFFERENT tenant/user, or is admin-only data a member should not see. A 200 response or a bypassed redirect is NOT sufficient on its own — demonstrate that the exposed data is sensitive and out-of-scope for the test identity.
+- If you bypassed an authorization boundary but the data returned is non-sensitive or plausibly same-tenant/expected-visible, say so plainly in the evidence and impact. This is still a boundary failure worth reporting, but do not overstate the confidentiality impact — let the CVSS reflect what was actually exposed.
+- When you cannot confirm whether exposed data is cross-tenant vs same-tenant, state the uncertainty rather than assuming the worst case.
+
+Remediation quality:
+- Give specific, root-cause remediation — not generic "add an authorization check".
+- For authorization failures, emphasize enforcing the check AT the data-access boundary (in the data-fetching function / handler), not relying solely on layout-, middleware-, or routing-level protection that streaming, prefetch, or direct calls can bypass. Name the anti-pattern when present.
+- OAuth state / CSRF / PKCE: the core requirement is a state value that is unguessable (high-entropy random), bound to the user/session that initiated the flow, single-use, and validated on return — or PKCE as an equivalent fix. Frame these as the primary remediation. HMAC-signing or encrypting the state is valid defense-in-depth, but do NOT present "lacks cryptographic signature" as the core issue when an unguessable, properly-bound, validated state (or PKCE) resolves it.`;
+
 const SECTION_SECURITY_HEADERS_CORS = `Security Headers & CORS:
 - Do NOT recommend X-XSS-Protection — it is deprecated by all major browsers (Chrome, Firefox, Edge). Recommend Content-Security-Policy instead.
 - CORS analysis must account for the endpoint's authentication model:
@@ -426,6 +448,8 @@ ${SECTION_CREDENTIAL_DISCOVERY}
 
 ${SECTION_SECURITY_HEADERS_CORS}
 
+${SECTION_FINDING_QUALITY}
+
 ${SECTION_STATE_CHECKPOINTING}`;
 
 const PENTEST_SYSTEM_PROMPT_EXFIL = `You are an expert penetration tester performing a targeted security assessment with the goal of demonstrating full exploit impact.
@@ -471,6 +495,8 @@ ${SECTION_CREDENTIAL_DISCOVERY}
 
 ${SECTION_SECURITY_HEADERS_CORS}
 
+${SECTION_FINDING_QUALITY}
+
 ${SECTION_STATE_CHECKPOINTING}`;
 
 // ---------------------------------------------------------------------------
@@ -514,6 +540,8 @@ ${SECTION_CREDENTIAL_DISCOVERY}
 
 ${SECTION_SECURITY_HEADERS_CORS}
 
+${SECTION_FINDING_QUALITY}
+
 ${SECTION_STATE_CHECKPOINTING}`;
 
 const PENTEST_SYSTEM_PROMPT_TASK_DRIVEN_EXFIL = `You are an expert penetration tester performing a targeted security assessment with the goal of demonstrating full exploit impact.
@@ -552,6 +580,8 @@ ${SECTION_AUTHENTICATION}
 ${SECTION_CREDENTIAL_DISCOVERY}
 
 ${SECTION_SECURITY_HEADERS_CORS}
+
+${SECTION_FINDING_QUALITY}
 
 ${SECTION_STATE_CHECKPOINTING}`;
 

--- a/src/core/findings/registry.test.ts
+++ b/src/core/findings/registry.test.ts
@@ -1346,6 +1346,52 @@ describe("groupByRootCause", () => {
     expect(allFindings[2]!.rootCauseLead).toBe(false);
   });
 
+  it("derives each group's severity from pre-normalization ranks when a finding spans multiple groups", async () => {
+    // finding[1] is in BOTH groups. group g1 normalizes it up to HIGH; g2 must
+    // still see its ORIGINAL severity (LOW) so it isn't over-normalized.
+    mockedGenerate.mockResolvedValueOnce({
+      groups: [
+        { groupId: "g1", findingIndices: [0, 1], rootCause: "shared cause A" },
+        { groupId: "g2", findingIndices: [1, 2], rootCause: "shared cause B" },
+      ],
+    });
+
+    const findings = [
+      makeFinding({
+        title: "High severity root",
+        severity: "HIGH",
+        endpoint: "https://target.com/a",
+        description: "High-severity finding in group 1.",
+      }),
+      makeFinding({
+        title: "Shared low finding",
+        severity: "LOW",
+        endpoint: "https://target.com/b",
+        description: "Low-severity finding that the LLM places in both groups.",
+      }),
+      makeFinding({
+        title: "Other low finding",
+        severity: "LOW",
+        endpoint: "https://target.com/c",
+        description: "Low-severity finding only in group 2.",
+      }),
+    ];
+    const registry = FindingsRegistry.fromFindings(findings, {
+      model: "test-model",
+    });
+
+    const groups = await registry.groupByRootCause();
+
+    const g2 = groups.find((g) => g.groupId === "g2")!;
+    // g2 contains two originally-LOW findings; it must stay LOW, not inherit
+    // HIGH from g1's mutation of the shared finding.
+    expect(g2.normalizedSeverity).toBe("LOW");
+
+    const all = registry.getFindings();
+    // finding[2] is only in g2 and must not be inflated.
+    expect(all[2]!.severity).toBe("LOW");
+  });
+
   it("groups same-endpoint auth + rate-limiting findings", async () => {
     mockedGenerate.mockResolvedValueOnce({
       groups: [

--- a/src/core/findings/registry.test.ts
+++ b/src/core/findings/registry.test.ts
@@ -1287,6 +1287,65 @@ describe("groupByRootCause", () => {
     expect(allFindings[1]!.relatedFindings).toEqual([allFindings[0]!.title]);
   });
 
+  it("normalizes grouped findings to the group's max severity and designates the lead", async () => {
+    mockedGenerate.mockResolvedValueOnce({
+      groups: [
+        {
+          groupId: "dev-layout-authz-bypass",
+          findingIndices: [0, 1, 2],
+          rootCause:
+            "Authorization enforced only at the /dev layout, leaking page content via RSC/307 bodies across all /dev routes",
+        },
+      ],
+    });
+
+    const findings = [
+      makeFinding({
+        title: "RSC Header Bypass on /dev/files",
+        severity: "HIGH",
+        endpoint: "https://target.com/dev/files",
+        description:
+          "The /dev/files page leaks the full file inventory because authorization is only enforced at the layout.",
+      }),
+      makeFinding({
+        title: "RSC Header Bypass on /dev/tags",
+        severity: "MEDIUM",
+        endpoint: "https://target.com/dev/tags",
+        description:
+          "The /dev/tags page leaks tag data via the same layout-only auth gap.",
+      }),
+      makeFinding({
+        title: "RSC Header Bypass on /dev/usage",
+        severity: "MEDIUM",
+        endpoint: "https://target.com/dev/usage",
+        description:
+          "The /dev/usage page leaks billing analytics via the same layout-only auth gap.",
+      }),
+    ];
+    const registry = FindingsRegistry.fromFindings(findings, {
+      model: "test-model",
+    });
+
+    const groups = await registry.groupByRootCause();
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.normalizedSeverity).toBe("HIGH");
+    expect(groups[0]!.leadFindingIndex).toBe(0);
+
+    const allFindings = registry.getFindings();
+    // All grouped findings normalized up to the group max (HIGH).
+    expect(allFindings.map((f) => f.severity)).toEqual([
+      "HIGH",
+      "HIGH",
+      "HIGH",
+    ]);
+    // Exactly one lead, and it is the originally-highest-severity finding.
+    expect(allFindings.filter((f) => f.rootCauseLead)).toHaveLength(1);
+    expect(allFindings[0]!.rootCauseLead).toBe(true);
+    expect(allFindings[1]!.rootCauseLead).toBe(false);
+    expect(allFindings[2]!.rootCauseLead).toBe(false);
+  });
+
   it("groups same-endpoint auth + rate-limiting findings", async () => {
     mockedGenerate.mockResolvedValueOnce({
       groups: [

--- a/src/core/findings/registry.ts
+++ b/src/core/findings/registry.ts
@@ -246,6 +246,26 @@ export interface RootCauseGroup {
   groupId: string;
   findingIndices: number[];
   rootCause: string;
+  /** The highest severity among the group's findings, applied to all of them. */
+  normalizedSeverity: Finding["severity"];
+  /** Index (into the snapshot passed to groupByRootCause) of the group's lead finding. */
+  leadFindingIndex: number;
+}
+
+const SEVERITY_RANK: Record<Finding["severity"], number> = {
+  CRITICAL: 4,
+  HIGH: 3,
+  MEDIUM: 2,
+  LOW: 1,
+};
+
+/** Return the highest-ranked severity among the given findings. */
+function maxSeverity(findings: readonly Finding[]): Finding["severity"] {
+  return findings.reduce<Finding["severity"]>(
+    (acc, f) =>
+      SEVERITY_RANK[f.severity] > SEVERITY_RANK[acc] ? f.severity : acc,
+    "LOW",
+  );
 }
 
 const RootCauseGroupResultSchema = z.object({
@@ -646,15 +666,41 @@ export class FindingsRegistry {
           );
           if (validIndices.length < 2) continue;
 
+          const groupFindings = validIndices.map((i: number) => snapshot[i]!);
+          const normalizedSeverity = maxSeverity(groupFindings);
+
+          // Lead = highest severity, tie-broken by the most detailed
+          // (longest description) finding so the consolidated write-up
+          // anchors on the richest evidence.
+          const leadFindingIndex = validIndices.reduce((best, i) => {
+            const a = snapshot[i]!;
+            const b = snapshot[best]!;
+            if (SEVERITY_RANK[a.severity] !== SEVERITY_RANK[b.severity]) {
+              return SEVERITY_RANK[a.severity] > SEVERITY_RANK[b.severity]
+                ? i
+                : best;
+            }
+            return (a.description?.length ?? 0) > (b.description?.length ?? 0)
+              ? i
+              : best;
+          }, validIndices[0]!);
+
           sanitised.push({
             groupId: group.groupId,
             findingIndices: validIndices,
             rootCause: group.rootCause,
+            normalizedSeverity,
+            leadFindingIndex,
           });
 
           for (const idx of validIndices) {
             const finding = snapshot[idx]!;
             finding.rootCauseGroup = group.groupId;
+            // Findings that share a root cause are one underlying weakness;
+            // normalize them to the group's highest severity so a member-vs-
+            // admin boundary failure isn't split across High/Medium.
+            finding.severity = normalizedSeverity;
+            finding.rootCauseLead = idx === leadFindingIndex;
             // Use index-based exclusion so same-titled findings are handled correctly
             finding.relatedFindings = validIndices
               .filter((i: number) => i !== idx)

--- a/src/core/findings/registry.ts
+++ b/src/core/findings/registry.ts
@@ -259,11 +259,12 @@ const SEVERITY_RANK: Record<Finding["severity"], number> = {
   LOW: 1,
 };
 
-/** Return the highest-ranked severity among the given findings. */
-function maxSeverity(findings: readonly Finding[]): Finding["severity"] {
-  return findings.reduce<Finding["severity"]>(
-    (acc, f) =>
-      SEVERITY_RANK[f.severity] > SEVERITY_RANK[acc] ? f.severity : acc,
+/** Return the highest-ranked severity among the given severities. */
+function maxSeverity(
+  severities: readonly Finding["severity"][],
+): Finding["severity"] {
+  return severities.reduce<Finding["severity"]>(
+    (acc, s) => (SEVERITY_RANK[s] > SEVERITY_RANK[acc] ? s : acc),
     "LOW",
   );
 }
@@ -660,27 +661,34 @@ export class FindingsRegistry {
 
     await new Promise<void>((resolve) => {
       this.mutex = this.mutex.then(() => {
+        // Capture severities before any normalization so that each group's
+        // max/lead is derived from the original ranks. Without this, a finding
+        // that the LLM places in more than one group would have its severity
+        // mutated by the first group and then inflate the second group's
+        // computation (over-normalizing and mispicking the lead).
+        const baseSeverities = snapshot.map((f) => f.severity);
+
         for (const group of result.groups) {
           const validIndices = group.findingIndices.filter(
             (i: number) => i >= 0 && i < snapshot.length,
           );
           if (validIndices.length < 2) continue;
 
-          const groupFindings = validIndices.map((i: number) => snapshot[i]!);
-          const normalizedSeverity = maxSeverity(groupFindings);
+          const normalizedSeverity = maxSeverity(
+            validIndices.map((i: number) => baseSeverities[i]!),
+          );
 
-          // Lead = highest severity, tie-broken by the most detailed
+          // Lead = highest (original) severity, tie-broken by the most detailed
           // (longest description) finding so the consolidated write-up
           // anchors on the richest evidence.
           const leadFindingIndex = validIndices.reduce((best, i) => {
-            const a = snapshot[i]!;
-            const b = snapshot[best]!;
-            if (SEVERITY_RANK[a.severity] !== SEVERITY_RANK[b.severity]) {
-              return SEVERITY_RANK[a.severity] > SEVERITY_RANK[b.severity]
-                ? i
-                : best;
+            const aRank = SEVERITY_RANK[baseSeverities[i]!];
+            const bRank = SEVERITY_RANK[baseSeverities[best]!];
+            if (aRank !== bRank) {
+              return aRank > bRank ? i : best;
             }
-            return (a.description?.length ?? 0) > (b.description?.length ?? 0)
+            return (snapshot[i]!.description?.length ?? 0) >
+              (snapshot[best]!.description?.length ?? 0)
               ? i
               : best;
           }, validIndices[0]!);

--- a/src/core/report/builder.ts
+++ b/src/core/report/builder.ts
@@ -50,6 +50,7 @@ export function buildPentestReport(
       cwes: f.cwes,
       rootCauseGroup: f.rootCauseGroup,
       relatedFindings: f.relatedFindings,
+      rootCauseLead: f.rootCauseLead,
       evidenceFiles: f.evidenceFiles,
     })),
   };

--- a/src/core/report/schemas.ts
+++ b/src/core/report/schemas.ts
@@ -15,6 +15,7 @@ export const PentestReportFindingSchema = z.object({
   cwes: z.array(ValidatedCweEntrySchema.or(CweEntrySchema)).optional(),
   rootCauseGroup: z.string().optional(),
   relatedFindings: z.array(z.string()).optional(),
+  rootCauseLead: z.boolean().optional(),
   evidenceFiles: z.array(EvidenceFileEntrySchema).optional(),
 });
 


### PR DESCRIPTION
## Summary

Improvements to agent-generated finding quality, driven by professional pentester review feedback. The reviewer praised the underlying detections (IDORs, open redirects, RSC-bypass findings) but flagged recurring issues in how findings are **rated, framed, and consolidated**. These are calibration/prompt changes plus one registry behavior change — not a rebuild.

### Patterns addressed
- **Severity over-rating for availability & chained findings** — a DoS was rated High (`VA:H` + `E:A`) where a single slow request only justifies Medium; a missing-PKCE finding was Medium (`VC:H/VI:H`) despite needing a separate, undemonstrated interception chain (should be Low).
- **Framing not leading with strongest impact** — a cross-tenant file-content read was titled as mere "file existence enumeration."
- **Title hygiene** — titles naming one example route for a systemic issue, or carrying editorial asides.
- **Access-model delta unproven** — boundary-bypass findings that don't establish whether exposed data is cross-tenant/sensitive, causing inconsistent High/Medium ratings.
- **Imprecise remediation** — OAuth-state framed around "missing cryptographic signature" when the core fix is an unguessable, bound, validated state (or PKCE).
- **Fragmented root cause** — multiple findings from one anti-pattern (authz enforced at layout/middleware, not the data-access boundary) split across severities.

### Changes
- `cvssScorer/index.ts`: Severity Calibration Principles; DoS/Resource-Exhaustion and OAuth Flow Weakness vuln classes; `E:A` no longer defaults from a clean POC exit.
- `pentest/agent.ts`: new `SECTION_FINDING_QUALITY` (impact-first framing, title hygiene, access-model proof, root-cause remediation, OAuth-state guidance) wired into all four worker prompts.
- `findingJudge/prompts.ts`: require proof that bypassed-boundary data is out-of-scope; cap confidence when demonstrated impact < claimed.
- `findings/registry.ts` + `offSecAgent/types.ts` + `report/{builder,schemas}.ts`: `groupByRootCause` normalizes grouped findings to the group max severity and designates a `rootCauseLead`, threaded through the report.

## Test plan
- [x] `bunx vitest run src/core/findings src/core/report` — 123 pass (incl. new severity-normalization/lead test)
- [x] `bunx vitest run .../findingJudge .../pentest` — 9 pass
- [x] `tsc` clean for all edited files (pre-existing `src/tui/*` React-19 JSX errors unrelated)
- [x] Biome formatted
- [ ] Optional: re-run a pentest to confirm recalibration end-to-end (costs model spend)

## Notes
- Console-side consolidation persistence (threading normalized severity / related locations into `scan_issues`) is intentionally **out of scope** — it needs a schema change and touches the rebase-sensitive incremental-issue path. Tracked separately.

Made with [Cursor](https://cursor.com)