### PR TITLE
Cursor/fix orphaned chromium leak 8c88

### DIFF
--- a/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
@@ -1,8 +1,10 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  collectDescendantPids,
   createBrowserTools,
   PlaywrightMcpSession,
   parseStorageStateResult,
@@ -246,6 +248,48 @@ describe("PlaywrightMcpSession.disconnect()", () => {
     await vi.advanceTimersByTimeAsync(5_000);
     await done;
     expect(settled).toBe(true);
+  });
+});
+
+// Regression: forceKillProcess() only group-killed the MCP node, which isn't a
+// process-group leader — so the kill fell back to killing just the node and
+// orphaned the Chromium it launched (reparented to init), leaking ~0.5GB per
+// completed endpoint until the sandbox OOM'd. collectDescendantPids enumerates
+// the browser tree so it can be SIGKILLed explicitly.
+describe("collectDescendantPids", () => {
+  const hasProc = existsSync("/proc/self");
+
+  (hasProc ? it : it.skip)(
+    "enumerates descendant processes spawned under a parent",
+    async () => {
+      // sh forks two background `sleep` children we can discover + reap.
+      const parent = spawn("sh", ["-c", "sleep 30 & sleep 30 & wait"], {
+        stdio: "ignore",
+      });
+      const cleanup = (pids: number[]) => {
+        for (const pid of pids) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {
+            /* already gone */
+          }
+        }
+      };
+      try {
+        // Give sh a moment to fork its children.
+        await new Promise((r) => setTimeout(r, 400));
+        const descendants = collectDescendantPids(parent.pid!);
+        expect(descendants.length).toBeGreaterThanOrEqual(2);
+        cleanup([...descendants, parent.pid!]);
+      } finally {
+        cleanup([parent.pid!]);
+      }
+    },
+  );
+
+  (hasProc ? it : it.skip)("returns [] for a leaf pid with no children", () => {
+    // A made-up high pid that almost certainly has no children.
+    expect(collectDescendantPids(2_147_483_646)).toEqual([]);
   });
 });
 

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -8,7 +8,13 @@
  * - "operator": User-driven operator mode - SPA reconnaissance, authenticated flows, attack surface mapping
  */
 
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -280,6 +286,65 @@ function withTimeout<T>(
   return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
+/**
+ * Collect every descendant PID of `rootPid` by walking `/proc` parent links
+ * (Linux only). Returns `[]` on platforms without `/proc` (e.g. macOS dev),
+ * where the process-group SIGKILL path is relied on instead.
+ *
+ * Used to reap the Chromium browser tree a Playwright MCP `node` child
+ * launches. `StdioClientTransport` does not spawn that `node` as a
+ * process-group leader, so `process.kill(-pid)` fails and only the `node`
+ * dies — orphaning Chromium (reparented to init) and leaking ~0.5GB per
+ * completed endpoint until the sandbox OOMs. Enumerating descendants lets us
+ * SIGKILL the browser explicitly. Must be called BEFORE the parent is killed:
+ * once it dies its children reparent to init and are no longer reachable via
+ * its pid.
+ *
+ * @internal Exported for testing.
+ */
+export function collectDescendantPids(rootPid: number): number[] {
+  let entries: string[];
+  try {
+    entries = readdirSync("/proc");
+  } catch {
+    return [];
+  }
+
+  const childrenByPpid = new Map<number, number[]>();
+  for (const name of entries) {
+    if (!/^\d+$/.test(name)) continue;
+    const pid = Number(name);
+    let ppid: number;
+    try {
+      // /proc/<pid>/stat: "pid (comm) state ppid ...". comm can contain spaces
+      // and parens, so parse the ppid from after the final ')'.
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const afterComm = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+      ppid = Number(afterComm[1]);
+    } catch {
+      continue; // process exited between readdir and read
+    }
+    if (!Number.isFinite(ppid)) continue;
+    const list = childrenByPpid.get(ppid);
+    if (list) list.push(pid);
+    else childrenByPpid.set(ppid, [pid]);
+  }
+
+  const descendants: number[] = [];
+  const seen = new Set<number>([rootPid]);
+  const stack = [rootPid];
+  while (stack.length > 0) {
+    const pid = stack.pop()!;
+    for (const child of childrenByPpid.get(pid) ?? []) {
+      if (seen.has(child)) continue;
+      seen.add(child);
+      descendants.push(child);
+      stack.push(child);
+    }
+  }
+  return descendants;
+}
+
 // ---------------------------------------------------------------------------
 // Module-level defaults (used when not explicitly provided)
 // ---------------------------------------------------------------------------
@@ -439,6 +504,13 @@ export class PlaywrightMcpSession {
   ): void {
     if (!proc || proc.exitCode !== null) return;
 
+    // Snapshot the descendant tree (Chromium browser + renderers) BEFORE the
+    // node dies — afterwards they reparent to init and can't be found via its
+    // pid. The group-kill below misses them because the MCP node isn't spawned
+    // as a process-group leader, which orphaned Chromium and leaked memory
+    // across endpoints until the sandbox OOM'd.
+    const descendants = proc.pid ? collectDescendantPids(proc.pid) : [];
+
     try {
       if (proc.pid) {
         try {
@@ -451,6 +523,15 @@ export class PlaywrightMcpSession {
       }
     } catch {
       // Already dead — fine
+    }
+
+    // Reap the browser tree explicitly so a failed group-kill can't strand it.
+    for (const pid of descendants) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // Already gone — fine
+      }
     }
   }
 

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -352,9 +352,47 @@ const fs = require('fs');
         fs.writeFileSync('${SANDBOX_CONSOLE_FILE}', JSON.stringify(existing));
       } catch {}
     }
+    // Tear the browser down so a wedged Camoufox can't orphan inside the
+    // sandbox and accumulate across tool calls until it OOMs. context.close()
+    // can hang on a stuck browser (same wedge class as the host MCP path), so
+    // bound it, then SIGKILL any surviving descendant PIDs of this script — the
+    // in-sandbox analog of collectDescendantPids() in playwrightMcp.ts. Only
+    // this script's own children are touched, so it is safe under the parent +
+    // worker concurrency that shares a sandbox.
     if (context) {
-      try { await context.close(); } catch {}
+      let __closeTimer;
+      await Promise.race([
+        (async () => { try { await context.close(); } catch {} })(),
+        new Promise((r) => { __closeTimer = setTimeout(r, 8000); }),
+      ]);
+      if (__closeTimer) clearTimeout(__closeTimer);
     }
+    try {
+      if (fs.existsSync('/proc')) {
+        const __childrenByPpid = new Map();
+        for (const __name of fs.readdirSync('/proc')) {
+          if (!/^[0-9]+$/.test(__name)) continue;
+          try {
+            const __stat = fs.readFileSync('/proc/' + __name + '/stat', 'utf8');
+            const __ppid = Number(__stat.slice(__stat.lastIndexOf(')') + 2).split(' ')[1]);
+            if (!Number.isFinite(__ppid)) continue;
+            if (!__childrenByPpid.has(__ppid)) __childrenByPpid.set(__ppid, []);
+            __childrenByPpid.get(__ppid).push(Number(__name));
+          } catch {}
+        }
+        const __doomed = [];
+        const __seen = new Set([process.pid]);
+        const __stack = [process.pid];
+        while (__stack.length) {
+          const __p = __stack.pop();
+          for (const __c of (__childrenByPpid.get(__p) || [])) {
+            if (__seen.has(__c)) continue;
+            __seen.add(__c); __doomed.push(__c); __stack.push(__c);
+          }
+        }
+        for (const __p of __doomed) { try { process.kill(__p, 'SIGKILL'); } catch {} }
+      }
+    } catch {}
   }
 })();
 `;


### PR DESCRIPTION
### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Teardown now force-kills process trees via `/proc`; wrong PID selection could affect unrelated processes, though sandbox logic limits kills to the script’s descendants and host logic targets the MCP child tree.
> 
> **Overview**
> Fixes **orphaned Chromium/Camoufox** processes that survived MCP and sandbox browser teardown. Group `SIGKILL` on the Playwright MCP `node` child often only killed that process (it is not a process-group leader), leaving the browser tree running and leaking memory until sandboxes OOM.
> 
> On the **host MCP path**, adds **`collectDescendantPids`** (Linux `/proc` parent walk) and updates **`forceKillProcess`** to snapshot descendants **before** killing the parent, then **`SIGKILL`** each descendant after the usual group/single kill.
> 
> On the **sandbox Playwright path**, each generated script now **bounds `context.close()`** (8s) and, when `/proc` exists, **walks and SIGKILLs descendant PIDs** of the script process—same idea, scoped to that script’s children for shared-sandbox safety.
> 
> Adds **Linux-gated tests** for `collectDescendantPids` (skipped without `/proc`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd5f35f54f0b16d5b0d3d3343227a3107d862456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->