### PR TITLE
fix: remove unpublished module entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   ],
   "license": "MIT",
   "main": "build/cli.js",
-  "module": "src/tui/index.tsx",
   "name": "@pensar/apex",
   "optionalDependencies": {
     "weave": "^0.12.1"


### PR DESCRIPTION
## Summary
- remove the package-level `module` field that points at unpublished source
- keep the existing `main: build/cli.js` entrypoint as the published package entry

## Why
The published `@pensar/apex@2.0.1` tarball includes `build/cli.js`, but does not include `src/tui/index.tsx`. Bundlers that prefer the `module` field can resolve to that missing unpublished source file instead of the CLI build.

## Validation
- `node -e "const p=require('./package.json'); if ('module' in p) process.exit(1); console.log('module-field-removed main='+p.main)"`
- `npm pack @pensar/apex@2.0.1 --dry-run --json` confirms the published package includes `build/cli.js` and not `src/tui/index.tsx`
- `git diff --check`

Note: Bun is not installed in this environment, so I could not run the repo's Bun-based test/build commands here. This is a package metadata-only change.