### PR TITLE
feat(browser): per-session display option for headed isolation

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -278,6 +278,10 @@ export class OffensiveSecurityAgent<TResult = void> {
       planSubagentId: input.planSubagentId,
       subagentId: input.subagentId,
       browserSession: this.browserSession,
+      // Propagate this agent's display so spawned workers run on the SAME
+      // virtual desktop (their browsers belong to the same endpoint's stream),
+      // rather than falling back to the process-wide DISPLAY (:0).
+      display: input.display,
     });
 
     let tools: ToolSet = input.extraTools

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -207,6 +207,7 @@ export class OffensiveSecurityAgent<TResult = void> {
         input.browserSession ??
         new PlaywrightMcpSession({
           extraHttpHeaders: stripBrowserManagedHeaders(sessionHeaders),
+          display: input.display,
         });
     } else {
       this.ownsBrowserSession = false;

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
@@ -172,6 +172,7 @@ describe("PlaywrightMcpSession — constructor defaults", () => {
     headless: boolean;
     userAgent: string | undefined;
     viewportSize: string | undefined;
+    display: string | undefined;
   };
 
   it("defaults to headless + desktop UA + 1920x1080 when constructed with no args and no display (regression: don't fall back to Chromium's tiny default viewport)", () => {
@@ -237,6 +238,33 @@ describe("PlaywrightMcpSession — constructor defaults", () => {
         headless: true,
       }) as unknown as InternalShape;
       expect(session.headless).toBe(true);
+    });
+
+    it("an explicit display option defaults to headed and overrides process.env.DISPLAY", () => {
+      // Pin the process-wide display to a different value (or absent) to prove
+      // the per-session option wins — this is what lets concurrent headed
+      // sessions in one process each target their own virtual desktop.
+      process.env.DISPLAY = ":1";
+      const session = new PlaywrightMcpSession({
+        display: ":11",
+      }) as unknown as InternalShape;
+      expect(session.display).toBe(":11");
+      expect(session.headless).toBe(false);
+    });
+
+    it("falls back to process.env.DISPLAY when no explicit display is given", () => {
+      process.env.DISPLAY = ":7";
+      const session = new PlaywrightMcpSession() as unknown as InternalShape;
+      expect(session.display).toBe(":7");
+    });
+
+    it("an explicit display still yields headed even with no process-wide display", () => {
+      delete process.env.DISPLAY;
+      const session = new PlaywrightMcpSession({
+        display: ":12",
+      }) as unknown as InternalShape;
+      expect(session.display).toBe(":12");
+      expect(session.headless).toBe(false);
     });
   });
 

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -412,6 +412,14 @@ export interface PlaywrightMcpSessionOptions {
   readonly userAgent?: string | null;
   readonly viewportSize?: string | null;
   readonly extraHttpHeaders?: Record<string, string> | null;
+  /**
+   * X display for this session's spawned browser (e.g. `":11"`). Overrides
+   * `process.env.DISPLAY` for THIS session only. Required for per-agent display
+   * isolation: when several headed sessions run in one process (e.g. concurrent
+   * per-endpoint pentests), a single process-wide `DISPLAY` env can't separate
+   * them, so each is given its own display explicitly.
+   */
+  readonly display?: string;
 }
 
 /**
@@ -435,6 +443,8 @@ export class PlaywrightMcpSession {
   private readonly userAgent: string | undefined;
   private readonly viewportSize: string | undefined;
   private readonly extraHttpHeaders: Record<string, string> | undefined;
+  /** X display for the spawned browser; overrides `process.env.DISPLAY`. */
+  private readonly display: string | undefined;
   /** Temp config file written for MCP launch — deleted on disconnect. */
   private mcpConfigPath: string | null = null;
   /** Cached Camoufox launch options — resolved once, reused on reconnect. */
@@ -446,15 +456,22 @@ export class PlaywrightMcpSession {
    * hard floor of `HARDCODED_VIEWPORT_FALLBACK` to avoid Chromium's tiny built-in.
    */
   constructor(options: PlaywrightMcpSessionOptions = {}) {
-    const { headless, userAgent, viewportSize, extraHttpHeaders } = options;
+    const { headless, userAgent, viewportSize, extraHttpHeaders, display } =
+      options;
+
+    // An explicit `display` option wins over the process-wide env (needed when
+    // concurrent headed sessions each need their own display); fall back to
+    // `process.env.DISPLAY`.
+    this.display = display ?? process.env.DISPLAY ?? undefined;
 
     // An explicit option always wins. Otherwise, if a virtual display is
-    // present (e.g. a Daytona computer-use desktop on `DISPLAY=:1`), default
-    // to headed — Camoufox is far less detectable headful and the display
-    // lets the session be streamed/observed. With no display we keep the
-    // module default (headless). Mirrors the `DISPLAY`-aware policy already
-    // used on the sandbox-executor path (`sandboxPlaywright.ts`).
-    this.headless = headless ?? (process.env.DISPLAY ? false : defaultHeadless);
+    // present (an explicit one, or a Daytona computer-use desktop on
+    // `process.env.DISPLAY`), default to headed — Camoufox is far less
+    // detectable headful and the display lets the session be streamed/observed.
+    // With no display we keep the module default (headless). Mirrors the
+    // `DISPLAY`-aware policy already used on the sandbox-executor path
+    // (`sandboxPlaywright.ts`).
+    this.headless = headless ?? (this.display ? false : defaultHeadless);
     this.userAgent =
       userAgent === null ? undefined : (userAgent ?? defaultUserAgent);
     this.viewportSize =
@@ -622,12 +639,13 @@ export class PlaywrightMcpSession {
           // `DISPLAY` is NOT in the transport's default-inherited set, so a
           // headful launch on a virtual display needs it threaded explicitly
           // — without it Firefox can't find the X server and headed mode
-          // fails to start.
+          // fails to start. Use this session's `display` (an explicit
+          // per-session display wins over the process-wide env).
           env: {
             ...Object.fromEntries(
               Object.entries(camou.env).map(([k, v]) => [k, String(v)]),
             ),
-            ...(process.env.DISPLAY ? { DISPLAY: process.env.DISPLAY } : {}),
+            ...(this.display ? { DISPLAY: this.display } : {}),
           },
         });
 

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -156,6 +156,9 @@ Returns the worker's summary, objective results, and finding count — but NOT t
           const state = await ctx.browserSession.captureStorageState();
           workerBrowserSession = new PlaywrightMcpSession({
             extraHttpHeaders: inheritedHeaders,
+            // Keep the worker on the orchestrator's display so its browser
+            // streams under the same endpoint instead of leaking to :0.
+            display: ctx.display,
           });
           if (state) {
             await workerBrowserSession.seedStorageState(state);
@@ -168,6 +171,7 @@ Returns the worker's summary, objective results, and finding count — but NOT t
           if (!workerBrowserSession) {
             workerBrowserSession = new PlaywrightMcpSession({
               extraHttpHeaders: inheritedHeaders,
+              display: ctx.display,
             });
           }
         }
@@ -204,6 +208,9 @@ Returns the worker's summary, objective results, and finding count — but NOT t
           openAIReasoningEffort: ctx.openAIReasoningEffort,
           role: "worker",
           browserSession: workerBrowserSession,
+          // When no cloned session is handed in (e.g. sandbox mode), the worker
+          // builds its own — give it the orchestrator's display too.
+          display: ctx.display,
         });
 
         const { findings, objectiveResults } = await agent.consume();

--- a/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
@@ -97,6 +97,7 @@ Pass every target you want tested — the swarm handles concurrency automaticall
         concurrency: DEFAULT_CONCURRENCY,
         enableThinking: ctx.enableThinking,
         openAIReasoningEffort: ctx.openAIReasoningEffort,
+        display: ctx.display,
       });
 
       // Aggregate

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -153,4 +153,11 @@ export type ToolContext = {
    * its own session and wires `abortSignal` to disconnect.
    */
   browserSession?: PlaywrightMcpSession;
+
+  /**
+   * X display (e.g. `":11"`) the owning agent's browser runs on. Spawn tools
+   * pass it to worker sessions so a spawned worker's browser shares the same
+   * virtual desktop instead of falling back to the process-wide `DISPLAY`.
+   */
+  display?: string;
 };

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -316,6 +316,16 @@ export type OffensiveSecurityAgentInput<TResult = void> = {
    * worker session on completion).
    */
   browserSession?: PlaywrightMcpSession;
+
+  /**
+   * X display (e.g. `":11"`) for this agent's browser. Overrides
+   * `process.env.DISPLAY` for the session this agent constructs, so several
+   * headed agents in one process (concurrent per-endpoint pentests) each run
+   * on their own virtual desktop. Ignored when `browserSession` is supplied
+   * (that session already owns its display). Omit to fall back to the
+   * process-wide `DISPLAY`.
+   */
+  display?: string;
 };
 
 /**
@@ -409,6 +419,13 @@ export interface SpecializedAgentInput {
    * {@link OffensiveSecurityAgentInput}.
    */
   browserSession?: PlaywrightMcpSession;
+
+  /**
+   * X display (e.g. `":11"`) for this agent's browser, forwarded to the
+   * underlying {@link OffensiveSecurityAgentInput} so concurrent per-endpoint
+   * pentests can each run headed on their own virtual desktop.
+   */
+  display?: string;
 }
 
 /**

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -180,6 +180,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       openAIReasoningEffort,
       role = "orchestrator",
       browserSession,
+      display,
     } = opts;
 
     // The base class creates the response tool from responseSchema and
@@ -225,6 +226,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       enableThinking,
       openAIReasoningEffort,
       browserSession,
+      display,
       activeTools: buildPentestActiveTools(role, session),
 
       responseSchema: PentestResponseSchema,

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -142,6 +142,12 @@ export interface PentestSwarmInput {
   }) => void;
   enableThinking?: boolean;
   openAIReasoningEffort?: OpenAIReasoningEffort | null;
+  /**
+   * X display (e.g. `":11"`) for every swarm sub-agent's browser, so a swarm
+   * launched by an orchestrator on a per-endpoint virtual desktop keeps its
+   * workers on that same display instead of the process-wide `DISPLAY`.
+   */
+  display?: string;
 }
 
 interface TokenUsageTotals {
@@ -196,6 +202,7 @@ export async function runPentestSwarm(
     onStepFinish,
     enableThinking,
     openAIReasoningEffort,
+    display,
   } = input;
 
   const completedIds = getCompletedAgentIds(session);
@@ -273,6 +280,7 @@ export async function runPentestSwarm(
             eventBus,
             enableThinking,
             openAIReasoningEffort,
+            display,
           });
           await planAgent.consume();
         } catch (planErr) {
@@ -299,6 +307,7 @@ export async function runPentestSwarm(
           subagentId,
           enableThinking,
           openAIReasoningEffort,
+          display,
         });
 
         const result = await agent.consume();


### PR DESCRIPTION
## Summary
Adds a `display` option to `PlaywrightMcpSession` (threaded through `OffensiveSecurityAgentInput` / `SpecializedAgentInput` → `TargetedPentestAgent`) that overrides `process.env.DISPLAY` for that session's spawned MCP/browser child.

### Why
A single process-wide `DISPLAY` can't separate concurrent headed sessions. When several pentest agents run in one process — e.g. the console runs concurrent per-endpoint pentests in one shared sandbox — every headed Camoufox renders on the same X display, so a single noVNC stream shows all of them piled on top of each other.

With a per-session `display`, the consumer can start an `Xvfb`/`x11vnc`/`noVNC` per endpoint and pin each agent's browser to its own virtual desktop, so the live stream for an endpoint shows only that endpoint's browser.

## Behavior
- `new PlaywrightMcpSession({ display: ":11" })` launches its browser child with `DISPLAY=:11`, regardless of `process.env.DISPLAY`.
- An explicit `display` also defaults the session to **headed** (same DISPLAY-aware policy as the env path) and wins over `process.env.DISPLAY`.
- Omitting `display` preserves existing behavior (fall back to the process-wide `DISPLAY`).
- Ignored when a pre-built `browserSession` is supplied (that session already owns its display).

## Changes
- `playwrightMcp.ts`: `display` option + field; MCP child env uses `this.display ?? process.env.DISPLAY`.
- `types.ts`: `display?` on `OffensiveSecurityAgentInput` and `SpecializedAgentInput`.
- `offensiveSecurityAgent.ts`: pass `display` into the session it constructs.
- `specialized/pentest/agent.ts`: forward `display` to the base.

## Test plan
- [x] `playwrightMcp.test.ts`: explicit `display` → headed + overrides env; falls back to env when omitted; explicit display headed even with no env display. (44 passed / 2 skipped)
- [x] `tsc` + biome clean.
- Consumer wiring (per-endpoint Xvfb + passing `display`) lands in the console repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to browser launch env and optional typing; default path unchanged when `display` is omitted, with unit tests for the new session behavior.
> 
> **Overview**
> Adds an optional **`display`** (X11 display, e.g. `":11"`) on `PlaywrightMcpSession` and threads it through offensive-security / pentest agent inputs, tool context, swarm workflow, and spawn tools so each headed browser can target its **own** virtual desktop instead of sharing `process.env.DISPLAY`.
> 
> **`PlaywrightMcpSession`** resolves `display` as explicit option → `process.env.DISPLAY`; an explicit display also drives the existing DISPLAY-aware **headed** default. The MCP child env now sets `DISPLAY` from **`this.display`**, not only the process-wide env.
> 
> **Propagation:** `OffensiveSecurityAgent` passes `display` into new sessions and into `createAllTools`; `spawn_pentest_agent` / `spawn_pentest_swarm` and `runPentestSwarm` forward the orchestrator’s display to workers so browsers stay on the same endpoint stream. Omitted `display` keeps prior behavior; pre-supplied `browserSession` is unchanged.
> 
> Tests cover explicit display overriding env, env fallback, and headed defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06163880e83149c83f79b08186fa52522bbf5c26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->