### PR TITLE
feat(cli): add 'pensar builds upload' for desktop-app build artifacts

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -112,6 +112,10 @@
                 "message": "Import from the offSecAgent/tools/email barrel (index), not its internals."
               },
               {
+                "group": ["**/core/desktop/*", "!**/core/desktop/index"],
+                "message": "Import from the core/desktop barrel (index), not its internals."
+              },
+              {
                 "group": [
                   "**/core/skills/builtins/*",
                   "!**/core/skills/builtins/index"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -210,6 +210,7 @@ Usage:
   pensar uninstall                    Uninstall Pensar (keeps sessions, memories, skills)
   pensar apps                         Manage the attack surface (apps & endpoints)
   pensar pentests                     List and manage pentests
+  pensar builds                       Upload desktop-app build artifacts
   pensar targets                      List pentest targets and view their agent logs
   pensar issues                       List and manage security issues
   pensar fixes                        View security fixes
@@ -636,6 +637,9 @@ if (hasFlag("-p") || command === "--prompt") {
 } else if (command === "pentests") {
   process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
   await import("./cli/pentests");
+} else if (command === "builds") {
+  process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
+  await import("./cli/builds");
 } else if (command === "targets") {
   process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
   await import("./cli/targets");

--- a/src/cli/builds.ts
+++ b/src/cli/builds.ts
@@ -14,6 +14,8 @@ import {
   type ReleaseChannel,
   uploadDesktopBuild,
 } from "../core/api/builds";
+import { runDesktopBuild } from "../core/api/desktopBuild";
+import type { DesktopOs } from "../core/desktop";
 
 function getFlag(flag: string, argv: string[]): string | undefined {
   const idx = argv.indexOf(flag);
@@ -30,6 +32,12 @@ All commands operate on the selected workspace (set via \`pensar login\`).
 
 Usage:
   pensar builds upload <file> [options]
+  pensar builds run <manifest.json> [--os linux|windows|macos]
+
+run:
+  Installs + launches a desktop build from a pensar-build.json manifest using
+  the local OS shell (intended to run inside the target sandbox). The OS is
+  read from the manifest's artifact.platform unless --os overrides it.
 
 upload options (required):
   --app <ref>            Application id or label (e.g. APP-3) the build belongs to
@@ -63,6 +71,41 @@ async function main(): Promise<void> {
 
   if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
     showHelp();
+    return;
+  }
+
+  if (sub === "run") {
+    const manifestPath =
+      args[1] && !args[1].startsWith("--") ? args[1] : undefined;
+    if (!manifestPath) {
+      console.error("Error: missing required argument: <manifest.json>");
+      console.error("Usage: pensar builds run <manifest.json> [--os <os>]");
+      process.exit(1);
+    }
+    const osOverride = getFlag("--os", args) as DesktopOs | undefined;
+    if (osOverride && !PLATFORMS.includes(osOverride as ArtifactPlatform)) {
+      console.error(`Error: --os must be one of: ${PLATFORMS.join(", ")}`);
+      process.exit(1);
+    }
+    try {
+      const result = await runDesktopBuild({
+        manifestPath,
+        os: osOverride,
+        onLog: (line) => console.error(`[desktop] ${line}`),
+      });
+      console.log(JSON.stringify(result, null, 2));
+      if (!result.ready) {
+        console.error(
+          `\nError: the app never became ready (${result.readinessKind} check timed out).`,
+        );
+        process.exit(1);
+      }
+    } catch (err) {
+      console.error(
+        `\nError: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(1);
+    }
     return;
   }
 

--- a/src/cli/builds.ts
+++ b/src/cli/builds.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env bun
+
+/**
+ * pensar builds — Upload desktop-app build artifacts to the Pensar Console
+ *
+ * All commands operate on the selected workspace (set via `pensar login`).
+ *
+ * Usage:
+ *   pensar builds upload <file> --app <ref> --version <v> --platform <p> [opts]
+ */
+
+import {
+  type ArtifactPlatform,
+  type ReleaseChannel,
+  uploadDesktopBuild,
+} from "../core/api/builds";
+
+function getFlag(flag: string, argv: string[]): string | undefined {
+  const idx = argv.indexOf(flag);
+  return idx !== -1 && idx + 1 < argv.length ? argv[idx + 1] : undefined;
+}
+
+const PLATFORMS: ArtifactPlatform[] = ["linux", "windows", "macos"];
+const CHANNELS: ReleaseChannel[] = ["stable", "beta", "nightly", "dev"];
+
+function showHelp(): void {
+  console.log(`pensar builds — Upload desktop-app build artifacts
+
+All commands operate on the selected workspace (set via \`pensar login\`).
+
+Usage:
+  pensar builds upload <file> [options]
+
+upload options (required):
+  --app <ref>            Application id or label (e.g. APP-3) the build belongs to
+  --version <v>          Release version, e.g. 1.4.2
+  --platform <p>         Target OS: linux | windows | macos
+
+upload options (optional):
+  --arch <a>             Architecture: x64 (default) | arm64 | universal
+  --channel <c>          Release channel: stable (default) | beta | nightly | dev
+  --format <f>           Package format (auto-detected from the filename if omitted)
+  --content-type <ct>    Override the upload Content-Type
+  --commit <sha>         Source commit SHA (provenance)
+  --repo-id <uuid>       Source repository id (provenance)
+  --ref <ref>            Source branch/tag (provenance)
+  --repo-path <path>     Monorepo subpath the build came from (provenance)
+  --build-url <url>      CI build/run URL (provenance)
+  --ci                   Mark the release sourceKind as "ci"
+
+Options:
+  -h, --help             Show this help message
+
+Examples:
+  pensar builds upload ./dist/app-1.4.2.AppImage --app APP-3 --version 1.4.2 --platform linux
+  pensar builds upload ./dist/App.exe --app APP-3 --version 1.4.2 --platform windows --arch x64 \\
+    --ci --commit $GITHUB_SHA --repo-id <uuid> --build-url $RUN_URL`);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+    showHelp();
+    return;
+  }
+
+  if (sub !== "upload") {
+    console.error(`Error: Unknown subcommand "${sub}"`);
+    showHelp();
+    process.exit(1);
+  }
+
+  const filePath = args[1] && !args[1].startsWith("--") ? args[1] : undefined;
+  const application = getFlag("--app", args);
+  const version = getFlag("--version", args);
+  const platform = getFlag("--platform", args) as ArtifactPlatform | undefined;
+
+  const missing: string[] = [];
+  if (!filePath) missing.push("<file>");
+  if (!application) missing.push("--app");
+  if (!version) missing.push("--version");
+  if (!platform) missing.push("--platform");
+  if (missing.length > 0) {
+    console.error(`Error: missing required argument(s): ${missing.join(", ")}`);
+    console.error(
+      "Usage: pensar builds upload <file> --app <ref> --version <v> --platform <p>",
+    );
+    process.exit(1);
+  }
+  if (!PLATFORMS.includes(platform as ArtifactPlatform)) {
+    console.error(`Error: --platform must be one of: ${PLATFORMS.join(", ")}`);
+    process.exit(1);
+  }
+  const channel = getFlag("--channel", args) as ReleaseChannel | undefined;
+  if (channel && !CHANNELS.includes(channel)) {
+    console.error(`Error: --channel must be one of: ${CHANNELS.join(", ")}`);
+    process.exit(1);
+  }
+
+  const source = {
+    repositoryId: getFlag("--repo-id", args),
+    commitSha: getFlag("--commit", args),
+    ref: getFlag("--ref", args),
+    repositoryPath: getFlag("--repo-path", args),
+    buildUrl: getFlag("--build-url", args),
+  };
+  const hasSource = Object.values(source).some((v) => v !== undefined);
+
+  try {
+    console.error(`Uploading ${filePath} …`);
+    const artifact = await uploadDesktopBuild({
+      filePath: filePath as string,
+      application: application as string,
+      version: version as string,
+      platform: platform as ArtifactPlatform,
+      architecture: getFlag("--arch", args),
+      channel,
+      format: getFlag("--format", args),
+      contentType: getFlag("--content-type", args),
+      sourceKind: args.includes("--ci") ? "ci" : undefined,
+      source: hasSource ? source : undefined,
+    });
+    console.log(JSON.stringify(artifact, null, 2));
+  } catch (err) {
+    console.error(
+      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/core/agents/offSecAgent/tools/sandbox.ts
+++ b/src/core/agents/offSecAgent/tools/sandbox.ts
@@ -11,7 +11,7 @@
  * ```
  */
 
-export type SandboxType = "linux" | "windows";
+export type SandboxType = "linux" | "windows" | "macos";
 
 export interface SandboxExecuteOptions {
   cwd?: string;

--- a/src/core/api/builds.test.ts
+++ b/src/core/api/builds.test.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiRequest = vi.hoisted(() => vi.fn());
+const readFile = vi.hoisted(() => vi.fn());
+
+vi.mock("./apiClient", () => ({ apiRequest }));
+vi.mock("node:fs/promises", () => ({ readFile }));
+
+import { uploadDesktopBuild } from "./builds";
+
+const BYTES = Buffer.from("fake-appimage-bytes");
+const EXPECTED_SHA = createHash("sha256").update(BYTES).digest("hex");
+
+describe("uploadDesktopBuild", () => {
+  beforeEach(() => {
+    apiRequest.mockReset();
+    readFile.mockReset();
+    readFile.mockResolvedValue(BYTES);
+    apiRequest
+      .mockResolvedValueOnce({
+        releaseId: "rel-1",
+        artifactId: "art-1",
+        s3Key: "workspaces/ws/app/rel-1/artifacts/art-1/app.AppImage",
+        uploadUrl: "https://s3.example/put?sig=1",
+        expiresInSeconds: 600,
+      })
+      .mockResolvedValueOnce({
+        artifact: {
+          id: "art-1",
+          release: "rel-1",
+          filename: "app.AppImage",
+          platform: "linux",
+          architecture: "x64",
+          format: "appimage",
+          size: BYTES.byteLength,
+          sha256: EXPECTED_SHA,
+          uploadStatus: "uploaded",
+          scanStatus: "pending",
+        },
+      });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, text: async () => "" }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("presigns with a detected filename + size, PUTs bytes, then finalizes with the sha256", async () => {
+    const artifact = await uploadDesktopBuild({
+      filePath: "/tmp/dist/app.AppImage",
+      application: "APP-3",
+      version: "1.4.2",
+      platform: "linux",
+    });
+
+    // presign
+    expect(apiRequest).toHaveBeenNthCalledWith(
+      1,
+      "POST",
+      "/api/cli/artifacts/presign",
+      expect.objectContaining({
+        application: "APP-3",
+        version: "1.4.2",
+        platform: "linux",
+        fileName: "app.AppImage",
+        size: BYTES.byteLength,
+        contentType: "application/octet-stream",
+      }),
+    );
+
+    // direct S3 PUT with the same content-type presign signed
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://s3.example/put?sig=1",
+      expect.objectContaining({
+        method: "PUT",
+        headers: { "Content-Type": "application/octet-stream" },
+      }),
+    );
+
+    // finalize with the locally-computed hash
+    expect(apiRequest).toHaveBeenNthCalledWith(
+      2,
+      "POST",
+      "/api/cli/artifacts/finalize",
+      { artifactId: "art-1", sha256: EXPECTED_SHA },
+    );
+
+    expect(artifact.id).toBe("art-1");
+    expect(artifact.uploadStatus).toBe("uploaded");
+  });
+
+  it("forwards provenance + ci sourceKind in the presign call", async () => {
+    await uploadDesktopBuild({
+      filePath: "/tmp/dist/App.exe",
+      application: "APP-3",
+      version: "2.0.0",
+      platform: "windows",
+      sourceKind: "ci",
+      source: { commitSha: "deadbeef", repositoryId: "repo-uuid" },
+    });
+    expect(apiRequest).toHaveBeenNthCalledWith(
+      1,
+      "POST",
+      "/api/cli/artifacts/presign",
+      expect.objectContaining({
+        sourceKind: "ci",
+        source: { commitSha: "deadbeef", repositoryId: "repo-uuid" },
+      }),
+    );
+  });
+
+  it("throws when the S3 PUT fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: async () => "denied",
+      }),
+    );
+    await expect(
+      uploadDesktopBuild({
+        filePath: "/tmp/dist/app.AppImage",
+        application: "APP-3",
+        version: "1.4.2",
+        platform: "linux",
+      }),
+    ).rejects.toThrow(/upload to storage failed \(403\)/);
+    // finalize must not be called after a failed PUT
+    expect(apiRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an empty file before calling the API", async () => {
+    readFile.mockResolvedValue(Buffer.alloc(0));
+    await expect(
+      uploadDesktopBuild({
+        filePath: "/tmp/empty.AppImage",
+        application: "APP-3",
+        version: "1.4.2",
+        platform: "linux",
+      }),
+    ).rejects.toThrow(/File is empty/);
+    expect(apiRequest).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/api/builds.ts
+++ b/src/core/api/builds.ts
@@ -1,0 +1,127 @@
+/**
+ * Desktop-app build artifact upload against the Pensar Console API.
+ *
+ * Three steps, mirroring the browser flow:
+ *   1. presign  — POST /api/cli/artifacts/presign  → { artifactId, uploadUrl }
+ *   2. PUT bytes directly to S3 (not through the API — avoids gateway payload
+ *      limits for multi-hundred-MB installers)
+ *   3. finalize — POST /api/cli/artifacts/finalize  → { artifact }
+ *
+ * `apiRequest` is JSON-only, so the raw byte PUT uses `fetch` directly with the
+ * exact Content-Type sent to presign (SigV4 signs that header).
+ */
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { apiRequest } from "./apiClient";
+
+export type ArtifactPlatform = "linux" | "windows" | "macos";
+export type ReleaseChannel = "stable" | "beta" | "nightly" | "dev";
+
+export interface UploadBuildInput {
+  filePath: string;
+  application: string; // application id or applicationLabel
+  version: string;
+  platform: ArtifactPlatform;
+  architecture?: string;
+  channel?: ReleaseChannel;
+  format?: string;
+  contentType?: string;
+  sourceKind?: "upload" | "ci" | "release-url";
+  source?: {
+    repositoryId?: string;
+    commitSha?: string;
+    ref?: string;
+    repositoryPath?: string;
+    buildUrl?: string;
+    workflowRunId?: string;
+  };
+}
+
+export interface UploadedArtifact {
+  id: string;
+  release: string;
+  filename: string;
+  platform: string;
+  architecture: string;
+  format: string;
+  size: number | null;
+  sha256: string | null;
+  uploadStatus: string;
+  scanStatus: string;
+}
+
+interface PresignResponse {
+  releaseId: string;
+  artifactId: string;
+  s3Key: string;
+  uploadUrl: string;
+  expiresInSeconds: number;
+}
+
+// Minimal extension → MIME guess. Falls back to octet-stream; the server treats
+// content-type as advisory (format drives behavior).
+function guessContentType(fileName: string): string {
+  const lower = fileName.toLowerCase();
+  if (lower.endsWith(".zip")) return "application/zip";
+  if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz"))
+    return "application/gzip";
+  if (lower.endsWith(".deb")) return "application/vnd.debian.binary-package";
+  if (lower.endsWith(".rpm")) return "application/x-rpm";
+  if (lower.endsWith(".dmg")) return "application/x-apple-diskimage";
+  if (lower.endsWith(".exe") || lower.endsWith(".msi"))
+    return "application/octet-stream";
+  return "application/octet-stream";
+}
+
+export async function uploadDesktopBuild(
+  input: UploadBuildInput,
+): Promise<UploadedArtifact> {
+  const fileName = path.basename(input.filePath);
+  const bytes = await readFile(input.filePath);
+  const size = bytes.byteLength;
+  if (size === 0) {
+    throw new Error(`File is empty: ${input.filePath}`);
+  }
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  const contentType = input.contentType ?? guessContentType(fileName);
+
+  const presign = await apiRequest<PresignResponse>(
+    "POST",
+    "/api/cli/artifacts/presign",
+    {
+      application: input.application,
+      version: input.version,
+      platform: input.platform,
+      architecture: input.architecture,
+      channel: input.channel,
+      format: input.format,
+      contentType,
+      fileName,
+      size,
+      sourceKind: input.sourceKind,
+      source: input.source,
+    },
+  );
+
+  // Direct S3 PUT. Content-Type must match what presign signed.
+  const putResponse = await fetch(presign.uploadUrl, {
+    method: "PUT",
+    body: bytes,
+    headers: { "Content-Type": contentType },
+  });
+  if (!putResponse.ok) {
+    const text = await putResponse.text().catch(() => "");
+    throw new Error(
+      `Artifact upload to storage failed (${putResponse.status}): ${text}`,
+    );
+  }
+
+  const { artifact } = await apiRequest<{ artifact: UploadedArtifact }>(
+    "POST",
+    "/api/cli/artifacts/finalize",
+    { artifactId: presign.artifactId, sha256 },
+  );
+
+  return artifact;
+}

--- a/src/core/api/desktopBuild.ts
+++ b/src/core/api/desktopBuild.ts
@@ -1,0 +1,69 @@
+/**
+ * Run a desktop build from a `pensar-build.json` manifest.
+ *
+ * Executes install → launch → readiness locally (via the OS shell) — the shape
+ * used when the agent runs *inside* a Windows/macOS/Linux sandbox. The heavy
+ * lifting + per-OS command building lives in `core/desktop`; this is the thin
+ * public entrypoint that wires a local executor and reads the manifest.
+ */
+import { exec as cpExec } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import {
+  type BuildManifest,
+  type DesktopExec,
+  type DesktopOs,
+  type RunBuildResult,
+  runBuildManifest,
+} from "../desktop";
+
+const pexec = promisify(cpExec);
+
+const localExec: DesktopExec = async (command, opts) => {
+  try {
+    const { stdout, stderr } = await pexec(command, {
+      cwd: opts?.cwd,
+      env: opts?.envVars ? { ...process.env, ...opts.envVars } : process.env,
+      timeout: opts?.timeout ? opts.timeout * 1000 : undefined,
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return { stdout, stderr, exitCode: 0, success: true };
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string; code?: number };
+    return {
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? String(e),
+      exitCode: typeof err.code === "number" ? err.code : 1,
+      success: false,
+    };
+  }
+};
+
+const VALID_OS: DesktopOs[] = ["linux", "windows", "macos"];
+
+function osFromManifest(platform: string): DesktopOs {
+  if ((VALID_OS as string[]).includes(platform)) return platform as DesktopOs;
+  throw new Error(
+    `Manifest artifact.platform "${platform}" is not a runnable desktop OS (${VALID_OS.join(", ")}).`,
+  );
+}
+
+export interface RunDesktopBuildInput {
+  manifestPath: string;
+  os?: DesktopOs;
+  onLog?: (line: string) => void;
+}
+
+export async function runDesktopBuild(
+  input: RunDesktopBuildInput,
+): Promise<RunBuildResult> {
+  const raw = await readFile(input.manifestPath, "utf8");
+  const manifest = JSON.parse(raw) as BuildManifest;
+  const os = input.os ?? osFromManifest(manifest.artifact.platform);
+  return runBuildManifest({
+    exec: localExec,
+    os,
+    manifest,
+    onLog: input.onLog,
+  });
+}

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -50,6 +50,13 @@ export type { AuthenticationAgentInput } from "./authentication";
 export { runAuthenticationAgent } from "./authentication";
 export { runBenchmarkComparisonAgent } from "./benchmark";
 export { runPentestAgent } from "./blackboxPentest";
+export type {
+  ArtifactPlatform,
+  ReleaseChannel,
+  UploadBuildInput,
+  UploadedArtifact,
+} from "./builds";
+export { uploadDesktopBuild } from "./builds";
 export {
   getPensarApiUrl,
   getPensarConsoleUrl,

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -64,6 +64,8 @@ export {
   PENSAR_API_BASE_URL,
   PENSAR_CONSOLE_BASE_URL,
 } from "./constants";
+export type { RunDesktopBuildInput } from "./desktopBuild";
+export { runDesktopBuild } from "./desktopBuild";
 export type { EnvironmentAgentInput, EnvironmentResult } from "./environment";
 export { runEnvironmentAgent } from "./environment";
 export type {

--- a/src/core/desktop/commands.test.ts
+++ b/src/core/desktop/commands.test.ts
@@ -1,0 +1,156 @@
+import { exec } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { launchCommand, readinessProbe, shellRun } from "./commands";
+import type { BuildManifest } from "./types";
+
+describe("shellRun", () => {
+  it("wraps linux/macos scripts in bash", () => {
+    expect(shellRun("linux", "echo hi")).toBe("bash -lc 'echo hi'");
+    expect(shellRun("macos", "echo hi")).toBe("bash -lc 'echo hi'");
+  });
+
+  it("wraps windows scripts in PowerShell", () => {
+    expect(shellRun("windows", "Write-Host hi")).toBe(
+      "powershell -NoProfile -NonInteractive -Command 'Write-Host hi'",
+    );
+  });
+
+  it("escapes embedded single quotes per shell", () => {
+    expect(shellRun("linux", "echo 'x'")).toContain(`'\\''`);
+    expect(shellRun("windows", "echo 'x'")).toContain("''");
+  });
+});
+
+const launch: BuildManifest["launch"] = {
+  executablePath: "/opt/app/app",
+  args: ["--headless", "--port=9000"],
+  workingDirectory: "/opt/app",
+  environment: [
+    { name: "LOG", value: "debug" },
+    { name: "TOKEN", secretRef: "cred-1" },
+  ],
+};
+
+describe("launchCommand", () => {
+  it("backgrounds the app with env + cwd on linux", () => {
+    const cmd = launchCommand("linux", launch);
+    expect(cmd).toContain("cd ");
+    expect(cmd).toContain("/opt/app");
+    expect(cmd).toContain("LOG=");
+    expect(cmd).toContain("--headless");
+    expect(cmd).toContain("&"); // backgrounded
+    // secretRef-only env (no value) is not inlined
+    expect(cmd).not.toContain("TOKEN=");
+  });
+
+  it("uses Start-Process on windows", () => {
+    const cmd = launchCommand("windows", launch);
+    expect(cmd).toContain("Start-Process");
+    expect(cmd).toContain("-ArgumentList");
+    expect(cmd).toContain("$env:LOG=");
+  });
+
+  it("skips env entries whose value is not a string", () => {
+    // Manifests are parsed JSON — a null/numeric value must not reach quoting.
+    const withNull = {
+      ...launch,
+      environment: [
+        { name: "NULLED", value: null },
+        { name: "LOG", value: "debug" },
+      ] as unknown as BuildManifest["launch"]["environment"],
+    };
+    expect(() => launchCommand("linux", withNull)).not.toThrow();
+    expect(launchCommand("linux", withNull)).not.toContain("NULLED");
+    expect(launchCommand("linux", withNull)).toContain("LOG=");
+    expect(launchCommand("windows", withNull)).not.toContain("NULLED");
+  });
+
+  it("throws without an executablePath", () => {
+    expect(() =>
+      launchCommand("linux", { ...launch, executablePath: null }),
+    ).toThrow(/executablePath is required/);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "returns to the executor without waiting for the app to exit",
+    async () => {
+      // Regression: `cd X && app >log &` backgrounds a subshell that keeps the
+      // executor's stdout/stderr pipes open, so the launch step blocked until
+      // the app exited — i.e. forever, for a real desktop app.
+      const dir = await mkdtemp(join(tmpdir(), "pensar-launch-"));
+      const script = join(dir, "app.sh");
+      await writeFile(script, "#!/usr/bin/env bash\nsleep 5\n", {
+        mode: 0o755,
+      });
+
+      const started = Date.now();
+      await new Promise<void>((resolve, reject) => {
+        exec(
+          launchCommand("linux", {
+            executablePath: script,
+            args: [],
+            workingDirectory: dir,
+            environment: [],
+          }),
+          (err) => (err ? reject(err) : resolve()),
+        );
+      });
+      expect(Date.now() - started).toBeLessThan(3000);
+    },
+  );
+});
+
+describe("readinessProbe", () => {
+  it("returns null for sleep (runner waits instead)", () => {
+    expect(readinessProbe("linux", { kind: "sleep", seconds: 3 })).toBeNull();
+  });
+
+  it("builds process probes per OS", () => {
+    expect(
+      readinessProbe("linux", { kind: "process", process: "app" }),
+    ).toContain("pgrep");
+    expect(
+      readinessProbe("windows", { kind: "process", process: "app" }),
+    ).toContain("Get-CimInstance Win32_Process");
+  });
+
+  it("matches the windows process probe against the command line", () => {
+    // pgrep -f accepts a path fragment; the windows probe must too, so it
+    // checks CommandLine (not just the bare image name).
+    const probe = readinessProbe("windows", {
+      kind: "process",
+      process: "C:\\Program Files\\App\\app.exe --headless",
+    });
+    expect(probe).toContain("$_.CommandLine -like");
+    expect(probe).toContain("$_.Name -like");
+    expect(probe).toContain("app.exe --headless");
+  });
+
+  it("escapes -like wildcards in windows patterns", () => {
+    expect(
+      readinessProbe("windows", { kind: "process", process: "a[p]p*" }),
+    ).toContain("*a`[p`]p`**");
+    expect(
+      readinessProbe("windows", {
+        kind: "window-title",
+        titleContains: "Save?",
+      }),
+    ).toContain("*Save`?*");
+  });
+
+  it("builds port probes per OS", () => {
+    const linux = readinessProbe("linux", { kind: "port", port: 8080 });
+    expect(linux).toContain(":8080");
+    // ss is missing on minimal images, so the probe must have a fallback.
+    expect(linux).toContain("/dev/tcp/127.0.0.1/8080");
+    expect(readinessProbe("macos", { kind: "port", port: 8080 })).toContain(
+      "lsof",
+    );
+    expect(readinessProbe("windows", { kind: "port", port: 8080 })).toContain(
+      "Get-NetTCPConnection",
+    );
+  });
+});

--- a/src/core/desktop/commands.ts
+++ b/src/core/desktop/commands.ts
@@ -131,7 +131,7 @@ export function readinessProbe(
       return `bash -lc ${singleQuote(`ss -ltn 2>/dev/null | grep -q ":${check.port} " || (exec 3<>/dev/tcp/127.0.0.1/${check.port}) 2>/dev/null`)}`;
     case "window-title":
       if (os === "linux") {
-        return `bash -lc ${singleQuote(`xdotool search --name ${JSON.stringify(check.titleContains)} >/dev/null 2>&1`)}`;
+        return `bash -lc ${singleQuote(`xdotool search --name ${quoteArg(os, check.titleContains)} >/dev/null 2>&1`)}`;
       }
       if (os === "macos") {
         return `osascript -e 'tell application "System Events" to (name of every window of every process) as string' 2>/dev/null | grep -q ${quoteArg(os, check.titleContains)}`;

--- a/src/core/desktop/commands.ts
+++ b/src/core/desktop/commands.ts
@@ -1,0 +1,146 @@
+/**
+ * Pure, per-OS command builders for the desktop environment.
+ *
+ * These produce the exact shell strings the runner hands to `DesktopExec`.
+ * Deterministic string builders (no I/O) so every OS dialect is unit-tested in
+ * isolation — installing/launching a desktop app is a deterministic transform,
+ * not a model judgement.
+ */
+import type { BuildManifest, DesktopOs, ReadinessCheck } from "./types";
+
+// Escape a script body for embedding inside a single-quoted shell argument.
+function singleQuote(body: string): string {
+  return `'${body.replace(/'/g, `'\\''`)}'`;
+}
+
+// PowerShell single-quote escaping doubles the quote.
+function psQuote(body: string): string {
+  return `'${body.replace(/'/g, "''")}'`;
+}
+
+// Manifest strings are literals, but PowerShell's -like treats these as
+// wildcards — backtick-escape them so the match stays literal.
+function escapeLikePattern(value: string): string {
+  return value.replace(/([`*?[\]])/g, "`$1");
+}
+
+/**
+ * Wrap an install/teardown script body in the OS's shell. Windows scripts run
+ * under PowerShell; Linux/macOS under bash. The body itself is author-supplied
+ * (or synthesized by the Console recipe) and already OS-appropriate.
+ */
+export function shellRun(os: DesktopOs, scriptBody: string): string {
+  if (os === "windows") {
+    return `powershell -NoProfile -NonInteractive -Command ${psQuote(scriptBody)}`;
+  }
+  return `bash -lc ${singleQuote(scriptBody)}`;
+}
+
+function quoteArg(os: DesktopOs, arg: string): string {
+  if (os === "windows") return `'${arg.replace(/'/g, "''")}'`;
+  return `"${arg.replace(/(["\\$`])/g, "\\$1")}"`;
+}
+
+// Where a backgrounded linux/macOS app's stdout+stderr land, so the readiness
+// log-line check has something to grep.
+const LAUNCH_LOG_PATH = "/tmp/pensar-app.log";
+
+/**
+ * Build a command that launches the app in the background so the runner can
+ * proceed to readiness checks. Requires `launch.executablePath`.
+ */
+export function launchCommand(
+  os: DesktopOs,
+  launch: BuildManifest["launch"],
+): string {
+  if (!launch.executablePath) {
+    throw new Error(
+      "launch.executablePath is required to launch a desktop app",
+    );
+  }
+  const args = (launch.args ?? []).map((a) => quoteArg(os, a)).join(" ");
+  // Manifests are parsed JSON: only inline entries that actually carry a
+  // string value (secretRef-only entries, and nulls, are not inlined).
+  const envPairs = (launch.environment ?? []).filter(
+    (e): e is { name: string; value: string } =>
+      typeof e.name === "string" && typeof e.value === "string",
+  );
+
+  if (os === "windows") {
+    const argList = launch.args?.length
+      ? ` -ArgumentList ${launch.args.map((a) => quoteArg(os, a)).join(",")}`
+      : "";
+    const env = envPairs
+      .map((e) => `$env:${e.name}=${quoteArg(os, e.value)}; `)
+      .join("");
+    const wd = launch.workingDirectory
+      ? ` -WorkingDirectory ${quoteArg(os, launch.workingDirectory)}`
+      : "";
+    return `powershell -NoProfile -Command "${env}Start-Process -FilePath ${quoteArg(os, launch.executablePath)}${argList}${wd}"`;
+  }
+
+  // linux / macos: cd (if wd) then background the process with env prefix.
+  // The redirects must wrap the whole group, not just the app: `cd X && app
+  // >log &` backgrounds a subshell that keeps the executor's stdout/stderr
+  // pipes open, so the executor blocks until the app exits.
+  const env = envPairs
+    .map((e) => `${e.name}=${quoteArg(os, e.value)}`)
+    .join(" ");
+  const cd = launch.workingDirectory
+    ? `cd ${quoteArg(os, launch.workingDirectory)} && `
+    : "";
+  const run = [env, quoteArg(os, launch.executablePath), args]
+    .filter((part) => part !== "")
+    .join(" ");
+  return `bash -lc ${singleQuote(`{ ${cd}${run}; } </dev/null >${LAUNCH_LOG_PATH} 2>&1 &`)}`;
+}
+
+/**
+ * A single-shot readiness probe: a command that exits 0 when the app is ready.
+ * The runner polls it. `sleep` returns null (the runner just waits). Best-effort
+ * for window-title / log-line.
+ */
+export function readinessProbe(
+  os: DesktopOs,
+  check: ReadinessCheck,
+): string | null {
+  switch (check.kind) {
+    case "sleep":
+      return null;
+    case "process": {
+      if (os === "windows") {
+        // Match the full command line (and fall back to the image name) so the
+        // same manifest string — a path fragment or an argv substring — works
+        // here as it does under `pgrep -f`. Get-Process -Name only matches the
+        // bare image name, which silently never fires for those manifests.
+        const pattern = psQuote(`*${escapeLikePattern(check.process)}*`);
+        return `powershell -NoProfile -Command "if (Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like ${pattern} -or $_.Name -like ${pattern} }) { exit 0 } else { exit 1 }"`;
+      }
+      // pgrep works on linux; macOS ships it too.
+      return `pgrep -f ${quoteArg(os, check.process)} >/dev/null`;
+    }
+    case "port":
+      if (os === "windows") {
+        return `powershell -NoProfile -Command "if (Get-NetTCPConnection -State Listen -LocalPort ${check.port} -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }"`;
+      }
+      if (os === "macos") {
+        return `lsof -iTCP:${check.port} -sTCP:LISTEN >/dev/null 2>&1`;
+      }
+      // linux: prefer ss, but minimal images often ship without iproute2 — fall
+      // back to a loopback connect so the probe doesn't silently never fire.
+      return `bash -lc ${singleQuote(`ss -ltn 2>/dev/null | grep -q ":${check.port} " || (exec 3<>/dev/tcp/127.0.0.1/${check.port}) 2>/dev/null`)}`;
+    case "window-title":
+      if (os === "linux") {
+        return `bash -lc ${singleQuote(`xdotool search --name ${JSON.stringify(check.titleContains)} >/dev/null 2>&1`)}`;
+      }
+      if (os === "macos") {
+        return `osascript -e 'tell application "System Events" to (name of every window of every process) as string' 2>/dev/null | grep -q ${quoteArg(os, check.titleContains)}`;
+      }
+      return `powershell -NoProfile -Command "if (Get-Process | Where-Object { $_.MainWindowTitle -like ${psQuote(`*${escapeLikePattern(check.titleContains)}*`)} }) { exit 0 } else { exit 1 }"`;
+    case "log-line":
+      if (os === "windows") {
+        return `powershell -NoProfile -Command "if (Select-String -Path ${psQuote(check.path)} -Pattern ${psQuote(check.contains)} -Quiet) { exit 0 } else { exit 1 }"`;
+      }
+      return `grep -q ${quoteArg(os, check.contains)} ${quoteArg(os, check.path)}`;
+  }
+}

--- a/src/core/desktop/index.ts
+++ b/src/core/desktop/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Desktop environment support: install + launch a build artifact from a
+ * `pensar-build.json` manifest inside a Windows / macOS / Linux sandbox.
+ *
+ * Public API for the module — import from here, not the internals.
+ */
+
+export {
+  type RunBuildOptions,
+  type RunBuildResult,
+  runBuildManifest,
+} from "./runner";
+export type {
+  BuildManifest,
+  DesktopExec,
+  DesktopExecResult,
+  DesktopOs,
+  ReadinessCheck,
+} from "./types";

--- a/src/core/desktop/runner.test.ts
+++ b/src/core/desktop/runner.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import { runBuildManifest } from "./runner";
+import type { BuildManifest, DesktopExecResult } from "./types";
+
+const ok: DesktopExecResult = {
+  stdout: "",
+  stderr: "",
+  exitCode: 0,
+  success: true,
+};
+const fail: DesktopExecResult = {
+  stdout: "",
+  stderr: "boom",
+  exitCode: 1,
+  success: false,
+};
+
+function manifest(overrides: Partial<BuildManifest> = {}): BuildManifest {
+  return {
+    manifestVersion: 1,
+    artifact: {
+      id: "a1",
+      filename: "app.AppImage",
+      path: "/work/app.AppImage",
+      format: "appimage",
+      platform: "linux",
+      architecture: "x64",
+      sha256: null,
+    },
+    install: {
+      mode: "appimage-direct",
+      script: 'chmod +x "/work/app.AppImage"',
+    },
+    launch: {
+      executablePath: "/work/app.AppImage",
+      args: [],
+      workingDirectory: null,
+      environment: [],
+    },
+    readinessCheck: null,
+    teardownScript: null,
+    ...overrides,
+  };
+}
+
+const noSleep = () => Promise.resolve();
+
+describe("runBuildManifest", () => {
+  it("runs install then launch then reports ready when no readiness check", async () => {
+    const exec = vi.fn().mockResolvedValue(ok);
+    const result = await runBuildManifest({
+      exec,
+      os: "linux",
+      manifest: manifest(),
+      sleep: noSleep,
+    });
+    expect(result).toEqual({
+      installed: true,
+      launched: true,
+      ready: true,
+      readinessKind: null,
+    });
+    // install call first, launch second
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(exec.mock.calls[0][0]).toContain("chmod +x");
+    expect(exec.mock.calls[1][0]).toContain("app.AppImage");
+  });
+
+  it("throws when the install step fails and does not launch", async () => {
+    const exec = vi.fn().mockResolvedValue(fail);
+    await expect(
+      runBuildManifest({
+        exec,
+        os: "linux",
+        manifest: manifest(),
+        sleep: noSleep,
+      }),
+    ).rejects.toThrow(/Install step failed/);
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls a process readiness probe until it succeeds", async () => {
+    // install ok, launch ok, probe fails once then succeeds.
+    const exec = vi
+      .fn()
+      .mockResolvedValueOnce(ok) // install
+      .mockResolvedValueOnce(ok) // launch
+      .mockResolvedValueOnce(fail) // probe #1
+      .mockResolvedValueOnce(ok); // probe #2
+    const result = await runBuildManifest({
+      exec,
+      os: "linux",
+      manifest: manifest({
+        readinessCheck: { kind: "process", process: "app", timeoutSeconds: 30 },
+      }),
+      sleep: noSleep,
+      pollIntervalMs: 1,
+    });
+    expect(result.ready).toBe(true);
+    expect(result.readinessKind).toBe("process");
+    expect(exec).toHaveBeenCalledTimes(4);
+  });
+
+  it("honors a sleep readiness check without a probe", async () => {
+    const exec = vi.fn().mockResolvedValue(ok);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const result = await runBuildManifest({
+      exec,
+      os: "linux",
+      manifest: manifest({ readinessCheck: { kind: "sleep", seconds: 5 } }),
+      sleep,
+    });
+    expect(result.ready).toBe(true);
+    expect(sleep).toHaveBeenCalledWith(5000);
+    // only install + launch hit exec; sleep is not a probe
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips launch when there is no executable", async () => {
+    const exec = vi.fn().mockResolvedValue(ok);
+    const result = await runBuildManifest({
+      exec,
+      os: "windows",
+      manifest: manifest({
+        launch: {
+          executablePath: null,
+          args: [],
+          workingDirectory: null,
+          environment: [],
+        },
+      }),
+      sleep: noSleep,
+    });
+    expect(result.launched).toBe(false);
+    expect(exec).toHaveBeenCalledTimes(1); // install only
+  });
+
+  it("rejects an unsupported manifest version", async () => {
+    const exec = vi.fn().mockResolvedValue(ok);
+    await expect(
+      runBuildManifest({
+        exec,
+        os: "linux",
+        manifest: manifest({ manifestVersion: 99 }),
+        sleep: noSleep,
+      }),
+    ).rejects.toThrow(/Unsupported build manifest version 99/);
+    expect(exec).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/desktop/runner.ts
+++ b/src/core/desktop/runner.ts
@@ -1,0 +1,128 @@
+/**
+ * Desktop build-manifest runner: install → launch → wait-for-ready.
+ *
+ * Consumes a `pensar-build.json` produced by the Console and executes it inside
+ * the desktop environment via an injected `DesktopExec` (a Daytona sandbox's
+ * `execute`, or a local shell when the agent runs inside the sandbox). Sequences
+ * are deterministic; the model is only involved once the app is up.
+ */
+import { launchCommand, readinessProbe, shellRun } from "./commands";
+import {
+  type BuildManifest,
+  type DesktopExec,
+  type DesktopOs,
+  SUPPORTED_MANIFEST_VERSION,
+} from "./types";
+
+export interface RunBuildOptions {
+  exec: DesktopExec;
+  os: DesktopOs;
+  manifest: BuildManifest;
+  // Injected for testability; defaults to real wall-clock sleep.
+  sleep?: (ms: number) => Promise<void>;
+  // Poll cadence for readiness probes.
+  pollIntervalMs?: number;
+  onLog?: (line: string) => void;
+}
+
+export interface RunBuildResult {
+  installed: boolean;
+  launched: boolean;
+  ready: boolean;
+  readinessKind: string | null;
+}
+
+const DEFAULT_READINESS_TIMEOUT_S = 60;
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+
+const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function waitForReadiness(
+  opts: Required<Pick<RunBuildOptions, "exec" | "os" | "sleep">> & {
+    manifest: BuildManifest;
+    pollIntervalMs: number;
+    onLog?: (line: string) => void;
+  },
+): Promise<boolean> {
+  const check = opts.manifest.readinessCheck;
+  if (!check) return true;
+
+  if (check.kind === "sleep") {
+    await opts.sleep(check.seconds * 1000);
+    return true;
+  }
+
+  const probe = readinessProbe(opts.os, check);
+  if (!probe) return true;
+
+  const timeoutMs =
+    (("timeoutSeconds" in check && check.timeoutSeconds) ||
+      DEFAULT_READINESS_TIMEOUT_S) * 1000;
+  const deadline = Date.now() + timeoutMs;
+
+  // First attempt immediately, then poll until the deadline.
+  for (;;) {
+    const res = await opts.exec(probe);
+    if (res.success) return true;
+    if (Date.now() >= deadline) {
+      opts.onLog?.(
+        `readiness (${check.kind}) not satisfied within ${timeoutMs / 1000}s`,
+      );
+      return false;
+    }
+    await opts.sleep(opts.pollIntervalMs);
+  }
+}
+
+export async function runBuildManifest(
+  opts: RunBuildOptions,
+): Promise<RunBuildResult> {
+  const { exec, os, manifest } = opts;
+  const sleep = opts.sleep ?? realSleep;
+  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+  if (manifest.manifestVersion !== SUPPORTED_MANIFEST_VERSION) {
+    throw new Error(
+      `Unsupported build manifest version ${manifest.manifestVersion} (this runner supports ${SUPPORTED_MANIFEST_VERSION}).`,
+    );
+  }
+
+  // 1. Install.
+  opts.onLog?.(`installing (${manifest.install.mode})`);
+  const install = await exec(shellRun(os, manifest.install.script));
+  if (!install.success) {
+    throw new Error(
+      `Install step failed (exit ${install.exitCode}): ${install.stderr || install.stdout}`,
+    );
+  }
+
+  // 2. Launch (skip when no executable — e.g. a headless service build).
+  let launched = false;
+  if (manifest.launch.executablePath) {
+    opts.onLog?.(`launching ${manifest.launch.executablePath}`);
+    const launch = await exec(launchCommand(os, manifest.launch));
+    if (!launch.success) {
+      throw new Error(
+        `Launch step failed (exit ${launch.exitCode}): ${launch.stderr || launch.stdout}`,
+      );
+    }
+    launched = true;
+  }
+
+  // 3. Wait for readiness.
+  const ready = await waitForReadiness({
+    exec,
+    os,
+    sleep,
+    manifest,
+    pollIntervalMs,
+    onLog: opts.onLog,
+  });
+
+  return {
+    installed: true,
+    launched,
+    ready,
+    readinessKind: manifest.readinessCheck?.kind ?? null,
+  };
+}

--- a/src/core/desktop/types.ts
+++ b/src/core/desktop/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Desktop-environment execution types.
+ *
+ * Mirrors the `pensar-build.json` contract produced by the Console
+ * (`packages/core/applicationBuilds/recipe.ts` `buildBuildManifest`) so the
+ * runner can install + launch a build artifact deterministically inside a
+ * Windows / macOS / Linux sandbox. Keep field names in lockstep with that
+ * producer.
+ */
+
+export type DesktopOs = "linux" | "windows" | "macos";
+
+// Result of one command executed in the desktop environment. Matches the shape
+// of `UnifiedSandbox.execute` so a sandbox can be passed directly as the exec.
+export interface DesktopExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  success: boolean;
+}
+
+// Abstract command executor. In a Console Daytona sandbox the agent runs
+// locally (exec = local shell); a host-drives-remote flow passes a
+// `UnifiedSandbox.execute`. Injecting it keeps the runner testable.
+export type DesktopExec = (
+  command: string,
+  opts?: { cwd?: string; envVars?: Record<string, string>; timeout?: number },
+) => Promise<DesktopExecResult>;
+
+export type ReadinessCheck =
+  | { kind: "sleep"; seconds: number }
+  | { kind: "process"; process: string; timeoutSeconds?: number }
+  | { kind: "port"; port: number; timeoutSeconds?: number }
+  | { kind: "window-title"; titleContains: string; timeoutSeconds?: number }
+  | {
+      kind: "log-line";
+      path: string;
+      contains: string;
+      timeoutSeconds?: number;
+    };
+
+interface BuildManifestLaunchEnv {
+  name: string;
+  secretRef?: string;
+  value?: string;
+}
+
+export interface BuildManifest {
+  manifestVersion: number;
+  artifact: {
+    id: string;
+    filename: string;
+    path: string;
+    format: string;
+    platform: string;
+    architecture: string;
+    sha256: string | null;
+  };
+  install: {
+    mode: string;
+    script: string;
+  };
+  launch: {
+    executablePath: string | null;
+    args: string[];
+    workingDirectory: string | null;
+    environment: BuildManifestLaunchEnv[];
+  };
+  readinessCheck: ReadinessCheck | null;
+  teardownScript: string | null;
+}
+
+export const SUPPORTED_MANIFEST_VERSION = 1;


### PR DESCRIPTION
Adds a two-step presigned upload command that pushes a desktop application build artifact to the Pensar Console API:

- core/api/builds.ts: uploadDesktopBuild() computes sha256, presigns via POST /api/cli/artifacts/presign, PUTs bytes directly to S3, then confirms via POST /api/cli/artifacts/finalize.
- cli/builds.ts: 'pensar builds upload <file> --app <ref> --version <v>
  --platform <p>' with optional --arch/--channel/--format/--ci + provenance flags (--commit/--repo-id/--ref/--repo-path/--build-url).
- Wired into the cli.ts router + help; exported from core/api barrel.
- Unit tests mock the API client + fetch and assert the presign/PUT/finalize sequence, provenance forwarding, and failure paths.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New CLI runs arbitrary install/launch scripts from manifests and uploads large binaries to S3; logic is well-tested but touches shell execution and external storage.
> 
> **Overview**
> Adds **`pensar builds`** for desktop-app artifacts: **`upload`** pushes installers to Pensar Console via presign → direct S3 PUT → finalize (with optional CI provenance), and **`run`** installs/launches from a `pensar-build.json` manifest in the local/sandbox shell.
> 
> Introduces **`core/desktop`** to execute Console manifests deterministically—per-OS install/launch command builders, readiness probes (process, port, sleep, window-title, log-line), and a runner that polls until ready. **`SandboxType`** now includes **`macos`**, and Biome enforces imports through the **`core/desktop`** barrel.
> 
> Unit tests cover the upload sequence, S3 failure/empty-file paths, command quoting/background launch behavior, and runner install/launch/readiness flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0046b57f79aab9477799c79273665cfb7c9f90b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->