### PR TITLE
feat(prompt-injections): export catalog schema + validator for producers

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -17,6 +17,7 @@
     "src/core/agents/offSecAgent/tools/index.ts",
     "src/lib/cvss/index.ts",
     "src/core/ai/ai.ts",
+    "src/core/prompt-injections/index.ts",
     "src/core/session/index.ts",
     "src/core/workflows/whiteboxAttackSurface.ts"
   ],

--- a/src/core/agents/offSecAgent/tools/executeCommand.test.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.test.ts
@@ -98,7 +98,6 @@ describe("executeCommand prompt injection pointer", () => {
     expect(capturedCommand).toBe("echo hello");
   });
 
-
   it("passes a payload file path pointer through env vars and redacts echoed payloads", async () => {
     const payload = "TEST PAYLOAD: direct override";
     const payloadFilePath = "/tmp/apex-prompt-library/payloads/direct.txt";

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -40,7 +40,7 @@ const promptInjectionPointerSchema = z.object({
     .nullable()
     .optional()
     .describe(
-      "Stable prompt-injection id returned by list_prompt_injections. Leave unset/null unless you are intentionally running a prompt-injection harness. Do NOT pass placeholder values like \"__omit__\", \"none\", or \"null\" — just omit the field.",
+      'Stable prompt-injection id returned by list_prompt_injections. Leave unset/null unless you are intentionally running a prompt-injection harness. Do NOT pass placeholder values like "__omit__", "none", or "null" — just omit the field.',
     ),
   envVar: z
     .string()

--- a/src/core/prompt-injections/index.test.ts
+++ b/src/core/prompt-injections/index.test.ts
@@ -10,6 +10,7 @@ import {
   redactPromptInjectionPayloads,
   resolvePromptInjectionRefs,
   StaticPromptInjectionLibrary,
+  validatePromptInjectionCatalog,
 } from "./index";
 
 const TEST_LIBRARY = new StaticPromptInjectionLibrary([
@@ -194,6 +195,47 @@ describe("prompt injection library", () => {
     } finally {
       await rm(root, { recursive: true, force: true });
     }
+  });
+
+  describe("validatePromptInjectionCatalog", () => {
+    it("accepts a well-formed { payloads: [...] } catalog", () => {
+      const result = validatePromptInjectionCatalog({
+        payloads: [
+          { id: "a", name: "A", category: "x", payloadPath: "payloads/a.txt" },
+          { id: "b", payloadPath: "payloads/b.txt" },
+        ],
+      });
+      expect(result).toEqual({ ok: true, entryCount: 2 });
+    });
+
+    it("accepts a bare array catalog", () => {
+      const result = validatePromptInjectionCatalog([
+        { id: "a", payloadPath: "payloads/a.txt" },
+      ]);
+      expect(result).toEqual({ ok: true, entryCount: 1 });
+    });
+
+    it("rejects entries missing payloadPath with a path-scoped message", () => {
+      const result = validatePromptInjectionCatalog({
+        payloads: [{ id: "a", path: "payloads/a.txt" }],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain("payloadPath");
+      }
+    });
+
+    it("rejects entries missing id", () => {
+      const result = validatePromptInjectionCatalog({
+        payloads: [{ payloadPath: "payloads/a.txt" }],
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it("rejects a non-object/array top level", () => {
+      expect(validatePromptInjectionCatalog("nope").ok).toBe(false);
+      expect(validatePromptInjectionCatalog(null).ok).toBe(false);
+    });
   });
 
   it("rejects remote prompt injection library sources", async () => {

--- a/src/core/prompt-injections/index.ts
+++ b/src/core/prompt-injections/index.ts
@@ -61,7 +61,11 @@ function sha256(value: string): string {
 // every other field is optional and tolerant so a new taxonomy or a missing
 // display name never hard-fails the whole library load (and never surfaces a
 // raw Zod union error to the agent calling list_prompt_injections).
-const PromptInjectionCatalogEntrySchema = z.object({
+//
+// Exported so producers of the catalog (e.g. the console admin upload route)
+// can validate against the exact same contract Apex parses at runtime, instead
+// of duplicating the shape and silently drifting.
+export const PromptInjectionCatalogEntrySchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1).optional(),
   category: z.string().min(1).optional(),
@@ -72,7 +76,7 @@ const PromptInjectionCatalogEntrySchema = z.object({
   payloadPath: z.string().min(1),
 });
 
-const PromptInjectionLibraryFileSchema = z.union([
+export const PromptInjectionLibraryFileSchema = z.union([
   z.array(PromptInjectionCatalogEntrySchema),
   z.object({
     payloads: z.array(PromptInjectionCatalogEntrySchema),
@@ -81,6 +85,63 @@ const PromptInjectionLibraryFileSchema = z.union([
     injections: z.array(PromptInjectionCatalogEntrySchema),
   }),
 ]);
+
+export type PromptInjectionCatalogValidation =
+  | { ok: true; entryCount: number }
+  | { ok: false; error: string };
+
+/**
+ * Structurally validate a parsed `catalog.json` against the canonical schema
+ * Apex's loader uses, WITHOUT touching the filesystem (the payload files the
+ * entries point at are uploaded separately and may not exist yet at validation
+ * time). Returns the entry count on success or a concise, human-readable error
+ * string on failure. Intended for upload-time validation at the perimeter.
+ */
+export function validatePromptInjectionCatalog(
+  raw: unknown,
+): PromptInjectionCatalogValidation {
+  // Resolve the accepted container shape first so per-entry errors carry a
+  // useful path (e.g. `payloads.0.payloadPath`). Validating against the raw
+  // `z.union` instead collapses to a single unhelpful "(root): Invalid input".
+  let entriesRaw: unknown;
+  let pathPrefix: string;
+  if (Array.isArray(raw)) {
+    entriesRaw = raw;
+    pathPrefix = "";
+  } else if (
+    raw !== null &&
+    typeof raw === "object" &&
+    Array.isArray((raw as { payloads?: unknown }).payloads)
+  ) {
+    entriesRaw = (raw as { payloads: unknown }).payloads;
+    pathPrefix = "payloads.";
+  } else if (
+    raw !== null &&
+    typeof raw === "object" &&
+    Array.isArray((raw as { injections?: unknown }).injections)
+  ) {
+    entriesRaw = (raw as { injections: unknown }).injections;
+    pathPrefix = "injections.";
+  } else {
+    return {
+      ok: false,
+      error:
+        "Catalog must be a JSON array of entries, or an object with a `payloads` (or `injections`) array.",
+    };
+  }
+
+  const result = z
+    .array(PromptInjectionCatalogEntrySchema)
+    .safeParse(entriesRaw);
+  if (!result.success) {
+    const error = result.error.issues
+      .slice(0, 8)
+      .map((issue) => `${pathPrefix}${issue.path.join(".")}: ${issue.message}`)
+      .join("; ");
+    return { ok: false, error: error || "Invalid prompt-injection catalog" };
+  }
+  return { ok: true, entryCount: result.data.length };
+}
 
 function isPromptInjectionRef(value: unknown): value is PromptInjectionRef {
   return (


### PR DESCRIPTION
## Summary

The `catalog.json` contract previously lived only inside the loader, so producers of the catalog (notably the **console admin upload route**) had no way to validate against the exact shape Apex parses. A malformed catalog only blew up at runtime inside the sandbox — `list_prompt_injections` returning a raw Zod error and `count: 0`.

This exports the contract so producers can validate against it directly:

- `PromptInjectionCatalogEntrySchema` and `PromptInjectionLibraryFileSchema` are now exported.
- New `validatePromptInjectionCatalog(raw)` helper — filesystem-free (the payload files entries point at are uploaded separately and may not exist at validation time). Returns `{ ok: true, entryCount }` or `{ ok: false, error }` with a concise, **path-scoped** message (e.g. `payloads.0.payloadPath: ...`) instead of the union's collapsed `(root): Invalid input`.

The canonical schema is unchanged (`id` + `payloadPath` required; `name`/`category`/etc. optional). This is purely additive.

## Test plan

- [x] New unit tests for `validatePromptInjectionCatalog` (valid `{payloads}`/array, missing `payloadPath`, missing `id`, non-object) — 14/14 pass
- [x] `bun run tsc` clean
- [x] Biome clean (pre-existing warnings only)

## Context

Consumed by the console admin prompt-injection upload route to validate `catalog.json` at upload time (pensarai/console). Replaces an earlier approach of loosening the loader; the team's decision is that Apex's `payloadPath`/`name` schema is canonical, and producers conform to it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive exports and validation helper with unit tests; no change to runtime catalog loading or agent tools beyond quote/formatting.
> 
> **Overview**
> Exports the **same Zod schemas** Apex uses when loading `catalog.json` (`PromptInjectionCatalogEntrySchema`, `PromptInjectionLibraryFileSchema`) so upload paths (e.g. console admin) can validate without copying the shape.
> 
> Adds **`validatePromptInjectionCatalog(raw)`** for perimeter checks on parsed JSON only—no filesystem reads, so payload files need not exist yet. It accepts array, `{ payloads }`, or `{ injections }` wrappers and returns `{ ok: true, entryCount }` or `{ ok: false, error }` with **path-scoped** messages (e.g. `payloads.0.payloadPath`) instead of a generic union failure. Runtime loader behavior is unchanged; **`knip.json`** registers `src/core/prompt-injections/index.ts` as an entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c6f97eccd54897681ceeb596d5cf9178cd1bc95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->