### PR TITLE
feat(patching): expand autonomous coding-agent toolset

### DIFF
--- a/src/core/agents/offSecAgent/tools/applyPatch.test.ts
+++ b/src/core/agents/offSecAgent/tools/applyPatch.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  type ApplyPatchResult,
+  applyHunksToContent,
+  applyPatch,
+  parseUnifiedDiff,
+} from "./applyPatch";
+import type { ToolContext } from "./types";
+
+function makeCtx(agentCwd: string): ToolContext {
+  return {
+    agentCwd,
+    session: { id: "ses_test", rootPath: agentCwd },
+  } as ToolContext;
+}
+
+describe("parseUnifiedDiff", () => {
+  it("parses a single-file hunk", () => {
+    const patch = `--- a/src/a.ts
++++ b/src/a.ts
+@@ -1,3 +1,3 @@
+ line1
+-old
++new
+ line3
+`;
+    const files = parseUnifiedDiff(patch);
+    expect(files).toHaveLength(1);
+    expect(files[0].oldPath).toBe("src/a.ts");
+    expect(files[0].hunks).toHaveLength(1);
+  });
+
+  it("throws when the patch has no file diffs", () => {
+    expect(() => parseUnifiedDiff("not a patch")).toThrow(/no file diffs/i);
+  });
+});
+
+describe("applyHunksToContent", () => {
+  it("applies a simple replacement", () => {
+    const content = "line1\nold\nline3\n";
+    const files = parseUnifiedDiff(`--- a/f
++++ b/f
+@@ -1,3 +1,3 @@
+ line1
+-old
++new
+ line3
+`);
+    const updated = applyHunksToContent(content, files[0].hunks);
+    expect(updated).toBe("line1\nnew\nline3\n");
+  });
+
+  it("throws on context mismatch", () => {
+    const content = "line1\nNOT_OLD\nline3\n";
+    const files = parseUnifiedDiff(`--- a/f
++++ b/f
+@@ -1,3 +1,3 @@
+ line1
+-old
++new
+ line3
+`);
+    expect(() => applyHunksToContent(content, files[0].hunks)).toThrow(
+      /context mismatch/i,
+    );
+  });
+});
+
+describe("applyPatch tool", () => {
+  it("applies a multi-hunk patch to disk", async () => {
+    const root = mkdtempSync(join(tmpdir(), "apex-patch-"));
+    writeFileSync(
+      join(root, "file.ts"),
+      "const a = 1;\nconst b = 2;\nconst c = 3;\n",
+    );
+
+    const patch = `--- a/file.ts
++++ b/file.ts
+@@ -1,3 +1,3 @@
+-const a = 1;
++const a = 10;
+ const b = 2;
+-const c = 3;
++const c = 30;
+`;
+
+    const tool = applyPatch(makeCtx(root));
+    const result = (await tool.execute?.(
+      { patch, toolCallDescription: "Bump constants" },
+      { toolCallId: "t1", messages: [] },
+    )) as ApplyPatchResult;
+
+    expect(result.success).toBe(true);
+    expect(result.files[0].success).toBe(true);
+    expect(readFileSync(join(root, "file.ts"), "utf-8")).toBe(
+      "const a = 10;\nconst b = 2;\nconst c = 30;\n",
+    );
+  });
+
+  it("fails loudly and stops on a bad hunk", async () => {
+    const root = mkdtempSync(join(tmpdir(), "apex-patch-bad-"));
+    writeFileSync(join(root, "file.ts"), "hello\n");
+
+    const patch = `--- a/file.ts
++++ b/file.ts
+@@ -1,1 +1,1 @@
+-goodbye
++hi
+`;
+
+    const tool = applyPatch(makeCtx(root));
+    const result = (await tool.execute?.(
+      { patch, toolCallDescription: "Bad hunk" },
+      { toolCallId: "t1", messages: [] },
+    )) as ApplyPatchResult;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Failed applying patch/);
+    expect(readFileSync(join(root, "file.ts"), "utf-8")).toBe("hello\n");
+  });
+});

--- a/src/core/agents/offSecAgent/tools/applyPatch.ts
+++ b/src/core/agents/offSecAgent/tools/applyPatch.ts
@@ -1,0 +1,388 @@
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { tool } from "ai";
+import { z } from "zod";
+import type { ToolContext } from "./types";
+
+const applyPatchInputSchema = z.object({
+  patch: z
+    .string()
+    .describe(
+      "Unified diff to apply. May contain one or more file hunks (---/+++/@@). Paths are relative to the agent working directory unless absolute.",
+    ),
+  toolCallDescription: z
+    .string()
+    .describe(
+      "A concise, human-readable description of what this tool call is doing (e.g., 'Apply parameterized-query fix across auth handlers')",
+    ),
+});
+
+export type FilePatchResult = {
+  path: string;
+  success: boolean;
+  error?: string;
+  hunksApplied?: number;
+};
+
+export type ApplyPatchResult = {
+  success: boolean;
+  error: string;
+  files: FilePatchResult[];
+};
+
+type Hunk = {
+  oldStart: number;
+  oldCount: number;
+  newStart: number;
+  newCount: number;
+  lines: string[];
+};
+
+type FileDiff = {
+  oldPath: string;
+  newPath: string;
+  hunks: Hunk[];
+  isNew: boolean;
+  isDelete: boolean;
+};
+
+function stripPrefix(p: string): string {
+  if (p.startsWith("a/") || p.startsWith("b/")) return p.slice(2);
+  return p;
+}
+
+/**
+ * Parse a unified diff into per-file diffs. Fails loudly on malformed input.
+ */
+export function parseUnifiedDiff(patch: string): FileDiff[] {
+  const lines = patch.replace(/\r\n/g, "\n").split("\n");
+  const files: FileDiff[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    // Skip empty / git headers until a --- line
+    while (
+      i < lines.length &&
+      !lines[i].startsWith("--- ") &&
+      !lines[i].startsWith("diff --git ")
+    ) {
+      i++;
+    }
+    if (i >= lines.length) break;
+
+    if (lines[i].startsWith("diff --git ")) {
+      i++;
+      continue;
+    }
+
+    const oldLine = lines[i];
+    if (!oldLine.startsWith("--- ")) {
+      throw new Error(`Expected "---" file header at line ${i + 1}`);
+    }
+    i++;
+    if (i >= lines.length || !lines[i].startsWith("+++ ")) {
+      throw new Error(`Expected "+++" file header after "---" at line ${i}`);
+    }
+    const newLine = lines[i];
+    i++;
+
+    const oldPathRaw = oldLine.slice(4).split("\t")[0].trim();
+    const newPathRaw = newLine.slice(4).split("\t")[0].trim();
+    const isNew = oldPathRaw === "/dev/null";
+    const isDelete = newPathRaw === "/dev/null";
+    const oldPath = isNew ? "" : stripPrefix(oldPathRaw);
+    const newPath = isDelete ? "" : stripPrefix(newPathRaw);
+
+    const hunks: Hunk[] = [];
+    while (i < lines.length && lines[i].startsWith("@@ ")) {
+      const header = lines[i];
+      const match = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(header);
+      if (!match) {
+        throw new Error(`Malformed hunk header: ${header}`);
+      }
+      i++;
+      const hunkLines: string[] = [];
+      while (
+        i < lines.length &&
+        !lines[i].startsWith("@@ ") &&
+        !lines[i].startsWith("--- ") &&
+        !lines[i].startsWith("diff --git ")
+      ) {
+        const l = lines[i];
+        if (
+          l.startsWith(" ") ||
+          l.startsWith("+") ||
+          l.startsWith("-") ||
+          l === "\\ No newline at end of file"
+        ) {
+          hunkLines.push(l);
+          i++;
+        } else if (l === "") {
+          // Trailing blank between files — stop hunk
+          break;
+        } else {
+          throw new Error(`Unexpected line in hunk: ${l}`);
+        }
+      }
+      hunks.push({
+        oldStart: Number(match[1]),
+        oldCount: match[2] !== undefined ? Number(match[2]) : 1,
+        newStart: Number(match[3]),
+        newCount: match[4] !== undefined ? Number(match[4]) : 1,
+        lines: hunkLines,
+      });
+    }
+
+    if (hunks.length === 0 && !isNew && !isDelete) {
+      throw new Error(
+        `No hunks found for file ${newPath || oldPath || "(unknown)"}`,
+      );
+    }
+
+    files.push({ oldPath, newPath, hunks, isNew, isDelete });
+  }
+
+  if (files.length === 0) {
+    throw new Error("Patch contained no file diffs");
+  }
+
+  return files;
+}
+
+function resolveUnderCwd(agentCwd: string, filePath: string): string {
+  const resolved = isAbsolute(filePath)
+    ? filePath
+    : resolve(agentCwd, filePath);
+  const rel = relative(agentCwd, resolved);
+  if (rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error(`Path escapes agent working directory: ${filePath}`);
+  }
+  return resolved;
+}
+
+/**
+ * Apply hunks to file content. Throws if context does not match exactly.
+ */
+export function applyHunksToContent(content: string, hunks: Hunk[]): string {
+  // Normalize to lines without retaining a trailing empty from final newline
+  // so index math matches unified-diff 1-based line numbers.
+  const endsWithNewline = content.endsWith("\n");
+  const lines =
+    content === ""
+      ? []
+      : content.endsWith("\n")
+        ? content.slice(0, -1).split("\n")
+        : content.split("\n");
+
+  // Apply from bottom to top so earlier line numbers stay valid.
+  const ordered = [...hunks].sort((a, b) => b.oldStart - a.oldStart);
+
+  for (const hunk of ordered) {
+    const startIdx = Math.max(0, hunk.oldStart - 1);
+    let cursor = startIdx;
+    const replacement: string[] = [];
+
+    for (const raw of hunk.lines) {
+      if (raw === "\\ No newline at end of file") continue;
+      const tag = raw[0];
+      const text = raw.slice(1);
+      if (tag === " " || tag === "-") {
+        if (cursor >= lines.length || lines[cursor] !== text) {
+          const actual = cursor < lines.length ? lines[cursor] : "<EOF>";
+          throw new Error(
+            `Hunk context mismatch at line ${cursor + 1}: expected ${JSON.stringify(text)}, got ${JSON.stringify(actual)}`,
+          );
+        }
+        if (tag === " ") {
+          replacement.push(text);
+        }
+        cursor++;
+      } else if (tag === "+") {
+        replacement.push(text);
+      } else {
+        throw new Error(`Invalid hunk line prefix: ${raw}`);
+      }
+    }
+
+    const endIdx = cursor;
+    lines.splice(startIdx, endIdx - startIdx, ...replacement);
+  }
+
+  // Unified diffs imply a trailing newline for non-empty text files.
+  if (lines.length === 0) return endsWithNewline ? "\n" : "";
+  return `${lines.join("\n")}\n`;
+}
+
+async function readLocal(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+async function writeLocal(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, "utf-8");
+}
+
+async function readViaSandbox(
+  ctx: ToolContext,
+  path: string,
+): Promise<string | null> {
+  const result = await ctx.sandbox!.execute(
+    `test -f "${path}" && cat "${path}" | base64 -w 0`,
+  );
+  if (!result.success || !result.stdout.trim()) {
+    // Distinguish missing vs empty
+    const exists = await ctx.sandbox!.execute(`test -f "${path}"`);
+    if (exists.exitCode !== 0) return null;
+    return "";
+  }
+  return Buffer.from(result.stdout.trim(), "base64").toString("utf-8");
+}
+
+async function writeViaSandbox(
+  ctx: ToolContext,
+  path: string,
+  content: string,
+): Promise<void> {
+  const dir = dirname(path);
+  await ctx.sandbox!.execute(`mkdir -p "${dir}"`);
+  const b64 = Buffer.from(content).toString("base64");
+  const result = await ctx.sandbox!.execute(
+    `echo "${b64}" | base64 -d > "${path}"`,
+  );
+  if (!result.success) {
+    throw new Error(result.stderr || `Failed to write ${path} in sandbox`);
+  }
+}
+
+async function deleteViaSandbox(ctx: ToolContext, path: string): Promise<void> {
+  const result = await ctx.sandbox!.execute(`rm "${path}"`);
+  if (!result.success) {
+    throw new Error(result.stderr || `Failed to delete ${path} in sandbox`);
+  }
+}
+
+export function applyPatch(ctx: ToolContext) {
+  return tool({
+    description: `Apply a unified diff patch to one or more files.
+
+Use this for multi-hunk or multi-file edits. For a single small string replace,
+prefer update_file.
+
+The patch must be a standard unified diff with ---/+++ headers and @@ hunks.
+Context lines must match the current file contents exactly — the tool fails
+loudly on mismatch and does not partially apply remaining files after a failure
+within a file. Paths must stay under the agent working directory.
+
+Example:
+\`\`\`
+--- a/src/auth.ts
++++ b/src/auth.ts
+@@ -10,7 +10,7 @@
+  function login(user, pass) {
+-   query = "SELECT * FROM users WHERE name='" + user + "'"
++   query = db.prepare("SELECT * FROM users WHERE name=?")
+  }
+\`\`\``,
+    inputSchema: applyPatchInputSchema,
+    execute: async ({ patch }): Promise<ApplyPatchResult> => {
+      let files: FileDiff[];
+      try {
+        files = parseUnifiedDiff(patch);
+      } catch (err: unknown) {
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+          files: [],
+        };
+      }
+
+      const results: FilePatchResult[] = [];
+
+      for (const file of files) {
+        const displayPath = file.newPath || file.oldPath;
+        try {
+          const targetPath = resolveUnderCwd(
+            ctx.agentCwd,
+            file.isDelete ? file.oldPath : file.newPath || file.oldPath,
+          );
+
+          if (file.isDelete) {
+            if (ctx.sandbox) {
+              await deleteViaSandbox(ctx, targetPath);
+            } else {
+              await unlink(targetPath);
+            }
+            results.push({
+              path: displayPath,
+              success: true,
+              hunksApplied: 0,
+            });
+            continue;
+          }
+
+          const existing = ctx.sandbox
+            ? await readViaSandbox(ctx, targetPath)
+            : await readLocal(targetPath);
+
+          if (file.isNew) {
+            if (existing !== null) {
+              throw new Error(
+                `Cannot create ${targetPath}: file already exists`,
+              );
+            }
+            const created = applyHunksToContent("", file.hunks);
+            if (ctx.sandbox) {
+              await writeViaSandbox(ctx, targetPath, created);
+            } else {
+              await writeLocal(targetPath, created);
+            }
+            results.push({
+              path: displayPath,
+              success: true,
+              hunksApplied: file.hunks.length,
+            });
+            continue;
+          }
+
+          if (existing === null) {
+            throw new Error(`File not found: ${targetPath}`);
+          }
+
+          const updated = applyHunksToContent(existing, file.hunks);
+          if (ctx.sandbox) {
+            await writeViaSandbox(ctx, targetPath, updated);
+          } else {
+            await writeLocal(targetPath, updated);
+          }
+          results.push({
+            path: displayPath,
+            success: true,
+            hunksApplied: file.hunks.length,
+          });
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          results.push({
+            path: displayPath,
+            success: false,
+            error: message,
+          });
+          return {
+            success: false,
+            error: `Failed applying patch to ${displayPath}: ${message}`,
+            files: results,
+          };
+        }
+      }
+
+      return {
+        success: true,
+        error: "",
+        files: results,
+      };
+    },
+  });
+}

--- a/src/core/agents/offSecAgent/tools/applyPatch.ts
+++ b/src/core/agents/offSecAgent/tools/applyPatch.ts
@@ -227,15 +227,15 @@ async function writeLocal(path: string, content: string): Promise<void> {
 }
 
 async function readViaSandbox(
-  ctx: ToolContext,
+  sandbox: NonNullable<ToolContext["sandbox"]>,
   path: string,
 ): Promise<string | null> {
-  const result = await ctx.sandbox!.execute(
+  const result = await sandbox.execute(
     `test -f "${path}" && cat "${path}" | base64 -w 0`,
   );
   if (!result.success || !result.stdout.trim()) {
     // Distinguish missing vs empty
-    const exists = await ctx.sandbox!.execute(`test -f "${path}"`);
+    const exists = await sandbox.execute(`test -f "${path}"`);
     if (exists.exitCode !== 0) return null;
     return "";
   }
@@ -243,23 +243,24 @@ async function readViaSandbox(
 }
 
 async function writeViaSandbox(
-  ctx: ToolContext,
+  sandbox: NonNullable<ToolContext["sandbox"]>,
   path: string,
   content: string,
 ): Promise<void> {
   const dir = dirname(path);
-  await ctx.sandbox!.execute(`mkdir -p "${dir}"`);
+  await sandbox.execute(`mkdir -p "${dir}"`);
   const b64 = Buffer.from(content).toString("base64");
-  const result = await ctx.sandbox!.execute(
-    `echo "${b64}" | base64 -d > "${path}"`,
-  );
+  const result = await sandbox.execute(`echo "${b64}" | base64 -d > "${path}"`);
   if (!result.success) {
     throw new Error(result.stderr || `Failed to write ${path} in sandbox`);
   }
 }
 
-async function deleteViaSandbox(ctx: ToolContext, path: string): Promise<void> {
-  const result = await ctx.sandbox!.execute(`rm "${path}"`);
+async function deleteViaSandbox(
+  sandbox: NonNullable<ToolContext["sandbox"]>,
+  path: string,
+): Promise<void> {
+  const result = await sandbox.execute(`rm "${path}"`);
   if (!result.success) {
     throw new Error(result.stderr || `Failed to delete ${path} in sandbox`);
   }
@@ -312,7 +313,7 @@ Example:
 
           if (file.isDelete) {
             if (ctx.sandbox) {
-              await deleteViaSandbox(ctx, targetPath);
+              await deleteViaSandbox(ctx.sandbox, targetPath);
             } else {
               await unlink(targetPath);
             }
@@ -325,7 +326,7 @@ Example:
           }
 
           const existing = ctx.sandbox
-            ? await readViaSandbox(ctx, targetPath)
+            ? await readViaSandbox(ctx.sandbox, targetPath)
             : await readLocal(targetPath);
 
           if (file.isNew) {
@@ -336,7 +337,7 @@ Example:
             }
             const created = applyHunksToContent("", file.hunks);
             if (ctx.sandbox) {
-              await writeViaSandbox(ctx, targetPath, created);
+              await writeViaSandbox(ctx.sandbox, targetPath, created);
             } else {
               await writeLocal(targetPath, created);
             }
@@ -354,7 +355,7 @@ Example:
 
           const updated = applyHunksToContent(existing, file.hunks);
           if (ctx.sandbox) {
-            await writeViaSandbox(ctx, targetPath, updated);
+            await writeViaSandbox(ctx.sandbox, targetPath, updated);
           } else {
             await writeLocal(targetPath, updated);
           }

--- a/src/core/agents/offSecAgent/tools/createTask.ts
+++ b/src/core/agents/offSecAgent/tools/createTask.ts
@@ -7,28 +7,30 @@ const createTaskInputSchema = z.object({
   subject: z
     .string()
     .describe(
-      "Short subject line for the task (e.g., 'Test /api/users id param for UNION-based SQLi')",
+      "Short subject line for the task (e.g., 'Apply parameterized query fix in login handler', 'Test /api/users id param for UNION-based SQLi')",
     ),
   description: z
     .string()
     .describe(
-      "Detailed description of what to test and how — include specific payloads, encoding strategies, or bypass techniques to try",
+      "Detailed description of the work — for coding: what to change and how to verify; for testing: payloads, encoding strategies, or bypass techniques",
     ),
   objective: z
     .string()
+    .optional()
     .describe(
-      "The testing objective this task addresses (from your assigned objectives)",
+      "Optional higher-level objective this task addresses (e.g. a pentest objective or 'Fix SQL injection in auth'). Defaults to the subject when omitted.",
     ),
   technique: z
     .string()
+    .optional()
     .describe(
-      "The specific attack technique (e.g., 'UNION-based SQL injection', 'reflected XSS via search parameter', 'time-based blind SQLi')",
+      "Optional technique or approach label (e.g. 'parameterized queries', 'UNION-based SQL injection'). Defaults to 'general' when omitted.",
     ),
   metadata: z
     .record(z.string(), z.unknown())
     .optional()
     .describe(
-      "Optional metadata (e.g., { priority: 'high', endpoint: '/api/users', parameter: 'id' })",
+      "Optional metadata (e.g. { priority: 'high', file: 'src/auth.ts', endpoint: '/api/users' })",
     ),
 });
 
@@ -46,16 +48,19 @@ type CreateTaskResult = {
 
 export function createTask(ctx: ToolContext) {
   return tool({
-    description: `Create a testing task to track your work.
+    description: `Create a task to track your work.
 
-Decompose each objective into concrete, atomic testing tasks — one task per technique × endpoint combination. Tasks track what you've planned, what you're doing, and what's done.
+Use tasks as a lightweight todo list: decompose the job into concrete, atomic steps, create them early, and update status as you go.
 
-Call this BEFORE you start testing to build your task list. You can also add tasks mid-run when you discover new attack vectors.
+Works for both coding agents (patch/fix/verify steps) and pentest agents (technique × endpoint tests).
+
+Call this BEFORE you start substantive work to build your task list. Add more mid-run when you discover extra work.
 
 Examples of good tasks:
-- "Test /api/users id parameter for error-based SQL injection"
-- "Test /search q parameter for reflected XSS with event handler payloads"
-- "Test /api/auth for JWT signature bypass via algorithm confusion"`,
+- "Read vulnerable login handler and related DB helpers"
+- "Apply parameterized query fix in src/auth/login.ts"
+- "Run lint, typecheck, and unit tests"
+- "Test /api/users id parameter for error-based SQL injection"`,
     inputSchema: createTaskInputSchema,
     execute: async ({
       subject,
@@ -75,8 +80,8 @@ Examples of good tasks:
         const task = coreCreateTask(ctx.tasksDir, {
           subject,
           description,
-          objective,
-          technique,
+          objective: objective ?? subject,
+          technique: technique ?? "general",
           metadata,
         });
 

--- a/src/core/agents/offSecAgent/tools/deleteFile.test.ts
+++ b/src/core/agents/offSecAgent/tools/deleteFile.test.ts
@@ -1,0 +1,54 @@
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { type DeleteFileResult, deleteFile } from "./deleteFile";
+import type { ToolContext } from "./types";
+
+function makeCtx(agentCwd: string): ToolContext {
+  return {
+    agentCwd,
+    session: { id: "ses_test", rootPath: agentCwd },
+  } as ToolContext;
+}
+
+describe("deleteFile", () => {
+  it("deletes an existing file", async () => {
+    const root = mkdtempSync(join(tmpdir(), "apex-del-"));
+    const path = join(root, "doomed.ts");
+    writeFileSync(path, "export {}");
+
+    const tool = deleteFile(makeCtx(root));
+    const result = (await tool.execute?.(
+      { path: "doomed.ts", toolCallDescription: "Remove doomed file" },
+      { toolCallId: "t1", messages: [] },
+    )) as DeleteFileResult;
+
+    expect(result.success).toBe(true);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("fails loudly when the file is missing", async () => {
+    const root = mkdtempSync(join(tmpdir(), "apex-del-miss-"));
+    const tool = deleteFile(makeCtx(root));
+    const result = (await tool.execute?.(
+      { path: "missing.ts", toolCallDescription: "Try delete missing" },
+      { toolCallId: "t1", messages: [] },
+    )) as DeleteFileResult;
+
+    expect(result.success).toBe(false);
+    expect(result.error.length).toBeGreaterThan(0);
+  });
+
+  it("rejects paths outside agentCwd", async () => {
+    const root = mkdtempSync(join(tmpdir(), "apex-del-esc-"));
+    const tool = deleteFile(makeCtx(root));
+    const result = (await tool.execute?.(
+      { path: "../escape.ts", toolCallDescription: "Escape attempt" },
+      { toolCallId: "t1", messages: [] },
+    )) as DeleteFileResult;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/escapes/);
+  });
+});

--- a/src/core/agents/offSecAgent/tools/deleteFile.ts
+++ b/src/core/agents/offSecAgent/tools/deleteFile.ts
@@ -19,7 +19,7 @@ export type DeleteFileResult = {
   path: string;
 };
 
-export function resolveUnderCwd(agentCwd: string, filePath: string): string {
+function resolveUnderCwd(agentCwd: string, filePath: string): string {
   const resolved = isAbsolute(filePath)
     ? filePath
     : resolve(agentCwd, filePath);

--- a/src/core/agents/offSecAgent/tools/deleteFile.ts
+++ b/src/core/agents/offSecAgent/tools/deleteFile.ts
@@ -1,0 +1,92 @@
+import { unlink } from "node:fs/promises";
+import { isAbsolute, relative, resolve } from "node:path";
+import { tool } from "ai";
+import { z } from "zod";
+import type { ToolContext } from "./types";
+
+const deleteFileInputSchema = z.object({
+  path: z.string().describe("Absolute or relative path to the file to delete"),
+  toolCallDescription: z
+    .string()
+    .describe(
+      "A concise, human-readable description of what this tool call is doing (e.g., 'Remove obsolete insecure helper')",
+    ),
+});
+
+export type DeleteFileResult = {
+  success: boolean;
+  error: string;
+  path: string;
+};
+
+export function resolveUnderCwd(agentCwd: string, filePath: string): string {
+  const resolved = isAbsolute(filePath)
+    ? filePath
+    : resolve(agentCwd, filePath);
+  const rel = relative(agentCwd, resolved);
+  if (rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error(`Path escapes agent working directory: ${filePath}`);
+  }
+  return resolved;
+}
+
+export function deleteFile(ctx: ToolContext) {
+  return tool({
+    description: `Delete a file from the filesystem.
+
+Only deletes files (not directories). Path must stay within the agent working directory.
+Fails loudly if the file does not exist.`,
+    inputSchema: deleteFileInputSchema,
+    execute: async ({ path: filePath }): Promise<DeleteFileResult> => {
+      let target: string;
+      try {
+        target = resolveUnderCwd(ctx.agentCwd, filePath);
+      } catch (err: unknown) {
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+          path: filePath,
+        };
+      }
+
+      if (ctx.sandbox) {
+        try {
+          const check = await ctx.sandbox.execute(`test -f "${target}"`);
+          if (check.exitCode !== 0) {
+            return {
+              success: false,
+              error: `File not found: ${target}`,
+              path: target,
+            };
+          }
+          const result = await ctx.sandbox.execute(`rm "${target}"`);
+          if (!result.success) {
+            return {
+              success: false,
+              error: result.stderr || "Failed to delete file in sandbox",
+              path: target,
+            };
+          }
+          return { success: true, error: "", path: target };
+        } catch (err: unknown) {
+          return {
+            success: false,
+            error: err instanceof Error ? err.message : String(err),
+            path: target,
+          };
+        }
+      }
+
+      try {
+        await unlink(target);
+        return { success: true, error: "", path: target };
+      } catch (err: unknown) {
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+          path: target,
+        };
+      }
+    },
+  });
+}

--- a/src/core/agents/offSecAgent/tools/gitDiff.ts
+++ b/src/core/agents/offSecAgent/tools/gitDiff.ts
@@ -1,0 +1,68 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { runGit } from "./gitStatus";
+import type { ToolContext } from "./types";
+
+const gitDiffInputSchema = z.object({
+  path: z
+    .string()
+    .optional()
+    .describe("Optional path to limit the diff to a single file or directory"),
+  staged: z
+    .boolean()
+    .optional()
+    .describe("If true, show staged (--cached) diff. Default: unstaged."),
+  toolCallDescription: z
+    .string()
+    .describe(
+      "A concise, human-readable description of what this tool call is doing (e.g., 'Review unstaged patch before finalize')",
+    ),
+});
+
+export type GitDiffResult = {
+  success: boolean;
+  error: string;
+  diff: string;
+  cwd: string;
+};
+
+const MAX_DIFF = 100_000;
+
+export function gitDiff(ctx: ToolContext) {
+  return tool({
+    description: `Show the git diff for the agent repository.
+
+Defaults to unstaged working-tree changes. Set staged=true for the index.
+Optionally pass path to limit output to one file/directory.
+Does not commit, stage, push, or open a PR.`,
+    inputSchema: gitDiffInputSchema,
+    execute: async ({ path, staged = false }): Promise<GitDiffResult> => {
+      const args = ["diff"];
+      if (staged) args.push("--cached");
+      if (path) args.push("--", path);
+
+      const result = await runGit(ctx, args);
+      if (!result.success) {
+        return {
+          success: false,
+          error: result.stderr || "git diff failed",
+          diff: result.stdout,
+          cwd: ctx.agentCwd,
+        };
+      }
+
+      const raw = result.stdout;
+      const truncated = raw.length > MAX_DIFF;
+      return {
+        success: true,
+        error: truncated
+          ? `Diff truncated to ${MAX_DIFF} characters — narrow with path`
+          : "",
+        diff: truncated
+          ? `${raw.slice(0, MAX_DIFF)}\n\n(truncated)`
+          : raw || "(no changes)",
+        cwd: ctx.agentCwd,
+      };
+    },
+  });
+}

--- a/src/core/agents/offSecAgent/tools/gitStatus.ts
+++ b/src/core/agents/offSecAgent/tools/gitStatus.ts
@@ -1,0 +1,85 @@
+import { tool } from "ai";
+import { z } from "zod";
+import type { ToolContext } from "./types";
+
+const gitStatusInputSchema = z.object({
+  toolCallDescription: z
+    .string()
+    .describe(
+      "A concise, human-readable description of what this tool call is doing (e.g., 'Check which files were modified')",
+    ),
+});
+
+export type GitStatusResult = {
+  success: boolean;
+  error: string;
+  status: string;
+  cwd: string;
+};
+
+async function runGit(
+  ctx: ToolContext,
+  args: string[],
+): Promise<{ success: boolean; stdout: string; stderr: string }> {
+  const command = `git ${args.map((a) => `'${a.replace(/'/g, `'\\''`)}'`).join(" ")}`;
+  const full = `cd "${ctx.agentCwd}" && ${command}`;
+
+  if (ctx.sandbox) {
+    const result = await ctx.sandbox.execute(full, { timeout: 30 });
+    return {
+      success: result.success,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  }
+
+  if (ctx.persistentShell) {
+    const result = await ctx.persistentShell.execute(
+      full,
+      30,
+      undefined,
+      ctx.abortSignal,
+    );
+    return {
+      success: result.exitCode === 0,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  }
+
+  return {
+    success: false,
+    stdout: "",
+    stderr: "No shell or sandbox available",
+  };
+}
+
+export function gitStatus(ctx: ToolContext) {
+  return tool({
+    description: `Show git working-tree status (porcelain) for the agent repository.
+
+Use this to self-check which files you changed before finalizing.
+Does not commit, stage, push, or open a PR.`,
+    inputSchema: gitStatusInputSchema,
+    execute: async (): Promise<GitStatusResult> => {
+      const result = await runGit(ctx, ["status", "--porcelain"]);
+      if (!result.success) {
+        return {
+          success: false,
+          error: result.stderr || "git status failed",
+          status: result.stdout,
+          cwd: ctx.agentCwd,
+        };
+      }
+      return {
+        success: true,
+        error: "",
+        status: result.stdout.trim() || "(clean)",
+        cwd: ctx.agentCwd,
+      };
+    },
+  });
+}
+
+// Re-export helper for git_diff tool
+export { runGit };

--- a/src/core/agents/offSecAgent/tools/gitTools.test.ts
+++ b/src/core/agents/offSecAgent/tools/gitTools.test.ts
@@ -1,0 +1,64 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { type GitDiffResult, gitDiff } from "./gitDiff";
+import { type GitStatusResult, gitStatus } from "./gitStatus";
+import { PersistentShell } from "./persistentShell";
+import type { ToolContext } from "./types";
+
+function makeGitRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "apex-git-"));
+  execSync("git init", { cwd: root });
+  execSync('git config user.email "test@example.com"', { cwd: root });
+  execSync('git config user.name "Test"', { cwd: root });
+  writeFileSync(join(root, "a.ts"), "export const a = 1;\n");
+  execSync("git add a.ts && git commit -m init", { cwd: root });
+  writeFileSync(join(root, "a.ts"), "export const a = 2;\n");
+  return root;
+}
+
+function makeCtx(agentCwd: string): ToolContext {
+  const shell = new PersistentShell({ cwd: agentCwd });
+  return {
+    agentCwd,
+    session: { id: "ses_test", rootPath: agentCwd },
+    persistentShell: shell,
+  } as ToolContext;
+}
+
+describe("git_status / git_diff", () => {
+  it("reports porcelain status for modified files", async () => {
+    const root = makeGitRepo();
+    const ctx = makeCtx(root);
+    try {
+      const tool = gitStatus(ctx);
+      const result = (await tool.execute?.(
+        { toolCallDescription: "status" },
+        { toolCallId: "t1", messages: [] },
+      )) as GitStatusResult;
+      expect(result.success).toBe(true);
+      expect(result.status).toMatch(/a\.ts/);
+    } finally {
+      ctx.persistentShell?.dispose();
+    }
+  });
+
+  it("returns an unstaged diff", async () => {
+    const root = makeGitRepo();
+    const ctx = makeCtx(root);
+    try {
+      const tool = gitDiff(ctx);
+      const result = (await tool.execute?.(
+        { toolCallDescription: "diff" },
+        { toolCallId: "t1", messages: [] },
+      )) as GitDiffResult;
+      expect(result.success).toBe(true);
+      expect(result.diff).toContain("-export const a = 1;");
+      expect(result.diff).toContain("+export const a = 2;");
+    } finally {
+      ctx.persistentShell?.dispose();
+    }
+  });
+});

--- a/src/core/agents/offSecAgent/tools/glob.test.ts
+++ b/src/core/agents/offSecAgent/tools/glob.test.ts
@@ -1,0 +1,50 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { type GlobResult, globFiles, resolveGlobRoot } from "./glob";
+import type { ToolContext } from "./types";
+
+function makeCtx(agentCwd: string): ToolContext {
+  return {
+    agentCwd,
+    session: { id: "ses_test", rootPath: agentCwd },
+  } as ToolContext;
+}
+
+describe("resolveGlobRoot", () => {
+  it("defaults to agentCwd", () => {
+    expect(resolveGlobRoot("/repo")).toBe("/repo");
+  });
+
+  it("rejects paths that escape agentCwd", () => {
+    expect(() => resolveGlobRoot("/repo", "../outside")).toThrow(/escapes/);
+  });
+});
+
+describe("globFiles", () => {
+  it("matches files by pattern and skips node_modules", async () => {
+    const root = mkdtempSync(join(tmpdir(), "apex-glob-"));
+    mkdirSync(join(root, "src"), { recursive: true });
+    mkdirSync(join(root, "node_modules", "pkg"), { recursive: true });
+    writeFileSync(join(root, "src", "a.ts"), "export {}");
+    writeFileSync(join(root, "src", "b.tsx"), "export {}");
+    writeFileSync(join(root, "node_modules", "pkg", "index.ts"), "export {}");
+
+    const tool = globFiles(makeCtx(root));
+    const result = (await tool.execute?.(
+      {
+        pattern: "**/*.{ts,tsx}",
+        toolCallDescription: "Find TS sources",
+      },
+      { toolCallId: "t1", messages: [] },
+    )) as GlobResult;
+
+    expect(result.success).toBe(true);
+    expect(result.files).toContain("src/a.ts");
+    expect(result.files).toContain("src/b.tsx");
+    expect(result.files.some((f: string) => f.includes("node_modules"))).toBe(
+      false,
+    );
+  });
+});

--- a/src/core/agents/offSecAgent/tools/glob.ts
+++ b/src/core/agents/offSecAgent/tools/glob.ts
@@ -59,9 +59,7 @@ export function resolveGlobRoot(agentCwd: string, path?: string): string {
     : agentCwd;
   const rel = relative(agentCwd, root);
   if (rel.startsWith("..") || isAbsolute(rel)) {
-    throw new Error(
-      `Path escapes agent working directory: ${path ?? root}`,
-    );
+    throw new Error(`Path escapes agent working directory: ${path ?? root}`);
   }
   return root;
 }

--- a/src/core/agents/offSecAgent/tools/glob.ts
+++ b/src/core/agents/offSecAgent/tools/glob.ts
@@ -1,0 +1,156 @@
+import { isAbsolute, relative, resolve } from "node:path";
+import { tool } from "ai";
+import { glob as globAsync } from "glob";
+import { z } from "zod";
+import type { ToolContext } from "./types";
+
+const DEFAULT_IGNORE = [
+  "**/node_modules/**",
+  "**/.git/**",
+  "**/dist/**",
+  "**/build/**",
+  "**/.next/**",
+  "**/coverage/**",
+  "**/__pycache__/**",
+  "**/.venv/**",
+  "**/venv/**",
+];
+
+const MAX_RESULTS = 200;
+
+const globInputSchema = z.object({
+  pattern: z
+    .string()
+    .describe(
+      'Glob pattern to match files (e.g. "**/*.ts", "src/**/*.tsx", "**/package.json")',
+    ),
+  path: z
+    .string()
+    .optional()
+    .describe(
+      "Directory to search from (absolute or relative to agent cwd). Defaults to agent cwd.",
+    ),
+  toolCallDescription: z
+    .string()
+    .describe(
+      "A concise, human-readable description of what this tool call is doing (e.g., 'Find all TypeScript source files')",
+    ),
+});
+
+export type GlobResult = {
+  success: boolean;
+  error: string;
+  files: string[];
+  count: number;
+  totalFound?: number;
+  pattern: string;
+  cwd: string;
+};
+
+/**
+ * Resolve the search root and ensure it stays under agentCwd.
+ * Throws when the resolved path escapes the agent working directory.
+ */
+export function resolveGlobRoot(agentCwd: string, path?: string): string {
+  const root = path
+    ? isAbsolute(path)
+      ? path
+      : resolve(agentCwd, path)
+    : agentCwd;
+  const rel = relative(agentCwd, root);
+  if (rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error(
+      `Path escapes agent working directory: ${path ?? root}`,
+    );
+  }
+  return root;
+}
+
+export function globFiles(ctx: ToolContext) {
+  return tool({
+    description: `Find files by glob pattern under the agent working directory.
+
+Examples:
+- "**/*.ts" — all TypeScript files
+- "src/**/*.{ts,tsx}" — sources under src/
+- "**/package.json" — package manifests
+
+Skips common junk directories (node_modules, .git, dist, build, .next, coverage, venv).
+Results are capped at ${MAX_RESULTS}; narrow the pattern if truncated.`,
+    inputSchema: globInputSchema,
+    execute: async ({ pattern, path }): Promise<GlobResult> => {
+      let root: string;
+      try {
+        root = resolveGlobRoot(ctx.agentCwd, path);
+      } catch (err: unknown) {
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+          files: [],
+          count: 0,
+          pattern,
+          cwd: ctx.agentCwd,
+        };
+      }
+
+      try {
+        if (ctx.sandbox) {
+          // Sandbox: shell out to find matching paths via a bounded find/glob.
+          // Use bash globstar when available; fall back to find + case filter.
+          const escapedPattern = pattern.replace(/"/g, '\\"');
+          const cmd = `shopt -s globstar nullglob 2>/dev/null; cd "${root}" && compgen -G "${escapedPattern}" | head -n ${MAX_RESULTS + 1}`;
+          const result = await ctx.sandbox.execute(cmd, { timeout: 30 });
+          const lines = result.stdout
+            .split("\n")
+            .map((l) => l.trim())
+            .filter(Boolean);
+          const truncated = lines.length > MAX_RESULTS;
+          const files = lines.slice(0, MAX_RESULTS);
+          return {
+            success: true,
+            error: truncated
+              ? `Showing ${MAX_RESULTS} of at least ${lines.length} matches — narrow the pattern`
+              : "",
+            files,
+            count: files.length,
+            totalFound: truncated ? lines.length : undefined,
+            pattern,
+            cwd: root,
+          };
+        }
+
+        const matches = await globAsync(pattern, {
+          cwd: root,
+          nodir: true,
+          dot: false,
+          ignore: DEFAULT_IGNORE,
+          absolute: false,
+        });
+
+        const truncated = matches.length > MAX_RESULTS;
+        const files = matches.slice(0, MAX_RESULTS).sort();
+
+        return {
+          success: true,
+          error: truncated
+            ? `Showing ${MAX_RESULTS} of ${matches.length} matches — narrow the pattern`
+            : "",
+          files,
+          count: files.length,
+          totalFound: truncated ? matches.length : undefined,
+          pattern,
+          cwd: root,
+        };
+      } catch (err: unknown) {
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+          files: [],
+          count: 0,
+          pattern,
+          cwd: root,
+        };
+      }
+    },
+  });
+}

--- a/src/core/agents/offSecAgent/tools/index.ts
+++ b/src/core/agents/offSecAgent/tools/index.ts
@@ -1,5 +1,6 @@
 // Memory tools
 export { addMemory } from "./addMemory";
+export { applyPatch } from "./applyPatch";
 // askUserQuestions schema/types — used by TUI for the question-prompt UX.
 export {
   type AskUserQuestion,
@@ -19,6 +20,7 @@ export { createFile } from "./createFile";
 // Task decomposition tools
 export { createTask } from "./createTask";
 export { delegateAuth } from "./delegateAuth";
+export { deleteFile } from "./deleteFile";
 export { detectAuthScheme } from "./detectAuthScheme";
 // Attack surface / recon tools
 export { documentApp } from "./documentApp";
@@ -35,6 +37,9 @@ export { executeCommand } from "./executeCommand";
 export { extractJsEndpoints } from "./extractJsEndpoints";
 export { getMemory } from "./getMemory";
 export { getPage } from "./getPage";
+export { gitDiff } from "./gitDiff";
+export { gitStatus } from "./gitStatus";
+export { globFiles } from "./glob";
 export { grep } from "./grep";
 export { httpRequest } from "./httpRequest";
 export { listFiles } from "./listFiles";
@@ -148,6 +153,7 @@ export { writePlan } from "./writePlan";
 // ---------------------------------------------------------------------------
 
 import { addMemory } from "./addMemory";
+import { applyPatch } from "./applyPatch";
 import {
   ASK_USER_QUESTIONS_TOOL_NAME,
   askUserQuestions,
@@ -160,6 +166,7 @@ import { createAttackSurfaceReport } from "./createAttackSurfaceReport";
 import { createFile } from "./createFile";
 import { createTask } from "./createTask";
 import { delegateAuth } from "./delegateAuth";
+import { deleteFile } from "./deleteFile";
 import { detectAuthScheme } from "./detectAuthScheme";
 import { documentApp } from "./documentApp";
 import { documentEndpoint } from "./documentEndpoint";
@@ -175,6 +182,9 @@ import { executeCommand } from "./executeCommand";
 import { extractJsEndpoints } from "./extractJsEndpoints";
 import { getMemory } from "./getMemory";
 import { getPage } from "./getPage";
+import { gitDiff } from "./gitDiff";
+import { gitStatus } from "./gitStatus";
+import { globFiles } from "./glob";
 import { grep } from "./grep";
 import { httpRequest } from "./httpRequest";
 import { listFiles } from "./listFiles";
@@ -237,12 +247,17 @@ export function createAllTools(ctx: ToolContext) {
     // Filesystem / search tools
     read_file: readFile(ctx),
     list_files: listFiles(ctx),
+    glob: globFiles(ctx),
     grep: grep(ctx),
     profile_codebase: profileCodebase(ctx),
     query_whitebox_catalog: queryWhiteboxCatalog(ctx),
     run_code_query: runCodeQuery(ctx),
     create_file: createFile(ctx),
     update_file: updateFile(ctx),
+    delete_file: deleteFile(ctx),
+    apply_patch: applyPatch(ctx),
+    git_status: gitStatus(ctx),
+    git_diff: gitDiff(ctx),
 
     // Attack surface / recon tools
     document_app: documentApp(ctx),
@@ -341,12 +356,17 @@ export const ALL_TOOL_NAMES: ToolName[] = [
   // Filesystem / search
   "read_file",
   "list_files",
+  "glob",
   "grep",
   "profile_codebase",
   "query_whitebox_catalog",
   "run_code_query",
   "create_file",
   "update_file",
+  "delete_file",
+  "apply_patch",
+  "git_status",
+  "git_diff",
   "document_app",
   "document_endpoint",
   "delegate_to_auth_subagent",
@@ -450,8 +470,11 @@ export const PLAN_MODE_TOOL_NAMES: ToolName[] = [
   // Filesystem / search (read-only)
   "read_file",
   "list_files",
+  "glob",
   "grep",
   "query_whitebox_catalog",
+  "git_status",
+  "git_diff",
   // Recon (read-only probing and discovery)
   "delegate_to_auth_subagent",
   "complete_authentication",

--- a/src/core/agents/specialized/patching/agent.test.ts
+++ b/src/core/agents/specialized/patching/agent.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { PATCHING_ACTIVE_TOOLS } from "./agent";
+import { buildPatchingPrompt, buildSystemPrompt } from "./prompts";
+
+describe("PatchingAgent toolset", () => {
+  it("exposes a Cursor/Claude-Code-like autonomous coding toolset", () => {
+    expect(PATCHING_ACTIVE_TOOLS).toEqual(
+      expect.arrayContaining([
+        "read_file",
+        "list_files",
+        "glob",
+        "grep",
+        "profile_codebase",
+        "run_code_query",
+        "web_search",
+        "get_page",
+        "create_task",
+        "update_task",
+        "list_tasks",
+        "create_file",
+        "update_file",
+        "delete_file",
+        "apply_patch",
+        "git_status",
+        "git_diff",
+        "execute_command",
+        "response",
+      ]),
+    );
+    expect(PATCHING_ACTIVE_TOOLS).not.toContain("ask_user_questions");
+    expect(PATCHING_ACTIVE_TOOLS).not.toContain("spawn_coding_agent");
+    expect(PATCHING_ACTIVE_TOOLS).not.toContain("browser_navigate");
+  });
+});
+
+describe("patching prompts", () => {
+  it("prescribes the autonomous coding-agent workflow and new tools", () => {
+    const system = buildSystemPrompt();
+    expect(system).toContain("Track Work with Tasks");
+    expect(system).toContain("apply_patch");
+    expect(system).toContain("git_status");
+    expect(system).toContain("web_search");
+    expect(system).toContain("Stay Autonomous");
+    expect(system).toContain("Do not commit, push, or open a pull request");
+  });
+
+  it("includes vulnerability details and the numbered workflow in the user prompt", () => {
+    const prompt = buildPatchingPrompt(
+      {
+        name: "SQL Injection",
+        severity: "critical",
+        description: "Unparameterized query",
+        location: "src/auth.ts",
+      },
+      "/tmp/repo",
+    );
+    expect(prompt).toContain("SQL Injection");
+    expect(prompt).toContain("src/auth.ts");
+    expect(prompt).toContain("Self-Check with Git");
+    expect(prompt).toContain("create_task");
+  });
+});

--- a/src/core/agents/specialized/patching/agent.ts
+++ b/src/core/agents/specialized/patching/agent.ts
@@ -17,6 +17,33 @@ const AGENTS_MD_FILENAMES = [
 const MAX_AGENTS_MD_SIZE = 50_000;
 
 /**
+ * Tools available to the autonomous patching agent.
+ * Mirrors a Cursor / Claude Code coding loop: explore, research, todo,
+ * multi-file edit, git self-check, verify, structured finalize.
+ */
+export const PATCHING_ACTIVE_TOOLS = [
+  "read_file",
+  "list_files",
+  "glob",
+  "grep",
+  "profile_codebase",
+  "run_code_query",
+  "web_search",
+  "get_page",
+  "create_task",
+  "update_task",
+  "list_tasks",
+  "create_file",
+  "update_file",
+  "delete_file",
+  "apply_patch",
+  "git_status",
+  "git_diff",
+  "execute_command",
+  "response",
+] as const;
+
+/**
  * Try to read an AGENTS.md (or similar) file from the repository root.
  * Returns the file content or undefined if none is found.
  */
@@ -100,15 +127,7 @@ export class PatchingAgent extends OffensiveSecurityAgent<PatchResult> {
       thinkingEffort,
       openAIReasoningEffort,
 
-      activeTools: [
-        "read_file",
-        "list_files",
-        "grep",
-        "create_file",
-        "update_file",
-        "execute_command",
-        "response",
-      ],
+      activeTools: [...PATCHING_ACTIVE_TOOLS],
 
       responseSchema: PatchResultSchema,
     });

--- a/src/core/agents/specialized/patching/index.ts
+++ b/src/core/agents/specialized/patching/index.ts
@@ -1,7 +1,7 @@
 // Stable external import path. External consumers depend on this barrel.
 // Tracked for migration into the public API in #726 — do not delete or
 // restructure until those consumers are moved off the deep import.
-export { PatchingAgent } from "./agent";
+export { PATCHING_ACTIVE_TOOLS, PatchingAgent } from "./agent";
 export {
   buildPatchingPrompt,
   buildSystemPrompt,

--- a/src/core/agents/specialized/patching/prompts.ts
+++ b/src/core/agents/specialized/patching/prompts.ts
@@ -4,46 +4,61 @@ import type { VulnerabilityDetails } from "./types";
 // System prompt
 // ---------------------------------------------------------------------------
 
-const PREAMBLE = `You are an expert security vulnerability patching agent. Your goal is to analyze security vulnerabilities, provide high-quality fixes, and verify the fixes don't break existing functionality.`;
+const PREAMBLE = `You are an expert security vulnerability patching agent — an autonomous coding agent specialized in fixing security issues. Your goal is to analyze security vulnerabilities, apply high-quality fixes, verify they don't break existing functionality, and return structured PR metadata.`;
 
 const ORIENT_STEP = `1. **Orient Yourself**:
    - Review the AGENTS.md / project documentation provided in your prompt for build, lint, and test commands
-   - Use list_files to explore the repository structure
+   - Use glob / list_files to explore the repository structure (prefer glob for pattern searches like "**/*.ts")
    - Read package.json, Makefile, or equivalent to understand the project's toolchain
-   - Identify the lint command, test command, type-check command, and any other verification scripts`;
+   - Identify the lint command, test command, type-check command, and any other verification scripts
+   - Optionally call profile_codebase for a high-level map of the repo`;
 
-const UNDERSTAND_STEP = `2. **Understand the Vulnerability**: 
+const TASK_STEP = `2. **Track Work with Tasks**:
+   - Use create_task early to decompose the job into concrete steps (orient, understand, edit, verify, finalize)
+   - Update tasks with update_task as you progress (in_progress → completed / failed)
+   - Use list_tasks when you need to recall what's left
+   - Keep tasks atomic — one clear outcome per task`;
+
+const UNDERSTAND_STEP = `3. **Understand the Vulnerability**:
    - Carefully read the vulnerability description, CWE mappings, and any dataflow analysis provided
    - Understand the root cause: What makes this code vulnerable?
    - Identify the attack vector: How would an attacker exploit this?
-   - Consider the context: What is the application trying to do?`;
+   - Consider the context: What is the application trying to do?
+   - Use web_search / get_page when you need framework-specific security guidance or CVE details`;
 
-const REVIEW_STEP = `3. **Review the Code**:
+const REVIEW_STEP = `4. **Review the Code**:
    - Use read_file to read the vulnerable file(s) mentioned in the issue
-   - Use grep to search for related code patterns, similar vulnerabilities, or existing security controls
+   - Use grep or run_code_query for structural searches (rg / ast-grep) across related patterns
    - Review related files: imports, dependencies, configuration files
    - Understand the data flow: Where does user input come from? Where does it go?`;
 
-const PLAN_STEP = `4. **Plan Your Fix**:
+const PLAN_STEP = `5. **Plan Your Fix**:
    - Identify the exact code that needs to change
    - Determine the appropriate security control (input validation, parameterized queries, access control, etc.)
    - Consider side effects: Will this break existing functionality?
    - Think about edge cases: What other inputs or scenarios need to be handled?
    - Look for framework-specific or language-specific best practices
-   - State your complete plan clearly before making changes`;
+   - State your complete plan clearly before making changes, and reflect it in your task list`;
 
-const APPLY_STEP = `5. **Apply the Patch**:
-   - Use update_file to modify existing files with your security fixes
+const APPLY_STEP = `6. **Apply the Patch**:
+   - Prefer update_file for small, exact string replacements
+   - Prefer apply_patch (unified diff) for multi-hunk or multi-file edits
    - Use create_file if you need to add new security utilities or middleware
+   - Use delete_file only when removing obsolete insecure code that is truly unused
    - Make minimal, targeted changes — don't refactor unrelated code
    - Follow the existing code style and conventions
    - Ensure your changes integrate cleanly with the existing codebase`;
 
-const RESTART_STEP = `6. **Restart Dev Environment** (if applicable):
+const GIT_STEP = `7. **Self-Check with Git**:
+   - Use git_status to see which files changed
+   - Use git_diff to review the exact patch before verification
+   - Do NOT commit, push, or open a PR — the host handles that after you finalize`;
+
+const RESTART_STEP = `8. **Restart Dev Environment** (if applicable):
    - Use execute_command to restart any dev servers or services so your changes are loaded
    - Wait for the services to become healthy`;
 
-const VERIFY_STEP = `7. **Verify the Patch**:
+const VERIFY_STEP = `9. **Verify the Patch**:
    - Use execute_command to run the project's lint command (e.g. \`npm run lint\`, \`ruff check\`, \`cargo clippy\`)
    - Use execute_command to run the project's type-check command if applicable (e.g. \`npx tsc --noEmit\`, \`mypy\`)
    - Use execute_command to run the project's test suite (e.g. \`npm test\`, \`pytest\`, \`cargo test\`)
@@ -51,7 +66,8 @@ const VERIFY_STEP = `7. **Verify the Patch**:
    - If any check fails, read the error output carefully, fix the issues, and re-run until all checks pass
    - If the project has no clear lint/test commands, at minimum verify the changed files parse correctly (e.g. \`node -c file.js\`, \`python -m py_compile file.py\`)`;
 
-const FINALIZE_STEP = `8. **Finalize**:
+const FINALIZE_STEP = `10. **Finalize**:
+   - Mark remaining tasks completed
    - Use the response tool to complete the patching process
    - Provide a clear, detailed summary of:
      * Each file you changed and why
@@ -120,12 +136,18 @@ const SECURITY_BEST_PRACTICES = `# Security Best Practices by Vulnerability Type
 
 const TOOL_USAGE = `# Tool Usage
 
-- **list_files**: Explore directory structure and find relevant files
+- **glob**: Find files by pattern (e.g. "**/*.ts", "**/package.json")
+- **list_files**: Explore directory structure
 - **read_file**: Read file contents to understand code
-- **grep**: Search for patterns across the codebase
-- **update_file**: Modify existing files with security fixes
-- **create_file**: Create new files if needed (utilities, middleware, etc.)
-- **execute_command**: Run shell commands — use for linting, type-checking, running tests, restarting services, running POCs, installing dependencies, and verifying your changes
+- **grep** / **run_code_query**: Search for patterns (run_code_query supports rg / ast-grep / comby)
+- **profile_codebase**: High-level codebase map when orientation is hard
+- **web_search** / **get_page**: Look up CVE details, framework security docs
+- **create_task** / **update_task** / **list_tasks**: Todo tracking for the run
+- **update_file**: Small exact search-and-replace edits
+- **apply_patch**: Multi-hunk / multi-file unified diffs
+- **create_file** / **delete_file**: Add or remove files when needed
+- **git_status** / **git_diff**: Self-check changes (do not commit/push/PR)
+- **execute_command**: Lint, type-check, tests, restart services, run POCs
 - **response**: Complete the process with the structured patch result`;
 
 const REQUIREMENTS = `# Critical Requirements
@@ -138,6 +160,7 @@ const REQUIREMENTS = `# Critical Requirements
 6. **Test the Fix**: If a POC is provided, run it after patching. The POC should FAIL (non-zero exit code) once the vulnerability is fixed.
 7. **Be Persistent**: It may take multiple iterations to get the fix right — iterate until the POC fails and tests pass.
 8. **Be Complete**: Address the root cause, not just symptoms
+9. **Stay Autonomous**: You will not receive follow-up messages — finish the job in this run
 
 # Important Notes
 
@@ -148,7 +171,8 @@ const REQUIREMENTS = `# Critical Requirements
 - Follow language and framework conventions
 - When multiple approaches exist, choose the most secure and idiomatic
 - If a fix requires configuration changes or environment variables, note this clearly
-- If AGENTS.md or project docs specify particular lint/test/build commands, use those exact commands`;
+- If AGENTS.md or project docs specify particular lint/test/build commands, use those exact commands
+- Do not commit, push, or open a pull request — the host does that after your response`;
 
 /**
  * Build the patching agent system prompt.
@@ -159,9 +183,11 @@ export function buildSystemPrompt(): string {
     "",
     "# Process",
     "",
-    "You MUST follow this prescriptive process:",
+    "You MUST follow this autonomous coding-agent process:",
     "",
     ORIENT_STEP,
+    "",
+    TASK_STEP,
     "",
     UNDERSTAND_STEP,
     "",
@@ -170,6 +196,8 @@ export function buildSystemPrompt(): string {
     PLAN_STEP,
     "",
     APPLY_STEP,
+    "",
+    GIT_STEP,
     "",
     RESTART_STEP,
     "",
@@ -293,45 +321,18 @@ export function buildPatchingPrompt(
   sections.push(
     "## Your Task",
     "",
-    "Follow the prescriptive process outlined in your system prompt:",
+    "Follow the autonomous coding-agent process in your system prompt:",
     "",
-    "1. **Orient Yourself**",
-    "   - Review the AGENTS.md content above (if provided) for build/lint/test commands",
-    "   - Read package.json or equivalent to understand the project toolchain",
-    "",
-    "2. **Understand the Vulnerability**",
-    "   - Analyze the vulnerability description, CWE mappings, and dataflow",
-    "   - Identify the root cause and attack vector",
-    "",
-    "3. **Review the Code**",
-    "   - Use list_files to explore the repository structure",
-    "   - Use read_file to examine the vulnerable file and related code",
-    "   - Use grep to search for patterns, similar issues, or existing security controls",
-    "",
-    "4. **Plan Your Fix**",
-    "   - Determine exactly what code needs to change",
-    "   - Choose the appropriate security control",
-    "   - Consider side effects and edge cases",
-    "   - State your complete plan clearly",
-    "",
-    "5. **Apply the Patch**",
-    "   - Use update_file to implement your security fixes",
-    "   - Use create_file if you need to add new utilities",
-    "   - Make minimal, targeted changes",
-    "   - Follow existing code style and conventions",
-    "",
-    "6. **Restart Dev Environment** (if applicable)",
-    "   - Restart any dev servers so your changes are loaded",
-    "",
-    "7. **Verify the Patch**",
-    "   - Run lint, type-check, and tests via execute_command",
-    "   - If a POC was provided, run it — it should FAIL after a successful patch",
-    "   - If any check fails, fix the issues and re-run",
-    "",
-    "8. **Finalize**",
-    "   - Use the response tool to submit your result",
-    "   - Include verification results (and POC result if applicable) in your descriptions",
-    "   - Write a professional PR title and description",
+    "1. **Orient Yourself** — glob/list_files, read AGENTS.md and package manifests",
+    "2. **Track Work with Tasks** — create_task for the steps you will take",
+    "3. **Understand the Vulnerability** — analyze description, CWE, dataflow; research if needed",
+    "4. **Review the Code** — read_file, grep, run_code_query",
+    "5. **Plan Your Fix** — state the plan; keep tasks in sync",
+    "6. **Apply the Patch** — update_file / apply_patch / create_file / delete_file",
+    "7. **Self-Check with Git** — git_status / git_diff",
+    "8. **Restart Dev Environment** (if applicable)",
+    "9. **Verify the Patch** — lint, type-check, tests, POC",
+    "10. **Finalize** — response tool with PR title/description and file change summaries",
     "",
     "## Success Criteria",
     "",
@@ -342,8 +343,8 @@ export function buildPatchingPrompt(
     "- Lint, type-check, and tests pass after the patch",
     "- The POC fails after patching (if one was provided)",
     "",
-    "Begin by orienting yourself: read the project documentation and package.json,",
-    "then explore the repository and read the vulnerable file(s).",
+    "Begin by creating your task list, then orient yourself: read the project",
+    "documentation and package.json, explore the repository, and read the vulnerable file(s).",
   );
 
   return sections.filter(Boolean).join("\n");

--- a/src/tui/components/shared/tool-registry.ts
+++ b/src/tui/components/shared/tool-registry.ts
@@ -34,6 +34,15 @@ const TOOL_SUMMARY_MAP: Record<string, ToolSummaryFn> = {
   Write: (args) => `write ${args.path || args.file_path || ""}`,
   create_file: (args) => `create ${args.path || ""}`,
   update_file: (args) => `update ${args.path || ""}`,
+  delete_file: (args) => `delete ${args.path || ""}`,
+  apply_patch: () => "apply_patch",
+  git_status: () => "git status",
+  git_diff: (args) =>
+    args.path
+      ? `git diff ${args.path}`
+      : args.staged
+        ? "git diff --staged"
+        : "git diff",
   document_vulnerability: (args) => {
     const title = args.title || args.name || "";
     const pocName = args.pocName || "";
@@ -45,6 +54,7 @@ const TOOL_SUMMARY_MAP: Record<string, ToolSummaryFn> = {
   Grep: (args) => `grep ${args.pattern || ""}`,
   grep: (args) => `grep ${args.pattern || ""}`,
   Glob: (args) => `glob ${args.pattern || ""}`,
+  glob: (args) => `glob ${args.pattern || ""}`,
 
   // Web search
   web_search: (args) => `search "${args.query || ""}"`,


### PR DESCRIPTION
Enable research/search/task tools on PatchingAgent and add glob, delete_file, apply_patch, git_status, and git_diff primitives so the autonomous patch loop matches a Cursor/Claude Code style workflow.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New agent capabilities can delete files and apply multi-file patches on disk (with cwd escape checks); PatchingAgent behavior and tool surface change materially, though git tools are read-only and tests cover core paths.
> 
> **Overview**
> Adds **offSec agent primitives** for a Cursor/Claude Code–style patch loop: `glob`, `delete_file`, `apply_patch` (unified diff parse/apply with strict context matching and cwd sandboxing), plus read-only `git_status` / `git_diff`. These are registered in the main toolset and exposed in plan mode where appropriate (`glob`, git read-only).
> 
> **`create_task`** is generalized for coding work: optional `objective` / `technique` with defaults, and copy/examples that cover fix/verify steps—not only pentest tasks.
> 
> **`PatchingAgent`** switches from a minimal read/edit/shell set to `PATCHING_ACTIVE_TOOLS` (explore, research, tasks, multi-file edit, git self-check, verify, `response`). Prompts document the 10-step autonomous workflow (tasks, `apply_patch`, git review without commit/PR).
> 
> TUI **tool-registry** labels cover the new tools; **vitest** covers patch/delete/glob/git and patching toolset/prompt expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 195686dd4a67418c9159f8caa6f0d8c3e49a13f3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->