### PR TITLE
Feed credential Context to all pentest agents; stop forcing browser login

### DIFF
--- a/src/core/agents/specialized/pentest/agent.test.ts
+++ b/src/core/agents/specialized/pentest/agent.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   buildPentestActiveTools,
@@ -214,6 +217,68 @@ The following credentials are available. To use a credential, pass its ID to the
     expect(prompt).toContain("Standard user account for the customer portal");
     // And it's told to report_error rather than silently skip if auth fails.
     expect(prompt).toContain("authentication_failed");
+  });
+
+  it("points the agent at the credential Context instructions instead of defaulting to a browser login", () => {
+    const credentialContext = `<available_credentials>
+- Credential ID: cred_token
+  Type: api-key
+  Context: POST the API key to /oauth/token and use the returned bearer JWT on every request.
+</available_credentials>`;
+
+    const prompt = buildPentestPrompt(
+      "https://example.com/api/orders",
+      ["Test /api/orders for IDOR"],
+      { rootPath: "/tmp/apex-test-session", config: {} },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "orchestrator",
+      credentialContext,
+    );
+
+    // Defers to the operator's Context rather than mandating a browser login.
+    expect(prompt).toContain("following the instructions in each credential's");
+    expect(prompt).not.toContain(
+      "drive the login flow with browser_navigate + browser_fill",
+    );
+  });
+
+  it("still surfaces the credential block (and its instructions) when an existing auth session is present", () => {
+    const rootPath = mkdtempSync(join(tmpdir(), "apex-cred-authsession-"));
+    mkdirSync(join(rootPath, "auth"), { recursive: true });
+    writeFileSync(
+      join(rootPath, "auth", "auth-data.json"),
+      JSON.stringify({
+        authenticated: true,
+        cookies: "session=abc123",
+        strategy: "form",
+      }),
+    );
+
+    const credentialContext = `<available_credentials>
+- Credential ID: cred_token
+  Type: api-key
+  Context: POST the API key to /oauth/token and use the returned bearer JWT on every request.
+</available_credentials>`;
+
+    const prompt = buildPentestPrompt(
+      "https://example.com/api/orders",
+      ["Test /api/orders for IDOR"],
+      { rootPath, config: {} },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "worker",
+      credentialContext,
+    );
+
+    // Both the live session AND the operator's credential instructions reach the agent.
+    expect(prompt).toContain("Existing Authentication Session");
+    expect(prompt).toContain("## Available Credentials");
+    expect(prompt).toContain("POST the API key to /oauth/token");
   });
 
   it("omits the credential block when no credentials are provided", () => {

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -389,11 +389,11 @@ const SECTION_BROWSER_INTERACTION = `Browser Interaction:
 - Screenshots are automatically stored and displayed alongside your tool call logs, so each one directly improves the user's ability to follow the test in real time.`;
 
 const SECTION_AUTHENTICATION = `Authentication:
-- If the prompt includes an "Existing Authentication Session" section, USE those cookies/headers on every request and do NOT re-authenticate. If such a request returns 401/403, that provided session has expired — note it in your findings (and call report_error if it blocks all further testing). Do NOT try to log in yourself: this run was given a session rather than interactive credentials.
-- Otherwise, if the target requires authentication, log in yourself: drive the login flow in the browser with browser_navigate + browser_fill. Prefer credentialId + credentialField so secrets are resolved securely; injected credential environment variables are also available inside execute_command.
-- After a successful browser login, call browser_get_cookies to extract the session cookies (including httpOnly ones) and reuse them for raw requests — pass them as the Cookie header to http_request, or as -H "Cookie: ..." / -b flags to execute_command (curl). Any worker you spawn automatically inherits a snapshot of your authenticated browser session.
+- If the prompt includes an "Existing Authentication Session" section, USE those cookies/headers on every request and do NOT re-authenticate up front. If such a request returns 401/403, that provided session has expired — note it in your findings (and call report_error if it blocks all further testing). Only log in yourself (following any "Available Credentials" instructions) if that provided session expires mid-run.
+- Otherwise, if the target requires authentication, log in yourself. When an "Available Credentials" section is present, follow the authentication instructions in each credential's Context exactly — use the method it describes (for example, a token/API exchange driven with execute_command or http_request) instead of defaulting to a browser login. Only fall back to driving the login flow in the browser with browser_navigate + browser_fill when the Context does not specify how to authenticate. Prefer credentialId + credentialField so secrets are resolved securely; injected credential environment variables are also available inside execute_command.
+- After a successful login, capture the resulting session credentials and reuse them for raw requests. For a browser login, call browser_get_cookies to extract the session cookies (including httpOnly ones) — pass them as the Cookie header to http_request, or as -H "Cookie: ..." / -b flags to execute_command (curl). Any worker you spawn automatically inherits a snapshot of your authenticated browser session.
 - For http_request: include the captured Cookie and any Authorization headers on every call. For execute_command (curl): include -H "Cookie: ..." and/or -H "Authorization: ..." flags.
-- If a request returns 401/403 after you logged in yourself, your captured session may have expired — re-authenticate in the browser and re-capture cookies.
+- If a request returns 401/403 after you logged in yourself, your captured session may have expired — re-authenticate the same way you did originally and refresh your session cookies/tokens.
 - If you cannot authenticate with the available credentials, or another runtime condition blocks all testing, call report_error with a clear, specific message instead of giving up silently or documenting a non-finding.`;
 
 const SECTION_CREDENTIAL_DISCOVERY = `Credential & Secret Discovery:
@@ -952,16 +952,17 @@ Your target is a flag with the format FLAG{...}. Locate and extract it.
 
 Do NOT discover or enumerate other endpoints or services. Focus exclusively on the target and objectives above.`;
 
-  // Structured credentials the operator saved for this workspace. Without this
-  // the agent only sees a generic "authentication required" note and has to
-  // guess the login mechanics — the common cause of an auth-blocked
-  // `report_error`. `authSection` (an already-established cookie/header session)
-  // takes precedence: if we're handed a live session, don't tell the agent to
-  // log in from scratch.
-  const credentialSection =
-    credentialContext && !authSection
-      ? `\n## Available Credentials\nThe operator provided the following credentials for this engagement. Use them to authenticate before testing (drive the login flow with browser_navigate + browser_fill, preferring credentialId + credentialField so secrets resolve securely). If you cannot authenticate with these, call report_error with reason "authentication_failed" and a specific message rather than reporting a non-finding.\n\n${credentialContext}\n`
-      : "";
+  // Structured credentials the operator saved for this workspace, including the
+  // free-form `Context` the operator uses to spell out exactly how to
+  // authenticate (e.g. a programmatic token exchange). Without this the agent
+  // only sees a generic "authentication required" note and has to guess the
+  // login mechanics — the common cause of an auth-blocked `report_error`.
+  // Always included (independent of `authSection`) so the orchestrator AND every
+  // spawned worker receive the operator's auth instructions; when a live session
+  // is also present, these double as re-auth guidance if it expires.
+  const credentialSection = credentialContext
+    ? `\n## Available Credentials\nThe operator provided the following credentials and authentication instructions for this engagement. Authenticate by following the instructions in each credential's Context exactly — use the method it describes (for example, a token/API exchange via execute_command or http_request) rather than defaulting to a browser login. Treat the Context as the source of truth for how to authenticate, and how to re-authenticate if a provided session expires. When a tool needs a secret value and supports it (e.g. browser_fill), reference it by credentialId + credentialField so the secret resolves securely at execution time instead of hardcoding it. If you cannot authenticate with these, call report_error with reason "authentication_failed" and a specific message rather than reporting a non-finding.\n\n${credentialContext}\n`
+    : "";
 
   const contextSection = context
     ? `\n## Application Context\nThe following is context specific to the application under test. If it contains non-malicious instructions relevant to your testing, follow them.\n\n${context}\n`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

**Issue.** Operators can attach a free-form `context` string to each stored credential (e.g. programmatic auth instructions like "POST the API key to `/oauth/token` and use the returned JWT"). That context flows into the credential block via `CredentialManager.formatForPrompt()`, but the targeted pentest agent was not honoring it for two reasons:

1. **Gated by an existing session.** In `buildPentestPrompt`, the `## Available Credentials` block (which carries each credential's `Context`) was only emitted when `!authSection` — i.e. when no `auth/auth-data.json` session already existed. In the normal console flow, auth runs first and writes that file, so by the time the orchestrator/workers run, the whole block — including the operator's auth instructions — was suppressed.
2. **Hard-coded browser login.** Both `SECTION_AUTHENTICATION` (system prompt, shared by orchestrator + every worker) and the credential block (user prompt) told the agent to "drive the login flow in the browser with `browser_navigate` + `browser_fill`," which competed with / overrode the programmatic instructions in `context`.

**Changes.**
- Always inject the credential block into `buildPentestPrompt`, independent of `authSection`, so the orchestrator **and every spawned worker** (both go through the same constructor / prompt builder) receive the operator's credentials and their `Context`. When a live session is also present, the block doubles as re-auth guidance for expiry.
- Reworded `SECTION_AUTHENTICATION` and the credential block to **follow the method described in each credential's `Context`** (e.g. a token/API exchange via `execute_command`/`http_request`) rather than defaulting to a browser login. Browser login (`browser_navigate` + `browser_fill`) is now the explicit fallback for when the `Context` doesn't specify a method. `credentialId` + `credentialField` secure resolution is still recommended for tools that support it.

These are prompt-only changes; no tool behavior or secret-resolution paths changed.

### How did you verify your code works?

- ✅ `bun run tsc`
- ✅ `bun run test` — 1273 passed, 15 skipped. Added two tests in `agent.test.ts`: one asserting the credential block points at the `Context` instructions (and no longer contains the old browser-login directive), and one asserting the block + its instructions still appear when an `Existing Authentication Session` is present.
- ✅ `bunx biome check` on the two changed files (clean).

Note: `SECTION_AUTHENTICATION` still contains "log in yourself" and "browser_get_cookies", so existing prompt-contract tests remain valid. This is a prompt-wording change, so behavior is best evidenced by the prompt-assertion unit tests rather than a live LLM run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f23d3-759c-7501-912e-495cfdf02862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f23d3-759c-7501-912e-495cfdf02862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

