### PR TITLE
feat(cli): add `pensar targets` to query pentest target logs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -210,6 +210,7 @@ Usage:
   pensar uninstall                    Uninstall Pensar (keeps sessions, memories, skills)
   pensar apps                         Manage the attack surface (apps & endpoints)
   pensar pentests                     List and manage pentests
+  pensar targets                      List pentest targets and view their agent logs
   pensar issues                       List and manage security issues
   pensar fixes                        View security fixes
   pensar logs                         View agent execution logs
@@ -625,6 +626,9 @@ if (hasFlag("-p") || command === "--prompt") {
 } else if (command === "pentests") {
   process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
   await import("./cli/pentests");
+} else if (command === "targets") {
+  process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
+  await import("./cli/targets");
 } else if (command === "issues") {
   process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
   await import("./cli/issues");

--- a/src/cli/targets.ts
+++ b/src/cli/targets.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env bun
+
+/**
+ * pensar targets — View pentest targets and their agent logs via the Pensar API
+ *
+ * A "target" is a single attack-surface endpoint exercised during a pentest.
+ * Pentest execution logs are persisted against the target (not against the
+ * issues it produced), so targets are the way to query the full pentest
+ * activity for an endpoint — including runs that produced no issue.
+ *
+ * All commands operate on the selected workspace (set via `pensar login`).
+ *
+ * Usage:
+ *   pensar targets <pentestId>                       List targets for a pentest
+ *   pensar targets logs <targetId> [filters]          List agent logs for a target
+ *   pensar targets search <targetId> <query> [opts]   Search agent logs for a target
+ */
+
+import {
+  listPentestTargets,
+  listTargetLogs,
+  searchTargetLogs,
+} from "../core/api";
+
+function getFlag(flag: string, argv: string[]): string | undefined {
+  const idx = argv.indexOf(flag);
+  return idx !== -1 && idx + 1 < argv.length ? argv[idx + 1] : undefined;
+}
+
+function showHelp(): void {
+  console.log(`pensar targets — View pentest targets and their agent logs
+
+A target is a single endpoint tested during a pentest. Pentest logs are stored
+per target, so this is how you query the full activity for an endpoint.
+
+All commands operate on the selected workspace (set via \`pensar login\`).
+
+Usage:
+  pensar targets <pentestId>                      List targets for a pentest
+  pensar targets logs <targetId> [filters]         List agent logs for a target
+  pensar targets search <targetId> <query> [opts]  Search agent logs for a target
+
+Logs filters:
+  --level <level>       Filter: debug, info, warn, error
+  --role <role>         Filter: assistant, user, system, tool-call, tool-result
+  --limit <n>           Max entries (default: 100, max: 500)
+
+Search options:
+  --level <level>       Filter: debug, info, warn, error
+  --role <role>         Filter: assistant, user, system, tool-call, tool-result
+  --context <n>         Context lines around matches (default: 3)
+
+Options:
+  -h, --help            Show this help message`);
+}
+
+type LogLevel = "debug" | "info" | "warn" | "error";
+type LogRole = "assistant" | "user" | "system" | "tool-call" | "tool-result";
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+    showHelp();
+    return;
+  }
+
+  try {
+    if (sub === "logs") {
+      const targetId = args[1];
+      if (!targetId) {
+        console.error("Error: target ID is required");
+        console.error(
+          "Usage: pensar targets logs <targetId> [--level <level>] [--role <role>] [--limit <n>]",
+        );
+        process.exit(1);
+      }
+      const level = getFlag("--level", args) as LogLevel | undefined;
+      const role = getFlag("--role", args) as LogRole | undefined;
+      const limitStr = getFlag("--limit", args);
+      const limit = limitStr ? parseInt(limitStr, 10) : undefined;
+
+      const result = await listTargetLogs(targetId, { level, role, limit });
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub === "search") {
+      const targetId = args[1];
+      const query = args[2];
+      if (!targetId || !query) {
+        console.error("Error: target ID and query are required");
+        console.error(
+          "Usage: pensar targets search <targetId> <query> [--level <level>] [--role <role>] [--context <n>]",
+        );
+        process.exit(1);
+      }
+      const level = getFlag("--level", args) as LogLevel | undefined;
+      const role = getFlag("--role", args) as LogRole | undefined;
+      const contextStr = getFlag("--context", args);
+      const contextLines = contextStr ? parseInt(contextStr, 10) : undefined;
+
+      const result = await searchTargetLogs(targetId, query, {
+        level,
+        role,
+        contextLines,
+      });
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub.startsWith("--")) {
+      console.error("Error: pentest ID is required");
+      console.error("Usage: pensar targets <pentestId>");
+      process.exit(1);
+    } else {
+      const pentestId = sub;
+      const targets = await listPentestTargets(pentestId);
+      console.log(JSON.stringify(targets, null, 2));
+    }
+  } catch (err) {
+    console.error(
+      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -67,9 +67,12 @@ export type {
   IssueDetail,
   IssueSummary,
   ListAgentLogsResult,
+  ListTargetLogsResult,
+  PentestTargetSummary,
   ScanDetail,
   ScanSummary,
   SearchAgentLogsResult,
+  SearchTargetLogsResult,
   UpdateIssueResult,
 } from "./issues";
 export {
@@ -80,8 +83,11 @@ export {
   listAgentLogs,
   listFixes,
   listIssues,
+  listPentestTargets,
   listScans,
+  listTargetLogs,
   searchAgentLogs,
+  searchTargetLogs,
   updateIssue,
 } from "./issues";
 export type { RunAgentResult } from "./offesecAgent";

--- a/src/core/api/issues.ts
+++ b/src/core/api/issues.ts
@@ -79,6 +79,24 @@ export interface DispatchPentestResult {
   message: string;
 }
 
+/**
+ * A pentest "target" is a single attack-surface endpoint exercised during a
+ * pentest (a `scan_endpoints` row on the backend). Pentest execution logs are
+ * persisted against the target rather than against any issue it produced, so
+ * targets are the entry point for querying those logs.
+ */
+export interface PentestTargetSummary {
+  id: string;
+  url: string | null;
+  applicationId: string;
+  applicationName: string;
+  status: string;
+  attempt: number;
+  startedAt?: string;
+  completedAt?: string;
+  error: string | null;
+}
+
 export interface AgentLogEntry {
   id: string;
   createdAt: string;
@@ -109,6 +127,25 @@ export interface SearchAgentLogsResult {
   }>;
 }
 
+export interface ListTargetLogsResult {
+  targetId: string;
+  totalLogs: number;
+  returnedLogs: number;
+  logs: AgentLogEntry[];
+}
+
+export interface SearchTargetLogsResult {
+  targetId: string;
+  query: string;
+  totalMatches: number;
+  totalLogs?: number;
+  contextLines?: number;
+  matches: Array<{
+    matchIndex: number;
+    entries: Array<AgentLogEntry & { isMatch: boolean }>;
+  }>;
+}
+
 // ── API functions ────────────────────────────────────────────────────
 
 export async function listScans(): Promise<ScanSummary[]> {
@@ -117,6 +154,15 @@ export async function listScans(): Promise<ScanSummary[]> {
 
 export async function getScan(scanId: string): Promise<ScanDetail> {
   return apiRequest<ScanDetail>("GET", `/pentests/${scanId}`);
+}
+
+export async function listPentestTargets(
+  pentestId: string,
+): Promise<PentestTargetSummary[]> {
+  return apiRequest<PentestTargetSummary[]>(
+    "GET",
+    `/pentests/${pentestId}/targets`,
+  );
 }
 
 export async function dispatchPentest(opts?: {
@@ -198,6 +244,40 @@ export async function searchAgentLogs(
   return apiRequest<SearchAgentLogsResult>(
     "POST",
     `/issues/${issueId}/logs/search`,
+    { query, ...opts },
+  );
+}
+
+export async function listTargetLogs(
+  targetId: string,
+  opts?: {
+    level?: "debug" | "info" | "warn" | "error";
+    role?: "assistant" | "user" | "system" | "tool-call" | "tool-result";
+    limit?: number;
+  },
+): Promise<ListTargetLogsResult> {
+  const params = new URLSearchParams();
+  if (opts?.level) params.set("level", opts.level);
+  if (opts?.role) params.set("role", opts.role);
+  if (opts?.limit) params.set("limit", String(opts.limit));
+
+  const qs = params.toString();
+  const path = `/targets/${targetId}/logs${qs ? `?${qs}` : ""}`;
+  return apiRequest<ListTargetLogsResult>("GET", path);
+}
+
+export async function searchTargetLogs(
+  targetId: string,
+  query: string,
+  opts?: {
+    level?: "debug" | "info" | "warn" | "error";
+    role?: "assistant" | "user" | "system" | "tool-call" | "tool-result";
+    contextLines?: number;
+  },
+): Promise<SearchTargetLogsResult> {
+  return apiRequest<SearchTargetLogsResult>(
+    "POST",
+    `/targets/${targetId}/logs/search`,
     { query, ...opts },
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Pentest agent logs are persisted against a **scan endpoint** (a single endpoint exercised during the pentest), not against the issues the pentest produces. So `pensar logs <issueId>` can never show the original pentest discovery activity, and there's no way to read logs for an endpoint that produced no issue.

This adds a `pensar targets` command to query those logs. The CLI deliberately calls these scan endpoints **"targets"** rather than exposing the internal `scan_endpoints` name.

```
pensar targets <pentestId>                       List a pentest's targets
pensar targets logs <targetId> [filters]          List a target's agent logs
pensar targets search <targetId> <query> [opts]   Search a target's agent logs
```

`logs` supports `--level` / `--role` / `--limit`; `search` supports `--level` / `--role` / `--context`, mirroring the existing `pensar logs` command.

Backed by three new API client functions in `src/core/api/issues.ts` — `listPentestTargets`, `listTargetLogs`, `searchTargetLogs` — hitting the new console REST endpoints `GET /pentests/:id/targets`, `GET /targets/:id/logs`, and `POST /targets/:id/logs/search`. New types and functions are re-exported from the `./core/api` barrel, and `targets` is registered in the CLI router and `--help`.

> Requires the companion console PR (`feat(api): expose pentest target logs over the REST API`) for the backing endpoints.

### How did you verify your code works?

- `bun run tsc` — clean.
- `bun run check` (Biome lint + format + organize imports) — clean on all changed/new files.
- `bun run test` — full suite passes (1138 passed, 15 skipped).
- `bun run build` — succeeds.
- Smoke-tested routing: `pensar targets --help` renders the new command help, and `targets` routes through `src/cli.ts` to `src/cli/targets.ts`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aac8d105-d1e2-4817-91d4-6212a9549f9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aac8d105-d1e2-4817-91d4-6212a9549f9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

