### PR TITLE
Cursor/deepseek qwen bedrock toolcalls 8c88

### DIFF
--- a/src/core/ai/ai.test.ts
+++ b/src/core/ai/ai.test.ts
@@ -1,11 +1,56 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { streamResponse } from "./ai";
+import {
+  applySequentialToolCallPolicy,
+  SEQUENTIAL_TOOL_CALL_INSTRUCTION,
+  streamResponse,
+} from "./ai";
 import { consumeStream } from "./utils";
 
 // Skip tests if API keys are not available (e.g., in CI)
 const hasApiKeys = process.env.ANTHROPIC_API_KEY || process.env.OPENAI_API_KEY;
 const describeOrSkip = hasApiKeys ? describe : describe.skip;
+
+describe("applySequentialToolCallPolicy", () => {
+  const tools = {
+    probe: {
+      description: "test tool",
+      inputSchema: z.object({ q: z.string() }),
+    },
+  };
+
+  it("appends the instruction for DeepSeek models when tools are bound", () => {
+    const result = applySequentialToolCallPolicy(
+      "Base system prompt.",
+      tools,
+      "deepseek.v3-v1:0",
+    );
+    expect(result).toBe(
+      `Base system prompt.\n\n${SEQUENTIAL_TOOL_CALL_INSTRUCTION}`,
+    );
+  });
+
+  it("uses the instruction alone when there is no base system prompt", () => {
+    expect(
+      applySequentialToolCallPolicy(undefined, tools, "deepseek.v3-v1:0"),
+    ).toBe(SEQUENTIAL_TOOL_CALL_INSTRUCTION);
+  });
+
+  it("leaves the system prompt unchanged when no tools are bound", () => {
+    expect(applySequentialToolCallPolicy("Base.", {}, "deepseek.v3-v1:0")).toBe(
+      "Base.",
+    );
+    expect(
+      applySequentialToolCallPolicy("Base.", undefined, "deepseek.v3-v1:0"),
+    ).toBe("Base.");
+  });
+
+  it("leaves the system prompt unchanged for non-DeepSeek models", () => {
+    expect(
+      applySequentialToolCallPolicy("Base.", tools, "claude-haiku-4-5"),
+    ).toBe("Base.");
+  });
+});
 
 describeOrSkip("AI Stream Response", () => {
   it("should stream a basic response", async () => {

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -156,6 +156,26 @@ const SEQUENTIAL_TOOL_CALL_INSTRUCTION =
   "wait for its result before making the next one. Emitting multiple tool " +
   "calls in one turn corrupts their arguments.";
 
+// Returns the system prompt that is actually sent to the provider, accounting
+// for the sequential-tool-call policy appended for models that mis-parse
+// parallel tool calls. Token budgeting (`fitMessagesToContext`) must use this
+// value, not the raw `system`, or it underestimates the system prompt size and
+// overestimates the message budget near the context limit.
+function applySequentialToolCallPolicy(
+  system: string | undefined,
+  tools: ToolSet | undefined,
+  model: AIModel,
+): string | undefined {
+  if (
+    tools &&
+    Object.keys(tools).length > 0 &&
+    prefersSequentialToolCalls(model)
+  ) {
+    return `${system ? `${system}\n\n` : ""}${SEQUENTIAL_TOOL_CALL_INSTRUCTION}`;
+  }
+  return system;
+}
+
 const MAX_RATE_LIMIT_RETRIES = 20;
 const MAX_IDLE_RESUME_RETRIES = 3;
 const STREAM_IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
@@ -410,7 +430,11 @@ function wrapStreamWithErrorHandler(
                 const fitted = fitMessagesToContext(currentMessages, {
                   contextWindow: getContextWindow(opts.model),
                   maxOutputTokens: getMaxOutputTokens(opts.model),
-                  system: opts.system,
+                  system: applySequentialToolCallPolicy(
+                    opts.system,
+                    opts.tools,
+                    opts.model,
+                  ),
                   tools: opts.tools,
                   sessionPath: opts.sessionPath,
                 });
@@ -718,6 +742,18 @@ export function streamResponse(
   const providerModel = getProviderModel(model, authConfig);
   const useAnthropicCaching = isAnthropicProvider(model);
 
+  // Models that mis-parse multiple tool calls per turn (DeepSeek V3.1 on
+  // Bedrock) are constrained to one tool call per turn via system prompt —
+  // single calls parse correctly, parallel calls drop/empty arguments. Only
+  // applied when tools are actually bound. See prefersSequentialToolCalls.
+  // Computed before context fitting so token budgeting accounts for the
+  // appended instruction that is actually sent to the provider.
+  const systemWithToolPolicy = applySequentialToolCallPolicy(
+    system,
+    tools,
+    model,
+  );
+
   // Proactive context fit: compact before the call. Reactive recovery
   // below is a safety net for tokenizer drift the estimate doesn't catch.
   let fittedMessages = messages;
@@ -726,7 +762,7 @@ export function streamResponse(
     const fitted = fitMessagesToContext(messages, {
       contextWindow: getContextWindow(model),
       maxOutputTokens: getMaxOutputTokens(model),
-      system,
+      system: systemWithToolPolicy,
       tools,
       sessionPath: opts.sessionPath,
     });
@@ -769,15 +805,6 @@ export function streamResponse(
       silent,
     );
   }
-
-  // Models that mis-parse multiple tool calls per turn (DeepSeek V3.1 on
-  // Bedrock) are constrained to one tool call per turn via system prompt —
-  // single calls parse correctly, parallel calls drop/empty arguments. Only
-  // applied when tools are actually bound. See prefersSequentialToolCalls.
-  const systemWithToolPolicy =
-    tools && Object.keys(tools).length > 0 && prefersSequentialToolCalls(model)
-      ? `${system ? `${system}\n\n` : ""}${SEQUENTIAL_TOOL_CALL_INSTRUCTION}`
-      : system;
 
   // For Anthropic models, move the system prompt into messages with cache_control.
   // This caches tools + system prompt across multi-turn conversations (~90% cost reduction on cache hits).
@@ -1236,4 +1263,10 @@ const MAX_SCHEMA_CHARS = 6_000;
 const MINIMAL_RESTART_PROMPT =
   "Continue the previous task. Earlier context was discarded due to repeated context-length errors.";
 
-export { createToolExecutionGate, StreamIdleTimeoutError, withIdleTimeout };
+export {
+  applySequentialToolCallPolicy,
+  createToolExecutionGate,
+  SEQUENTIAL_TOOL_CALL_INSTRUCTION,
+  StreamIdleTimeoutError,
+  withIdleTimeout,
+};

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -21,7 +21,11 @@ import { shouldRecordAiPayloads } from "../observability";
 import { scopedLogger } from "../util/lazyLogger";
 import { withCachedLastMessage, withCachedSystemPrompt } from "./caching";
 import { fitMessagesToContext, truncateWithMarker } from "./contextManagement";
-import { getMaxOutputTokens, getModelInfo } from "./models";
+import {
+  getMaxOutputTokens,
+  getModelInfo,
+  prefersSequentialToolCalls,
+} from "./models";
 import {
   type AIAuthConfig,
   checkIfContextLengthError,
@@ -143,6 +147,14 @@ function checkIfRateLimitError(error: unknown): boolean {
     errorString.includes("request rate")
   );
 }
+
+// Injected into the system prompt for models that mis-parse parallel tool
+// calls (DeepSeek V3.1 on Bedrock). See prefersSequentialToolCalls.
+const SEQUENTIAL_TOOL_CALL_INSTRUCTION =
+  "CRITICAL TOOL-CALLING RULE: Emit EXACTLY ONE tool call per response. " +
+  "Never emit more than one tool call in a single turn. After each tool call, " +
+  "wait for its result before making the next one. Emitting multiple tool " +
+  "calls in one turn corrupts their arguments.";
 
 const MAX_RATE_LIMIT_RETRIES = 20;
 const MAX_IDLE_RESUME_RETRIES = 3;
@@ -758,16 +770,28 @@ export function streamResponse(
     );
   }
 
+  // Models that mis-parse multiple tool calls per turn (DeepSeek V3.1 on
+  // Bedrock) are constrained to one tool call per turn via system prompt —
+  // single calls parse correctly, parallel calls drop/empty arguments. Only
+  // applied when tools are actually bound. See prefersSequentialToolCalls.
+  const systemWithToolPolicy =
+    tools && Object.keys(tools).length > 0 && prefersSequentialToolCalls(model)
+      ? `${system ? `${system}\n\n` : ""}${SEQUENTIAL_TOOL_CALL_INSTRUCTION}`
+      : system;
+
   // For Anthropic models, move the system prompt into messages with cache_control.
   // This caches tools + system prompt across multi-turn conversations (~90% cost reduction on cache hits).
-  let effectiveSystem: string | undefined = system;
+  let effectiveSystem: string | undefined = systemWithToolPolicy;
   let effectiveMessages: ModelMessage[] | undefined = fittedMessages;
 
-  if (useAnthropicCaching && system) {
+  if (useAnthropicCaching && systemWithToolPolicy) {
     const baseMessages: ModelMessage[] = fittedMessages ?? [
       { role: "user" as const, content: prompt },
     ];
-    effectiveMessages = withCachedSystemPrompt(system, baseMessages);
+    effectiveMessages = withCachedSystemPrompt(
+      systemWithToolPolicy,
+      baseMessages,
+    );
     effectiveSystem = undefined;
   }
 

--- a/src/core/ai/models/bedrock.ts
+++ b/src/core/ai/models/bedrock.ts
@@ -418,6 +418,23 @@ export const BEDROCK_MODELS: ModelInfo[] = [
     provider: "bedrock",
     contextLength: 64000,
   },
+  // Manually added — not yet emitted by the SDK model enumeration that
+  // generate-models.ts reads. DeepSeek V3.1 and Qwen3 Coder are in-region only
+  // (no cross-region inference profile). DeepSeek V3.1 does NOT support native
+  // Bedrock Converse tool calling (see needsTextToolCalling in ai.ts); Qwen3
+  // Coder does. Keep these on re-generation.
+  {
+    id: "deepseek.v3-v1:0",
+    name: "DeepSeek V3.1 (Bedrock)",
+    provider: "bedrock",
+    contextLength: 128000,
+  },
+  {
+    id: "qwen.qwen3-coder-480b-a35b-v1:0",
+    name: "Qwen3 Coder 480B A35B Instruct (Bedrock)",
+    provider: "bedrock",
+    contextLength: 131072,
+  },
   {
     id: "us.mistral.pixtral-large-2502-v1:0",
     name: "Pixtral Large-2502 (US)",

--- a/src/core/ai/models/bedrock.ts
+++ b/src/core/ai/models/bedrock.ts
@@ -436,6 +436,12 @@ export const BEDROCK_MODELS: ModelInfo[] = [
     contextLength: 131072,
   },
   {
+    id: "zai.glm-5",
+    name: "Z.AI GLM 5 (Bedrock)",
+    provider: "bedrock",
+    contextLength: 200000,
+  },
+  {
     id: "us.mistral.pixtral-large-2502-v1:0",
     name: "Pixtral Large-2502 (US)",
     provider: "bedrock",

--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -179,9 +179,24 @@ function lookupOutputBudgetByPattern(modelId: string): number {
     return 128_000;
   }
 
-  // GLM 5.2 ships a 131.1K (128Ki) max-output window over its 1M context.
-  if (modelId.includes("glm-5.2")) {
+  // GLM 5 / 5.2 ship a ~131K (128Ki) max-output window. Matching both keeps the
+  // Bedrock `zai.glm-5` id and OpenRouter `z-ai/glm-5.2` on the same budget.
+  if (modelId.includes("glm-5")) {
     return 131_072;
+  }
+
+  // DeepSeek (V3.1, R1, chat). Bedrock documents an 8K output window for
+  // DeepSeek V3.1; the rest of the family is no larger, so this is a safe floor
+  // that keeps new `deepseek.*` ids off the 4,096 catch-all.
+  if (modelId.includes("deepseek")) {
+    return 8_192;
+  }
+
+  // Qwen3 Coder ships a 16K max-output window over its 128K+ context. Match the
+  // whole `qwen` family so future Bedrock/OpenRouter qwen ids don't silently
+  // inherit the 4,096 default.
+  if (modelId.includes("qwen")) {
+    return 16_000;
   }
 
   return 4_096;

--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -32,6 +32,23 @@ export function getModelInfo(model: AIModel): ModelInfo {
 }
 
 /**
+ * Whether a model must be constrained to ONE tool call per assistant turn.
+ *
+ * DeepSeek V3.1 emits tool calls via special tokens
+ * (`<｜tool▁call▁begin｜>name<｜tool▁sep｜>args<｜tool▁call▁end｜>`). When it
+ * emits MULTIPLE tool calls in a single turn, Bedrock's tool-call extraction
+ * mis-parses them and drops/empties the arguments of the 2nd+ call (observed:
+ * a parallel `get_weather` call came back with `{"city":""}`). Single tool
+ * calls parse correctly. The portable mitigation — the one the DeepSeek model
+ * card and community use — is to instruct the model to make one tool call per
+ * turn (see `SEQUENTIAL_TOOL_CALL_INSTRUCTION` in ai.ts). Qwen3 and Claude
+ * parse parallel calls fine, so this is scoped to DeepSeek.
+ */
+export function prefersSequentialToolCalls(model: AIModel): boolean {
+  return /(^|[./:-])deepseek([./:-]|$)/i.test(model);
+}
+
+/**
  * Single source of truth for a model's default `max_tokens`. Both
  * `streamResponse`'s budget and the Pensar gateway formatter must agree,
  * so the lookup lives next to the registry it queries against.

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -50,8 +50,17 @@ describe("getMaxOutputTokens", () => {
     expect(getMaxOutputTokens("minimax/minimax-m3")).toBe(128_000);
   });
 
-  it("recognizes GLM 5.2's 131.1K max-output window", () => {
+  it("recognizes GLM 5 / 5.2's 131.1K max-output window", () => {
     expect(getMaxOutputTokens("z-ai/glm-5.2")).toBe(131_072);
+    expect(getMaxOutputTokens("zai.glm-5")).toBe(131_072);
+  });
+
+  it("recognizes the new Bedrock DeepSeek / Qwen output budgets", () => {
+    // These three were silently inheriting the 4,096 catch-all, capping
+    // replies far below each model's documented Bedrock limit.
+    expect(getMaxOutputTokens("deepseek.v3-v1:0")).toBe(8_192);
+    expect(getMaxOutputTokens("us.deepseek.r1-v1:0")).toBe(8_192);
+    expect(getMaxOutputTokens("qwen.qwen3-coder-480b-a35b-v1:0")).toBe(16_000);
   });
 
   it("recognizes Claude tier-specific budgets", () => {

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -5,7 +5,12 @@ import {
   modelSupportsOpenAIReasoning,
   normalizeOpenAIReasoningEffort,
 } from "../ai";
-import { AVAILABLE_MODELS, getMaxOutputTokens, getModelInfo } from "./index";
+import {
+  AVAILABLE_MODELS,
+  getMaxOutputTokens,
+  getModelInfo,
+  prefersSequentialToolCalls,
+} from "./index";
 
 describe("getMaxOutputTokens", () => {
   it("returns a positive value for every model in AVAILABLE_MODELS", () => {
@@ -149,6 +154,37 @@ describe("getMaxOutputTokens", () => {
 
   it("falls back to a small default for genuinely unknown providers", () => {
     expect(getMaxOutputTokens("totally-unknown-model")).toBe(4_096);
+  });
+});
+
+describe("prefersSequentialToolCalls", () => {
+  it("is true for DeepSeek models (Bedrock mis-parses parallel tool calls)", () => {
+    expect(prefersSequentialToolCalls("deepseek.v3-v1:0")).toBe(true);
+    expect(prefersSequentialToolCalls("us.deepseek.r1-v1:0")).toBe(true);
+    expect(prefersSequentialToolCalls("deepseek/deepseek-chat")).toBe(true);
+  });
+
+  it("is false for models that parse parallel tool calls natively", () => {
+    expect(prefersSequentialToolCalls("qwen.qwen3-coder-480b-a35b-v1:0")).toBe(
+      false,
+    );
+    expect(
+      prefersSequentialToolCalls(
+        "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+      ),
+    ).toBe(false);
+    expect(prefersSequentialToolCalls("us.anthropic.claude-opus-4-6-v1")).toBe(
+      false,
+    );
+    // Don't false-positive on substrings of unrelated ids.
+    expect(prefersSequentialToolCalls("some-deepseeker-model")).toBe(false);
+  });
+
+  it("registers DeepSeek V3.1 and Qwen3 Coder 480B as bedrock models", () => {
+    expect(getModelInfo("deepseek.v3-v1:0").provider).toBe("bedrock");
+    expect(getModelInfo("qwen.qwen3-coder-480b-a35b-v1:0").provider).toBe(
+      "bedrock",
+    );
   });
 });
 

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -180,10 +180,18 @@ describe("prefersSequentialToolCalls", () => {
     expect(prefersSequentialToolCalls("some-deepseeker-model")).toBe(false);
   });
 
-  it("registers DeepSeek V3.1 and Qwen3 Coder 480B as bedrock models", () => {
+  it("registers DeepSeek V3.1, Qwen3 Coder 480B, and GLM 5 as bedrock models", () => {
     expect(getModelInfo("deepseek.v3-v1:0").provider).toBe("bedrock");
     expect(getModelInfo("qwen.qwen3-coder-480b-a35b-v1:0").provider).toBe(
       "bedrock",
+    );
+    expect(getModelInfo("zai.glm-5").provider).toBe("bedrock");
+  });
+
+  it("does not force GLM 5 / Qwen into sequential tool calls (they parse parallel calls natively)", () => {
+    expect(prefersSequentialToolCalls("zai.glm-5")).toBe(false);
+    expect(prefersSequentialToolCalls("qwen.qwen3-coder-480b-a35b-v1:0")).toBe(
+      false,
     );
   });
 });


### PR DESCRIPTION
### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core `streamResponse` system prompt and context budgeting for tool-enabled DeepSeek runs; incorrect scoping could affect other models, but behavior is gated by `prefersSequentialToolCalls` and tests.
> 
> **Overview**
> Adds **DeepSeek V3.1**, **Qwen3 Coder 480B**, and **Z.AI GLM 5** to the Bedrock model registry and fixes **output token budgets** for DeepSeek (8K), Qwen (16K), and GLM 5 (shared with GLM 5.2) so they no longer fall through to the 4K default.
> 
> For **DeepSeek** with tools bound, the streaming path appends a **one-tool-call-per-turn** system instruction via `applySequentialToolCallPolicy`, because Bedrock mis-parses parallel tool calls and corrupts later arguments. That augmented prompt is used for **context fitting** and Anthropic caching paths so token budgeting matches what the provider receives. **`prefersSequentialToolCalls`** scopes this to DeepSeek IDs only; Qwen and GLM are unchanged.
> 
> Unit tests cover the policy helper, sequential-tool detection, registry entries, and the new output budgets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cdc0e7c5b04c22571ac8a5f0ef2fd8fb938ffca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->