### PR TITLE
feat(release): build and publish linux-arm64 binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ jobs:
             target: bun-linux-x64
             name: pensar-linux-x64
             ext: ""
+          - os: ubuntu-24.04-arm
+            target: bun-linux-arm64
+            name: pensar-linux-arm64
+            ext: ""
           - os: windows-latest
             target: bun-windows-x64
             name: pensar-windows-x64
@@ -106,6 +110,7 @@ jobs:
             artifacts/pensar-darwin-arm64/pensar-darwin-arm64.tar.gz
             artifacts/pensar-darwin-x64/pensar-darwin-x64.tar.gz
             artifacts/pensar-linux-x64/pensar-linux-x64.tar.gz
+            artifacts/pensar-linux-arm64/pensar-linux-arm64.tar.gz
             artifacts/pensar-windows-x64/pensar-windows-x64.zip
           generate_release_notes: true
           body: |
@@ -190,10 +195,12 @@ jobs:
           curl -sL "${BASE_URL}/pensar-darwin-arm64.tar.gz" -o darwin-arm64.tar.gz
           curl -sL "${BASE_URL}/pensar-darwin-x64.tar.gz" -o darwin-x64.tar.gz
           curl -sL "${BASE_URL}/pensar-linux-x64.tar.gz" -o linux-x64.tar.gz
+          curl -sL "${BASE_URL}/pensar-linux-arm64.tar.gz" -o linux-arm64.tar.gz
 
           echo "darwin_arm64=$(sha256sum darwin-arm64.tar.gz | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
           echo "darwin_x64=$(sha256sum darwin-x64.tar.gz | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
           echo "linux_x64=$(sha256sum linux-x64.tar.gz | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
+          echo "linux_arm64=$(sha256sum linux-arm64.tar.gz | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
 
       - name: Checkout Homebrew tap
         uses: actions/checkout@v4
@@ -208,6 +215,7 @@ jobs:
           SHA_DARWIN_ARM64: ${{ steps.sha256.outputs.darwin_arm64 }}
           SHA_DARWIN_X64: ${{ steps.sha256.outputs.darwin_x64 }}
           SHA_LINUX_X64: ${{ steps.sha256.outputs.linux_x64 }}
+          SHA_LINUX_ARM64: ${{ steps.sha256.outputs.linux_arm64 }}
         run: |
           cat > homebrew-tap/Formula/apex.rb << EOF
           class Apex < Formula
@@ -231,6 +239,10 @@ jobs:
               on_intel do
                 url "https://github.com/pensarai/apex/releases/download/v${VERSION}/pensar-linux-x64.tar.gz"
                 sha256 "${SHA_LINUX_X64}"
+              end
+              on_arm do
+                url "https://github.com/pensarai/apex/releases/download/v${VERSION}/pensar-linux-arm64.tar.gz"
+                sha256 "${SHA_LINUX_ARM64}"
               end
             end
 


### PR DESCRIPTION
## Problem
Installing on linux-arm64 (e.g. `curl -fsSL https://pensarai.com/install.sh | bash`) fails with an "not supported" error. The release pipeline only builds `darwin-arm64`, `darwin-x64`, and `linux-x64` — there is no `linux-arm64` artifact, so the install script has nothing to serve for that platform.

## Change
- Add a `bun-linux-arm64` target to the build matrix on a native `ubuntu-24.04-arm` runner
- Upload `pensar-linux-arm64.tar.gz` to the GitHub release
- Compute its SHA256 and add an `on_linux`/`on_arm` block to the Homebrew formula

## Non-breaking
Purely additive — a new matrix entry and a new release asset. Existing darwin/linux-x64/windows builds, URLs, and formula blocks are unchanged, so current installs are unaffected.

## Note
The `install.sh` served from pensarai.com lives outside this repo. Once a release ships with this change, verify install.sh maps linux + arm64 → `pensar-linux-arm64.tar.gz` (it should if it derives the asset name from `uname -m`/`uname -s`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CI and release packaging only; no application runtime or auth/data logic changes.
> 
> **Overview**
> Adds **linux-arm64** to the release pipeline so ARM Linux machines can install from published artifacts.
> 
> The build matrix gains `bun-linux-arm64` on `ubuntu-24.04-arm`, producing `pensar-linux-arm64.tar.gz` that is attached to GitHub releases alongside existing platforms. The Homebrew tap update step now downloads that tarball, records its SHA256, and writes an `on_linux` / `on_arm` block in `apex.rb` pointing at the new asset.
> 
> Existing darwin, linux-x64, and windows build entries and URLs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 996b98a80adfe73d656542aba8905cee5a159d76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->