### PR TITLE
fix(ai): record cache read tokens in trace usage telemetry

### DIFF
--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -1071,9 +1071,11 @@ export function streamResponse(
 
             // Pensar provider doesn't populate providerMetadata.anthropic;
             // fall back to the SDK's normalized usage.inputTokenDetails.
-            if (cacheRead === 0 && cacheCreation === 0) {
-              const { inputTokenDetails } = stepResult.usage;
+            const { inputTokenDetails } = stepResult.usage;
+            if (cacheRead === 0) {
               cacheRead = inputTokenDetails?.cacheReadTokens ?? 0;
+            }
+            if (cacheCreation === 0) {
               cacheCreation = inputTokenDetails?.cacheWriteTokens ?? 0;
             }
 

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -14,6 +14,11 @@ import { buildStreamingFetchSignal } from "../utils";
 import { convertToBedrockFormat } from "./pensarFormatters";
 import { signGatewayRequest } from "./pensarSigning";
 import { parseSSE } from "./pensarSSE";
+import {
+  applyAnthropicStreamUsage,
+  createEmptyStreamUsage,
+  toLanguageModelV3Usage,
+} from "./pensarStreamUsage";
 
 const structuredLog = scopedLogger(() => createLogger("pensar"));
 
@@ -331,10 +336,7 @@ export function createPensarModel(
       const abortSignal = options.abortSignal;
       const stream = new ReadableStream<LanguageModelV3StreamPart>({
         async start(controller) {
-          let inputTokens = 0;
-          let outputTokens = 0;
-          let cacheReadTokens = 0;
-          let cacheCreationTokens = 0;
+          const streamUsage = createEmptyStreamUsage();
           let finishReasonUnified: LanguageModelV3FinishReason["unified"] =
             "other";
           let finishReasonRaw: string | undefined;
@@ -424,15 +426,7 @@ export function createPensarModel(
                   const usage = msg?.usage as
                     | Record<string, number>
                     | undefined;
-                  if (usage?.input_tokens) {
-                    inputTokens = usage.input_tokens;
-                  }
-                  if (usage?.cache_read_input_tokens) {
-                    cacheReadTokens = usage.cache_read_input_tokens;
-                  }
-                  if (usage?.cache_creation_input_tokens) {
-                    cacheCreationTokens = usage.cache_creation_input_tokens;
-                  }
+                  applyAnthropicStreamUsage(streamUsage, usage);
                   break;
                 }
 
@@ -561,9 +555,7 @@ export function createPensarModel(
                   const usage = parsed.usage as
                     | Record<string, number>
                     | undefined;
-                  if (usage?.output_tokens) {
-                    outputTokens = usage.output_tokens;
-                  }
+                  applyAnthropicStreamUsage(streamUsage, usage);
                   break;
                 }
 
@@ -576,7 +568,7 @@ export function createPensarModel(
             }
 
             logInfo(
-              `  stream complete: ${finishReasonUnified}, ${inputTokens}in/${outputTokens}out, cacheRead=${cacheReadTokens}, cacheWrite=${cacheCreationTokens} (${Date.now() - startTime}ms)`,
+              `  stream complete: ${finishReasonUnified}, ${streamUsage.inputTokens}in/${streamUsage.outputTokens}out, cacheRead=${streamUsage.cacheReadTokens}, cacheWrite=${streamUsage.cacheCreationTokens} (${Date.now() - startTime}ms)`,
             );
 
             controller.enqueue({
@@ -585,22 +577,7 @@ export function createPensarModel(
                 unified: finishReasonUnified,
                 raw: finishReasonRaw,
               },
-              usage: {
-                inputTokens: {
-                  total:
-                    inputTokens +
-                    (cacheReadTokens || 0) +
-                    (cacheCreationTokens || 0),
-                  noCache: inputTokens,
-                  cacheRead: cacheReadTokens || undefined,
-                  cacheWrite: cacheCreationTokens || undefined,
-                },
-                outputTokens: {
-                  total: outputTokens,
-                  text: undefined,
-                  reasoning: undefined,
-                },
-              },
+              usage: toLanguageModelV3Usage(streamUsage),
             });
             telemetry.finish(wallNow());
             controller.close();

--- a/src/core/ai/providers/pensarStreamUsage.test.ts
+++ b/src/core/ai/providers/pensarStreamUsage.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyAnthropicStreamUsage,
+  createEmptyStreamUsage,
+  toLanguageModelV3Usage,
+} from "./pensarStreamUsage";
+
+describe("applyAnthropicStreamUsage", () => {
+  it("captures cache write from message_start (turn 1)", () => {
+    const state = createEmptyStreamUsage();
+    applyAnthropicStreamUsage(state, {
+      input_tokens: 3,
+      cache_creation_input_tokens: 24_542,
+      cache_read_input_tokens: 0,
+      output_tokens: 1,
+    });
+    expect(state).toEqual({
+      inputTokens: 3,
+      outputTokens: 1,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 24_542,
+    });
+  });
+
+  it("captures cache read from message_delta (turn 2+)", () => {
+    const state = createEmptyStreamUsage();
+    // message_start — cache read often 0 at stream open
+    applyAnthropicStreamUsage(state, {
+      input_tokens: 45,
+      cache_creation_input_tokens: 944,
+      cache_read_input_tokens: 0,
+      output_tokens: 1,
+    });
+    // message_delta — final cumulative usage includes cache read
+    applyAnthropicStreamUsage(state, {
+      input_tokens: 45,
+      cache_creation_input_tokens: 944,
+      cache_read_input_tokens: 24_000,
+      output_tokens: 125,
+    });
+    expect(state.cacheReadTokens).toBe(24_000);
+    expect(state.cacheCreationTokens).toBe(944);
+    expect(state.outputTokens).toBe(125);
+  });
+
+  it("replaces cumulative values rather than summing across events", () => {
+    const state = createEmptyStreamUsage();
+    applyAnthropicStreamUsage(state, {
+      input_tokens: 100,
+      cache_read_input_tokens: 1_000,
+      cache_creation_input_tokens: 500,
+    });
+    applyAnthropicStreamUsage(state, {
+      input_tokens: 100,
+      cache_read_input_tokens: 1_000,
+      cache_creation_input_tokens: 500,
+      output_tokens: 50,
+    });
+    expect(state.cacheReadTokens).toBe(1_000);
+    expect(state.cacheCreationTokens).toBe(500);
+    expect(state.outputTokens).toBe(50);
+  });
+
+  it("maps to LanguageModelV3Usage with separate buckets", () => {
+    const state = createEmptyStreamUsage();
+    applyAnthropicStreamUsage(state, {
+      input_tokens: 45,
+      cache_read_input_tokens: 24_000,
+      cache_creation_input_tokens: 944,
+      output_tokens: 125,
+    });
+    const usage = toLanguageModelV3Usage(state);
+    expect(usage.inputTokens.noCache).toBe(45);
+    expect(usage.inputTokens.cacheRead).toBe(24_000);
+    expect(usage.inputTokens.cacheWrite).toBe(944);
+    expect(usage.inputTokens.total).toBe(45 + 24_000 + 944);
+    expect(usage.outputTokens.total).toBe(125);
+  });
+});

--- a/src/core/ai/providers/pensarStreamUsage.ts
+++ b/src/core/ai/providers/pensarStreamUsage.ts
@@ -1,0 +1,62 @@
+import type { LanguageModelV3Usage } from "@ai-sdk/provider";
+
+/** Mutable usage counters accumulated from Anthropic SSE events. */
+export interface AnthropicStreamUsageState {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+}
+
+export function createEmptyStreamUsage(): AnthropicStreamUsageState {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+  };
+}
+
+/**
+ * Apply usage fields from a `message_start` or `message_delta` event.
+ *
+ * Anthropic streaming usage is cumulative within a message — values in
+ * `message_delta` replace (not add to) those from `message_start`.
+ *
+ * @see https://platform.claude.com/docs/en/build-with-claude/streaming
+ */
+export function applyAnthropicStreamUsage(
+  state: AnthropicStreamUsageState,
+  usage: Record<string, number> | undefined,
+): void {
+  if (!usage) return;
+  if (usage.input_tokens != null) state.inputTokens = usage.input_tokens;
+  if (usage.cache_read_input_tokens != null) {
+    state.cacheReadTokens = usage.cache_read_input_tokens;
+  }
+  if (usage.cache_creation_input_tokens != null) {
+    state.cacheCreationTokens = usage.cache_creation_input_tokens;
+  }
+  if (usage.output_tokens != null) state.outputTokens = usage.output_tokens;
+}
+
+export function toLanguageModelV3Usage(
+  state: AnthropicStreamUsageState,
+): LanguageModelV3Usage {
+  const { inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens } =
+    state;
+
+  return {
+    inputTokens: {
+      total: inputTokens + cacheReadTokens + cacheCreationTokens,
+      noCache: inputTokens,
+      cacheRead: cacheReadTokens || undefined,
+      cacheWrite: cacheCreationTokens || undefined,
+    },
+    outputTokens: {
+      total: outputTokens,
+      text: undefined,
+      reasoning: undefined,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Session traces reported `cacheWriteTokens` on agent steps but **`cacheReadTokens` stayed at `0`**, even on long multi-turn runs where prompt caching clearly dominated billing. Downstream cost aggregation (eval harness, TUI metrics) then priced the full per-step `inputTokens` at base input rates — producing costs ~6× higher than actual Anthropic billing.

**This fixes measurement only.** Prompt caching was already working server-side; we were blind to cache reads.

Closes #894

### The gap

Two independent bugs in the usage pipeline:

1. **`src/core/ai/providers/pensar.ts`** — parsed `cache_read_input_tokens` on `message_start` but **`message_delta`** only updated `output_tokens`. Anthropic's final cumulative usage (including cache reads) arrives on `message_delta`.
2. **`src/core/ai/ai.ts`** — `onCacheMetrics` only fell back to `usage.inputTokenDetails` when **both** meta cache fields were zero. When cache *writes* were recorded but cache *reads* were missing from `providerMetadata`, reads were dropped entirely.

Traces are written via `onCacheMetrics` → `recordStep` in `offensiveSecurityAgent.ts`. Direct Anthropic (`claude-opus-4-6` + `ANTHROPIC_API_KEY`) hit bug #2; Pensar gateway hits both.

### The fix

- Extract **`pensarStreamUsage.ts`** — `applyAnthropicStreamUsage()` applies replacement (not additive) semantics from `message_start` / `message_delta`; `toLanguageModelV3Usage()` maps to AI SDK buckets.
- **`pensar.ts`** — both SSE handlers call `applyAnthropicStreamUsage`; finish event uses shared mapper.
- **`ai.ts`** — fall back to `inputTokenDetails` for cache read and cache write **independently**.

### Validation

#### Direct Anthropic (disposable key, CASE-001, Opus 4.6)

Session `ses_0dc9705b8ffetPV5LBzFNI4cU5`, run `billing-confirm-2026-07-02T15-18-29`:

| | Before fix | After fix |
|---|---|---|
| `cacheReadTokens` in trace | always `0` | **2.54M** |
| Harness-reported cost | ~$16 (double-counts cache) | still wrong — harness bug |
| Per-step trace cost (list pricing) | N/A | **$2.66** |
| **Anthropic console (disposable key)** | — | **$2.70 confirmed** |

#### Pensar gateway (Console auth, Opus 4.8)

Branch `fix/pensar-cache-read-usage`, model `pensar:anthropic.claude-opus-4-8`, workspace `pensar`, `ANTHROPIC_API_KEY` unset:

**streamResponse (2 turns):**

| Turn | cacheWrite | cacheRead |
|------|------------|-----------|
| 1 | 9,023 | 0 |
| 2 | 24 | **9,023** ✓ |

**Headless agent trace** (`ses_0dc660dc5ffeZPYgBmpq5CUNzv`, 2 invocations):

| Turn | cacheWrite | cacheRead |
|------|------------|-----------|
| 1 | 38,005 | 0 |
| 2 | 84 | **37,923** ✓ |

Both paths record cache reads on turn 2+. No token refresh failures.

**Note:** GHSA eval harness `computeAnthropicCostUsd()` still bills full `inputTokens` plus cache buckets separately (`noCache = input - cacheRead - cacheWrite` needed). That's a harness follow-up, not Apex.

## Test plan

- [x] `pensarStreamUsage.test.ts` — message_start write, message_delta read, replacement semantics, V3 usage mapping (4 tests)
- [x] `pensarSSE.test.ts` — existing SSE parser tests still pass
- [x] Live: disposable Anthropic key, CASE-001 Apex run — console $2.70 matches per-step trace math
- [x] Pensar gateway path with valid Console auth — `message_delta` cache read through gateway SSE (tables above)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry and Pensar SSE usage parsing only; no auth, billing, or agent control-flow changes beyond more accurate token metrics.
> 
> **Overview**
> Fixes **under-reported `cacheReadTokens`** in agent traces and step telemetry when Anthropic prompt caching is active on later turns.
> 
> **Pensar gateway (`pensar.ts`)** now merges usage from both `message_start` and `message_delta` via shared **`pensarStreamUsage`** helpers, using Anthropic’s cumulative replacement semantics so final **`cache_read_input_tokens`** from `message_delta` are not dropped (previously only output tokens were updated there).
> 
> **`streamResponse` cache metrics (`ai.ts`)** now falls back to `usage.inputTokenDetails` **separately** for cache read and cache write when `providerMetadata.anthropic` is incomplete, so a recorded cache write no longer blocks picking up missing cache reads.
> 
> Adds **`pensarStreamUsage.test.ts`** covering turn-1 writes, turn-2+ reads, replacement (not summing) behavior, and V3 usage bucket mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eace5df1044c169557adac149ff5a79f9e1eaad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->