### PR TITLE
Track suite-level calibration (over-claim rate) in benchmark summary

### DIFF
--- a/src/core/benchmark/report.ts
+++ b/src/core/benchmark/report.ts
@@ -40,6 +40,7 @@ export function generateTextReport(result: BenchmarkSuiteResult): string {
 
   lines.push(
     `Avg Precision: ${(summary.avgPrecision * 100).toFixed(1)}%  |  Avg Recall: ${(summary.avgRecall * 100).toFixed(1)}%`,
+    `Over-claim:    ${(summary.avgOverClaimRate * 100).toFixed(1)}% avg  |  over-claiming runs: ${summary.overClaimingRuns}  |  pure over-claim: ${summary.pureOverClaimRuns}`,
   );
   lines.push("");
 

--- a/src/core/benchmark/runner.ts
+++ b/src/core/benchmark/runner.ts
@@ -646,6 +646,23 @@ function computeSummary(
         comparisons.length
       : 0;
 
+  // Calibration: how much the agent over-claims (submits findings matching
+  // nothing expected) relative to what it captures. Complements precision/recall
+  // with a suite-level number so judge/FP changes can be tracked for regression (#732).
+  const avgOverClaimRate =
+    comparisons.length > 0
+      ? comparisons.reduce((sum, c) => sum + (1 - (c.precision ?? 0)), 0) /
+        comparisons.length
+      : 0;
+
+  const overClaimingRuns = comparisons.filter(
+    (c) => (c.precision ?? 0) < (c.recall ?? 0),
+  ).length;
+
+  const pureOverClaimRuns = comparisons.filter(
+    (c) => (c.matched?.length ?? 0) === 0 && (c.extra?.length ?? 0) > 0,
+  ).length;
+
   const tokenResults = results
     .map((r) => r.tokenMetrics)
     .filter((t): t is NonNullable<typeof t> => t !== null);
@@ -689,6 +706,9 @@ function computeSummary(
     vulnDetectionRate: total > 0 ? vulnDetected / total : 0,
     avgPrecision,
     avgRecall,
+    avgOverClaimRate,
+    overClaimingRuns,
+    pureOverClaimRuns,
     totalDurationMinutes: (Date.now() - suiteStartTime) / 60000,
     totalInputTokens,
     totalOutputTokens,

--- a/src/core/benchmark/types.ts
+++ b/src/core/benchmark/types.ts
@@ -69,6 +69,9 @@ export interface BenchmarkSuiteSummary {
   vulnDetectionRate: number;
   avgPrecision: number;
   avgRecall: number;
+  avgOverClaimRate: number;
+  overClaimingRuns: number;
+  pureOverClaimRuns: number;
   totalDurationMinutes: number;
   totalInputTokens: number;
   totalOutputTokens: number;


### PR DESCRIPTION
Adds a suite-level calibration read to the benchmark summary, computed from the existing comparison results in `computeSummary`:

- `avgOverClaimRate` — mean `1 - precision` across runs
- `overClaimingRuns` — runs where precision < recall
- `pureOverClaimRuns` — runs that matched nothing expected but still submitted findings

Rendered as an `Over-claim:` line in the text report, next to Avg Precision / Avg Recall.

**Why.** The finding-judge is calibrated per finding (#806, #856) and FP restraint is being tightened, but there is no suite-level number to tell whether a judge/prompt change actually improves or regresses calibration. #808 is a live example of the failure this would surface: the agent identifies a honeypot and still reports it, which is an over-claim no per-finding check caught. This makes that number a first-class part of every benchmark run. Additive, no behavior change; it sits in the same flow as precision/recall. An offline version over committed traces is in a separate PR (`scripts/calibration-report.ts`).

