### PR TITLE
feat(ai): add GPT-5.6 model support

### DIFF
--- a/scripts/generate-models.ts
+++ b/scripts/generate-models.ts
@@ -57,6 +57,7 @@ const CONTEXT_LENGTHS: Record<string, number> = {
   "claude-instant": 100000,
 
   // OpenAI
+  "gpt-5.6": 1050000,
   "gpt-5.5": 1050000,
   "gpt-5": 200000,
   "gpt-4.5": 128000,
@@ -619,7 +620,13 @@ function main() {
   ).filter(isRelevantChatModel);
 
   // Models available on the OpenAI API but not yet in the AI SDK type definitions
-  appendMissing(openaiIds, ["gpt-5.5", "gpt-5.5-2026-04-23"]);
+  appendMissing(openaiIds, [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+    "gpt-5.5-2026-04-23",
+  ]);
 
   // OpenAI's SDK lists generations oldest-first; flip so the picker shows the
   // newest family first. Stable sort preserves intra-family declaration order.

--- a/src/core/ai/ai.test.ts
+++ b/src/core/ai/ai.test.ts
@@ -127,6 +127,14 @@ describe("buildReasoningProviderOptions", () => {
     expect(result?.bedrock).toBeUndefined();
   });
 
+  it("sends GPT-5.6 ultra effort as the API-supported max value", () => {
+    expect(
+      buildReasoningProviderOptions("gpt-5.6-sol", {
+        openAIReasoningEffort: "ultra",
+      }),
+    ).toEqual({ openai: { reasoningEffort: "max" } });
+  });
+
   it("carries the adaptive-thinking effort hint on both anthropic and bedrock for a 4.6 model", () => {
     const result = buildReasoningProviderOptions(
       "global.anthropic.claude-opus-4-6-v1",

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -50,7 +50,9 @@ export type OpenAIReasoningEffort =
   | "low"
   | "medium"
   | "high"
-  | "xhigh";
+  | "xhigh"
+  | "max"
+  | "ultra";
 
 export const DEFAULT_OPENAI_REASONING_EFFORT: OpenAIReasoningEffort = "medium";
 
@@ -77,6 +79,9 @@ const OPENAI_REASONING_MODEL_IDS = new Set([
   "gpt-5.4-pro-2026-03-05",
   "gpt-5.5",
   "gpt-5.5-2026-04-23",
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
 ]);
 
 /** Per-step billing context attached to a usage report, attributing cost to a specific `(sessionId, stepSeq)`. */
@@ -753,6 +758,9 @@ export function getOpenAIReasoningEfforts(
   modelId: string,
 ): OpenAIReasoningEffort[] {
   if (!modelSupportsOpenAIReasoning(modelId)) return [];
+  if (/^gpt-5\.6(?:\b|-)/.test(modelId)) {
+    return ["low", "medium", "high", "xhigh", "max", "ultra"];
+  }
   if (/^gpt-5\.5(?:\b|-)/.test(modelId)) {
     return ["none", "low", "medium", "high", "xhigh"];
   }
@@ -765,7 +773,10 @@ export function normalizeOpenAIReasoningEffort(
 ): OpenAIReasoningEffort | undefined {
   const efforts = getOpenAIReasoningEfforts(modelId);
   if (efforts.length === 0) return undefined;
-  if (effort && efforts.includes(effort)) return effort;
+  if (effort && efforts.includes(effort)) {
+    // ponytail: OpenAI has no distinct ultra level; keep the UI choice as a max alias.
+    return effort === "ultra" ? "max" : effort;
+  }
   return DEFAULT_OPENAI_REASONING_EFFORT;
 }
 

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   DEFAULT_OPENAI_REASONING_EFFORT,
+  getOpenAIReasoningEfforts,
   modelSupportsOpenAIReasoning,
   normalizeOpenAIReasoningEffort,
 } from "../ai";
@@ -147,6 +148,15 @@ describe("getMaxOutputTokens", () => {
     expect(getModelInfo("gpt-5.5-2026-04-23").contextLength).toBe(1_050_000);
   });
 
+  it("registers the GPT-5.6 family with its 1.05M context window", () => {
+    for (const id of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+      expect(getModelInfo(id)).toMatchObject({
+        provider: "openai",
+        contextLength: 1_050_000,
+      });
+    }
+  });
+
   it("recognizes Google Gemini family budgets", () => {
     expect(getMaxOutputTokens("gemini-2.5-pro")).toBe(65_000);
     expect(getMaxOutputTokens("gemini-2.5-flash")).toBe(65_000);
@@ -206,6 +216,20 @@ describe("prefersSequentialToolCalls", () => {
 });
 
 describe("OpenAI reasoning effort support", () => {
+  it("supports the requested GPT-5.6 effort levels", () => {
+    expect(getOpenAIReasoningEfforts("gpt-5.6-sol")).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultra",
+    ]);
+    expect(modelSupportsOpenAIReasoning("gpt-5.6-terra")).toBe(true);
+    expect(modelSupportsOpenAIReasoning("gpt-5.6-luna")).toBe(true);
+    expect(normalizeOpenAIReasoningEffort("gpt-5.6-sol", "ultra")).toBe("max");
+  });
+
   it("supports GPT-5.5 and o-series reasoning models", () => {
     expect(modelSupportsOpenAIReasoning("gpt-5.5")).toBe(true);
     expect(modelSupportsOpenAIReasoning("gpt-5.5-2026-04-23")).toBe(true);

--- a/src/core/ai/models/openai.ts
+++ b/src/core/ai/models/openai.ts
@@ -5,6 +5,24 @@ import type { ModelInfo } from "../ai";
 
 export const OPENAI_MODELS: ModelInfo[] = [
   {
+    id: "gpt-5.6-sol",
+    name: "GPT-5.6-sol",
+    provider: "openai",
+    contextLength: 1050000,
+  },
+  {
+    id: "gpt-5.6-terra",
+    name: "GPT-5.6-terra",
+    provider: "openai",
+    contextLength: 1050000,
+  },
+  {
+    id: "gpt-5.6-luna",
+    name: "GPT-5.6-luna",
+    provider: "openai",
+    contextLength: 1050000,
+  },
+  {
     id: "gpt-5.5",
     name: "GPT-5.5",
     provider: "openai",

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -36,7 +36,15 @@ export interface Config {
   selectedModelId?: string | null;
   // Extended thinking / reasoning
   reasoningEnabled?: boolean;
-  openAIReasoningEffort?: "none" | "low" | "medium" | "high" | "xhigh" | null;
+  openAIReasoningEffort?:
+    | "none"
+    | "low"
+    | "medium"
+    | "high"
+    | "xhigh"
+    | "max"
+    | "ultra"
+    | null;
   // Whitebox attack surface: when false, skip the @pensar/surface deterministic
   // enumeration path and use the legacy pages+apiEndpoints discovery agents.
   // Defaults to true when unset.

--- a/src/core/providers/utils.test.ts
+++ b/src/core/providers/utils.test.ts
@@ -49,7 +49,7 @@ describe("getDefaultModelForConfig", () => {
     const model = getDefaultModelForConfig(config);
     expect(model).not.toBeNull();
     expect(model?.provider).toBe("openai");
-    expect(model?.id).toBe("gpt-5.5");
+    expect(model?.id).toBe("gpt-5.6-sol");
   });
 
   it("returns Google best model when only Google is configured", () => {

--- a/src/core/providers/utils.ts
+++ b/src/core/providers/utils.ts
@@ -18,7 +18,7 @@ const PROVIDER_PREFERENCE_ORDER: ProviderType[] = [
 const PREFERRED_MODEL_BY_PROVIDER: Record<string, string> = {
   pensar: "pensar:anthropic.claude-opus-4-6-v1",
   anthropic: "claude-opus-4-6",
-  openai: "gpt-5.5",
+  openai: "gpt-5.6-sol",
   google: "gemini-3.1-pro-preview",
   openrouter: "anthropic/claude-opus-4.6",
   bedrock: "anthropic.claude-opus-4-6-v1",

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -767,7 +767,10 @@ export function ModelPicker({
         <box flexShrink={0} paddingTop={1}>
           <PickerRow id="openai-reasoning-effort">
             <text fg={isOpenAIReasoningFocused ? colors.primary : colors.text}>
-              Reasoning Effort: {openAIReasoningEffort}
+              Reasoning Effort:{" "}
+              {openAIReasoningEffort === "xhigh"
+                ? "extra high"
+                : openAIReasoningEffort}
             </text>
           </PickerRow>
         </box>


### PR DESCRIPTION
### What does this PR do?

Adds minimum viable OpenAI support for GPT-5.6 Sol, Terra, and Luna:

- Registers all three models with their 1.05M context window.
- Makes GPT-5.6 Sol the preferred direct OpenAI model.
- Adds low, medium, high, extra high, max, and ultra effort choices in the existing model picker.
- Sends extra high as xhigh and aliases ultra to the API-supported max effort.
- Adds focused catalog, default-selection, and provider-option regression coverage.

### How did you verify your code works?

- NODE_OPTIONS=--max-old-space-size=8192 bun run tsc
- bun run test — 1,311 passed, 18 skipped
- bun run build
- Biome check on all changed files

The repository-wide Biome check still reports unrelated pre-existing diagnostics outside this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog and provider-option wiring with no auth or data-path changes; default model shift only affects new OpenAI-only setups without a saved model preference.
> 
> **Overview**
> Adds **GPT-5.6 Sol, Terra, and Luna** to the OpenAI catalog (1.05M context) via `generate-models` and the generated `openai.ts` list, and switches the default direct OpenAI pick from `gpt-5.5` to **`gpt-5.6-sol`**.
> 
> For GPT-5.6 reasoning models, the picker and config now support **`max`** and **`ultra`** effort levels (alongside low through xhigh). **`ultra`** is normalized to **`max`** when building OpenAI provider options, since the API has no separate ultra tier. The model picker labels **`xhigh`** as “extra high” in the UI.
> 
> Regression tests cover catalog metadata, default model selection, effort lists, and the ultra→max mapping in `buildReasoningProviderOptions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f5380c48f45f05ccd090de041fd336fffd17029. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->