### PR TITLE
feat(shell): merge sandbox-provided agent env vars into execute_command

### DIFF
--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -6,6 +6,7 @@ import {
   extractFallbackStdout,
   getApexTmpRoot,
   PersistentShell,
+  readSandboxAgentEnv,
 } from "./persistentShell";
 
 function tempfileCount(): number {
@@ -547,5 +548,98 @@ describe("extractFallbackStdout", () => {
   it("handles cutover immediately followed by exit marker (empty command output)", () => {
     const leaked = `${cut}\n${exitPrefix}0\n`;
     expect(extractFallbackStdout(mk(leaked))).toBe("(no output)");
+  });
+});
+
+describe("readSandboxAgentEnv", () => {
+  const orig = process.env.PENSAR_AGENT_ENV_VARS;
+  afterEach(() => {
+    if (orig === undefined) delete process.env.PENSAR_AGENT_ENV_VARS;
+    else process.env.PENSAR_AGENT_ENV_VARS = orig;
+  });
+
+  it("parses a JSON object of string values", () => {
+    process.env.PENSAR_AGENT_ENV_VARS = JSON.stringify({
+      API_TOKEN: "tok",
+      BASE_URL: "https://x",
+    });
+    expect(readSandboxAgentEnv()).toEqual({
+      API_TOKEN: "tok",
+      BASE_URL: "https://x",
+    });
+  });
+
+  it("returns {} when unset", () => {
+    delete process.env.PENSAR_AGENT_ENV_VARS;
+    expect(readSandboxAgentEnv()).toEqual({});
+  });
+
+  it("fails soft to {} on malformed JSON", () => {
+    process.env.PENSAR_AGENT_ENV_VARS = "{not json";
+    expect(readSandboxAgentEnv()).toEqual({});
+  });
+
+  it("ignores non-string values and non-object blobs", () => {
+    process.env.PENSAR_AGENT_ENV_VARS = JSON.stringify({
+      KEEP: "yes",
+      DROP: 123,
+    });
+    expect(readSandboxAgentEnv()).toEqual({ KEEP: "yes" });
+
+    process.env.PENSAR_AGENT_ENV_VARS = JSON.stringify(["a", "b"]);
+    expect(readSandboxAgentEnv()).toEqual({});
+  });
+});
+
+describe("PersistentShell — sandbox agent env injection", () => {
+  const shells: PersistentShell[] = [];
+  const orig = process.env.PENSAR_AGENT_ENV_VARS;
+
+  afterEach(() => {
+    while (shells.length) {
+      try {
+        shells.pop()?.dispose();
+      } catch {
+        // ignore
+      }
+    }
+    if (orig === undefined) delete process.env.PENSAR_AGENT_ENV_VARS;
+    else process.env.PENSAR_AGENT_ENV_VARS = orig;
+  });
+
+  it("exposes PENSAR_AGENT_ENV_VARS to execute_command", async () => {
+    process.env.PENSAR_AGENT_ENV_VARS = JSON.stringify({
+      MY_AGENT_TOKEN: "s3cr3t-value",
+    });
+    const shell = new PersistentShell();
+    shells.push(shell);
+
+    const r = await shell.execute('echo "tok=$MY_AGENT_TOKEN"', 5);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("tok=s3cr3t-value");
+  });
+
+  it("lets explicit per-agent env override the sandbox blob", async () => {
+    process.env.PENSAR_AGENT_ENV_VARS = JSON.stringify({
+      SHARED: "from-blob",
+    });
+    const shell = new PersistentShell({ env: { SHARED: "from-extra-env" } });
+    shells.push(shell);
+
+    const r = await shell.execute('echo "v=$SHARED"', 5);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("v=from-extra-env");
+  });
+
+  it("does not leak unrelated process.env into the shell", async () => {
+    delete process.env.PENSAR_AGENT_ENV_VARS;
+    process.env.__APEX_TEST_LEAK_CHECK = "should-not-appear";
+    const shell = new PersistentShell();
+    shells.push(shell);
+
+    const r = await shell.execute('echo "leak=[$__APEX_TEST_LEAK_CHECK]"', 5);
+    delete process.env.__APEX_TEST_LEAK_CHECK;
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("leak=[]");
   });
 });

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -105,6 +105,36 @@ interface PendingCommand {
   _activeSalvageId?: object;
 }
 
+/**
+ * Workspace-configured agent environment variables, transported into the
+ * sandbox as a single JSON blob (`PENSAR_AGENT_ENV_VARS`) by the platform's
+ * dispatch layer. They are merged into every shell's environment so the
+ * agent's `execute_command` calls see them — the curated env below
+ * deliberately does NOT inherit arbitrary `process.env`, so platform secrets
+ * (AGENT_API_TOKEN, AWS creds, …) never leak into the agent's shell, but that
+ * also means these workspace vars must be re-introduced explicitly here.
+ *
+ * Fail-soft: a missing or malformed blob yields no extra vars rather than
+ * throwing — a parse failure must not break command execution.
+ */
+export function readSandboxAgentEnv(): Record<string, string> {
+  const raw = process.env.PENSAR_AGENT_ENV_VARS;
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v === "string") out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
 let stdbufAvailable: boolean | null = null;
 function hasStdbuf(): boolean {
   if (stdbufAvailable !== null) return stdbufAvailable;
@@ -195,6 +225,10 @@ export class PersistentShell {
       // interactive prompts off the TUI's TTY.
       detached: process.platform !== "win32",
       env: {
+        // Workspace-configured agent env vars first (lowest precedence) so the
+        // curated essentials below and explicit per-agent `extraEnv` always
+        // win — a workspace var can never clobber PATH/HOME or shell controls.
+        ...readSandboxAgentEnv(),
         PATH: process.env.PATH ?? "",
         HOME: process.env.HOME ?? "",
         USER: process.env.USER ?? "",


### PR DESCRIPTION
PersistentShell builds its child env from a curated allowlist plus the agent's extraEnv and deliberately does not inherit arbitrary process.env, so platform secrets never leak into the agent's shell. That also meant workspace-configured agent env vars (transported into the sandbox as the PENSAR_AGENT_ENV_VARS JSON blob by the platform dispatch layer) never reached execute_command.

Add readSandboxAgentEnv() to parse that blob (fail-soft) and merge it into the shell env at lowest precedence, so the curated essentials (PATH/HOME/…) and any explicit per-agent extraEnv still win. This makes the configured env vars available to every agent's commands without per-agent wiring.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which secrets and config reach the agent shell; behavior is intentional but workspace-provided values (including tokens) become available to every command in that shell.
> 
> **Overview**
> **PersistentShell** now re-injects workspace agent configuration into the child shell by parsing the platform’s `PENSAR_AGENT_ENV_VARS` JSON blob via new **`readSandboxAgentEnv()`**, which only keeps string key/value pairs and **fails soft** (empty object) when the variable is missing or invalid.
> 
> Those vars are spread into the spawned shell env at **lowest precedence**—below the curated `PATH`/`HOME`/… allowlist and below per-agent `extraEnv`—so workspace settings reach `execute_command` without inheriting arbitrary `process.env` or overriding shell essentials.
> 
> Tests cover JSON parsing edge cases, end-to-end visibility in the shell, override behavior, and that unrelated host env vars still do not leak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bceabca17dc206c742baf34965cc0f87a171ebef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->