### PR TITLE
fix(tui): stop browser/clipboard child stderr from corrupting the TUI

### DIFF
--- a/src/tui/clipboard.ts
+++ b/src/tui/clipboard.ts
@@ -8,11 +8,13 @@ export function createClipboardManager(renderer: CliRenderer) {
   const copyToClipboard = (text: string) => {
     renderer.copyToClipboardOSC52(text);
     try {
+      // Suppress child stdio — xclip errors (e.g. "Can't open display" on
+      // headless systems) would otherwise print over the TUI.
       const proc = Bun.spawn(
         process.platform === "darwin"
           ? ["pbcopy"]
           : ["xclip", "-selection", "clipboard"],
-        { stdin: "pipe" },
+        { stdin: "pipe", stdout: "ignore", stderr: "ignore" },
       );
       proc.stdin.write(text);
       proc.stdin.end();

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -15,7 +15,9 @@ import {
 import { config } from "../../../core/config";
 import { useConfig } from "../../context/config";
 import { Dialog } from "../../context/dialog";
+import { useToast } from "../../context/toast";
 import { useTheme } from "../../theme";
+import { openUrlInBrowser } from "../../utils/open-url";
 import DialogLayout, { type FooterAction } from "../dialog-layout";
 
 interface AuthFlowProps {
@@ -36,6 +38,7 @@ type AuthStep =
 export default function AuthFlow({ onClose, hideEsc }: AuthFlowProps) {
   const { colors } = useTheme();
   const appConfig = useConfig();
+  const { toast } = useToast();
 
   const alreadyConnected = isConnected(appConfig.data);
   const hasWorkspace = !!appConfig.data.workspaceId;
@@ -82,18 +85,9 @@ export default function AuthFlow({ onClose, hideEsc }: AuthFlowProps) {
   }, [cleanup]);
 
   const openUrl = (url: string) => {
-    try {
-      const platform = process.platform;
-      if (platform === "darwin") {
-        Bun.spawn(["open", url]);
-      } else if (platform === "win32") {
-        Bun.spawn(["cmd", "/c", "start", url]);
-      } else {
-        Bun.spawn(["xdg-open", url]);
-      }
-    } catch {
-      // Browser open failed — user will see the fallback URL
-    }
+    openUrlInBrowser(url).then((err) => {
+      if (err) toast(err, "warn");
+    });
   };
 
   const consoleUrlRef = useRef<string>(getPensarConsoleUrl());

--- a/src/tui/components/commands/credits-flow.tsx
+++ b/src/tui/components/commands/credits-flow.tsx
@@ -4,7 +4,9 @@ import { getPensarConsoleUrl } from "../../../core/api";
 import { validateGateway } from "../../../core/auth";
 import { Dialog } from "../../context/dialog";
 import { useRoute } from "../../context/route";
+import { useToast } from "../../context/toast";
 import { useTheme } from "../../theme";
+import { openUrlInBrowser } from "../../utils/open-url";
 import DialogLayout, { type FooterAction } from "../dialog-layout";
 
 type CreditsStep = "loading" | "no-auth" | "display" | "browser-opened";
@@ -25,6 +27,7 @@ export default function CreditsFlow({
 }: CreditsFlowProps) {
   const route = useRoute();
   const { colors } = useTheme();
+  const { toast } = useToast();
   const [step, setStep] = useState<CreditsStep>("loading");
   const [credits, setCredits] = useState<CreditsInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -40,19 +43,9 @@ export default function CreditsFlow({
   };
 
   const openBrowser = () => {
-    const url = creditsUrl;
-    try {
-      const platform = process.platform;
-      if (platform === "darwin") {
-        Bun.spawn(["open", url]);
-      } else if (platform === "win32") {
-        Bun.spawn(["cmd", "/c", "start", url]);
-      } else {
-        Bun.spawn(["xdg-open", url]);
-      }
-    } catch {
-      // Browser open failed — user will see the fallback URL
-    }
+    openUrlInBrowser(creditsUrl).then((err) => {
+      if (err) toast(err, "warn");
+    });
     setStep("browser-opened");
   };
 

--- a/src/tui/utils/open-url.ts
+++ b/src/tui/utils/open-url.ts
@@ -1,0 +1,39 @@
+const OPEN_FAILED_MSG = "Couldn't open browser — visit the URL shown instead";
+
+/**
+ * Open a URL in the user's default browser.
+ * Child stdio is suppressed so launcher errors (e.g. xdg-open's
+ * "Can't open display") never leak into the TUI's terminal.
+ * Returns "" on success, or an error message string on failure.
+ */
+export async function openUrlInBrowser(url: string): Promise<string> {
+  try {
+    const platform = process.platform;
+    let proc: ReturnType<typeof Bun.spawn>;
+
+    if (platform === "darwin") {
+      proc = Bun.spawn(["open", url], {
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+    } else if (platform === "win32") {
+      proc = Bun.spawn(["cmd", "/c", "start", "", url], {
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+    } else {
+      proc = Bun.spawn(["xdg-open", url], {
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+    }
+
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      return OPEN_FAILED_MSG;
+    }
+    return "";
+  } catch {
+    return OPEN_FAILED_MSG;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes #905.

The "Error: Can't open display: (null)" text in the issue screenshot is raw **stderr from a child process** (`xdg-open` / the browser it launches on a headless or misconfigured X display), not a message the app rendered. `Bun.spawn` inherits the parent's stderr by default, so when `/login` (and `/credits`) spawned `xdg-open <url>` with no stdio options, the launcher's error output was written straight to the terminal at whatever position the cursor happened to be — corrupting the TUI at a "random" inline position.

Changes:

- **`src/tui/utils/open-url.ts` (new)** — shared `openUrlInBrowser()` util (mirrors the existing `openFileInDefaultApp` in `open-file.ts`): spawns the platform opener with `stdout`/`stderr` set to `"ignore"` so launcher errors can never leak into the terminal, awaits the exit code, and returns an error message string on failure.
- **`auth-flow.tsx` / `credits-flow.tsx`** — replaced their duplicated inline `Bun.spawn` blocks with the shared util. On failure they now show a proper warn toast in the top-right corner ("Couldn't open browser — visit the URL shown instead"); both dialogs already render the fallback URL, so the user can still continue.
- **`clipboard.ts`** — the `xclip` spawn had the same latent leak (`xclip` prints exactly `Error: Can't open display: (null)` when there's no X display, e.g. over SSH); its stdio is now ignored too.

`src/tui/utils/open-file.ts` already piped child stdio, and the headless CLI's `openUrl` (`src/cli/auth.ts`) uses Node `spawn` whose default stdio is piped — both unaffected.

### How did you verify your code works?

Reproduced end-to-end in the TUI with a stub `xdg-open` that fails exactly like the headless case, then re-ran the same `/login` flow with the fix.

Before — the raw error leaks inline over the UI (same as the issue screenshot):

<a href="https://cursor.com/agents/bc-159d31a2-5814-4f00-a2a1-4a99396a4941/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbug_repro_before_fix_error_leaks_inline.mp4"><img src="https://cursor.com/artifacts/c/art-87603e4d-e944-4f98-ac06-089ba98556c5" alt="bug_repro_before_fix_error_leaks_inline.mp4" /></a>

![Before: leaked error text inline](https://cursor.com/artifacts/c/art-a9ddb4ac-4ac6-4852-9c24-15414eda601b)

After — nothing leaks; a warn toast appears in the top-right corner and auto-dismisses:

<a href="https://cursor.com/agents/bc-159d31a2-5814-4f00-a2a1-4a99396a4941/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffix_verified_toast_in_top_right_no_leak.mp4"><img src="https://cursor.com/artifacts/c/art-c3b037cf-2440-49e9-9f03-586378dc68e9" alt="fix_verified_toast_in_top_right_no_leak.mp4" /></a>

![After: toast in top-right corner](https://cursor.com/artifacts/c/art-8a0b40b0-66c7-4045-909d-d954090bd814)

Also ran `bun run lint` (warning count unchanged from baseline), `bun run tsc` (clean), and `bun run test` (1297 passed, 15 skipped).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-159d31a2-5814-4f00-a2a1-4a99396a4941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-159d31a2-5814-4f00-a2a1-4a99396a4941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

