### PR TITLE
fix(prompt-injections): accept catalogs using `path`/`title` field names

### DIFF
--- a/src/core/prompt-injections/index.test.ts
+++ b/src/core/prompt-injections/index.test.ts
@@ -196,6 +196,57 @@ describe("prompt injection library", () => {
     }
   });
 
+  it("accepts catalogs that name fields `path`/`title` (L1B3RT4S schemaVersion 1)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "apex-prompt-library-l1b-"));
+    try {
+      await mkdir(join(root, "payloads", "anthropic"), { recursive: true });
+      await writeFile(
+        join(root, "payloads", "anthropic", "00-opus.txt"),
+        "RAW L1B3RT4S PAYLOAD",
+      );
+      await writeFile(
+        join(root, "catalog.json"),
+        JSON.stringify({
+          schemaVersion: 1,
+          name: "L1B3RT4S prompt-injection payload library",
+          payloads: [
+            {
+              id: "anthropic-opus-1",
+              title: "Anthropic Opus",
+              category: "anthropic",
+              vendor: "Anthropic (Claude)",
+              path: "payloads/anthropic/00-opus.txt",
+              sourceFile: "ANTHROPIC.mkd",
+              bytes: 19,
+              sha256: "ignored",
+              techniques: ["invisible-unicode"],
+              tags: ["jailbreak", "prompt-injection"],
+            },
+          ],
+        }),
+      );
+
+      const library = await getPromptInjectionLibrary({ source: root });
+      const catalog = library.listCatalog();
+
+      expect(catalog).toHaveLength(1);
+      const entry = catalog[0];
+      expect(entry.id).toBe("anthropic-opus-1");
+      // `title` is normalized to `name`.
+      expect(entry.name).toBe("Anthropic Opus");
+      expect(entry.category).toBe("anthropic");
+      // `path` is normalized to the payload pointer and resolves the file.
+      expect(library.getPayload("anthropic-opus-1")).toBe(
+        "RAW L1B3RT4S PAYLOAD",
+      );
+      // Unknown extra fields never leak into the safe catalog metadata.
+      expect(JSON.stringify(entry)).not.toContain("sourceFile");
+      expect(JSON.stringify(entry)).not.toContain("RAW L1B3RT4S PAYLOAD");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("rejects remote prompt injection library sources", async () => {
     await expect(
       getPromptInjectionLibrary({

--- a/src/core/prompt-injections/index.ts
+++ b/src/core/prompt-injections/index.ts
@@ -61,16 +61,36 @@ function sha256(value: string): string {
 // every other field is optional and tolerant so a new taxonomy or a missing
 // display name never hard-fails the whole library load (and never surfaces a
 // raw Zod union error to the agent calling list_prompt_injections).
-const PromptInjectionCatalogEntrySchema = z.object({
-  id: z.string().min(1),
-  name: z.string().min(1).optional(),
-  category: z.string().min(1).optional(),
-  description: z.string().default(""),
-  tags: z.array(z.string()).default([]),
-  deliveryHints: z.array(z.string()).default([]),
-  expectedObservation: z.string().default(""),
-  payloadPath: z.string().min(1),
-});
+//
+// Field-name tolerance: real-world catalogs (e.g. the L1B3RT4S ingest deployed
+// to the sandbox library bucket, schemaVersion 1) name the payload pointer
+// `path` and the display name `title`. Normalize those to Apex's canonical
+// `payloadPath` / `name` before validation so the loader accepts either shape.
+// Unknown extra fields (vendor, sourceFile, bytes, sha256, techniques, …) are
+// stripped by the object schema.
+const PromptInjectionCatalogEntrySchema = z.preprocess(
+  (value) => {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const entry = value as Record<string, unknown>;
+      return {
+        ...entry,
+        payloadPath: entry.payloadPath ?? entry.path,
+        name: entry.name ?? entry.title,
+      };
+    }
+    return value;
+  },
+  z.object({
+    id: z.string().min(1),
+    name: z.string().min(1).optional(),
+    category: z.string().min(1).optional(),
+    description: z.string().default(""),
+    tags: z.array(z.string()).default([]),
+    deliveryHints: z.array(z.string()).default([]),
+    expectedObservation: z.string().default(""),
+    payloadPath: z.string().min(1),
+  }),
+);
 
 const PromptInjectionLibraryFileSchema = z.union([
   z.array(PromptInjectionCatalogEntrySchema),


### PR DESCRIPTION
## Summary

`list_prompt_injections` was returning `count: 0` and a raw Zod `invalid_union` error to the agent. The catalog loader required each entry to carry `payloadPath` (and treated `name` as the display field) — matching the in-repo `examples/prompt-injection/catalog.json`. But the **real externally-curated dataset** deployed to the sandbox library bucket (the **L1B3RT4S ingest, `schemaVersion: 1`**) names the payload pointer `path` and the display name `title`:

```json
{ "id": "anthropic-opus-1", "title": "...", "path": "payloads/anthropic/00-opus.txt", "vendor": "...", "sourceFile": "...", "sha256": "...", "techniques": [...] }
```

So the loader hard-failed on every entry — the opposite of the "tolerate an externally-curated dataset that evolves independently of Apex" behavior the schema comment promises.

## Fix

Normalize field names with a `z.preprocess` step before validation:
- `path` → `payloadPath`
- `title` → `name`

Unknown extra fields (`vendor`, `sourceFile`, `bytes`, `sha256`, `techniques`, …) are stripped by the object schema, so they never leak into the model-visible catalog metadata. Fully backward-compatible with the canonical `payloadPath`/`name` shape (and the example catalog).

## Verification

- New unit test covering the `path`/`title` (L1B3RT4S schemaVersion 1) shape; existing tests still pass (`bun run test src/core/prompt-injections/index.test.ts` → 10 passed).
- `tsc` clean; Biome clean (pre-existing non-null-assertion warnings only).
- Ran the **live staging catalog** (`console-staging-promptinjectionlibrarybucket`, 113 payloads) through `getPromptInjectionLibrary` end-to-end: **113/113 entries parse, 0 missing payloads**, `title`→`name` and `path`→payload pointer resolved, extra fields stripped.

## Context

This is the second half of getting sandbox pentest workers prompt-injection access. The console-side wiring (threading the library source into the pentest session) is pensarai/console#1932; this PR fixes the catalog parse so the now-active tool actually loads the deployed library.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow schema preprocessing with backward-compatible fallbacks; no auth or runtime behavior changes beyond catalog parse success.
> 
> **Overview**
> Fixes prompt-injection catalog loading when entries use **L1B3RT4S-style** field names (`path`, `title`) instead of Apex’s `payloadPath` and `name`, which previously caused Zod validation to fail and `list_prompt_injections` to return an empty catalog.
> 
> The loader now **normalizes** `path` → `payloadPath` and `title` → `name` via `z.preprocess` before validation, while still accepting the canonical shape. Extra catalog fields (`vendor`, `sourceFile`, `bytes`, etc.) continue to be stripped from model-visible metadata.
> 
> A new unit test covers the `schemaVersion: 1` / `path`+`title` catalog shape and asserts payloads resolve and sensitive extras do not appear in catalog JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f419b51b9ac98ae11314d8fa57dcd8149faeaad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->