### PR TITLE
feat(tui): Strike Mode toggle in /advanced settings

### DIFF
--- a/src/core/config/config.test.ts
+++ b/src/core/config/config.test.ts
@@ -1,0 +1,59 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { get, init, update } from "./config";
+
+let homeDirectory: string;
+
+beforeEach(() => {
+  homeDirectory = mkdtempSync(path.join(os.tmpdir(), "apex-config-test-"));
+  vi.spyOn(os, "homedir").mockReturnValue(homeDirectory);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(homeDirectory, { recursive: true, force: true });
+});
+
+describe("Strike Mode config", () => {
+  it("defaults to off for a new installation", async () => {
+    const config = await init();
+
+    expect(config.strikeMode).toBe(false);
+  });
+
+  it("defaults to off when an existing config predates Strike Mode", async () => {
+    const configDirectory = path.join(homeDirectory, ".pensar");
+    mkdirSync(configDirectory, { recursive: true });
+    writeFileSync(
+      path.join(configDirectory, "config.json"),
+      JSON.stringify({ responsibleUseAccepted: true }),
+    );
+
+    const config = await get();
+
+    expect(config.strikeMode).toBe(false);
+  });
+
+  it("persists the enabled state across a fresh config load", async () => {
+    await init();
+    await update({ strikeMode: true });
+
+    vi.resetModules();
+    const { get: getReloadedConfig } = await import("./config");
+    const reloaded = await getReloadedConfig();
+
+    expect(reloaded.strikeMode).toBe(true);
+    const persisted = JSON.parse(
+      readFileSync(path.join(homeDirectory, ".pensar", "config.json"), "utf8"),
+    ) as { strikeMode?: boolean };
+    expect(persisted.strikeMode).toBe(true);
+  });
+});

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -6,6 +6,7 @@ import { getCurrentVersion } from "../installation";
 const DEFAULT_CONFIG: Config = {
   responsibleUseAccepted: false,
   defaultHeaders: { "User-Agent": "pensar-apex" },
+  strikeMode: false,
 };
 
 export interface Config {
@@ -45,6 +46,8 @@ export interface Config {
     | "max"
     | "ultra"
     | null;
+  // Default workflow for newly created TUI operator sessions.
+  strikeMode?: boolean;
   // Whitebox attack surface: when false, skip the @pensar/surface deterministic
   // enumeration path and use the legacy pages+apiEndpoints discovery agents.
   // Defaults to true when unset.
@@ -108,6 +111,7 @@ function applyEnvFallbacks(parsedConfig: Partial<Config>): Config {
     responsibleUseAccepted: parsedConfig.responsibleUseAccepted ?? false,
     defaultHeaders:
       parsedConfig.defaultHeaders ?? DEFAULT_CONFIG.defaultHeaders,
+    strikeMode: parsedConfig.strikeMode ?? DEFAULT_CONFIG.strikeMode,
     surfaceIntegrationEnabled:
       parsedConfig.surfaceIntegrationEnabled ??
       parseBoolEnv(process.env.PENSAR_SURFACE_INTEGRATION),

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -88,6 +88,8 @@ const OperatorSettingsObject = z.object({
   initialMode: z.enum(["plan", "manual", "auto"]).default("manual"),
   requireApproval: z.boolean().default(true),
   enableSuggestions: z.boolean().default(true),
+  /** Run the top-level operator as a focused solo researcher without orchestration tools. */
+  strikeMode: z.boolean().optional(),
 });
 
 export type OperatorSettings = z.infer<typeof OperatorSettingsObject>;
@@ -928,6 +930,7 @@ export async function updateOperatorSettings(
         initialMode: "manual",
         requireApproval: true,
         enableSuggestions: true,
+        strikeMode: false,
       };
     }
 
@@ -942,6 +945,9 @@ export async function updateOperatorSettings(
     if (settings.enableSuggestions !== undefined) {
       session.config.operatorSettings.enableSuggestions =
         settings.enableSuggestions;
+    }
+    if (settings.strikeMode !== undefined) {
+      session.config.operatorSettings.strikeMode = settings.strikeMode;
     }
   });
 }

--- a/src/tui/command-registry.test.ts
+++ b/src/tui/command-registry.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./theme", () => ({ getAllThemeNames: () => [] }));
+
+import {
+  type AppCommandContext,
+  type CommandConfig,
+  commands,
+} from "./command-registry";
+
+function getCommand(name: string): CommandConfig {
+  const command = commands.find((candidate) => candidate.name === name);
+  if (!command) throw new Error(`Missing /${name} command`);
+  return command;
+}
+
+function createContext(
+  overrides: Partial<AppCommandContext> = {},
+): AppCommandContext {
+  return {
+    route: { type: "base", path: "home" },
+    navigate: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("advanced settings command", () => {
+  it("opens the Advanced Settings dialog", async () => {
+    const openAdvancedDialog = vi.fn();
+
+    await getCommand("advanced").handler(
+      [],
+      createContext({ openAdvancedDialog }),
+    );
+
+    expect(openAdvancedDialog).toHaveBeenCalledOnce();
+  });
+});
+
+describe("autonomous workflow Strike Mode overrides", () => {
+  it("keeps direct /pentest launches in standard mode", async () => {
+    const navigate = vi.fn();
+
+    await getCommand("pentest").handler(
+      ["--target", "https://example.com", "--strict"],
+      createContext({ navigate }),
+    );
+
+    expect(navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "operator",
+        initialConfig: expect.objectContaining({ strikeMode: false }),
+        initialSkill: expect.objectContaining({ slug: "pentest" }),
+      }),
+    );
+  });
+
+  it("keeps /threat-model launches in standard mode", async () => {
+    const navigate = vi.fn();
+
+    await getCommand("threat-model").handler([], createContext({ navigate }));
+
+    expect(navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "operator",
+        initialConfig: expect.objectContaining({ strikeMode: false }),
+        initialSkill: expect.objectContaining({ slug: "threat-model" }),
+      }),
+    );
+  });
+});

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -26,6 +26,7 @@ export interface AppCommandContext {
   navigate: (route: Route) => void;
   openSessionsDialog?: () => void;
   openThemeDialog?: () => void;
+  openAdvancedDialog?: () => void;
   openModelDialog?: () => void;
   openProvidersDialog?: () => void;
   openCreditsDialog?: () => void;
@@ -181,6 +182,7 @@ export const commands: CommandConfig[] = [
           initialConfig: {
             requireApproval: false,
             target: flags.target,
+            strikeMode: false,
             sandbox: true,
             headers: resolveHeadersFromFlags(flags),
           },
@@ -319,6 +321,7 @@ export const commands: CommandConfig[] = [
         nonce: Date.now(),
         initialConfig: {
           requireApproval: true,
+          strikeMode: false,
         },
         initialSkill: {
           slug: "threat-model",
@@ -463,6 +466,15 @@ export const commands: CommandConfig[] = [
           : "Obfuscation mode disabled.",
         next ? "warn" : "default",
       );
+    },
+  },
+  {
+    name: "advanced",
+    aliases: ["advanced-settings"],
+    description: "Manage advanced operator settings",
+    category: "Configuration",
+    handler: async (_args, ctx) => {
+      ctx.openAdvancedDialog?.();
     },
   },
   {

--- a/src/tui/components/commands/advanced-settings.tsx
+++ b/src/tui/components/commands/advanced-settings.tsx
@@ -1,0 +1,94 @@
+import { useKeyboard } from "@opentui/react";
+import { useCallback, useState } from "react";
+import { useConfig } from "../../context/config";
+import { Dialog } from "../../context/dialog";
+import { useTheme } from "../../theme";
+import DialogLayout from "../dialog-layout";
+
+interface AdvancedSettingsProps {
+  onClose: () => void;
+}
+
+export default function AdvancedSettings({ onClose }: AdvancedSettingsProps) {
+  const { colors } = useTheme();
+  const config = useConfig();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [draftStrikeMode, setDraftStrikeMode] = useState(
+    config.data.strikeMode ?? false,
+  );
+
+  const saveSettings = useCallback(async () => {
+    if (saving) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      await config.update({ strikeMode: draftStrikeMode });
+      onClose();
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? `Could not save Strike Mode: ${cause.message}`
+          : "Could not save Strike Mode.",
+      );
+      setSaving(false);
+    }
+  }, [config, draftStrikeMode, onClose, saving]);
+
+  useKeyboard((key) => {
+    if (key.name === "escape") {
+      key.preventDefault();
+      onClose();
+      return;
+    }
+
+    if (key.name === "tab") {
+      key.preventDefault();
+      setDraftStrikeMode((enabled) => !enabled);
+      return;
+    }
+
+    if (key.name === "return") {
+      key.preventDefault();
+      void saveSettings();
+    }
+  });
+
+  return (
+    <Dialog size="medium" onClose={onClose}>
+      <DialogLayout
+        title="Advanced Settings"
+        footerActions={[
+          { key: "Enter", label: "Save & Close", variant: "primary" },
+          { key: "Tab", label: "Toggle" },
+        ]}
+      >
+        <box flexDirection="column" gap={1} overflow="hidden">
+          <box
+            flexDirection="row"
+            justifyContent="space-between"
+            overflow="hidden"
+          >
+            <text fg={colors.text}>Strike Mode</text>
+            <text fg={draftStrikeMode ? colors.warning : colors.textMuted}>
+              {draftStrikeMode ? "● Enabled" : "○ Disabled"}
+            </text>
+          </box>
+
+          <text fg={colors.textMuted}>
+            Use one focused operator for iterative vulnerability research.
+            Disables automatic discovery and agent fan-out.
+          </text>
+          <text fg={colors.textMuted}>
+            Applies to new operator sessions. Existing sessions keep their saved
+            mode.
+          </text>
+
+          {saving && <text fg={colors.textMuted}>Saving…</text>}
+          {error && <text fg={colors.error}>{error}</text>}
+        </box>
+      </DialogLayout>
+    </Dialog>
+  );
+}

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -104,6 +104,8 @@ import {
   resolveAbortAction,
   resolveInputFocused,
   resolveKeyboardShortcut,
+  resolveOperatorAgentMode,
+  resolveOperatorStrikeMode,
   resolveSubmit,
   routeCommand,
 } from "./logic";
@@ -148,6 +150,7 @@ export default function OperatorDashboard({
     requireApproval?: boolean;
     target?: string;
     operatorMode?: OperatorMode;
+    strikeMode?: boolean;
     sandbox?: boolean;
     taskDriven?: boolean;
     headers?: Record<string, string>;
@@ -187,18 +190,35 @@ export default function OperatorDashboard({
     clear: clearDialog,
   } = useDialog();
   const { refocusPrompt } = useFocus();
+  const initialStrikeModeRef = useRef(
+    resolveOperatorStrikeMode({
+      resuming: !!sessionId,
+      routeOverride: initialConfig?.strikeMode,
+      persistedDefault: config.data.strikeMode,
+    }),
+  );
+  const [strikeMode, setStrikeMode] = useState(initialStrikeModeRef.current);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: `skillsVersion` is an intentional cache-buster — forces recomputation when skills are refreshed even though `skillsRegistry` (stable ref) hasn't changed.
   const autocompleteOptions = useMemo(() => {
-    const commandOptions = filterOperatorAutocomplete(allAutocompleteOptions);
-    const skillOptions = skillsRegistry.list().map((s) => {
-      const slug = `/${s.slug}`;
-      return {
-        value: slug,
-        label: slug,
-        description: s.manifest.description || "Skill",
-      };
-    });
+    const commandOptions = filterOperatorAutocomplete(
+      allAutocompleteOptions,
+    ).filter((option) => !strikeMode || option.value !== "/pentest");
+    const skillOptions = skillsRegistry
+      .list()
+      .filter(
+        (skill) =>
+          !strikeMode ||
+          (skill.slug !== "pentest" && skill.slug !== "threat-model"),
+      )
+      .map((skill) => {
+        const slug = `/${skill.slug}`;
+        return {
+          value: slug,
+          label: slug,
+          description: skill.manifest.description || "Skill",
+        };
+      });
     const operatorOnlyOptions = [
       {
         value: "/open-session",
@@ -207,7 +227,7 @@ export default function OperatorDashboard({
       },
     ];
     return [...commandOptions, ...operatorOnlyOptions, ...skillOptions];
-  }, [allAutocompleteOptions, skillsRegistry, skillsVersion]);
+  }, [allAutocompleteOptions, skillsRegistry, skillsVersion, strikeMode]);
 
   // Session state
   const [session, setSession] = useState<SessionInfo | null>(null);
@@ -322,7 +342,10 @@ export default function OperatorDashboard({
   const [operatorMode, setOperatorMode] = useState<OperatorMode>(
     initialConfig?.operatorMode ?? "manual",
   );
-  const agentMode: AgentMode = operatorMode === "plan" ? "plan" : "default";
+  const agentMode: AgentMode = resolveOperatorAgentMode(
+    operatorMode,
+    strikeMode,
+  );
   const requireApproval = operatorMode === "manual";
   // Plan mode review state
   const [approvedPlanContent, setApprovedPlanContent] = useState<string | null>(
@@ -394,6 +417,12 @@ export default function OperatorDashboard({
           const s = await sessions.get(sessionId);
           setSession(s);
           setSessionCwd(s.rootPath);
+          setStrikeMode(
+            resolveOperatorStrikeMode({
+              resuming: true,
+              savedSessionValue: s.config?.operatorSettings?.strikeMode,
+            }),
+          );
 
           const hasState = sessions.hasOperatorState(s);
           if (hasState) {
@@ -476,6 +505,7 @@ export default function OperatorDashboard({
         } else {
           // New session — just set up operator config; the agent creates the
           // session on the first runAgent call.
+          setStrikeMode(initialStrikeModeRef.current);
           const newMode = initialConfig?.operatorMode ?? "manual";
           setOperatorMode(newMode);
           const requireApproval = newMode === "manual";
@@ -1297,6 +1327,7 @@ export default function OperatorDashboard({
               initialMode: operatorMode,
               requireApproval,
               enableSuggestions: true,
+              strikeMode,
             },
             agentCwd: initialConfig?.sandbox ? undefined : process.cwd(),
             codebasePath: initialConfig?.sandbox ? undefined : process.cwd(),
@@ -1442,6 +1473,7 @@ export default function OperatorDashboard({
       initialConfig?.target,
       initialConfig?.headers,
       initialConfig?.promptInjectionLibrarySource,
+      strikeMode,
       route.data,
       setSessionCwd,
       subagentStore.setState,
@@ -1726,6 +1758,15 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
           showModelPicker();
           return;
         case "run-skill": {
+          if (
+            strikeMode &&
+            (action.slug === "pentest" || action.slug === "threat-model")
+          ) {
+            addSystemMessage(
+              `/${action.slug} requires standard operator mode. Disable Strike Mode in /advanced, then start a new session.`,
+            );
+            return;
+          }
           if (action.autopilot) {
             setOperatorMode("auto");
             approvalGateRef.current.updateConfig({ requireApproval: false });
@@ -1795,6 +1836,7 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
       showModelPicker,
       addSystemMessage,
       handleHeadersSlash,
+      strikeMode,
     ],
   );
 
@@ -2401,6 +2443,7 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
       >
         <box flexDirection="row" gap={2}>
           <text fg={colors.text}>{session?.name ?? "New Session"}</text>
+          {strikeMode && <text fg={colors.warning}>STRIKE</text>}
           {(session?.targets[0] || initialConfig?.target) && (
             <>
               <text fg={colors.textMuted}>•</text>

--- a/src/tui/components/operator-dashboard/logic.test.ts
+++ b/src/tui/components/operator-dashboard/logic.test.ts
@@ -9,6 +9,8 @@ import {
   resolveAbortAction,
   resolveInputFocused,
   resolveKeyboardShortcut,
+  resolveOperatorAgentMode,
+  resolveOperatorStrikeMode,
   resolveSubmit,
   routeCommand,
 } from "./logic";
@@ -23,6 +25,11 @@ const allOptions: AutocompleteOption[] = [
   { value: "/help", label: "/help", description: "Show help" },
   { value: "/models", label: "/models", description: "Switch model" },
   { value: "/skills", label: "/skills", description: "View skills" },
+  {
+    value: "/advanced",
+    label: "/advanced",
+    description: "Advanced settings",
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -30,11 +37,12 @@ const allOptions: AutocompleteOption[] = [
 // ---------------------------------------------------------------------------
 
 describe("filterOperatorAutocomplete", () => {
-  it("includes allowed commands (/models, /skills)", () => {
+  it("includes allowed commands (/models, /skills, /advanced)", () => {
     const result = filterOperatorAutocomplete(allOptions);
     const values = result.map((o) => o.value);
     expect(values).toContain("/models");
     expect(values).toContain("/skills");
+    expect(values).toContain("/advanced");
   });
 
   it("excludes commands that are not in the allowed set", () => {
@@ -45,7 +53,7 @@ describe("filterOperatorAutocomplete", () => {
 
   it("returns only allowed commands", () => {
     const result = filterOperatorAutocomplete(allOptions);
-    expect(result).toHaveLength(4);
+    expect(result).toHaveLength(5);
   });
 
   it("preserves description on allowed commands", () => {
@@ -56,6 +64,70 @@ describe("filterOperatorAutocomplete", () => {
 
   it("returns empty for empty input", () => {
     expect(filterOperatorAutocomplete([])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Operator agent mode
+// ---------------------------------------------------------------------------
+
+describe("resolveOperatorAgentMode", () => {
+  it("uses Strike Mode for manual and automatic operator sessions", () => {
+    expect(resolveOperatorAgentMode("manual", true)).toBe("fast-strike");
+    expect(resolveOperatorAgentMode("auto", true)).toBe("fast-strike");
+  });
+
+  it("keeps the standard agent mode when Strike Mode is disabled", () => {
+    expect(resolveOperatorAgentMode("manual", false)).toBe("default");
+    expect(resolveOperatorAgentMode("auto", false)).toBe("default");
+  });
+
+  it("gives plan mode precedence over Strike Mode", () => {
+    expect(resolveOperatorAgentMode("plan", true)).toBe("plan");
+  });
+});
+
+describe("resolveOperatorStrikeMode", () => {
+  it("defaults new operator sessions to off", () => {
+    expect(resolveOperatorStrikeMode({ resuming: false })).toBe(false);
+  });
+
+  it("uses the persisted preference for new operator sessions", () => {
+    expect(
+      resolveOperatorStrikeMode({
+        resuming: false,
+        persistedDefault: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("lets an explicit workflow override the persisted preference", () => {
+    expect(
+      resolveOperatorStrikeMode({
+        resuming: false,
+        routeOverride: false,
+        persistedDefault: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("restores a resumed session's saved mode", () => {
+    expect(
+      resolveOperatorStrikeMode({
+        resuming: true,
+        savedSessionValue: true,
+        persistedDefault: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps legacy resumed sessions off instead of applying a global default", () => {
+    expect(
+      resolveOperatorStrikeMode({
+        resuming: true,
+        persistedDefault: true,
+      }),
+    ).toBe(false);
   });
 });
 
@@ -537,12 +609,47 @@ describe("buildOperatorSystemPrompt", () => {
     expect(prompt).not.toContain("PLAN MODE");
   });
 
+  it("includes the focused research loop in Strike Mode", () => {
+    const prompt = buildOperatorSystemPrompt(target, state, "fast-strike");
+    expect(prompt).toContain("# Strike Mode");
+    expect(prompt).toContain("OBSERVE");
+    expect(prompt).toContain("HYPOTHESIZE");
+    expect(prompt).toContain("Do not delegate");
+  });
+
+  it("does not include Strike Mode instructions in the standard mode", () => {
+    const prompt = buildOperatorSystemPrompt(target, state, "default");
+    expect(prompt).not.toContain("# Strike Mode");
+  });
+
+  it("does not add task-driven instructions when Strike Mode excludes task tools", () => {
+    const prompt = buildOperatorSystemPrompt(target, state, "fast-strike", {
+      taskDriven: true,
+    });
+    expect(prompt).not.toContain("# Task-Driven Testing");
+  });
+
+  it("keeps task-driven instructions when the agent mode is omitted", () => {
+    const prompt = buildOperatorSystemPrompt(target, state, undefined, {
+      taskDriven: true,
+    });
+    expect(prompt).toContain("# Task-Driven Testing");
+  });
+
   it("includes approved plan content when provided outside plan mode", () => {
     const prompt = buildOperatorSystemPrompt(target, state, "default", {
       approvedPlanContent: "Test plan content",
     });
     expect(prompt).toContain("Approved Plan");
     expect(prompt).toContain("Test plan content");
+  });
+
+  it("keeps approved plan content when executing in Strike Mode", () => {
+    const prompt = buildOperatorSystemPrompt(target, state, "fast-strike", {
+      approvedPlanContent: "Focused strike plan",
+    });
+    expect(prompt).toContain("# Strike Mode");
+    expect(prompt).toContain("Focused strike plan");
   });
 
   it("includes refinement block when existingPlanContent provided in plan mode", () => {

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -1,6 +1,12 @@
-import { buildBaseSystemPrompt } from "../../../core/agents/offSecAgent";
+import {
+  type AgentMode,
+  buildBaseSystemPrompt,
+} from "../../../core/agents/offSecAgent";
 import { detectOSAndEnhancePrompt } from "../../../core/agents/specialized/utils";
-import type { OperatorSessionState } from "../../../core/operator";
+import type {
+  OperatorMode,
+  OperatorSessionState,
+} from "../../../core/operator";
 import type { AutocompleteOption } from "../shared";
 
 // ---------------------------------------------------------------------------
@@ -16,6 +22,7 @@ const OPERATOR_ALLOWED_COMMANDS = new Set([
   "/pentest",
   "/skills",
   "/plan",
+  "/advanced",
   "/obfuscate",
   "/headers",
   "/help",
@@ -32,6 +39,31 @@ export function filterOperatorAutocomplete(
 // ---------------------------------------------------------------------------
 
 export type DashboardStatus = "idle" | "running" | "waiting" | "done";
+
+export function resolveOperatorAgentMode(
+  operatorMode: OperatorMode,
+  strikeMode: boolean,
+): AgentMode {
+  if (operatorMode === "plan") return "plan";
+  return strikeMode ? "fast-strike" : "default";
+}
+
+interface StrikeModeResolutionInput {
+  resuming: boolean;
+  savedSessionValue?: boolean;
+  routeOverride?: boolean;
+  persistedDefault?: boolean;
+}
+
+export function resolveOperatorStrikeMode({
+  resuming,
+  savedSessionValue,
+  routeOverride,
+  persistedDefault,
+}: StrikeModeResolutionInput): boolean {
+  if (resuming) return savedSessionValue ?? false;
+  return routeOverride ?? persistedDefault ?? false;
+}
 
 export interface SubmitResult {
   action: "run" | "blocked" | "empty";
@@ -245,7 +277,7 @@ export function resolveAbortAction(
 export function buildOperatorSystemPrompt(
   target: string | undefined,
   operatorState: OperatorSessionState,
-  agentMode?: "default" | "plan",
+  agentMode?: AgentMode,
   opts?: {
     requireApproval?: boolean;
     sandboxMode?: boolean;
@@ -269,8 +301,26 @@ export function buildOperatorSystemPrompt(
       opts?.planFilePath,
       opts?.existingPlanContent,
     );
-  } else if (opts?.approvedPlanContent) {
-    modeSection = `
+  } else {
+    if (agentMode === "fast-strike") {
+      modeSection = `
+
+# Strike Mode
+
+Work as one focused vulnerability researcher under the human operator's direction. Do not delegate, spawn agents, map the entire attack surface, or create task lists.
+
+For each directive, run a tight loop:
+1. OBSERVE — read the available evidence and state the strongest new signal.
+2. HYPOTHESIZE — choose the single most likely vulnerability or next pivot.
+3. ACT — use the minimum tool calls needed to confirm or reject it.
+4. PRUNE — drop disproven leads instead of repeating them.
+5. EXPLOIT — prove impact and document confirmed vulnerabilities.
+
+Stop and summarize when the objective is met, credible leads are exhausted, or human input is needed. Stay in scope and never trade verification for speed.`;
+    }
+
+    if (opts?.approvedPlanContent) {
+      modeSection += `
 
 # Approved Plan
 
@@ -279,6 +329,7 @@ The operator has approved the following pentest plan. Execute it systematically,
 <plan>
 ${opts.approvedPlanContent}
 </plan>`;
+    }
   }
 
   let prompt = `${detectOSAndEnhancePrompt(buildBaseSystemPrompt({ sandboxMode: opts?.sandboxMode }))}
@@ -324,7 +375,7 @@ still win over session headers if you need a one-off override.${modeSection}`;
     }
   }
 
-  if (opts?.taskDriven && agentMode !== "plan") {
+  if (opts?.taskDriven && (agentMode ?? "default") === "default") {
     prompt += `
 
 # Task-Driven Testing

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -56,6 +56,7 @@ interface CommandProviderProps {
   children: ReactNode;
   onOpenSessionsDialog?: () => void;
   onOpenThemeDialog?: () => void;
+  onOpenAdvancedDialog?: () => void;
   onOpenModelDialog?: () => void;
   onOpenProvidersDialog?: () => void;
   onOpenCreditsDialog?: () => void;
@@ -69,6 +70,7 @@ export function CommandProvider({
   children,
   onOpenSessionsDialog,
   onOpenThemeDialog,
+  onOpenAdvancedDialog,
   onOpenModelDialog,
   onOpenProvidersDialog,
   onOpenCreditsDialog,
@@ -89,6 +91,7 @@ export function CommandProvider({
       navigate: route.navigate,
       openSessionsDialog: onOpenSessionsDialog,
       openThemeDialog: onOpenThemeDialog,
+      openAdvancedDialog: onOpenAdvancedDialog,
       openModelDialog: onOpenModelDialog,
       openProvidersDialog: onOpenProvidersDialog,
       openCreditsDialog: onOpenCreditsDialog,
@@ -113,6 +116,7 @@ export function CommandProvider({
     route,
     onOpenSessionsDialog,
     onOpenThemeDialog,
+    onOpenAdvancedDialog,
     onOpenModelDialog,
     onOpenProvidersDialog,
     onOpenCreditsDialog,

--- a/src/tui/context/route.tsx
+++ b/src/tui/context/route.tsx
@@ -68,6 +68,8 @@ export type Route =
         requireApproval?: boolean;
         target?: string;
         operatorMode?: import("../../core/operator").OperatorMode;
+        /** Overrides the persisted Strike Mode preference for this new session. */
+        strikeMode?: boolean;
         sandbox?: boolean;
         taskDriven?: boolean;
         /** Headers from wizard/CLI; replace the snapshotted global defaults. */

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -10,6 +10,7 @@ import type { SessionConfig } from "../core/session";
 import { setupAutoCopy } from "./auto-copy";
 import { createClipboardManager } from "./clipboard";
 import { ChatApp } from "./components/chat";
+import AdvancedSettings from "./components/commands/advanced-settings";
 import AuthFlow from "./components/commands/auth-flow";
 import CreditsFlow from "./components/commands/credits-flow";
 import HelpDialog from "./components/commands/help-dialog";
@@ -92,6 +93,7 @@ function App({ appConfig }: AppProps) {
   const [showSessionsDialog, setShowSessionsDialog] = useState(false);
   const [showShortcutsDialog, setShowShortcutsDialog] = useState(false);
   const [showThemeDialog, setShowThemeDialog] = useState(false);
+  const [showAdvancedDialog, setShowAdvancedDialog] = useState(false);
   const [showAuthDialog, setShowAuthDialog] = useState(false);
   const [showModelDialog, setShowModelDialog] = useState(false);
   const [showProvidersDialog, setShowProvidersDialog] = useState(false);
@@ -120,6 +122,7 @@ function App({ appConfig }: AppProps) {
                   <CommandProvider
                     onOpenSessionsDialog={() => setShowSessionsDialog(true)}
                     onOpenThemeDialog={() => setShowThemeDialog(true)}
+                    onOpenAdvancedDialog={() => setShowAdvancedDialog(true)}
                     onOpenModelDialog={() => setShowModelDialog(true)}
                     onOpenProvidersDialog={() => setShowProvidersDialog(true)}
                     onOpenCreditsDialog={() => setShowCreditsDialog(true)}
@@ -154,6 +157,8 @@ function App({ appConfig }: AppProps) {
                         setShowShortcutsDialog={setShowShortcutsDialog}
                         showThemeDialog={showThemeDialog}
                         setShowThemeDialog={setShowThemeDialog}
+                        showAdvancedDialog={showAdvancedDialog}
+                        setShowAdvancedDialog={setShowAdvancedDialog}
                         showModelDialog={showModelDialog}
                         setShowModelDialog={setShowModelDialog}
                         showProvidersDialog={showProvidersDialog}
@@ -199,6 +204,8 @@ function AppContent({
   setShowShortcutsDialog,
   showThemeDialog,
   setShowThemeDialog,
+  showAdvancedDialog,
+  setShowAdvancedDialog,
   showModelDialog,
   setShowModelDialog,
   showProvidersDialog,
@@ -231,6 +238,8 @@ function AppContent({
   setShowShortcutsDialog: (show: boolean) => void;
   showThemeDialog: boolean;
   setShowThemeDialog: (show: boolean) => void;
+  showAdvancedDialog: boolean;
+  setShowAdvancedDialog: (show: boolean) => void;
   showModelDialog: boolean;
   setShowModelDialog: (show: boolean) => void;
   showProvidersDialog: boolean;
@@ -323,6 +332,7 @@ function AppContent({
   // Track external dialog state so operator input unfocuses while a dialog overlay is open
   const anyExternalDialog =
     showThemeDialog ||
+    showAdvancedDialog ||
     showModelDialog ||
     showProvidersDialog ||
     showCreditsDialog ||
@@ -365,6 +375,12 @@ function AppContent({
 
   const handleCloseThemeDialog = () => {
     setShowThemeDialog(false);
+    setInputKey((prev) => prev + 1);
+    refocusPrompt();
+  };
+
+  const handleCloseAdvancedDialog = () => {
+    setShowAdvancedDialog(false);
     setInputKey((prev) => prev + 1);
     refocusPrompt();
   };
@@ -459,6 +475,7 @@ function AppContent({
       initialConfig: {
         requireApproval: false,
         target,
+        strikeMode: false,
         sandbox: isBlackbox,
         headers: sessionConfig.headers,
       },
@@ -500,6 +517,10 @@ function AppContent({
       )}
 
       {showThemeDialog && <ThemePicker onClose={handleCloseThemeDialog} />}
+
+      {showAdvancedDialog && (
+        <AdvancedSettings onClose={handleCloseAdvancedDialog} />
+      )}
 
       {showModelDialog && (
         <ModelPickerDialog onClose={handleCloseModelDialog} />


### PR DESCRIPTION
## Why

I ran vulnerability research against a large repository using our standard workflow and burned roughly **251M tokens profiling the codebase before getting a single result** — and it still hadn't finished profiling. All of that spend went into attack-surface enumeration and swarm fan-out before any actual vulnerability hunting started.

The `--fast-strike` workflow already exists and skips exactly that, but it's CLI-flag-only, which means I can't reach for it from inside a TUI session. This exposes it as a real setting so I have more flexibility to experiment with orchestration instead of being locked into one profiling-heavy path.

## What

A `/advanced` dialog with a **Strike Mode** toggle, persisted in global config. When enabled, new operator sessions run as a single focused researcher on a tight OBSERVE → HYPOTHESIZE → ACT → PRUNE → EXPLOIT loop, with orchestration tools excluded.

- `/advanced` (alias `/advanced-settings`) dialog — `Tab` toggles, `Enter` saves
- `strikeMode` added to `Config`, `OperatorSettings`, and the session route
- `resolveOperatorStrikeMode` / `resolveOperatorAgentMode` — precedence is route override → persisted default → `false`; resuming a session always uses its own saved value
- `/pentest` and `/threat-model` hidden from autocomplete while Strike Mode is on, with a clear message if invoked anyway
- `STRIKE` indicator in the operator status bar

Existing sessions keep their saved mode, so turning this on never changes a session already in flight.

## Testing

96 tests passing across `logic.test.ts` (90), `config.test.ts` (3), and `command-registry.test.ts` (3), covering the resolution precedence, the prompt section, and the autocomplete filtering. Typecheck and Biome clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator agent mode, tool exposure (via existing fast-strike), and session/config persistence; behavior is gated and tested but alters how new sessions run offensive workflows.
> 
> **Overview**
> Adds **Strike Mode** as a persisted TUI preference so new operator sessions can run the existing `fast-strike` workflow without the CLI `--fast-strike` flag.
> 
> **`/advanced`** opens a dialog to toggle Strike Mode (saved to global `config.strikeMode`). New sessions pick it up via `resolveOperatorStrikeMode` (route override → global default → off); resumed sessions use `operatorSettings.strikeMode` only. When enabled, manual/auto operators map to `fast-strike`, the system prompt adds the focused OBSERVE→EXPLOIT loop, and **STRIKE** shows in the header. `/pentest` and `/threat-model` are forced to standard mode on launch and are hidden/blocked in Strike sessions.
> 
> Tests cover config defaults/migration, command handlers, resolution precedence, and prompt/autocomplete behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3597f201c9a60ba57d9913c8ae2de1cdacb2164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->