### PR TITLE
fix(tui): render orchestrator replies and keep logs off the live frame

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -658,10 +658,8 @@ export class OffensiveSecurityAgent<TResult = void> {
       // Tool-call part ids are minted once and reused for the WHOLE session, never reset per step.
       const toolParts = new Map<string, string>();
       const ids: StreamIdContext = {
-        // Orchestrator (top-level) MUST leave subagentId undefined — the TUI
-        // routes any event with a subagentId into a subagent panel. Only real
-        // subagents (this.subagentId set) claim one. sessionId still carries the
-        // full id for telemetry.
+        // The TUI routes any event with a subagentId into a subagent panel, so
+        // the orchestrator must leave it undefined; only real subagents set it.
         subagentId: this.subagentId,
         sessionId: this.busSessionId,
         messageId: undefined,

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -658,7 +658,11 @@ export class OffensiveSecurityAgent<TResult = void> {
       // Tool-call part ids are minted once and reused for the WHOLE session, never reset per step.
       const toolParts = new Map<string, string>();
       const ids: StreamIdContext = {
-        subagentId: this.busSessionId,
+        // Orchestrator (top-level) MUST leave subagentId undefined — the TUI
+        // routes any event with a subagentId into a subagent panel. Only real
+        // subagents (this.subagentId set) claim one. sessionId still carries the
+        // full id for telemetry.
+        subagentId: this.subagentId,
         sessionId: this.busSessionId,
         messageId: undefined,
         textPartId: undefined,

--- a/src/core/eventBus.test.ts
+++ b/src/core/eventBus.test.ts
@@ -244,6 +244,24 @@ describe("emitStreamPart — native id threading", () => {
     expect(received[0].subagentId).toBe("sub-1");
     expect(received[0].sessionId).toBeUndefined();
   });
+
+  it("leaves subagentId undefined for orchestrator streams (sessionId set, no subagentId)", () => {
+    // Regression (#851): emitStreamPart must NOT alias sessionId into
+    // subagentId. The orchestrator emits with no subagentId; if sessionId
+    // leaks into it, the TUI's `if (d.subagentId)` check routes the reply into
+    // a (non-existent) subagent panel and it never renders in the main view.
+    const bus = new AgentEventBus();
+    const sessionId = newSessionId();
+    const received: AgentEventMapText[] = [];
+    bus.on("text-delta", (e) => received.push(e));
+
+    bus.emitStreamPart(part({ type: "text-delta", id: "t1", text: "hi" }), {
+      sessionId,
+    });
+
+    expect(received[0].subagentId).toBeUndefined();
+    expect(received[0].sessionId).toBe(sessionId);
+  });
 });
 
 describe("attachChild — session id injection", () => {

--- a/src/core/eventBus.test.ts
+++ b/src/core/eventBus.test.ts
@@ -246,10 +246,8 @@ describe("emitStreamPart — native id threading", () => {
   });
 
   it("leaves subagentId undefined for orchestrator streams (sessionId set, no subagentId)", () => {
-    // Regression (#851): emitStreamPart must NOT alias sessionId into
-    // subagentId. The orchestrator emits with no subagentId; if sessionId
-    // leaks into it, the TUI's `if (d.subagentId)` check routes the reply into
-    // a (non-existent) subagent panel and it never renders in the main view.
+    // Regression (#851): emitStreamPart must not alias sessionId into subagentId,
+    // or the TUI routes the orchestrator's reply into a subagent panel.
     const bus = new AgentEventBus();
     const sessionId = newSessionId();
     const received: AgentEventMapText[] = [];

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -284,8 +284,7 @@ export class AgentEventBus {
   ): void {
     const ctx: StreamIdContext =
       typeof ids === "string" ? { subagentId: ids } : (ids ?? {});
-    // Do NOT fall back to sessionId: subagentId must stay undefined for the
-    // orchestrator so consumers can distinguish it from a subagent's stream.
+    // No sessionId fallback: subagentId stays undefined for the orchestrator.
     const subagentId = ctx.subagentId;
     const sessionId = ctx.sessionId;
     const messageId = ctx.messageId;

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -284,7 +284,9 @@ export class AgentEventBus {
   ): void {
     const ctx: StreamIdContext =
       typeof ids === "string" ? { subagentId: ids } : (ids ?? {});
-    const subagentId = ctx.subagentId ?? ctx.sessionId;
+    // Do NOT fall back to sessionId: subagentId must stay undefined for the
+    // orchestrator so consumers can distinguish it from a subagent's stream.
+    const subagentId = ctx.subagentId;
     const sessionId = ctx.sessionId;
     const messageId = ctx.messageId;
 

--- a/src/core/logger/errorLog.test.ts
+++ b/src/core/logger/errorLog.test.ts
@@ -73,9 +73,6 @@ describe("error() → ~/.pensar/error.log", () => {
     expect(readFileSync(errLog, "utf8")).toBe(before);
   });
 
-  // error.log mixes human `<ts> - [ERROR]` entries with structured JSON lines
-  // (the TUI sink). Prune must date each shape on its own, or a recent JSON line
-  // trailing an expired human entry inherits its drop decision and is deleted.
   it("prune keeps a recent JSON line that follows an expired human entry", async () => {
     const dir = path.join(tmpHome, ".pensar");
     mkdirSync(dir, { recursive: true });
@@ -90,12 +87,12 @@ describe("error() → ~/.pensar/error.log", () => {
       "utf8",
     );
 
-    // Any write triggers the once-per-process prune before appending.
+    // Any write triggers the once-per-process prune.
     const { writeErrorLog } = await import("./index");
     writeErrorLog("trigger prune", "TEST");
 
     const content = readFileSync(errLog, "utf8");
-    expect(content).toContain("recent structured line"); // survives (regression guard)
-    expect(content).not.toContain("expired legacy entry"); // pruned
+    expect(content).toContain("recent structured line");
+    expect(content).not.toContain("expired legacy entry");
   });
 });

--- a/src/core/logger/errorLog.test.ts
+++ b/src/core/logger/errorLog.test.ts
@@ -1,4 +1,11 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
 import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -64,5 +71,31 @@ describe("error() → ~/.pensar/error.log", () => {
     log.error("second", new Error("y")); // suppressed
 
     expect(readFileSync(errLog, "utf8")).toBe(before);
+  });
+
+  // error.log mixes human `<ts> - [ERROR]` entries with structured JSON lines
+  // (the TUI sink). Prune must date each shape on its own, or a recent JSON line
+  // trailing an expired human entry inherits its drop decision and is deleted.
+  it("prune keeps a recent JSON line that follows an expired human entry", async () => {
+    const dir = path.join(tmpHome, ".pensar");
+    mkdirSync(dir, { recursive: true });
+    const errLog = path.join(dir, "error.log");
+
+    const oldTs = new Date(Date.now() - 30 * 86_400_000).toISOString();
+    const recentTs = new Date().toISOString();
+    writeFileSync(
+      errLog,
+      `${oldTs} - [ERROR] expired legacy entry\n` +
+        `{"ts":"${recentTs}","level":"WARN","msg":"recent structured line"}\n`,
+      "utf8",
+    );
+
+    // Any write triggers the once-per-process prune before appending.
+    const { writeErrorLog } = await import("./index");
+    writeErrorLog("trigger prune", "TEST");
+
+    const content = readFileSync(errLog, "utf8");
+    expect(content).toContain("recent structured line"); // survives (regression guard)
+    expect(content).not.toContain("expired legacy entry"); // pruned
   });
 });

--- a/src/core/logger/index.ts
+++ b/src/core/logger/index.ts
@@ -23,18 +23,12 @@ export enum LogLevel {
 
 const ERROR_LOG_PATH = path.join(os.homedir(), ".pensar", "error.log");
 const RETENTION_DAYS = 7;
-// error.log holds two line shapes: the human `<ts> - [LEVEL]` entries from
-// writeErrorLog, and structured JSON lines (`{"ts":"<ts>",...}`) that the TUI
-// sink appends. Prune must recognize both, or a recent JSON line following an
-// expired human entry inherits its drop decision and gets deleted.
+// error.log holds human `<ts> - [ERROR]` entries and structured JSON lines
+// (the TUI sink); prune dates both shapes so neither is dropped by the other.
 const TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2}T[\d:.]+Z) - /;
 const JSON_TS_RE = /^\{"ts":"(\d{4}-\d{2}-\d{2}T[\d:.]+Z)"/;
 
-/**
- * ISO timestamp starting a log entry, from either shape. Returns null for
- * continuation lines (e.g. stack-trace lines) that carry no timestamp of their
- * own — those inherit the preceding entry's keep decision.
- */
+/** Entry timestamp (ms) from either line shape; null for continuation lines. */
 function entryTimestamp(line: string): number | null {
   const m = TIMESTAMP_RE.exec(line) ?? JSON_TS_RE.exec(line);
   return m ? new Date(m[1]!).getTime() : null;
@@ -119,17 +113,12 @@ export function writeErrorLog(
 }
 
 /**
- * Redirect all structured-logger output from stderr into ~/.pensar/error.log.
- *
- * The interactive TUI calls this at startup: OpenTUI owns the screen, so any
- * raw stderr write (a `log.warn`, a stack trace) lands on the live frame and
- * garbles it — e.g. the per-turn Weave flush warning bleeding into the input
- * box. User-facing errors are surfaced through the TUI itself; the file keeps
- * everything diagnosable. Headless/CLI runs never call this, so they keep
- * logging to stderr as before.
+ * Redirect structured-logger output from stderr into ~/.pensar/error.log.
+ * The TUI calls this at startup: OpenTUI owns the screen, so a raw stderr write
+ * garbles the live frame. Headless/CLI runs keep logging to stderr.
  */
 export function routeLogsToErrorFile(): void {
-  // Force JSON so pretty-format ANSI color codes don't end up in the file.
+  // JSON so pretty-format ANSI codes don't end up in the file.
   process.env.PENSAR_LOG_FORMAT = "json";
   setLogSink((line) => {
     try {

--- a/src/core/logger/index.ts
+++ b/src/core/logger/index.ts
@@ -10,6 +10,7 @@ import path from "node:path";
 import { type SessionInfo, sessions } from "../session";
 
 export { type LogLevel as StructuredLogLevel, logger } from "./structured";
+
 import { setLogSink } from "./structured";
 
 export enum LogLevel {
@@ -22,7 +23,22 @@ export enum LogLevel {
 
 const ERROR_LOG_PATH = path.join(os.homedir(), ".pensar", "error.log");
 const RETENTION_DAYS = 7;
+// error.log holds two line shapes: the human `<ts> - [LEVEL]` entries from
+// writeErrorLog, and structured JSON lines (`{"ts":"<ts>",...}`) that the TUI
+// sink appends. Prune must recognize both, or a recent JSON line following an
+// expired human entry inherits its drop decision and gets deleted.
 const TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2}T[\d:.]+Z) - /;
+const JSON_TS_RE = /^\{"ts":"(\d{4}-\d{2}-\d{2}T[\d:.]+Z)"/;
+
+/**
+ * ISO timestamp starting a log entry, from either shape. Returns null for
+ * continuation lines (e.g. stack-trace lines) that carry no timestamp of their
+ * own — those inherit the preceding entry's keep decision.
+ */
+function entryTimestamp(line: string): number | null {
+  const m = TIMESTAMP_RE.exec(line) ?? JSON_TS_RE.exec(line);
+  return m ? new Date(m[1]!).getTime() : null;
+}
 
 let hasPruned = false;
 
@@ -43,9 +59,9 @@ function pruneErrorLog(): void {
     const kept: string[] = [];
     let keeping = true;
     for (const line of lines) {
-      const match = TIMESTAMP_RE.exec(line);
-      if (match) {
-        keeping = new Date(match[1]!).getTime() >= cutoff;
+      const ts = entryTimestamp(line);
+      if (ts !== null) {
+        keeping = ts >= cutoff;
       }
       if (keeping) {
         kept.push(line);

--- a/src/core/logger/index.ts
+++ b/src/core/logger/index.ts
@@ -10,6 +10,7 @@ import path from "node:path";
 import { type SessionInfo, sessions } from "../session";
 
 export { type LogLevel as StructuredLogLevel, logger } from "./structured";
+import { setLogSink } from "./structured";
 
 export enum LogLevel {
   INFO = "INFO",
@@ -99,6 +100,32 @@ export function writeErrorLog(
   } catch {
     // Last resort — don't throw from the error logger
   }
+}
+
+/**
+ * Redirect all structured-logger output from stderr into ~/.pensar/error.log.
+ *
+ * The interactive TUI calls this at startup: OpenTUI owns the screen, so any
+ * raw stderr write (a `log.warn`, a stack trace) lands on the live frame and
+ * garbles it — e.g. the per-turn Weave flush warning bleeding into the input
+ * box. User-facing errors are surfaced through the TUI itself; the file keeps
+ * everything diagnosable. Headless/CLI runs never call this, so they keep
+ * logging to stderr as before.
+ */
+export function routeLogsToErrorFile(): void {
+  // Force JSON so pretty-format ANSI color codes don't end up in the file.
+  process.env.PENSAR_LOG_FORMAT = "json";
+  setLogSink((line) => {
+    try {
+      const dir = path.dirname(ERROR_LOG_PATH);
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+      }
+      appendFileSync(ERROR_LOG_PATH, `${line}\n`, "utf8");
+    } catch {
+      // Last resort — never throw from the logger.
+    }
+  });
 }
 
 export class Logger {

--- a/src/core/logger/structured.test.ts
+++ b/src/core/logger/structured.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createLogger, type LogLevel, resolveInitialLevel } from "./structured";
+import {
+  createLogger,
+  type LogLevel,
+  resolveInitialLevel,
+  setLogSink,
+} from "./structured";
 
 // Capture process.stderr.write into `sink`; returns a restore fn.
 function captureStderr(sink: string[]): () => void {
@@ -171,5 +176,37 @@ describe("JSON record shape", () => {
     const rec = firstRecord(writes);
     expect(rec.code).toBe("E_X");
     expect(rec.error).toBeUndefined();
+  });
+});
+
+describe("setLogSink — redirect away from stderr", () => {
+  afterEach(() => setLogSink(null));
+
+  it("routes emitted lines to the custom sink, not stderr (TUI corruption fix)", () => {
+    const stderrWrites: string[] = [];
+    const restore = captureStderr(stderrWrites);
+    const captured: string[] = [];
+    setLogSink((line) => captured.push(line));
+    try {
+      createLogger("wandb").warn("getGlobalClient not found — flush skipped.");
+    } finally {
+      restore();
+    }
+    expect(stderrWrites).toHaveLength(0);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toContain("flush skipped");
+  });
+
+  it("restores the stderr sink when reset with null", () => {
+    setLogSink(() => {});
+    setLogSink(null);
+    const stderrWrites: string[] = [];
+    const restore = captureStderr(stderrWrites);
+    try {
+      createLogger("t").warn("hello");
+    } finally {
+      restore();
+    }
+    expect(stderrWrites.length).toBeGreaterThan(0);
   });
 });

--- a/src/core/logger/structured.ts
+++ b/src/core/logger/structured.ts
@@ -60,9 +60,8 @@ const COLORS: Record<LogLevel, string> = {
 const RESET = "\x1b[0m";
 const DIM = "\x1b[2m";
 
-// Sink for emitted log lines. Defaults to stderr; the interactive TUI redirects
-// this to a file (see `routeLogsToErrorFile`) so a raw terminal write never
-// corrupts the OpenTUI frame while it owns the screen.
+// Sink for emitted lines. Defaults to stderr; the TUI redirects it to a file
+// (routeLogsToErrorFile) so writes don't corrupt the OpenTUI frame.
 type LogSink = (line: string) => void;
 const stderrSink: LogSink = (line) => process.stderr.write(`${line}\n`);
 let sink: LogSink = stderrSink;

--- a/src/core/logger/structured.ts
+++ b/src/core/logger/structured.ts
@@ -60,6 +60,17 @@ const COLORS: Record<LogLevel, string> = {
 const RESET = "\x1b[0m";
 const DIM = "\x1b[2m";
 
+// Sink for emitted log lines. Defaults to stderr; the interactive TUI redirects
+// this to a file (see `routeLogsToErrorFile`) so a raw terminal write never
+// corrupts the OpenTUI frame while it owns the screen.
+type LogSink = (line: string) => void;
+const stderrSink: LogSink = (line) => process.stderr.write(`${line}\n`);
+let sink: LogSink = stderrSink;
+
+export function setLogSink(next: LogSink | null): void {
+  sink = next ?? stderrSink;
+}
+
 class Logger {
   private level: LogLevel;
   private explicit = false;
@@ -134,7 +145,7 @@ class Logger {
         ? this.formatJson(ts, level, msg, fields)
         : this.formatPretty(ts, level, msg, fields);
 
-    process.stderr.write(`${line}\n`);
+    sink(line);
   }
 
   private formatJson(

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -670,8 +670,7 @@ function CommandDisplay({
 }
 
 async function main() {
-  // OpenTUI is about to take over the screen — send all logger output to the
-  // error log so no raw stderr write can garble a live frame.
+  // OpenTUI is about to own the screen — route logs to file, not stderr.
   routeLogsToErrorFile();
 
   const appConfig = await config.get();

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { config } from "../core/config";
 import type { Config } from "../core/config/config";
 import { checkForUpdate } from "../core/installation";
-import { writeErrorLog } from "../core/logger";
+import { routeLogsToErrorFile, writeErrorLog } from "../core/logger";
 import { hasAnyProviderConfigured } from "../core/providers";
 import type { SessionConfig } from "../core/session";
 import { setupAutoCopy } from "./auto-copy";
@@ -670,6 +670,10 @@ function CommandDisplay({
 }
 
 async function main() {
+  // OpenTUI is about to take over the screen — send all logger output to the
+  // error log so no raw stderr write can garble a live frame.
+  routeLogsToErrorFile();
+
   const appConfig = await config.get();
 
   registerBuiltinThemes();


### PR DESCRIPTION
After #851, the interactive TUI stopped showing agent replies and leaked a garbled `getGlobalClient not found — flush skipped` warning into the input box.

Two independent causes: the orchestrator started tagging its own stream events with a `subagentId` (the root session id), so the TUI routed them into a subagent panel and dropped them — no reply rendered. And the structured logger writes every level straight to `process.stderr`, so the per-turn Weave flush warning painted raw bytes onto the live OpenTUI frame.

Fixes the first by keeping `subagentId` unset for the orchestrator (and not aliasing it from `sessionId`), and the second by giving the logger a redirectable sink that the TUI points at `~/.pensar/error.log` while it owns the screen. Headless/CLI runs still log to stderr.

Closes #889.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted fixes to event routing and logging sinks with regression tests; no auth, data, or payment paths touched.
> 
> **Overview**
> Fixes two TUI regressions: **orchestrator replies missing** and **log text corrupting the live frame**.
> 
> **Stream routing:** The orchestrator no longer tags its stream events with a `subagentId` (it was incorrectly using the root session id). `emitStreamPart` also stops falling back from `sessionId` to `subagentId`, so the TUI routes main-agent text to the chat instead of a subagent panel. Real subagents still set `subagentId` via `OffensiveSecurityAgent.consume()`.
> 
> **Logging:** Structured logs use a redirectable sink (`setLogSink` / `routeLogsToErrorFile`). The TUI enables this at startup so output goes to `~/.pensar/error.log` as JSON while OpenTUI owns the screen; CLI/headless runs still use stderr. Error log pruning now recognizes both legacy human lines and structured JSON timestamps so mixed files retain recent entries correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec90e71d17d1f0c50d0b92b88ce8ee498c639779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->