### PR TITLE
refactor(operator): centralize correlation ID minters

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -19,6 +19,7 @@ import { createLogger } from "../../logger/structured";
 import { getApexTracer } from "../../observability";
 import type { ApprovalGate } from "../../operator";
 import { ApprovalDeniedError } from "../../operator";
+import { mintToolCallId } from "../../operator/ids";
 import { create as createSession, type SessionInfo } from "../../session";
 import { scopedLogger } from "../../util/lazyLogger";
 import { detectOSAndEnhancePrompt } from "../specialized/utils";
@@ -624,9 +625,7 @@ function wrapToolsWithApprovalGate(
       ...t,
       // biome-ignore lint/suspicious/noExplicitAny: ai-sdk tool execute receives an opaque ExecuteContext we don't need to narrow.
       execute: async (args: Record<string, unknown>, options: any) => {
-        const toolCallId =
-          args.toolCallId ??
-          `tc_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+        const toolCallId = args.toolCallId ?? mintToolCallId();
 
         log.debug(`${name} (${toolCallId}): checking`);
         try {

--- a/src/core/operator/approvalGate.test.ts
+++ b/src/core/operator/approvalGate.test.ts
@@ -7,6 +7,16 @@ import {
 } from "./approvalGate";
 import type { PendingApproval } from "./types";
 
+function expectApprovalId(
+  approvalId: PendingApproval["id"] | undefined,
+): PendingApproval["id"] {
+  expect(approvalId).toBeDefined();
+  if (approvalId === undefined) {
+    throw new Error("approval-needed event did not fire");
+  }
+  return approvalId;
+}
+
 describe("ApprovalGate — operator decision timeout", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -54,16 +64,16 @@ describe("ApprovalGate — operator decision timeout", () => {
       decisionTimeoutMs: 1_000,
     });
 
-    let approvalId = "";
+    let approvalId: PendingApproval["id"] | undefined;
     gate.once("approval-needed", (e) => {
-      approvalId = (e as { approval: { id: string } }).approval.id;
+      approvalId = (e as { approval: PendingApproval }).approval.id;
     });
 
     const pending = gate.check("http_request", "tc_2", { url: "https://t/" });
-    expect(approvalId).not.toBe("");
+    expect(approvalId).toBeDefined();
 
     await vi.advanceTimersByTimeAsync(500);
-    gate.approve(approvalId);
+    gate.approve(expectApprovalId(approvalId));
     await vi.advanceTimersByTimeAsync(1_000);
 
     await expect(pending).resolves.toBe("approved");
@@ -76,15 +86,15 @@ describe("ApprovalGate — operator decision timeout", () => {
       decisionTimeoutMs: 1_000,
     });
 
-    let approvalId = "";
+    let approvalId: PendingApproval["id"] | undefined;
     gate.once("approval-needed", (e) => {
-      approvalId = (e as { approval: { id: string } }).approval.id;
+      approvalId = (e as { approval: PendingApproval }).approval.id;
     });
 
     const pending = gate.check("http_request", "tc_3", { url: "https://t/" });
     const assertion = expect(pending).rejects.toThrow("Action denied by user");
     await vi.advanceTimersByTimeAsync(500);
-    gate.deny(approvalId);
+    gate.deny(expectApprovalId(approvalId));
     await vi.advanceTimersByTimeAsync(1_000);
 
     await assertion;
@@ -105,9 +115,9 @@ describe("ApprovalGate — operator decision timeout", () => {
       decisionTimeoutMs: 0,
     });
 
-    let approvalId = "";
+    let approvalId: PendingApproval["id"] | undefined;
     gate.once("approval-needed", (e) => {
-      approvalId = (e as { approval: { id: string } }).approval.id;
+      approvalId = (e as { approval: PendingApproval }).approval.id;
     });
 
     const pending = gate.check("http_request", "tc_4", { url: "https://t/" });
@@ -116,7 +126,7 @@ describe("ApprovalGate — operator decision timeout", () => {
     await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
     expect(gate.getPendingApprovals()).toHaveLength(1);
 
-    gate.approve(approvalId);
+    gate.approve(expectApprovalId(approvalId));
     await expect(pending).resolves.toBe("approved");
   });
 
@@ -155,9 +165,9 @@ describe("ApprovalGate — approval-resolved payload shape", () => {
     }> = [];
     gate.on("approval-resolved", (e) => resolvedEvents.push(e));
 
-    let approvalId = "";
+    let approvalId: PendingApproval["id"] | undefined;
     gate.once("approval-needed", (e) => {
-      approvalId = (e as { approval: { id: string } }).approval.id;
+      approvalId = (e as { approval: PendingApproval }).approval.id;
     });
 
     const pending = gate.check("execute_command", "tc_payload_1", {
@@ -165,7 +175,7 @@ describe("ApprovalGate — approval-resolved payload shape", () => {
       toolCallDescription: "Running ffuf against example.com",
     });
 
-    gate.approve(approvalId);
+    gate.approve(expectApprovalId(approvalId));
     await expect(pending).resolves.toBe("approved");
 
     expect(resolvedEvents).toHaveLength(1);
@@ -193,9 +203,9 @@ describe("ApprovalGate — approval-resolved payload shape", () => {
     }> = [];
     gate.on("approval-resolved", (e) => resolvedEvents.push(e));
 
-    let approvalId = "";
+    let approvalId: PendingApproval["id"] | undefined;
     gate.once("approval-needed", (e) => {
-      approvalId = (e as { approval: { id: string } }).approval.id;
+      approvalId = (e as { approval: PendingApproval }).approval.id;
     });
 
     const pending = gate.check("http_request", "tc_payload_2", {
@@ -203,7 +213,7 @@ describe("ApprovalGate — approval-resolved payload shape", () => {
     });
     const assertion = expect(pending).rejects.toThrow("Action denied by user");
 
-    gate.deny(approvalId);
+    gate.deny(expectApprovalId(approvalId));
     await assertion;
 
     expect(resolvedEvents).toHaveLength(1);
@@ -263,18 +273,18 @@ describe("ApprovalGate — INTERNAL_ID_PATTERN format-source coupling", () => {
       decisionTimeoutMs: 0,
     });
 
-    let approvalId = "";
+    let approvalId: PendingApproval["id"] | undefined;
     gate.once("approval-needed", (e) => {
-      approvalId = (e as { approval: { id: string } }).approval.id;
+      approvalId = (e as { approval: PendingApproval }).approval.id;
     });
 
     const pending = gate.check("http_request", "tc_pin_1", {});
     const assertion = expect(pending).rejects.toThrow("Action denied by user");
 
     expect(approvalId).toMatch(INTERNAL_ID_PATTERN);
-    expect(approvalId.startsWith("apr_")).toBe(true);
+    expect(expectApprovalId(approvalId).startsWith("apr_")).toBe(true);
 
-    gate.deny(approvalId);
+    gate.deny(expectApprovalId(approvalId));
     await assertion;
   });
 
@@ -284,13 +294,13 @@ describe("ApprovalGate — INTERNAL_ID_PATTERN format-source coupling", () => {
       decisionTimeoutMs: 0,
     });
 
-    let approvalId = "";
+    let approvalId: PendingApproval["id"] | undefined;
     gate.once("approval-needed", (e) => {
-      approvalId = (e as { approval: { id: string } }).approval.id;
+      approvalId = (e as { approval: PendingApproval }).approval.id;
     });
 
     const pending = gate.check("http_request", "tc_pin_2", {});
-    gate.approve(approvalId);
+    gate.approve(expectApprovalId(approvalId));
     await expect(pending).resolves.toBe("approved");
 
     const [historyEntry] = gate.getActionHistory();

--- a/src/core/operator/approvalGate.ts
+++ b/src/core/operator/approvalGate.ts
@@ -1,5 +1,6 @@
-import { randomBytes } from "crypto";
-import { EventEmitter } from "events";
+import { EventEmitter } from "node:events";
+import type { ApprovalId } from "./ids";
+import { mintActionId, mintApprovalId, mintToolCallId } from "./ids";
 import type {
   ActionHistoryEntry,
   ApprovalDecision,
@@ -23,7 +24,6 @@ export interface ApprovalGateConfig {
 /** Default operator decision SLA when `requireApproval` is true. */
 export const DEFAULT_DECISION_TIMEOUT_MS = 15 * 60 * 1000;
 
-/** Internal correlation IDs minted by this module: `apr_*`, `act_*`, `tc_*`. Never user-facing. */
 export const INTERNAL_ID_PATTERN = /^(apr|act|tc)_\d+_[0-9a-f]{8}$/;
 
 interface DeferredApproval {
@@ -42,7 +42,7 @@ interface DeferredApproval {
  */
 export class ApprovalGate extends EventEmitter {
   private config: ApprovalGateConfig;
-  private pendingApprovals: Map<string, DeferredApproval> = new Map();
+  private pendingApprovals: Map<ApprovalId, DeferredApproval> = new Map();
   private actionHistory: ActionHistoryEntry[] = [];
 
   constructor(config: ApprovalGateConfig) {
@@ -96,7 +96,7 @@ export class ApprovalGate extends EventEmitter {
     args: Record<string, unknown>,
   ): Promise<ApprovalDecision> {
     const approval: PendingApproval = {
-      id: `apr_${Date.now()}_${randomBytes(4).toString("hex")}`,
+      id: mintApprovalId(),
       toolName,
       toolCallId,
       args,
@@ -122,7 +122,7 @@ export class ApprovalGate extends EventEmitter {
     });
   }
 
-  private timeoutApproval(approvalId: string, timeoutMs: number): void {
+  private timeoutApproval(approvalId: ApprovalId, timeoutMs: number): void {
     const deferred = this.pendingApprovals.get(approvalId);
     if (!deferred) return;
 
@@ -149,7 +149,7 @@ export class ApprovalGate extends EventEmitter {
     );
   }
 
-  approve(approvalId: string): void {
+  approve(approvalId: ApprovalId): void {
     const deferred = this.pendingApprovals.get(approvalId);
     if (!deferred) {
       throw new Error(`No pending approval with id: ${approvalId}`);
@@ -174,7 +174,7 @@ export class ApprovalGate extends EventEmitter {
     deferred.resolve("approved");
   }
 
-  deny(approvalId: string): void {
+  deny(approvalId: ApprovalId): void {
     const deferred = this.pendingApprovals.get(approvalId);
     if (!deferred) return;
 
@@ -197,7 +197,7 @@ export class ApprovalGate extends EventEmitter {
     deferred.reject(new ApprovalDeniedError("Action denied by user"));
   }
 
-  batchApprove(approvalIds: string[]): void {
+  batchApprove(approvalIds: ApprovalId[]): void {
     for (const id of approvalIds) {
       if (this.pendingApprovals.has(id)) {
         this.approve(id);
@@ -217,7 +217,7 @@ export class ApprovalGate extends EventEmitter {
     decision: ApprovalDecision,
   ): ActionHistoryEntry {
     const entry: ActionHistoryEntry = {
-      id: `act_${Date.now()}_${randomBytes(4).toString("hex")}`,
+      id: mintActionId(),
       toolName,
       toolCallId,
       tier: 1,
@@ -277,8 +277,7 @@ function wrapToolWithApproval<TArgs extends Record<string, unknown>, TResult>(
   originalTool: (args: TArgs) => Promise<TResult>,
 ): (args: TArgs & { toolCallId?: string }) => Promise<TResult> {
   return async (args) => {
-    const toolCallId =
-      args.toolCallId || `tc_${Date.now()}_${randomBytes(4).toString("hex")}`;
+    const toolCallId = args.toolCallId || mintToolCallId();
     const { toolCallId: _, ...toolArgs } = args;
 
     await gate.check(toolName, toolCallId, toolArgs as Record<string, unknown>);

--- a/src/core/operator/ids.test.ts
+++ b/src/core/operator/ids.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ActionId,
+  mintActionId,
+  mintApprovalId,
+  mintToolCallId,
+} from "./ids";
+
+describe("operator ID minters", () => {
+  it("mints approval IDs with the shared shape", () => {
+    expect(mintApprovalId()).toMatch(/^apr_\d+_[0-9a-f]{8}$/);
+  });
+
+  it("mints action IDs with the shared shape", () => {
+    expect(mintActionId()).toMatch(/^act_\d+_[0-9a-f]{8}$/);
+  });
+
+  it("mints tool-call IDs with the shared shape", () => {
+    expect(mintToolCallId()).toMatch(/^tc_\d+_[0-9a-f]{8}$/);
+  });
+
+  it("produces unique IDs in a tight loop", () => {
+    expect(new Set(Array.from({ length: 1_000 }, mintApprovalId)).size).toBe(
+      1_000,
+    );
+    expect(new Set(Array.from({ length: 1_000 }, mintActionId)).size).toBe(
+      1_000,
+    );
+    expect(new Set(Array.from({ length: 1_000 }, mintToolCallId)).size).toBe(
+      1_000,
+    );
+  });
+
+  it("keeps approval and action IDs nominally distinct", () => {
+    // @ts-expect-error ApprovalId must not be assignable to ActionId.
+    const actionId: ActionId = mintApprovalId();
+    expect(actionId).toMatch(/^apr_/);
+  });
+});

--- a/src/core/operator/ids.ts
+++ b/src/core/operator/ids.ts
@@ -1,0 +1,13 @@
+import { randomBytes } from "node:crypto";
+
+declare const __brand: unique symbol;
+type Branded<B extends string> = string & { readonly [__brand]: B };
+
+export type ApprovalId = Branded<"ApprovalId">;
+export type ActionId = Branded<"ActionId">;
+
+const stamp = () => `${Date.now()}_${randomBytes(4).toString("hex")}`;
+
+export const mintApprovalId = (): ApprovalId => `apr_${stamp()}` as ApprovalId;
+export const mintActionId = (): ActionId => `act_${stamp()}` as ActionId;
+export const mintToolCallId = (): string => `tc_${stamp()}`;

--- a/src/core/operator/types.ts
+++ b/src/core/operator/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { ActionId, ApprovalId } from "./ids";
 
 /**
  * Permission tiers for tool classification
@@ -193,7 +194,7 @@ function getNextStage(current: OperatorStage): OperatorStage | null {
 
 /** Pending approval request. `id` is an internal correlation key, not a label. */
 export interface PendingApproval {
-  id: string;
+  id: ApprovalId;
   toolName: string;
   toolCallId: string;
   args: Record<string, unknown>;
@@ -206,7 +207,7 @@ export type ApprovalDecision = "approved" | "denied" | "auto-approved";
 
 /** Action history entry for audit log */
 export interface ActionHistoryEntry {
-  id: string;
+  id: ActionId;
   toolName: string;
   toolCallId: string;
   tier: PermissionTier;
@@ -325,7 +326,7 @@ export type OperatorEvent =
   | { type: "approval-needed"; approval: PendingApproval }
   | {
       type: "approval-resolved";
-      id: string;
+      id: ApprovalId;
       decision: ApprovalDecision;
       approval: PendingApproval;
     }

--- a/src/tui/components/shared/action-label.test.ts
+++ b/src/tui/components/shared/action-label.test.ts
@@ -6,7 +6,7 @@ function makeApproval(
   overrides: Partial<PendingApproval> = {},
 ): PendingApproval {
   return {
-    id: "apr_1777922893504_0d385b65",
+    id: "apr_1777922893504_0d385b65" as PendingApproval["id"],
     toolName: "execute_command",
     toolCallId: "tc_test_1",
     args: { command: "ls -la" },


### PR DESCRIPTION
### What does this PR do?

Closes #717.

This centralizes the internal operator correlation ID minters into `src/core/operator/ids.ts`:

- adds shared `mintApprovalId`, `mintActionId`, and `mintToolCallId` helpers
- narrows `PendingApproval.id` to `ApprovalId`
- narrows `ActionHistoryEntry.id` and `approval-resolved.id` to `ActionId` / `ApprovalId` where appropriate
- replaces the second `tc_` fallback minter in `offensiveSecurityAgent.ts` so operator and offsec tool-call fallbacks use the same shape

`toolCallId` remains an unbranded `string` because callers can still supply external AI SDK IDs for that field. This keeps the change scoped to the internal `apr_` / `act_` IDs and the fallback `tc_` minter shape described in the issue.

### How did you verify your code works?

- `npm run test -- src/core/operator/ids.test.ts src/core/operator/approvalGate.test.ts src/tui/components/shared/action-label.test.ts`
- `npm run test`
- `npm run tsc`
- `npx --yes bun@latest build src/cli.ts --outdir build --target node --format esm --splitting --external @opentui/core --external @opentui/react --external @opentui/react/* --external react --external react/jsx-runtime --external react/jsx-dev-runtime --external react-reconciler --external weave`
- `npx biome check src/core/operator/ids.ts src/core/operator/ids.test.ts src/core/operator/approvalGate.ts src/core/operator/approvalGate.test.ts src/core/operator/types.ts src/core/agents/offSecAgent/offensiveSecurityAgent.ts src/tui/components/shared/action-label.test.ts`
- Verified no inline minted `apr_${...}` / `act_${...}` / `tc_${...}` literals remain outside `src/core/operator/ids.ts`
- Verified `randomBytes(4).toString` no longer appears under `src/core/operator` or `src/core/agents` outside `src/core/operator/ids.ts`
