### PR TITLE
feat(whitebox-recon): bound total agent concurrency across apps

### DIFF
--- a/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.concurrency.test.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.concurrency.test.ts
@@ -1,0 +1,124 @@
+import pLimit from "p-limit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConsolidatedEndpoint } from "../../../integrations/surface/types";
+import type { SessionInfo } from "../../../session";
+import { runWithBoundedConcurrency } from "../../../utils/concurrency";
+import type { AppInfo } from "./types";
+
+// Tracks how many mocked CodeAgent runs are executing at once so we can assert
+// the workflow's shared limiter actually bounds total concurrency.
+const tracker = vi.hoisted(() => {
+  let live = 0;
+  let peak = 0;
+  let total = 0;
+  return {
+    reset() {
+      live = 0;
+      peak = 0;
+      total = 0;
+    },
+    get peak() {
+      return peak;
+    },
+    get total() {
+      return total;
+    },
+    async run() {
+      live++;
+      total++;
+      if (live > peak) peak = live;
+      // Hold the "slot" across a macrotask so concurrent runs actually overlap.
+      await new Promise((r) => setTimeout(r, 1));
+      live--;
+    },
+  };
+});
+
+vi.mock("../codeAgent/agent", () => ({
+  CodeAgent: class {
+    async consume() {
+      await tracker.run();
+      return { summary: "ok", endpointsDocumented: 1 };
+    }
+  },
+}));
+
+import { runAppEndpointDocumentation } from "./endpointDocumentationAgent";
+
+const NUM_APPS = 50;
+const ENDPOINTS_PER_APP = 100;
+const CAP = 12;
+// Mirror the workflow's Phase 2 app-level fan-out (DEFAULT_CONCURRENCY) and the
+// per-app endpoint fan-out (ENDPOINT_DOCUMENTATION_CONCURRENCY) so the control
+// reproduces the real pre-fix peak (APP_CONCURRENCY * ENDPOINT_CONCURRENCY).
+const APP_CONCURRENCY = 5;
+
+function makeApp(name: string): AppInfo {
+  return {
+    name,
+    framework: "express",
+    description: "synthetic",
+    location: `apps/${name}`,
+    type: "api",
+  };
+}
+
+function makeEndpoints(n: number, appName: string): ConsolidatedEndpoint[] {
+  return Array.from({ length: n }, (_, i) => ({
+    method: ["GET"],
+    kind: "api",
+    path: `/api/${appName}/r${i}`,
+    handler: "handler",
+    file: `apps/${appName}/r${i}.ts`,
+    line: i + 1,
+    framework: "express",
+    auth: [],
+    internal: false,
+  }));
+}
+
+async function runAllApps(
+  agentLimiter?: <T>(fn: () => Promise<T>) => Promise<T>,
+): Promise<void> {
+  const apps = Array.from({ length: NUM_APPS }, (_, a) => `app${a}`);
+  // Same two-level nesting the workflow uses: up to APP_CONCURRENCY apps run at
+  // once, each documenting its endpoints. The shared `agentLimiter` (when given)
+  // is the only thing bounding the *total* across apps.
+  await runWithBoundedConcurrency(apps, APP_CONCURRENCY, (name) =>
+    runAppEndpointDocumentation({
+      codebasePath: "/repo",
+      app: makeApp(name),
+      endpoints: makeEndpoints(ENDPOINTS_PER_APP, name),
+      frameworks: ["express"],
+      model: "test-model",
+      session: {} as unknown as SessionInfo,
+      agentLimiter,
+    }),
+  );
+}
+
+describe("endpoint documentation concurrency (50 apps x 100 endpoints)", () => {
+  beforeEach(() => tracker.reset());
+
+  it("bounds total concurrent agents to the shared limiter across all apps", async () => {
+    const slots = pLimit(CAP);
+    const agentLimiter = <T>(fn: () => Promise<T>): Promise<T> => slots(fn);
+
+    await runAllApps(agentLimiter);
+
+    // All 5000 endpoints were processed...
+    expect(tracker.total).toBe(NUM_APPS * ENDPOINTS_PER_APP);
+    // ...but never more than CAP ran at once, regardless of app count.
+    expect(tracker.peak).toBeLessThanOrEqual(CAP);
+  });
+
+  it("control: without the shared limiter concurrency multiplies past the cap", async () => {
+    await runAllApps(undefined);
+
+    expect(tracker.total).toBe(NUM_APPS * ENDPOINTS_PER_APP);
+    // Pre-fix peak = APP_CONCURRENCY (5) * ENDPOINT_DOCUMENTATION_CONCURRENCY
+    // (10) = ~50, independent of how many endpoints — and it grows with more
+    // apps allowed in flight. Well above the bounded cap.
+    expect(tracker.peak).toBeGreaterThanOrEqual(APP_CONCURRENCY * 8);
+  });
+});

--- a/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/endpointDocumentationAgent.ts
@@ -26,12 +26,22 @@ const log = scopedLogger(() => createLogger("endpoint-documentation-agent"));
 // ---------------------------------------------------------------------------
 
 /**
- * Per-app fan-out concurrency. Each app's documentation runs N endpoint
- * agents in parallel up to this cap. Workflow-level concurrency (across
- * apps) is separately bounded by `DEFAULT_CONCURRENCY` in
- * `runWhiteboxAttackSurfaceWorkflow` Phase 2.
+ * Per-app fan-out concurrency — the maximum number of endpoint agents a single
+ * app may *schedule* at once. The number that actually *run* concurrently is
+ * additionally bounded across ALL apps by the workflow-level `agentLimiter`
+ * (see {@link SharedAgentOptions.agentLimiter}); without that shared gate this
+ * per-app cap multiplied by the app-level concurrency, so a repo with many apps
+ * could run ~50 endpoint agents at once.
  */
 const ENDPOINT_DOCUMENTATION_CONCURRENCY = 10;
+
+/**
+ * A shared concurrency gate (e.g. a `p-limit` instance). When provided, every
+ * endpoint/discovery CodeAgent run is funneled through it so the TOTAL number of
+ * concurrently-running agents across all apps stays bounded regardless of how
+ * many apps/endpoints the repo has.
+ */
+export type AgentConcurrencyLimiter = <T>(fn: () => Promise<T>) => Promise<T>;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -52,6 +62,11 @@ interface SharedAgentOptions {
   projectThreatModel?: string;
   /** Parent subagent id for hierarchy tracking on emitted lifecycle events. */
   parentSubagentId?: string;
+  /**
+   * Optional shared gate bounding total concurrent agents across the whole
+   * workflow. When omitted, agents run ungated (per-app cap only).
+   */
+  agentLimiter?: AgentConcurrencyLimiter;
 }
 
 interface EndpointDocumentationInput extends SharedAgentOptions {
@@ -172,6 +187,7 @@ async function runEndpointDocumentationAgent(
     enableThinking,
     projectThreatModel,
     parentSubagentId,
+    agentLimiter,
   } = opts;
 
   const subagentId = `endpoint-doc-${slug(app.name)}-${slug(endpoint.path)}`;
@@ -223,7 +239,9 @@ async function runEndpointDocumentationAgent(
   });
 
   try {
-    await agent.consume();
+    await (agentLimiter
+      ? agentLimiter(() => agent.consume())
+      : agent.consume());
     eventBus?.emit("subagent-complete", {
       subagentId,
       status: "completed",

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import type { StreamTextOnStepFinishCallback, ToolSet } from "ai";
+import pLimit from "p-limit";
 import { z } from "zod";
 import type { DocumentedEndpointRecord } from "../agents/specialized/attackSurface/schemas";
 import { CodeAgent } from "../agents/specialized/codeAgent/agent";
@@ -47,6 +48,17 @@ const log = scopedLogger(() => createLogger("whitebox-workflow"));
 // ---------------------------------------------------------------------------
 
 const DEFAULT_CONCURRENCY = 5;
+
+/**
+ * Hard ceiling on CodeAgents running concurrently across ALL apps and their
+ * endpoints. Previously the app-level cap (`DEFAULT_CONCURRENCY` = 5) and the
+ * per-app endpoint cap (`ENDPOINT_DOCUMENTATION_CONCURRENCY` = 10) multiplied,
+ * so a repo with many apps could run ~50 agents at once — the dominant memory
+ * driver in the 8 GiB recon sandbox. A single shared `p-limit` gate makes the
+ * cap independent of app/endpoint counts. Override via
+ * `WhiteboxAttackSurfaceWorkflowInput.maxConcurrentAgents`.
+ */
+const MAX_CONCURRENT_AGENTS = 12;
 
 type DiscoveryTaskType = "pages" | "apiEndpoints" | "cloudResourceEndpoints";
 
@@ -118,6 +130,12 @@ export interface WhiteboxAttackSurfaceWorkflowInput {
    * service apps. Defaults to `true`.
    */
   surfaceIntegrationEnabled?: boolean;
+  /**
+   * Hard ceiling on CodeAgents running concurrently across all apps/endpoints.
+   * Defaults to {@link MAX_CONCURRENT_AGENTS}. Bounds total agent fan-out so it
+   * doesn't scale with the number of apps in the repo.
+   */
+  maxConcurrentAgents?: number;
 }
 
 interface IncrementalWhiteboxInput extends WhiteboxAttackSurfaceWorkflowInput {
@@ -165,7 +183,17 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     projectThreatModel,
     environments,
     surfaceIntegrationEnabled = true,
+    maxConcurrentAgents = MAX_CONCURRENT_AGENTS,
   } = input;
+
+  // Single shared gate for every CodeAgent run in this workflow (Phase 1
+  // discovery, Phase 2 per-app discovery, and per-endpoint documentation). This
+  // is what makes total concurrency independent of app count: the nested
+  // app-level (`DEFAULT_CONCURRENCY`) and per-app endpoint-level
+  // (`ENDPOINT_DOCUMENTATION_CONCURRENCY`) loops still control scheduling, but
+  // the number of agents actually running at once can never exceed this.
+  const agentSlots = pLimit(Math.max(1, maxConcurrentAgents));
+  const agentLimiter = <T>(fn: () => Promise<T>): Promise<T> => agentSlots(fn);
 
   // =========================================================================
   // Phase 1: Identify all apps in the repository
@@ -212,7 +240,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     input: { codebasePath },
   });
 
-  const appsResult = await appsAgent.consume();
+  const appsResult = await agentLimiter(() => appsAgent.consume());
 
   log.info(
     `Phase 1 complete: ${appsResult?.apps.length ?? 0} apps discovered` +
@@ -353,7 +381,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
     });
 
     try {
-      await agent.consume();
+      await agentLimiter(() => agent.consume());
 
       log.debug(`Phase 2: agent "${subagentId}" completed`);
 
@@ -442,6 +470,7 @@ export async function runWhiteboxAttackSurfaceWorkflow(
               enableThinking,
               projectThreatModel,
               parentSubagentId: appNodeId,
+              agentLimiter,
             });
           } else {
             log.debug(`${app.name}: fallback (${surfaceResult.reason})`);


### PR DESCRIPTION
Phase 2 of the whitebox attack-surface workflow nested two independent concurrency limits: the app-level loop (DEFAULT_CONCURRENCY=5) and the per-app endpoint-documentation loop (ENDPOINT_DOCUMENTATION_CONCURRENCY=10). These multiplied, so a repo with many apps ran up to ~50 CodeAgents at once (5 apps x 10 endpoints) — the dominant memory driver in the 8GiB recon sandbox, and it scales with app count.

Introduce a single workflow-scoped p-limit gate (MAX_CONCURRENT_AGENTS=12, overridable via WhiteboxAttackSurfaceWorkflowInput.maxConcurrentAgents) that every CodeAgent run is funneled through (Phase 1 apps discovery, Phase 2 per-app discovery agents, and per-endpoint documentation). The nested loops still drive scheduling/ordering, but the number of agents actually running at once is now bounded independent of how many apps/endpoints the repo has. Threat-model generation keeps its own separate p-limit(10) — it must not share this gate or a parent endpoint agent holding a slot while awaiting its threat-model child would deadlock.

Adds a test replicating 50 apps x 100 endpoints: peak concurrency drops from 50 (unbounded control) to 12 (bounded), with all 5000 endpoints still processed.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration concurrency for a memory-sensitive recon path; mis-tuning the cap could slow large repos but behavior is overrideable and scoped to agent scheduling, not auth or data handling.
> 
> **Overview**
> **Fixes unbounded memory in Phase 2** by replacing multiplied nested limits (5 apps × 10 endpoints ≈ ~50 concurrent `CodeAgent`s) with one workflow-wide `p-limit` gate defaulting to **12**, overridable via `WhiteboxAttackSurfaceWorkflowInput.maxConcurrentAgents`.
> 
> Every `CodeAgent.consume()` in the main whitebox workflow—Phase 1 apps discovery, Phase 2 per-app discovery agents, and per-endpoint documentation—runs through the shared `agentLimiter`. Nested `runWithBoundedConcurrency` loops still schedule work; they no longer define how many agents actually run at once.
> 
> `endpointDocumentationAgent` accepts optional `agentLimiter` and funnels each endpoint doc agent through it when provided; docs clarify that per-app `ENDPOINT_DOCUMENTATION_CONCURRENCY` only caps scheduling without the shared gate.
> 
> Adds a **50 apps × 100 endpoints** test: with the limiter, peak concurrency ≤ 12 and all endpoints process; without it, peak stays high (control reproducing pre-fix behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1775030ee856fc0f274ab67445a5b19d63442224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->