### PR TITLE
fix(ai): don't route extended thinking to non-adaptive models

### DIFF
--- a/src/core/ai/ai.test.ts
+++ b/src/core/ai/ai.test.ts
@@ -87,6 +87,20 @@ describe("buildReasoningProviderOptions", () => {
     ).toBeUndefined();
   });
 
+  it("requests no thinking for pre-4.6 Opus models (Opus 4.0, 4.1, 4.5)", () => {
+    for (const id of [
+      "claude-opus-4-0",
+      "claude-opus-4-20250514",
+      "claude-opus-4-1-20250805",
+      "claude-opus-4-5",
+      "global.anthropic.claude-opus-4-5-20251101-v1:0",
+    ]) {
+      expect(
+        buildReasoningProviderOptions(id, { enableThinking: true }),
+      ).toBeUndefined();
+    }
+  });
+
   it("returns undefined when thinking is disabled and no OpenAI effort applies", () => {
     expect(
       buildReasoningProviderOptions("global.anthropic.claude-opus-4-6-v1", {

--- a/src/core/ai/ai.test.ts
+++ b/src/core/ai/ai.test.ts
@@ -68,11 +68,23 @@ describe("buildReasoningProviderOptions", () => {
     });
   });
 
-  it("sets anthropic.thinking for a direct Anthropic model when thinking is enabled", () => {
-    const result = buildReasoningProviderOptions("claude-sonnet-4-5", {
-      enableThinking: true,
-    });
-    expect(result?.anthropic).toEqual({ thinking: { type: "adaptive" } });
+  it("requests no thinking for the Bedrock recon model (Haiku 4.5), which rejects adaptive", () => {
+    // Regression: Haiku 4.5 supports extended thinking but not the adaptive
+    // type; requesting it failed recon. Non-4.6 models get no thinking.
+    expect(
+      buildReasoningProviderOptions(
+        "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+        { enableThinking: true },
+      ),
+    ).toBeUndefined();
+  });
+
+  it("requests no thinking for pre-4.6 thinking models (Sonnet 4.5)", () => {
+    expect(
+      buildReasoningProviderOptions("claude-sonnet-4-5", {
+        enableThinking: true,
+      }),
+    ).toBeUndefined();
   });
 
   it("returns undefined when thinking is disabled and no OpenAI effort applies", () => {

--- a/src/core/ai/ai.test.ts
+++ b/src/core/ai/ai.test.ts
@@ -68,27 +68,11 @@ describe("buildReasoningProviderOptions", () => {
     });
   });
 
-  it("uses the legacy `enabled` form for the Bedrock recon model (Haiku 4.5), never adaptive", () => {
-    // Regression: Haiku 4.5 rejects `adaptive` — recon must get the legacy form.
-    const result = buildReasoningProviderOptions(
-      "global.anthropic.claude-haiku-4-5-20251001-v1:0",
-      { enableThinking: true },
-    );
-    expect(result).toEqual({
-      anthropic: { thinking: { type: "enabled", budgetTokens: 10_000 } },
-      bedrock: {
-        reasoningConfig: { type: "enabled", budgetTokens: 10_000 },
-      },
-    });
-  });
-
-  it("uses the legacy `enabled` form for pre-4.6 thinking models (Sonnet 4.5)", () => {
+  it("sets anthropic.thinking for a direct Anthropic model when thinking is enabled", () => {
     const result = buildReasoningProviderOptions("claude-sonnet-4-5", {
       enableThinking: true,
     });
-    expect(result?.anthropic).toEqual({
-      thinking: { type: "enabled", budgetTokens: 10_000 },
-    });
+    expect(result?.anthropic).toEqual({ thinking: { type: "adaptive" } });
   });
 
   it("returns undefined when thinking is disabled and no OpenAI effort applies", () => {

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -694,39 +694,24 @@ export interface ModelInfo {
   contextLength?: number;
 }
 
-function normalizeClaudeModelId(modelId: string): string {
-  return modelId
-    .replace(/^pensar:/, "")
-    .replace(/^(us\.|eu\.|global\.|ap\.)?anthropic\./, "");
-}
-
 /**
- * Whether a model supports extended thinking in any form (Claude 3.7 Sonnet
- * and all 4.x+). Whether it accepts the newer `adaptive` type or only the
- * legacy `enabled` form is separate — see `modelSupportsAdaptiveThinking`.
+ * Check whether a model supports extended thinking based on its ID.
+ *
+ * Thinking is available on Claude 3.7 Sonnet and all Claude 4.x+ models
+ * (Sonnet, Opus, Haiku 4.5). Works for Anthropic direct, Bedrock, and
+ * Pensar provider IDs.
  */
 export function modelSupportsThinking(modelId: string): boolean {
-  const normalized = normalizeClaudeModelId(modelId);
+  // Normalize: strip provider prefixes so we match the base Claude model ID
+  const normalized = modelId
+    .replace(/^pensar:/, "")
+    .replace(/^(us\.|eu\.|global\.|ap\.)?anthropic\./, "");
 
   return (
     /^claude-3-7-sonnet/.test(normalized) ||
     /^claude-sonnet-4/.test(normalized) ||
     /^claude-opus-4/.test(normalized) ||
     /^claude-haiku-4-5/.test(normalized)
-  );
-}
-
-/**
- * Whether a model accepts the `adaptive` thinking type. Only Claude 4.6+
- * families do; older thinking-capable models reject it. Conservative: when
- * unsure return false, since the legacy `enabled` form works everywhere.
- */
-function modelSupportsAdaptiveThinking(modelId: string): boolean {
-  const normalized = normalizeClaudeModelId(modelId);
-
-  return (
-    /^claude-(sonnet|opus|haiku)-4-[6-9]/.test(normalized) ||
-    /^claude-(sonnet|opus|haiku)-[5-9]/.test(normalized)
   );
 }
 
@@ -770,19 +755,10 @@ export function normalizeOpenAIReasoningEffort(
  *   - `openai.reasoningEffort` — OpenAI/o-series reasoning models.
  */
 export type ReasoningProviderOptions = {
-  anthropic?: {
-    thinking: { type: "adaptive" } | { type: "enabled"; budgetTokens: number };
-  };
-  bedrock?: {
-    reasoningConfig:
-      | { type: "adaptive"; display: "summarized" }
-      | { type: "enabled"; budgetTokens: number };
-  };
+  anthropic?: { thinking: { type: "adaptive" } };
+  bedrock?: { reasoningConfig: { type: "adaptive"; display: "summarized" } };
   openai?: OpenAIResponsesProviderOptions;
 };
-
-// Budget for legacy `enabled` thinking; matches the Pensar gateway default.
-const LEGACY_THINKING_BUDGET_TOKENS = 10_000;
 
 /**
  * Build the `providerOptions` for a request based on the model and reasoning
@@ -812,32 +788,18 @@ export function buildReasoningProviderOptions(
 
   if (!useThinking && !normalizedOpenAIEffort) return undefined;
 
-  const thinkingOptions: ReasoningProviderOptions = !useThinking
-    ? {}
-    : modelSupportsAdaptiveThinking(model)
+  return {
+    ...(useThinking
       ? {
-          anthropic: { thinking: { type: "adaptive" } },
-          bedrock: {
-            reasoningConfig: { type: "adaptive", display: "summarized" },
-          },
-        }
-      : {
-          anthropic: {
-            thinking: {
-              type: "enabled",
-              budgetTokens: LEGACY_THINKING_BUDGET_TOKENS,
-            },
-          },
+          anthropic: { thinking: { type: "adaptive" as const } },
           bedrock: {
             reasoningConfig: {
-              type: "enabled",
-              budgetTokens: LEGACY_THINKING_BUDGET_TOKENS,
+              type: "adaptive" as const,
+              display: "summarized" as const,
             },
           },
-        };
-
-  return {
-    ...thinkingOptions,
+        }
+      : {}),
     ...(normalizedOpenAIEffort
       ? { openai: { reasoningEffort: normalizedOpenAIEffort } }
       : {}),

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -716,9 +716,10 @@ export function modelSupportsThinking(modelId: string): boolean {
 }
 
 /**
- * Whether a model accepts the `adaptive` thinking type — Claude Opus 4.x and
- * Sonnet 4.6+. Haiku 4.5 and Sonnet 4.5 support extended thinking but reject
- * `adaptive`, so we don't request thinking for them at all.
+ * Whether a model accepts the `adaptive` thinking type — Claude Opus 4.6+ and
+ * Sonnet 4.6+. Pre-4.6 models (Opus 4.0–4.5, Sonnet 4.5, Haiku 4.5) support
+ * extended thinking but reject `adaptive`, so we don't request thinking for
+ * them at all.
  */
 function modelSupportsAdaptiveThinking(modelId: string): boolean {
   const normalized = modelId
@@ -726,8 +727,8 @@ function modelSupportsAdaptiveThinking(modelId: string): boolean {
     .replace(/^(us\.|eu\.|global\.|ap\.)?anthropic\./, "");
 
   return (
-    /^claude-sonnet-4-6/.test(normalized) ||
-    /^claude-opus-4/.test(normalized)
+    /^claude-sonnet-4-[6-9]/.test(normalized) ||
+    /^claude-opus-4-[6-9]/.test(normalized)
   );
 }
 

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -715,6 +715,22 @@ export function modelSupportsThinking(modelId: string): boolean {
   );
 }
 
+/**
+ * Whether a model accepts the `adaptive` thinking type — Claude Opus 4.x and
+ * Sonnet 4.6+. Haiku 4.5 and Sonnet 4.5 support extended thinking but reject
+ * `adaptive`, so we don't request thinking for them at all.
+ */
+function modelSupportsAdaptiveThinking(modelId: string): boolean {
+  const normalized = modelId
+    .replace(/^pensar:/, "")
+    .replace(/^(us\.|eu\.|global\.|ap\.)?anthropic\./, "");
+
+  return (
+    /^claude-sonnet-4-6/.test(normalized) ||
+    /^claude-opus-4/.test(normalized)
+  );
+}
+
 export function modelSupportsOpenAIReasoning(modelId: string): boolean {
   const { provider } = getModelInfo(modelId);
   if (provider !== "openai") return false;
@@ -780,7 +796,7 @@ export function buildReasoningProviderOptions(
   const useThinking =
     !!opts.enableThinking &&
     isAnthropicProvider(model) &&
-    modelSupportsThinking(model);
+    modelSupportsAdaptiveThinking(model);
   const normalizedOpenAIEffort = normalizeOpenAIReasoningEffort(
     model,
     opts.openAIReasoningEffort,


### PR DESCRIPTION
Scopes adaptive thinking to models that actually support it — Claude **Opus/Sonnet 4.6+**. Pre-4.6 Claude models (Haiku 4.5, Sonnet 4.5, Opus 4.0–4.5) support extended thinking but reject the `adaptive` type, so we don't request thinking for them at all.

## Why

Recon (attack-surface) runs on **Haiku 4.5**, and requesting `adaptive` thinking there fails with `adaptive thinking is not supported on this model`. The earlier fix (#887) tried to keep thinking on for those models via the legacy `enabled` form, but that carries a required token budget that inflates `max_tokens` and caused further trouble on the recon path. This PR takes the simpler route: only request thinking where `adaptive` is actually accepted.

## Change

- Add `modelSupportsAdaptiveThinking(modelId)` — mirrors `modelSupportsThinking`; matches Opus/Sonnet **4.6+**.
- Gate `buildReasoningProviderOptions` on it (was `modelSupportsThinking`).
- Reverts #887; `providerOptions` is back to adaptive-only.

Net effect vs. before #887: thinking is requested only on 4.6+ models. Opus 4.6 (the pentest/patching default) keeps adaptive; Haiku 4.5 (recon) gets none.

## Tests

`bunx vitest run src/core/ai/ai.test.ts` — Opus 4.6 → adaptive; Haiku 4.5 / Sonnet 4.5 / Opus 4.0·4.1·4.5 → no thinking. `tsc`, `biome check`, `knip` all clean.
