### PR TITLE
fix(deps): pin @pensar/surface back to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentui/core": "^0.1.107",
     "@opentui/react": "^0.1.107",
-    "@pensar/surface": "0.2.2",
+    "@pensar/surface": "0.2.1",
     "@playwright/mcp": "^0.0.54",
     "ai": "^6.0.105",
     "glob": "^13.0.0",


### PR DESCRIPTION
## Summary

Restores green CI on `canary` (and all open PRs).

`#854` bumped `@pensar/surface` to `0.2.2` in `package.json` but did **not** regenerate `bun.lock` (still `0.2.1`). `bun install --frozen-lockfile` therefore fails:
- It can't satisfy the `package.json`/lockfile mismatch under `--frozen-lockfile`.
- It also can't resolve `0.2.2`: it was published 2026-06-18, and bunfig's `minimumReleaseAge = 259200` (3-day supply-chain delay) blocks it until ~2026-06-21 01:22 UTC.

Pinning back to `0.2.1` (already in the lockfile) makes `package.json` and `bun.lock` consistent and unblocked.

## Test plan
- [x] `bun install --frozen-lockfile` passes locally (no lockfile changes)
- [ ] CI green on this PR

## Follow-up
Re-bump to `0.2.2` once it clears the release-age gate (~2026-06-21), committing a regenerated `bun.lock` alongside the `package.json` change.

Made with [Cursor](https://cursor.com)