### PR TITLE
chore: temporarily exempt @pensar/surface from release-age gate

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@opentelemetry/api": "^1.9.0",
         "@opentui/core": "^0.1.107",
         "@opentui/react": "^0.1.107",
-        "@pensar/surface": "0.2.1",
+        "@pensar/surface": "0.2.2",
         "@playwright/mcp": "^0.0.54",
         "ai": "^6.0.105",
         "glob": "^13.0.0",
@@ -467,7 +467,7 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.19.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw=="],
 
-    "@pensar/surface": ["@pensar/surface@0.2.1", "", { "dependencies": { "js-yaml": "^4.1.1" }, "peerDependencies": { "typescript": "^5" }, "bin": { "surface": "dist/cli.js" } }, "sha512-RgStnnre304CFN7B8A4wMraNFiL63iGPiwrASa46DEvU0s7HTS8hNjUqm1zgEkCTRy3r2TOp8u4JCfVBxZiWEQ=="],
+    "@pensar/surface": ["@pensar/surface@0.2.2", "", { "dependencies": { "js-yaml": "^4.1.1" }, "peerDependencies": { "typescript": "^5" }, "bin": { "surface": "dist/cli.js" } }, "sha512-8EmtJ0YaoUdXEsDwpaxCDnQU7jJ4M3BsZUoTjaR7l73J16cJdZhS/jXASRVhZGgGcxAZJsnLp0Or2rGi6u8XWw=="],
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,5 @@
 [install]
 # Refuse to install packages published less than 3 days ago (supply chain mitigation).
 minimumReleaseAge = 259200
-minimumReleaseAgeExcludes = []
+# Temporarily exempting this package from the release-age gate.
+minimumReleaseAgeExcludes = ["@pensar/surface"]


### PR DESCRIPTION
## What
`minimumReleaseAge` (3-day supply-chain mitigation) was also gating `@pensar/surface`, blocking installs of freshly published first-party releases.

## Change
- Add `@pensar/surface` to `minimumReleaseAgeExcludes` in `bunfig.toml` so it installs regardless of publish age.
- Comment notes this is a temporary exemption.

## Verification
- `bun install` resolves a sub-3-day `@pensar/surface` release without the release-age error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Install-policy and lockfile-only changes; slightly weakens the release-age gate for one first-party package only.
> 
> **Overview**
> Bun’s **3-day `minimumReleaseAge`** supply-chain rule was blocking installs of freshly published **`@pensar/surface`** releases. This PR adds **`@pensar/surface`** to **`minimumReleaseAgeExcludes`** in `bunfig.toml` (with a comment that the exemption is temporary) so first-party Surface versions can install immediately.
> 
> The lockfile is updated to resolve **`@pensar/surface` `0.2.2`** (from `0.2.1`), consistent with pulling in a sub-3-day release after the config change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffb8ac4da88dc849be02f8647e90e9222174d76e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->