### PR TITLE
Harden WorkOS auth persistence and token refresh

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@googleapis/gmail": "^16.1.2",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@napi-rs/keyring": "^1.3.0",
         "@openrouter/ai-sdk-provider": "^2.9.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentui/core": "^0.1.107",
@@ -357,6 +358,32 @@
     "@microsoft/microsoft-graph-client": ["@microsoft/microsoft-graph-client@3.0.7", "", { "dependencies": { "@babel/runtime": "^7.12.5", "tslib": "^2.2.0" } }, "sha512-/AazAV/F+HK4LIywF9C+NYHcJo038zEnWkteilcxC1FM/uK/4NVGDKGrxx7nNq1ybspAroRKT4I1FHfxQzxkUw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@napi-rs/keyring": ["@napi-rs/keyring@1.3.0", "", { "optionalDependencies": { "@napi-rs/keyring-darwin-arm64": "1.3.0", "@napi-rs/keyring-darwin-x64": "1.3.0", "@napi-rs/keyring-freebsd-x64": "1.3.0", "@napi-rs/keyring-linux-arm-gnueabihf": "1.3.0", "@napi-rs/keyring-linux-arm64-gnu": "1.3.0", "@napi-rs/keyring-linux-arm64-musl": "1.3.0", "@napi-rs/keyring-linux-riscv64-gnu": "1.3.0", "@napi-rs/keyring-linux-x64-gnu": "1.3.0", "@napi-rs/keyring-linux-x64-musl": "1.3.0", "@napi-rs/keyring-win32-arm64-msvc": "1.3.0", "@napi-rs/keyring-win32-ia32-msvc": "1.3.0", "@napi-rs/keyring-win32-x64-msvc": "1.3.0" } }, "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA=="],
+
+    "@napi-rs/keyring-darwin-arm64": ["@napi-rs/keyring-darwin-arm64@1.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ=="],
+
+    "@napi-rs/keyring-darwin-x64": ["@napi-rs/keyring-darwin-x64@1.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw=="],
+
+    "@napi-rs/keyring-freebsd-x64": ["@napi-rs/keyring-freebsd-x64@1.3.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw=="],
+
+    "@napi-rs/keyring-linux-arm-gnueabihf": ["@napi-rs/keyring-linux-arm-gnueabihf@1.3.0", "", { "os": "linux", "cpu": "arm" }, "sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ=="],
+
+    "@napi-rs/keyring-linux-arm64-gnu": ["@napi-rs/keyring-linux-arm64-gnu@1.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg=="],
+
+    "@napi-rs/keyring-linux-arm64-musl": ["@napi-rs/keyring-linux-arm64-musl@1.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw=="],
+
+    "@napi-rs/keyring-linux-riscv64-gnu": ["@napi-rs/keyring-linux-riscv64-gnu@1.3.0", "", { "os": "linux", "cpu": "none" }, "sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ=="],
+
+    "@napi-rs/keyring-linux-x64-gnu": ["@napi-rs/keyring-linux-x64-gnu@1.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A=="],
+
+    "@napi-rs/keyring-linux-x64-musl": ["@napi-rs/keyring-linux-x64-musl@1.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw=="],
+
+    "@napi-rs/keyring-win32-arm64-msvc": ["@napi-rs/keyring-win32-arm64-msvc@1.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw=="],
+
+    "@napi-rs/keyring-win32-ia32-msvc": ["@napi-rs/keyring-win32-ia32-msvc@1.3.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ=="],
+
+    "@napi-rs/keyring-win32-x64-msvc": ["@napi-rs/keyring-win32-x64-msvc@1.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 

--- a/decisions/PDR-008-cli-auth-storage.md
+++ b/decisions/PDR-008-cli-auth-storage.md
@@ -1,0 +1,66 @@
+# PDR-008: Native credential storage for CLI sessions
+
+## Context
+
+WorkOS access tokens are intentionally short-lived. Keeping users signed in
+requires a refresh token, but refresh tokens are long-lived credentials and
+WorkOS rotates them after every successful refresh. Persisting both tokens in
+`~/.pensar/config.json` exposed the refresh credential as ordinary application
+configuration and made simultaneous Apex processes vulnerable to refresh-token
+rotation races.
+
+## Decision
+
+Apex stores WorkOS refresh tokens through Bun's Secrets API, which uses the
+operating system credential store: macOS Keychain, Windows Credential Manager,
+or Linux Secret Service. The Node-compatible packaged CLI uses the equivalent
+`@napi-rs/keyring` adapter. Access tokens remain in process memory and are
+recreated from the refresh token when Apex starts.
+
+When a native credential service is unavailable, Apex uses a dedicated
+`~/.pensar/auth.json` fallback with `0600` permissions inside a `0700`
+directory and records the active backend in non-secret config metadata. Legacy
+tokens are migrated out of `config.json` on first use.
+
+Refreshes are single-flighted within a process and protected by a cross-process
+lock. Rotated refresh tokens are persisted before session metadata is updated.
+An authenticated request may force one refresh and retry once after a `401`;
+further failures are returned normally. Only WorkOS `400` and `401` refresh
+responses end the local session. Network and server failures preserve the
+refresh token so temporary outages do not sign the user out.
+
+## Rationale
+
+Native credential stores provide OS-managed encryption and access control
+without asking users to manage another secret. Memory-only access tokens reduce
+the value of filesystem disclosure and naturally respect their short lifetime.
+Serialized refresh rotation prevents two TUI or CLI processes from consuming
+the same single-use token. The restricted fallback keeps authentication usable
+in headless Linux environments where Secret Service is commonly absent while
+remaining separate from general configuration.
+
+## Alternatives considered
+
+- **Keep refresh tokens in `config.json`** — rejected because application
+  configuration is routinely inspected, copied, and backed up as plain text.
+- **Persist access and refresh tokens together** — rejected because access
+  tokens can be recreated and do not need to survive process exit.
+- **Require the native credential service with no fallback** — rejected because
+  many headless Linux and SSH environments do not have an unlocked Secret
+  Service session.
+- **Refresh only on locally decoded JWT expiry** — rejected because tokens can
+  be revoked early; a bounded `401` refresh handles server-side invalidation.
+
+## Consequences
+
+- ✅ Refresh credentials use the strongest storage available on each desktop
+  operating system.
+- ✅ Short access-token lifetimes and normal refresh rotation are hidden from
+  the user.
+- ✅ Concurrent Apex processes cannot race a single-use refresh token locally.
+- ✅ Temporary WorkOS or network outages do not destroy a valid local session.
+- ⚠️ The secure-file fallback is permission-protected rather than backed by an
+  OS credential vault; Apex logs whenever it must use it.
+- ⚠️ Bun currently marks its Secrets API experimental, so runtime upgrades must
+  include an auth-storage regression check.
+- ⚠️ Users may see an operating-system credential access prompt on first use.

--- a/decisions/index.md
+++ b/decisions/index.md
@@ -27,6 +27,7 @@ Apex serves three audiences:
 | [PDR-005](./PDR-005-findings-registry.md)   | Shared findings registry                                                     |
 | [PDR-006](./PDR-006-public-api.md)          | Public API layer separate from the TUI                                       |
 | [PDR-007](./PDR-007-multi-provider.md)      | Multi-provider AI model support                                              |
+| [PDR-008](./PDR-008-cli-auth-storage.md)    | Native credential storage and serialized WorkOS refresh rotation             |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@googleapis/gmail": "^16.1.2",
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@napi-rs/keyring": "^1.3.0",
     "@openrouter/ai-sdk-provider": "^2.9.1",
     "@opentelemetry/api": "^1.9.1",
     "@opentui/core": "^0.1.107",

--- a/src/cli/auth.test.ts
+++ b/src/cli/auth.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  ensureValidToken,
+  getConfig,
+  getPensarApiUrl,
+  isConnected,
+  updateConfig,
+} = vi.hoisted(() => ({
+  ensureValidToken: vi.fn(),
+  getConfig: vi.fn(),
+  getPensarApiUrl: vi.fn(() => "https://console.example.com"),
+  isConnected: vi.fn(() => true),
+  updateConfig: vi.fn(),
+}));
+
+vi.mock("../core/api", () => ({
+  getPensarApiUrl,
+  getPensarConsoleUrl: () => "https://console.example.com",
+}));
+
+vi.mock("../core/auth", () => ({
+  AuthSessionExpiredError: class AuthSessionExpiredError extends Error {},
+  disconnect: vi.fn(),
+  ensureValidToken,
+  fetchWorkspaces: vi.fn(),
+  isConnected,
+  pollForWorkspaceCreation: vi.fn(),
+  pollLegacyToken: vi.fn(),
+  pollWorkOSToken: vi.fn(),
+  saveWorkOSSession: vi.fn(),
+  selectWorkspace: vi.fn(),
+  startDeviceFlow: vi.fn(),
+}));
+
+vi.mock("../core/auth/token", () => ({
+  AuthRefreshError: class AuthRefreshError extends Error {},
+}));
+
+vi.mock("../core/config", () => ({
+  config: { get: getConfig, update: updateConfig },
+}));
+
+const originalArgv = process.argv;
+
+beforeEach(() => {
+  vi.resetModules();
+  ensureValidToken.mockReset();
+  getConfig.mockReset();
+  getPensarApiUrl.mockClear();
+  isConnected.mockClear();
+  updateConfig.mockReset();
+  process.argv = ["bun", "auth.ts", "status"];
+});
+
+afterEach(() => {
+  process.argv = originalArgv;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+async function runStatus(): Promise<ReturnType<typeof vi.spyOn>> {
+  const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  await import("./auth");
+  await vi.waitFor(() =>
+    expect(consoleLog).toHaveBeenCalledWith(
+      expect.stringContaining("Connected to Pensar Console"),
+    ),
+  );
+  return consoleLog;
+}
+
+describe("login status", () => {
+  it("does not resolve an API-key workspace for an active WorkOS session", async () => {
+    getConfig.mockResolvedValue({
+      pensarAPIKey: "legacy-key",
+      workosSession: true,
+    });
+    ensureValidToken.mockResolvedValue({
+      token: "workos-token",
+      type: "workos",
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const consoleLog = await runStatus();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
+    expect(consoleLog).toHaveBeenCalledWith(
+      expect.stringContaining("Auth: WorkOS"),
+    );
+  });
+
+  it("resolves the legacy workspace when WorkOS falls back to an API key", async () => {
+    getConfig.mockResolvedValue({
+      pensarAPIKey: "legacy-key",
+      workosSession: true,
+    });
+    ensureValidToken.mockResolvedValue({
+      token: "legacy-key",
+      type: "legacy",
+    });
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        workspace: { id: "workspace-1", name: "Workspace", slug: "workspace" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const consoleLog = await runStatus();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://console.example.com/auth/validate",
+      { headers: { Authorization: "Bearer legacy-key" } },
+    );
+    expect(updateConfig).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      workspaceSlug: "workspace",
+    });
+    expect(consoleLog).toHaveBeenCalledWith(
+      expect.stringContaining("Auth: API key"),
+    );
+  });
+});

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -17,17 +17,21 @@
 import * as readline from "node:readline";
 import { getPensarApiUrl, getPensarConsoleUrl } from "../core/api";
 import {
+  AuthSessionExpiredError,
   createWorkspaceSelection,
   disconnect,
+  ensureValidToken,
   fetchWorkspaces,
   isConnected,
   pollForWorkspaceCreation,
   pollLegacyToken,
   pollWorkOSToken,
   pollWorkspaceSelection,
+  saveWorkOSSession,
   selectWorkspace,
   startDeviceFlow,
 } from "../core/auth";
+import { AuthRefreshError } from "../core/auth/token";
 import { config } from "../core/config";
 
 // ---------------------------------------------------------------------------
@@ -129,10 +133,7 @@ async function login(): Promise<void> {
       expiresIn: deviceInfo.expires_in,
     });
 
-    await config.update({
-      accessToken: tokens.accessToken,
-      refreshToken: tokens.refreshToken,
-    });
+    await saveWorkOSSession(tokens);
 
     console.log("\nAuthenticated successfully. Fetching workspaces...");
     await handleWorkspaces(apiUrl, tokens.accessToken);
@@ -258,12 +259,44 @@ async function logout(): Promise<void> {
 
 async function status(): Promise<void> {
   const appConfig = await config.get();
+  let authMethod = appConfig.pensarAPIKey ? "API key" : "WorkOS";
 
   if (!isConnected(appConfig)) {
     console.log(
       "Not connected to Pensar Console.\n\nRun `pensar login` to connect.",
     );
     return;
+  }
+
+  if (
+    appConfig.workosSession ||
+    appConfig.refreshToken ||
+    appConfig.accessToken
+  ) {
+    try {
+      const validToken = await ensureValidToken(appConfig);
+      if (!validToken) {
+        console.log(
+          "Not connected to Pensar Console.\n\nRun `pensar login` to connect.",
+        );
+        return;
+      }
+      authMethod = validToken.type === "workos" ? "WorkOS" : "API key";
+    } catch (error) {
+      if (error instanceof AuthSessionExpiredError) {
+        console.log(
+          "Not connected to Pensar Console.\n\nRun `pensar login` to connect.",
+        );
+        return;
+      }
+      if (error instanceof AuthRefreshError) {
+        console.log(
+          "Unable to access secure credentials. Unlock your system and try again.\n\nRun `pensar login` if the problem persists.",
+        );
+        return;
+      }
+      throw error;
+    }
   }
 
   // If using an API key without stored workspace info, resolve it from the server
@@ -295,7 +328,6 @@ async function status(): Promise<void> {
     }
   }
 
-  const authMethod = appConfig.accessToken ? "WorkOS" : "API key";
   console.log(
     `✓ Connected to Pensar Console\n  Workspace: ${appConfig.workspaceSlug ?? "not set"}\n  Auth: ${authMethod}`,
   );

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -299,9 +299,11 @@ async function status(): Promise<void> {
     }
   }
 
-  // If using an API key without stored workspace info, resolve it from the server
+  // If the active credential is an API key without stored workspace info,
+  // resolve it from the server. WorkOS access tokens are memory-only, so the
+  // absence of appConfig.accessToken does not identify API-key auth.
   if (
-    !appConfig.accessToken &&
+    authMethod === "API key" &&
     appConfig.pensarAPIKey &&
     !appConfig.workspaceSlug
   ) {

--- a/src/core/agents/offSecAgent/tools/webSearch.ts
+++ b/src/core/agents/offSecAgent/tools/webSearch.ts
@@ -149,10 +149,12 @@ COMMON SEARCH PATTERNS:
           return handleSearchResponse(response);
         }
 
-        const tokenResult = await ensureValidToken({
+        let tokenResult = await ensureValidToken({
           accessToken: cfg.accessToken,
           refreshToken: cfg.refreshToken,
           pensarAPIKey: cfg.pensarAPIKey,
+          workosSession: cfg.workosSession,
+          credentialBackend: cfg.credentialBackend,
         });
 
         if (!tokenResult) {
@@ -182,25 +184,47 @@ COMMON SEARCH PATTERNS:
           };
         }
 
-        const { signature, timestamp, nonce } = signGatewayRequest(
-          cfg.gatewaySigningKey,
-          "web_search",
-          body,
-        );
+        const workspaceId = cfg.workspaceId;
+        const gatewaySigningKey = cfg.gatewaySigningKey;
 
-        // biome-ignore lint/style/noRestrictedGlobals: Pensar Console (not the pentest target); must not pass through targetFetch.
-        const response = await fetch(`${apiUrl}/agents/web_search`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${tokenResult.token}`,
-            "X-Workspace-Id": cfg.workspaceId,
-            "X-Pensar-Timestamp": timestamp,
-            "X-Pensar-Nonce": nonce,
-            "X-Pensar-Signature": signature,
-          },
-          body,
-        });
+        const sendRequest = (token: string) => {
+          const { signature, timestamp, nonce } = signGatewayRequest(
+            gatewaySigningKey,
+            "web_search",
+            body,
+          );
+          // biome-ignore lint/style/noRestrictedGlobals: Pensar Console (not the pentest target); must not pass through targetFetch.
+          return fetch(`${apiUrl}/agents/web_search`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+              "X-Workspace-Id": workspaceId,
+              "X-Pensar-Timestamp": timestamp,
+              "X-Pensar-Nonce": nonce,
+              "X-Pensar-Signature": signature,
+            },
+            body,
+          });
+        };
+
+        let response = await sendRequest(tokenResult.token);
+        if (response.status === 401 && tokenResult.type === "workos") {
+          const refreshed = await ensureValidToken(
+            {
+              accessToken: cfg.accessToken,
+              refreshToken: cfg.refreshToken,
+              pensarAPIKey: cfg.pensarAPIKey,
+              workosSession: cfg.workosSession,
+              credentialBackend: cfg.credentialBackend,
+            },
+            { forceRefresh: true, rejectedToken: tokenResult.token },
+          );
+          if (refreshed) {
+            tokenResult = refreshed;
+            response = await sendRequest(tokenResult.token);
+          }
+        }
 
         return handleSearchResponse(response);
       } catch (error: unknown) {

--- a/src/core/agents/offSecAgent/tools/webSearch.ts
+++ b/src/core/agents/offSecAgent/tools/webSearch.ts
@@ -135,7 +135,7 @@ COMMON SEARCH PATTERNS:
         const body = JSON.stringify({ query });
 
         // API key mode: authenticate directly without token exchange or signing
-        if (cfg.pensarAPIKey && !cfg.accessToken) {
+        if (cfg.pensarAPIKey && !cfg.workosSession) {
           // biome-ignore lint/style/noRestrictedGlobals: Pensar Console (not the pentest target); must not pass through targetFetch.
           const response = await fetch(`${apiUrl}/agents/web_search`, {
             method: "POST",

--- a/src/core/ai/providers/pensar.ts
+++ b/src/core/ai/providers/pensar.ts
@@ -61,7 +61,10 @@ export interface PensarModelConfig {
    * If provided, this is called instead of using `apiKey` directly,
    * allowing transparent token refresh for WorkOS auth.
    */
-  getToken?: () => Promise<{ token: string; type: "workos" | "legacy" } | null>;
+  getToken?: (options?: {
+    forceRefresh?: boolean;
+    rejectedToken?: string;
+  }) => Promise<{ token: string; type: "workos" | "legacy" } | null>;
 }
 
 /**
@@ -88,13 +91,16 @@ export function createPensarModel(
   /**
    * Build request headers, resolving the token via getToken() if available.
    */
-  async function buildHeaders(): Promise<Record<string, string>> {
+  async function buildHeaders(options?: {
+    forceRefresh?: boolean;
+    rejectedToken?: string;
+  }): Promise<Record<string, string>> {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
 
     if (config.getToken) {
-      const result = await config.getToken();
+      const result = await config.getToken(options);
       if (!result) {
         logError("buildHeaders: getToken() returned null — auth failed");
         throw new Error(
@@ -264,31 +270,47 @@ export function createPensarModel(
         modelId: bedrockModelId,
         body,
       });
-      const headers = await buildHeaders();
-
-      if (config.signingKey) {
-        const sig = signGatewayRequest(
-          config.signingKey,
-          bedrockModelId,
-          serializedBody,
-        );
-        headers["X-Pensar-Signature"] = sig.signature;
-        headers["X-Pensar-Timestamp"] = sig.timestamp;
-        headers["X-Pensar-Nonce"] = sig.nonce;
-      }
-
-      log(`  headers: ${Object.keys(headers).join(", ")}`);
-
       const fetchSignal = buildStreamingFetchSignal(options.abortSignal);
 
-      let response: Response;
-      try {
-        response = await fetch(url, {
+      const sendRequest = async (authOptions?: {
+        forceRefresh?: boolean;
+        rejectedToken?: string;
+      }) => {
+        const headers = await buildHeaders(authOptions);
+        if (config.signingKey) {
+          const sig = signGatewayRequest(
+            config.signingKey,
+            bedrockModelId,
+            serializedBody,
+          );
+          headers["X-Pensar-Signature"] = sig.signature;
+          headers["X-Pensar-Timestamp"] = sig.timestamp;
+          headers["X-Pensar-Nonce"] = sig.nonce;
+        }
+        log(`  headers: ${Object.keys(headers).join(", ")}`);
+
+        const response = await fetch(url, {
           method: "POST",
           headers,
           signal: fetchSignal,
           body: serializedBody,
         });
+        return { headers, response };
+      };
+
+      let requestResult: Awaited<ReturnType<typeof sendRequest>>;
+      try {
+        requestResult = await sendRequest();
+        if (requestResult.response.status === 401 && config.getToken) {
+          const rejectedToken = requestResult.headers.Authorization?.replace(
+            /^Bearer\s+/,
+            "",
+          );
+          requestResult = await sendRequest({
+            forceRefresh: true,
+            rejectedToken,
+          });
+        }
       } catch (err) {
         logError(`  SSE fetch failed (${Date.now() - startTime}ms):`, err);
         throw new Error(
@@ -296,6 +318,7 @@ export function createPensarModel(
           { cause: err },
         );
       }
+      const { response } = requestResult;
 
       const contentType = response.headers.get("content-type") ?? "unknown";
       const transferEncoding =

--- a/src/core/ai/providers/pensarAuthRetry.test.ts
+++ b/src/core/ai/providers/pensarAuthRetry.test.ts
@@ -1,0 +1,82 @@
+import type { LanguageModelV3CallOptions } from "@ai-sdk/provider";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPensarModel } from "./pensar";
+
+const options = {
+  prompt: [{ role: "user", content: [{ type: "text", text: "test" }] }],
+} as unknown as LanguageModelV3CallOptions;
+
+describe("Pensar model authentication", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("refreshes and retries a rejected WorkOS token once", async () => {
+    const getToken = vi
+      .fn()
+      .mockResolvedValueOnce({ token: "rejected-token", type: "workos" })
+      .mockResolvedValueOnce({ token: "fresh-token", type: "workos" });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("unauthorized", { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response("", {
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const model = createPensarModel("anthropic.claude-test", {
+      apiKey: "",
+      baseUrl: "https://gateway.example.com",
+      getToken,
+      signingKey: "signing-key",
+      workspaceId: "workspace-1",
+    });
+    const result = await model.doStream(options);
+    const reader = result.stream.getReader();
+    while (!(await reader.read()).done) {}
+    reader.releaseLock();
+
+    expect(getToken).toHaveBeenNthCalledWith(1, undefined);
+    expect(getToken).toHaveBeenNthCalledWith(2, {
+      forceRefresh: true,
+      rejectedToken: "rejected-token",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
+      Authorization: "Bearer rejected-token",
+      "X-Workspace-Id": "workspace-1",
+    });
+    expect(fetchMock.mock.calls[1]?.[1]?.headers).toMatchObject({
+      Authorization: "Bearer fresh-token",
+      "X-Workspace-Id": "workspace-1",
+    });
+    expect(fetchMock.mock.calls[1]?.[1]?.headers["X-Pensar-Nonce"]).not.toBe(
+      fetchMock.mock.calls[0]?.[1]?.headers["X-Pensar-Nonce"],
+    );
+  });
+
+  it("does not make a third request when the retry is also rejected", async () => {
+    const getToken = vi
+      .fn()
+      .mockResolvedValueOnce({ token: "rejected-token", type: "workos" })
+      .mockResolvedValueOnce({ token: "still-rejected", type: "workos" });
+    const fetchMock = vi.fn(
+      async () => new Response("unauthorized", { status: 401 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const model = createPensarModel("anthropic.claude-test", {
+      apiKey: "",
+      baseUrl: "https://gateway.example.com",
+      getToken,
+    });
+
+    await expect(model.doStream(options)).rejects.toThrow(
+      "Pensar streaming error (401)",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(getToken).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/core/ai/utils.pensar.test.ts
+++ b/src/core/ai/utils.pensar.test.ts
@@ -1,17 +1,21 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { createPensarModel } = vi.hoisted(() => ({
+const { createPensarModel, ensureValidToken, getConfig } = vi.hoisted(() => ({
   createPensarModel: vi.fn((modelId: string, config: unknown) => ({
     specificationVersion: "v3",
     provider: "pensar",
     modelId: `pensar:${modelId}`,
     config,
   })),
+  ensureValidToken: vi.fn(),
+  getConfig: vi.fn(),
 }));
 
 vi.mock("./providers/pensar", () => ({
   createPensarModel,
 }));
+vi.mock("../auth", () => ({ ensureValidToken }));
+vi.mock("../config", () => ({ config: { get: getConfig } }));
 
 import { getProviderModel } from "./utils";
 
@@ -23,6 +27,8 @@ describe("getProviderModel pensar routing", () => {
 
   afterEach(() => {
     createPensarModel.mockClear();
+    ensureValidToken.mockReset();
+    getConfig.mockReset();
     if (originalEnv.AGENT_API_URL === undefined) {
       delete process.env.AGENT_API_URL;
     } else {
@@ -54,6 +60,46 @@ describe("getProviderModel pensar routing", () => {
         apiKey: "agent-token",
         baseUrl: "https://stage-api.example.com/agent",
       }),
+    );
+  });
+
+  it("restores a persisted WorkOS session through the token manager", async () => {
+    delete process.env.AGENT_API_URL;
+    delete process.env.AGENT_API_TOKEN;
+    getConfig.mockResolvedValue({
+      credentialBackend: "os-vault",
+      workosSession: true,
+    });
+    ensureValidToken.mockResolvedValue({
+      token: "restored-token",
+      type: "workos",
+    });
+
+    const model = getProviderModel("pensar:openai.gpt-5.5", {
+      gatewayUrl: "https://gateway.example.com",
+      workosSession: true,
+      workspaceId: "workspace-1",
+    }) as unknown as {
+      config: {
+        getToken: (options: {
+          forceRefresh: boolean;
+          rejectedToken: string;
+        }) => Promise<unknown>;
+      };
+    };
+
+    await expect(
+      model.config.getToken({
+        forceRefresh: true,
+        rejectedToken: "old-token",
+      }),
+    ).resolves.toEqual({ token: "restored-token", type: "workos" });
+    expect(ensureValidToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentialBackend: "os-vault",
+        workosSession: true,
+      }),
+      { forceRefresh: true, rejectedToken: "old-token" },
     );
   });
 });

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -65,6 +65,7 @@ export type AIAuthConfig = {
   // WorkOS CLI auth
   accessToken?: string;
   refreshToken?: string;
+  workosSession?: boolean;
   workspaceId?: string;
   // Gateway request signing
   gatewaySigningKey?: string;
@@ -96,6 +97,7 @@ export function buildAuthConfig(cfg: {
   pensarAPIKey?: string | null;
   accessToken?: string | null;
   refreshToken?: string | null;
+  workosSession?: boolean;
   workspaceId?: string | null;
   gatewaySigningKey?: string | null;
   gatewayUrl?: string | null;
@@ -111,6 +113,7 @@ export function buildAuthConfig(cfg: {
     pensarAPIKey: cfg.pensarAPIKey ?? undefined,
     accessToken: cfg.accessToken ?? undefined,
     refreshToken: cfg.refreshToken ?? undefined,
+    workosSession: cfg.workosSession,
     workspaceId: cfg.workspaceId ?? undefined,
     gatewaySigningKey: cfg.gatewaySigningKey ?? undefined,
     gatewayUrl: cfg.gatewayUrl ?? undefined,
@@ -252,7 +255,11 @@ export function getProviderModel(
         authConfig?.pensarAPIKey || process.env.PENSAR_API_KEY;
       const agentApiUrl = process.env.AGENT_API_URL;
       const agentApiToken = process.env.AGENT_API_TOKEN;
-      const hasWorkOSAuth = !!authConfig?.accessToken;
+      const hasWorkOSAuth = !!(
+        authConfig?.workosSession ||
+        authConfig?.refreshToken ||
+        authConfig?.accessToken
+      );
       const hasSandboxAgentAuth = !!agentApiUrl && !!agentApiToken;
 
       if (!pensarApiKey && !hasWorkOSAuth && !hasSandboxAgentAuth) {
@@ -283,13 +290,18 @@ export function getProviderModel(
       // Read fresh config each time so rotated tokens are picked up
       // (WorkOS refresh tokens are single-use).
       if (!hasSandboxAgentAuth && hasWorkOSAuth) {
-        modelConfig.getToken = async () => {
+        modelConfig.getToken = async (options) => {
           const freshConfig = await config.get();
-          return ensureValidToken({
-            accessToken: freshConfig.accessToken,
-            refreshToken: freshConfig.refreshToken,
-            pensarAPIKey: freshConfig.pensarAPIKey,
-          });
+          return ensureValidToken(
+            {
+              accessToken: freshConfig.accessToken,
+              refreshToken: freshConfig.refreshToken,
+              pensarAPIKey: freshConfig.pensarAPIKey,
+              workosSession: freshConfig.workosSession,
+              credentialBackend: freshConfig.credentialBackend,
+            },
+            options,
+          );
         };
       }
 

--- a/src/core/api/apiClient.test.ts
+++ b/src/core/api/apiClient.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { ensureValidToken, getConfig } = vi.hoisted(() => ({
+  ensureValidToken: vi.fn(),
+  getConfig: vi.fn(async () => ({
+    workosSession: true,
+    workspaceId: "workspace-1",
+  })),
+}));
+
+vi.mock("../auth", () => ({ ensureValidToken }));
+vi.mock("../config", () => ({ config: { get: getConfig } }));
+vi.mock("./constants", () => ({
+  getPensarApiUrl: () => "https://console.example.com",
+}));
+
+import { apiRequest } from "./apiClient";
+
+describe("apiRequest authentication", () => {
+  afterEach(() => {
+    ensureValidToken.mockReset();
+    getConfig.mockClear();
+    vi.unstubAllGlobals();
+  });
+
+  it("refreshes and retries once after a WorkOS token is rejected", async () => {
+    ensureValidToken
+      .mockResolvedValueOnce({ token: "rejected-token", type: "workos" })
+      .mockResolvedValueOnce({ token: "fresh-token", type: "workos" });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("unauthorized", { status: 401 }))
+      .mockResolvedValueOnce(Response.json({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiRequest("GET", "/resource")).resolves.toEqual({
+      ok: true,
+    });
+
+    expect(ensureValidToken).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ workosSession: true }),
+      { forceRefresh: true, rejectedToken: "rejected-token" },
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[1]?.headers).toMatchObject({
+      Authorization: "Bearer fresh-token",
+      "X-Workspace-Id": "workspace-1",
+    });
+  });
+
+  it("does not refresh or retry rejected legacy credentials", async () => {
+    ensureValidToken.mockResolvedValue({
+      token: "legacy-token",
+      type: "legacy",
+    });
+    const fetchMock = vi.fn(
+      async () => new Response("unauthorized", { status: 401 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiRequest("GET", "/resource")).rejects.toThrow(
+      "API error (401)",
+    );
+    expect(ensureValidToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/api/apiClient.ts
+++ b/src/core/api/apiClient.ts
@@ -9,14 +9,26 @@ import { ensureValidToken } from "../auth";
 import { config } from "../config";
 import { getPensarApiUrl } from "./constants";
 
-async function getAuthHeaders(): Promise<Record<string, string>> {
+async function getAuthHeaders(options?: {
+  forceRefresh?: boolean;
+  rejectedToken?: string;
+}): Promise<{
+  headers: Record<string, string>;
+  token: string;
+  type: "workos" | "legacy";
+}> {
   const cfg = await config.get();
 
-  const validToken = await ensureValidToken({
-    accessToken: cfg.accessToken,
-    refreshToken: cfg.refreshToken,
-    pensarAPIKey: cfg.pensarAPIKey,
-  });
+  const validToken = await ensureValidToken(
+    {
+      accessToken: cfg.accessToken,
+      refreshToken: cfg.refreshToken,
+      pensarAPIKey: cfg.pensarAPIKey,
+      workosSession: cfg.workosSession,
+      credentialBackend: cfg.credentialBackend,
+    },
+    options,
+  );
 
   if (!validToken) {
     throw new Error(
@@ -33,7 +45,7 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
     headers["X-Workspace-Id"] = cfg.workspaceId;
   }
 
-  return headers;
+  return { headers, token: validToken.token, type: validToken.type };
 }
 
 export async function apiRequest<T>(
@@ -42,15 +54,22 @@ export async function apiRequest<T>(
   body?: unknown,
 ): Promise<T> {
   const baseUrl = getPensarApiUrl();
-  const headers = await getAuthHeaders();
+  let auth = await getAuthHeaders();
   const url = `${baseUrl}${path}`;
 
-  const init: RequestInit = { method, headers };
+  const init: RequestInit = { method, headers: auth.headers };
   if (body !== undefined) {
     init.body = JSON.stringify(body);
   }
 
-  const response = await fetch(url, init);
+  let response = await fetch(url, init);
+  if (response.status === 401 && auth.type === "workos") {
+    auth = await getAuthHeaders({
+      forceRefresh: true,
+      rejectedToken: auth.token,
+    });
+    response = await fetch(url, { ...init, headers: auth.headers });
+  }
 
   if (!response.ok) {
     const text = await response.text();

--- a/src/core/auth/connection.ts
+++ b/src/core/auth/connection.ts
@@ -1,4 +1,5 @@
 import { config } from "../config";
+import { clearWorkOSSession } from "./token";
 
 /**
  * Check whether the user is connected to Pensar Console
@@ -7,20 +8,27 @@ import { config } from "../config";
 export function isConnected(cfg: {
   accessToken?: string | null;
   pensarAPIKey?: string | null;
+  refreshToken?: string | null;
+  workosSession?: boolean;
 }): boolean {
-  return !!(cfg.accessToken || cfg.pensarAPIKey);
+  return !!(
+    cfg.workosSession ||
+    cfg.refreshToken ||
+    cfg.accessToken ||
+    cfg.pensarAPIKey
+  );
 }
 
 /**
  * Disconnect from Pensar Console by clearing all auth fields in the config.
  */
 export async function disconnect(): Promise<void> {
+  await clearWorkOSSession();
   await config.update({
     pensarAPIKey: null,
-    accessToken: null,
-    refreshToken: null,
     workspaceId: null,
     workspaceSlug: null,
     gatewaySigningKey: null,
+    gatewayUrl: null,
   });
 }

--- a/src/core/auth/credential-store.test.ts
+++ b/src/core/auth/credential-store.test.ts
@@ -1,0 +1,140 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CredentialStoreUnavailableError,
+  createCredentialStore,
+} from "./credential-store";
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryHome(): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "apex-credentials-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe("credential store", () => {
+  it("uses the native credential store when available", async () => {
+    const homeDir = await temporaryHome();
+    let password: string | undefined;
+    const store = createCredentialStore({
+      homeDir,
+      nativeSecrets: {
+        delete: async () => {
+          password = undefined;
+          return true;
+        },
+        get: async () => password ?? null,
+        set: async ({ value }) => {
+          password = value;
+        },
+      },
+    });
+
+    await expect(store.save("refresh-token")).resolves.toBe("os-vault");
+    await expect(store.load()).resolves.toEqual({
+      backend: "os-vault",
+      refreshToken: "refresh-token",
+    });
+
+    await store.clear();
+    await expect(store.load()).resolves.toBeNull();
+  });
+
+  it("falls back to a private file when the native store is unavailable", async () => {
+    const homeDir = await temporaryHome();
+    const unavailable = async () => {
+      throw new Error("secret service unavailable");
+    };
+    const store = createCredentialStore({
+      homeDir,
+      nativeSecrets: {
+        delete: unavailable,
+        get: unavailable,
+        set: unavailable,
+      },
+    });
+
+    await expect(store.save("refresh-token")).resolves.toBe("secure-file");
+    await expect(store.load()).resolves.toEqual({
+      backend: "secure-file",
+      refreshToken: "refresh-token",
+    });
+
+    const pensarDir = path.join(homeDir, ".pensar");
+    const authFile = path.join(pensarDir, "auth.json");
+    expect(JSON.parse(await readFile(authFile, "utf8"))).toEqual({
+      refreshToken: "refresh-token",
+    });
+    if (process.platform !== "win32") {
+      expect((await stat(pensarDir)).mode & 0o777).toBe(0o700);
+      expect((await stat(authFile)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("does not confuse a temporarily unavailable OS vault with logout", async () => {
+    const homeDir = await temporaryHome();
+    const store = createCredentialStore({
+      homeDir,
+      nativeSecrets: {
+        delete: async () => false,
+        get: async () => {
+          throw new Error("credential vault locked");
+        },
+        set: async () => {},
+      },
+    });
+
+    await expect(store.load()).rejects.toBeInstanceOf(
+      CredentialStoreUnavailableError,
+    );
+  });
+
+  it("removes the fallback after the native store becomes available", async () => {
+    const homeDir = await temporaryHome();
+    const fallbackStore = createCredentialStore({
+      homeDir,
+      nativeSecrets: {
+        delete: async () => false,
+        get: async () => {
+          throw new Error("credential vault locked");
+        },
+        set: async () => {
+          throw new Error("credential vault locked");
+        },
+      },
+    });
+    await fallbackStore.save("old-token");
+
+    let password: string | undefined;
+    const nativeStore = createCredentialStore({
+      homeDir,
+      nativeSecrets: {
+        delete: async () => true,
+        get: async () => password ?? null,
+        set: async ({ value }) => {
+          password = value;
+        },
+      },
+    });
+
+    await expect(nativeStore.save("new-token")).resolves.toBe("os-vault");
+    await expect(nativeStore.load()).resolves.toEqual({
+      backend: "os-vault",
+      refreshToken: "new-token",
+    });
+    await expect(
+      readFile(path.join(homeDir, ".pensar", "auth.json"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/src/core/auth/credential-store.ts
+++ b/src/core/auth/credential-store.ts
@@ -173,6 +173,14 @@ export function createCredentialStore(
         log.warn("Native credential store unavailable; using secure file", {
           error: String(error),
         });
+        try {
+          await getNativeSecrets(options).delete({
+            service: SERVICE,
+            name: ACCOUNT,
+          });
+        } catch {
+          // Ignore errors clearing vault - already in fallback mode
+        }
         await saveFallback(refreshToken);
         return "secure-file";
       }

--- a/src/core/auth/credential-store.ts
+++ b/src/core/auth/credential-store.ts
@@ -178,8 +178,12 @@ export function createCredentialStore(
             service: SERVICE,
             name: ACCOUNT,
           });
-        } catch {
-          // Ignore errors clearing vault - already in fallback mode
+        } catch (clearError) {
+          if (!isMissingEntryError(clearError)) {
+            log.warn("Unable to clear stale vault credential during fallback", {
+              error: String(clearError),
+            });
+          }
         }
         await saveFallback(refreshToken);
         return "secure-file";
@@ -187,11 +191,13 @@ export function createCredentialStore(
     },
 
     async clear() {
+      let vaultCleared = false;
       try {
         await getNativeSecrets(options).delete({
           service: SERVICE,
           name: ACCOUNT,
         });
+        vaultCleared = true;
       } catch (error) {
         if (!isMissingEntryError(error)) {
           log.warn("Unable to clear native auth credential", {

--- a/src/core/auth/credential-store.ts
+++ b/src/core/auth/credential-store.ts
@@ -185,14 +185,11 @@ export function createCredentialStore(
           name: ACCOUNT,
         });
       } catch (error) {
-        if (isMissingEntryError(error)) {
-          await clearFallback();
-          return;
+        if (!isMissingEntryError(error)) {
+          log.warn("Unable to clear native auth credential", {
+            error: String(error),
+          });
         }
-        log.warn("Unable to clear native auth credential", {
-          error: String(error),
-        });
-        throw new CredentialStoreUnavailableError({ cause: error });
       }
       await clearFallback();
     },

--- a/src/core/auth/credential-store.ts
+++ b/src/core/auth/credential-store.ts
@@ -1,0 +1,199 @@
+import {
+  chmod,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { createLogger } from "../logger/structured";
+import { scopedLogger } from "../util/lazyLogger";
+
+const SERVICE = "dev.pensar.apex";
+const ACCOUNT = "workos-refresh-token";
+const log = scopedLogger(() => createLogger("auth:credential-store"));
+
+export type CredentialBackend = "os-vault" | "secure-file";
+
+export interface StoredRefreshToken {
+  backend: CredentialBackend;
+  refreshToken: string;
+}
+
+export interface AuthCredentialStore {
+  clear(): Promise<void>;
+  load(): Promise<StoredRefreshToken | null>;
+  save(refreshToken: string): Promise<CredentialBackend>;
+}
+
+export class CredentialStoreUnavailableError extends Error {
+  constructor(options?: ErrorOptions) {
+    super("The operating system credential store is unavailable", options);
+    this.name = "CredentialStoreUnavailableError";
+  }
+}
+
+interface NativeSecrets {
+  delete(options: { name: string; service: string }): Promise<boolean>;
+  get(options: { name: string; service: string }): Promise<string | null>;
+  set(options: { name: string; service: string; value: string }): Promise<void>;
+}
+
+interface KeyringEntry {
+  deleteCredential(): Promise<boolean>;
+  getPassword(): Promise<string | undefined>;
+  setPassword(password: string): Promise<void>;
+}
+
+interface KeyringModule {
+  AsyncEntry: new (service: string, account: string) => KeyringEntry;
+}
+
+interface CredentialStoreOptions {
+  homeDir?: string;
+  nativeSecrets?: NativeSecrets;
+}
+
+let nodeSecrets: NativeSecrets | null = null;
+
+function getNativeSecrets(options: CredentialStoreOptions): NativeSecrets {
+  if (options.nativeSecrets) return options.nativeSecrets;
+  if (typeof Bun !== "undefined" && Bun.secrets) return Bun.secrets;
+  if (nodeSecrets) return nodeSecrets;
+
+  const require = createRequire(import.meta.url);
+  const { AsyncEntry } = require("@napi-rs/keyring") as KeyringModule;
+  const entry = new AsyncEntry(SERVICE, ACCOUNT);
+  nodeSecrets = {
+    delete: () => entry.deleteCredential(),
+    get: async () => (await entry.getPassword()) ?? null,
+    set: ({ value }) => entry.setPassword(value),
+  };
+  return nodeSecrets;
+}
+
+function isMissingEntryError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /no entry|not found|no matching/i.test(message);
+}
+
+export function createCredentialStore(
+  options: CredentialStoreOptions = {},
+): AuthCredentialStore {
+  const homeDir = options.homeDir ?? os.homedir();
+  const pensarDir = path.join(homeDir, ".pensar");
+  const fallbackPath = path.join(pensarDir, "auth.json");
+
+  const ensurePrivateDirectory = async () => {
+    await mkdir(pensarDir, { recursive: true, mode: 0o700 });
+    await chmod(pensarDir, 0o700).catch(() => {});
+  };
+
+  const loadFallback = async (): Promise<string | null> => {
+    try {
+      const raw = JSON.parse(await readFile(fallbackPath, "utf8")) as {
+        refreshToken?: unknown;
+      };
+      await chmod(fallbackPath, 0o600).catch(() => {});
+      return typeof raw.refreshToken === "string" && raw.refreshToken
+        ? raw.refreshToken
+        : null;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") return null;
+      log.warn("Unable to read secure auth fallback", { error: String(error) });
+      return null;
+    }
+  };
+
+  const saveFallback = async (refreshToken: string) => {
+    await ensurePrivateDirectory();
+    const temporaryPath = `${fallbackPath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+    try {
+      await writeFile(temporaryPath, JSON.stringify({ refreshToken }), {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+      await chmod(temporaryPath, 0o600).catch(() => {});
+      await rename(temporaryPath, fallbackPath);
+      await chmod(fallbackPath, 0o600).catch(() => {});
+    } finally {
+      await rm(temporaryPath, { force: true }).catch(() => {});
+    }
+  };
+
+  const clearFallback = async () => {
+    await rm(fallbackPath, { force: true }).catch(() => {});
+  };
+
+  return {
+    async load() {
+      let nativeStoreError: unknown;
+      try {
+        const refreshToken = await getNativeSecrets(options).get({
+          service: SERVICE,
+          name: ACCOUNT,
+        });
+        if (refreshToken) return { backend: "os-vault", refreshToken };
+      } catch (error) {
+        if (!isMissingEntryError(error)) {
+          nativeStoreError = error;
+          log.warn(
+            "Native credential store unavailable; checking secure file fallback",
+            { error: String(error) },
+          );
+        }
+      }
+
+      const refreshToken = await loadFallback();
+      if (refreshToken) return { backend: "secure-file", refreshToken };
+      if (nativeStoreError) {
+        throw new CredentialStoreUnavailableError({
+          cause: nativeStoreError,
+        });
+      }
+      return null;
+    },
+
+    async save(refreshToken) {
+      if (!refreshToken) throw new Error("Cannot store an empty refresh token");
+
+      try {
+        await getNativeSecrets(options).set({
+          service: SERVICE,
+          name: ACCOUNT,
+          value: refreshToken,
+        });
+        await clearFallback();
+        return "os-vault";
+      } catch (error) {
+        log.warn("Native credential store unavailable; using secure file", {
+          error: String(error),
+        });
+        await saveFallback(refreshToken);
+        return "secure-file";
+      }
+    },
+
+    async clear() {
+      try {
+        await getNativeSecrets(options).delete({
+          service: SERVICE,
+          name: ACCOUNT,
+        });
+      } catch (error) {
+        if (!isMissingEntryError(error)) {
+          log.warn("Unable to clear native auth credential", {
+            error: String(error),
+          });
+        }
+      }
+      await clearFallback();
+    },
+  };
+}
+
+export const authCredentialStore = createCredentialStore();

--- a/src/core/auth/credential-store.ts
+++ b/src/core/auth/credential-store.ts
@@ -185,11 +185,14 @@ export function createCredentialStore(
           name: ACCOUNT,
         });
       } catch (error) {
-        if (!isMissingEntryError(error)) {
-          log.warn("Unable to clear native auth credential", {
-            error: String(error),
-          });
+        if (isMissingEntryError(error)) {
+          await clearFallback();
+          return;
         }
+        log.warn("Unable to clear native auth credential", {
+          error: String(error),
+        });
+        throw new CredentialStoreUnavailableError({ cause: error });
       }
       await clearFallback();
     },

--- a/src/core/auth/gateway.ts
+++ b/src/core/auth/gateway.ts
@@ -28,26 +28,44 @@ export interface GatewayValidateResult {
 export async function validateGateway(): Promise<GatewayValidateResult | null> {
   const cfg = await config.get();
 
-  const tokenResult = await ensureValidToken({
+  let tokenResult = await ensureValidToken({
     accessToken: cfg.accessToken,
     refreshToken: cfg.refreshToken,
     pensarAPIKey: cfg.pensarAPIKey,
+    workosSession: cfg.workosSession,
+    credentialBackend: cfg.credentialBackend,
   });
 
   if (!tokenResult) return null;
 
   const gatewayUrl = cfg.gatewayUrl || getPensarGatewayUrl();
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${tokenResult.token}`,
+  const sendRequest = (token: string) => {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    };
+    if (cfg.workspaceId) headers["X-Workspace-Id"] = cfg.workspaceId;
+    return fetch(`${gatewayUrl}/gateway/validate`, {
+      method: "GET",
+      headers,
+    });
   };
-  if (cfg.workspaceId) {
-    headers["X-Workspace-Id"] = cfg.workspaceId;
-  }
 
-  const response = await fetch(`${gatewayUrl}/gateway/validate`, {
-    method: "GET",
-    headers,
-  });
+  let response = await sendRequest(tokenResult.token);
+  if (response.status === 401 && tokenResult.type === "workos") {
+    const refreshed = await ensureValidToken(
+      {
+        accessToken: cfg.accessToken,
+        refreshToken: cfg.refreshToken,
+        pensarAPIKey: cfg.pensarAPIKey,
+        workosSession: cfg.workosSession,
+        credentialBackend: cfg.credentialBackend,
+      },
+      { forceRefresh: true, rejectedToken: tokenResult.token },
+    );
+    if (!refreshed) return null;
+    tokenResult = refreshed;
+    response = await sendRequest(tokenResult.token);
+  }
 
   if (!response.ok) {
     throw new Error(`Gateway validation failed (${response.status})`);

--- a/src/core/auth/index.ts
+++ b/src/core/auth/index.ts
@@ -13,13 +13,9 @@ export type {
   WorkOSSessionTokens,
 } from "./token";
 export {
-  AuthRefreshError,
   AuthSessionExpiredError,
-  clearWorkOSSession,
   ensureValidToken,
-  isTokenExpired,
   saveWorkOSSession,
-  WorkOSTokenManager,
 } from "./token";
 export type {
   CreateWorkspaceSelectionResponse,

--- a/src/core/auth/index.ts
+++ b/src/core/auth/index.ts
@@ -7,7 +7,20 @@ export {
 export type { GatewayValidateResult } from "./gateway";
 export { validateGateway } from "./gateway";
 export { signGatewayRequest } from "./signing";
-export { ensureValidToken, isTokenExpired } from "./token";
+export type {
+  EnsureValidTokenOptions,
+  TokenConfig,
+  WorkOSSessionTokens,
+} from "./token";
+export {
+  AuthRefreshError,
+  AuthSessionExpiredError,
+  clearWorkOSSession,
+  ensureValidToken,
+  isTokenExpired,
+  saveWorkOSSession,
+  WorkOSTokenManager,
+} from "./token";
 export type {
   CreateWorkspaceSelectionResponse,
   DeviceFlowInfo,

--- a/src/core/auth/refresh-lock.test.ts
+++ b/src/core/auth/refresh-lock.test.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withAuthRefreshLock } from "./refresh-lock";
+
+describe("withAuthRefreshLock", () => {
+  it("serializes refresh work across callers", async () => {
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "apex-auth-lock-"));
+    const events: string[] = [];
+    let releaseFirst: () => void = () => {};
+    const firstCanFinish = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let markFirstStarted: () => void = () => {};
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+
+    try {
+      const first = withAuthRefreshLock(
+        async () => {
+          events.push("first:start");
+          markFirstStarted();
+          await firstCanFinish;
+          events.push("first:end");
+        },
+        { homeDir, retryMs: 5 },
+      );
+      await firstStarted;
+      const second = withAuthRefreshLock(
+        async () => {
+          events.push("second:start");
+          events.push("second:end");
+        },
+        { homeDir, retryMs: 5 },
+      );
+
+      releaseFirst();
+      await Promise.all([first, second]);
+      expect(events).toEqual([
+        "first:start",
+        "first:end",
+        "second:start",
+        "second:end",
+      ]);
+    } finally {
+      await rm(homeDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/src/core/auth/refresh-lock.ts
+++ b/src/core/auth/refresh-lock.ts
@@ -1,9 +1,9 @@
-import { chmod, mkdir, open, rm, stat } from "node:fs/promises";
+import { chmod, mkdir, open, readFile, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
 const LOCK_RETRY_MS = 50;
-const LOCK_TIMEOUT_MS = 15_000;
+const LOCK_TIMEOUT_MS = 35_000;
 const STALE_LOCK_MS = 30_000;
 
 interface RefreshLockOptions {
@@ -37,14 +37,22 @@ export async function withAuthRefreshLock<T>(
   while (true) {
     try {
       const handle = await open(lockPath, "wx", 0o600);
+      const pid = process.pid;
       try {
-        await handle.writeFile(
-          JSON.stringify({ pid: process.pid, createdAt: now() }),
-        );
+        await handle.writeFile(JSON.stringify({ pid, createdAt: now() }));
         return await action();
       } finally {
         await handle.close().catch(() => {});
-        await rm(lockPath, { force: true }).catch(() => {});
+        // Only remove if we still own it
+        try {
+          const content = await readFile(lockPath, "utf8");
+          const lock = JSON.parse(content) as { pid: number };
+          if (lock.pid === pid) {
+            await rm(lockPath, { force: true }).catch(() => {});
+          }
+        } catch {
+          // Lock was already removed or is unreadable
+        }
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;

--- a/src/core/auth/refresh-lock.ts
+++ b/src/core/auth/refresh-lock.ts
@@ -1,0 +1,65 @@
+import { chmod, mkdir, open, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const LOCK_RETRY_MS = 50;
+const LOCK_TIMEOUT_MS = 15_000;
+const STALE_LOCK_MS = 30_000;
+
+interface RefreshLockOptions {
+  homeDir?: string;
+  now?: () => number;
+  retryMs?: number;
+  staleMs?: number;
+  timeoutMs?: number;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function withAuthRefreshLock<T>(
+  action: () => Promise<T>,
+  options: RefreshLockOptions = {},
+): Promise<T> {
+  const homeDir = options.homeDir ?? os.homedir();
+  const pensarDir = path.join(homeDir, ".pensar");
+  const lockPath = path.join(pensarDir, "auth-refresh.lock");
+  const now = options.now ?? Date.now;
+  const retryMs = options.retryMs ?? LOCK_RETRY_MS;
+  const staleMs = options.staleMs ?? STALE_LOCK_MS;
+  const timeoutMs = options.timeoutMs ?? LOCK_TIMEOUT_MS;
+  const deadline = now() + timeoutMs;
+
+  await mkdir(pensarDir, { recursive: true, mode: 0o700 });
+  await chmod(pensarDir, 0o700).catch(() => {});
+
+  while (true) {
+    try {
+      const handle = await open(lockPath, "wx", 0o600);
+      try {
+        await handle.writeFile(
+          JSON.stringify({ pid: process.pid, createdAt: now() }),
+        );
+        return await action();
+      } finally {
+        await handle.close().catch(() => {});
+        await rm(lockPath, { force: true }).catch(() => {});
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+
+      const lockStat = await stat(lockPath).catch(() => null);
+      if (lockStat && now() - lockStat.mtimeMs > staleMs) {
+        await rm(lockPath, { force: true }).catch(() => {});
+        continue;
+      }
+      if (now() >= deadline) {
+        throw new Error(
+          "Timed out waiting for another Apex process to refresh auth",
+        );
+      }
+      await sleep(retryMs);
+    }
+  }
+}

--- a/src/core/auth/token.test.ts
+++ b/src/core/auth/token.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AuthCredentialStore,
+  CredentialBackend,
+  StoredRefreshToken,
+} from "./credential-store";
+import { CredentialStoreUnavailableError } from "./credential-store";
+import {
+  AuthRefreshError,
+  AuthSessionExpiredError,
+  WorkOSTokenManager,
+} from "./token";
+
+function futureJwt(subject: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none" })).toString(
+    "base64url",
+  );
+  const payload = Buffer.from(
+    JSON.stringify({ subject, exp: Math.floor(Date.now() / 1000) + 3600 }),
+  ).toString("base64url");
+  return `${header}.${payload}.signature`;
+}
+
+function memoryStore(initial?: string): AuthCredentialStore & {
+  current(): string | null;
+} {
+  let refreshToken = initial ?? null;
+  return {
+    clear: vi.fn(async () => {
+      refreshToken = null;
+    }),
+    current: () => refreshToken,
+    load: vi.fn(
+      async (): Promise<StoredRefreshToken | null> =>
+        refreshToken ? { backend: "os-vault", refreshToken } : null,
+    ),
+    save: vi.fn(async (next): Promise<CredentialBackend> => {
+      refreshToken = next;
+      return "os-vault";
+    }),
+  };
+}
+
+function refreshedResponse(
+  accessToken: string,
+  refreshToken: string,
+): Response {
+  return Response.json({
+    access_token: accessToken,
+    refresh_token: refreshToken,
+  });
+}
+
+function createManager(options: {
+  fetch?: typeof fetch;
+  initialRefreshToken?: string;
+}) {
+  const store = memoryStore(options.initialRefreshToken);
+  const updates: Record<string, unknown>[] = [];
+  const manager = new WorkOSTokenManager({
+    fetch: options.fetch,
+    getClientId: async () => "client-id",
+    store,
+    updateConfig: async (next) => {
+      updates.push(next);
+    },
+    withRefreshLock: async (action) => action(),
+  });
+  return { manager, store, updates };
+}
+
+describe("WorkOSTokenManager", () => {
+  it("stores only the refresh token and keeps the access token in memory", async () => {
+    const { manager, store, updates } = createManager({});
+    const accessToken = futureJwt("saved");
+
+    await manager.saveSession({ accessToken, refreshToken: "refresh-1" });
+
+    expect(store.current()).toBe("refresh-1");
+    expect(updates).toEqual([
+      {
+        accessToken: null,
+        credentialBackend: "os-vault",
+        refreshToken: null,
+        workosSession: true,
+      },
+    ]);
+    await expect(
+      manager.ensureValidToken({ workosSession: true }),
+    ).resolves.toEqual({ token: accessToken, type: "workos" });
+  });
+
+  it("single-flights concurrent refreshes and persists the rotated token first", async () => {
+    const accessToken = futureJwt("rotated");
+    const fetchMock = vi.fn(async () =>
+      refreshedResponse(accessToken, "refresh-2"),
+    );
+    const { manager, store, updates } = createManager({
+      fetch: fetchMock as unknown as typeof fetch,
+      initialRefreshToken: "refresh-1",
+    });
+
+    const results = await Promise.all([
+      manager.ensureValidToken({ workosSession: true }),
+      manager.ensureValidToken({ workosSession: true }),
+    ]);
+
+    expect(results).toEqual([
+      { token: accessToken, type: "workos" },
+      { token: accessToken, type: "workos" },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(store.current()).toBe("refresh-2");
+    expect(updates.at(-1)).toMatchObject({
+      credentialBackend: "os-vault",
+      workosSession: true,
+    });
+  });
+
+  it("force refreshes a token rejected by the API exactly once", async () => {
+    const initialAccessToken = futureJwt("initial");
+    const refreshedAccessToken = futureJwt("refreshed");
+    const fetchMock = vi.fn(async () =>
+      refreshedResponse(refreshedAccessToken, "refresh-2"),
+    );
+    const { manager } = createManager({
+      fetch: fetchMock as unknown as typeof fetch,
+      initialRefreshToken: "refresh-1",
+    });
+    await manager.saveSession({
+      accessToken: initialAccessToken,
+      refreshToken: "refresh-1",
+    });
+
+    await expect(
+      manager.ensureValidToken(
+        { workosSession: true },
+        { forceRefresh: true, rejectedToken: initialAccessToken },
+      ),
+    ).resolves.toEqual({ token: refreshedAccessToken, type: "workos" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the refresh token after a transient refresh failure", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("offline");
+    });
+    const { manager, store } = createManager({
+      fetch: fetchMock as unknown as typeof fetch,
+      initialRefreshToken: "refresh-1",
+    });
+
+    await expect(
+      manager.ensureValidToken({ workosSession: true }),
+    ).rejects.toBeInstanceOf(AuthRefreshError);
+    expect(store.current()).toBe("refresh-1");
+  });
+
+  it("preserves the session marker when the credential store is locked", async () => {
+    const updates: Record<string, unknown>[] = [];
+    const manager = new WorkOSTokenManager({
+      getClientId: async () => "client-id",
+      store: {
+        clear: async () => {},
+        load: async () => {
+          throw new CredentialStoreUnavailableError();
+        },
+        save: async () => "os-vault",
+      },
+      updateConfig: async (next) => {
+        updates.push(next);
+      },
+      withRefreshLock: async (action) => action(),
+    });
+
+    await expect(
+      manager.ensureValidToken({ workosSession: true }),
+    ).rejects.toBeInstanceOf(AuthRefreshError);
+    expect(updates).toEqual([]);
+  });
+
+  it("clears an invalid refresh session", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 401 }));
+    const { manager, store, updates } = createManager({
+      fetch: fetchMock as unknown as typeof fetch,
+      initialRefreshToken: "invalid-refresh",
+    });
+
+    await expect(
+      manager.ensureValidToken({ workosSession: true }),
+    ).rejects.toBeInstanceOf(AuthSessionExpiredError);
+    expect(store.current()).toBeNull();
+    expect(updates.at(-1)).toEqual({
+      accessToken: null,
+      credentialBackend: null,
+      refreshToken: null,
+      workosSession: false,
+    });
+  });
+
+  it("migrates legacy plaintext tokens into secure storage", async () => {
+    const { manager, store, updates } = createManager({});
+    const accessToken = futureJwt("legacy");
+
+    await expect(
+      manager.ensureValidToken({
+        accessToken,
+        refreshToken: "legacy-refresh",
+      }),
+    ).resolves.toEqual({ token: accessToken, type: "workos" });
+
+    expect(store.current()).toBe("legacy-refresh");
+    expect(updates).toContainEqual({
+      accessToken: null,
+      credentialBackend: "os-vault",
+      refreshToken: null,
+      workosSession: true,
+    });
+  });
+
+  it("clears a stale session marker when its credential is gone", async () => {
+    const { manager, updates } = createManager({});
+
+    await expect(
+      manager.ensureValidToken({ workosSession: true }),
+    ).rejects.toBeInstanceOf(AuthSessionExpiredError);
+    expect(updates).toContainEqual({
+      credentialBackend: null,
+      workosSession: false,
+    });
+  });
+});

--- a/src/core/auth/token.ts
+++ b/src/core/auth/token.ts
@@ -229,6 +229,9 @@ export class WorkOSTokenManager {
       }
       return;
     }
+    if (current.workosSession !== undefined) {
+      return;
+    }
     if (this.migrationPromise) return this.migrationPromise;
 
     this.migrationPromise = this.withRefreshLock(async () => {

--- a/src/core/auth/token.ts
+++ b/src/core/auth/token.ts
@@ -2,12 +2,63 @@
 // module directly.
 import { getPensarApiUrl } from "../api/constants";
 import { config } from "../config";
+import { createLogger } from "../logger/structured";
+import { scopedLogger } from "../util/lazyLogger";
+import {
+  type AuthCredentialStore,
+  authCredentialStore,
+  type CredentialBackend,
+  CredentialStoreUnavailableError,
+  type StoredRefreshToken,
+} from "./credential-store";
+import { withAuthRefreshLock } from "./refresh-lock";
 import type { ValidToken } from "./types";
 
-/**
- * Decode a JWT payload without verifying the signature.
- * Used client-side to check token expiry before making API calls.
- */
+const log = scopedLogger(() => createLogger("auth:token"));
+
+export interface WorkOSSessionTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface TokenConfig {
+  accessToken?: string | null;
+  credentialBackend?: CredentialBackend | null;
+  pensarAPIKey?: string | null;
+  refreshToken?: string | null;
+  workosSession?: boolean;
+}
+
+export interface EnsureValidTokenOptions {
+  forceRefresh?: boolean;
+  rejectedToken?: string;
+}
+
+interface TokenManagerOptions {
+  fetch?: typeof fetch;
+  getClientId?: () => Promise<string | null>;
+  store?: AuthCredentialStore;
+  updateConfig?: (next: Partial<TokenConfig>) => Promise<void>;
+  withRefreshLock?: <T>(action: () => Promise<T>) => Promise<T>;
+}
+
+export class AuthSessionExpiredError extends Error {
+  constructor(
+    message = "Your Pensar Console session expired. Run /login to reconnect.",
+  ) {
+    super(message);
+    this.name = "AuthSessionExpiredError";
+  }
+}
+
+export class AuthRefreshError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "AuthRefreshError";
+  }
+}
+
+/** Decode a JWT payload for local expiry scheduling only. */
 function decodeJwtPayload(token: string): Record<string, unknown> | null {
   try {
     const parts = token.split(".");
@@ -19,10 +70,7 @@ function decodeJwtPayload(token: string): Record<string, unknown> | null {
   }
 }
 
-/**
- * Check if a JWT access token is expired or about to expire.
- * Returns true if the token should be refreshed (expires within bufferSeconds).
- */
+/** Return true when an access token is expired or within the refresh buffer. */
 export function isTokenExpired(
   token: string,
   bufferSeconds: number = 60,
@@ -34,21 +82,16 @@ export function isTokenExpired(
   return payload.exp - nowSeconds < bufferSeconds;
 }
 
-/**
- * Fetch the WorkOS client ID from the CLI config endpoint.
- * Caches the result for the lifetime of the process.
- */
 let cachedClientId: string | null = null;
 
 async function fetchWorkOSClientId(): Promise<string | null> {
   if (cachedClientId) return cachedClientId;
 
   try {
-    const apiUrl = getPensarApiUrl();
-    const response = await fetch(`${apiUrl}/api/cli/config`);
-
+    const response = await fetch(`${getPensarApiUrl()}/api/cli/config`, {
+      signal: AbortSignal.timeout(10_000),
+    });
     if (!response.ok) return null;
-
     const data = (await response.json()) as { workosClientId: string };
     cachedClientId = data.workosClientId;
     return cachedClientId;
@@ -57,84 +100,287 @@ async function fetchWorkOSClientId(): Promise<string | null> {
   }
 }
 
-/**
- * Refresh a WorkOS access token using the refresh token.
- * Updates the stored config with new tokens on success.
- *
- * @returns The new access token, or null if refresh fails
- */
-async function refreshAccessToken(
-  clientId: string,
-  refreshToken: string,
-): Promise<string | null> {
-  try {
-    const response = await fetch(
-      "https://api.workos.com/user_management/authenticate",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          client_id: clientId,
-          grant_type: "refresh_token",
-          refresh_token: refreshToken,
-        }),
-      },
-    );
+export class WorkOSTokenManager {
+  private accessToken: string | null = null;
+  private migrationPromise: Promise<void> | null = null;
+  private refreshPromise: Promise<ValidToken> | null = null;
+  private readonly fetchImpl: typeof fetch;
+  private readonly getClientId: () => Promise<string | null>;
+  private readonly store: AuthCredentialStore;
+  private readonly updateConfig: (next: Partial<TokenConfig>) => Promise<void>;
+  private readonly withRefreshLock: <T>(action: () => Promise<T>) => Promise<T>;
 
-    if (!response.ok) {
-      console.error(
-        `[pensar] Token refresh failed: ${response.status} ${response.statusText}`,
-      );
-      return null;
+  constructor(options: TokenManagerOptions = {}) {
+    this.fetchImpl = options.fetch ?? fetch;
+    this.getClientId = options.getClientId ?? fetchWorkOSClientId;
+    this.store = options.store ?? authCredentialStore;
+    this.updateConfig = options.updateConfig ?? ((next) => config.update(next));
+    this.withRefreshLock = options.withRefreshLock ?? withAuthRefreshLock;
+  }
+
+  async saveSession(tokens: WorkOSSessionTokens): Promise<CredentialBackend> {
+    const backend = await this.store.save(tokens.refreshToken);
+    this.accessToken = tokens.accessToken;
+    try {
+      await this.updateConfig({
+        accessToken: null,
+        refreshToken: null,
+        workosSession: true,
+        credentialBackend: backend,
+      });
+    } catch (error) {
+      this.accessToken = null;
+      await this.store.clear();
+      throw error;
+    }
+    return backend;
+  }
+
+  async clearSession(): Promise<void> {
+    this.accessToken = null;
+    await this.store.clear();
+    await this.updateConfig({
+      accessToken: null,
+      refreshToken: null,
+      workosSession: false,
+      credentialBackend: null,
+    });
+  }
+
+  async ensureValidToken(
+    current: TokenConfig,
+    options: EnsureValidTokenOptions = {},
+  ): Promise<ValidToken | null> {
+    await this.migrateLegacyTokens(current);
+
+    if (
+      options.forceRefresh &&
+      options.rejectedToken &&
+      this.accessToken &&
+      this.accessToken !== options.rejectedToken &&
+      !isTokenExpired(this.accessToken)
+    ) {
+      return { token: this.accessToken, type: "workos" };
     }
 
-    const data = (await response.json()) as {
-      access_token: string;
-      refresh_token: string;
-    };
+    if (
+      !options.forceRefresh &&
+      this.accessToken &&
+      !isTokenExpired(this.accessToken)
+    ) {
+      return { token: this.accessToken, type: "workos" };
+    }
 
-    await config.update({
-      accessToken: data.access_token,
-      refreshToken: data.refresh_token,
+    let stored: StoredRefreshToken | null;
+    try {
+      stored = await this.store.load();
+    } catch (error) {
+      if (error instanceof CredentialStoreUnavailableError) {
+        throw new AuthRefreshError(
+          "Unable to access secure Pensar credentials. Unlock your system credential store and try again.",
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+    if (stored) {
+      try {
+        return await this.refreshAccessToken(options);
+      } catch (error) {
+        if (error instanceof AuthSessionExpiredError && current.pensarAPIKey) {
+          return { token: current.pensarAPIKey, type: "legacy" };
+        }
+        throw error;
+      }
+    }
+
+    if (current.accessToken && !isTokenExpired(current.accessToken)) {
+      this.accessToken = current.accessToken;
+      return { token: current.accessToken, type: "workos" };
+    }
+
+    if (current.workosSession) {
+      await this.updateConfig({
+        workosSession: false,
+        credentialBackend: null,
+      });
+      if (!current.pensarAPIKey) throw new AuthSessionExpiredError();
+    }
+
+    if (current.pensarAPIKey) {
+      return { token: current.pensarAPIKey, type: "legacy" };
+    }
+
+    return null;
+  }
+
+  private async migrateLegacyTokens(current: TokenConfig): Promise<void> {
+    const legacyRefreshToken = current.refreshToken;
+    if (!legacyRefreshToken) {
+      if (current.accessToken && !this.accessToken) {
+        this.accessToken = current.accessToken;
+      }
+      return;
+    }
+    if (this.migrationPromise) return this.migrationPromise;
+
+    this.migrationPromise = this.withRefreshLock(async () => {
+      const existing = await this.store.load().catch((error) => {
+        if (error instanceof CredentialStoreUnavailableError) return null;
+        throw error;
+      });
+      const backend =
+        existing?.backend ?? (await this.store.save(legacyRefreshToken));
+      if (current.accessToken && !isTokenExpired(current.accessToken)) {
+        this.accessToken = current.accessToken;
+      }
+      await this.updateConfig({
+        accessToken: null,
+        refreshToken: null,
+        workosSession: true,
+        credentialBackend: backend,
+      });
+      log.info("Migrated WorkOS refresh token out of config", { backend });
+    }).finally(() => {
+      this.migrationPromise = null;
     });
 
-    return data.access_token;
-  } catch (err) {
-    console.error("[pensar] Token refresh error:", err);
-    return null;
+    return this.migrationPromise;
+  }
+
+  private async refreshAccessToken(
+    options: EnsureValidTokenOptions,
+  ): Promise<ValidToken> {
+    if (this.refreshPromise) return this.refreshPromise;
+
+    this.refreshPromise = this.withRefreshLock(async () => {
+      if (
+        options.forceRefresh &&
+        options.rejectedToken &&
+        this.accessToken &&
+        this.accessToken !== options.rejectedToken &&
+        !isTokenExpired(this.accessToken)
+      ) {
+        return { token: this.accessToken, type: "workos" as const };
+      }
+
+      if (
+        !options.forceRefresh &&
+        this.accessToken &&
+        !isTokenExpired(this.accessToken)
+      ) {
+        return { token: this.accessToken, type: "workos" as const };
+      }
+
+      let stored: StoredRefreshToken | null;
+      try {
+        stored = await this.store.load();
+      } catch (error) {
+        if (error instanceof CredentialStoreUnavailableError) {
+          throw new AuthRefreshError(
+            "Unable to access secure Pensar credentials. Unlock your system credential store and try again.",
+            { cause: error },
+          );
+        }
+        throw error;
+      }
+      if (!stored) {
+        await this.updateConfig({
+          workosSession: false,
+          credentialBackend: null,
+        });
+        throw new AuthSessionExpiredError();
+      }
+
+      const clientId = await this.getClientId();
+      if (!clientId) {
+        throw new AuthRefreshError(
+          "Unable to refresh Pensar authentication. Check your connection and try again.",
+        );
+      }
+
+      let response: Response;
+      try {
+        response = await this.fetchImpl(
+          "https://api.workos.com/user_management/authenticate",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            signal: AbortSignal.timeout(15_000),
+            body: JSON.stringify({
+              client_id: clientId,
+              grant_type: "refresh_token",
+              refresh_token: stored.refreshToken,
+            }),
+          },
+        );
+      } catch (error) {
+        throw new AuthRefreshError(
+          "Unable to refresh Pensar authentication. Check your connection and try again.",
+          { cause: error },
+        );
+      }
+
+      if (response.status === 400 || response.status === 401) {
+        await this.clearSession();
+        throw new AuthSessionExpiredError();
+      }
+      if (!response.ok) {
+        throw new AuthRefreshError(
+          `Unable to refresh Pensar authentication (${response.status}). Try again shortly.`,
+        );
+      }
+
+      let data: Partial<{
+        access_token: string;
+        refresh_token: string;
+      }>;
+      try {
+        data = (await response.json()) as typeof data;
+      } catch (error) {
+        throw new AuthRefreshError(
+          "WorkOS returned an invalid token refresh response.",
+          { cause: error },
+        );
+      }
+      if (!data.access_token || !data.refresh_token) {
+        throw new AuthRefreshError(
+          "WorkOS returned an incomplete token refresh response.",
+        );
+      }
+
+      const backend = await this.store.save(data.refresh_token);
+      this.accessToken = data.access_token;
+      await this.updateConfig({
+        accessToken: null,
+        refreshToken: null,
+        workosSession: true,
+        credentialBackend: backend,
+      });
+      return { token: data.access_token, type: "workos" as const };
+    }).finally(() => {
+      this.refreshPromise = null;
+    });
+
+    return this.refreshPromise;
   }
 }
 
-/**
- * Ensure a valid access token is available.
- * If the current token is expired, attempts to refresh it.
- *
- * @returns A valid access token, or null if no valid token is available
- */
-export async function ensureValidToken(cfg: {
-  accessToken?: string | null;
-  refreshToken?: string | null;
-  pensarAPIKey?: string | null;
-}): Promise<ValidToken | null> {
-  if (cfg.accessToken) {
-    if (!isTokenExpired(cfg.accessToken)) {
-      return { token: cfg.accessToken, type: "workos" };
-    }
+const tokenManager = new WorkOSTokenManager();
 
-    if (cfg.refreshToken) {
-      const clientId = await fetchWorkOSClientId();
-      if (clientId) {
-        const newToken = await refreshAccessToken(clientId, cfg.refreshToken);
-        if (newToken) {
-          return { token: newToken, type: "workos" };
-        }
-      }
-    }
-  }
+export function ensureValidToken(
+  current: TokenConfig,
+  options?: EnsureValidTokenOptions,
+): Promise<ValidToken | null> {
+  return tokenManager.ensureValidToken(current, options);
+}
 
-  if (cfg.pensarAPIKey) {
-    return { token: cfg.pensarAPIKey, type: "legacy" };
-  }
+export function saveWorkOSSession(
+  tokens: WorkOSSessionTokens,
+): Promise<CredentialBackend> {
+  return tokenManager.saveSession(tokens);
+}
 
-  return null;
+export function clearWorkOSSession(): Promise<void> {
+  return tokenManager.clearSession();
 }

--- a/src/core/auth/token.ts
+++ b/src/core/auth/token.ts
@@ -131,26 +131,27 @@ export class WorkOSTokenManager {
           credentialBackend: backend,
         });
       } catch (error) {
-        this.accessToken = null;
-        await this.store.clear();
+        await this.clearSessionUnlocked();
         throw error;
       }
       return backend;
     });
   }
 
-  async clearSession(): Promise<void> {
-    return this.withRefreshLock(async () => {
-      this.refreshPromise = null;
-      this.accessToken = null;
-      await this.store.clear();
-      await this.updateConfig({
-        accessToken: null,
-        refreshToken: null,
-        workosSession: false,
-        credentialBackend: null,
-      });
+  private async clearSessionUnlocked(): Promise<void> {
+    this.refreshPromise = null;
+    this.accessToken = null;
+    await this.store.clear();
+    await this.updateConfig({
+      accessToken: null,
+      refreshToken: null,
+      workosSession: false,
+      credentialBackend: null,
     });
+  }
+
+  async clearSession(): Promise<void> {
+    return this.withRefreshLock(() => this.clearSessionUnlocked());
   }
 
   async ensureValidToken(
@@ -328,7 +329,7 @@ export class WorkOSTokenManager {
       }
 
       if (response.status === 400 || response.status === 401) {
-        await this.clearSession();
+        await this.clearSessionUnlocked();
         throw new AuthSessionExpiredError();
       }
       if (!response.ok) {

--- a/src/core/auth/token.ts
+++ b/src/core/auth/token.ts
@@ -71,10 +71,7 @@ function decodeJwtPayload(token: string): Record<string, unknown> | null {
 }
 
 /** Return true when an access token is expired or within the refresh buffer. */
-export function isTokenExpired(
-  token: string,
-  bufferSeconds: number = 60,
-): boolean {
+function isTokenExpired(token: string, bufferSeconds: number = 60): boolean {
   const payload = decodeJwtPayload(token);
   if (!payload || typeof payload.exp !== "number") return true;
 
@@ -207,11 +204,17 @@ export class WorkOSTokenManager {
     }
 
     if (current.workosSession) {
-      await this.updateConfig({
-        workosSession: false,
-        credentialBackend: null,
+      return this.withRefreshLock(async () => {
+        const stillStored = await this.store.load().catch(() => null);
+        if (!stillStored) {
+          await this.updateConfig({
+            workosSession: false,
+            credentialBackend: null,
+          });
+          if (!current.pensarAPIKey) throw new AuthSessionExpiredError();
+        }
+        return null;
       });
-      if (!current.pensarAPIKey) throw new AuthSessionExpiredError();
     }
 
     if (current.pensarAPIKey) {
@@ -235,12 +238,20 @@ export class WorkOSTokenManager {
     if (this.migrationPromise) return this.migrationPromise;
 
     this.migrationPromise = this.withRefreshLock(async () => {
+      const currentCfg = await config.get();
+      if (currentCfg.workosSession !== undefined) {
+        return;
+      }
       const existing = await this.store.load().catch((error) => {
         if (error instanceof CredentialStoreUnavailableError) return null;
         throw error;
       });
-      const backend =
-        existing?.backend ?? (await this.store.save(legacyRefreshToken));
+      let backend: CredentialBackend;
+      if (existing && existing.refreshToken === legacyRefreshToken) {
+        backend = existing.backend;
+      } else {
+        backend = await this.store.save(legacyRefreshToken);
+      }
       if (current.accessToken && !isTokenExpired(current.accessToken)) {
         this.accessToken = current.accessToken;
       }

--- a/src/core/auth/token.ts
+++ b/src/core/auth/token.ts
@@ -119,31 +119,37 @@ export class WorkOSTokenManager {
   }
 
   async saveSession(tokens: WorkOSSessionTokens): Promise<CredentialBackend> {
-    const backend = await this.store.save(tokens.refreshToken);
-    this.accessToken = tokens.accessToken;
-    try {
-      await this.updateConfig({
-        accessToken: null,
-        refreshToken: null,
-        workosSession: true,
-        credentialBackend: backend,
-      });
-    } catch (error) {
-      this.accessToken = null;
-      await this.store.clear();
-      throw error;
-    }
-    return backend;
+    return this.withRefreshLock(async () => {
+      this.refreshPromise = null;
+      const backend = await this.store.save(tokens.refreshToken);
+      this.accessToken = tokens.accessToken;
+      try {
+        await this.updateConfig({
+          accessToken: null,
+          refreshToken: null,
+          workosSession: true,
+          credentialBackend: backend,
+        });
+      } catch (error) {
+        this.accessToken = null;
+        await this.store.clear();
+        throw error;
+      }
+      return backend;
+    });
   }
 
   async clearSession(): Promise<void> {
-    this.accessToken = null;
-    await this.store.clear();
-    await this.updateConfig({
-      accessToken: null,
-      refreshToken: null,
-      workosSession: false,
-      credentialBackend: null,
+    return this.withRefreshLock(async () => {
+      this.refreshPromise = null;
+      this.accessToken = null;
+      await this.store.clear();
+      await this.updateConfig({
+        accessToken: null,
+        refreshToken: null,
+        workosSession: false,
+        credentialBackend: null,
+      });
     });
   }
 

--- a/src/core/config/config.security.test.ts
+++ b/src/core/config/config.security.test.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      homedir: () => process.env.APEX_CONFIG_TEST_HOME ?? actual.homedir(),
+    },
+  };
+});
+
+import { init, update } from "./config";
+
+let homeDir: string;
+
+beforeEach(async () => {
+  homeDir = await mkdtemp(path.join(os.tmpdir(), "apex-config-"));
+  process.env.APEX_CONFIG_TEST_HOME = homeDir;
+});
+
+afterEach(async () => {
+  delete process.env.APEX_CONFIG_TEST_HOME;
+  await rm(homeDir, { force: true, recursive: true });
+});
+
+describe("config persistence", () => {
+  it("uses private permissions and atomic queued updates", async () => {
+    await init();
+    const pensarDir = path.join(homeDir, ".pensar");
+    const configFile = path.join(pensarDir, "config.json");
+
+    await Promise.all([
+      update({ theme: "midnight" }),
+      update({ workspaceId: "workspace-1" }),
+    ]);
+
+    const stored = JSON.parse(await readFile(configFile, "utf8"));
+    expect(stored).toMatchObject({
+      theme: "midnight",
+      workspaceId: "workspace-1",
+    });
+    if (process.platform !== "win32") {
+      expect((await stat(pensarDir)).mode & 0o777).toBe(0o700);
+      expect((await stat(configFile)).mode & 0o777).toBe(0o600);
+    }
+  });
+});

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -55,6 +55,8 @@ export interface Config {
   // WorkOS CLI auth (replaces pensarAPIKey for new auth flow)
   accessToken?: string | null;
   refreshToken?: string | null;
+  workosSession?: boolean;
+  credentialBackend?: "os-vault" | "secure-file" | null;
   workspaceId?: string | null;
   workspaceSlug?: string | null;
   // Gateway request signing key (server-issued)
@@ -74,15 +76,17 @@ export async function init() {
     .then(() => true)
     .catch(() => false);
   if (!dirExists) {
-    await fs.mkdir(folder, { recursive: true });
+    await fs.mkdir(folder, { recursive: true, mode: 0o700 });
   }
+  await fs.chmod(folder, 0o700).catch(() => {});
   const fileExists = await fs
     .access(file)
     .then(() => true)
     .catch(() => false);
   if (!fileExists) {
-    await fs.writeFile(file, JSON.stringify(DEFAULT_CONFIG));
+    await fs.writeFile(file, JSON.stringify(DEFAULT_CONFIG), { mode: 0o600 });
   }
+  await fs.chmod(file, 0o600).catch(() => {});
 
   const version = getCurrentVersion();
   return { ...DEFAULT_CONFIG, version };
@@ -145,21 +149,44 @@ export async function get(): Promise<Config> {
     await init();
     return applyEnvFallbacks(DEFAULT_CONFIG);
   }
+  await fs.chmod(folder, 0o700).catch(() => {});
+  await fs.chmod(file, 0o600).catch(() => {});
   const config = await fs.readFile(file, "utf8");
   const parsedConfig = JSON.parse(config);
   return applyEnvFallbacks(parsedConfig);
 }
 
-export async function update(config: Partial<Config>) {
-  const folder = path.join(os.homedir(), ".pensar");
-  const file = path.join(folder, "config.json");
-  const exists = await fs
-    .access(file)
-    .then(() => true)
-    .catch(() => false);
-  const currentConfig = exists
-    ? JSON.parse(await fs.readFile(file, "utf8"))
-    : DEFAULT_CONFIG;
-  const newConfig = { ...currentConfig, ...config };
-  await fs.writeFile(file, JSON.stringify(newConfig));
+let updateQueue: Promise<void> = Promise.resolve();
+
+export async function update(next: Partial<Config>) {
+  const write = async () => {
+    const folder = path.join(os.homedir(), ".pensar");
+    const file = path.join(folder, "config.json");
+    const temporaryFile = `${file}.${process.pid}.${crypto.randomUUID()}.tmp`;
+    await fs.mkdir(folder, { recursive: true, mode: 0o700 });
+    await fs.chmod(folder, 0o700).catch(() => {});
+    const exists = await fs
+      .access(file)
+      .then(() => true)
+      .catch(() => false);
+    const currentConfig = exists
+      ? JSON.parse(await fs.readFile(file, "utf8"))
+      : DEFAULT_CONFIG;
+    const newConfig = { ...currentConfig, ...next };
+
+    try {
+      await fs.writeFile(temporaryFile, JSON.stringify(newConfig), {
+        mode: 0o600,
+      });
+      await fs.chmod(temporaryFile, 0o600).catch(() => {});
+      await fs.rename(temporaryFile, file);
+      await fs.chmod(file, 0o600).catch(() => {});
+    } finally {
+      await fs.rm(temporaryFile, { force: true }).catch(() => {});
+    }
+  };
+
+  const result = updateQueue.then(write, write);
+  updateQueue = result.catch(() => {});
+  return result;
 }

--- a/src/core/providers/utils.ts
+++ b/src/core/providers/utils.ts
@@ -59,7 +59,12 @@ function isProviderConfigured(
         process.env.LOCAL_MODEL_URL
       );
     case "pensar":
-      return !!(config.pensarAPIKey || config.accessToken);
+      return !!(
+        config.pensarAPIKey ||
+        config.workosSession ||
+        config.refreshToken ||
+        config.accessToken
+      );
     default:
       return false;
   }
@@ -77,6 +82,8 @@ export function hasAnyProviderConfigured(config: Config): boolean {
     !!config.localModelName ||
     !!process.env.LOCAL_MODEL_URL ||
     !!config.pensarAPIKey ||
+    !!config.workosSession ||
+    !!config.refreshToken ||
     !!config.accessToken
   );
 }

--- a/src/tui/components/commands/auth-flow.tsx
+++ b/src/tui/components/commands/auth-flow.tsx
@@ -4,11 +4,13 @@ import { getPensarApiUrl, getPensarConsoleUrl } from "../../../core/api";
 import type { DeviceFlowInfo, WorkspaceInfo } from "../../../core/auth";
 import {
   disconnect,
+  ensureValidToken,
   fetchWorkspaces,
   isConnected,
   pollForWorkspaceCreation,
   pollLegacyToken,
   pollWorkOSToken,
+  saveWorkOSSession,
   selectWorkspace as selectWorkspaceApi,
   startDeviceFlow,
 } from "../../../core/auth";
@@ -43,7 +45,13 @@ export default function AuthFlow({ onClose, hideEsc }: AuthFlowProps) {
   const alreadyConnected = isConnected(appConfig.data);
   const hasWorkspace = !!appConfig.data.workspaceId;
   const needsWorkspace =
-    alreadyConnected && !hasWorkspace && !!appConfig.data.accessToken;
+    alreadyConnected &&
+    !hasWorkspace &&
+    !!(
+      appConfig.data.workosSession ||
+      appConfig.data.refreshToken ||
+      appConfig.data.accessToken
+    );
 
   const [step, setStep] = useState<AuthStep>(
     needsWorkspace ? "requesting" : alreadyConnected ? "success" : "start",
@@ -63,6 +71,7 @@ export default function AuthFlow({ onClose, hideEsc }: AuthFlowProps) {
   } | null>(null);
 
   const abortRef = useRef<AbortController | null>(null);
+  const accessTokenRef = useRef<string | null>(null);
 
   const connectedWorkspace = appConfig.data.workspaceSlug
     ? {
@@ -167,10 +176,8 @@ export default function AuthFlow({ onClose, hideEsc }: AuthFlowProps) {
 
       if (ac.signal.aborted) return;
 
-      await config.update({
-        accessToken: tokens.accessToken,
-        refreshToken: tokens.refreshToken,
-      });
+      accessTokenRef.current = tokens.accessToken;
+      await saveWorkOSSession(tokens);
       await appConfig.reload();
 
       await handleFetchWorkspaces(apiUrl, tokens.accessToken, ac);
@@ -241,6 +248,7 @@ export default function AuthFlow({ onClose, hideEsc }: AuthFlowProps) {
     ac: AbortController,
   ) => {
     try {
+      accessTokenRef.current = accessToken;
       const wsResult = await fetchWorkspaces(apiUrl, accessToken);
       if (ac.signal.aborted) return;
 
@@ -353,13 +361,30 @@ export default function AuthFlow({ onClose, hideEsc }: AuthFlowProps) {
     const ac = new AbortController();
     abortRef.current = ac;
     const apiUrl = getPensarApiUrl();
-    handleFetchWorkspaces(apiUrl, appConfig.data.accessToken!, ac);
+    ensureValidToken(appConfig.data)
+      .then((token) => {
+        if (ac.signal.aborted) return;
+        if (!token || token.type !== "workos") {
+          throw new Error("Pensar Console authentication is unavailable");
+        }
+        return handleFetchWorkspaces(apiUrl, token.token, ac);
+      })
+      .catch((error) => {
+        if (ac.signal.aborted) return;
+        setError(
+          error instanceof Error
+            ? error.message
+            : "Failed to restore authentication",
+        );
+        setStep("error");
+      });
   }, []);
 
   // ── Disconnect ──────────────────────────────────────────────────────
 
   const handleDisconnect = async () => {
     await disconnect();
+    accessTokenRef.current = null;
     appConfig.reload();
     setFlowInfo(null);
     setSelectedWorkspace(null);
@@ -427,9 +452,13 @@ export default function AuthFlow({ onClose, hideEsc }: AuthFlowProps) {
         setSelectedIndex((i) => i + 1);
       }
       if (key.name === "return" && workspaces[selectedIndex]) {
-        const currentConfig = appConfig.data;
         const apiUrl = getPensarApiUrl();
-        const accessToken = currentConfig.accessToken!;
+        const accessToken = accessTokenRef.current;
+        if (!accessToken) {
+          setError("Pensar Console authentication is unavailable");
+          setStep("error");
+          return;
+        }
         const ac = abortRef.current ?? new AbortController();
         handleSelectWorkspace(
           apiUrl,

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -287,27 +287,30 @@ function AppContent({
       },
     );
 
-    // Check if auth token needs refresh
+    // Restore WorkOS auth in the background. Successful refreshes stay hidden;
+    // only a genuinely expired/revoked session asks the user to reconnect.
     const checkAuthToken = async () => {
-      const { isTokenExpired, isConnected } = await import("../core/auth");
-      // Only show toast if access token is expired AND there's no recovery path.
-      // ensureValidToken() can recover via refresh token OR fall back to pensarAPIKey,
-      // so we only warn when both are unavailable.
-      if (
-        isConnected(config.data) &&
-        config.data.accessToken &&
-        isTokenExpired(config.data.accessToken, 60) &&
-        !config.data.refreshToken &&
-        !config.data.pensarAPIKey
-      ) {
-        toast(
-          "Your Pensar Console session has expired. Run /login to refresh.",
-          "warn",
-          8000,
-        );
+      const { AuthSessionExpiredError, ensureValidToken } = await import(
+        "../core/auth"
+      );
+      const hasWorkOSSession = Boolean(
+        config.data.workosSession ||
+          config.data.refreshToken ||
+          config.data.accessToken,
+      );
+      if (!hasWorkOSSession) return;
+
+      try {
+        await ensureValidToken(config.data);
+        await config.reload();
+      } catch (error) {
+        if (error instanceof AuthSessionExpiredError) {
+          await config.reload();
+          toast(error.message, "warn", 8000);
+        }
       }
     };
-    checkAuthToken();
+    void checkAuthToken();
   }, []);
 
   useEffect(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
-  }
+  },
+  "exclude": ["build", "dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary

This PR hardens WorkOS authentication persistence and makes short access-token lifetimes transparent to Apex users.

- Store refresh tokens in the native OS credential vault:
  - macOS Keychain
  - Windows Credential Manager
  - Linux Secret Service
- Use Bun Secrets in standalone/Bun builds and @napi-rs/keyring for the Node-compatible packaged CLI.
- Keep access tokens in process memory only.
- Migrate legacy plaintext access and refresh tokens out of config.json on first use.
- Fall back to a dedicated auth.json with 0600 permissions inside a 0700 directory when a native credential service is unavailable, primarily for headless Linux.
- Record only non-secret session/backend metadata in config.

## Refresh and request hardening

- Single-flight refreshes inside one process.
- Serialize refresh-token rotation across concurrent Apex processes with an ownership-safe lock and stale-lock recovery.
- Persist the newly rotated refresh token before updating session metadata.
- Add bounded WorkOS/client-config network timeouts.
- Preserve credentials on network errors, malformed responses, rate limits, and 5xx failures.
- Clear the session only when WorkOS rejects refresh credentials with 400/401.
- Force one refresh and retry exactly once when a WorkOS-authenticated request receives 401.
- Regenerate gateway HMAC timestamp, nonce, and signature for every retry.
- Apply the retry path consistently to Console API requests, gateway validation, managed model streaming, and web search.

## UX and migration

- Restore WorkOS sessions silently on TUI startup.
- Show reconnect guidance only for genuinely expired or revoked sessions.
- Treat a locked/unavailable OS vault as a temporary error rather than logging the user out.
- Make CLI login, status, logout, TUI auth, provider detection, and workspace selection understand persisted sessions.
- Preserve legacy API-key fallback behavior.
- Remove access and refresh tokens from config during logout and clear workspace/signing metadata.
- Harden config persistence with atomic queued writes and private permissions.

## Architecture

Adds PDR-008 documenting native credential storage, memory-only access tokens, the restricted-file fallback, and serialized single-use refresh rotation.

Generated build artifacts are now excluded from TypeScript input so allowJs can remain enabled without type-checking bundled output.

## Verification

- bun run lint
- bun run format:check
- bun run tsc
- bunx vitest run: 87 files passed, 1,389 tests passed, 20 existing integration tests skipped
- bun run build
- bun run build:binary
- Node CLI smoke test
- Standalone binary smoke test
- Native Node credential adapter load test

The full multi-architecture build proceeds through auth compilation and macOS arm64, then hits the existing missing @opentui/core-darwin-x64 optional package when cross-compiling on arm64; this is unrelated to the auth changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication storage, refresh rotation, and session lifecycle across CLI, TUI, API client, and gateway paths—security-critical behavior with multi-process edge cases.
> 
> **Overview**
> WorkOS refresh tokens no longer live in `config.json`. They are stored in the OS credential vault (Bun Secrets or `@napi-rs/keyring`), with access tokens kept in memory only. Legacy plaintext tokens migrate on first use; headless Linux can use a restricted `~/.pensar/auth.json` fallback. Config keeps only `workosSession` and `credentialBackend` metadata.
> 
> **Refresh and concurrency:** `WorkOSTokenManager` single-flights in-process refreshes and uses a cross-process file lock so rotated single-use refresh tokens are not raced. Rotated refresh credentials are persisted before session metadata updates. Only WorkOS `400`/`401` on refresh clears the session; transient network/server failures keep the local session.
> 
> **401 retry:** WorkOS-authenticated calls (Console API, gateway validate, Pensar model streaming, web search) force one refresh and retry once on `401`, with fresh gateway HMAC nonces on retry.
> 
> **CLI/TUI:** Login uses `saveWorkOSSession`; status distinguishes WorkOS vs API key without mis-identifying sessions when access tokens are memory-only. TUI restores auth silently and toasts only on true session expiry; locked keychains surface as retryable errors.
> 
> **Config:** Atomic queued writes and `0700`/`0600` permissions on `~/.pensar`. Adds PDR-008 and excludes build artifacts from `tsconfig` input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea1f861ff40dd5085778402ae2d9484850ef9f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->