### PR TITLE
feat(pentest): deterministic destructive-action guard

### DIFF
--- a/src/core/agents/offSecAgent/tools/destructiveGuard.test.ts
+++ b/src/core/agents/offSecAgent/tools/destructiveGuard.test.ts
@@ -402,6 +402,82 @@ describe("classifyCommandAction", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Regression: in-script HTTP DELETE nested inside execute_command
+// (the Lilt multipart-delete vector — a fetch/axios/Playwright DELETE run via a
+// JS runtime, which curl-based and http_request-level controls both miss).
+// ---------------------------------------------------------------------------
+
+describe("in-script HTTP DELETE inside execute_command", () => {
+  // Encoding 1 — sanitized curl equivalent.
+  it("flags a curl DELETE to the multipart path", () => {
+    expect(
+      classifyCommandAction(
+        'curl -i -X DELETE -H "Cookie: session=x" "https://mock-target.test/app/api/upload/s3/multipart/undefined"',
+      ).category,
+    ).toBe("http-delete-method");
+  });
+
+  // Encoding 2 — literal fetch with method: 'DELETE'.
+  it("flags a fetch() call with method DELETE", () => {
+    expect(
+      classifyCommandAction(
+        "fetch('/app/api/upload/s3/multipart/undefined', { method: 'DELETE' });",
+      ).category,
+    ).toBe("http-delete-method");
+  });
+
+  // Encoding 3 — dynamically-built path (the closest reproduction: the path is
+  // interpolated, so it never contains a literal delete keyword or "undefined").
+  it("flags a fetch() DELETE whose path is built dynamically", () => {
+    expect(
+      classifyCommandAction(
+        "node -e \"const id = resp.id; fetch(`/app/api/upload/s3/multipart/${id}`, { method: 'DELETE' })\"",
+      ).destructive,
+    ).toBe(true);
+  });
+
+  it("flags valid-ID DELETE variants and parallel bursts", () => {
+    expect(
+      classifyCommandAction(
+        "node -e \"fetch('/app/api/upload/s3/multipart/81029', { method: 'DELETE' })\"",
+      ).destructive,
+    ).toBe(true);
+    expect(
+      classifyCommandAction(
+        "node -e \"await Promise.all(Array.from({length:10}, () => fetch('/app/api/upload/s3/multipart/undefined', { method: 'DELETE' })))\"",
+      ).destructive,
+    ).toBe(true);
+  });
+
+  it("flags positional client DELETE calls (axios / Playwright)", () => {
+    expect(
+      classifyCommandAction("node -e \"axios.delete('/api/x/1')\"").destructive,
+    ).toBe(true);
+    expect(
+      classifyCommandAction(
+        "npx playwright test -c \"await page.request.delete('/app/api/upload/s3/multipart/81067')\"",
+      ).destructive,
+    ).toBe(true);
+  });
+
+  it("does not flag benign look-alikes (recon greps, Map.delete, GET fetch)", () => {
+    // Grepping source for the literal string is recon, not an HTTP call.
+    expect(
+      classifyCommandAction("grep -rn \"method: 'DELETE'\" src/").destructive,
+    ).toBe(false);
+    // Map/Set/Cache .delete() is not an HTTP client.
+    expect(
+      classifyCommandAction("node -e \"seen.delete('key')\"").destructive,
+    ).toBe(false);
+    // A non-destructive fetch (GET) stays allowed.
+    expect(
+      classifyCommandAction("node -e \"fetch('/app/api/upload/s3/multipart')\"")
+        .destructive,
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Enforcement
 // ---------------------------------------------------------------------------
 

--- a/src/core/agents/offSecAgent/tools/destructiveGuard.test.ts
+++ b/src/core/agents/offSecAgent/tools/destructiveGuard.test.ts
@@ -210,6 +210,18 @@ describe("classifyCommandAction", () => {
     expect(classifyCommandAction("rm -rf /etc").category).toBe(
       "host-destructive",
     );
+    // Split flags, long options, other flags, and sensitive-prefix subpaths
+    // are all equivalent host wipes.
+    expect(classifyCommandAction("rm -r -f /").destructive).toBe(true);
+    expect(classifyCommandAction("rm --recursive --force /").destructive).toBe(
+      true,
+    );
+    expect(
+      classifyCommandAction("rm --no-preserve-root -rf /").destructive,
+    ).toBe(true);
+    expect(classifyCommandAction("rm -rf /home/ubuntu").category).toBe(
+      "host-destructive",
+    );
     expect(classifyCommandAction("mkfs.ext4 /dev/sda1").destructive).toBe(true);
     expect(
       classifyCommandAction("dd if=/dev/zero of=/dev/sda").destructive,

--- a/src/core/agents/offSecAgent/tools/destructiveGuard.test.ts
+++ b/src/core/agents/offSecAgent/tools/destructiveGuard.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "vitest";
+import type { SessionConfig, SessionInfo } from "../../../session";
+import {
+  assertCommandActionAllowed,
+  assertHttpActionAllowed,
+  classifyCommandAction,
+  classifyHttpAction,
+  DestructiveActionError,
+  isDestructiveTestingAllowed,
+} from "./destructiveGuard";
+import type { ToolContext } from "./types";
+
+function makeCtx(config: Partial<SessionConfig> = {}): ToolContext {
+  return {
+    session: {
+      id: "ses_test",
+      version: "1.0.0",
+      targets: [],
+      time: { created: Date.now(), updated: Date.now() },
+      rootPath: "/tmp/test",
+      logsPath: "/tmp/test/logs",
+      findingsPath: "/tmp/test/findings",
+      scratchpadPath: "/tmp/test/scratchpad",
+      pocsPath: "/tmp/test/pocs",
+      config,
+    } as SessionInfo,
+    agentCwd: "/tmp/test",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// classifyHttpAction
+// ---------------------------------------------------------------------------
+
+describe("classifyHttpAction", () => {
+  it("flags HTTP DELETE as an API write-delete", () => {
+    const c = classifyHttpAction({
+      method: "DELETE",
+      url: "https://api.example.com/users/42",
+    });
+    expect(c.destructive).toBe(true);
+    expect(c.category).toBe("http-delete-method");
+  });
+
+  it("is case-insensitive on the method", () => {
+    expect(
+      classifyHttpAction({ method: "delete", url: "https://x.com/a" })
+        .destructive,
+    ).toBe(true);
+  });
+
+  it("allows ordinary reads and writes", () => {
+    expect(
+      classifyHttpAction({ method: "GET", url: "https://x.com/users/1" })
+        .destructive,
+    ).toBe(false);
+    expect(
+      classifyHttpAction({
+        method: "POST",
+        url: "https://x.com/users",
+        body: '{"name":"a"}',
+      }).destructive,
+    ).toBe(false);
+    expect(
+      classifyHttpAction({
+        method: "PUT",
+        url: "https://x.com/users/1",
+        body: '{"displayName":"new"}',
+      }).destructive,
+    ).toBe(false);
+  });
+
+  it("flags a write method aimed at a delete/destroy route", () => {
+    expect(
+      classifyHttpAction({
+        method: "POST",
+        url: "https://x.com/users/1/delete",
+      }).destructive,
+    ).toBe(true);
+    expect(
+      classifyHttpAction({
+        method: "POST",
+        url: "https://x.com/account/destroy",
+      }).category,
+    ).toBe("http-destructive-path");
+    expect(
+      classifyHttpAction({ method: "PATCH", url: "https://x.com/db/purge" })
+        .destructive,
+    ).toBe(true);
+  });
+
+  it("does not flag a listing route that merely contains 'deleted'", () => {
+    expect(
+      classifyHttpAction({ method: "POST", url: "https://x.com/deleted-items" })
+        .destructive,
+    ).toBe(false);
+    expect(
+      classifyHttpAction({ method: "GET", url: "https://x.com/users/1/delete" })
+        .destructive,
+    ).toBe(false);
+  });
+
+  it("flags a method-override to DELETE", () => {
+    expect(
+      classifyHttpAction({
+        method: "POST",
+        url: "https://x.com/users/1?_method=DELETE",
+      }).destructive,
+    ).toBe(true);
+  });
+
+  it("flags destructive SQL in the body regardless of method", () => {
+    const c = classifyHttpAction({
+      method: "POST",
+      url: "https://x.com/graphql",
+      body: 'mutation { raw(q: "DROP TABLE users") }',
+    });
+    expect(c.destructive).toBe(true);
+    expect(c.category).toBe("sql-destructive");
+  });
+
+  it("flags a destructive SQLi payload in the query string", () => {
+    expect(
+      classifyHttpAction({
+        method: "GET",
+        url: "https://x.com/p?id=1;DROP TABLE sessions--",
+      }).destructive,
+    ).toBe(true);
+  });
+
+  it("flags destructive NoSQL/cache operations in the body", () => {
+    expect(
+      classifyHttpAction({
+        method: "POST",
+        url: "https://x.com/admin/eval",
+        body: "db.users.drop()",
+      }).category,
+    ).toBe("nosql-destructive");
+    expect(
+      classifyHttpAction({
+        method: "POST",
+        url: "https://x.com/admin/eval",
+        body: "FLUSHALL",
+      }).destructive,
+    ).toBe(true);
+  });
+
+  it("ignores non-string bodies (e.g. prompt-injection refs)", () => {
+    expect(
+      classifyHttpAction({
+        method: "POST",
+        url: "https://x.com/chat",
+        body: { kind: "prompt_injection_ref", id: "abc" },
+      }).destructive,
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyCommandAction
+// ---------------------------------------------------------------------------
+
+describe("classifyCommandAction", () => {
+  it("flags destructive SQL run through a db client", () => {
+    expect(
+      classifyCommandAction('psql -h db.example.com -c "DROP TABLE users"')
+        .category,
+    ).toBe("sql-destructive");
+    expect(
+      classifyCommandAction('mysql -e "TRUNCATE TABLE sessions"').destructive,
+    ).toBe(true);
+    expect(
+      classifyCommandAction('sqlite3 app.db "DELETE FROM audit_log"')
+        .destructive,
+    ).toBe(true);
+  });
+
+  it("flags destructive NoSQL/cache operations", () => {
+    expect(
+      classifyCommandAction("redis-cli -h cache FLUSHALL").destructive,
+    ).toBe(true);
+    expect(
+      classifyCommandAction('mongosh --eval "db.dropDatabase()"').category,
+    ).toBe("nosql-destructive");
+  });
+
+  it("flags an HTTP DELETE issued via curl/wget", () => {
+    expect(
+      classifyCommandAction("curl -X DELETE https://x.com/users/1").category,
+    ).toBe("http-delete-method");
+    expect(
+      classifyCommandAction("curl --request delete https://x.com/a")
+        .destructive,
+    ).toBe(true);
+  });
+
+  it("flags catastrophic host operations", () => {
+    expect(classifyCommandAction("rm -rf /").destructive).toBe(true);
+    expect(classifyCommandAction("rm -rf ~").destructive).toBe(true);
+    expect(classifyCommandAction("rm -rf /etc").category).toBe(
+      "host-destructive",
+    );
+    expect(classifyCommandAction("mkfs.ext4 /dev/sda1").destructive).toBe(true);
+    expect(
+      classifyCommandAction("dd if=/dev/zero of=/dev/sda").destructive,
+    ).toBe(true);
+    expect(classifyCommandAction("sudo reboot").destructive).toBe(true);
+  });
+
+  it("allows ordinary recon / scratch commands", () => {
+    expect(classifyCommandAction("curl -i https://x.com/").destructive).toBe(
+      false,
+    );
+    expect(
+      classifyCommandAction("curl -X POST -d 'a=1' https://x.com/login")
+        .destructive,
+    ).toBe(false);
+    expect(classifyCommandAction("nmap -sV -p- example.com").destructive).toBe(
+      false,
+    );
+    // Sandbox scratch cleanup must not be classed as catastrophic.
+    expect(
+      classifyCommandAction("rm -rf /tmp/apex-scratch-123").destructive,
+    ).toBe(false);
+    expect(
+      classifyCommandAction('sqlmap -u "https://x.com/p?id=1" --batch')
+        .destructive,
+    ).toBe(false);
+    // A read-oriented SELECT is not destructive.
+    expect(
+      classifyCommandAction('psql -c "SELECT * FROM users LIMIT 1"')
+        .destructive,
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enforcement
+// ---------------------------------------------------------------------------
+
+describe("isDestructiveTestingAllowed", () => {
+  it("is false by default (fail-closed)", () => {
+    expect(isDestructiveTestingAllowed(makeCtx())).toBe(false);
+    expect(
+      isDestructiveTestingAllowed(makeCtx({ allowDestructiveActions: false })),
+    ).toBe(false);
+  });
+  it("is true only when explicitly enabled", () => {
+    expect(
+      isDestructiveTestingAllowed(makeCtx({ allowDestructiveActions: true })),
+    ).toBe(true);
+  });
+});
+
+describe("assertHttpActionAllowed", () => {
+  it("throws for a destructive request when not authorized", () => {
+    expect(() =>
+      assertHttpActionAllowed(
+        { method: "DELETE", url: "https://x.com/a" },
+        makeCtx(),
+      ),
+    ).toThrow(DestructiveActionError);
+  });
+
+  it("is a no-op for a destructive request when authorized", () => {
+    expect(() =>
+      assertHttpActionAllowed(
+        { method: "DELETE", url: "https://x.com/a" },
+        makeCtx({ allowDestructiveActions: true }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("is a no-op for a non-destructive request", () => {
+    expect(() =>
+      assertHttpActionAllowed(
+        { method: "GET", url: "https://x.com/a" },
+        makeCtx(),
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("assertCommandActionAllowed", () => {
+  it("throws for a destructive command when not authorized", () => {
+    expect(() =>
+      assertCommandActionAllowed('psql -c "DROP TABLE t"', makeCtx()),
+    ).toThrow(DestructiveActionError);
+  });
+
+  it("is a no-op when authorized", () => {
+    expect(() =>
+      assertCommandActionAllowed(
+        'psql -c "DROP TABLE t"',
+        makeCtx({ allowDestructiveActions: true }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("is a no-op for a benign command", () => {
+    expect(() =>
+      assertCommandActionAllowed("curl -i https://x.com/", makeCtx()),
+    ).not.toThrow();
+  });
+});

--- a/src/core/agents/offSecAgent/tools/destructiveGuard.test.ts
+++ b/src/core/agents/offSecAgent/tools/destructiveGuard.test.ts
@@ -315,6 +315,9 @@ describe("classifyCommandAction", () => {
 
   it("flags rm -rf variants that wipe a root/home/system dir", () => {
     expect(classifyCommandAction("rm -r -f /").destructive).toBe(true);
+    expect(classifyCommandAction("rm --recursive --force /").destructive).toBe(
+      true,
+    );
     expect(
       classifyCommandAction("rm --no-preserve-root -rf /").destructive,
     ).toBe(true);
@@ -327,18 +330,6 @@ describe("classifyCommandAction", () => {
     expect(classifyCommandAction("rm -rf /").destructive).toBe(true);
     expect(classifyCommandAction("rm -rf ~").destructive).toBe(true);
     expect(classifyCommandAction("rm -rf /etc").category).toBe(
-      "host-destructive",
-    );
-    // Split flags, long options, other flags, and sensitive-prefix subpaths
-    // are all equivalent host wipes.
-    expect(classifyCommandAction("rm -r -f /").destructive).toBe(true);
-    expect(classifyCommandAction("rm --recursive --force /").destructive).toBe(
-      true,
-    );
-    expect(
-      classifyCommandAction("rm --no-preserve-root -rf /").destructive,
-    ).toBe(true);
-    expect(classifyCommandAction("rm -rf /home/ubuntu").category).toBe(
       "host-destructive",
     );
     expect(classifyCommandAction("mkfs.ext4 /dev/sda1").destructive).toBe(true);

--- a/src/core/agents/offSecAgent/tools/destructiveGuard.test.ts
+++ b/src/core/agents/offSecAgent/tools/destructiveGuard.test.ts
@@ -402,6 +402,96 @@ describe("classifyCommandAction", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Hardening (round 3): obfuscation bypasses + false-positive fixes
+// ---------------------------------------------------------------------------
+
+describe("classifier hardening", () => {
+  it("flags comment-obfuscated destructive SQL via a DB client", () => {
+    expect(
+      classifyCommandAction('psql -c "DROP/**/TABLE users"').category,
+    ).toBe("sql-destructive");
+    expect(
+      classifyCommandAction('mysql -e "DELETE/**/FROM sessions"').destructive,
+    ).toBe(true);
+  });
+
+  it("flags percent-encoded destructive SQL in DB-client args", () => {
+    expect(
+      classifyCommandAction('psql -c "DROP%20TABLE%20audit"').destructive,
+    ).toBe(true);
+  });
+
+  it("flags destructive SQL sent through curl/wget (not just http_request)", () => {
+    expect(
+      classifyCommandAction(
+        'curl -X POST -d "q=1;DROP TABLE users--" https://x.com/api',
+      ).category,
+    ).toBe("sql-destructive");
+  });
+
+  it("flags httpie and wget writes to a delete route", () => {
+    expect(
+      classifyCommandAction("http POST https://x.com/users/1/delete")
+        .destructive,
+    ).toBe(true);
+    expect(
+      classifyCommandAction(
+        "wget --post-data='x=1' https://x.com/account/destroy",
+      ).category,
+    ).toBe("http-destructive-path");
+  });
+
+  it("normalizes rm path tricks and ~user home wipes", () => {
+    expect(classifyCommandAction("rm -rf /tmp/../").destructive).toBe(true);
+    expect(classifyCommandAction("rm -rf //").destructive).toBe(true);
+    expect(
+      classifyCommandAction("rm -rf /home/ubuntu/../../").destructive,
+    ).toBe(true);
+    expect(classifyCommandAction("rm -rf /*").destructive).toBe(true);
+    expect(classifyCommandAction("rm -rf ~alice").destructive).toBe(true);
+    // A genuinely-scoped scratch path stays allowed.
+    expect(
+      classifyCommandAction("rm -rf /tmp/build/../cache").destructive,
+    ).toBe(false);
+  });
+
+  it("flags dd/redirect wipes of virtual disks but allows pseudo-devices", () => {
+    expect(
+      classifyCommandAction("dd if=/dev/zero of=/dev/vda").destructive,
+    ).toBe(true);
+    expect(classifyCommandAction("cat img > /dev/xvda").category).toBe(
+      "host-destructive",
+    );
+    // Discarding output to a pseudo-device is safe.
+    expect(
+      classifyCommandAction("dd if=/dev/urandom of=/dev/null bs=1M count=1")
+        .destructive,
+    ).toBe(false);
+  });
+
+  it("sees host-destructive commands wrapped in bash -c / sh -lc", () => {
+    expect(
+      classifyCommandAction('bash -c "dd if=/dev/zero of=/dev/sda"')
+        .destructive,
+    ).toBe(true);
+    expect(
+      classifyCommandAction("sh -lc 'mkfs.ext4 /dev/sdb1'").destructive,
+    ).toBe(true);
+    expect(classifyCommandAction('bash -c "reboot"').destructive).toBe(true);
+  });
+
+  it("does not flag DELETE keywords in recon with no HTTP client", () => {
+    expect(
+      classifyCommandAction('grep -rn "_method=DELETE" src/').destructive,
+    ).toBe(false);
+    expect(
+      classifyCommandAction('echo "pass the -X DELETE flag to remove"')
+        .destructive,
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Regression: in-script HTTP DELETE nested inside execute_command
 // (the Lilt multipart-delete vector — a fetch/axios/Playwright DELETE run via a
 // JS runtime, which curl-based and http_request-level controls both miss).

--- a/src/core/agents/offSecAgent/tools/destructiveGuard.test.ts
+++ b/src/core/agents/offSecAgent/tools/destructiveGuard.test.ts
@@ -164,6 +164,81 @@ describe("classifyHttpAction", () => {
       }).destructive,
     ).toBe(false);
   });
+
+  it("flags method-override to DELETE via alternate header spellings", () => {
+    for (const name of [
+      "X-HTTP-Method-Override",
+      "X-HTTP-Method",
+      "X-Method-Override",
+      "X-Method",
+    ]) {
+      expect(
+        classifyHttpAction({
+          method: "POST",
+          url: "https://x.com/users/1",
+          headers: { [name]: "DELETE" },
+        }).destructive,
+      ).toBe(true);
+    }
+  });
+
+  it("flags a GET that overrides the method to DELETE (some stacks honor it)", () => {
+    expect(
+      classifyHttpAction({
+        method: "GET",
+        url: "https://x.com/users/1?_method=DELETE",
+      }).destructive,
+    ).toBe(true);
+    expect(
+      classifyHttpAction({
+        method: "GET",
+        url: "https://x.com/users/1",
+        headers: { "X-HTTP-Method-Override": "DELETE" },
+      }).destructive,
+    ).toBe(true);
+  });
+
+  it("flags a write to a percent-encoded delete route", () => {
+    expect(
+      classifyHttpAction({
+        method: "POST",
+        url: "https://x.com/users/1%2Fdelete",
+      }).category,
+    ).toBe("http-destructive-path");
+  });
+
+  it("flags percent-encoded destructive SQLi payloads", () => {
+    expect(
+      classifyHttpAction({
+        method: "GET",
+        url: "https://x.com/p?id=1%3B%20DROP%20TABLE%20sessions%2D%2D",
+      }).category,
+    ).toBe("sql-destructive");
+  });
+
+  it("does not flag SQL keywords used in natural-language / JSON prose", () => {
+    expect(
+      classifyHttpAction({
+        method: "POST",
+        url: "https://x.com/feedback",
+        body: '{"message":"Please delete from my account and drop table tennis from the amenities list"}',
+      }).destructive,
+    ).toBe(false);
+  });
+
+  it("does not flag NoSQL keywords merely mentioned in a read path", () => {
+    expect(
+      classifyHttpAction({ method: "GET", url: "https://x.com/docs/flushall" })
+        .destructive,
+    ).toBe(false);
+    expect(
+      classifyHttpAction({
+        method: "POST",
+        url: "https://x.com/search",
+        body: '{"q":"how do I run flushall safely"}',
+      }).destructive,
+    ).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -202,6 +277,50 @@ describe("classifyCommandAction", () => {
       classifyCommandAction("curl --request delete https://x.com/a")
         .destructive,
     ).toBe(true);
+  });
+
+  it("flags glued and alternate HTTP DELETE command forms", () => {
+    expect(
+      classifyCommandAction("curl -XDELETE https://x.com/a").destructive,
+    ).toBe(true);
+    expect(
+      classifyCommandAction("curl --request=DELETE https://x.com/a")
+        .destructive,
+    ).toBe(true);
+    // httpie / xh positional method verb.
+    expect(
+      classifyCommandAction("http DELETE https://x.com/a").destructive,
+    ).toBe(true);
+    expect(classifyCommandAction("xh delete https://x.com/a").destructive).toBe(
+      true,
+    );
+    // Method-override header carried on a command.
+    expect(
+      classifyCommandAction(
+        'curl -X POST -H "X-HTTP-Method-Override: DELETE" https://x.com/a',
+      ).destructive,
+    ).toBe(true);
+  });
+
+  it("flags a curl write to a delete/destroy route", () => {
+    expect(
+      classifyCommandAction("curl -X POST https://x.com/users/1/delete")
+        .category,
+    ).toBe("http-destructive-path");
+    expect(
+      classifyCommandAction("curl -d 'x=1' https://x.com/account/destroy")
+        .destructive,
+    ).toBe(true);
+  });
+
+  it("flags rm -rf variants that wipe a root/home/system dir", () => {
+    expect(classifyCommandAction("rm -r -f /").destructive).toBe(true);
+    expect(
+      classifyCommandAction("rm --no-preserve-root -rf /").destructive,
+    ).toBe(true);
+    expect(classifyCommandAction("rm -rf /home/ubuntu").destructive).toBe(true);
+    expect(classifyCommandAction("rm -fr ~/").destructive).toBe(true);
+    expect(classifyCommandAction("rm -rf $HOME").destructive).toBe(true);
   });
 
   it("flags catastrophic host operations", () => {
@@ -253,6 +372,41 @@ describe("classifyCommandAction", () => {
       classifyCommandAction('psql -c "SELECT * FROM users LIMIT 1"')
         .destructive,
     ).toBe(false);
+  });
+
+  it("does not flag SQL/NoSQL keywords in recon (no DB client executing them)", () => {
+    // Grepping logs/config for destructive keywords is recon, not a DB op.
+    expect(
+      classifyCommandAction('grep -r "DROP TABLE" /var/log/app').destructive,
+    ).toBe(false);
+    expect(
+      classifyCommandAction("cat dump.sql | grep -i 'delete from'").destructive,
+    ).toBe(false);
+    expect(
+      classifyCommandAction('echo "run FLUSHALL to reset" >> notes.txt')
+        .destructive,
+    ).toBe(false);
+  });
+
+  it("does not flag delete/power-state keywords appearing only in a URL/path", () => {
+    // 'reboot' / 'shutdown' in a request path is not a host power action.
+    expect(
+      classifyCommandAction("curl -i https://x.com/admin/reboot").destructive,
+    ).toBe(false);
+    expect(
+      classifyCommandAction("curl -i https://x.com/system/shutdown-status")
+        .destructive,
+    ).toBe(false);
+    // A GET to a delete-ish path (no write) is not classified destructive.
+    expect(
+      classifyCommandAction("curl -i https://x.com/users/1/delete").destructive,
+    ).toBe(false);
+  });
+
+  it("still flags real host power-state commands", () => {
+    expect(classifyCommandAction("sudo reboot").destructive).toBe(true);
+    expect(classifyCommandAction("shutdown -h now").destructive).toBe(true);
+    expect(classifyCommandAction("echo hi && poweroff").destructive).toBe(true);
   });
 });
 

--- a/src/core/agents/offSecAgent/tools/destructiveGuard.test.ts
+++ b/src/core/agents/offSecAgent/tools/destructiveGuard.test.ts
@@ -109,6 +109,16 @@ describe("classifyHttpAction", () => {
     ).toBe(true);
   });
 
+  it("flags a method-override to DELETE via header", () => {
+    expect(
+      classifyHttpAction({
+        method: "POST",
+        url: "https://x.com/users/1",
+        headers: { "X-HTTP-Method-Override": "DELETE" },
+      }).destructive,
+    ).toBe(true);
+  });
+
   it("flags destructive SQL in the body regardless of method", () => {
     const c = classifyHttpAction({
       method: "POST",

--- a/src/core/agents/offSecAgent/tools/destructiveGuard.ts
+++ b/src/core/agents/offSecAgent/tools/destructiveGuard.ts
@@ -74,10 +74,13 @@ const NOSQL_DESTRUCTIVE_PATTERN =
  */
 const HOST_DESTRUCTIVE_PATTERNS: Array<{ id: string; re: RegExp }> = [
   // rm -rf targeting a filesystem root, home, or wildcard root (`/`, `/*`,
-  // `~`, `$HOME`, `/etc`, `/var`, ...). Flags may appear in any order.
+  // `~`, `$HOME`, `/etc`, `/var`, `/home/ubuntu`, ...). The recursive and force
+  // flags may appear in any order, combined (`-rf`/`-fr`), split (`-r -f`), or
+  // long-form (`--recursive --force`), interleaved with other flags such as
+  // `--no-preserve-root`; sensitive prefixes match with or without a subpath.
   {
     id: "rm-rf-root",
-    re: /\brm\s+(?:-[a-z]*\s+)*-?[a-z]*(?:rf|fr)[a-z]*\s+(?:--\s+)?(?:['"]?(?:\/(?:\*|etc|var|usr|bin|boot|lib|root|home|sys|proc|dev)?|~|\$HOME)(?:['"\s]|$))/i,
+    re: /\brm\s+(?=(?:-\S+\s+)*(?:-\w*r\w*|--recursive))(?=(?:-\S+\s+)*(?:-\w*f\w*|--force))(?:-\S+\s+)*(?:--\s+)?(?:['"]?(?:\/(?:\*|(?:etc|var|usr|bin|boot|lib|root|home|sys|proc|dev)(?:\/\S*)?)?|~|\$HOME)(?:['"\s/]|$))/i,
   },
   // Raw block-device write / disk imaging.
   { id: "dd-to-device", re: /\bdd\b[^\n;|&]*\bof=\s*['"]?\/dev\//i },

--- a/src/core/agents/offSecAgent/tools/destructiveGuard.ts
+++ b/src/core/agents/offSecAgent/tools/destructiveGuard.ts
@@ -251,7 +251,27 @@ const CURL_WRITE_METHOD =
 const CURL_DATA_FLAG =
   /(?:^|\s)(?:-d|--data(?:-raw|-binary|-urlencode|-ascii)?|-F|--form|--json)\b/i;
 
-/** Classify an HTTP call expressed as a shell command (curl/wget/httpie/xh). */
+/**
+ * In-script HTTP DELETE nested inside `execute_command` (Node/Bun/Deno,
+ * Playwright, ts-node, etc.) — the path apex's http_request-level controls and
+ * the curl-based detection above both miss. The reliable signal is a DELETE
+ * method on an HTTP call, NOT the URL: the dangerous path is frequently built
+ * dynamically (`fetch(`/api/x/${id}`, …)` where `id` resolves to `undefined`),
+ * so it never contains a literal delete keyword.
+ *
+ * Two forms:
+ *  - a request-options object carrying `method: 'DELETE'` (fetch / axios config
+ *    / Playwright request options), paired with an HTTP-client token so a grep
+ *    for the literal string is not misclassified; and
+ *  - a positional client delete call (`axios.delete(`, `page.request.delete(`).
+ */
+const JS_METHOD_DELETE = /\bmethod\s*:\s*['"`]?\s*delete\b/i;
+const JS_HTTP_CLIENT_HINT =
+  /\b(?:fetch|axios|got|ky|superagent|needle|node-fetch|undici|phin|XMLHttpRequest|xhr)\b|\.\s*(?:request|open)\s*\(/i;
+const JS_CLIENT_DELETE_CALL =
+  /\b(?:axios|got|ky|superagent|needle|supertest|phin|page|apiContext|apiRequestContext|request)\s*(?:\.\s*\w+)*\.\s*delete\s*\(/i;
+
+/** Classify an HTTP call expressed as a shell command (curl/wget/httpie/xh, or an in-script fetch/axios). */
 function classifyCommandHttp(command: string): DestructiveClassification {
   const decoded = safeDecode(command);
 
@@ -263,6 +283,20 @@ function classifyCommandHttp(command: string): DestructiveClassification {
       category: "http-delete-method",
       ruleId: "cmd-http-delete",
       reason: "command issues an HTTP DELETE against the target",
+    };
+  }
+
+  // In-script HTTP DELETE (fetch/axios/Playwright) run via a JS runtime.
+  if (
+    (JS_METHOD_DELETE.test(command) && JS_HTTP_CLIENT_HINT.test(command)) ||
+    JS_CLIENT_DELETE_CALL.test(command)
+  ) {
+    return {
+      destructive: true,
+      category: "http-delete-method",
+      ruleId: "cmd-script-http-delete",
+      reason:
+        "command runs an in-script HTTP DELETE (fetch/axios/Playwright) against the target",
     };
   }
 

--- a/src/core/agents/offSecAgent/tools/destructiveGuard.ts
+++ b/src/core/agents/offSecAgent/tools/destructiveGuard.ts
@@ -1,0 +1,291 @@
+/**
+ * Destructive-action guard — deterministic, latency-free classification of
+ * tool calls that would perform irreversible / high-blast-radius operations
+ * against a target (or the host), plus fail-closed enforcement.
+ *
+ * Motivation: a pentest routinely needs to send writes (POST/PUT/PATCH) to
+ * prove authorization/IDOR flaws, so blocking *all* writes would neuter the
+ * agent. What clients want gated behind an explicit opt-in is the destructive
+ * subset — DB deletes/drops/truncates, API write-deletes, and catastrophic
+ * host operations. This module classifies exactly that subset.
+ *
+ * Design: a layered pipeline of pure predicates (regex + structural rules).
+ * NO LLM, NO network, NO I/O — classification is O(input length) so it adds
+ * effectively zero latency on the tool-call hot path. Each rule is named so a
+ * block reason is specific and debuggable.
+ *
+ * Enforcement mirrors {@link scopeGuard}: the assert helpers are a no-op when
+ * destructive testing is authorized (`session.config.allowDestructiveActions
+ * === true`) and otherwise throw {@link DestructiveActionError}, which the
+ * `http_request` / `execute_command` tools translate into a structured, non-
+ * fatal error result the model can read and route around.
+ */
+
+import type { ToolContext } from "./types";
+
+/** Destructive category, used for the block reason + observability. */
+export type DestructiveCategory =
+  | "http-delete-method"
+  | "http-destructive-path"
+  | "sql-destructive"
+  | "nosql-destructive"
+  | "host-destructive";
+
+export interface DestructiveClassification {
+  destructive: boolean;
+  /** Populated when `destructive` is true. */
+  category?: DestructiveCategory;
+  /** Stable rule id that fired (for logs / block message). */
+  ruleId?: string;
+  /** Human-readable explanation of what was matched. */
+  reason?: string;
+}
+
+const NOT_DESTRUCTIVE: DestructiveClassification = { destructive: false };
+
+// ---------------------------------------------------------------------------
+// Pattern layers
+// ---------------------------------------------------------------------------
+
+/**
+ * Destructive SQL DML/DDL. Matches the statement kinds that delete or
+ * irreversibly reshape data: DROP {TABLE,DATABASE,SCHEMA,...}, TRUNCATE,
+ * DELETE FROM, and ALTER TABLE ... DROP. Deliberately does NOT match
+ * INSERT/UPDATE/SELECT — ordinary writes stay allowed. Applied to shell
+ * commands (psql/mysql/sqlite3 -c "...", sqlmap --sql-query, etc.) and to
+ * HTTP bodies/URLs (raw-SQL and SQLi payloads).
+ */
+const SQL_DESTRUCTIVE_PATTERN =
+  /\b(?:drop\s+(?:table|database|schema|index|view|column|role|user|sequence|trigger|function|procedure)|truncate\s+(?:table\s+)?[`"\w]|delete\s+from\s+[`"\w]|alter\s+table\s+[^;]*\bdrop\b)/i;
+
+/**
+ * Destructive NoSQL / cache operations. Mongo collection/database drops and
+ * mass deletes; Redis flushes and pattern deletes. Applied to shell commands
+ * (mongosh --eval, redis-cli ...) and HTTP bodies.
+ */
+const NOSQL_DESTRUCTIVE_PATTERN =
+  /(?:\bdb(?:\.\w+)*\.(?:drop(?:Database)?|deleteMany|remove)\s*\(|\.drop\s*\(\s*\)|\bflushall\b|\bflushdb\b)/i;
+
+/**
+ * Catastrophic host operations that are never a legitimate, reversible step in
+ * a black-box test. Narrowly targeted so ordinary sandbox scratch use (e.g.
+ * `rm -rf /tmp/apex-xxx`) does NOT match — only root/home wipes, raw-device
+ * writes, filesystem creation, fork bombs, and power state changes.
+ */
+const HOST_DESTRUCTIVE_PATTERNS: Array<{ id: string; re: RegExp }> = [
+  // rm -rf targeting a filesystem root, home, or wildcard root (`/`, `/*`,
+  // `~`, `$HOME`, `/etc`, `/var`, ...). Flags may appear in any order.
+  {
+    id: "rm-rf-root",
+    re: /\brm\s+(?:-[a-z]*\s+)*-?[a-z]*(?:rf|fr)[a-z]*\s+(?:--\s+)?(?:['"]?(?:\/(?:\*|etc|var|usr|bin|boot|lib|root|home|sys|proc|dev)?|~|\$HOME)(?:['"\s]|$))/i,
+  },
+  // Raw block-device write / disk imaging.
+  { id: "dd-to-device", re: /\bdd\b[^\n;|&]*\bof=\s*['"]?\/dev\//i },
+  // Filesystem creation over an existing device.
+  { id: "mkfs", re: /\bmkfs(?:\.\w+)?\s+/i },
+  // Redirect into a block device.
+  { id: "clobber-device", re: />\s*['"]?\/dev\/(?:sd|nvme|hd|mapper|disk)/i },
+  // Classic fork bomb.
+  { id: "fork-bomb", re: /:\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:/ },
+  // Power-state changes.
+  { id: "power-state", re: /\b(?:shutdown|reboot|halt|poweroff|init\s+0)\b/i },
+];
+
+/**
+ * HTTP write methods that are not themselves destructive but become so when
+ * the path/query signals a delete/destroy/purge intent (covers REST delete
+ * endpoints reached via POST, method-override, and GraphQL-style delete
+ * mutation routes).
+ */
+const WRITE_METHODS = new Set(["POST", "PUT", "PATCH"]);
+
+/**
+ * Path/query segments that signal an intent to delete or wipe. Word-bounded so
+ * `/deleted-items` (a listing) does not match while `/users/1/delete` does.
+ */
+const DESTRUCTIVE_PATH_PATTERN =
+  /(?:^|[/_?&=.-])(?:delete|destroy|drop|purge|truncate|wipe|obliterate|nuke|remove|hard[-_]?delete|force[-_]?delete)(?:[/_?&=.-]|$)/i;
+
+/** Method-override to DELETE via query/body (e.g. `?_method=DELETE`). */
+const METHOD_OVERRIDE_DELETE_PATTERN =
+  /(?:_method|x-http-method-override|httpmethod)\s*[=:]\s*['"]?delete\b/i;
+
+// ---------------------------------------------------------------------------
+// Classifiers (pure)
+// ---------------------------------------------------------------------------
+
+/** Classify an HTTP request. `body` is only inspected when it is a string. */
+export function classifyHttpAction(input: {
+  method: string;
+  url: string;
+  body?: unknown;
+}): DestructiveClassification {
+  const method = input.method.toUpperCase();
+  const bodyText = typeof input.body === "string" ? input.body : "";
+  const haystack = `${input.url}\n${bodyText}`;
+
+  // Raw destructive SQL / NoSQL carried in the URL or body (SQLi payloads,
+  // admin/query endpoints) — destructive regardless of method.
+  if (SQL_DESTRUCTIVE_PATTERN.test(haystack)) {
+    return {
+      destructive: true,
+      category: "sql-destructive",
+      ruleId: "http-body-sql",
+      reason:
+        "request carries a destructive SQL statement (DROP/TRUNCATE/DELETE FROM/ALTER…DROP)",
+    };
+  }
+  if (NOSQL_DESTRUCTIVE_PATTERN.test(haystack)) {
+    return {
+      destructive: true,
+      category: "nosql-destructive",
+      ruleId: "http-body-nosql",
+      reason:
+        "request carries a destructive NoSQL/cache operation (drop/deleteMany/flush)",
+    };
+  }
+
+  // The DELETE verb is the canonical "API write-delete".
+  if (method === "DELETE") {
+    return {
+      destructive: true,
+      category: "http-delete-method",
+      ruleId: "http-method-delete",
+      reason: "HTTP DELETE removes a resource on the target",
+    };
+  }
+
+  // A write method aimed at a delete/destroy route, or overriding to DELETE.
+  if (WRITE_METHODS.has(method)) {
+    if (METHOD_OVERRIDE_DELETE_PATTERN.test(haystack)) {
+      return {
+        destructive: true,
+        category: "http-delete-method",
+        ruleId: "http-method-override-delete",
+        reason: "write request overrides the method to DELETE",
+      };
+    }
+    if (DESTRUCTIVE_PATH_PATTERN.test(input.url)) {
+      return {
+        destructive: true,
+        category: "http-destructive-path",
+        ruleId: "http-destructive-path",
+        reason: "write request targets a delete/destroy/purge route",
+      };
+    }
+  }
+
+  return NOT_DESTRUCTIVE;
+}
+
+/** Classify a shell command string. */
+export function classifyCommandAction(
+  command: string,
+): DestructiveClassification {
+  for (const { id, re } of HOST_DESTRUCTIVE_PATTERNS) {
+    if (re.test(command)) {
+      return {
+        destructive: true,
+        category: "host-destructive",
+        ruleId: id,
+        reason: `command performs a catastrophic host operation (${id})`,
+      };
+    }
+  }
+
+  if (SQL_DESTRUCTIVE_PATTERN.test(command)) {
+    return {
+      destructive: true,
+      category: "sql-destructive",
+      ruleId: "cmd-sql",
+      reason:
+        "command runs a destructive SQL statement (DROP/TRUNCATE/DELETE FROM/ALTER…DROP)",
+    };
+  }
+  if (NOSQL_DESTRUCTIVE_PATTERN.test(command)) {
+    return {
+      destructive: true,
+      category: "nosql-destructive",
+      ruleId: "cmd-nosql",
+      reason:
+        "command runs a destructive NoSQL/cache operation (drop/deleteMany/flush)",
+    };
+  }
+
+  // curl/wget issuing an HTTP DELETE against the target.
+  if (
+    /(?:^|[;&|]|\s)(?:curl|wget|http|xh|httpie)\b[^\n]*(?:-X|--request|--method)[=\s]+['"]?delete\b/i.test(
+      command,
+    )
+  ) {
+    return {
+      destructive: true,
+      category: "http-delete-method",
+      ruleId: "cmd-http-delete",
+      reason: "command issues an HTTP DELETE against the target",
+    };
+  }
+
+  return NOT_DESTRUCTIVE;
+}
+
+// ---------------------------------------------------------------------------
+// Enforcement
+// ---------------------------------------------------------------------------
+
+export class DestructiveActionError extends Error {
+  constructor(
+    public readonly classification: DestructiveClassification,
+    subject: string,
+  ) {
+    super(
+      `Destructive action blocked: ${subject} — ${classification.reason ?? "destructive operation"}. ` +
+        `Destructive testing (DB deletes/drops, API write-deletes, catastrophic host operations) is NOT authorized for this engagement. ` +
+        `Prove the flaw without completing the destructive step (e.g. demonstrate the authorization boundary is crossed with a read or a reversible action), or ask the operator to enable destructive testing.`,
+    );
+    this.name = "DestructiveActionError";
+  }
+}
+
+/**
+ * True when the caller has explicitly authorized destructive testing. Absent /
+ * false → destructive actions are blocked (fail-closed, off by default).
+ */
+export function isDestructiveTestingAllowed(ctx: ToolContext): boolean {
+  return ctx.session?.config?.allowDestructiveActions === true;
+}
+
+/**
+ * Assert an HTTP request is permitted. No-op when destructive testing is
+ * authorized; otherwise throws {@link DestructiveActionError} for a
+ * destructive-classified request.
+ */
+export function assertHttpActionAllowed(
+  input: { method: string; url: string; body?: unknown },
+  ctx: ToolContext,
+): void {
+  if (isDestructiveTestingAllowed(ctx)) return;
+  const classification = classifyHttpAction(input);
+  if (classification.destructive) {
+    throw new DestructiveActionError(
+      classification,
+      `${input.method.toUpperCase()} ${input.url}`,
+    );
+  }
+}
+
+/**
+ * Assert a shell command is permitted. No-op when destructive testing is
+ * authorized; otherwise throws {@link DestructiveActionError} for a
+ * destructive-classified command.
+ */
+export function assertCommandActionAllowed(
+  command: string,
+  ctx: ToolContext,
+): void {
+  if (isDestructiveTestingAllowed(ctx)) return;
+  const classification = classifyCommandAction(command);
+  if (classification.destructive) {
+    throw new DestructiveActionError(classification, command);
+  }
+}

--- a/src/core/agents/offSecAgent/tools/destructiveGuard.ts
+++ b/src/core/agents/offSecAgent/tools/destructiveGuard.ts
@@ -14,6 +14,14 @@
  * effectively zero latency on the tool-call hot path. Each rule is named so a
  * block reason is specific and debuggable.
  *
+ * Two false-signal traps this deliberately avoids:
+ *  - Over-blocking benign recon: a destructive keyword merely *mentioned* in a
+ *    URL/path, a doc, a grepped log, or prose is NOT destructive. SQL/NoSQL in
+ *    a command is only destructive when an actual DB client executes it; in an
+ *    HTTP request only when it appears as a real statement/injection payload.
+ *  - Under-blocking real ops: encoded payloads are decoded first, and method /
+ *    delete-verb / override detection covers the common obfuscations.
+ *
  * Enforcement mirrors {@link scopeGuard}: the assert helpers are a no-op when
  * destructive testing is authorized (`session.config.allowDestructiveActions
  * === true`) and otherwise throw {@link DestructiveActionError}, which the
@@ -44,83 +52,265 @@ export interface DestructiveClassification {
 const NOT_DESTRUCTIVE: DestructiveClassification = { destructive: false };
 
 // ---------------------------------------------------------------------------
-// Pattern layers
+// Decoding
 // ---------------------------------------------------------------------------
 
 /**
- * Destructive SQL DML/DDL. Matches the statement kinds that delete or
- * irreversibly reshape data: DROP {TABLE,DATABASE,SCHEMA,...}, TRUNCATE,
- * DELETE FROM, and ALTER TABLE ... DROP. Deliberately does NOT match
- * INSERT/UPDATE/SELECT — ordinary writes stay allowed. Applied to shell
- * commands (psql/mysql/sqlite3 -c "...", sqlmap --sql-query, etc.) and to
- * HTTP bodies/URLs (raw-SQL and SQLi payloads).
+ * Best-effort URL/form decode so percent- or `+`-encoded payloads are matched
+ * the same as their plaintext form (`%2Fdelete` → `/delete`, `DROP%20TABLE` →
+ * `DROP TABLE`). Runs up to two passes to unwrap double-encoding, decodes each
+ * `%XX` sequence independently so a stray `%` never throws.
  */
-const SQL_DESTRUCTIVE_PATTERN =
-  /\b(?:drop\s+(?:table|database|schema|index|view|column|role|user|sequence|trigger|function|procedure)|truncate\s+(?:table\s+)?[`"\w]|delete\s+from\s+[`"\w]|alter\s+table\s+[^;]*\bdrop\b)/i;
+export function safeDecode(input: string): string {
+  let out = input ?? "";
+  for (let pass = 0; pass < 2; pass++) {
+    const decoded = out.replace(/\+/g, " ").replace(/%[0-9a-fA-F]{2}/g, (m) => {
+      try {
+        return decodeURIComponent(m);
+      } catch {
+        return m;
+      }
+    });
+    if (decoded === out) break;
+    out = decoded;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// SQL / NoSQL statement patterns
+// ---------------------------------------------------------------------------
 
 /**
- * Destructive NoSQL / cache operations. Mongo collection/database drops and
- * mass deletes; Redis flushes and pattern deletes. Applied to shell commands
- * (mongosh --eval, redis-cli ...) and HTTP bodies.
+ * Destructive SQL DML/DDL statement head: DROP {TABLE,DATABASE,...}, TRUNCATE,
+ * DELETE FROM, ALTER TABLE ... DROP. Deliberately does NOT match
+ * INSERT/UPDATE/SELECT — ordinary writes stay allowed.
  */
-const NOSQL_DESTRUCTIVE_PATTERN =
-  /(?:\bdb(?:\.\w+)*\.(?:drop(?:Database)?|deleteMany|remove)\s*\(|\.drop\s*\(\s*\)|\bflushall\b|\bflushdb\b)/i;
+const SQL_DESTRUCTIVE_STATEMENT =
+  /(?:drop\s+(?:table|database|schema|index|view|column|role|user|sequence|trigger|function|procedure)|truncate\s+(?:table\s+)?[`"\w]|delete\s+from\s+[`"\w]|alter\s+table\s+[^;]*\bdrop\b)/i;
+
+/** The statement is the (trimmed) start of the payload — a raw-SQL body. */
+const SQL_STATEMENT_START = new RegExp(
+  `^\\s*['"\`;)\\s]*(?:${SQL_DESTRUCTIVE_STATEMENT.source})`,
+  "i",
+);
+
+/** Classic SQLi break: a quote (and/or `;`) immediately preceding the statement. */
+const SQL_INJECTION_CONTEXT = new RegExp(
+  `['"\`]\\s*;?\\s*(?:${SQL_DESTRUCTIVE_STATEMENT.source})|;\\s*(?:${SQL_DESTRUCTIVE_STATEMENT.source})`,
+  "i",
+);
 
 /**
- * Catastrophic host operations that are never a legitimate, reversible step in
- * a black-box test. Narrowly targeted so ordinary sandbox scratch use (e.g.
- * `rm -rf /tmp/apex-xxx`) does NOT match — only root/home wipes, raw-device
- * writes, filesystem creation, fork bombs, and power state changes.
+ * Destructive SQL carried in an HTTP request. Requires the statement to look
+ * like an actual statement or injection payload — a raw statement at the start,
+ * or a statement right after a SQLi break (`'`, `"`, `;`) — so prose or JSON
+ * that merely mentions "delete from" / "drop table" is not flagged.
  */
-const HOST_DESTRUCTIVE_PATTERNS: Array<{ id: string; re: RegExp }> = [
-  // rm -rf targeting a filesystem root, home, or wildcard root (`/`, `/*`,
-  // `~`, `$HOME`, `/etc`, `/var`, `/home/ubuntu`, ...). The recursive and force
-  // flags may appear in any order, combined (`-rf`/`-fr`), split (`-r -f`), or
-  // long-form (`--recursive --force`), interleaved with other flags such as
-  // `--no-preserve-root`; sensitive prefixes match with or without a subpath.
-  {
-    id: "rm-rf-root",
-    re: /\brm\s+(?=(?:-\S+\s+)*(?:-\w*r\w*|--recursive))(?=(?:-\S+\s+)*(?:-\w*f\w*|--force))(?:-\S+\s+)*(?:--\s+)?(?:['"]?(?:\/(?:\*|(?:etc|var|usr|bin|boot|lib|root|home|sys|proc|dev)(?:\/\S*)?)?|~|\$HOME)(?:['"\s/]|$))/i,
-  },
-  // Raw block-device write / disk imaging.
-  { id: "dd-to-device", re: /\bdd\b[^\n;|&]*\bof=\s*['"]?\/dev\//i },
-  // Filesystem creation over an existing device.
-  { id: "mkfs", re: /\bmkfs(?:\.\w+)?\s+/i },
-  // Redirect into a block device.
-  { id: "clobber-device", re: />\s*['"]?\/dev\/(?:sd|nvme|hd|mapper|disk)/i },
-  // Classic fork bomb.
-  { id: "fork-bomb", re: /:\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:/ },
-  // Power-state changes.
-  { id: "power-state", re: /\b(?:shutdown|reboot|halt|poweroff|init\s+0)\b/i },
-];
+function httpCarriesDestructiveSql(decoded: string): boolean {
+  if (!SQL_DESTRUCTIVE_STATEMENT.test(decoded)) return false;
+  return (
+    SQL_STATEMENT_START.test(decoded) || SQL_INJECTION_CONTEXT.test(decoded)
+  );
+}
 
 /**
- * HTTP write methods that are not themselves destructive but become so when
- * the path/query signals a delete/destroy/purge intent (covers REST delete
- * endpoints reached via POST, method-override, and GraphQL-style delete
- * mutation routes).
+ * Destructive NoSQL / cache operation in an HTTP body. Structured call forms
+ * (`db.x.drop()`, `dropDatabase(`, `deleteMany(`) or a Redis flush issued as a
+ * command line (start-of-body / after `;`/newline) — not a bare word buried in
+ * a path or prose.
  */
+const NOSQL_HTTP_DESTRUCTIVE =
+  /\bdb(?:\.\w+)+\.(?:drop(?:Database)?|deleteMany|remove)\s*\(|\.dropDatabase\s*\(|\.drop\s*\(\s*\)|\bdeleteMany\s*\(\s*\{|(?:^|[\n;])\s*(?:flushall|flushdb)\b/i;
+
+/** Destructive NoSQL / cache op in a shell command (paired with a DB client). */
+const NOSQL_CMD_DESTRUCTIVE =
+  /\bdb(?:\.\w+)*\.(?:drop(?:Database)?|deleteMany|remove)\s*\(|\.dropDatabase\s*\(|\.drop\s*\(\s*\)|\bflushall\b|\bflushdb\b/i;
+
+// ---------------------------------------------------------------------------
+// HTTP method / path / override
+// ---------------------------------------------------------------------------
+
+/** Write methods that become destructive when aimed at a delete/destroy route. */
 const WRITE_METHODS = new Set(["POST", "PUT", "PATCH"]);
 
 /**
  * Path/query segments that signal an intent to delete or wipe. Word-bounded so
  * `/deleted-items` (a listing) does not match while `/users/1/delete` does.
+ * Run against the DECODED url.
  */
 const DESTRUCTIVE_PATH_PATTERN =
   /(?:^|[/_?&=.-])(?:delete|destroy|drop|purge|truncate|wipe|obliterate|nuke|remove|hard[-_]?delete|force[-_]?delete)(?:[/_?&=.-]|$)/i;
 
-/** Method-override to DELETE via header/query/body (e.g. `?_method=DELETE`). */
+/**
+ * Method-override to DELETE via header, query, or body — covers the common
+ * override header spellings (`X-HTTP-Method-Override`, `X-HTTP-Method`,
+ * `X-Method-Override`, `X-Method`) plus `_method` / `httpMethod` params.
+ */
 const METHOD_OVERRIDE_DELETE_PATTERN =
-  /(?:_method|x-http-method-override|httpmethod)\s*[=:]\s*['"]?delete\b/i;
+  /(?:_method|x-http-method-override|x-http-method|x-method-override|x-method|httpmethod)\s*[=:]\s*['"]?delete\b/i;
+
+// ---------------------------------------------------------------------------
+// Host-destructive command rules (anchored to command position, not substring)
+// ---------------------------------------------------------------------------
+
+/** Start of a command word: line start, or after a shell separator. */
+const CMD_BOUNDARY = String.raw`(?:^|[\n;&|]|&&|\|\|)\s*(?:sudo\s+)?`;
+
+/**
+ * `rm` with BOTH recursive and force semantics (flags in any order, combined or
+ * split) aimed at a filesystem root, home, or system dir — or with
+ * `--no-preserve-root`. Ordinary sandbox scratch cleanup (`rm -rf /tmp/x`,
+ * `rm -rf ./build`) does NOT match.
+ */
+export function isDangerousRm(command: string): boolean {
+  const rmRe = /\brm\b([^\n;|&]*)/gi;
+  for (const match of command.matchAll(rmRe)) {
+    const args = match[1] ?? "";
+    const hasRecursive = /(?:^|\s)(?:-[a-z]*r[a-z]*|--recursive)\b/i.test(args);
+    const hasForce = /(?:^|\s)(?:-[a-z]*f[a-z]*|--force)\b/i.test(args);
+    if (!hasRecursive || !hasForce) continue;
+    if (/--no-preserve-root/i.test(args)) return true;
+    for (const rawToken of args.split(/\s+/)) {
+      if (!rawToken || rawToken.startsWith("-")) continue;
+      const token = rawToken.replace(/^['"]|['"]$/g, "");
+      // Root / wildcard-root / home shorthands.
+      if (/^(?:\/|\/\*|~|\$HOME|\$\{HOME\})$/.test(token)) return true;
+      if (/^(?:~|\$HOME|\$\{HOME\})\//.test(token)) return true;
+      // A system or home directory, with or without a subpath.
+      if (
+        /^\/(?:etc|var|usr|bin|sbin|boot|lib|lib64|root|home|opt|srv|sys|proc|dev)(?:\/|$)/i.test(
+          token,
+        )
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+const HOST_DESTRUCTIVE_RULES: Array<{
+  id: string;
+  test: (command: string) => boolean;
+}> = [
+  { id: "rm-rf-root", test: isDangerousRm },
+  // Raw block-device write / disk imaging.
+  {
+    id: "dd-to-device",
+    test: (c) =>
+      new RegExp(
+        `${CMD_BOUNDARY}dd\\b[^\\n;|&]*\\bof=\\s*['"]?/dev/`,
+        "i",
+      ).test(c),
+  },
+  // Filesystem creation over a device.
+  {
+    id: "mkfs",
+    test: (c) =>
+      new RegExp(`${CMD_BOUNDARY}(?:/s?bin/)?mkfs(?:\\.\\w+)?\\b`, "i").test(c),
+  },
+  // Redirect into a block device.
+  {
+    id: "clobber-device",
+    test: (c) => />\s*['"]?\/dev\/(?:sd|nvme|hd|mapper|disk)/i.test(c),
+  },
+  // Classic fork bomb.
+  {
+    id: "fork-bomb",
+    test: (c) => /:\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:/.test(c),
+  },
+  // Power-state changes — only as an executed command, not a URL/path token.
+  {
+    id: "power-state",
+    test: (c) =>
+      new RegExp(
+        `${CMD_BOUNDARY}(?:/(?:usr/)?s?bin/)?(?:shutdown|reboot|halt|poweroff)\\b`,
+        "i",
+      ).test(c) || new RegExp(`${CMD_BOUNDARY}init\\s+0\\b`, "i").test(c),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// HTTP-in-command detection
+// ---------------------------------------------------------------------------
+
+const HTTP_CLIENT_PATTERN = /\b(?:curl|wget|xh|httpie)\b/i;
+const URL_IN_COMMAND = /https?:\/\/[^\s"'`;|&)<>]+/gi;
+
+/** `-X DELETE`, `-XDELETE`, `--request=DELETE`, `--method delete`. */
+const CURL_DELETE = /(?:-X|--request|--method)[=\s]*['"]?delete\b/i;
+
+/** httpie/xh positional method: `http DELETE url`, `xh delete url` (at cmd pos). */
+const HTTPIE_METHOD = new RegExp(
+  `${CMD_BOUNDARY}(?:https?|xh|httpie)\\s+(?:-{1,2}\\S+\\s+)*(delete|post|put|patch)\\b`,
+  "i",
+);
+const CURL_WRITE_METHOD =
+  /(?:-X|--request|--method)[=\s]*['"]?(?:post|put|patch)\b/i;
+const CURL_DATA_FLAG =
+  /(?:^|\s)(?:-d|--data(?:-raw|-binary|-urlencode|-ascii)?|-F|--form|--json)\b/i;
+
+/** Classify an HTTP call expressed as a shell command (curl/wget/httpie/xh). */
+function classifyCommandHttp(command: string): DestructiveClassification {
+  const decoded = safeDecode(command);
+
+  // Explicit DELETE via flag or httpie positional method.
+  const httpieMethod = HTTPIE_METHOD.exec(command)?.[1]?.toLowerCase();
+  if (CURL_DELETE.test(command) || httpieMethod === "delete") {
+    return {
+      destructive: true,
+      category: "http-delete-method",
+      ruleId: "cmd-http-delete",
+      reason: "command issues an HTTP DELETE against the target",
+    };
+  }
+
+  // Method-override to DELETE carried in headers/data.
+  if (METHOD_OVERRIDE_DELETE_PATTERN.test(decoded)) {
+    return {
+      destructive: true,
+      category: "http-delete-method",
+      ruleId: "cmd-http-override-delete",
+      reason: "command overrides the HTTP method to DELETE",
+    };
+  }
+
+  // A write request to a delete/destroy route.
+  const writeIndicated =
+    CURL_WRITE_METHOD.test(command) ||
+    CURL_DATA_FLAG.test(command) ||
+    httpieMethod === "post" ||
+    httpieMethod === "put" ||
+    httpieMethod === "patch";
+  if (HTTP_CLIENT_PATTERN.test(command) && writeIndicated) {
+    for (const rawUrl of command.match(URL_IN_COMMAND) ?? []) {
+      if (DESTRUCTIVE_PATH_PATTERN.test(safeDecode(rawUrl))) {
+        return {
+          destructive: true,
+          category: "http-destructive-path",
+          ruleId: "cmd-http-destructive-path",
+          reason:
+            "command sends a write request to a delete/destroy/purge route",
+        };
+      }
+    }
+  }
+
+  return NOT_DESTRUCTIVE;
+}
+
+const DB_CLIENT_PATTERN =
+  /\b(?:psql|mysql|mariadb|mongosh|mongo|sqlite3|sqlcmd|sqlplus|cqlsh|clickhouse-client|redis-cli|sqlmap)\b|\bcockroach\s+sql\b/i;
 
 // ---------------------------------------------------------------------------
 // Classifiers (pure)
 // ---------------------------------------------------------------------------
 
 /**
- * Classify an HTTP request. `body` is only inspected when it is a string.
- * `headers` are folded into the haystack as `name: value` lines so a
- * method-override header (e.g. `X-HTTP-Method-Override: DELETE`) is caught.
+ * Classify an HTTP request. `body` is only inspected when it is a string;
+ * `headers` are folded in so a method-override header is caught. URL and body
+ * are decoded first so encoded payloads are matched.
  */
 export function classifyHttpAction(input: {
   method: string;
@@ -129,34 +319,16 @@ export function classifyHttpAction(input: {
   headers?: Record<string, unknown>;
 }): DestructiveClassification {
   const method = input.method.toUpperCase();
-  const bodyText = typeof input.body === "string" ? input.body : "";
+  const decodedUrl = safeDecode(input.url);
+  const decodedBody = safeDecode(
+    typeof input.body === "string" ? input.body : "",
+  );
   const headerText = input.headers
     ? Object.entries(input.headers)
         .map(([name, value]) => `${name}: ${String(value)}`)
         .join("\n")
     : "";
-  const haystack = `${input.url}\n${bodyText}\n${headerText}`;
-
-  // Raw destructive SQL / NoSQL carried in the URL or body (SQLi payloads,
-  // admin/query endpoints) — destructive regardless of method.
-  if (SQL_DESTRUCTIVE_PATTERN.test(haystack)) {
-    return {
-      destructive: true,
-      category: "sql-destructive",
-      ruleId: "http-body-sql",
-      reason:
-        "request carries a destructive SQL statement (DROP/TRUNCATE/DELETE FROM/ALTER…DROP)",
-    };
-  }
-  if (NOSQL_DESTRUCTIVE_PATTERN.test(haystack)) {
-    return {
-      destructive: true,
-      category: "nosql-destructive",
-      ruleId: "http-body-nosql",
-      reason:
-        "request carries a destructive NoSQL/cache operation (drop/deleteMany/flush)",
-    };
-  }
+  const overrideHaystack = `${decodedUrl}\n${decodedBody}\n${headerText}`;
 
   // The DELETE verb is the canonical "API write-delete".
   if (method === "DELETE") {
@@ -168,24 +340,46 @@ export function classifyHttpAction(input: {
     };
   }
 
-  // A write method aimed at a delete/destroy route, or overriding to DELETE.
-  if (WRITE_METHODS.has(method)) {
-    if (METHOD_OVERRIDE_DELETE_PATTERN.test(haystack)) {
-      return {
-        destructive: true,
-        category: "http-delete-method",
-        ruleId: "http-method-override-delete",
-        reason: "write request overrides the method to DELETE",
-      };
-    }
-    if (DESTRUCTIVE_PATH_PATTERN.test(input.url)) {
-      return {
-        destructive: true,
-        category: "http-destructive-path",
-        ruleId: "http-destructive-path",
-        reason: "write request targets a delete/destroy/purge route",
-      };
-    }
+  // Method-override to DELETE — honored by some stacks regardless of the verb.
+  if (METHOD_OVERRIDE_DELETE_PATTERN.test(overrideHaystack)) {
+    return {
+      destructive: true,
+      category: "http-delete-method",
+      ruleId: "http-method-override-delete",
+      reason: "request overrides the HTTP method to DELETE",
+    };
+  }
+
+  // Raw destructive SQL as a statement / injection payload in url or body.
+  if (httpCarriesDestructiveSql(`${decodedUrl}\n${decodedBody}`)) {
+    return {
+      destructive: true,
+      category: "sql-destructive",
+      ruleId: "http-body-sql",
+      reason:
+        "request carries a destructive SQL statement (DROP/TRUNCATE/DELETE FROM/ALTER…DROP)",
+    };
+  }
+
+  // Structured destructive NoSQL/cache op in the body.
+  if (NOSQL_HTTP_DESTRUCTIVE.test(decodedBody)) {
+    return {
+      destructive: true,
+      category: "nosql-destructive",
+      ruleId: "http-body-nosql",
+      reason:
+        "request carries a destructive NoSQL/cache operation (drop/deleteMany/flush)",
+    };
+  }
+
+  // A write method aimed at a delete/destroy route.
+  if (WRITE_METHODS.has(method) && DESTRUCTIVE_PATH_PATTERN.test(decodedUrl)) {
+    return {
+      destructive: true,
+      category: "http-destructive-path",
+      ruleId: "http-destructive-path",
+      reason: "write request targets a delete/destroy/purge route",
+    };
   }
 
   return NOT_DESTRUCTIVE;
@@ -195,8 +389,8 @@ export function classifyHttpAction(input: {
 export function classifyCommandAction(
   command: string,
 ): DestructiveClassification {
-  for (const { id, re } of HOST_DESTRUCTIVE_PATTERNS) {
-    if (re.test(command)) {
+  for (const { id, test } of HOST_DESTRUCTIVE_RULES) {
+    if (test(command)) {
       return {
         destructive: true,
         category: "host-destructive",
@@ -206,40 +400,30 @@ export function classifyCommandAction(
     }
   }
 
-  if (SQL_DESTRUCTIVE_PATTERN.test(command)) {
-    return {
-      destructive: true,
-      category: "sql-destructive",
-      ruleId: "cmd-sql",
-      reason:
-        "command runs a destructive SQL statement (DROP/TRUNCATE/DELETE FROM/ALTER…DROP)",
-    };
-  }
-  if (NOSQL_DESTRUCTIVE_PATTERN.test(command)) {
-    return {
-      destructive: true,
-      category: "nosql-destructive",
-      ruleId: "cmd-nosql",
-      reason:
-        "command runs a destructive NoSQL/cache operation (drop/deleteMany/flush)",
-    };
-  }
-
-  // curl/wget issuing an HTTP DELETE against the target.
-  if (
-    /(?:^|[;&|]|\s)(?:curl|wget|http|xh|httpie)\b[^\n]*(?:-X|--request|--method)[=\s]+['"]?delete\b/i.test(
-      command,
-    )
-  ) {
-    return {
-      destructive: true,
-      category: "http-delete-method",
-      ruleId: "cmd-http-delete",
-      reason: "command issues an HTTP DELETE against the target",
-    };
+  // SQL/NoSQL is destructive only when an actual DB client executes it — a
+  // grep/cat/echo that merely contains "DROP TABLE" or "FLUSHALL" is recon.
+  if (DB_CLIENT_PATTERN.test(command)) {
+    if (SQL_DESTRUCTIVE_STATEMENT.test(command)) {
+      return {
+        destructive: true,
+        category: "sql-destructive",
+        ruleId: "cmd-sql",
+        reason:
+          "command runs a destructive SQL statement via a DB client (DROP/TRUNCATE/DELETE FROM/ALTER…DROP)",
+      };
+    }
+    if (NOSQL_CMD_DESTRUCTIVE.test(command)) {
+      return {
+        destructive: true,
+        category: "nosql-destructive",
+        ruleId: "cmd-nosql",
+        reason:
+          "command runs a destructive NoSQL/cache operation via a DB client (drop/deleteMany/flush)",
+      };
+    }
   }
 
-  return NOT_DESTRUCTIVE;
+  return classifyCommandHttp(command);
 }
 
 // ---------------------------------------------------------------------------
@@ -272,6 +456,14 @@ export function isDestructiveTestingAllowed(ctx: ToolContext): boolean {
  * Assert an HTTP request is permitted. No-op when destructive testing is
  * authorized; otherwise throws {@link DestructiveActionError} for a
  * destructive-classified request.
+ *
+ * Trust boundary: this classifies the AGENT-AUTHORED request — method, url,
+ * headers, and a literal string body. A prompt-injection ref body is delivered
+ * by reference to a curated, operator-provided payload library (the agent never
+ * authors its content), so it is intentionally out of scope here; re-checking
+ * the resolved payload would break prompt-injection testing without adding real
+ * safety (the library is not agent-controlled). Method / override / delete-path
+ * detection does not depend on the body and is unaffected by resolution.
  */
 export function assertHttpActionAllowed(
   input: {

--- a/src/core/agents/offSecAgent/tools/destructiveGuard.ts
+++ b/src/core/agents/offSecAgent/tools/destructiveGuard.ts
@@ -106,7 +106,7 @@ const WRITE_METHODS = new Set(["POST", "PUT", "PATCH"]);
 const DESTRUCTIVE_PATH_PATTERN =
   /(?:^|[/_?&=.-])(?:delete|destroy|drop|purge|truncate|wipe|obliterate|nuke|remove|hard[-_]?delete|force[-_]?delete)(?:[/_?&=.-]|$)/i;
 
-/** Method-override to DELETE via query/body (e.g. `?_method=DELETE`). */
+/** Method-override to DELETE via header/query/body (e.g. `?_method=DELETE`). */
 const METHOD_OVERRIDE_DELETE_PATTERN =
   /(?:_method|x-http-method-override|httpmethod)\s*[=:]\s*['"]?delete\b/i;
 
@@ -114,15 +114,25 @@ const METHOD_OVERRIDE_DELETE_PATTERN =
 // Classifiers (pure)
 // ---------------------------------------------------------------------------
 
-/** Classify an HTTP request. `body` is only inspected when it is a string. */
+/**
+ * Classify an HTTP request. `body` is only inspected when it is a string.
+ * `headers` are folded into the haystack as `name: value` lines so a
+ * method-override header (e.g. `X-HTTP-Method-Override: DELETE`) is caught.
+ */
 export function classifyHttpAction(input: {
   method: string;
   url: string;
   body?: unknown;
+  headers?: Record<string, unknown>;
 }): DestructiveClassification {
   const method = input.method.toUpperCase();
   const bodyText = typeof input.body === "string" ? input.body : "";
-  const haystack = `${input.url}\n${bodyText}`;
+  const headerText = input.headers
+    ? Object.entries(input.headers)
+        .map(([name, value]) => `${name}: ${String(value)}`)
+        .join("\n")
+    : "";
+  const haystack = `${input.url}\n${bodyText}\n${headerText}`;
 
   // Raw destructive SQL / NoSQL carried in the URL or body (SQLi payloads,
   // admin/query endpoints) — destructive regardless of method.
@@ -261,7 +271,12 @@ export function isDestructiveTestingAllowed(ctx: ToolContext): boolean {
  * destructive-classified request.
  */
 export function assertHttpActionAllowed(
-  input: { method: string; url: string; body?: unknown },
+  input: {
+    method: string;
+    url: string;
+    body?: unknown;
+    headers?: Record<string, unknown>;
+  },
   ctx: ToolContext,
 ): void {
   if (isDestructiveTestingAllowed(ctx)) return;

--- a/src/core/agents/offSecAgent/tools/destructiveGuard.ts
+++ b/src/core/agents/offSecAgent/tools/destructiveGuard.ts
@@ -457,13 +457,10 @@ export function isDestructiveTestingAllowed(ctx: ToolContext): boolean {
  * authorized; otherwise throws {@link DestructiveActionError} for a
  * destructive-classified request.
  *
- * Trust boundary: this classifies the AGENT-AUTHORED request — method, url,
- * headers, and a literal string body. A prompt-injection ref body is delivered
- * by reference to a curated, operator-provided payload library (the agent never
- * authors its content), so it is intentionally out of scope here; re-checking
- * the resolved payload would break prompt-injection testing without adding real
- * safety (the library is not agent-controlled). Method / override / delete-path
- * detection does not depend on the body and is unaffected by resolution.
+ * `http_request` calls this on the FULLY-RESOLVED request (after any
+ * prompt-injection ref in the body expands to a concrete string), so a resolved
+ * payload carrying destructive SQL/NoSQL is classified before the request is
+ * sent. `body` is only inspected when it is a string.
  */
 export function assertHttpActionAllowed(
   input: {

--- a/src/core/agents/offSecAgent/tools/destructiveGuard.ts
+++ b/src/core/agents/offSecAgent/tools/destructiveGuard.ts
@@ -61,7 +61,7 @@ const NOT_DESTRUCTIVE: DestructiveClassification = { destructive: false };
  * `DROP TABLE`). Runs up to two passes to unwrap double-encoding, decodes each
  * `%XX` sequence independently so a stray `%` never throws.
  */
-export function safeDecode(input: string): string {
+function safeDecode(input: string): string {
   let out = input ?? "";
   for (let pass = 0; pass < 2; pass++) {
     const decoded = out.replace(/\+/g, " ").replace(/%[0-9a-fA-F]{2}/g, (m) => {
@@ -82,12 +82,24 @@ export function safeDecode(input: string): string {
 // ---------------------------------------------------------------------------
 
 /**
+ * Inter-keyword separator: whitespace or an inline SQL block comment, so
+ * comment-obfuscated forms like `DROP/**​/TABLE` or `DELETE/**​/FROM` still
+ * match (a common SQLi bypass).
+ */
+const SQL_SEP = String.raw`(?:\s|/\*[\s\S]*?\*/)+`;
+
+/**
  * Destructive SQL DML/DDL statement head: DROP {TABLE,DATABASE,...}, TRUNCATE,
  * DELETE FROM, ALTER TABLE ... DROP. Deliberately does NOT match
  * INSERT/UPDATE/SELECT — ordinary writes stay allowed.
  */
-const SQL_DESTRUCTIVE_STATEMENT =
-  /(?:drop\s+(?:table|database|schema|index|view|column|role|user|sequence|trigger|function|procedure)|truncate\s+(?:table\s+)?[`"\w]|delete\s+from\s+[`"\w]|alter\s+table\s+[^;]*\bdrop\b)/i;
+const SQL_DESTRUCTIVE_STATEMENT = new RegExp(
+  `(?:drop${SQL_SEP}(?:table|database|schema|index|view|column|role|user|sequence|trigger|function|procedure)` +
+    `|truncate${SQL_SEP}(?:table${SQL_SEP})?[\`"\\w]` +
+    `|delete${SQL_SEP}from${SQL_SEP}[\`"\\w]` +
+    `|alter${SQL_SEP}table${SQL_SEP}[^;]*\\bdrop\\b)`,
+  "i",
+);
 
 /** The statement is the (trimmed) start of the payload — a raw-SQL body. */
 const SQL_STATEMENT_START = new RegExp(
@@ -154,16 +166,45 @@ const METHOD_OVERRIDE_DELETE_PATTERN =
 // Host-destructive command rules (anchored to command position, not substring)
 // ---------------------------------------------------------------------------
 
-/** Start of a command word: line start, or after a shell separator. */
-const CMD_BOUNDARY = String.raw`(?:^|[\n;&|]|&&|\|\|)\s*(?:sudo\s+)?`;
+/**
+ * Start of a command word: line start, after a shell separator or subshell
+ * `(`, or immediately inside a shell wrapper's quoted `-c "…"` argument (so
+ * `bash -c "dd …"` / `sh -lc 'mkfs …'` are not hidden from the host rules).
+ */
+const CMD_BOUNDARY = String.raw`(?:^|[\n;&|(]|&&|\|\||-[a-z]*c\s+["']?)\s*(?:sudo\s+)?`;
+
+/** Home-directory reference: `~`, `~user`, `$HOME`, `${HOME}`. */
+const HOME_REF = /^(?:~[^/]*|\$\{?HOME\}?)(?:\/|$)/;
+
+/**
+ * Normalize an `rm` target so path tricks resolve to their real destination:
+ * strip quotes, collapse `//` and `.`/`..` segments. Home refs collapse to
+ * `~`. Returns the normalized absolute/relative path (or `~`).
+ */
+function normalizeRmTarget(raw: string): string {
+  const unquoted = raw.replace(/^['"]|['"]$/g, "");
+  if (HOME_REF.test(unquoted)) return "~";
+  if (!unquoted.startsWith("/")) return unquoted;
+  const stack: string[] = [];
+  for (const seg of unquoted.split("/")) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") {
+      stack.pop();
+      continue;
+    }
+    stack.push(seg);
+  }
+  return `/${stack.join("/")}`;
+}
 
 /**
  * `rm` with BOTH recursive and force semantics (flags in any order, combined or
  * split) aimed at a filesystem root, home, or system dir — or with
- * `--no-preserve-root`. Ordinary sandbox scratch cleanup (`rm -rf /tmp/x`,
- * `rm -rf ./build`) does NOT match.
+ * `--no-preserve-root`. Path tricks (`/tmp/../`, `//`, `/.`) are normalized
+ * first. Ordinary sandbox scratch cleanup (`rm -rf /tmp/x`, `rm -rf ./build`)
+ * does NOT match.
  */
-export function isDangerousRm(command: string): boolean {
+function isDangerousRm(command: string): boolean {
   const rmRe = /\brm\b([^\n;|&]*)/gi;
   for (const match of command.matchAll(rmRe)) {
     const args = match[1] ?? "";
@@ -173,14 +214,15 @@ export function isDangerousRm(command: string): boolean {
     if (/--no-preserve-root/i.test(args)) return true;
     for (const rawToken of args.split(/\s+/)) {
       if (!rawToken || rawToken.startsWith("-")) continue;
-      const token = rawToken.replace(/^['"]|['"]$/g, "");
-      // Root / wildcard-root / home shorthands.
-      if (/^(?:\/|\/\*|~|\$HOME|\$\{HOME\})$/.test(token)) return true;
-      if (/^(?:~|\$HOME|\$\{HOME\})\//.test(token)) return true;
+      // Wildcard root (`/*`) — a full-filesystem glob.
+      if (/^['"]?\/\*/.test(rawToken)) return true;
+      const norm = normalizeRmTarget(rawToken);
+      if (norm === "~") return true; // home directory wipe
+      if (norm === "/") return true; // filesystem root
       // A system or home directory, with or without a subpath.
       if (
         /^\/(?:etc|var|usr|bin|sbin|boot|lib|lib64|root|home|opt|srv|sys|proc|dev)(?:\/|$)/i.test(
-          token,
+          norm,
         )
       ) {
         return true;
@@ -195,14 +237,21 @@ const HOST_DESTRUCTIVE_RULES: Array<{
   test: (command: string) => boolean;
 }> = [
   { id: "rm-rf-root", test: isDangerousRm },
-  // Raw block-device write / disk imaging.
+  // Raw block-device write / disk imaging — excluding safe pseudo-devices
+  // (`/dev/null`, `/dev/stdout`, …) that ordinary commands write to.
   {
     id: "dd-to-device",
-    test: (c) =>
-      new RegExp(
-        `${CMD_BOUNDARY}dd\\b[^\\n;|&]*\\bof=\\s*['"]?/dev/`,
+    test: (c) => {
+      const m = new RegExp(
+        `${CMD_BOUNDARY}dd\\b[^\\n;|&]*\\bof=\\s*['"]?(/dev/\\S+)`,
         "i",
-      ).test(c),
+      ).exec(c);
+      if (!m) return false;
+      const dev = m[1].replace(/['"].*$/, "");
+      return !/^\/dev\/(?:null|zero|full|random|urandom|stdout|stderr|tty|fd\/)/i.test(
+        dev,
+      );
+    },
   },
   // Filesystem creation over a device.
   {
@@ -210,10 +259,11 @@ const HOST_DESTRUCTIVE_RULES: Array<{
     test: (c) =>
       new RegExp(`${CMD_BOUNDARY}(?:/s?bin/)?mkfs(?:\\.\\w+)?\\b`, "i").test(c),
   },
-  // Redirect into a block device.
+  // Redirect into a block device (physical or virtual/cloud root disks).
   {
     id: "clobber-device",
-    test: (c) => />\s*['"]?\/dev\/(?:sd|nvme|hd|mapper|disk)/i.test(c),
+    test: (c) =>
+      />\s*['"]?\/dev\/(?:sd|nvme|hd|vd|xvd|mapper|disk|loop|dm-|md)/i.test(c),
   },
   // Classic fork bomb.
   {
@@ -248,8 +298,10 @@ const HTTPIE_METHOD = new RegExp(
 );
 const CURL_WRITE_METHOD =
   /(?:-X|--request|--method)[=\s]*['"]?(?:post|put|patch)\b/i;
+// Body/data flags across curl (-d/--data*/-F/--form/--json) and wget
+// (--post-data/--post-file/--body-data/--body-file) that indicate a write.
 const CURL_DATA_FLAG =
-  /(?:^|\s)(?:-d|--data(?:-raw|-binary|-urlencode|-ascii)?|-F|--form|--json)\b/i;
+  /(?:^|\s)(?:-d|--data(?:-raw|-binary|-urlencode|-ascii)?|-F|--form|--json|--post-data|--post-file|--body-data|--body-file)\b/i;
 
 /**
  * In-script HTTP DELETE nested inside `execute_command` (Node/Bun/Deno,
@@ -274,10 +326,19 @@ const JS_CLIENT_DELETE_CALL =
 /** Classify an HTTP call expressed as a shell command (curl/wget/httpie/xh, or an in-script fetch/axios). */
 function classifyCommandHttp(command: string): DestructiveClassification {
   const decoded = safeDecode(command);
-
-  // Explicit DELETE via flag or httpie positional method.
   const httpieMethod = HTTPIE_METHOD.exec(command)?.[1]?.toLowerCase();
-  if (CURL_DELETE.test(command) || httpieMethod === "delete") {
+  // A real HTTP context — a shell client (curl/wget/xh/httpie) or an in-script
+  // JS client. DELETE / override / SQL detection is gated on this so a benign
+  // recon `grep -X DELETE` / `echo _method=DELETE` is not misclassified.
+  const hasShellHttpClient =
+    HTTP_CLIENT_PATTERN.test(command) || httpieMethod !== undefined;
+  const hasJsHttpClient = JS_HTTP_CLIENT_HINT.test(command);
+
+  // Explicit DELETE via curl flag or httpie positional method.
+  if (
+    hasShellHttpClient &&
+    (CURL_DELETE.test(command) || httpieMethod === "delete")
+  ) {
     return {
       destructive: true,
       category: "http-delete-method",
@@ -288,7 +349,7 @@ function classifyCommandHttp(command: string): DestructiveClassification {
 
   // In-script HTTP DELETE (fetch/axios/Playwright) run via a JS runtime.
   if (
-    (JS_METHOD_DELETE.test(command) && JS_HTTP_CLIENT_HINT.test(command)) ||
+    (JS_METHOD_DELETE.test(command) && hasJsHttpClient) ||
     JS_CLIENT_DELETE_CALL.test(command)
   ) {
     return {
@@ -300,13 +361,37 @@ function classifyCommandHttp(command: string): DestructiveClassification {
     };
   }
 
-  // Method-override to DELETE carried in headers/data.
-  if (METHOD_OVERRIDE_DELETE_PATTERN.test(decoded)) {
+  // Method-override to DELETE carried in headers/data — only in an HTTP context.
+  if (
+    (hasShellHttpClient || hasJsHttpClient) &&
+    METHOD_OVERRIDE_DELETE_PATTERN.test(decoded)
+  ) {
     return {
       destructive: true,
       category: "http-delete-method",
       ruleId: "cmd-http-override-delete",
       reason: "command overrides the HTTP method to DELETE",
+    };
+  }
+
+  // Destructive SQL / NoSQL carried in an HTTP client's URL or data body — the
+  // same statement `http_request` blocks, but delivered through curl/wget.
+  if (hasShellHttpClient && httpCarriesDestructiveSql(decoded)) {
+    return {
+      destructive: true,
+      category: "sql-destructive",
+      ruleId: "cmd-http-sql",
+      reason:
+        "command sends a destructive SQL statement in an HTTP request (DROP/TRUNCATE/DELETE FROM/ALTER…DROP)",
+    };
+  }
+  if (hasShellHttpClient && NOSQL_HTTP_DESTRUCTIVE.test(decoded)) {
+    return {
+      destructive: true,
+      category: "nosql-destructive",
+      ruleId: "cmd-http-nosql",
+      reason:
+        "command sends a destructive NoSQL/cache operation in an HTTP request",
     };
   }
 
@@ -317,7 +402,7 @@ function classifyCommandHttp(command: string): DestructiveClassification {
     httpieMethod === "post" ||
     httpieMethod === "put" ||
     httpieMethod === "patch";
-  if (HTTP_CLIENT_PATTERN.test(command) && writeIndicated) {
+  if (hasShellHttpClient && writeIndicated) {
     for (const rawUrl of command.match(URL_IN_COMMAND) ?? []) {
       if (DESTRUCTIVE_PATH_PATTERN.test(safeDecode(rawUrl))) {
         return {
@@ -436,8 +521,10 @@ export function classifyCommandAction(
 
   // SQL/NoSQL is destructive only when an actual DB client executes it — a
   // grep/cat/echo that merely contains "DROP TABLE" or "FLUSHALL" is recon.
+  // Decode first so percent-encoded statements in client args are matched.
+  const decodedCommand = safeDecode(command);
   if (DB_CLIENT_PATTERN.test(command)) {
-    if (SQL_DESTRUCTIVE_STATEMENT.test(command)) {
+    if (SQL_DESTRUCTIVE_STATEMENT.test(decodedCommand)) {
       return {
         destructive: true,
         category: "sql-destructive",
@@ -446,7 +533,7 @@ export function classifyCommandAction(
           "command runs a destructive SQL statement via a DB client (DROP/TRUNCATE/DELETE FROM/ALTER…DROP)",
       };
     }
-    if (NOSQL_CMD_DESTRUCTIVE.test(command)) {
+    if (NOSQL_CMD_DESTRUCTIVE.test(decodedCommand)) {
       return {
         destructive: true,
         category: "nosql-destructive",

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -348,12 +348,8 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
 
       try {
         assertCommandInScope(command, ctx);
-        assertCommandActionAllowed(command, ctx);
       } catch (e) {
-        if (
-          e instanceof ScopeViolationError ||
-          e instanceof DestructiveActionError
-        ) {
+        if (e instanceof ScopeViolationError) {
           return {
             success: false,
             error: e.message,
@@ -389,6 +385,27 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
       }
       const commandWithHeaders =
         inject.status === "injected" ? inject.command : command;
+
+      // Enforce the destructive-action guard on the header-injected command so
+      // a method-override header (e.g. `X-HTTP-Method-Override: DELETE`) added
+      // by the session/credential layer is classified, not just agent-authored
+      // flags. (Prompt-injection payloads are written to a temp file and
+      // referenced by env var below — never inlined into the command string —
+      // so their content is out of scope for this string classifier.)
+      try {
+        assertCommandActionAllowed(commandWithHeaders, ctx);
+      } catch (e) {
+        if (e instanceof DestructiveActionError) {
+          return {
+            success: false,
+            error: e.message,
+            stdout: "",
+            stderr: e.message,
+            command,
+          };
+        }
+        throw e;
+      }
 
       let promptInjectionLibrary: PromptInjectionLibrary | undefined;
       let promptInjectionEnvVars: Record<string, string> | undefined;

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -10,6 +10,10 @@ import {
 } from "../../../prompt-injections";
 import { agentLogsDir } from "./agentScratch";
 import {
+  assertCommandActionAllowed,
+  DestructiveActionError,
+} from "./destructiveGuard";
+import {
   assertCommandInScope,
   extractHostsFromCommand,
   resolverSessionFromCtx,
@@ -344,8 +348,12 @@ IMPORTANT: Always analyze results and adjust your approach based on findings.`,
 
       try {
         assertCommandInScope(command, ctx);
+        assertCommandActionAllowed(command, ctx);
       } catch (e) {
-        if (e instanceof ScopeViolationError) {
+        if (
+          e instanceof ScopeViolationError ||
+          e instanceof DestructiveActionError
+        ) {
           return {
             success: false,
             error: e.message,

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -192,9 +192,11 @@ COMMON TESTING PATTERNS:
       followRedirects,
       timeout,
     }): Promise<HttpRequestResult> => {
+      let headers = parseHeaders(rawHeaders);
+
       try {
         assertUrlInScope(url, ctx);
-        assertHttpActionAllowed({ method, url, body }, ctx);
+        assertHttpActionAllowed({ method, url, body, headers }, ctx);
       } catch (e) {
         if (
           e instanceof ScopeViolationError ||
@@ -215,7 +217,6 @@ COMMON TESTING PATTERNS:
         throw e;
       }
 
-      let headers = parseHeaders(rawHeaders);
       let resolvedBody: string | undefined;
       let library: PromptInjectionLibrary = EMPTY_PROMPT_INJECTION_LIBRARY;
 

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -234,11 +234,18 @@ COMMON TESTING PATTERNS:
               );
 
         // Enforce the destructive-action guard on the fully resolved body and
-        // headers — a prompt-injection ref expands to a concrete string only
-        // here, so classifying before this point would miss destructive
-        // SQL/NoSQL payloads delivered via a ref.
+        // the EFFECTIVE headers (agent-supplied + session/credential headers
+        // merged in) — a prompt-injection ref expands to a concrete string only
+        // here, and a method-override header can be injected by the session
+        // layer, so classifying before this point (or on agent headers alone)
+        // would miss those.
+        const effectiveHeaders = resolveEffectiveHeaders(
+          resolverSessionFromCtx(ctx),
+          url,
+          headers,
+        );
         assertHttpActionAllowed(
-          { method, url, body: resolvedBody, headers },
+          { method, url, body: resolvedBody, headers: effectiveHeaders },
           ctx,
         );
       } catch (e) {

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -16,10 +16,7 @@ import {
   resolvePromptInjectionRefs,
 } from "../../../prompt-injections";
 import { agentLogsDir } from "./agentScratch";
-import {
-  assertHttpActionAllowed,
-  DestructiveActionError,
-} from "./destructiveGuard";
+import { assertHttpActionAllowed } from "./destructiveGuard";
 import {
   assertUrlInScope,
   resolverSessionFromCtx,
@@ -196,12 +193,8 @@ COMMON TESTING PATTERNS:
 
       try {
         assertUrlInScope(url, ctx);
-        assertHttpActionAllowed({ method, url, body, headers }, ctx);
       } catch (e) {
-        if (
-          e instanceof ScopeViolationError ||
-          e instanceof DestructiveActionError
-        ) {
+        if (e instanceof ScopeViolationError) {
           return {
             success: false,
             error: e.message,
@@ -239,6 +232,15 @@ COMMON TESTING PATTERNS:
             : String(
                 resolvePromptInjectionRefs(body as HttpRequestBody, library),
               );
+
+        // Enforce the destructive-action guard on the fully resolved body and
+        // headers — a prompt-injection ref expands to a concrete string only
+        // here, so classifying before this point would miss destructive
+        // SQL/NoSQL payloads delivered via a ref.
+        assertHttpActionAllowed(
+          { method, url, body: resolvedBody, headers },
+          ctx,
+        );
       } catch (e) {
         return {
           success: false,

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -17,6 +17,10 @@ import {
 } from "../../../prompt-injections";
 import { agentLogsDir } from "./agentScratch";
 import {
+  assertHttpActionAllowed,
+  DestructiveActionError,
+} from "./destructiveGuard";
+import {
   assertUrlInScope,
   resolverSessionFromCtx,
   ScopeViolationError,
@@ -190,8 +194,12 @@ COMMON TESTING PATTERNS:
     }): Promise<HttpRequestResult> => {
       try {
         assertUrlInScope(url, ctx);
+        assertHttpActionAllowed({ method, url, body }, ctx);
       } catch (e) {
-        if (e instanceof ScopeViolationError) {
+        if (
+          e instanceof ScopeViolationError ||
+          e instanceof DestructiveActionError
+        ) {
           return {
             success: false,
             error: e.message,

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -418,6 +418,15 @@ const SECTION_AUTHENTICATION = `Authentication:
   2. If a reversible state-changing write is the only convincing proof, capture the current value, make the change, capture evidence (response/screenshot), then immediately restore the original value — and prefer your own account or a throwaway account you registered for this test over a shared or provided account. Do NOT rely on end-of-run cleanup alone; a crash mid-run can strip it before it runs.
   3. NEVER complete an irreversible or security-weakening mutation against a shared or provided account, against any other user's account reached via broken authorization / IDOR, or against an org- or tenant-wide security setting (e.g. disabling MFA for an entire team): overwriting/resetting, disabling, or otherwise weakening an MFA/TOTP device or any second factor / security control, consuming a single-use reset token, changing the account email, rotating the password, or deleting the account. This hard ban is not limited to the identity you authenticated as — an IDOR or org-level authz flaw does not make it acceptable to actually disable or weaken another user's or the whole team's protections; prove the boundary is crossed without completing the weakening step. Irreversible changes cannot be undone (you never hold the original TOTP secret to restore), and locking an account out, disabling protections for other users, or weakening an org-wide control invalidates or endangers the credentials for every other agent — even a "reversible" toggle like disabling MFA leaves the account or team exposed if a crash strips the restore step. Demonstrate reachability/authorization instead, or perform the destructive step only against a throwaway account you registered for this test.`;
 
+const SECTION_DESTRUCTIVE_ALLOWED = `Destructive Testing (AUTHORIZED):
+- The client has authorized destructive testing for this engagement. You MAY perform DB deletes/drops/truncates, API write-deletes (HTTP DELETE), and other destructive operations when they are necessary to prove impact.
+- Still prefer the least-invasive proof that convincingly demonstrates the flaw, and follow the blast-radius rungs in the Authentication section — authorization to be destructive is not license to be reckless with shared or provided accounts.`;
+
+const SECTION_DESTRUCTIVE_BLOCKED = `Destructive Testing (OUT OF SCOPE):
+- The client has NOT authorized destructive testing for this engagement. Destructive operations are BLOCKED at the tool boundary and will return an error, so do not attempt them — they only waste turns.
+- Blocked operations include: destructive SQL (DROP / TRUNCATE / DELETE FROM / ALTER … DROP), destructive NoSQL/cache operations (collection/database drops, deleteMany, FLUSHALL/FLUSHDB), API write-deletes (HTTP DELETE, or writes overriding to DELETE / targeting a delete/destroy/purge route), and catastrophic host operations (rm -rf of a root/home, mkfs, dd to a device, fork bombs, power-state changes).
+- Prove destructive-class flaws WITHOUT completing the destructive step: demonstrate that the authorization boundary is crossed (e.g. the DELETE endpoint accepts your request / returns a pre-flight that would delete) with a read or a benign, reversible action, and describe the impact rather than actually deleting or dropping data.`;
+
 const SECTION_CREDENTIAL_DISCOVERY = `Credential & Secret Discovery:
 - When you find exposed configuration in client-side code (JS bundles, HTML source, config files), distinguish between:
   - SENSITIVE SECRETS (API keys granting backend access, database credentials, JWT signing keys, private keys, service account tokens) — document as a HIGH/CRITICAL finding
@@ -673,18 +682,32 @@ ${SECTION_FINDING_QUALITY}
 
 ${SECTION_STATE_CHECKPOINTING}`;
 
+/**
+ * Destructive-testing prompt section, driven by session config. When
+ * destructive testing is not authorized (default), the section tells the agent
+ * the operations the guard blocks so it doesn't waste turns attempting them.
+ */
+function destructiveSection(allow: boolean | undefined): string {
+  return allow ? SECTION_DESTRUCTIVE_ALLOWED : SECTION_DESTRUCTIVE_BLOCKED;
+}
+
 export function buildPentestSystemPrompt(
   session: {
     config?: {
       exfilMode?: boolean;
       taskDriven?: boolean;
       promptInjectionLibrarySource?: string;
+      allowDestructiveActions?: boolean;
     };
   },
   role: PentestAgentRole = "orchestrator",
 ): string {
+  const destructive = destructiveSection(
+    session.config?.allowDestructiveActions,
+  );
+
   if (role === "orchestrator") {
-    return PENTEST_SYSTEM_PROMPT_ORCHESTRATOR;
+    return `${PENTEST_SYSTEM_PROMPT_ORCHESTRATOR}\n\n${destructive}`;
   }
 
   const taskDriven = session.config?.taskDriven ?? false;
@@ -698,11 +721,13 @@ export function buildPentestSystemPrompt(
       ? PENTEST_SYSTEM_PROMPT_EXFIL
       : PENTEST_SYSTEM_PROMPT_BASE;
 
+  const withDestructive = `${base}\n\n${destructive}`;
+
   // Workers are the agents that actually deliver payloads, so the
   // prompt-injection methodology only ships when a library is configured.
   return session.config?.promptInjectionLibrarySource
-    ? `${base}\n\n${SECTION_PROMPT_INJECTION}`
-    : base;
+    ? `${withDestructive}\n\n${SECTION_PROMPT_INJECTION}`
+    : withDestructive;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -209,6 +209,14 @@ const SessionConfigObject = z.object({
     .optional(),
   authenticationInstructions: z.string().optional(),
   requestsPerSecond: z.number().optional(),
+  /**
+   * Opt-in: the client has authorized destructive testing (DB deletes/drops,
+   * API write-deletes, catastrophic host operations). Defaults to off — when
+   * absent or false, the destructive-action guard blocks those operations at
+   * the `http_request` / `execute_command` tool boundary. See
+   * `agents/offSecAgent/tools/destructiveGuard.ts`.
+   */
+  allowDestructiveActions: z.boolean().optional(),
   operatorSettings: OperatorSettingsObject.optional(),
   /** Toolset state for controlling which tools are available */
   toolsetState: ToolsetStateSchema.optional(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a **deterministic, latency-free guardrail** that classifies and blocks *destructive* tool calls during a pentest unless the client explicitly opts in.

Destructive testing was previously governed by prompt guidance only (`SECTION_AUTHENTICATION` bans irreversible mutations) — there was no hard enforcement layer. This adds one, modeled on the existing `scopeGuard` (host-scope) pattern.

### The classifier — `src/core/agents/offSecAgent/tools/destructiveGuard.ts`

A pure pipeline of regex + structural rules. **No LLM, no network, no I/O** — classification is O(input length), so it adds effectively zero latency on the tool-call hot path (this was an explicit requirement — the reviewer wanted to avoid the latency of an LLM-based judge).

It flags:
- **`sql-destructive`** — `DROP {TABLE,DATABASE,SCHEMA,…}`, `TRUNCATE`, `DELETE FROM`, `ALTER TABLE … DROP` (in a shell command, HTTP body, or SQLi payload). Does **not** match `INSERT`/`UPDATE`/`SELECT`.
- **`nosql-destructive`** — Mongo `drop`/`dropDatabase`/`deleteMany`/`remove`, Redis `FLUSHALL`/`FLUSHDB`.
- **`http-delete-method`** — HTTP `DELETE`, a write overriding to DELETE (`?_method=DELETE`), and `curl/wget -X DELETE`.
- **`http-destructive-path`** — a write method (`POST`/`PUT`/`PATCH`) aimed at a `delete`/`destroy`/`drop`/`purge`/`truncate`/`wipe`/`remove` route.
- **`host-destructive`** — `rm -rf` of a filesystem root/home, `mkfs`, `dd of=/dev/…`, fork bombs, power-state changes. Narrowly targeted so ordinary sandbox scratch cleanup (`rm -rf /tmp/apex-…`) does **not** match.

Ordinary reads and reversible writes stay allowed, so normal pentesting (proving IDOR/authz with a read or a benign reversible write) is unaffected.

### Enforcement

- `SessionConfig.allowDestructiveActions?: boolean` — **off by default** (fail-closed).
- `assertHttpActionAllowed` / `assertCommandActionAllowed` are wired into `http_request` and `execute_command` right after the scope check. When destructive testing is not authorized, a destructive call returns a structured, non-fatal error (`DestructiveActionError`, same shape as `ScopeViolationError`) that the model reads and routes around.
- A config-driven prompt section (`SECTION_DESTRUCTIVE_ALLOWED` / `SECTION_DESTRUCTIVE_BLOCKED`) tells the agent which operations are blocked so it doesn't waste turns attempting them.

### Scope / limitations

- The guard covers the two deterministic surfaces (`http_request`, `execute_command`). Browser-driven destructive actions (clicking a "Delete account" button) are not deterministically classifiable and remain governed by the existing `SECTION_AUTHENTICATION` prompt guidance.

## Tests

`destructiveGuard.test.ts` — 23 cases covering positive/negative classification and enforcement in both authorized and default (blocked) modes. Full suite: 1348 passed / 15 skipped. `tsc` and Biome clean.

## Companion change

Consumed by the console launch flow (a new "Test destructive actions" toggle on the Advanced testing step sets `allowDestructiveActions`). The console PR pins this behavior once the apex submodule pointer is advanced to this branch's merge commit.

Note: no matching GitHub issue was found for this work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b91b2a08-90dd-4a40-81a4-e9356fd19699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b91b2a08-90dd-4a40-81a4-e9356fd19699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

