### PR TITLE
feat: expose abortAndDrain for bounded Camoufox teardown

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -283,6 +283,17 @@ export class OffensiveSecurityAgent<TResult = void> {
           extraHttpHeaders: stripBrowserManagedHeaders(sessionHeaders),
           display: input.display,
         });
+      // Owned sessions aren't wired through createBrowserTools' abort path
+      // (existingSession skips that listener). Disconnect on abort so timeout/
+      // pause reaps Camoufox even when consume()'s drain is still unwinding.
+      if (this.ownsBrowserSession && this.abortSignal) {
+        const onAbort = () => {
+          void this.disconnectOwnedBrowser();
+        };
+        if (this.abortSignal.aborted) onAbort();
+        else
+          this.abortSignal.addEventListener("abort", onAbort, { once: true });
+      }
     } else {
       this.ownsBrowserSession = false;
     }
@@ -1105,6 +1116,17 @@ export class OffensiveSecurityAgent<TResult = void> {
     if (!this.ownsBrowserSession || !this.browserSession) return;
     this.browserDisconnected = true;
     await this.browserSession.disconnect().catch(() => {});
+  }
+
+  /**
+   * Idempotent teardown for hosts that abort before `consume()` settles
+   * (Console `settleOnAbort` on timeout/pause). Force-disconnects the owned
+   * browser, then awaits the drain so Camoufox is reaped before the next
+   * endpoint starts.
+   */
+  async abortAndDrain(): Promise<void> {
+    await this.disconnectOwnedBrowser();
+    await this.drained.catch(() => {});
   }
 
   /**

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -299,11 +299,9 @@ function withTimeout<T>(
  * SIGKILL the browser explicitly. Must be called BEFORE the parent is killed:
  * once it dies its children reparent to init and are no longer reachable via
  * its pid.
- *
- * @internal Exported for testing.
  */
 /** `/proc/<pid>/stat` starttime (field 22) — used to refuse PID-reuse kills. */
-export function readProcStartTime(pid: number): number | null {
+function readProcStartTime(pid: number): number | null {
   try {
     const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
     const afterComm = stat.slice(stat.lastIndexOf(")") + 2).split(" ");

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -545,8 +545,8 @@ export class PlaywrightMcpSession {
     // as a process-group leader, which orphaned Chromium and leaked memory
     // across endpoints until the sandbox OOM'd.
     const rootPid = proc.pid ?? null;
-    const rootStart = rootPid != null ? readProcStartTime(rootPid) : null;
     const descendants = rootPid != null ? collectDescendantPids(rootPid) : [];
+    // Snapshot starttimes before kill so we refuse PID-reuse kills after reparent.
     const descendantStarts = new Map<number, number | null>();
     for (const pid of descendants) {
       descendantStarts.set(pid, readProcStartTime(pid));
@@ -566,8 +566,6 @@ export class PlaywrightMcpSession {
       // Already dead — fine
     }
 
-    // Reap the browser tree explicitly so a failed group-kill can't strand it.
-    // Refuse to kill a PID whose starttime changed (kernel reused the pid).
     for (const pid of descendants) {
       const expected = descendantStarts.get(pid);
       if (expected != null) {
@@ -578,14 +576,6 @@ export class PlaywrightMcpSession {
         process.kill(pid, "SIGKILL");
       } catch {
         // Already gone — fine
-      }
-    }
-
-    if (rootPid != null && rootStart != null) {
-      const now = readProcStartTime(rootPid);
-      if (now != null && now !== rootStart) {
-        // Root pid was recycled — do not touch it.
-        return;
       }
     }
   }

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -302,6 +302,18 @@ function withTimeout<T>(
  *
  * @internal Exported for testing.
  */
+/** `/proc/<pid>/stat` starttime (field 22) — used to refuse PID-reuse kills. */
+export function readProcStartTime(pid: number): number | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const afterComm = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+    const starttime = Number(afterComm[19]);
+    return Number.isFinite(starttime) ? starttime : null;
+  } catch {
+    return null;
+  }
+}
+
 export function collectDescendantPids(rootPid: number): number[] {
   let entries: string[];
   try {
@@ -532,12 +544,18 @@ export class PlaywrightMcpSession {
     // pid. The group-kill below misses them because the MCP node isn't spawned
     // as a process-group leader, which orphaned Chromium and leaked memory
     // across endpoints until the sandbox OOM'd.
-    const descendants = proc.pid ? collectDescendantPids(proc.pid) : [];
+    const rootPid = proc.pid ?? null;
+    const rootStart = rootPid != null ? readProcStartTime(rootPid) : null;
+    const descendants = rootPid != null ? collectDescendantPids(rootPid) : [];
+    const descendantStarts = new Map<number, number | null>();
+    for (const pid of descendants) {
+      descendantStarts.set(pid, readProcStartTime(pid));
+    }
 
     try {
-      if (proc.pid) {
+      if (rootPid != null) {
         try {
-          process.kill(-proc.pid, "SIGKILL");
+          process.kill(-rootPid, "SIGKILL");
         } catch {
           proc.kill("SIGKILL");
         }
@@ -549,11 +567,25 @@ export class PlaywrightMcpSession {
     }
 
     // Reap the browser tree explicitly so a failed group-kill can't strand it.
+    // Refuse to kill a PID whose starttime changed (kernel reused the pid).
     for (const pid of descendants) {
+      const expected = descendantStarts.get(pid);
+      if (expected != null) {
+        const now = readProcStartTime(pid);
+        if (now == null || now !== expected) continue;
+      }
       try {
         process.kill(pid, "SIGKILL");
       } catch {
         // Already gone — fine
+      }
+    }
+
+    if (rootPid != null && rootStart != null) {
+      const now = readProcStartTime(rootPid);
+      if (now != null && now !== rootStart) {
+        // Root pid was recycled — do not touch it.
+        return;
       }
     }
   }

--- a/src/core/api/targetedPentest.test.ts
+++ b/src/core/api/targetedPentest.test.ts
@@ -16,10 +16,14 @@ vi.mock("../agents/specialized/pentest/agent", () => ({
     async consume() {
       return this._result;
     }
+    async abortAndDrain() {}
   },
 }));
 
-import { runTargetedPentestAgent } from "./targetedPentest";
+import {
+  runTargetedPentestAgent,
+  startTargetedPentestAgent,
+} from "./targetedPentest";
 
 // Mock ignores everything except __testResult; cast so the real input shape isn't required.
 function run(testResult: unknown) {
@@ -69,5 +73,17 @@ describe("runTargetedPentestAgent result-shape resilience", () => {
   it("does NOT throw when consume() returns null", async () => {
     const out = await run(null);
     expect(out.findings).toEqual([]);
+  });
+});
+
+describe("startTargetedPentestAgent handle", () => {
+  it("exposes result + abortAndDrain before consume settles", async () => {
+    const handle = startTargetedPentestAgent({
+      __testResult: { findings: [] },
+      eventBus: {},
+    } as never);
+    expect(typeof handle.abortAndDrain).toBe("function");
+    await expect(handle.abortAndDrain()).resolves.toBeUndefined();
+    await expect(handle.result).resolves.toMatchObject({ findings: [] });
   });
 });

--- a/src/core/api/targetedPentest.ts
+++ b/src/core/api/targetedPentest.ts
@@ -1,9 +1,57 @@
 import {
   type PentestAgentInput,
+  type PentestResult,
   TargetedPentestAgent,
 } from "../agents/specialized/pentest/agent";
 
-export async function runTargetedPentestAgent(input: PentestAgentInput) {
+export type TargetedPentestResult = {
+  findings: PentestResult["findings"];
+  findingsPath?: string;
+  pocsPath?: string;
+  objectiveResults?: PentestResult["objectiveResults"];
+  newObjectives?: PentestResult["newObjectives"];
+};
+
+/**
+ * Handle returned before `consume()` settles so callers can await browser
+ * teardown after abort/timeout without holding the agent instance.
+ */
+export type TargetedPentestHandle = {
+  result: Promise<TargetedPentestResult>;
+  /** Force-disconnect owned browser + await drain. Idempotent; never throws. */
+  abortAndDrain: () => Promise<void>;
+};
+
+function normalizeResult(result: unknown): TargetedPentestResult {
+  const r = result as Partial<PentestResult> | null | undefined;
+  if (!r || !Array.isArray(r.findings)) {
+    console.error(
+      "runTargetedPentestAgent: consume() returned unexpected shape",
+      { keys: result ? Object.keys(result as object) : null },
+    );
+  }
+
+  const findings = Array.isArray(r?.findings) ? r.findings : [];
+  const findingsPath = r?.findingsPath;
+  const pocsPath = r?.pocsPath;
+  const objectiveResults = Array.isArray(r?.objectiveResults)
+    ? r.objectiveResults
+    : undefined;
+  const newObjectives = Array.isArray(r?.newObjectives)
+    ? r.newObjectives
+    : undefined;
+
+  console.log(`\nFound ${findings.length} vulnerabilities`);
+  console.log(`Findings: ${findingsPath}`);
+  console.log(`POCs: ${pocsPath}`);
+
+  return { findings, findingsPath, pocsPath, objectiveResults, newObjectives };
+}
+
+/** Start a targeted pentest and return a handle for result + bounded teardown. */
+export function startTargetedPentestAgent(
+  input: PentestAgentInput,
+): TargetedPentestHandle {
   const agent = new TargetedPentestAgent(input);
 
   if (!input.eventBus) {
@@ -17,26 +65,17 @@ export async function runTargetedPentestAgent(input: PentestAgentInput) {
     agent.eventBus.on("error", (d) => console.error("Agent error:", d.error));
   }
 
-  const result = await agent.consume();
+  const result = agent.consume().then(normalizeResult);
 
-  // consume() should return { findings, ... }; fall back to [] rather than
-  // crash on findings.length if a malformed result slips through.
-  if (!result || !Array.isArray(result.findings)) {
-    console.error(
-      "runTargetedPentestAgent: consume() returned unexpected shape",
-      { keys: result ? Object.keys(result) : null },
-    );
-  }
+  return {
+    result,
+    abortAndDrain: () => agent.abortAndDrain(),
+  };
+}
 
-  const findings = Array.isArray(result?.findings) ? result.findings : [];
-  const findingsPath = result?.findingsPath;
-  const pocsPath = result?.pocsPath;
-  const objectiveResults = result?.objectiveResults;
-  const newObjectives = result?.newObjectives;
-
-  console.log(`\nFound ${findings.length} vulnerabilities`);
-  console.log(`Findings: ${findingsPath}`);
-  console.log(`POCs: ${pocsPath}`);
-
-  return { findings, findingsPath, pocsPath, objectiveResults, newObjectives };
+/** Convenience wrapper: await the full run (CLI / simple callers). */
+export async function runTargetedPentestAgent(
+  input: PentestAgentInput,
+): Promise<TargetedPentestResult> {
+  return startTargetedPentestAgent(input).result;
 }

--- a/src/core/api/targetedPentest.ts
+++ b/src/core/api/targetedPentest.ts
@@ -4,10 +4,13 @@ import {
   TargetedPentestAgent,
 } from "../agents/specialized/pentest/agent";
 
-export type TargetedPentestResult = Pick<
-  PentestResult,
-  "findings" | "findingsPath" | "pocsPath" | "objectiveResults" | "newObjectives"
->;
+export type TargetedPentestResult = {
+  findings: PentestResult["findings"];
+  findingsPath?: string;
+  pocsPath?: string;
+  objectiveResults?: PentestResult["objectiveResults"];
+  newObjectives?: PentestResult["newObjectives"];
+};
 
 /** Handle returned before `consume()` settles so hosts can await browser teardown. */
 export type TargetedPentestHandle = {

--- a/src/core/api/targetedPentest.ts
+++ b/src/core/api/targetedPentest.ts
@@ -4,24 +4,19 @@ import {
   TargetedPentestAgent,
 } from "../agents/specialized/pentest/agent";
 
-export type TargetedPentestResult = {
-  findings: PentestResult["findings"];
-  findingsPath?: string;
-  pocsPath?: string;
-  objectiveResults?: PentestResult["objectiveResults"];
-  newObjectives?: PentestResult["newObjectives"];
-};
+export type TargetedPentestResult = Pick<
+  PentestResult,
+  "findings" | "findingsPath" | "pocsPath" | "objectiveResults" | "newObjectives"
+>;
 
-/**
- * Handle returned before `consume()` settles so callers can await browser
- * teardown after abort/timeout without holding the agent instance.
- */
+/** Handle returned before `consume()` settles so hosts can await browser teardown. */
 export type TargetedPentestHandle = {
   result: Promise<TargetedPentestResult>;
   /** Force-disconnect owned browser + await drain. Idempotent; never throws. */
   abortAndDrain: () => Promise<void>;
 };
 
+/** Guard against malformed consume() shapes (don't crash on findings.length). */
 function normalizeResult(result: unknown): TargetedPentestResult {
   const r = result as Partial<PentestResult> | null | undefined;
   if (!r || !Array.isArray(r.findings)) {
@@ -32,20 +27,17 @@ function normalizeResult(result: unknown): TargetedPentestResult {
   }
 
   const findings = Array.isArray(r?.findings) ? r.findings : [];
-  const findingsPath = r?.findingsPath;
-  const pocsPath = r?.pocsPath;
-  const objectiveResults = Array.isArray(r?.objectiveResults)
-    ? r.objectiveResults
-    : undefined;
-  const newObjectives = Array.isArray(r?.newObjectives)
-    ? r.newObjectives
-    : undefined;
-
   console.log(`\nFound ${findings.length} vulnerabilities`);
-  console.log(`Findings: ${findingsPath}`);
-  console.log(`POCs: ${pocsPath}`);
+  console.log(`Findings: ${r?.findingsPath}`);
+  console.log(`POCs: ${r?.pocsPath}`);
 
-  return { findings, findingsPath, pocsPath, objectiveResults, newObjectives };
+  return {
+    findings,
+    findingsPath: r?.findingsPath,
+    pocsPath: r?.pocsPath,
+    objectiveResults: r?.objectiveResults,
+    newObjectives: r?.newObjectives,
+  };
 }
 
 /** Start a targeted pentest and return a handle for result + bounded teardown. */
@@ -65,10 +57,8 @@ export function startTargetedPentestAgent(
     agent.eventBus.on("error", (d) => console.error("Agent error:", d.error));
   }
 
-  const result = agent.consume().then(normalizeResult);
-
   return {
-    result,
+    result: agent.consume().then(normalizeResult),
     abortAndDrain: () => agent.abortAndDrain(),
   };
 }


### PR DESCRIPTION
## Summary
- Add `startTargetedPentestAgent` handle with `abortAndDrain` so hosts can await Camoufox reap after timeout/pause
- Disconnect owned browser on abort; PID-starttime guards before descendant SIGKILL
- Keep `runTargetedPentestAgent` as a thin wrapper for existing callers

## Test plan
- [x] `targetedPentest.test.ts` covers handle + abortAndDrain
- [ ] Console blackbox holds endpoint slots until drain completes


Made with [Cursor](https://cursor.com)