### PR TITLE
fix(prompt-injections): tolerate externally-curated catalogs in list_prompt_injections

### DIFF
--- a/src/core/agents/offSecAgent/tools/listPromptInjections.test.ts
+++ b/src/core/agents/offSecAgent/tools/listPromptInjections.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { StaticPromptInjectionLibrary } from "../../../prompt-injections";
 import type { SessionInfo } from "../../../session";
@@ -106,6 +109,76 @@ describe("listPromptInjections", () => {
     expect(result.success).toBe(true);
     expect(result.injections).toHaveLength(1);
     expect(result.injections[0].id).toBe("pi.encoded.override");
+  });
+
+  it("loads an externally-curated on-disk catalog and lists every payload", async () => {
+    const root = await mkdtemp(join(tmpdir(), "apex-listpi-"));
+    try {
+      await mkdir(join(root, "payloads"));
+      // Mimic the shape of the private S3 catalog: many entries, no `name`,
+      // categories outside Apex's built-in enum.
+      const payloads = Array.from({ length: 5 }, (_, i) => ({
+        id: `pi.ext.${i}`,
+        category: i % 2 === 0 ? "jailbreak" : "obfuscation",
+        payloadPath: `payloads/p${i}.txt`,
+      }));
+      await Promise.all(
+        payloads.map((p, i) =>
+          writeFile(join(root, "payloads", `p${i}.txt`), `RAW PAYLOAD ${i}`),
+        ),
+      );
+      await writeFile(join(root, "catalog.json"), JSON.stringify({ payloads }));
+
+      const tool = listPromptInjections(
+        makeCtx({ promptInjectionLibrarySource: root }),
+      );
+      const result = (await tool.execute?.(
+        { toolCallDescription: "List prompt injection tests" },
+        { toolCallId: "tc_test", messages: [], abortSignal: undefined },
+      )) as ListPromptInjectionsResult;
+
+      expect(result.success).toBe(true);
+      expect(result.configured).toBe(true);
+      expect(result.count).toBe(5);
+      expect(JSON.stringify(result)).not.toContain("RAW PAYLOAD");
+
+      const filtered = (await tool.execute?.(
+        { category: "jailbreak", toolCallDescription: "List jailbreaks" },
+        { toolCallId: "tc_test", messages: [], abortSignal: undefined },
+      )) as ListPromptInjectionsResult;
+      expect(filtered.count).toBe(3);
+      expect(filtered.injections.every((e) => e.category === "jailbreak")).toBe(
+        true,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns an agent-friendly error instead of throwing on a malformed catalog", async () => {
+    const root = await mkdtemp(join(tmpdir(), "apex-listpi-bad-"));
+    try {
+      // Entry missing the required payloadPath — schema parsing must fail.
+      await writeFile(
+        join(root, "catalog.json"),
+        JSON.stringify({ payloads: [{ id: "pi.broken" }] }),
+      );
+
+      const tool = listPromptInjections(
+        makeCtx({ promptInjectionLibrarySource: root }),
+      );
+      const result = (await tool.execute?.(
+        { toolCallDescription: "List prompt injection tests" },
+        { toolCallId: "tc_test", messages: [], abortSignal: undefined },
+      )) as ListPromptInjectionsResult & { error?: string };
+
+      expect(result.success).toBe(false);
+      expect(result.count).toBe(0);
+      expect(result.injections).toEqual([]);
+      expect(result.error).toContain("Failed to load the prompt-injection");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("returns an empty catalog when no library is configured", async () => {

--- a/src/core/agents/offSecAgent/tools/listPromptInjections.ts
+++ b/src/core/agents/offSecAgent/tools/listPromptInjections.ts
@@ -11,15 +11,14 @@ export function listPromptInjections(ctx: ToolContext) {
       'PromptInjectionRef: {"kind":"prompt_injection_ref","id":"<id>"} when a tool supports runtime injection references.',
     inputSchema: z.object({
       category: z
-        .enum([
-          "instruction-hijack",
-          "data-exfiltration",
-          "tool-misuse",
-          "role-confusion",
-          "encoding",
-        ])
+        .string()
         .optional()
-        .describe("Optional category filter."),
+        .describe(
+          "Optional category filter. Free-form string matched against the " +
+            "catalog's category field (e.g. instruction-hijack, " +
+            "data-exfiltration, tool-misuse, role-confusion, encoding). " +
+            "Omit to list every category.",
+        ),
       tag: z.string().optional().describe("Optional tag filter."),
       toolCallDescription: z
         .string()
@@ -28,18 +27,34 @@ export function listPromptInjections(ctx: ToolContext) {
         ),
     }),
     execute: async ({ category, tag }) => {
-      const library = await getPromptInjectionLibrary({
-        library: ctx.promptInjectionLibrary,
-        source: ctx.promptInjectionLibrarySource,
-      });
-      const injections = library
-        .listCatalog()
+      let library: Awaited<ReturnType<typeof getPromptInjectionLibrary>>;
+      try {
+        library = await getPromptInjectionLibrary({
+          library: ctx.promptInjectionLibrary,
+          source: ctx.promptInjectionLibrarySource,
+        });
+      } catch (err) {
+        // The catalog is externally curated; surface a concise, actionable
+        // message instead of dumping a raw schema/parse error at the agent.
+        return {
+          success: false,
+          configured: false,
+          count: 0,
+          injections: [],
+          error: `Failed to load the prompt-injection library: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        };
+      }
+
+      const catalog = library.listCatalog();
+      const injections = catalog
         .filter((entry) => !category || entry.category === category)
         .filter((entry) => !tag || entry.tags.includes(tag));
 
       return {
         success: true,
-        configured: library.listCatalog().length > 0,
+        configured: catalog.length > 0,
         count: injections.length,
         injections,
       };

--- a/src/core/agents/offSecAgent/tools/listPromptInjections.ts
+++ b/src/core/agents/offSecAgent/tools/listPromptInjections.ts
@@ -14,16 +14,31 @@ export function listPromptInjections(ctx: ToolContext) {
         .string()
         .optional()
         .describe(
-          "Optional category filter. Free-form string matched against the " +
-            "catalog's category field (e.g. instruction-hijack, " +
-            "data-exfiltration, tool-misuse, role-confusion, encoding). " +
-            "Omit to list every category.",
+          "Optional category filter. Returns only payloads whose `category` " +
+            "field matches this value exactly (case-sensitive). The library is " +
+            "externally curated, so categories vary; common ones include " +
+            "instruction-hijack, data-exfiltration, tool-misuse, role-confusion, " +
+            "and encoding. Call the tool once without filters first to discover " +
+            "the exact category strings available, then re-call with one of them. " +
+            "Omit to list payloads from every category.",
         ),
-      tag: z.string().optional().describe("Optional tag filter."),
+      tag: z
+        .string()
+        .optional()
+        .describe(
+          "Optional tag filter. Returns only payloads whose `tags` array " +
+            "contains this exact tag (case-sensitive). Tags are free-form labels " +
+            'defined by the library (e.g. "baseline", "encoding", "secrets"); ' +
+            "inspect the `tags` on an unfiltered listing to find valid values. " +
+            "Combine with `category` to narrow results further. Omit to ignore tags.",
+        ),
       toolCallDescription: z
         .string()
         .describe(
-          "A concise, human-readable description of why you are listing prompt-injection payloads.",
+          "A concise, human-readable description (one short sentence) of why " +
+            "you are listing prompt-injection payloads right now, e.g. " +
+            '"Finding tool-misuse payloads to test the support-ticket endpoint". ' +
+            "Shown in the run timeline for auditability.",
         ),
     }),
     execute: async ({ category, tag }) => {

--- a/src/core/prompt-injections/index.test.ts
+++ b/src/core/prompt-injections/index.test.ts
@@ -148,6 +148,54 @@ describe("prompt injection library", () => {
     }
   });
 
+  it("tolerates externally-curated catalogs with novel categories and missing names", async () => {
+    const root = await mkdtemp(join(tmpdir(), "apex-prompt-library-ext-"));
+    try {
+      await mkdir(join(root, "payloads"));
+      await writeFile(join(root, "payloads", "p0.txt"), "RAW PAYLOAD ZERO");
+      await writeFile(join(root, "payloads", "p1.txt"), "RAW PAYLOAD ONE");
+      await writeFile(
+        join(root, "catalog.json"),
+        JSON.stringify({
+          payloads: [
+            {
+              // No `name`, a category outside Apex's built-in set, and no
+              // `description` — the loader must still accept this entry.
+              id: "pi.ext.jailbreak",
+              category: "jailbreak",
+              payloadPath: "payloads/p0.txt",
+            },
+            {
+              id: "pi.ext.exfil",
+              name: "Exfil Variant",
+              category: "data-exfiltration",
+              tags: ["exfil"],
+              payloadPath: "payloads/p1.txt",
+            },
+          ],
+        }),
+      );
+
+      const library = await getPromptInjectionLibrary({ source: root });
+      const catalog = library.listCatalog();
+
+      expect(catalog).toHaveLength(2);
+
+      const jailbreak = catalog.find((e) => e.id === "pi.ext.jailbreak")!;
+      expect(jailbreak.category).toBe("jailbreak");
+      // Missing name falls back to the id.
+      expect(jailbreak.name).toBe("pi.ext.jailbreak");
+      expect(jailbreak.description).toBe("");
+      expect(jailbreak.tags).toEqual([]);
+
+      // Payload text is still resolvable but never present in the catalog.
+      expect(library.getPayload("pi.ext.jailbreak")).toBe("RAW PAYLOAD ZERO");
+      expect(JSON.stringify(catalog)).not.toContain("RAW PAYLOAD ZERO");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("rejects remote prompt injection library sources", async () => {
     await expect(
       getPromptInjectionLibrary({

--- a/src/core/prompt-injections/index.ts
+++ b/src/core/prompt-injections/index.ts
@@ -3,12 +3,25 @@ import { readFileSync, statSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { z } from "zod";
 
+/**
+ * Categories Apex ships with first-class knowledge of. The runtime library is
+ * an open-ended, externally-curated dataset, so the catalog schema accepts any
+ * non-empty category string — these are kept only for typing/autocomplete and
+ * as the suggested set surfaced to agents.
+ */
+export const KNOWN_PROMPT_INJECTION_CATEGORIES = [
+  "instruction-hijack",
+  "data-exfiltration",
+  "tool-misuse",
+  "role-confusion",
+  "encoding",
+] as const;
+
 export type PromptInjectionCategory =
-  | "instruction-hijack"
-  | "data-exfiltration"
-  | "tool-misuse"
-  | "role-confusion"
-  | "encoding";
+  | (typeof KNOWN_PROMPT_INJECTION_CATEGORIES)[number]
+  // Allow any other category the external library defines without losing
+  // autocomplete on the known values above.
+  | (string & {});
 
 export type PromptInjectionRef = {
   kind: "prompt_injection_ref";
@@ -43,17 +56,16 @@ function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
+// The runtime catalog is a large, externally-curated dataset that evolves
+// independently of Apex. Only `id` and `payloadPath` are structurally required;
+// every other field is optional and tolerant so a new taxonomy or a missing
+// display name never hard-fails the whole library load (and never surfaces a
+// raw Zod union error to the agent calling list_prompt_injections).
 const PromptInjectionCatalogEntrySchema = z.object({
   id: z.string().min(1),
-  name: z.string().min(1),
-  category: z.enum([
-    "instruction-hijack",
-    "data-exfiltration",
-    "tool-misuse",
-    "role-confusion",
-    "encoding",
-  ]),
-  description: z.string(),
+  name: z.string().min(1).optional(),
+  category: z.string().min(1).optional(),
+  description: z.string().default(""),
   tags: z.array(z.string()).default([]),
   deliveryHints: z.array(z.string()).default([]),
   expectedObservation: z.string().default(""),
@@ -183,8 +195,17 @@ function parsePromptInjectionLibrary(
   const entries: PromptInjectionEntry[] = catalogEntries.map((entry) => {
     const payloadFile = resolvePayloadPath(root, entry.payloadPath);
     const payload = readFileSync(payloadFile, "utf-8");
-    const { payloadPath: _payloadPath, ...safeEntry } = entry;
-    return { ...safeEntry, payload, payloadFilePath: payloadFile };
+    const { payloadPath: _payloadPath, name, category, ...safeEntry } = entry;
+    return {
+      ...safeEntry,
+      // Fall back to the id for display when the catalog omits a name, and to a
+      // neutral bucket when it omits a category, so downstream metadata is
+      // always populated.
+      name: name ?? entry.id,
+      category: category ?? "uncategorized",
+      payload,
+      payloadFilePath: payloadFile,
+    };
   });
 
   return new StaticPromptInjectionLibrary(entries);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

The `list_prompt_injections` tool was failing with a raw Zod `invalid_union` error and returning no payloads, even though the runtime library (a large private S3 catalog) had entries available.

**Root cause:** the catalog parser (`src/core/prompt-injections/index.ts`) hard-coded a strict 5-value `category` enum and required a per-entry `name`/`description`. The real, externally-curated catalog has entries that omit `name` and use `category` values outside Apex's built-in set, so every entry failed schema validation. The resulting Zod union error (`expected array, received object` on one branch; `name` undefined / `category` invalid option on the others) was then surfaced verbatim to the agent — confusing and useless.

**Changes:**

- Widen `PromptInjectionCategory` to accept any string while keeping the known set (`instruction-hijack`, `data-exfiltration`, `tool-misuse`, `role-confusion`, `encoding`) for typing/autocomplete via `KNOWN_PROMPT_INJECTION_CATEGORIES`.
- Relax the catalog entry schema so only `id` and `payloadPath` are required: `name` and `category` are optional (defaulting to the `id` and `"uncategorized"`), and `description` defaults to `""`. Tags/hints already defaulted.
- Make the tool's `category` filter a free-form string so agents can filter by whatever categories the catalog actually defines.
- Catch library load/parse failures inside the tool and return a concise, agent-friendly `{ success: false, error }` result instead of throwing a raw Zod union dump.
- Expand the input-field descriptions on the tool schema (`category`, `tag`, `toolCallDescription`) so the agent understands exact-match semantics, the discover-first workflow (call unfiltered to learn the valid category/tag strings), and what to put in `toolCallDescription`.

This keeps payloads file-backed and never returns raw payload text — only safe metadata, same as before.

### How did you verify your code works?

- Added a unit test that loads an on-disk catalog mimicking the private S3 shape (many entries, no `name`, categories outside the enum) and asserts the loader accepts it, defaults the name to the id, and keeps payload text out of the catalog.
- Added an end-to-end tool test that drives `listPromptInjections.execute` against such a catalog via `promptInjectionLibrarySource`, asserting it lists every payload and filters correctly by a free-form category.
- Added a test asserting a malformed catalog yields the agent-friendly error result instead of throwing.
- `bun run test` (prompt-injection + all offSecAgent tool suites), `bun run tsc`, and `bun run lint` / `format:check` all pass locally.

Note: the real catalog is private (S3), so the tests use a representative local catalog that reproduces the exact shapes that were failing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1979688b-8e51-4b95-8f68-af3bd2b3ba67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1979688b-8e51-4b95-8f68-af3bd2b3ba67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

