### PR TITLE
fix(tui): keep dialog backdrop transparent in transparent-background mode

### DIFF
--- a/src/tui/theme/context.tsx
+++ b/src/tui/theme/context.tsx
@@ -62,7 +62,15 @@ export function resolveThemeColors(
   for (const [key, value] of entries) {
     resolved[key] = resolveColor(value, mode);
   }
-  if (transparent) resolved.background = RGBA.defaultBackground();
+  if (transparent) {
+    resolved.background = RGBA.defaultBackground();
+    // A semi-transparent overlay alpha-blends against the layer beneath it.
+    // In transparent mode that layer is the terminal default, so blending
+    // resolves to a solid opaque color and the terminal no longer shows
+    // through once a dialog opens. Fall back to the terminal default so the
+    // dialog backdrop stays transparent, matching the rest of the UI.
+    resolved.backgroundOverlay = RGBA.defaultBackground();
+  }
   return resolved as unknown as ThemeColors;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes the reported issue where the TUI's background stops being transparent the moment a dialog (e.g. the pentest configuration dialog) opens.

**Root cause.** The dialog backdrop (`Dialog` in `src/tui/context/dialog.tsx`) is a full-screen box painted with the theme's semi-transparent `backgroundOverlay` (for apex: `rgba(0,0,0,200)`). A semi-transparent color has to alpha-blend against whatever is underneath it. In transparent-background mode, `resolveThemeColors` only overrides `background` to `RGBA.defaultBackground()` (the terminal's own background), so the layer beneath the overlay is the terminal default. When the ~78%-opaque black overlay blends against that, the result is a **solid, fully-opaque color** (near-black), and the rendered cells lose the "terminal default" intent that makes the terminal show through. So as soon as any dialog opens, the whole viewport switches from transparent to an opaque rectangle.

This is why the reporter tied it to the terminal-transparency feature (#841): that feature is what leaves the under-layer as the terminal default, which the semi-transparent overlay then paints over.

**Fix.** In `resolveThemeColors`, when `transparent` is set, also resolve `backgroundOverlay` to `RGBA.defaultBackground()`. A terminal-default color is fully opaque with a special "default" intent, so the backdrop box replaces the cells it covers with the terminal default (SGR `49`) instead of alpha-blending to solid black. The terminal keeps showing through around the dialog, consistent with the rest of the UI, while the dialog panel itself (`backgroundElement`, opaque) stays a readable solid box. Opaque (non-transparent) mode is untouched — the dimming backdrop behaves exactly as before.

The change is a single, surgical edit to the transparent branch of `resolveThemeColors`.

### How did you verify your code works?

- `bun run tsc`, `bunx biome check src/tui/theme/context.tsx`, and `bun run test` (1297 passed, 15 skipped) all pass.
- Manual end-to-end testing in an xfce4-terminal with a dark `#1D1F21` background, running the TUI inside tmux (mirroring the reporter's environment). Measured actual pixel colors around the open dialog:
  - **Before the fix (transparent mode):** home shows the terminal `#1D1F21` (`rgb(29,31,33)`), but opening the dialog turns the surrounding area solid black (`rgb(0,0,0)`).
  - **After the fix (transparent mode):** the area around the dialog stays `rgb(29,31,33)` — the terminal shows through — while the panel interior stays an opaque `rgb(38,38,38)` and remains readable.
  - **Opaque mode:** unchanged — the backdrop still dims to near-black, panel readable.

Before (transparent mode, dialog open — solid black around the panel):

![Before: dialog opens and paints a solid black background over the transparent terminal](https://cursor.com/artifacts/c/art-577b76cb-f731-4386-b131-3880ceddaf89)

After (transparent mode, dialog open — terminal background preserved around the panel):

![After: dialog opens and the terminal background keeps showing through around the panel](https://cursor.com/artifacts/c/art-701ff1d4-349d-4cd7-9fdf-b7774ca47abe)

End-to-end walkthrough (transparent mode: home → open pentest dialog → close), showing the background stays consistently transparent:

<a href="https://cursor.com/agents/bc-e28847d8-8ac4-4c73-9a0f-c68156dca110/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftransparent_mode_dialog_fixed.mp4"><img src="https://cursor.com/artifacts/c/art-df976518-bd4b-44ca-bca9-919e78f13d14" alt="transparent_mode_dialog_fixed.mp4" /></a>

#### Note on scope

The reporter's screenshots are from Apex 1.8.0 (older `@opentui/core` 0.1.100), whose alpha-blend path additionally could resolve a black overlay over a transparent cell straight to the terminal default — producing the exact "terminal shows through the dialog" look in the screenshots. On current `canary` (`@opentui/core` 0.1.107) that specific path no longer triggers in opaque mode, but the transparent-mode regression above is real and reproducible, and is the same underlying interaction between the transparency feature and the semi-transparent dialog backdrop. This fix addresses that interaction at its source.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e28847d8-8ac4-4c73-9a0f-c68156dca110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e28847d8-8ac4-4c73-9a0f-c68156dca110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

