### PR TITLE
feat(models): add Kimi K3 to OpenRouter

### DIFF
--- a/src/core/ai/models/openrouter.ts
+++ b/src/core/ai/models/openrouter.ts
@@ -130,6 +130,12 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
     contextLength: 262144,
   },
   {
+    id: "moonshotai/kimi-k3",
+    name: "Kimi K3",
+    provider: "openrouter",
+    contextLength: 1000000,
+  },
+  {
     id: "moonshot/kimi-k2-turbo",
     name: "Kimi K2 Turbo",
     provider: "openrouter",


### PR DESCRIPTION
Register `moonshotai/kimi-k3` (Kimi K3) as an OpenRouter model, 1M context.

Mirrors the pattern from #840 (GLM 5.2 / Kimi K2.7 Code). Like the other Kimi entries, this is registration only — no dedicated output-budget entry, so it uses the 4096 default. Add one if/when Kimi K3 documents a larger max-output window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single catalog entry in a manually curated model list; no runtime, auth, or routing logic changes.
> 
> **Overview**
> Registers **`moonshotai/kimi-k3`** (Kimi K3) in the curated OpenRouter model list with a **1M** context window, placed alongside the other Kimi entries in `openrouter.ts`.
> 
> This is **registration only**—no custom max-output mapping—so Kimi K3 uses the same **4096** default output budget as the other Kimi OpenRouter models until a larger documented limit is added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b888fdeee5c36a1633e88ea00fdf15ae1fdb9cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->