### PR TITLE
feat(desktop): desktop environment support — install/launch build man…

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -112,6 +112,10 @@
                 "message": "Import from the offSecAgent/tools/email barrel (index), not its internals."
               },
               {
+                "group": ["**/core/desktop/*", "!**/core/desktop/index"],
+                "message": "Import from the core/desktop barrel (index), not its internals."
+              },
+              {
                 "group": [
                   "**/core/skills/builtins/*",
                   "!**/core/skills/builtins/index"

--- a/src/cli/builds.ts
+++ b/src/cli/builds.ts
@@ -14,6 +14,8 @@ import {
   type ReleaseChannel,
   uploadDesktopBuild,
 } from "../core/api/builds";
+import { runDesktopBuild } from "../core/api/desktopBuild";
+import type { DesktopOs } from "../core/desktop";
 
 function getFlag(flag: string, argv: string[]): string | undefined {
   const idx = argv.indexOf(flag);
@@ -30,6 +32,12 @@ All commands operate on the selected workspace (set via \`pensar login\`).
 
 Usage:
   pensar builds upload <file> [options]
+  pensar builds run <manifest.json> [--os linux|windows|macos]
+
+run:
+  Installs + launches a desktop build from a pensar-build.json manifest using
+  the local OS shell (intended to run inside the target sandbox). The OS is
+  read from the manifest's artifact.platform unless --os overrides it.
 
 upload options (required):
   --app <ref>            Application id or label (e.g. APP-3) the build belongs to
@@ -63,6 +71,35 @@ async function main(): Promise<void> {
 
   if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
     showHelp();
+    return;
+  }
+
+  if (sub === "run") {
+    const manifestPath =
+      args[1] && !args[1].startsWith("--") ? args[1] : undefined;
+    if (!manifestPath) {
+      console.error("Error: missing required argument: <manifest.json>");
+      console.error("Usage: pensar builds run <manifest.json> [--os <os>]");
+      process.exit(1);
+    }
+    const osOverride = getFlag("--os", args) as DesktopOs | undefined;
+    if (osOverride && !PLATFORMS.includes(osOverride as ArtifactPlatform)) {
+      console.error(`Error: --os must be one of: ${PLATFORMS.join(", ")}`);
+      process.exit(1);
+    }
+    try {
+      const result = await runDesktopBuild({
+        manifestPath,
+        os: osOverride,
+        onLog: (line) => console.error(`[desktop] ${line}`),
+      });
+      console.log(JSON.stringify(result, null, 2));
+    } catch (err) {
+      console.error(
+        `\nError: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(1);
+    }
     return;
   }
 

--- a/src/cli/builds.ts
+++ b/src/cli/builds.ts
@@ -94,6 +94,12 @@ async function main(): Promise<void> {
         onLog: (line) => console.error(`[desktop] ${line}`),
       });
       console.log(JSON.stringify(result, null, 2));
+      if (!result.ready) {
+        console.error(
+          `\nError: the app never became ready (${result.readinessKind} check timed out).`,
+        );
+        process.exit(1);
+      }
     } catch (err) {
       console.error(
         `\nError: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/core/agents/offSecAgent/tools/sandbox.ts
+++ b/src/core/agents/offSecAgent/tools/sandbox.ts
@@ -11,7 +11,7 @@
  * ```
  */
 
-export type SandboxType = "linux" | "windows";
+export type SandboxType = "linux" | "windows" | "macos";
 
 export interface SandboxExecuteOptions {
   cwd?: string;

--- a/src/core/api/desktopBuild.ts
+++ b/src/core/api/desktopBuild.ts
@@ -1,0 +1,69 @@
+/**
+ * Run a desktop build from a `pensar-build.json` manifest.
+ *
+ * Executes install → launch → readiness locally (via the OS shell) — the shape
+ * used when the agent runs *inside* a Windows/macOS/Linux sandbox. The heavy
+ * lifting + per-OS command building lives in `core/desktop`; this is the thin
+ * public entrypoint that wires a local executor and reads the manifest.
+ */
+import { exec as cpExec } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import {
+  type BuildManifest,
+  type DesktopExec,
+  type DesktopOs,
+  type RunBuildResult,
+  runBuildManifest,
+} from "../desktop";
+
+const pexec = promisify(cpExec);
+
+const localExec: DesktopExec = async (command, opts) => {
+  try {
+    const { stdout, stderr } = await pexec(command, {
+      cwd: opts?.cwd,
+      env: opts?.envVars ? { ...process.env, ...opts.envVars } : process.env,
+      timeout: opts?.timeout ? opts.timeout * 1000 : undefined,
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return { stdout, stderr, exitCode: 0, success: true };
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string; code?: number };
+    return {
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? String(e),
+      exitCode: typeof err.code === "number" ? err.code : 1,
+      success: false,
+    };
+  }
+};
+
+const VALID_OS: DesktopOs[] = ["linux", "windows", "macos"];
+
+function osFromManifest(platform: string): DesktopOs {
+  if ((VALID_OS as string[]).includes(platform)) return platform as DesktopOs;
+  throw new Error(
+    `Manifest artifact.platform "${platform}" is not a runnable desktop OS (${VALID_OS.join(", ")}).`,
+  );
+}
+
+export interface RunDesktopBuildInput {
+  manifestPath: string;
+  os?: DesktopOs;
+  onLog?: (line: string) => void;
+}
+
+export async function runDesktopBuild(
+  input: RunDesktopBuildInput,
+): Promise<RunBuildResult> {
+  const raw = await readFile(input.manifestPath, "utf8");
+  const manifest = JSON.parse(raw) as BuildManifest;
+  const os = input.os ?? osFromManifest(manifest.artifact.platform);
+  return runBuildManifest({
+    exec: localExec,
+    os,
+    manifest,
+    onLog: input.onLog,
+  });
+}

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -64,6 +64,8 @@ export {
   PENSAR_API_BASE_URL,
   PENSAR_CONSOLE_BASE_URL,
 } from "./constants";
+export type { RunDesktopBuildInput } from "./desktopBuild";
+export { runDesktopBuild } from "./desktopBuild";
 export type { EnvironmentAgentInput, EnvironmentResult } from "./environment";
 export { runEnvironmentAgent } from "./environment";
 export type {

--- a/src/core/desktop/commands.test.ts
+++ b/src/core/desktop/commands.test.ts
@@ -49,6 +49,21 @@ describe("launchCommand", () => {
     expect(cmd).toContain("$env:LOG=");
   });
 
+  it("skips env entries whose value is not a string", () => {
+    // Manifests are parsed JSON — a null/numeric value must not reach quoting.
+    const withNull = {
+      ...launch,
+      environment: [
+        { name: "NULLED", value: null },
+        { name: "LOG", value: "debug" },
+      ] as unknown as BuildManifest["launch"]["environment"],
+    };
+    expect(() => launchCommand("linux", withNull)).not.toThrow();
+    expect(launchCommand("linux", withNull)).not.toContain("NULLED");
+    expect(launchCommand("linux", withNull)).toContain("LOG=");
+    expect(launchCommand("windows", withNull)).not.toContain("NULLED");
+  });
+
   it("throws without an executablePath", () => {
     expect(() =>
       launchCommand("linux", { ...launch, executablePath: null }),
@@ -67,7 +82,31 @@ describe("readinessProbe", () => {
     ).toContain("pgrep");
     expect(
       readinessProbe("windows", { kind: "process", process: "app" }),
-    ).toContain("Get-Process");
+    ).toContain("Get-CimInstance Win32_Process");
+  });
+
+  it("matches the windows process probe against the command line", () => {
+    // pgrep -f accepts a path fragment; the windows probe must too, so it
+    // checks CommandLine (not just the bare image name).
+    const probe = readinessProbe("windows", {
+      kind: "process",
+      process: "C:\\Program Files\\App\\app.exe --headless",
+    });
+    expect(probe).toContain("$_.CommandLine -like");
+    expect(probe).toContain("$_.Name -like");
+    expect(probe).toContain("app.exe --headless");
+  });
+
+  it("escapes -like wildcards in windows patterns", () => {
+    expect(
+      readinessProbe("windows", { kind: "process", process: "a[p]p*" }),
+    ).toContain("*a`[p`]p`**");
+    expect(
+      readinessProbe("windows", {
+        kind: "window-title",
+        titleContains: "Save?",
+      }),
+    ).toContain("*Save`?*");
   });
 
   it("builds port probes per OS", () => {

--- a/src/core/desktop/commands.test.ts
+++ b/src/core/desktop/commands.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  launchCommand,
-  readinessProbe,
-  screenshotCommand,
-  shellRun,
-} from "./commands";
+import { launchCommand, readinessProbe, shellRun } from "./commands";
 import type { BuildManifest } from "./types";
 
 describe("shellRun", () => {
@@ -85,15 +80,5 @@ describe("readinessProbe", () => {
     expect(readinessProbe("windows", { kind: "port", port: 8080 })).toContain(
       "Get-NetTCPConnection",
     );
-  });
-});
-
-describe("screenshotCommand", () => {
-  it("uses the OS-native capture tool", () => {
-    expect(screenshotCommand("macos", "/tmp/s.png")).toContain("screencapture");
-    expect(screenshotCommand("windows", "/tmp/s.png")).toContain(
-      "CopyFromScreen",
-    );
-    expect(screenshotCommand("linux", "/tmp/s.png")).toContain("scrot");
   });
 });

--- a/src/core/desktop/commands.test.ts
+++ b/src/core/desktop/commands.test.ts
@@ -1,3 +1,7 @@
+import { exec } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { launchCommand, readinessProbe, shellRun } from "./commands";
 import type { BuildManifest } from "./types";
@@ -69,6 +73,34 @@ describe("launchCommand", () => {
       launchCommand("linux", { ...launch, executablePath: null }),
     ).toThrow(/executablePath is required/);
   });
+
+  it.skipIf(process.platform === "win32")(
+    "returns to the executor without waiting for the app to exit",
+    async () => {
+      // Regression: `cd X && app >log &` backgrounds a subshell that keeps the
+      // executor's stdout/stderr pipes open, so the launch step blocked until
+      // the app exited — i.e. forever, for a real desktop app.
+      const dir = await mkdtemp(join(tmpdir(), "pensar-launch-"));
+      const script = join(dir, "app.sh");
+      await writeFile(script, "#!/usr/bin/env bash\nsleep 5\n", {
+        mode: 0o755,
+      });
+
+      const started = Date.now();
+      await new Promise<void>((resolve, reject) => {
+        exec(
+          launchCommand("linux", {
+            executablePath: script,
+            args: [],
+            workingDirectory: dir,
+            environment: [],
+          }),
+          (err) => (err ? reject(err) : resolve()),
+        );
+      });
+      expect(Date.now() - started).toBeLessThan(3000);
+    },
+  );
 });
 
 describe("readinessProbe", () => {
@@ -110,9 +142,10 @@ describe("readinessProbe", () => {
   });
 
   it("builds port probes per OS", () => {
-    expect(readinessProbe("linux", { kind: "port", port: 8080 })).toContain(
-      ":8080",
-    );
+    const linux = readinessProbe("linux", { kind: "port", port: 8080 });
+    expect(linux).toContain(":8080");
+    // ss is missing on minimal images, so the probe must have a fallback.
+    expect(linux).toContain("/dev/tcp/127.0.0.1/8080");
     expect(readinessProbe("macos", { kind: "port", port: 8080 })).toContain(
       "lsof",
     );

--- a/src/core/desktop/commands.test.ts
+++ b/src/core/desktop/commands.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  launchCommand,
+  readinessProbe,
+  screenshotCommand,
+  shellRun,
+} from "./commands";
+import type { BuildManifest } from "./types";
+
+describe("shellRun", () => {
+  it("wraps linux/macos scripts in bash", () => {
+    expect(shellRun("linux", "echo hi")).toBe("bash -lc 'echo hi'");
+    expect(shellRun("macos", "echo hi")).toBe("bash -lc 'echo hi'");
+  });
+
+  it("wraps windows scripts in PowerShell", () => {
+    expect(shellRun("windows", "Write-Host hi")).toBe(
+      "powershell -NoProfile -NonInteractive -Command 'Write-Host hi'",
+    );
+  });
+
+  it("escapes embedded single quotes per shell", () => {
+    expect(shellRun("linux", "echo 'x'")).toContain(`'\\''`);
+    expect(shellRun("windows", "echo 'x'")).toContain("''");
+  });
+});
+
+const launch: BuildManifest["launch"] = {
+  executablePath: "/opt/app/app",
+  args: ["--headless", "--port=9000"],
+  workingDirectory: "/opt/app",
+  environment: [
+    { name: "LOG", value: "debug" },
+    { name: "TOKEN", secretRef: "cred-1" },
+  ],
+};
+
+describe("launchCommand", () => {
+  it("backgrounds the app with env + cwd on linux", () => {
+    const cmd = launchCommand("linux", launch);
+    expect(cmd).toContain("cd ");
+    expect(cmd).toContain("/opt/app");
+    expect(cmd).toContain("LOG=");
+    expect(cmd).toContain("--headless");
+    expect(cmd).toContain("&"); // backgrounded
+    // secretRef-only env (no value) is not inlined
+    expect(cmd).not.toContain("TOKEN=");
+  });
+
+  it("uses Start-Process on windows", () => {
+    const cmd = launchCommand("windows", launch);
+    expect(cmd).toContain("Start-Process");
+    expect(cmd).toContain("-ArgumentList");
+    expect(cmd).toContain("$env:LOG=");
+  });
+
+  it("throws without an executablePath", () => {
+    expect(() =>
+      launchCommand("linux", { ...launch, executablePath: null }),
+    ).toThrow(/executablePath is required/);
+  });
+});
+
+describe("readinessProbe", () => {
+  it("returns null for sleep (runner waits instead)", () => {
+    expect(readinessProbe("linux", { kind: "sleep", seconds: 3 })).toBeNull();
+  });
+
+  it("builds process probes per OS", () => {
+    expect(
+      readinessProbe("linux", { kind: "process", process: "app" }),
+    ).toContain("pgrep");
+    expect(
+      readinessProbe("windows", { kind: "process", process: "app" }),
+    ).toContain("Get-Process");
+  });
+
+  it("builds port probes per OS", () => {
+    expect(readinessProbe("linux", { kind: "port", port: 8080 })).toContain(
+      ":8080",
+    );
+    expect(readinessProbe("macos", { kind: "port", port: 8080 })).toContain(
+      "lsof",
+    );
+    expect(readinessProbe("windows", { kind: "port", port: 8080 })).toContain(
+      "Get-NetTCPConnection",
+    );
+  });
+});
+
+describe("screenshotCommand", () => {
+  it("uses the OS-native capture tool", () => {
+    expect(screenshotCommand("macos", "/tmp/s.png")).toContain("screencapture");
+    expect(screenshotCommand("windows", "/tmp/s.png")).toContain(
+      "CopyFromScreen",
+    );
+    expect(screenshotCommand("linux", "/tmp/s.png")).toContain("scrot");
+  });
+});

--- a/src/core/desktop/commands.ts
+++ b/src/core/desktop/commands.ts
@@ -18,6 +18,12 @@ function psQuote(body: string): string {
   return `'${body.replace(/'/g, "''")}'`;
 }
 
+// Manifest strings are literals, but PowerShell's -like treats these as
+// wildcards — backtick-escape them so the match stays literal.
+function escapeLikePattern(value: string): string {
+  return value.replace(/([`*?[\]])/g, "`$1");
+}
+
 /**
  * Wrap an install/teardown script body in the OS's shell. Windows scripts run
  * under PowerShell; Linux/macOS under bash. The body itself is author-supplied
@@ -49,9 +55,12 @@ export function launchCommand(
     );
   }
   const args = (launch.args ?? []).map((a) => quoteArg(os, a)).join(" ");
-  const envPairs = (launch.environment ?? [])
-    .filter((e) => e.value !== undefined)
-    .map((e) => ({ name: e.name, value: e.value as string }));
+  // Manifests are parsed JSON: only inline entries that actually carry a
+  // string value (secretRef-only entries, and nulls, are not inlined).
+  const envPairs = (launch.environment ?? []).filter(
+    (e): e is { name: string; value: string } =>
+      typeof e.name === "string" && typeof e.value === "string",
+  );
 
   if (os === "windows") {
     const argList = launch.args?.length
@@ -89,12 +98,18 @@ export function readinessProbe(
   switch (check.kind) {
     case "sleep":
       return null;
-    case "process":
+    case "process": {
       if (os === "windows") {
-        return `powershell -NoProfile -Command "if (Get-Process -Name ${psQuote(check.process)} -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }"`;
+        // Match the full command line (and fall back to the image name) so the
+        // same manifest string — a path fragment or an argv substring — works
+        // here as it does under `pgrep -f`. Get-Process -Name only matches the
+        // bare image name, which silently never fires for those manifests.
+        const pattern = psQuote(`*${escapeLikePattern(check.process)}*`);
+        return `powershell -NoProfile -Command "if (Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like ${pattern} -or $_.Name -like ${pattern} }) { exit 0 } else { exit 1 }"`;
       }
       // pgrep works on linux; macOS ships it too.
       return `pgrep -f ${quoteArg(os, check.process)} >/dev/null`;
+    }
     case "port":
       if (os === "windows") {
         return `powershell -NoProfile -Command "if (Get-NetTCPConnection -State Listen -LocalPort ${check.port} -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }"`;
@@ -111,7 +126,7 @@ export function readinessProbe(
       if (os === "macos") {
         return `osascript -e 'tell application "System Events" to (name of every window of every process) as string' 2>/dev/null | grep -q ${quoteArg(os, check.titleContains)}`;
       }
-      return `powershell -NoProfile -Command "if (Get-Process | Where-Object { $_.MainWindowTitle -like '*${check.titleContains.replace(/'/g, "''")}*' }) { exit 0 } else { exit 1 }"`;
+      return `powershell -NoProfile -Command "if (Get-Process | Where-Object { $_.MainWindowTitle -like ${psQuote(`*${escapeLikePattern(check.titleContains)}*`)} }) { exit 0 } else { exit 1 }"`;
     case "log-line":
       if (os === "windows") {
         return `powershell -NoProfile -Command "if (Select-String -Path ${psQuote(check.path)} -Pattern ${psQuote(check.contains)} -Quiet) { exit 0 } else { exit 1 }"`;

--- a/src/core/desktop/commands.ts
+++ b/src/core/desktop/commands.ts
@@ -41,6 +41,10 @@ function quoteArg(os: DesktopOs, arg: string): string {
   return `"${arg.replace(/(["\\$`])/g, "\\$1")}"`;
 }
 
+// Where a backgrounded linux/macOS app's stdout+stderr land, so the readiness
+// log-line check has something to grep.
+const LAUNCH_LOG_PATH = "/tmp/pensar-app.log";
+
 /**
  * Build a command that launches the app in the background so the runner can
  * proceed to readiness checks. Requires `launch.executablePath`.
@@ -76,14 +80,19 @@ export function launchCommand(
   }
 
   // linux / macos: cd (if wd) then background the process with env prefix.
+  // The redirects must wrap the whole group, not just the app: `cd X && app
+  // >log &` backgrounds a subshell that keeps the executor's stdout/stderr
+  // pipes open, so the executor blocks until the app exits.
   const env = envPairs
     .map((e) => `${e.name}=${quoteArg(os, e.value)}`)
     .join(" ");
   const cd = launch.workingDirectory
     ? `cd ${quoteArg(os, launch.workingDirectory)} && `
     : "";
-  const prefix = env ? `${env} ` : "";
-  return `bash -lc ${singleQuote(`${cd}${prefix}${quoteArg(os, launch.executablePath)} ${args} >/tmp/pensar-app.log 2>&1 &`)}`;
+  const run = [env, quoteArg(os, launch.executablePath), args]
+    .filter((part) => part !== "")
+    .join(" ");
+  return `bash -lc ${singleQuote(`{ ${cd}${run}; } </dev/null >${LAUNCH_LOG_PATH} 2>&1 &`)}`;
 }
 
 /**
@@ -117,8 +126,9 @@ export function readinessProbe(
       if (os === "macos") {
         return `lsof -iTCP:${check.port} -sTCP:LISTEN >/dev/null 2>&1`;
       }
-      // linux: prefer ss, fall back to /proc-based check via grep on the hex port.
-      return `bash -lc ${singleQuote(`ss -ltn 2>/dev/null | grep -q ":${check.port} "`)}`;
+      // linux: prefer ss, but minimal images often ship without iproute2 — fall
+      // back to a loopback connect so the probe doesn't silently never fire.
+      return `bash -lc ${singleQuote(`ss -ltn 2>/dev/null | grep -q ":${check.port} " || (exec 3<>/dev/tcp/127.0.0.1/${check.port}) 2>/dev/null`)}`;
     case "window-title":
       if (os === "linux") {
         return `bash -lc ${singleQuote(`xdotool search --name ${JSON.stringify(check.titleContains)} >/dev/null 2>&1`)}`;

--- a/src/core/desktop/commands.ts
+++ b/src/core/desktop/commands.ts
@@ -119,17 +119,3 @@ export function readinessProbe(
       return `grep -q ${quoteArg(os, check.contains)} ${quoteArg(os, check.path)}`;
   }
 }
-
-/** Capture a screenshot of the desktop to `outPath`. */
-export function screenshotCommand(os: DesktopOs, outPath: string): string {
-  if (os === "windows") {
-    // Uses .NET via PowerShell to grab the virtual screen.
-    const body = `Add-Type -AssemblyName System.Windows.Forms,System.Drawing; $b=[System.Windows.Forms.SystemInformation]::VirtualScreen; $bmp=New-Object System.Drawing.Bitmap($b.Width,$b.Height); $g=[System.Drawing.Graphics]::FromImage($bmp); $g.CopyFromScreen($b.Location,[System.Drawing.Point]::Empty,$b.Size); $bmp.Save(${psQuote(outPath)})`;
-    return `powershell -NoProfile -Command ${psQuote(body)}`;
-  }
-  if (os === "macos") {
-    return `screencapture -x ${quoteArg(os, outPath)}`;
-  }
-  // linux: scrot or import (ImageMagick); try scrot first.
-  return `bash -lc ${singleQuote(`scrot ${outPath} 2>/dev/null || import -window root ${outPath}`)}`;
-}

--- a/src/core/desktop/commands.ts
+++ b/src/core/desktop/commands.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure, per-OS command builders for the desktop environment.
+ *
+ * These produce the exact shell strings the runner hands to `DesktopExec`.
+ * Deterministic string builders (no I/O) so every OS dialect is unit-tested in
+ * isolation — installing/launching a desktop app is a deterministic transform,
+ * not a model judgement.
+ */
+import type { BuildManifest, DesktopOs, ReadinessCheck } from "./types";
+
+// Escape a script body for embedding inside a single-quoted shell argument.
+function singleQuote(body: string): string {
+  return `'${body.replace(/'/g, `'\\''`)}'`;
+}
+
+// PowerShell single-quote escaping doubles the quote.
+function psQuote(body: string): string {
+  return `'${body.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Wrap an install/teardown script body in the OS's shell. Windows scripts run
+ * under PowerShell; Linux/macOS under bash. The body itself is author-supplied
+ * (or synthesized by the Console recipe) and already OS-appropriate.
+ */
+export function shellRun(os: DesktopOs, scriptBody: string): string {
+  if (os === "windows") {
+    return `powershell -NoProfile -NonInteractive -Command ${psQuote(scriptBody)}`;
+  }
+  return `bash -lc ${singleQuote(scriptBody)}`;
+}
+
+function quoteArg(os: DesktopOs, arg: string): string {
+  if (os === "windows") return `'${arg.replace(/'/g, "''")}'`;
+  return `"${arg.replace(/(["\\$`])/g, "\\$1")}"`;
+}
+
+/**
+ * Build a command that launches the app in the background so the runner can
+ * proceed to readiness checks. Requires `launch.executablePath`.
+ */
+export function launchCommand(
+  os: DesktopOs,
+  launch: BuildManifest["launch"],
+): string {
+  if (!launch.executablePath) {
+    throw new Error(
+      "launch.executablePath is required to launch a desktop app",
+    );
+  }
+  const args = (launch.args ?? []).map((a) => quoteArg(os, a)).join(" ");
+  const envPairs = (launch.environment ?? [])
+    .filter((e) => e.value !== undefined)
+    .map((e) => ({ name: e.name, value: e.value as string }));
+
+  if (os === "windows") {
+    const argList = launch.args?.length
+      ? ` -ArgumentList ${launch.args.map((a) => quoteArg(os, a)).join(",")}`
+      : "";
+    const env = envPairs
+      .map((e) => `$env:${e.name}=${quoteArg(os, e.value)}; `)
+      .join("");
+    const wd = launch.workingDirectory
+      ? ` -WorkingDirectory ${quoteArg(os, launch.workingDirectory)}`
+      : "";
+    return `powershell -NoProfile -Command "${env}Start-Process -FilePath ${quoteArg(os, launch.executablePath)}${argList}${wd}"`;
+  }
+
+  // linux / macos: cd (if wd) then background the process with env prefix.
+  const env = envPairs
+    .map((e) => `${e.name}=${quoteArg(os, e.value)}`)
+    .join(" ");
+  const cd = launch.workingDirectory
+    ? `cd ${quoteArg(os, launch.workingDirectory)} && `
+    : "";
+  const prefix = env ? `${env} ` : "";
+  return `bash -lc ${singleQuote(`${cd}${prefix}${quoteArg(os, launch.executablePath)} ${args} >/tmp/pensar-app.log 2>&1 &`)}`;
+}
+
+/**
+ * A single-shot readiness probe: a command that exits 0 when the app is ready.
+ * The runner polls it. `sleep` returns null (the runner just waits). Best-effort
+ * for window-title / log-line.
+ */
+export function readinessProbe(
+  os: DesktopOs,
+  check: ReadinessCheck,
+): string | null {
+  switch (check.kind) {
+    case "sleep":
+      return null;
+    case "process":
+      if (os === "windows") {
+        return `powershell -NoProfile -Command "if (Get-Process -Name ${psQuote(check.process)} -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }"`;
+      }
+      // pgrep works on linux; macOS ships it too.
+      return `pgrep -f ${quoteArg(os, check.process)} >/dev/null`;
+    case "port":
+      if (os === "windows") {
+        return `powershell -NoProfile -Command "if (Get-NetTCPConnection -State Listen -LocalPort ${check.port} -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }"`;
+      }
+      if (os === "macos") {
+        return `lsof -iTCP:${check.port} -sTCP:LISTEN >/dev/null 2>&1`;
+      }
+      // linux: prefer ss, fall back to /proc-based check via grep on the hex port.
+      return `bash -lc ${singleQuote(`ss -ltn 2>/dev/null | grep -q ":${check.port} "`)}`;
+    case "window-title":
+      if (os === "linux") {
+        return `bash -lc ${singleQuote(`xdotool search --name ${JSON.stringify(check.titleContains)} >/dev/null 2>&1`)}`;
+      }
+      if (os === "macos") {
+        return `osascript -e 'tell application "System Events" to (name of every window of every process) as string' 2>/dev/null | grep -q ${quoteArg(os, check.titleContains)}`;
+      }
+      return `powershell -NoProfile -Command "if (Get-Process | Where-Object { $_.MainWindowTitle -like '*${check.titleContains.replace(/'/g, "''")}*' }) { exit 0 } else { exit 1 }"`;
+    case "log-line":
+      if (os === "windows") {
+        return `powershell -NoProfile -Command "if (Select-String -Path ${psQuote(check.path)} -Pattern ${psQuote(check.contains)} -Quiet) { exit 0 } else { exit 1 }"`;
+      }
+      return `grep -q ${quoteArg(os, check.contains)} ${quoteArg(os, check.path)}`;
+  }
+}
+
+/** Capture a screenshot of the desktop to `outPath`. */
+export function screenshotCommand(os: DesktopOs, outPath: string): string {
+  if (os === "windows") {
+    // Uses .NET via PowerShell to grab the virtual screen.
+    const body = `Add-Type -AssemblyName System.Windows.Forms,System.Drawing; $b=[System.Windows.Forms.SystemInformation]::VirtualScreen; $bmp=New-Object System.Drawing.Bitmap($b.Width,$b.Height); $g=[System.Drawing.Graphics]::FromImage($bmp); $g.CopyFromScreen($b.Location,[System.Drawing.Point]::Empty,$b.Size); $bmp.Save(${psQuote(outPath)})`;
+    return `powershell -NoProfile -Command ${psQuote(body)}`;
+  }
+  if (os === "macos") {
+    return `screencapture -x ${quoteArg(os, outPath)}`;
+  }
+  // linux: scrot or import (ImageMagick); try scrot first.
+  return `bash -lc ${singleQuote(`scrot ${outPath} 2>/dev/null || import -window root ${outPath}`)}`;
+}

--- a/src/core/desktop/index.ts
+++ b/src/core/desktop/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Desktop environment support: install + launch a build artifact from a
+ * `pensar-build.json` manifest inside a Windows / macOS / Linux sandbox, plus
+ * per-OS command builders for driving the desktop.
+ *
+ * Public API for the module — import from here, not the internals.
+ */
+
+export {
+  launchCommand,
+  readinessProbe,
+  screenshotCommand,
+  shellRun,
+} from "./commands";
+export {
+  type RunBuildOptions,
+  type RunBuildResult,
+  runBuildManifest,
+  teardownBuild,
+} from "./runner";
+export type {
+  BuildManifest,
+  BuildManifestLaunchEnv,
+  DesktopExec,
+  DesktopExecResult,
+  DesktopOs,
+  ReadinessCheck,
+} from "./types";
+export { SUPPORTED_MANIFEST_VERSION } from "./types";

--- a/src/core/desktop/index.ts
+++ b/src/core/desktop/index.ts
@@ -1,29 +1,19 @@
 /**
  * Desktop environment support: install + launch a build artifact from a
- * `pensar-build.json` manifest inside a Windows / macOS / Linux sandbox, plus
- * per-OS command builders for driving the desktop.
+ * `pensar-build.json` manifest inside a Windows / macOS / Linux sandbox.
  *
  * Public API for the module — import from here, not the internals.
  */
 
 export {
-  launchCommand,
-  readinessProbe,
-  screenshotCommand,
-  shellRun,
-} from "./commands";
-export {
   type RunBuildOptions,
   type RunBuildResult,
   runBuildManifest,
-  teardownBuild,
 } from "./runner";
 export type {
   BuildManifest,
-  BuildManifestLaunchEnv,
   DesktopExec,
   DesktopExecResult,
   DesktopOs,
   ReadinessCheck,
 } from "./types";
-export { SUPPORTED_MANIFEST_VERSION } from "./types";

--- a/src/core/desktop/runner.test.ts
+++ b/src/core/desktop/runner.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import { runBuildManifest } from "./runner";
+import type { BuildManifest, DesktopExecResult } from "./types";
+
+const ok: DesktopExecResult = {
+  stdout: "",
+  stderr: "",
+  exitCode: 0,
+  success: true,
+};
+const fail: DesktopExecResult = {
+  stdout: "",
+  stderr: "boom",
+  exitCode: 1,
+  success: false,
+};
+
+function manifest(overrides: Partial<BuildManifest> = {}): BuildManifest {
+  return {
+    manifestVersion: 1,
+    artifact: {
+      id: "a1",
+      filename: "app.AppImage",
+      path: "/work/app.AppImage",
+      format: "appimage",
+      platform: "linux",
+      architecture: "x64",
+      sha256: null,
+    },
+    install: {
+      mode: "appimage-direct",
+      script: 'chmod +x "/work/app.AppImage"',
+    },
+    launch: {
+      executablePath: "/work/app.AppImage",
+      args: [],
+      workingDirectory: null,
+      environment: [],
+    },
+    readinessCheck: null,
+    teardownScript: null,
+    ...overrides,
+  };
+}
+
+const noSleep = () => Promise.resolve();
+
+describe("runBuildManifest", () => {
+  it("runs install then launch then reports ready when no readiness check", async () => {
+    const exec = vi.fn().mockResolvedValue(ok);
+    const result = await runBuildManifest({
+      exec,
+      os: "linux",
+      manifest: manifest(),
+      sleep: noSleep,
+    });
+    expect(result).toEqual({
+      installed: true,
+      launched: true,
+      ready: true,
+      readinessKind: null,
+    });
+    // install call first, launch second
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(exec.mock.calls[0][0]).toContain("chmod +x");
+    expect(exec.mock.calls[1][0]).toContain("app.AppImage");
+  });
+
+  it("throws when the install step fails and does not launch", async () => {
+    const exec = vi.fn().mockResolvedValue(fail);
+    await expect(
+      runBuildManifest({
+        exec,
+        os: "linux",
+        manifest: manifest(),
+        sleep: noSleep,
+      }),
+    ).rejects.toThrow(/Install step failed/);
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls a process readiness probe until it succeeds", async () => {
+    // install ok, launch ok, probe fails once then succeeds.
+    const exec = vi
+      .fn()
+      .mockResolvedValueOnce(ok) // install
+      .mockResolvedValueOnce(ok) // launch
+      .mockResolvedValueOnce(fail) // probe #1
+      .mockResolvedValueOnce(ok); // probe #2
+    const result = await runBuildManifest({
+      exec,
+      os: "linux",
+      manifest: manifest({
+        readinessCheck: { kind: "process", process: "app", timeoutSeconds: 30 },
+      }),
+      sleep: noSleep,
+      pollIntervalMs: 1,
+    });
+    expect(result.ready).toBe(true);
+    expect(result.readinessKind).toBe("process");
+    expect(exec).toHaveBeenCalledTimes(4);
+  });
+
+  it("honors a sleep readiness check without a probe", async () => {
+    const exec = vi.fn().mockResolvedValue(ok);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const result = await runBuildManifest({
+      exec,
+      os: "linux",
+      manifest: manifest({ readinessCheck: { kind: "sleep", seconds: 5 } }),
+      sleep,
+    });
+    expect(result.ready).toBe(true);
+    expect(sleep).toHaveBeenCalledWith(5000);
+    // only install + launch hit exec; sleep is not a probe
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips launch when there is no executable", async () => {
+    const exec = vi.fn().mockResolvedValue(ok);
+    const result = await runBuildManifest({
+      exec,
+      os: "windows",
+      manifest: manifest({
+        launch: {
+          executablePath: null,
+          args: [],
+          workingDirectory: null,
+          environment: [],
+        },
+      }),
+      sleep: noSleep,
+    });
+    expect(result.launched).toBe(false);
+    expect(exec).toHaveBeenCalledTimes(1); // install only
+  });
+
+  it("rejects an unsupported manifest version", async () => {
+    const exec = vi.fn().mockResolvedValue(ok);
+    await expect(
+      runBuildManifest({
+        exec,
+        os: "linux",
+        manifest: manifest({ manifestVersion: 99 }),
+        sleep: noSleep,
+      }),
+    ).rejects.toThrow(/Unsupported build manifest version 99/);
+    expect(exec).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/desktop/runner.ts
+++ b/src/core/desktop/runner.ts
@@ -126,14 +126,3 @@ export async function runBuildManifest(
     readinessKind: manifest.readinessCheck?.kind ?? null,
   };
 }
-
-export async function teardownBuild(opts: {
-  exec: DesktopExec;
-  os: DesktopOs;
-  manifest: BuildManifest;
-}): Promise<void> {
-  const { exec, os, manifest } = opts;
-  if (!manifest.teardownScript) return;
-  // Best-effort — the sandbox is destroyed regardless.
-  await exec(shellRun(os, manifest.teardownScript));
-}

--- a/src/core/desktop/runner.ts
+++ b/src/core/desktop/runner.ts
@@ -1,0 +1,139 @@
+/**
+ * Desktop build-manifest runner: install → launch → wait-for-ready.
+ *
+ * Consumes a `pensar-build.json` produced by the Console and executes it inside
+ * the desktop environment via an injected `DesktopExec` (a Daytona sandbox's
+ * `execute`, or a local shell when the agent runs inside the sandbox). Sequences
+ * are deterministic; the model is only involved once the app is up.
+ */
+import { launchCommand, readinessProbe, shellRun } from "./commands";
+import {
+  type BuildManifest,
+  type DesktopExec,
+  type DesktopOs,
+  SUPPORTED_MANIFEST_VERSION,
+} from "./types";
+
+export interface RunBuildOptions {
+  exec: DesktopExec;
+  os: DesktopOs;
+  manifest: BuildManifest;
+  // Injected for testability; defaults to real wall-clock sleep.
+  sleep?: (ms: number) => Promise<void>;
+  // Poll cadence for readiness probes.
+  pollIntervalMs?: number;
+  onLog?: (line: string) => void;
+}
+
+export interface RunBuildResult {
+  installed: boolean;
+  launched: boolean;
+  ready: boolean;
+  readinessKind: string | null;
+}
+
+const DEFAULT_READINESS_TIMEOUT_S = 60;
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+
+const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function waitForReadiness(
+  opts: Required<Pick<RunBuildOptions, "exec" | "os" | "sleep">> & {
+    manifest: BuildManifest;
+    pollIntervalMs: number;
+    onLog?: (line: string) => void;
+  },
+): Promise<boolean> {
+  const check = opts.manifest.readinessCheck;
+  if (!check) return true;
+
+  if (check.kind === "sleep") {
+    await opts.sleep(check.seconds * 1000);
+    return true;
+  }
+
+  const probe = readinessProbe(opts.os, check);
+  if (!probe) return true;
+
+  const timeoutMs =
+    (("timeoutSeconds" in check && check.timeoutSeconds) ||
+      DEFAULT_READINESS_TIMEOUT_S) * 1000;
+  const deadline = Date.now() + timeoutMs;
+
+  // First attempt immediately, then poll until the deadline.
+  for (;;) {
+    const res = await opts.exec(probe);
+    if (res.success) return true;
+    if (Date.now() >= deadline) {
+      opts.onLog?.(
+        `readiness (${check.kind}) not satisfied within ${timeoutMs / 1000}s`,
+      );
+      return false;
+    }
+    await opts.sleep(opts.pollIntervalMs);
+  }
+}
+
+export async function runBuildManifest(
+  opts: RunBuildOptions,
+): Promise<RunBuildResult> {
+  const { exec, os, manifest } = opts;
+  const sleep = opts.sleep ?? realSleep;
+  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+  if (manifest.manifestVersion !== SUPPORTED_MANIFEST_VERSION) {
+    throw new Error(
+      `Unsupported build manifest version ${manifest.manifestVersion} (this runner supports ${SUPPORTED_MANIFEST_VERSION}).`,
+    );
+  }
+
+  // 1. Install.
+  opts.onLog?.(`installing (${manifest.install.mode})`);
+  const install = await exec(shellRun(os, manifest.install.script));
+  if (!install.success) {
+    throw new Error(
+      `Install step failed (exit ${install.exitCode}): ${install.stderr || install.stdout}`,
+    );
+  }
+
+  // 2. Launch (skip when no executable — e.g. a headless service build).
+  let launched = false;
+  if (manifest.launch.executablePath) {
+    opts.onLog?.(`launching ${manifest.launch.executablePath}`);
+    const launch = await exec(launchCommand(os, manifest.launch));
+    if (!launch.success) {
+      throw new Error(
+        `Launch step failed (exit ${launch.exitCode}): ${launch.stderr || launch.stdout}`,
+      );
+    }
+    launched = true;
+  }
+
+  // 3. Wait for readiness.
+  const ready = await waitForReadiness({
+    exec,
+    os,
+    sleep,
+    manifest,
+    pollIntervalMs,
+    onLog: opts.onLog,
+  });
+
+  return {
+    installed: true,
+    launched,
+    ready,
+    readinessKind: manifest.readinessCheck?.kind ?? null,
+  };
+}
+
+export async function teardownBuild(opts: {
+  exec: DesktopExec;
+  os: DesktopOs;
+  manifest: BuildManifest;
+}): Promise<void> {
+  const { exec, os, manifest } = opts;
+  if (!manifest.teardownScript) return;
+  // Best-effort — the sandbox is destroyed regardless.
+  await exec(shellRun(os, manifest.teardownScript));
+}

--- a/src/core/desktop/types.ts
+++ b/src/core/desktop/types.ts
@@ -39,7 +39,7 @@ export type ReadinessCheck =
       timeoutSeconds?: number;
     };
 
-export interface BuildManifestLaunchEnv {
+interface BuildManifestLaunchEnv {
   name: string;
   secretRef?: string;
   value?: string;

--- a/src/core/desktop/types.ts
+++ b/src/core/desktop/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Desktop-environment execution types.
+ *
+ * Mirrors the `pensar-build.json` contract produced by the Console
+ * (`packages/core/applicationBuilds/recipe.ts` `buildBuildManifest`) so the
+ * runner can install + launch a build artifact deterministically inside a
+ * Windows / macOS / Linux sandbox. Keep field names in lockstep with that
+ * producer.
+ */
+
+export type DesktopOs = "linux" | "windows" | "macos";
+
+// Result of one command executed in the desktop environment. Matches the shape
+// of `UnifiedSandbox.execute` so a sandbox can be passed directly as the exec.
+export interface DesktopExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  success: boolean;
+}
+
+// Abstract command executor. In a Console Daytona sandbox the agent runs
+// locally (exec = local shell); a host-drives-remote flow passes a
+// `UnifiedSandbox.execute`. Injecting it keeps the runner testable.
+export type DesktopExec = (
+  command: string,
+  opts?: { cwd?: string; envVars?: Record<string, string>; timeout?: number },
+) => Promise<DesktopExecResult>;
+
+export type ReadinessCheck =
+  | { kind: "sleep"; seconds: number }
+  | { kind: "process"; process: string; timeoutSeconds?: number }
+  | { kind: "port"; port: number; timeoutSeconds?: number }
+  | { kind: "window-title"; titleContains: string; timeoutSeconds?: number }
+  | {
+      kind: "log-line";
+      path: string;
+      contains: string;
+      timeoutSeconds?: number;
+    };
+
+export interface BuildManifestLaunchEnv {
+  name: string;
+  secretRef?: string;
+  value?: string;
+}
+
+export interface BuildManifest {
+  manifestVersion: number;
+  artifact: {
+    id: string;
+    filename: string;
+    path: string;
+    format: string;
+    platform: string;
+    architecture: string;
+    sha256: string | null;
+  };
+  install: {
+    mode: string;
+    script: string;
+  };
+  launch: {
+    executablePath: string | null;
+    args: string[];
+    workingDirectory: string | null;
+    environment: BuildManifestLaunchEnv[];
+  };
+  readinessCheck: ReadinessCheck | null;
+  teardownScript: string | null;
+}
+
+export const SUPPORTED_MANIFEST_VERSION = 1;


### PR DESCRIPTION
…ifests

Adds the apex side of desktop-app testing: run a build artifact inside a Windows / macOS / Linux sandbox from a Console-produced pensar-build.json.

- SandboxType extended to include 'macos' (was linux|windows).
- New core/desktop module (kept barrel):
  - types.ts: BuildManifest (mirrors Console recipe.ts output), DesktopExec, ReadinessCheck.
  - commands.ts: pure per-OS command builders (shellRun, launchCommand, readinessProbe, screenshotCommand) with bash/PowerShell/macOS dialects.
  - runner.ts: runBuildManifest() sequences install -> launch -> wait-for-ready over an injected executor (a sandbox execute, or a local shell), with process/port/sleep/window-title/log-line readiness. teardownBuild().
- core/api/desktopBuild.ts: runDesktopBuild() reads a manifest and runs it via the local OS shell (used when the agent runs inside the target sandbox); exported from the api barrel.
- CLI: 'pensar builds run <manifest.json> [--os ...]'.
- biome.jsonc: register core/desktop as a kept module barrier.

Tests: per-OS command builders (10) + runner sequence/readiness/failure (6). Native GUI-driving tools and the external macOS/iOS provider are follow-ups; this lands the deterministic install/launch/readiness layer + OS abstraction.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The runner executes manifest-derived shell/PowerShell strings on the host or sandbox; risk is bounded by trusted manifests and sandbox context but still a command-execution surface worth careful review.
> 
> **Overview**
> Introduces **desktop build orchestration** on the apex side: read a Console-produced `pensar-build.json`, run install → background launch → readiness, then return structured status (`installed`, `launched`, `ready`).
> 
> The new **`core/desktop`** barrel holds manifest types aligned with Console, pure per-OS command builders (`shellRun`, `launchCommand`, `readinessProbe` for bash/PowerShell), and **`runBuildManifest`** with an injected executor so the same flow works from a sandbox `execute` or a local shell. Linux launch is fixed so backgrounding does not block the executor on long-running apps; Windows process probes match command lines and escape `-like` wildcards.
> 
> **`runDesktopBuild`** in `core/api` wires a local `child_process` executor and is exported from the API barrel. The CLI adds **`pensar builds run <manifest.json> [--os …]`**, exiting non-zero if readiness times out. **`SandboxType`** now includes **`macos`**, and Biome enforces imports through the `core/desktop` index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37bc39e5593285bda930e49424c6f901d4696f52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->