### PR TITLE
fix(pentest): share orchestrator's browser session with sandbox workers (fixes sandbox OOM)

### DIFF
--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.test.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.test.ts
@@ -402,7 +402,7 @@ describe("spawn_pentest_agent — copy-on-spawn browser isolation", () => {
     }
   });
 
-  it("skips the entire copy-on-spawn path in sandbox mode (sandbox shares state via user-data dir)", async () => {
+  it("shares the orchestrator's browser session with the worker in sandbox mode (no copy-on-spawn; one browser per endpoint)", async () => {
     const parent = makeStubParentSession({
       isConnected: true,
       storageState: { cookies: [], origins: [] },
@@ -433,7 +433,8 @@ describe("spawn_pentest_agent — copy-on-spawn browser isolation", () => {
       { toolCallId: "tc1", messages: [], abortSignal: undefined },
     );
 
-    // Nothing browser-related happened on the host.
+    // No copy-on-spawn: sandbox mode never clones (capture), seeds, or
+    // disconnects a per-worker session.
     expect(parent.capture).not.toHaveBeenCalled();
     expect(seedSpy).not.toHaveBeenCalled();
     expect(disconnectSpy).not.toHaveBeenCalled();
@@ -442,7 +443,10 @@ describe("spawn_pentest_agent — copy-on-spawn browser isolation", () => {
       context?: string;
       browserSession?: PlaywrightMcpSession;
     };
-    expect(workerInput.browserSession).toBeUndefined();
+    // The worker reuses the orchestrator's single session (one Camoufox per
+    // endpoint) rather than building its own — the sandbox OOM fix. It doesn't
+    // own the session, so it never tears down the orchestrator's browser.
+    expect(workerInput.browserSession).toBe(parent.session);
     expect(workerInput.context).toBe("ctx-from-orchestrator");
   });
 });

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -225,9 +225,21 @@ Returns the worker's summary, objective results, and finding count — but NOT t
           enableThinking: ctx.enableThinking,
           openAIReasoningEffort: ctx.openAIReasoningEffort,
           role: "worker",
-          browserSession: workerBrowserSession,
-          // When no cloned session is handed in (e.g. sandbox mode), the worker
-          // builds its own — give it the orchestrator's display too.
+          // Non-sandbox: hand the worker its cloned, isolated session (or
+          // undefined if cloning was skipped). Sandbox: share the orchestrator's
+          // single browser session instead of letting the worker spin up its own
+          // Camoufox. Workers run one at a time (this tool awaits each), so there
+          // is no concurrent access — sharing keeps ONE browser per endpoint
+          // instead of two (orchestrator + worker), which is what OOM'd the 8 GiB
+          // sandbox (2 Camoufox/endpoint × the endpoint concurrency ≈ the whole
+          // memory budget). The worker does not own this session (browserSession
+          // was provided ⇒ ownsBrowserSession=false), so it never tears down the
+          // orchestrator's browser; the orchestrator disconnects it at run end.
+          browserSession:
+            workerBrowserSession ??
+            (ctx.sandbox ? ctx.browserSession : undefined),
+          // The worker's own-built browser (non-sandbox, uncloned path) still
+          // runs on the orchestrator's display.
           display: ctx.display,
         });
 


### PR DESCRIPTION
## Summary

Fixes the sandbox OOM that kills large pentests: in sandbox mode each spawned worker was building its **own** Camoufox instead of reusing the orchestrator's, so every endpoint ran **2 concurrent Firefox** (orchestrator + current worker). At the endpoint concurrency that's ~2× the browsers needed and blows the agent sandbox's 8 GiB budget.

Observed on a live 176-endpoint prod run (console-side): **16 concurrent Firefox for 8 endpoints, ~5 GB Firefox RSS, cgroup at 7.7/8 GiB (96.5%)** and climbing → OOM. (Root-cause investigation: pensarai/console#1984.)

## Change

In `spawnPentestAgent`, `spawn_pentest_agent` awaits each worker — workers run **strictly one at a time**, so there is no concurrent browser access within an endpoint. In **sandbox mode**, hand the worker the orchestrator's existing `browserSession` instead of `undefined` (which made the base agent build its own):

```ts
browserSession:
  workerBrowserSession ?? (ctx.sandbox ? ctx.browserSession : undefined),
```

- One Camoufox per endpoint instead of two → ~halves browser RSS, keeping the run under the 8 GiB cap.
- The worker does **not** own the session (`browserSession` provided ⇒ `ownsBrowserSession = false`), so it never disconnects the orchestrator's browser; the orchestrator tears it down at run end.
- **Unchanged:** the non-sandbox copy-on-spawn isolation path (per-worker cloned + seeded + disconnected session) and the parallel `spawn_pentest_swarm` (whose workers *must* keep their own browsers because they run concurrently).

## Test plan

- [x] `bun run tsc` — clean
- [x] `bun run lint` / biome on the changed file — clean
- [x] `bun run test src/core/agents/offSecAgent/` — 285 passed / 9 skipped
- [x] Updated the sandbox-mode test to assert the worker reuses the orchestrator's session (was asserting `undefined`)
- [ ] Post-merge (console submodule bump + deploy): re-run a large prod pentest and confirm ~1 Camoufox/endpoint and cgroup memory well under 8 GiB

Refs pensarai/console#1984

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared browser lifecycle in sandbox pentest workers; sequential workers only, but concurrent misuse or teardown bugs could affect orchestrator browser state.
> 
> **Overview**
> Fixes sandbox OOM during large pentests by changing how **`spawn_pentest_agent`** wires the browser in **sandbox mode**.
> 
> Previously, sandbox workers got **`browserSession: undefined`**, so each worker started its **own** Camoufox while the orchestrator kept one—**two Firefox processes per endpoint** and memory pressure on the 8 GiB cgroup. Workers are **awaited one at a time**, so sharing is safe.
> 
> **`browserSession`** is now `workerBrowserSession ?? (ctx.sandbox ? ctx.browserSession : undefined)`: sandbox workers reuse the orchestrator’s session; non-sandbox **copy-on-spawn** (clone, seed, disconnect per worker) is unchanged.
> 
> The worker does **not** own the shared session (`ownsBrowserSession` false), so it won’t disconnect the orchestrator’s browser; teardown stays at orchestrator run end. The sandbox test now expects the worker to receive **`parent.session`**, not `undefined`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad3a1e20e96cf56f056ec5e207dc08b33b9a1700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->