### PR TITLE
Cursor/expose reasoning deltas a126

### DIFF
--- a/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.ts
@@ -48,6 +48,7 @@ interface SharedAgentOptions {
   onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
   onCacheMetrics?: (metrics: CacheMetrics) => void;
   openAIReasoningEffort?: OpenAIReasoningEffort | null;
+  enableThinking?: boolean;
   projectThreatModel?: string;
   /** Parent subagent id for hierarchy tracking on emitted lifecycle events. */
   parentSubagentId?: string;
@@ -168,6 +169,7 @@ async function runEndpointDocumentationAgent(
     onStepFinish,
     onCacheMetrics,
     openAIReasoningEffort,
+    enableThinking,
     projectThreatModel,
     parentSubagentId,
   } = opts;
@@ -209,6 +211,7 @@ async function runEndpointDocumentationAgent(
     onStepFinish: (event) => onStepFinish?.(event),
     onCacheMetrics,
     openAIReasoningEffort,
+    enableThinking,
     responseSchema: DiscoverySummarySchema,
     // Hard-exclude tools an endpoint documentation agent must never use:
     // - document_app: Phase 1 owns app discovery.

--- a/src/core/api/attackSurface.ts
+++ b/src/core/api/attackSurface.ts
@@ -74,6 +74,8 @@ async function runWhiteboxAttackSurface(
     attackSurfaceRegistry: input.attackSurfaceRegistry,
     eventBus: input.eventBus,
     surfaceIntegrationEnabled: input.surfaceIntegrationEnabled,
+    enableThinking: input.enableThinking,
+    openAIReasoningEffort: input.openAIReasoningEffort,
   });
 
   console.log(

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -11,6 +11,13 @@ import type { TextStreamPart, ToolSet } from "ai";
  */
 export type AgentEventMap = {
   "text-delta": { text: string; subagentId?: string };
+  /**
+   * Extended-thinking / reasoning output streamed incrementally. Mirrors
+   * `text-delta` but carries the model's reasoning tokens (Anthropic
+   * extended thinking, OpenAI reasoning) so consumers can surface a
+   * "thinking" indicator instead of appearing to hang between tool calls.
+   */
+  "reasoning-delta": { text: string; subagentId?: string };
   "tool-call-start": {
     toolCallId: string;
     toolName: string;
@@ -95,6 +102,7 @@ const CHILD_BUS_FORWARD_POLICY: {
   readonly [K in keyof AgentEventMap]: ChildForwardPolicy;
 } = {
   "text-delta": "forward",
+  "reasoning-delta": "forward",
   "tool-call-start": "forward",
   "tool-call-delta": "forward",
   "tool-call-complete": "forward",
@@ -232,6 +240,7 @@ export class AgentEventBus {
    *
    * Maps Vercel AI SDK `TextStreamPart` types to `AgentEventMap` keys:
    *   text-delta        → text-delta
+   *   reasoning-delta   → reasoning-delta
    *   tool-input-start  → tool-call-start
    *   tool-input-delta  → tool-call-delta
    *   tool-call         → tool-call-complete
@@ -242,6 +251,9 @@ export class AgentEventBus {
     switch (chunk.type) {
       case "text-delta":
         this.emit("text-delta", { text: chunk.text, subagentId });
+        break;
+      case "reasoning-delta":
+        this.emit("reasoning-delta", { text: chunk.text, subagentId });
         break;
       case "tool-input-start":
         this.emit("tool-call-start", {

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -18,6 +18,10 @@ export type AgentEventMap = {
    * "thinking" indicator instead of appearing to hang between tool calls.
    */
   "reasoning-delta": { text: string; subagentId?: string };
+  /** A reasoning block opened. Lets consumers time the thinking window. */
+  "reasoning-start": { subagentId?: string };
+  /** A reasoning block closed. Paired with `reasoning-start` to derive duration. */
+  "reasoning-end": { subagentId?: string };
   "tool-call-start": {
     toolCallId: string;
     toolName: string;
@@ -103,6 +107,8 @@ const CHILD_BUS_FORWARD_POLICY: {
 } = {
   "text-delta": "forward",
   "reasoning-delta": "forward",
+  "reasoning-start": "forward",
+  "reasoning-end": "forward",
   "tool-call-start": "forward",
   "tool-call-delta": "forward",
   "tool-call-complete": "forward",
@@ -240,7 +246,9 @@ export class AgentEventBus {
    *
    * Maps Vercel AI SDK `TextStreamPart` types to `AgentEventMap` keys:
    *   text-delta        → text-delta
+   *   reasoning-start   → reasoning-start
    *   reasoning-delta   → reasoning-delta
+   *   reasoning-end     → reasoning-end
    *   tool-input-start  → tool-call-start
    *   tool-input-delta  → tool-call-delta
    *   tool-call         → tool-call-complete
@@ -252,8 +260,14 @@ export class AgentEventBus {
       case "text-delta":
         this.emit("text-delta", { text: chunk.text, subagentId });
         break;
+      case "reasoning-start":
+        this.emit("reasoning-start", { subagentId });
+        break;
       case "reasoning-delta":
         this.emit("reasoning-delta", { text: chunk.text, subagentId });
+        break;
+      case "reasoning-end":
+        this.emit("reasoning-end", { subagentId });
         break;
       case "tool-input-start":
         this.emit("tool-call-start", {

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -104,6 +104,8 @@ export interface WhiteboxAttackSurfaceWorkflowInput {
   onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
   onCacheMetrics?: (metrics: CacheMetrics) => void;
   openAIReasoningEffort?: OpenAIReasoningEffort | null;
+  /** Enable extended thinking for supported models (Anthropic Claude 3.7+). */
+  enableThinking?: boolean;
   /** Known domains associated with the project — agents can map discovered apps to these. */
   domains?: string[];
   /** Project-level threat model content (e.g. from .pensar/threat_model.md), if found */
@@ -158,6 +160,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     onStepFinish,
     onCacheMetrics,
     openAIReasoningEffort,
+    enableThinking,
     domains,
     projectThreatModel,
     environments,
@@ -188,6 +191,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     onStepFinish: (event) => onStepFinish?.(event),
     onCacheMetrics,
     openAIReasoningEffort,
+    enableThinking,
     responseSchema: AppsDiscoveryResultSchema,
     projectThreatModel,
     // Reserved for Phase 2's per-app task agents. Inline documentation
@@ -342,6 +346,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
       onStepFinish: (event) => onStepFinish?.(event),
       onCacheMetrics,
       openAIReasoningEffort,
+      enableThinking,
       responseSchema: DiscoverySummarySchema,
       excludeTools: ["document_app"],
       projectThreatModel,
@@ -434,6 +439,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
               onStepFinish,
               onCacheMetrics,
               openAIReasoningEffort,
+              enableThinking,
               projectThreatModel,
               parentSubagentId: appNodeId,
             });
@@ -1153,6 +1159,7 @@ export async function runIncrementalWhiteboxAttackSurfaceWorkflow(
     subagentId: "whitebox-incremental",
     onStepFinish: (event) => onStepFinish?.(event),
     openAIReasoningEffort: input.openAIReasoningEffort,
+    enableThinking: input.enableThinking,
     responseSchema: IncrementalResultSchema,
     projectThreatModel,
   });


### PR DESCRIPTION
### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and optional model-config plumbing only; no auth, data, or attack-surface logic changes beyond passing flags into existing agents.
> 
> **Overview**
> **Exposes extended-thinking / reasoning stream chunks to UI and other bus consumers** so agents no longer look idle between tool calls when models emit reasoning tokens.
> 
> `AgentEventBus` gains **`reasoning-start`**, **`reasoning-delta`**, and **`reasoning-end`** events (with optional `subagentId`), mapped from the Vercel AI SDK `fullStream` in `emitStreamPart`. Those events are **`forward`**ed from child buses to parents like `text-delta`, so nested whitebox subagents still bubble reasoning to the top-level consumer.
> 
> **`enableThinking`** is threaded from the whitebox attack-surface entrypoint through `runWhiteboxAttackSurfaceWorkflow` into Phase 1/2 discovery agents, per-endpoint documentation agents, and the incremental workflow. **`runWhiteboxAttackSurface`** also now passes **`openAIReasoningEffort`** into the workflow (previously only other fields were forwarded).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acb9437fcdaa0c4cb3d9a4bb4e9b9fdad3b40858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->