### PR TITLE
feat(apps): support moving an endpoint to a different app via endpoin…

### DIFF
--- a/src/cli/apps.ts
+++ b/src/cli/apps.ts
@@ -173,6 +173,8 @@ Search options (scoped to the workspace):
   --offset <n>                 Page offset
 
 Endpoint fields (create requires --endpoint and --description):
+  --app <id>                   endpoint-update only: move the endpoint to a
+                               different application (UUID) in the workspace
   --endpoint <text>            Endpoint path / URL / route
   --description <text>         Endpoint description
   --type <type>                One of: ${ENDPOINT_TYPES.join(", ")}
@@ -280,6 +282,8 @@ function parseEndpointCreateOptions(argv: string[]): CreateEndpointInput {
 
 function parseEndpointUpdateOptions(argv: string[]): UpdateEndpointInput {
   const update: UpdateEndpointInput = {};
+  const applicationId = getFlag("--app", argv);
+  if (applicationId !== undefined) update.applicationId = applicationId;
   const endpoint = getFlag("--endpoint", argv);
   if (endpoint !== undefined) update.endpoint = endpoint;
   const description = getFlag("--description", argv);

--- a/src/core/api/apps.test.ts
+++ b/src/core/api/apps.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiRequest = vi.hoisted(() => vi.fn());
+
+vi.mock("./apiClient", () => ({ apiRequest }));
+
+import { updateEndpoint } from "./apps";
+
+const ENDPOINT_ID = "55555555-5555-5555-5555-555555555555";
+const NEW_APP_ID = "66666666-6666-6666-6666-666666666666";
+
+describe("updateEndpoint", () => {
+  beforeEach(() => {
+    apiRequest.mockReset();
+    apiRequest.mockResolvedValue({ id: ENDPOINT_ID });
+  });
+
+  it("PATCHes the endpoint and forwards applicationId when moving apps", async () => {
+    await updateEndpoint(ENDPOINT_ID, { applicationId: NEW_APP_ID });
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      "PATCH",
+      `/endpoints/${ENDPOINT_ID}`,
+      { applicationId: NEW_APP_ID },
+    );
+  });
+
+  it("forwards applicationId alongside other endpoint fields", async () => {
+    await updateEndpoint(ENDPOINT_ID, {
+      applicationId: NEW_APP_ID,
+      description: "moved",
+    });
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      "PATCH",
+      `/endpoints/${ENDPOINT_ID}`,
+      { applicationId: NEW_APP_ID, description: "moved" },
+    );
+  });
+});

--- a/src/core/api/apps.ts
+++ b/src/core/api/apps.ts
@@ -151,6 +151,8 @@ export interface CreateEndpointInput {
 }
 
 export interface UpdateEndpointInput {
+  /** Move the endpoint to a different application within the workspace. */
+  applicationId?: string;
   endpoint?: string;
   description?: string;
   type?: EndpointType | null;


### PR DESCRIPTION
…t-update

Add an optional --app <appId> flag to `pensar apps endpoint-update` and an `applicationId` field on UpdateEndpointInput so an endpoint can be reparented to another application in the workspace. The id is forwarded in the PATCH /endpoints/:id body.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI/API-client extension with tests; relies on backend accepting `applicationId` on PATCH but no auth or core infra changes in this diff.
> 
> **Overview**
> Adds **reparenting** for workspace endpoints: `pensar apps endpoint-update` now accepts `--app <uuid>` to move an endpoint to another application in the same workspace.
> 
> The CLI maps that flag to a new optional `applicationId` on `UpdateEndpointInput`, which is sent in the existing `PATCH /endpoints/:id` body (alongside other update fields). Help text clarifies that `--app` on endpoint fields is **endpoint-update only** (search-endpoints still uses `--app` to scope search).
> 
> Vitest coverage asserts `updateEndpoint` forwards `applicationId` alone and combined with other fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5a1c3a6e75d810459b5fcf89ac62244de3c1f71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->