### PR TITLE
fix(pentest): share orchestrator browser session with workers — the real OOM fix (supersedes #886)

### DIFF
--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.test.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.test.ts
@@ -1,21 +1,16 @@
 /**
- * Unit tests for the `spawn_pentest_agent` tool's copy-on-spawn browser
- * isolation.
+ * Unit tests for `spawn_pentest_agent`'s browser-session handling.
  *
- * Verifies that:
- *   1. Each worker gets its OWN PlaywrightMcpSession (isolation — no
- *      cross-worker contamination).
- *   2. When the orchestrator's session has been used, its
- *      `BrowserContext.storageState()` is captured and seeded into the
- *      worker's fresh session before the worker starts (auth persistence).
- *   3. The orchestrator's session is never passed to the worker directly,
- *      and is never touched by the worker's browser tools.
- *   4. The worker's session is torn down on completion (no leaked Chromium).
- *   5. The worker's `context` block carries a "Cloned Browser Session"
- *      note when the session was seeded, so the worker LLM knows it's
- *      isolated.
- *   6. Sandbox mode skips this entire path — sandbox state is shared via
- *      the per-sandbox user-data dir.
+ * Workers run one at a time and SHARE the orchestrator's live browser session
+ * (one Camoufox per endpoint) instead of each cloning their own — the fix for
+ * the agent-sandbox OOM (pensarai/console#1984), where 2 Camoufox per endpoint
+ * × the endpoint concurrency saturated memory. These tests verify:
+ *   1. Native mode: the worker is handed the orchestrator's session directly
+ *      (no clone — storageState is never captured; the shared session is never
+ *      disconnected by the worker).
+ *   2. The worker's `context` carries a "Shared Browser Session" note.
+ *   3. Remote-sandbox mode: no host session is shared (worker gets undefined).
+ *   4. No orchestrator session ⇒ worker gets undefined (builds its own).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -44,10 +39,7 @@ vi.mock("../../../findings/registry", () => ({
 
 import type { AIModel } from "../../../ai";
 import type { SessionInfo } from "../../../session";
-import {
-  type BrowserStorageState,
-  PlaywrightMcpSession,
-} from "./playwrightMcp";
+import { PlaywrightMcpSession } from "./playwrightMcp";
 import { spawnPentestAgent } from "./spawnPentestAgent";
 import type { ToolContext } from "./types";
 
@@ -67,90 +59,39 @@ function buildCtx(overrides: Partial<ToolContext> = {}): ToolContext {
   };
 }
 
-function makeStubParentSession(opts: {
-  isConnected: boolean;
-  storageState?: BrowserStorageState | null;
-}): {
+function makeParentSession(): {
   session: PlaywrightMcpSession;
   capture: ReturnType<typeof vi.fn>;
-  seed: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
 } {
   const session = new PlaywrightMcpSession();
-  vi.spyOn(session, "isConnected").mockReturnValue(opts.isConnected);
+  vi.spyOn(session, "isConnected").mockReturnValue(true);
   const capture = vi
     .spyOn(session, "captureStorageState")
-    .mockResolvedValue(opts.storageState ?? null);
-  // Parent should never be asked to seed — that would be backwards.
-  const seed = vi.spyOn(session, "seedStorageState").mockResolvedValue();
-  return {
-    session,
-    capture: capture as unknown as ReturnType<typeof vi.fn>,
-    seed: seed as unknown as ReturnType<typeof vi.fn>,
-  };
+    .mockResolvedValue(null) as unknown as ReturnType<typeof vi.fn>;
+  const disconnect = vi
+    .spyOn(session, "disconnect")
+    .mockResolvedValue() as unknown as ReturnType<typeof vi.fn>;
+  return { session, capture, disconnect };
 }
 
-function spyWorkerSessionConstruction(): {
-  workerSessions: PlaywrightMcpSession[];
-  seedCalls: BrowserStorageState[];
-  disconnectCalls: number;
-} {
-  const workerSessions: PlaywrightMcpSession[] = [];
-  const seedCalls: BrowserStorageState[] = [];
-  let disconnectCalls = 0;
-
-  // Replace the PlaywrightMcpSession prototype's seed/disconnect so we can
-  // observe what spawn_pentest_agent does with the freshly-constructed
-  // worker session WITHOUT it actually trying to spawn Chromium.
-  vi.spyOn(
-    PlaywrightMcpSession.prototype,
-    "seedStorageState",
-  ).mockImplementation(async function (this: PlaywrightMcpSession, state) {
-    seedCalls.push(state);
-  });
-  vi.spyOn(PlaywrightMcpSession.prototype, "disconnect").mockImplementation(
-    async () => {
-      disconnectCalls += 1;
+async function runSpawn(
+  ctx: ToolContext,
+  inputOverrides: Record<string, unknown> = {},
+): Promise<void> {
+  const tool = spawnPentestAgent(ctx);
+  // biome-ignore lint/suspicious/noExplicitAny: ai-sdk tool execute receives an opaque ExecuteContext we don't need to narrow for this test.
+  await (tool as any).execute(
+    {
+      name: "worker",
+      target: "https://example.com/api",
+      objectives: ["Test"],
+      context: "ctx-from-orchestrator",
+      toolCallDescription: "spawn worker",
+      ...inputOverrides,
     },
+    { toolCallId: "tc1", messages: [], abortSignal: undefined },
   );
-
-  // Track every newly-constructed session by hooking into initialize() —
-  // the spawn path constructs `new PlaywrightMcpSession()` for the worker.
-  const origInit = PlaywrightMcpSession.prototype.initialize;
-  vi.spyOn(PlaywrightMcpSession.prototype, "initialize").mockImplementation(
-    function (this: PlaywrightMcpSession) {
-      if (!workerSessions.includes(this)) {
-        workerSessions.push(this);
-      }
-      return origInit.call(this);
-    },
-  );
-
-  // Patch the constructor by hooking the class itself: every `new
-  // PlaywrightMcpSession()` push to the list. We do this by wrapping the
-  // prototype's `isConnected` to also auto-register on first call (the
-  // capture branch calls isConnected on the parent only, so we register
-  // workers from the first call to disconnect or seed instead — both are
-  // already mocked above to push when invoked).
-  vi.spyOn(PlaywrightMcpSession.prototype, "isConnected").mockImplementation(
-    function (this: PlaywrightMcpSession) {
-      if (!workerSessions.includes(this)) {
-        workerSessions.push(this);
-      }
-      return false;
-    },
-  );
-
-  return {
-    workerSessions,
-    seedCalls,
-    get disconnectCalls() {
-      return disconnectCalls;
-    },
-  } as unknown as {
-    workerSessions: PlaywrightMcpSession[];
-    seedCalls: BrowserStorageState[];
-    disconnectCalls: number;
-  };
 }
 
 afterEach(() => {
@@ -162,291 +103,64 @@ afterEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("spawn_pentest_agent — copy-on-spawn browser isolation", () => {
-  it("clones the orchestrator's storage state into a NEW session for the worker (worker session !== parent session)", async () => {
-    const sampleState: BrowserStorageState = {
-      cookies: [
-        {
-          name: "session",
-          value: "alice-token",
-          domain: "example.com",
-          path: "/",
-          httpOnly: true,
-          secure: true,
-          sameSite: "Lax",
-        },
-      ],
-      origins: [
-        {
-          origin: "https://example.com",
-          localStorage: [{ name: "uid", value: "alice" }],
-        },
-      ],
-    };
-
-    const parent = makeStubParentSession({
-      isConnected: true,
-      storageState: sampleState,
-    });
-
-    // Spy on PlaywrightMcpSession prototype methods that will be called on
-    // the freshly-constructed worker session. We don't want the worker
-    // session to actually launch Chromium.
-    const seedSpy = vi
-      .spyOn(PlaywrightMcpSession.prototype, "seedStorageState")
-      .mockResolvedValue();
-    const disconnectSpy = vi
-      .spyOn(PlaywrightMcpSession.prototype, "disconnect")
-      .mockResolvedValue();
-
+describe("spawn_pentest_agent — shared browser session", () => {
+  it("hands the worker the orchestrator's session directly (no clone) in native mode", async () => {
+    const parent = makeParentSession();
     const ctx = buildCtx({ browserSession: parent.session });
 
-    const tool = spawnPentestAgent(ctx);
-    // biome-ignore lint/suspicious/noExplicitAny: ai-sdk tool execute receives an opaque ExecuteContext we don't need to narrow for this test.
-    await (tool as any).execute(
-      {
-        name: "SQLi /api/users",
-        target: "https://example.com/api/users",
-        objectives: ["Test for SQL injection"],
-        toolCallDescription: "spawn worker",
-      },
-      { toolCallId: "tc1", messages: [], abortSignal: undefined },
-    );
+    await runSpawn(ctx);
 
-    // Parent's storage was captured exactly once.
-    expect(parent.capture).toHaveBeenCalledTimes(1);
-
-    // Parent was NEVER seeded (you don't write back into the orchestrator).
-    expect(parent.seed).not.toHaveBeenCalled();
-
-    // The worker's session was seeded with the captured state.
-    expect(seedSpy).toHaveBeenCalledTimes(1);
-    expect(seedSpy).toHaveBeenCalledWith(sampleState);
-
-    // The worker received a session, and it is NOT the parent's session.
-    expect(constructorCalls).toHaveLength(1);
     const workerInput = constructorCalls[0] as {
       browserSession?: PlaywrightMcpSession;
     };
-    expect(workerInput.browserSession).toBeDefined();
-    expect(workerInput.browserSession).not.toBe(parent.session);
-    expect((constructorCalls[0] as { role?: string }).role).toBe("worker");
-
-    // Cleanup: the worker's session was disconnected on completion.
-    expect(disconnectSpy).toHaveBeenCalledTimes(1);
+    // Worker reuses the SAME session object — one Camoufox per endpoint.
+    expect(workerInput.browserSession).toBe(parent.session);
+    // No cloning: storage is never captured, and the worker never disconnects
+    // the shared session (the orchestrator owns and tears it down).
+    expect(parent.capture).not.toHaveBeenCalled();
+    expect(parent.disconnect).not.toHaveBeenCalled();
   });
 
-  it("annotates the worker's context with a 'Cloned Browser Session' note when seeded", async () => {
-    const parent = makeStubParentSession({
-      isConnected: true,
-      storageState: { cookies: [], origins: [] },
-    });
-    vi.spyOn(
-      PlaywrightMcpSession.prototype,
-      "seedStorageState",
-    ).mockResolvedValue();
-    vi.spyOn(PlaywrightMcpSession.prototype, "disconnect").mockResolvedValue();
-
+  it("adds a Shared Browser Session note to the worker context when a session is shared", async () => {
+    const parent = makeParentSession();
     const ctx = buildCtx({ browserSession: parent.session });
-    const tool = spawnPentestAgent(ctx);
-    // biome-ignore lint/suspicious/noExplicitAny: ai-sdk tool execute receives an opaque ExecuteContext we don't need to narrow for this test.
-    await (tool as any).execute(
-      {
-        name: "IDOR orders",
-        target: "https://example.com/api/orders/{id}",
-        objectives: ["Test for IDOR"],
-        context: "Earlier worker observed numeric IDs.",
-        toolCallDescription: "spawn worker",
-      },
-      { toolCallId: "tc1", messages: [], abortSignal: undefined },
-    );
+
+    await runSpawn(ctx);
 
     const workerInput = constructorCalls[0] as { context?: string };
-    expect(workerInput.context).toContain("Cloned Browser Session");
-    expect(workerInput.context).toContain(
-      "isolated Chromium instance that was seeded",
-    );
-    expect(workerInput.context).toContain("NOT shared");
-    expect(workerInput.context).toContain(
-      "Earlier worker observed numeric IDs",
-    );
+    expect(workerInput.context).toContain("Shared Browser Session");
+    // Existing orchestrator context is preserved below the note.
+    expect(workerInput.context).toContain("ctx-from-orchestrator");
   });
 
-  it("does NOT clone (and does NOT inject the cloned-session note) when the orchestrator's browser was never used", async () => {
-    const parent = makeStubParentSession({
-      isConnected: false, // orchestrator never opened the browser
-    });
-    const seedSpy = vi
-      .spyOn(PlaywrightMcpSession.prototype, "seedStorageState")
-      .mockResolvedValue();
-    const disconnectSpy = vi
-      .spyOn(PlaywrightMcpSession.prototype, "disconnect")
-      .mockResolvedValue();
-
-    const ctx = buildCtx({ browserSession: parent.session });
-    const tool = spawnPentestAgent(ctx);
-    // biome-ignore lint/suspicious/noExplicitAny: ai-sdk tool execute receives an opaque ExecuteContext we don't need to narrow for this test.
-    await (tool as any).execute(
-      {
-        name: "Header probe",
-        target: "https://example.com/api",
-        objectives: ["Check security headers"],
-        context: "Pure http_request workflow.",
-        toolCallDescription: "spawn worker",
-      },
-      { toolCallId: "tc1", messages: [], abortSignal: undefined },
-    );
-
-    expect(parent.capture).not.toHaveBeenCalled();
-    expect(seedSpy).not.toHaveBeenCalled();
-    expect(disconnectSpy).not.toHaveBeenCalled();
-
-    const workerInput = constructorCalls[0] as {
-      context?: string;
-      browserSession?: PlaywrightMcpSession;
-    };
-    expect(workerInput.browserSession).toBeUndefined();
-    expect(workerInput.context).toBe("Pure http_request workflow.");
-  });
-
-  it("falls back to an unseeded fresh session when storage capture returns null but parent was used", async () => {
-    const parent = makeStubParentSession({
-      isConnected: true,
-      storageState: null, // capture failed / no page open
-    });
-    const seedSpy = vi
-      .spyOn(PlaywrightMcpSession.prototype, "seedStorageState")
-      .mockResolvedValue();
-    const disconnectSpy = vi
-      .spyOn(PlaywrightMcpSession.prototype, "disconnect")
-      .mockResolvedValue();
-
-    const ctx = buildCtx({ browserSession: parent.session });
-    const tool = spawnPentestAgent(ctx);
-    // biome-ignore lint/suspicious/noExplicitAny: ai-sdk tool execute receives an opaque ExecuteContext we don't need to narrow for this test.
-    await (tool as any).execute(
-      {
-        name: "Worker",
-        target: "https://example.com/x",
-        objectives: ["Test"],
-        toolCallDescription: "spawn worker",
-      },
-      { toolCallId: "tc1", messages: [], abortSignal: undefined },
-    );
-
-    // Capture was attempted, but seed was NOT called (no state to seed).
-    expect(parent.capture).toHaveBeenCalledTimes(1);
-    expect(seedSpy).not.toHaveBeenCalled();
-
-    // Worker still gets a fresh session (so its tool calls don't fall
-    // through to the orchestrator's session) and that session is still
-    // disposed on completion.
-    const workerInput = constructorCalls[0] as {
-      browserSession?: PlaywrightMcpSession;
-      context?: string;
-    };
-    expect(workerInput.browserSession).toBeDefined();
-    expect(workerInput.browserSession).not.toBe(parent.session);
-    expect(workerInput.context).toContain("Cloned Browser Session");
-
-    expect(disconnectSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("disconnects the worker session even when the worker throws", async () => {
-    const parent = makeStubParentSession({
-      isConnected: true,
-      storageState: { cookies: [], origins: [] },
-    });
-    vi.spyOn(
-      PlaywrightMcpSession.prototype,
-      "seedStorageState",
-    ).mockResolvedValue();
-    const disconnectSpy = vi
-      .spyOn(PlaywrightMcpSession.prototype, "disconnect")
-      .mockResolvedValue();
-
-    // Make the worker throw mid-consume.
-    const TargetedPentestAgent = (await import(
-      "../../specialized/pentest/agent"
-    )) as unknown as {
-      TargetedPentestAgent: new (
-        i: Record<string, unknown>,
-      ) => {
-        consume(): Promise<unknown>;
-      };
-    };
-    const origConsume =
-      TargetedPentestAgent.TargetedPentestAgent.prototype.consume;
-    TargetedPentestAgent.TargetedPentestAgent.prototype.consume = async () => {
-      throw new Error("worker boom");
-    };
-
-    try {
-      const ctx = buildCtx({ browserSession: parent.session });
-      const tool = spawnPentestAgent(ctx);
-      // biome-ignore lint/suspicious/noExplicitAny: ai-sdk tool execute receives an opaque ExecuteContext we don't need to narrow for this test.
-      const result = await (tool as any).execute(
-        {
-          name: "Bad worker",
-          target: "https://example.com/x",
-          objectives: ["Test"],
-          toolCallDescription: "spawn",
-        },
-        { toolCallId: "tc1", messages: [], abortSignal: undefined },
-      );
-
-      expect(result.success).toBe(false);
-      expect(disconnectSpy).toHaveBeenCalledTimes(1);
-    } finally {
-      TargetedPentestAgent.TargetedPentestAgent.prototype.consume = origConsume;
-    }
-  });
-
-  it("shares the orchestrator's browser session with the worker in sandbox mode (no copy-on-spawn; one browser per endpoint)", async () => {
-    const parent = makeStubParentSession({
-      isConnected: true,
-      storageState: { cookies: [], origins: [] },
-    });
-    const seedSpy = vi
-      .spyOn(PlaywrightMcpSession.prototype, "seedStorageState")
-      .mockResolvedValue();
-    const disconnectSpy = vi
-      .spyOn(PlaywrightMcpSession.prototype, "disconnect")
-      .mockResolvedValue();
-
+  it("shares nothing in remote-sandbox mode (worker gets no host session)", async () => {
+    const parent = makeParentSession();
     const ctx = buildCtx({
       browserSession: parent.session,
-      // biome-ignore lint/suspicious/noExplicitAny: stub sandbox object — spawn_pentest_agent only checks truthiness.
+      // biome-ignore lint/suspicious/noExplicitAny: stub sandbox — only truthiness matters here.
       sandbox: {} as any,
     });
 
-    const tool = spawnPentestAgent(ctx);
-    // biome-ignore lint/suspicious/noExplicitAny: ai-sdk tool execute receives an opaque ExecuteContext we don't need to narrow for this test.
-    await (tool as any).execute(
-      {
-        name: "Sandbox worker",
-        target: "https://example.com/api",
-        objectives: ["Test"],
-        context: "ctx-from-orchestrator",
-        toolCallDescription: "spawn worker",
-      },
-      { toolCallId: "tc1", messages: [], abortSignal: undefined },
-    );
-
-    // No copy-on-spawn: sandbox mode never clones (capture), seeds, or
-    // disconnects a per-worker session.
-    expect(parent.capture).not.toHaveBeenCalled();
-    expect(seedSpy).not.toHaveBeenCalled();
-    expect(disconnectSpy).not.toHaveBeenCalled();
+    await runSpawn(ctx);
 
     const workerInput = constructorCalls[0] as {
+      browserSession?: PlaywrightMcpSession;
       context?: string;
+    };
+    expect(workerInput.browserSession).toBeUndefined();
+    expect(parent.capture).not.toHaveBeenCalled();
+    // No shared-session note when nothing is shared.
+    expect(workerInput.context).toBe("ctx-from-orchestrator");
+  });
+
+  it("passes undefined when the orchestrator has no session (worker builds its own)", async () => {
+    const ctx = buildCtx({ browserSession: undefined });
+
+    await runSpawn(ctx);
+
+    const workerInput = constructorCalls[0] as {
       browserSession?: PlaywrightMcpSession;
     };
-    // The worker reuses the orchestrator's single session (one Camoufox per
-    // endpoint) rather than building its own — the sandbox OOM fix. It doesn't
-    // own the session, so it never tears down the orchestrator's browser.
-    expect(workerInput.browserSession).toBe(parent.session);
-    expect(workerInput.context).toBe("ctx-from-orchestrator");
+    expect(workerInput.browserSession).toBeUndefined();
   });
 });

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -2,14 +2,9 @@ import { tool } from "ai";
 import { z } from "zod";
 import { AgentEventBus } from "../../../eventBus";
 import { FindingsRegistry } from "../../../findings/registry";
-import {
-  resolveEffectiveHeaders,
-  stripBrowserManagedHeaders,
-} from "../../../http/targetHeaders";
 import { newSessionId } from "../../../id/id";
 // Type-only (erased) — the value is lazy-imported below to break a circular dep.
 import type { TargetedPentestAgent } from "../../specialized/pentest/agent";
-import { PlaywrightMcpSession } from "./playwrightMcp";
 import type { ToolContext } from "./types";
 
 // Cap the wait on a finished worker's background drain so it can't hang the slot.
@@ -125,79 +120,32 @@ Returns the worker's summary, objective results, and finding count — but NOT t
       const childBus = new AgentEventBus();
       AgentEventBus.attachChild(childBus, ctx.eventBus, subagentId);
 
-      // Copy-on-spawn browser session.
+      // Share the orchestrator's browser session with the worker instead of
+      // cloning it into a second Camoufox.
       //
-      // We do NOT reuse the orchestrator's Playwright session — that would
-      // mean the worker and the orchestrator (and every later worker) share
-      // one Chromium, so a `browser_navigate` / `browser_evaluate` /
-      // `localStorage.setItem` from one would clobber the others.
+      // `spawn_pentest_agent` awaits the worker (workers run strictly one at a
+      // time), and while a worker runs the orchestrator is blocked on this tool
+      // call — so there is never concurrent access to the shared browser.
+      // Sharing keeps ONE Camoufox per endpoint instead of two (orchestrator +
+      // a per-worker clone). Two-per-endpoint × the endpoint concurrency was
+      // saturating the agent sandbox's memory and OOM-thrashing large scans
+      // (pensarai/console#1984): the reused-session cloning launched a whole
+      // second Firefox for every worker.
       //
-      // Instead, when the orchestrator's browser has been used, we:
-      //   1. Snapshot its `BrowserContext.storageState()` (cookies +
-      //      per-origin localStorage).
-      //   2. Spin up a fresh PlaywrightMcpSession dedicated to this worker.
-      //   3. Seed that fresh session with the snapshot before any of the
-      //      worker's tools run, so the worker is already authenticated for
-      //      every origin the orchestrator was authenticated for.
-      //   4. After the worker finishes (or aborts), tear its session down
-      //      so we don't leak Chromium processes.
+      // The worker does NOT own the session (browserSession is provided ⇒
+      // ownsBrowserSession=false in the base agent), so it never disconnects the
+      // orchestrator's browser; the orchestrator tears it down at run end.
+      // Browser state (cookies, localStorage, current page) is shared live,
+      // which is fine — and useful — for the sequential per-objective → final
+      // chain/explore flow (a later worker sees what earlier ones set up).
       //
-      // The orchestrator's session is left untouched throughout, and each
-      // worker is fully isolated from the others.
-      //
-      // Sandbox mode skips this entirely: sandbox-side browser state is
-      // shared through the sandbox's persistent user-data directory, and
-      // workers spawned in the same sandbox already inherit it for free.
-      let workerBrowserSession: PlaywrightMcpSession | undefined;
-      let workerBrowserAbortHandler: (() => void) | undefined;
-      const parentBrowserUsed =
-        !ctx.sandbox && !!ctx.browserSession?.isConnected();
+      // Remote-sandbox mode (ctx.sandbox set — apex on a host driving a
+      // separate sandbox) has no host session object and shares state via the
+      // sandbox's user-data dir, so there is nothing to hand down.
+      const sharedBrowserSession = ctx.sandbox ? undefined : ctx.browserSession;
 
-      if (parentBrowserUsed && ctx.browserSession) {
-        // Pass resolved headers to the worker browser so subagent
-        // requests inherit the session/credential layers.
-        const inheritedHeaders = stripBrowserManagedHeaders(
-          target
-            ? resolveEffectiveHeaders(ctx.session, target)
-            : ctx.session.config?.headers,
-        );
-        try {
-          const state = await ctx.browserSession.captureStorageState();
-          workerBrowserSession = new PlaywrightMcpSession({
-            extraHttpHeaders: inheritedHeaders,
-            // Keep the worker on the orchestrator's display so its browser
-            // streams under the same endpoint instead of leaking to :0.
-            display: ctx.display,
-          });
-          if (state) {
-            await workerBrowserSession.seedStorageState(state);
-          }
-        } catch {
-          // Best-effort: if cloning fails the worker just runs with an
-          // unseeded fresh session. We still hand it the empty session so
-          // that the lifecycle path is consistent and we still tear it
-          // down on completion.
-          if (!workerBrowserSession) {
-            workerBrowserSession = new PlaywrightMcpSession({
-              extraHttpHeaders: inheritedHeaders,
-              display: ctx.display,
-            });
-          }
-        }
-
-        if (ctx.abortSignal && workerBrowserSession) {
-          const session = workerBrowserSession;
-          workerBrowserAbortHandler = () => {
-            session.disconnect().catch(() => {});
-          };
-          ctx.abortSignal.addEventListener("abort", workerBrowserAbortHandler, {
-            once: true,
-          });
-        }
-      }
-
-      const enrichedContext = workerBrowserSession
-        ? buildClonedBrowserSessionContext(context)
+      const enrichedContext = sharedBrowserSession
+        ? buildSharedBrowserSessionContext(context)
         : context;
 
       let agent: TargetedPentestAgent | undefined;
@@ -225,21 +173,10 @@ Returns the worker's summary, objective results, and finding count — but NOT t
           enableThinking: ctx.enableThinking,
           openAIReasoningEffort: ctx.openAIReasoningEffort,
           role: "worker",
-          // Non-sandbox: hand the worker its cloned, isolated session (or
-          // undefined if cloning was skipped). Sandbox: share the orchestrator's
-          // single browser session instead of letting the worker spin up its own
-          // Camoufox. Workers run one at a time (this tool awaits each), so there
-          // is no concurrent access — sharing keeps ONE browser per endpoint
-          // instead of two (orchestrator + worker), which is what OOM'd the 8 GiB
-          // sandbox (2 Camoufox/endpoint × the endpoint concurrency ≈ the whole
-          // memory budget). The worker does not own this session (browserSession
-          // was provided ⇒ ownsBrowserSession=false), so it never tears down the
-          // orchestrator's browser; the orchestrator disconnects it at run end.
-          browserSession:
-            workerBrowserSession ??
-            (ctx.sandbox ? ctx.browserSession : undefined),
-          // The worker's own-built browser (non-sandbox, uncloned path) still
-          // runs on the orchestrator's display.
+          // Reuse the orchestrator's browser session (see above) — one Camoufox
+          // per endpoint. Undefined only in remote-sandbox mode, where the
+          // worker's browser tools drive the sandbox browser directly instead.
+          browserSession: sharedBrowserSession,
           display: ctx.display,
         });
 
@@ -277,18 +214,10 @@ Returns the worker's summary, objective results, and finding count — but NOT t
           subagentId,
           message: `Worker '${name}' failed: ${message}`,
         };
-      } finally {
-        // Drain already awaited (bounded) before each completion emit above.
-        if (workerBrowserAbortHandler && ctx.abortSignal) {
-          ctx.abortSignal.removeEventListener(
-            "abort",
-            workerBrowserAbortHandler,
-          );
-        }
-        if (workerBrowserSession) {
-          await workerBrowserSession.disconnect().catch(() => {});
-        }
       }
+      // No browser teardown here: the worker shares (does not own) the
+      // orchestrator's session, so the orchestrator disconnects it at run end.
+      // The drain is already awaited (bounded) before each completion emit.
     },
   });
 }
@@ -298,22 +227,21 @@ Returns the worker's summary, objective results, and finding count — but NOT t
 // ---------------------------------------------------------------------------
 
 /**
- * Inject a "Cloned Browser Session" note at the top of the worker's
- * `context` block so the LLM driving the worker knows its Playwright
- * browser was *seeded* with the orchestrator's auth state but is otherwise
- * isolated. Without this hint the worker would either (a) waste turns
- * re-authenticating from scratch, or (b) wrongly assume its browser
- * mutations are visible to the orchestrator / sibling workers.
+ * Inject a "Shared Browser Session" note at the top of the worker's `context`
+ * block so the LLM driving the worker knows it is driving the orchestrator's
+ * live browser (already authenticated) and that its browser-side mutations
+ * persist. Without this hint the worker would either (a) waste turns
+ * re-authenticating from scratch, or (b) wrongly assume its browser state is
+ * throwaway.
  */
-function buildClonedBrowserSessionContext(
+function buildSharedBrowserSessionContext(
   existingContext: string | undefined,
 ): string {
-  const note = `## Cloned Browser Session
-Your Playwright browser is a fresh, isolated Chromium instance that was seeded at spawn time with a snapshot of the orchestrator's cookies and per-origin localStorage:
-- You are already authenticated for any origin the orchestrator was authenticated for. Do NOT re-authenticate unless a request returns 401/403.
-- Cookies are applied immediately. localStorage values are restored automatically on the FIRST navigation to each origin (via a Playwright init script), so call \`browser_navigate\` to your target origin before relying on \`localStorage\`.
-- Your browser is NOT shared. Navigations, \`browser_evaluate\` mutations, \`localStorage\`/\`sessionStorage\` writes, alerts, and any other browser-side state you create are LOCAL to your session. They will not be visible to the orchestrator or to sibling workers, and your session is torn down when you finish.
-- The orchestrator's browser is also not affected by your actions, so feel free to fire payloads, navigate aggressively, or clobber DOM state — you cannot break the orchestrator's session.`;
+  const note = `## Shared Browser Session
+You are driving the orchestrator's live Playwright browser (NOT a private copy):
+- You are already authenticated for any origin the orchestrator authenticated for. Do NOT re-authenticate unless a request returns 401/403.
+- Only one agent uses this browser at a time — the orchestrator is paused while you run — so you have exclusive control during your run.
+- Your navigations, \`browser_evaluate\` mutations, cookies, and \`localStorage\`/\`sessionStorage\` writes PERSIST in this browser and are visible to the orchestrator and to workers spawned after you. Leave the session in a reasonable state (avoid logging out or wedging the page) when you finish.`;
 
   if (!existingContext || existingContext.trim().length === 0) {
     return note;


### PR DESCRIPTION
## Summary

The **real** fix for the large-pentest sandbox OOM (pensarai/console#1984). Supersedes #886, which was a no-op.

### Why #886 didn't work
#886 gated the browser-sharing on `ctx.sandbox`. But `ctx.sandbox` (the `UnifiedSandbox` remote-exec handle) is only set when apex drives a **remote** sandbox from a host. In production **apex runs *inside* the Daytona sandbox**, so `ctx.sandbox` is `undefined` and the **native `PlaywrightMcpSession` path** is used — where `spawn_pentest_agent` **clones** the orchestrator's session into a brand-new Camoufox for every worker.

That clone is the real source of **~2 Camoufox per endpoint** (orchestrator + worker). At the endpoint concurrency it saturates the sandbox memory and OOM-thrashes big scans. Confirmed live on a 176-endpoint prod run (VEL-0012, with #886 deployed): **16 Camoufox, cgroup at 99.8% (8179/8192 MB), 0 endpoints done**.

### The fix
Replace the per-worker clone with a **direct share** of the orchestrator's session. `spawn_pentest_agent` awaits each worker (workers run strictly one at a time) and the orchestrator is blocked while a worker runs, so there's no concurrent access — **one Camoufox per endpoint**. The worker receives the orchestrator's session (`ownsBrowserSession=false`), so it never disconnects it; the orchestrator tears it down at run end. Live browser state is shared, which suits the sequential per-objective → final chain/explore flow (a later worker sees what earlier ones set up).

- Removes the now-dead clone/seed/`captureStorageState`/disconnect path and its imports.
- **Untouched:** the parallel `spawn_pentest_swarm` (concurrent workers must keep their own browsers).
- Tests rewritten to assert the worker reuses the orchestrator's session with no clone.

## Test plan

- [x] `bun run tsc` — clean
- [x] `bun run lint` / biome on changed files — clean
- [x] `bun run test src/core/agents/offSecAgent/` — 283 passed / 9 skipped
- [ ] Deploy (console submodule bump) → re-run a large prod pentest; confirm **~1 Camoufox per active endpoint** and cgroup memory well under cap (vs. 16 / 99.8% before)

Refs pensarai/console#1984

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pentest worker browser semantics from isolated clones to a shared live session; sequential execution limits races, but a worker can still leave cookies/DOM in a state that affects the orchestrator or the next worker.
> 
> **Overview**
> **`spawn_pentest_agent` no longer clones the orchestrator’s Playwright/Camoufox session for each worker.** In native (non–remote-sandbox) mode it passes the orchestrator’s live `browserSession` straight into `TargetedPentestAgent`, relying on the tool awaiting one worker at a time so only one agent touches that browser.
> 
> The old path—`captureStorageState`, a new `PlaywrightMcpSession`, `seedStorageState`, per-worker `disconnect`, and abort cleanup—is removed, along with related HTTP header imports. Worker context now gets a **“Shared Browser Session”** note (replacing “Cloned Browser Session”) telling the model that auth is inherited and that navigations/storage mutations persist for later workers and the orchestrator. When `ctx.sandbox` is set (remote sandbox) or there is no orchestrator session, workers still get `undefined` and build or use sandbox-side browser state as before.
> 
> Unit tests are rewritten around direct session reuse, no capture/disconnect on spawn, sandbox vs native behavior, and the new context note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc37a8d8b338240b8c3a64020b3fe21514d55ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->