### PR TITLE
perf(sandbox): reclaim per-subagent scratch artifacts mid-scan to avo…

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -536,7 +536,12 @@ export class OffensiveSecurityAgent<TResult = void> {
         activeTools,
         stopWhen,
         toolChoice: "auto",
-        sessionPath: input.session.rootPath,
+        // Per-subagent so the overflow tool-result dumps land next to this
+        // agent's messages.json (`subagents/{id}/tool-results/`) and a host
+        // can reclaim them when the subagent finishes, instead of piling up
+        // at the shared session root for the whole scan (ENOSPC). Falls back
+        // to the session root for the root/operator agent.
+        sessionPath: messagesDir,
         sessionId: this.busSessionId,
         onStepFinish: async (event) => {
           this.latestMessages = [

--- a/src/core/agents/offSecAgent/tools/agentScratch.test.ts
+++ b/src/core/agents/offSecAgent/tools/agentScratch.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import type { SessionInfo } from "../../../session";
+import { agentLogsDir } from "./agentScratch";
+import type { ToolContext } from "./types";
+
+function makeCtx(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    session: {
+      id: "ses_test",
+      version: "1.0.0",
+      targets: [],
+      time: { created: Date.now(), updated: Date.now() },
+      rootPath: "/tmp/test",
+      logsPath: "/tmp/test/logs",
+      findingsPath: "/tmp/test/findings",
+      scratchpadPath: "/tmp/test/scratchpad",
+      pocsPath: "/tmp/test/pocs",
+    } as SessionInfo,
+    agentCwd: "/tmp/test",
+    ...overrides,
+  };
+}
+
+describe("agentLogsDir", () => {
+  it("returns the shared session logs dir for the root agent (no subagentId)", () => {
+    expect(agentLogsDir(makeCtx())).toBe("/tmp/test/logs");
+  });
+
+  it("scopes the logs dir under the owning subagent so a host can reclaim it", () => {
+    expect(agentLogsDir(makeCtx({ subagentId: "endpoint-42" }))).toBe(
+      "/tmp/test/subagents/endpoint-42/logs",
+    );
+  });
+});

--- a/src/core/agents/offSecAgent/tools/agentScratch.ts
+++ b/src/core/agents/offSecAgent/tools/agentScratch.ts
@@ -1,0 +1,23 @@
+import { join } from "node:path";
+import type { ToolContext } from "./types";
+
+/**
+ * Directory for an agent's spilled log artifacts — large HTTP response bodies
+ * (`http-responses/`) and command output (`cmd-output/`).
+ *
+ * Scoped under the owning subagent's directory (`subagents/{subagentId}/logs`)
+ * so a host that orchestrates many subagents inside ONE shared session (e.g.
+ * Pensar Console runs every endpoint of a scan as a subagent under one session
+ * dir) can reclaim a finished subagent's spill by removing `subagents/{id}/` —
+ * the same place its `messages.json` / `{id}.trace.jsonl` already live. Without
+ * this, these dumps accumulate at the shared session root for the whole scan
+ * and are only freed at teardown, which can exhaust the sandbox disk (ENOSPC).
+ *
+ * The root/operator agent (no `subagentId`) keeps the shared session `logs/`
+ * dir, so single-session runs are unchanged.
+ */
+export function agentLogsDir(ctx: ToolContext): string {
+  return ctx.subagentId
+    ? join(ctx.session.rootPath, "subagents", ctx.subagentId, "logs")
+    : ctx.session.logsPath;
+}

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -8,6 +8,7 @@ import {
   type PromptInjectionLibrary,
   redactPromptInjectionPayloads,
 } from "../../../prompt-injections";
+import { agentLogsDir } from "./agentScratch";
 import {
   assertCommandInScope,
   extractHostsFromCommand,
@@ -129,9 +130,11 @@ export function normalizeExecuteCommandTimeout(
 }
 
 /**
- * If `raw` exceeds the inline limit, save the full text to a file under
- * `{session.logsPath}/cmd-output/` and return truncated text + file path.
- * Otherwise return the text as-is with no file.
+ * If `raw` exceeds the inline limit, save the full text to a file under this
+ * agent's log dir (`cmd-output/`) and return truncated text + file path.
+ * Otherwise return the text as-is with no file. Scoped per-subagent via
+ * {@link agentLogsDir} so a host can reclaim a finished subagent's command
+ * dumps mid-scan.
  */
 function maybeSaveFullOutput(
   raw: string,
@@ -141,7 +144,7 @@ function maybeSaveFullOutput(
     return { text: raw || "(no output)" };
   }
 
-  const outputDir = join(ctx.session.logsPath, "cmd-output");
+  const outputDir = join(agentLogsDir(ctx), "cmd-output");
   if (!existsSync(outputDir)) {
     mkdirSync(outputDir, { recursive: true });
   }

--- a/src/core/agents/offSecAgent/tools/httpRequest.test.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.test.ts
@@ -195,6 +195,40 @@ describe("httpRequest rate limiting", () => {
     expect(result.status).toBe(200);
   });
 
+  it("deletes the request-body temp file after a sandbox POST", async () => {
+    const { ctx } = ctxWithLimiter();
+    const commands: string[] = [];
+    const execute = vi.fn(async (command: string) => {
+      commands.push(command);
+      return {
+        success: true,
+        exitCode: 0,
+        stdout: "HTTP/1.1 200 OK\n\n",
+        stderr: "",
+      };
+    });
+    ctx.sandbox = { execute } as unknown as ToolContext["sandbox"];
+
+    await httpRequest(ctx).execute?.(
+      {
+        url: "https://example.com/api",
+        method: "POST",
+        body: "hello=world",
+        followRedirects: false,
+        timeout: 1000,
+        toolCallDescription: "Sandbox POST",
+      },
+      { toolCallId: "tc_test", messages: [], abortSignal: undefined },
+    );
+
+    const bodyFile = commands
+      .join("\n")
+      .match(/\/tmp\/apex_http_body_[^\s"']+\.txt/)?.[0];
+    expect(bodyFile).toBeDefined();
+    // The temp file is both written (curl --data-binary) and removed.
+    expect(commands.some((c) => c.includes(`rm -f ${bodyFile}`))).toBe(true);
+  });
+
   it("returns an aborted result without dispatching when already aborted", async () => {
     const fetchSpy = vi.fn(async () => new Response("ok", { status: 200 }));
     vi.stubGlobal("fetch", fetchSpy);

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -15,6 +15,7 @@ import {
   redactPromptInjectionPayloads,
   resolvePromptInjectionRefs,
 } from "../../../prompt-injections";
+import { agentLogsDir } from "./agentScratch";
 import {
   assertUrlInScope,
   resolverSessionFromCtx,
@@ -105,7 +106,9 @@ function containsPromptInjectionRef(value: unknown): boolean {
 
 /**
  * If `body` exceeds the inline limit, save the full text to a file under
- * `{session.logsPath}/http-responses/` and return truncated text + file path.
+ * this agent's log dir (`http-responses/`) and return truncated text + file
+ * path. Scoped per-subagent via {@link agentLogsDir} so a host can reclaim a
+ * finished subagent's response dumps mid-scan.
  */
 function maybeSaveBody(
   body: string,
@@ -113,7 +116,7 @@ function maybeSaveBody(
 ): { text: string; file?: string } {
   if (body.length <= MAX_INLINE_BODY) return { text: body };
 
-  const outputDir = join(ctx.session.logsPath, "http-responses");
+  const outputDir = join(agentLogsDir(ctx), "http-responses");
   if (!existsSync(outputDir)) {
     mkdirSync(outputDir, { recursive: true });
   }
@@ -375,6 +378,17 @@ async function executeSandboxHttpRequest(
 ): Promise<HttpRequestResult> {
   const { url, method, headers, body, followRedirects, timeout } = opts;
 
+  const { sandbox } = ctx;
+  if (!sandbox) {
+    throw new Error("executeSandboxHttpRequest requires a sandbox");
+  }
+
+  // Hoisted so the `finally` can delete the request-body temp file on every
+  // path — otherwise every POST/PUT/PATCH leaves a `/tmp/apex_http_body_*`
+  // file behind for the life of the sandbox, and a body-heavy scan can fill
+  // the disk (ENOSPC).
+  let bodyTempFile: string | null = null;
+
   try {
     let curlCommand = `curl -i -X ${method}`;
 
@@ -389,14 +403,8 @@ async function executeSandboxHttpRequest(
       curlCommand += ` -H "${shellQuote(`${key}: ${value}`)}"`;
     }
 
-    const { sandbox } = ctx;
-    if (!sandbox) {
-      throw new Error("executeSandboxHttpRequest requires a sandbox");
-    }
-
     // If we have a body to send, write it to a temp file in the sandbox
     // to avoid shell escaping issues with multiline content
-    let bodyTempFile: string | null = null;
     if (body && ["POST", "PUT", "PATCH"].includes(method)) {
       bodyTempFile = `/tmp/apex_http_body_${Date.now()}_${Math.random().toString(36).slice(2, 11)}.txt`;
 
@@ -494,5 +502,13 @@ async function executeSandboxHttpRequest(
       url,
       redirected: false,
     };
+  } finally {
+    // Reclaim the request-body temp file now that curl has read it. Best-effort
+    // — a failed cleanup must not change the request result.
+    if (bodyTempFile) {
+      await sandbox
+        .execute(`rm -f ${bodyTempFile}`, { timeout: 10 })
+        .catch(() => {});
+    }
   }
 }

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -637,6 +637,14 @@ Use this to document:
             mkdirSync(dir, { recursive: true });
           }
           writeFileSync(localPath, Buffer.from(result.data, "base64"));
+          // The PNG bytes are already back on the host (via base64) and
+          // written to `evidenceDir`; the sandbox-side staging copy in
+          // `/tmp/evidence` is never read again. Drop it so a
+          // screenshot-heavy scan doesn't accumulate them until teardown
+          // (ENOSPC). Best-effort — a failed cleanup must not fail the tool.
+          void sandbox
+            .execute(`rm -f ${sandboxPath}`, { timeout: 10 })
+            .catch(() => {});
           return {
             success: true,
             path: localPath,


### PR DESCRIPTION
…id ENOSPC

Large blackbox scans run every endpoint as a subagent under ONE shared apex session dir. Several scratch artifacts were written at the shared session root and only freed at teardown, so on a big scan they accumulated until the sandbox disk filled (ENOSPC after ~50 endpoints):

- http_request overflow bodies       (logs/http-responses/*.txt)
- execute_command overflow output    (logs/cmd-output/*.txt)
- context-management tool-result spill (tool-results/*.txt)

Scope these under the owning subagent's dir (subagents/{id}/...) — next to its messages.json / trace — so a host orchestrating many subagents in one session can reclaim a finished subagent's scratch by removing subagents/{id}/. The root/operator agent (no subagentId) keeps the shared session dirs, so single-session (local TUI) runs are unchanged.

Also delete two sandbox temp files as soon as they're consumed instead of leaving them for teardown:

- /tmp/apex_http_body_*  (curl request-body temp) — removed in a finally
- /tmp/evidence/*.png    (screenshot staging copy) — removed after the PNG is
  pulled back to the host evidence dir

Adds agentLogsDir() helper + unit tests, and a test asserting the sandbox POST body temp is removed.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk layout for subagent overflow artifacts and adds best-effort sandbox cleanup; root/single-session paths are unchanged but hosts that assumed shared session `logs/` for all workers may need to delete `subagents/{id}/` to reclaim space.
> 
> **Overview**
> **Reclaims disk during large multi-endpoint scans** by scoping scratch artifacts to each subagent and deleting sandbox temps as soon as they are no longer needed, instead of letting them pile up until session teardown (ENOSPC).
> 
> Adds **`agentLogsDir()`** so overflow **`http_request`** bodies (`http-responses/`) and **`execute_command`** output (`cmd-output/`) write under `subagents/{id}/logs` when `subagentId` is set; the root agent still uses the shared session `logs/`. **`streamResponse`** now passes **`messagesDir`** as **`sessionPath`**, so context-management **`tool-results/`** spills land beside that subagent’s `messages.json` and can be removed with `subagents/{id}/`.
> 
> In the sandbox, **`executeSandboxHttpRequest`** removes **`/tmp/apex_http_body_*`** in a **`finally`** after curl, and **`browser_screenshot`** best-effort deletes the **`/tmp/evidence`** staging PNG once bytes are on the host. Unit tests cover **`agentLogsDir`** and POST body temp cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f5a69103019f5c9d53e734125203c10914a5f68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->