### PR TITLE
fix(pentest): cap Firefox content processes to cut per-browser memory

### DIFF
--- a/src/core/agents/offSecAgent/tools/camoufox.test.ts
+++ b/src/core/agents/offSecAgent/tools/camoufox.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CAMOUFOX_OPTIONS,
+  MEMORY_FIREFOX_PREFS,
+  resolveCamoufoxLaunchOptions,
+} from "./camoufox";
+
+const launchOptionsMock = vi.fn();
+
+vi.mock("camoufox-js", () => ({
+  launchOptions: (...args: unknown[]) => launchOptionsMock(...args),
+}));
+
+afterEach(() => {
+  launchOptionsMock.mockReset();
+});
+
+describe("resolveCamoufoxLaunchOptions", () => {
+  it("layers the memory prefs on top of camoufox's fingerprint prefs", async () => {
+    launchOptionsMock.mockResolvedValue({
+      executablePath: "/opt/camoufox/camoufox-bin",
+      args: ["--foo"],
+      env: {},
+      firefoxUserPrefs: { "some.fingerprint.pref": "spoofed" },
+      headless: true,
+    });
+
+    const opts = await resolveCamoufoxLaunchOptions(true);
+
+    // camoufox's own prefs are preserved…
+    expect(opts.firefoxUserPrefs["some.fingerprint.pref"]).toBe("spoofed");
+    // …and every memory pref is merged in.
+    for (const [key, value] of Object.entries(MEMORY_FIREFOX_PREFS)) {
+      expect(opts.firefoxUserPrefs[key]).toBe(value);
+    }
+    // Fission stays off / content pool capped — the load-bearing keys.
+    expect(opts.firefoxUserPrefs["fission.autostart"]).toBe(false);
+    expect(opts.firefoxUserPrefs["dom.ipc.processCount"]).toBe(1);
+  });
+
+  it("lets the memory prefs win when camoufox sets the same key", async () => {
+    launchOptionsMock.mockResolvedValue({
+      executablePath: "/opt/camoufox/camoufox-bin",
+      args: [],
+      env: {},
+      // Camoufox (hypothetically) leaves Fission on — we must override it.
+      firefoxUserPrefs: { "fission.autostart": true },
+      headless: false,
+    });
+
+    const opts = await resolveCamoufoxLaunchOptions(false);
+
+    expect(opts.firefoxUserPrefs["fission.autostart"]).toBe(false);
+  });
+
+  it("forwards the stealth options and headless flag to camoufox-js", async () => {
+    launchOptionsMock.mockResolvedValue({
+      executablePath: "/opt/camoufox/camoufox-bin",
+      args: [],
+      env: {},
+      firefoxUserPrefs: {},
+      headless: true,
+    });
+
+    await resolveCamoufoxLaunchOptions(true);
+
+    expect(launchOptionsMock).toHaveBeenCalledWith({
+      ...CAMOUFOX_OPTIONS,
+      headless: true,
+    });
+  });
+});

--- a/src/core/agents/offSecAgent/tools/camoufox.ts
+++ b/src/core/agents/offSecAgent/tools/camoufox.ts
@@ -36,6 +36,29 @@ export const CAMOUFOX_OPTIONS = {
   // the agent grows proxy support — one object, both launch paths inherit it.
 } as const;
 
+/**
+ * Firefox prefs layered on top of Camoufox's fingerprint prefs to cut per-browser
+ * memory. Merged AFTER camoufox-js output so these win; every key here is
+ * process-topology / caching only — none are observable from page JS, so they do
+ * not weaken the fingerprint.
+ *
+ * Why: in the sandbox each endpoint drives ~one page at a time, but Firefox's
+ * Fission (per-origin site isolation) + default content-process pool fan a single
+ * browser out to ~6 content processes (~4 GB across 8 browsers, measured live).
+ * Site isolation is a defense for untrusted multi-origin browsing — irrelevant for
+ * a single-purpose recon driver — so collapsing it to one content process reclaims
+ * ~3 GB with no loss of capability. The rest drop caches a throwaway browser never
+ * reuses.
+ */
+export const MEMORY_FIREFOX_PREFS: Record<string, unknown> = {
+  "fission.autostart": false, // no per-origin site isolation → no process-per-origin fan-out
+  "dom.ipc.processCount": 1, // single content-process pool
+  "dom.ipc.processPrelaunch.enabled": false, // don't keep a spare content process warm
+  "browser.cache.disk.enable": false, // throwaway profile: never persists a cache
+  "browser.cache.memory.enable": false,
+  "browser.sessionhistory.max_total_viewers": 0, // disable bfcache page retention
+};
+
 /** What camoufox-js `launchOptions()` returns: Playwright-firefox launch opts. */
 export interface CamoufoxLaunchOptions {
   executablePath: string;
@@ -63,10 +86,16 @@ export async function resolveCamoufoxLaunchOptions(
   // commands (--version/--help) don't pull camoufox-js + its data-file deps
   // (fingerprint-generator/territoryInfo.xml) at module load.
   const { launchOptions: camoufoxLaunchOptions } = await import("camoufox-js");
-  return (await camoufoxLaunchOptions({
+  const opts = (await camoufoxLaunchOptions({
     ...CAMOUFOX_OPTIONS,
     headless,
   })) as CamoufoxLaunchOptions;
+  // Layer our memory prefs over Camoufox's fingerprint prefs (ours win).
+  opts.firefoxUserPrefs = {
+    ...opts.firefoxUserPrefs,
+    ...MEMORY_FIREFOX_PREFS,
+  };
+  return opts;
 }
 
 let ensurePromise: Promise<void> | null = null;

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -26,7 +26,7 @@ import {
   resolveEffectiveHeaders,
   stripBrowserManagedHeaders,
 } from "../../../http/targetHeaders";
-import { CAMOUFOX_OPTIONS } from "./camoufox";
+import { CAMOUFOX_OPTIONS, MEMORY_FIREFOX_PREFS } from "./camoufox";
 import type {
   BrowserClickResult,
   BrowserConsoleResult,
@@ -320,6 +320,10 @@ const fs = require('fs');
   try {
     context = await firefox.launchPersistentContext('/tmp/pw-user-data', {
       ...__camou,
+      // Layer memory prefs over Camoufox's fingerprint prefs (ours win); see
+      // MEMORY_FIREFOX_PREFS in ./camoufox — collapses Fission/content-process
+      // fan-out that otherwise costs ~3 GB across the run.
+      firefoxUserPrefs: { ...__camou.firefoxUserPrefs, ...${JSON.stringify(MEMORY_FIREFOX_PREFS)} },
       ...(__extraHeaders ? { extraHTTPHeaders: __extraHeaders } : {}),
     });
     const pages = context.pages();


### PR DESCRIPTION
## Summary

Layers memory-reduction Firefox prefs on top of Camoufox's fingerprint prefs at **both** launch sites (host MCP path via `resolveCamoufoxLaunchOptions`, and the in-sandbox generated `launchPersistentContext` script). This is the "shrink each browser" lever — chosen deliberately over lowering endpoint concurrency for streaming runs.

### Why

Measured live on a production streaming pentest (VEL-0014) pressed to **~15 GB / 16 GB**:
- 8 endpoints → 8 Camoufox browsers (1 each — the earlier session-sharing fix is holding)
- but each browser fans out to **~6 Firefox content processes** → **48 content procs ≈ 4 GB**

Firefox's Fission (per-origin site isolation) + the default content-process pool are what cause that fan-out. Site isolation is a defense for *untrusted multi-origin browsing* — irrelevant for a single-purpose recon driver that drives ~one page at a time. Collapsing it to one content process reclaims **~3 GB** with no loss of capability.

### The prefs (`MEMORY_FIREFOX_PREFS`)

| pref | value | effect |
|---|---|---|
| `fission.autostart` | `false` | no per-origin site isolation → no process-per-origin fan-out |
| `dom.ipc.processCount` | `1` | single content-process pool |
| `dom.ipc.processPrelaunch.enabled` | `false` | don't keep a spare content process warm |
| `browser.cache.disk.enable` | `false` | throwaway profile never persists a cache |
| `browser.cache.memory.enable` | `false` | " |
| `browser.sessionhistory.max_total_viewers` | `0` | disable bfcache page retention |

None of these keys are observable from page JS, so the **fingerprint is unchanged**. They're merged *after* camoufox-js output so ours win even if Camoufox sets the same key.

## Test plan

- [x] `bun run tsc` clean
- [x] new `camoufox.test.ts` (3 tests) green — asserts memory prefs merge over camoufox's, ours win on conflict, stealth opts still forwarded
- [ ] Verify on a live streaming run: content-proc count drops from ~6/browser and cgroup memory falls ~3 GB (Camoufox is patched Firefox and *could* re-assert a pref; the load-bearing keys aren't fingerprint-related so they should stick)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes browser process topology and caching for all Camoufox launches; low fingerprint risk but could affect stability or site behavior on edge cases until validated on live streaming runs.
> 
> **Overview**
> Adds **`MEMORY_FIREFOX_PREFS`** in `camoufox.ts` and merges those Firefox prefs **on top of** Camoufox’s fingerprint prefs so memory-oriented settings win on conflicts. The main levers are disabling Fission, capping content processes to one, turning off prelaunch, and disabling disk/memory cache and bfcache retention—aimed at cutting multi-process fan-out (~6 content procs per browser) without changing page-visible fingerprint behavior.
> 
> **`resolveCamoufoxLaunchOptions`** now applies that merge on the host MCP path; the sandbox **`launchPersistentContext`** script does the same merge when embedding prefs. New **`camoufox.test.ts`** covers merge behavior, override precedence, and that stealth/`headless` options still reach `camoufox-js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 723dae0899c70b8526f1e6c0973544e65b4cff7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->