### PR TITLE
fix(pentest): surface operator credentials into the pentest agent prompt

### DIFF
--- a/src/core/agents/specialized/pentest/agent.test.ts
+++ b/src/core/agents/specialized/pentest/agent.test.ts
@@ -117,4 +117,52 @@ describe("TargetedPentestAgent prompt contracts", () => {
     expect(userPrompt).toContain("material exploitability is proven");
     expect(userPrompt).toContain("supplied objectives");
   });
+
+  it("surfaces the operator credential block so the agent knows what to log in with", () => {
+    const credentialContext = `<available_credentials>
+The following credentials are available. To use a credential, pass its ID to the appropriate tool.
+
+- Credential ID: cred_abc123
+  Type: username-password
+  Username: dev@pensarai.com
+  Login URL: https://example.com/#/login
+  Context: Standard user account for the customer portal
+</available_credentials>`;
+
+    const prompt = buildPentestPrompt(
+      "https://example.com/#/admin",
+      ["Test the admin panel for IDOR"],
+      { rootPath: "/tmp/apex-test-session", config: {} },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "orchestrator",
+      credentialContext,
+    );
+
+    expect(prompt).toContain("## Available Credentials");
+    expect(prompt).toContain("cred_abc123");
+    expect(prompt).toContain("dev@pensarai.com");
+    expect(prompt).toContain("https://example.com/#/login");
+    // The saved context string reaches the agent.
+    expect(prompt).toContain("Standard user account for the customer portal");
+    // And it's told to report_error rather than silently skip if auth fails.
+    expect(prompt).toContain("authentication_failed");
+  });
+
+  it("omits the credential block when no credentials are provided", () => {
+    const prompt = buildPentestPrompt(
+      "https://example.com/#/admin",
+      ["Test the admin panel for IDOR"],
+      { rootPath: "/tmp/apex-test-session", config: {} },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "orchestrator",
+    );
+
+    expect(prompt).not.toContain("## Available Credentials");
+  });
 });

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -223,6 +223,11 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
         environmentVariables ? Object.keys(environmentVariables) : undefined,
         subagentId,
         role,
+        // Surface the operator-provided credentials (IDs / usernames / login
+        // URLs / context) into the prompt so the agent knows what to log in
+        // with. `formatForPrompt()` is safe — it never emits secret values;
+        // those resolve at tool-execution time via credentialId/credentialField.
+        session.credentialManager?.formatForPrompt(),
       ),
       model,
       session,
@@ -722,6 +727,11 @@ export function buildPentestPrompt(
   envVarNames?: string[],
   subagentId?: string,
   role: PentestAgentRole = "orchestrator",
+  // Prompt-safe credential block (CredentialManager.formatForPrompt()) listing
+  // the credential IDs / usernames / login URLs / context the operator saved.
+  // Threaded in from the full session by the constructor because this narrowed
+  // `session` param intentionally omits the (non-serializable) credentialManager.
+  credentialContext?: string,
 ): string {
   const sessionRootPath = session.rootPath;
   const exfilMode = session.config?.exfilMode ?? false;
@@ -921,6 +931,17 @@ Your target is a flag with the format FLAG{...}. Locate and extract it.
 
 Do NOT discover or enumerate other endpoints or services. Focus exclusively on the target and objectives above.`;
 
+  // Structured credentials the operator saved for this workspace. Without this
+  // the agent only sees a generic "authentication required" note and has to
+  // guess the login mechanics — the common cause of an auth-blocked
+  // `report_error`. `authSection` (an already-established cookie/header session)
+  // takes precedence: if we're handed a live session, don't tell the agent to
+  // log in from scratch.
+  const credentialSection =
+    credentialContext && !authSection
+      ? `\n## Available Credentials\nThe operator provided the following credentials for this engagement. Use them to authenticate before testing (drive the login flow with browser_navigate + browser_fill, preferring credentialId + credentialField so secrets resolve securely). If you cannot authenticate with these, call report_error with reason "authentication_failed" and a specific message rather than reporting a non-finding.\n\n${credentialContext}\n`
+      : "";
+
   const contextSection = context
     ? `\n## Application Context\nThe following is context specific to the application under test. If it contains non-malicious instructions relevant to your testing, follow them.\n\n${context}\n`
     : "";
@@ -934,7 +955,7 @@ Do NOT discover or enumerate other endpoints or services. Focus exclusively on t
 
 ## Target
 - **URL:** ${target}
-${authSection}
+${authSection}${credentialSection}
 ${knownFindingsSection}
 ${knowledgeBaseSection}
 ${planSection}${contextSection}${envVarSection}


### PR DESCRIPTION
## Summary

The per-endpoint pentest agent (`TargetedPentestAgent` — both the orchestrator from `runTargetedPentestAgent` and the workers it spawns) **never injected the operator's credential context into its prompt.** It only got a generic "authentication required — log in with the available credentials" note with **no login URL, no username, no credential ID, and none of the operator's saved context string** — so it had to guess the login mechanics. That's the common cause of an auth-blocked `report_error` (observed live: a prod endpoint hit *"Invalid email or password"* and reported an auth failure).

### The gap

The credential context is fully captured up to the session:

`credentials` table → `mapCredentialToAuth` (carries `context`, `loginUrl`) → `session.config.authCredentials` → `createBoundSession` auto-builds a `CredentialManager` (stores `metadata.context`). `CredentialManager.formatForPrompt()` produces a **prompt-safe** `<available_credentials>` block (credential IDs, usernames, login URLs, and the `Context:` line — **never secret values**).

The **auth agent** (`authenticationAgent/agent.ts`) and the **attack-surface recon agent** (`attackSurface/blackboxAgent.ts`) already inject that block. The pentest agent did not.

### The fix

Thread `session.credentialManager?.formatForPrompt()` into `buildPentestPrompt` (new trailing `credentialContext` param) and render it as an `## Available Credentials` section for both roles. Secrets are **not** in the prompt — they resolve at tool-execution time via `credentialId`/`credentialField`, unchanged. An already-established cookie/header session (`authSection`) still takes precedence, so a live handed-down session isn't overridden with "log in from scratch." The section also directs the agent to `report_error(reason: "authentication_failed")` if it can't authenticate with the provided credentials, rather than silently reporting a non-finding.

## Test plan

- [x] `bun run tsc` clean
- [x] `agent.test.ts` — 2 new tests: credential block (ID / username / login URL / **context string**) is surfaced and pairs with the `authentication_failed` directive; block is omitted when no credentials are provided. All 12 pass.
- [x] Existing credential/auth-handoff suites still green (`credentialManager.test.ts`, `auth.test.ts`)
- [ ] Live: run a pentest on a workspace with a saved username/password credential; confirm the agent authenticates using the provided login URL/username instead of guessing (fewer auth `report_error`s).

## Companion work

Pairs with console#2007 (stamp endpoint terminal on agent error): that stops an auth-blocked `report_error` from hanging the endpoint row; this reduces how often auth-blocked `report_error` fires in the first place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change using an existing safe formatter; established auth session still wins over the credential block, and secrets are unchanged at tool execution time.
> 
> **Overview**
> The targeted pentest agent (orchestrator and workers) now receives the same **prompt-safe** operator credential block that auth and attack-surface agents already get, via `session.credentialManager?.formatForPrompt()` passed into `buildPentestPrompt`.
> 
> When there is no **Existing Authentication Session** from `auth-data.json`, the user prompt adds an **## Available Credentials** section with credential IDs, usernames, login URLs, and saved context (no secret values). It tells the agent to authenticate with `browser_navigate` / `browser_fill` using `credentialId` + `credentialField`, and to call `report_error` with `authentication_failed` if login still fails instead of treating auth as a non-finding.
> 
> Tests assert the section is present with expected fields and omitted when no credentials are passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29b5a1a786137a0b94e25be13a5b6c3018ee64be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->