### PR TITLE
feat(browser): default to headed mode on a virtual display

### DIFF
--- a/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
@@ -174,11 +174,21 @@ describe("PlaywrightMcpSession — constructor defaults", () => {
     viewportSize: string | undefined;
   };
 
-  it("defaults to headless + desktop UA + 1920x1080 when constructed with no args (regression: don't fall back to Chromium's tiny default viewport)", () => {
-    const session = new PlaywrightMcpSession() as unknown as InternalShape;
-    expect(session.headless).toBe(true);
-    expect(session.viewportSize).toBe("1920,1080");
-    expect(session.userAgent).toContain("Chrome/");
+  it("defaults to headless + desktop UA + 1920x1080 when constructed with no args and no display (regression: don't fall back to Chromium's tiny default viewport)", () => {
+    // The headless default is DISPLAY-aware (headed when a virtual display is
+    // present), so pin DISPLAY off to assert the no-display contract
+    // deterministically regardless of the host environment.
+    const originalDisplay = process.env.DISPLAY;
+    delete process.env.DISPLAY;
+    try {
+      const session = new PlaywrightMcpSession() as unknown as InternalShape;
+      expect(session.headless).toBe(true);
+      expect(session.viewportSize).toBe("1920,1080");
+      expect(session.userAgent).toContain("Chrome/");
+    } finally {
+      if (originalDisplay === undefined) delete process.env.DISPLAY;
+      else process.env.DISPLAY = originalDisplay;
+    }
   });
 
   it("uses explicit values when provided", () => {
@@ -200,6 +210,34 @@ describe("PlaywrightMcpSession — constructor defaults", () => {
     }) as unknown as InternalShape;
     expect(session.userAgent).toBeUndefined();
     expect(session.viewportSize).toBeUndefined();
+  });
+
+  describe("DISPLAY-aware headless default", () => {
+    const originalDisplay = process.env.DISPLAY;
+    afterEach(() => {
+      if (originalDisplay === undefined) delete process.env.DISPLAY;
+      else process.env.DISPLAY = originalDisplay;
+    });
+
+    it("defaults to headed when a virtual display is present and no explicit headless is given", () => {
+      process.env.DISPLAY = ":1";
+      const session = new PlaywrightMcpSession() as unknown as InternalShape;
+      expect(session.headless).toBe(false);
+    });
+
+    it("defaults to headless when no display is present", () => {
+      delete process.env.DISPLAY;
+      const session = new PlaywrightMcpSession() as unknown as InternalShape;
+      expect(session.headless).toBe(true);
+    });
+
+    it("respects an explicit headless=true even when a display is present", () => {
+      process.env.DISPLAY = ":1";
+      const session = new PlaywrightMcpSession({
+        headless: true,
+      }) as unknown as InternalShape;
+      expect(session.headless).toBe(true);
+    });
   });
 
   it("falls back to a hardcoded 1920x1080 floor for viewport even if the module default was cleared (regression: don't ship a Chromium-tiny viewport just because someone called setViewportSize(undefined))", () => {

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -448,7 +448,13 @@ export class PlaywrightMcpSession {
   constructor(options: PlaywrightMcpSessionOptions = {}) {
     const { headless, userAgent, viewportSize, extraHttpHeaders } = options;
 
-    this.headless = headless ?? defaultHeadless;
+    // An explicit option always wins. Otherwise, if a virtual display is
+    // present (e.g. a Daytona computer-use desktop on `DISPLAY=:1`), default
+    // to headed — Camoufox is far less detectable headful and the display
+    // lets the session be streamed/observed. With no display we keep the
+    // module default (headless). Mirrors the `DISPLAY`-aware policy already
+    // used on the sandbox-executor path (`sandboxPlaywright.ts`).
+    this.headless = headless ?? (process.env.DISPLAY ? false : defaultHeadless);
     this.userAgent =
       userAgent === null ? undefined : (userAgent ?? defaultUserAgent);
     this.viewportSize =
@@ -613,9 +619,16 @@ export class PlaywrightMcpSession {
           // CAMOU_CONFIG_* fingerprint chunks must reach the actual browser
           // process. The MCP node child inherits them (the transport merges
           // these over getDefaultEnvironment) and Firefox inherits in turn.
-          env: Object.fromEntries(
-            Object.entries(camou.env).map(([k, v]) => [k, String(v)]),
-          ),
+          // `DISPLAY` is NOT in the transport's default-inherited set, so a
+          // headful launch on a virtual display needs it threaded explicitly
+          // — without it Firefox can't find the X server and headed mode
+          // fails to start.
+          env: {
+            ...Object.fromEntries(
+              Object.entries(camou.env).map(([k, v]) => [k, String(v)]),
+            ),
+            ...(process.env.DISPLAY ? { DISPLAY: process.env.DISPLAY } : {}),
+          },
         });
 
         const client = new Client({


### PR DESCRIPTION
When DISPLAY is present (e.g. a Daytona computer-use desktop on :1), default PlaywrightMcpSession to headed and thread DISPLAY through to the spawned MCP/browser process (the MCP stdio transport doesn't inherit DISPLAY by default). An explicit headless option still wins. Mirrors the DISPLAY-aware policy already used on the sandbox-executor path.

This lets Console stream the pentest browser session over noVNC.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default browser launch mode and child-process environment in the off-sec agent path; mis-detection of DISPLAY could flip headless/headed behavior or break headed startup, but explicit options still override and scope is limited to Playwright MCP session setup.
> 
> **Overview**
> **`PlaywrightMcpSession` now picks headed vs headless from the environment:** when `DISPLAY` is set (e.g. Daytona `:1`), the constructor defaults to **headed** unless `headless` is passed explicitly; with no display it keeps the existing module default (headless). This aligns the MCP path with the sandbox executor’s DISPLAY policy.
> 
> **Headful launches also forward `DISPLAY` into the MCP stdio child’s `env`**, because the transport does not inherit it by default—without that, Firefox cannot attach to the X server and headed mode fails to start.
> 
> Tests pin `DISPLAY` for the “no args” default case and add coverage for headed-by-default, headless-without-display, and explicit `headless: true` overriding a present display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9493366b5207452bbe90f13315c1a46f727a6f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->