### PR TITLE
fix(offsec): make PlaywrightMcpSession.disconnect() never hang

### DIFF
--- a/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
@@ -213,6 +213,42 @@ describe("PlaywrightMcpSession — constructor defaults", () => {
   });
 });
 
+describe("PlaywrightMcpSession.disconnect()", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  // Regression: disconnect() used to run forceKillProcess() AFTER resetState()
+  // had nulled this.mcpProcess (so the kill was a no-op) and AFTER awaiting
+  // client/transport.close(). A wedged MCP child made transport.close() hang
+  // forever, so disconnect() — and any caller awaiting it (the agent's
+  // consume() teardown) — hung, stranding an endpoint that had already
+  // finished. disconnect() must kill the child up front and never hang.
+  it("force-kills the child and resolves even when close() hangs forever", async () => {
+    const session = new PlaywrightMcpSession();
+    const kill = vi.fn();
+    const neverResolves = () => new Promise<void>(() => {});
+    // Inject wedged internals (no pid → forceKillProcess uses proc.kill()).
+    Object.assign(session as unknown as Record<string, unknown>, {
+      mcpProcess: { exitCode: null, kill },
+      mcpClient: { close: neverResolves },
+      mcpTransport: { close: neverResolves },
+    });
+
+    let settled = false;
+    const done = session.disconnect().then(() => {
+      settled = true;
+    });
+
+    // The child is SIGKILLed synchronously, before any await.
+    expect(kill).toHaveBeenCalledWith("SIGKILL");
+
+    // close() never resolves; the bounded race resolves disconnect() anyway.
+    await vi.advanceTimersByTimeAsync(5_000);
+    await done;
+    expect(settled).toBe(true);
+  });
+});
+
 describe("parseStorageStateResult", () => {
   it("returns null for null/undefined input", () => {
     expect(parseStorageStateResult(null)).toBeNull();

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -407,8 +407,9 @@ export class PlaywrightMcpSession {
    * shutdown, no waiting. Used during disconnect and error recovery so the
    * agent is never blocked on a hung Playwright process.
    */
-  private forceKillProcess(): void {
-    const proc = this.mcpProcess;
+  private forceKillProcess(
+    proc: import("child_process").ChildProcess | null = this.mcpProcess,
+  ): void {
     if (!proc || proc.exitCode !== null) return;
 
     try {
@@ -552,27 +553,46 @@ export class PlaywrightMcpSession {
 
     const transport = this.mcpTransport;
     const client = this.mcpClient;
+    // Capture the child BEFORE resetState() nulls it — otherwise the kill
+    // below is a no-op (the original bug).
+    const proc = this.mcpProcess;
 
     this.resetState();
     this.disconnecting = true; // re-set because resetState clears it
 
-    if (client) {
-      try {
-        await client.close();
-      } catch {
-        // Ignore — may already be closed
-      }
-    }
+    // SIGKILL the MCP child FIRST. Previously this ran *after* the awaited
+    // client/transport.close() calls AND read the already-nulled
+    // this.mcpProcess, so it never actually killed anything: disconnect relied
+    // entirely on close() to end the child. When the Playwright MCP child is
+    // wedged, transport.close() blocks indefinitely — so disconnect() (and any
+    // caller awaiting it, e.g. the agent's consume() teardown) hung forever,
+    // stranding an endpoint that had already finished its run. Killing the
+    // child up front makes the stdio transport observe EOF so close() resolves
+    // promptly, and guarantees disconnect() honors its "never hangs" contract.
+    this.forceKillProcess(proc);
 
-    if (transport) {
-      try {
-        await transport.close();
-      } catch {
-        // Ignore — may already be closed
-      }
-    }
-
-    this.forceKillProcess();
+    // Graceful close is best-effort cleanup and must never block the caller —
+    // bound it so a stuck client/transport can't re-introduce the hang.
+    const CLOSE_TIMEOUT_MS = 5_000;
+    let closeTimer: ReturnType<typeof setTimeout> | undefined;
+    await Promise.race([
+      (async () => {
+        try {
+          await client?.close();
+        } catch {
+          // Ignore — may already be closed
+        }
+        try {
+          await transport?.close();
+        } catch {
+          // Ignore — may already be closed
+        }
+      })(),
+      new Promise<void>((resolve) => {
+        closeTimer = setTimeout(resolve, CLOSE_TIMEOUT_MS);
+      }),
+    ]);
+    if (closeTimer) clearTimeout(closeTimer);
 
     if (this.mcpConfigPath) {
       const configPath = this.mcpConfigPath;


### PR DESCRIPTION
disconnect() called resetState() (which nulls this.mcpProcess) BEFORE forceKillProcess(), so the SIGKILL was a no-op — disconnect relied entirely on awaiting client.close() then transport.close() to terminate the MCP child. When the Playwright MCP child is wedged, transport.close() blocks forever, so disconnect() (and any caller awaiting it) hung indefinitely.

This surfaced after the leak fix (#854) started awaiting disconnect() in the agent's consume() teardown on every owned-session completion: an agent that had already called its response tool would hang in teardown, so the endpoint's runTargetedPentestAgent never returned and the scan endpoint was never marked complete (observed: 'Tool Complete: response' followed by 45+ min of silence, no completedAt, child Chromium still alive).

Fix: capture the child before resetState, SIGKILL it FIRST (so the stdio transport observes EOF and close() resolves promptly), then bound the best-effort client/transport.close() with a 5s race. disconnect() now honors its 'never hangs' contract and reliably reclaims Chromium (also strengthening the leak fix, whose kill was previously a no-op). Adds a regression test.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offsec agent browser teardown and process-kill ordering; low blast radius but directly affects whether pentest endpoints complete and Chromium is reclaimed.
> 
> **Overview**
> **`PlaywrightMcpSession.disconnect()`** no longer depends on a wedged MCP child exiting via `client.close()` / `transport.close()`. It keeps a reference to the child process before `resetState()` clears `this.mcpProcess`, **SIGKILLs that process immediately**, then runs graceful closes inside a **5s `Promise.race`** so teardown cannot block forever.
> 
> `forceKillProcess()` now accepts an optional process handle so the kill still runs after state is reset. A regression test asserts synchronous SIGKILL and that `disconnect()` settles when `close()` never resolves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6016ef8027745edf919d61130a24c333d60ef0dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->