### PR TITLE
Improve Fast Strike scripted exploit workflow

### DIFF
--- a/src/core/workflows/fastStrike.test.ts
+++ b/src/core/workflows/fastStrike.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { FAST_STRIKE_SYSTEM_PROMPT } from "./fastStrike";
+
+describe("Fast Strike system prompt", () => {
+  it("externalizes complex exploit chains into editable scripts", () => {
+    expect(FAST_STRIKE_SYSTEM_PROMPT).toContain(
+      "editable script in the session scratchpad directory",
+    );
+    expect(FAST_STRIKE_SYSTEM_PROMPT).toContain(
+      "Never create a scratchpad/ directory inside the target repository",
+    );
+    expect(FAST_STRIKE_SYSTEM_PROMPT).toContain("extending a working script");
+    expect(FAST_STRIKE_SYSTEM_PROMPT).toContain(
+      "account for each viable primitive",
+    );
+    expect(FAST_STRIKE_SYSTEM_PROMPT).not.toContain(
+      "minimum number of commands",
+    );
+  });
+
+  it("always terminates through the response tool after checking live primitives", () => {
+    expect(FAST_STRIKE_SYSTEM_PROMPT).toContain(
+      "whether the objective was met or every credible lead was genuinely exhausted",
+    );
+    expect(FAST_STRIKE_SYSTEM_PROMPT).toContain(
+      "call the response tool with the correct solved value",
+    );
+  });
+});

--- a/src/core/workflows/fastStrike.ts
+++ b/src/core/workflows/fastStrike.ts
@@ -28,20 +28,21 @@ const FastStrikeResult = z.object({
 
 type FastStrikeOutcome = z.infer<typeof FastStrikeResult>;
 
-const FAST_STRIKE_SYSTEM_PROMPT = `You are an elite offensive security operator running a fast strike against a single target. You work ALONE and finish the job yourself — there is no team to hand off to, no swarm to spawn, no plan to file. Your edge is discipline and observation, not volume.
+export const FAST_STRIKE_SYSTEM_PROMPT = `You are an elite offensive security operator running a fast strike against a single target. You work ALONE and finish the job yourself — there is no team to hand off to, no swarm to spawn, no plan to file. Your edge is discipline and observation, not volume.
 
 Run this loop, tightly:
 
 1. OBSERVE — Read every response for signal before you act. Note the stack, headers, cookies, tokens, form fields, error messages, redirects, disabled controls, ID patterns. State what you just learned in one line before the next move.
 2. HYPOTHESIZE — From that signal and your deep knowledge of web/app vulnerability classes, name the single most likely vulnerability and why the evidence points to it. Rank leads by signal strength and go for the strongest first. A disabled form field, an ID in a URL or JWT, advertised demo creds, an exposed schema — these are tells; read them.
-3. ACT — Test that one hypothesis with the minimum number of commands. Every tool call should exist to confirm or kill a specific hypothesis.
+3. ACT — Test that one hypothesis with the strongest available technique. Use direct tools for quick probes, but treat the shell as a working environment rather than merely a way to issue one-off commands. When the work becomes stateful, repetitive, concurrent, protocol-heavy, or multi-stage, externalize it into an editable script in the session scratchpad directory identified in the workspace instructions. Never create a scratchpad/ directory inside the target repository. Run the script, inspect the results, modify it, and rerun it as the attack develops.
 4. PRUNE — If the evidence disproves a lead, drop it and move to the next-strongest. Do NOT re-run a disproven approach or grind a dead end. Do NOT enumerate, brute-force, or run wordlists unless a specific signal demands it — choose techniques from evidence, not from a checklist.
-5. EXPLOIT — When a vulnerability is confirmed, exploit it: capture the flag, extract the sensitive data, and pivot through it if the objective requires more. Multi-step objectives are yours to finish end to end — foothold, then privesc, then the goal.
-6. DOCUMENT & FINISH — Record each confirmed vulnerability with the document_vulnerability tool as you go. When the objective is met (or every credible lead is exhausted), call the response tool with your result.
+5. EXPLOIT — When a vulnerability is confirmed, exploit it: capture the flag, extract the sensitive data, and pivot through it if the objective requires more. Preserve viable primitives and build on them. Prefer extending a working script into an end-to-end exploit over rebuilding the chain with repeated one-off tool calls or stopping at the next network or protocol boundary.
+6. DOCUMENT & FINISH — Record each confirmed vulnerability with the document_vulnerability tool as you go. Before concluding that every credible lead is exhausted, account for each viable primitive and pursue any concrete path that could still close the objective. After this check, whether the objective was met or every credible lead was genuinely exhausted, call the response tool with the correct solved value and a concise summary.
 
 Rules:
 - You are one operator. Plan in your head and in short text notes — never via planning tools, task lists, or sub-agents.
 - Recon and exploitation are the same loop. Do just enough recon to form the first hypothesis, then start testing. Do not map the entire surface before acting.
+- Spend your reasoning on choosing techniques and interpreting evidence; use scripts for deterministic mechanics, iteration, and chain execution.
 - Bias toward the shortest path that proves impact. Speed comes from picking the right lead, not from skipping verification — always confirm a finding before you claim it.
 - Stay in scope. Only touch the target you were given and hosts it legitimately depends on.`;
 

--- a/src/tui/components/operator-dashboard/logic.test.ts
+++ b/src/tui/components/operator-dashboard/logic.test.ts
@@ -615,6 +615,14 @@ describe("buildOperatorSystemPrompt", () => {
     expect(prompt).toContain("OBSERVE");
     expect(prompt).toContain("HYPOTHESIZE");
     expect(prompt).toContain("Do not delegate");
+    expect(prompt).toContain(
+      "editable script in the session scratchpad directory",
+    );
+    expect(prompt).toContain(
+      "Never create a scratchpad/ directory inside the target repository",
+    );
+    expect(prompt).toContain("extending a working script");
+    expect(prompt).toContain("account for each viable primitive");
   });
 
   it("does not include Strike Mode instructions in the standard mode", () => {

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -312,11 +312,11 @@ Work as one focused vulnerability researcher under the human operator's directio
 For each directive, run a tight loop:
 1. OBSERVE — read the available evidence and state the strongest new signal.
 2. HYPOTHESIZE — choose the single most likely vulnerability or next pivot.
-3. ACT — use the minimum tool calls needed to confirm or reject it.
+3. ACT — use direct tools for quick probes, but treat the shell as a working environment rather than merely a way to issue one-off commands. When the work becomes stateful, repetitive, concurrent, protocol-heavy, or multi-stage, externalize it into an editable script in the session scratchpad directory identified in the Session Workspace or Working Directory section. Never create a scratchpad/ directory inside the target repository. Run the script, inspect the results, modify it, and rerun it as the attack develops.
 4. PRUNE — drop disproven leads instead of repeating them.
-5. EXPLOIT — prove impact and document confirmed vulnerabilities.
+5. EXPLOIT — preserve viable primitives and build on them. Prefer extending a working script into an end-to-end exploit over rebuilding the chain with repeated one-off tool calls or stopping at the next network or protocol boundary. Prove impact and document confirmed vulnerabilities.
 
-Stop and summarize when the objective is met, credible leads are exhausted, or human input is needed. Stay in scope and never trade verification for speed.`;
+Spend your reasoning on choosing techniques and interpreting evidence; use scripts for deterministic mechanics, iteration, and chain execution. Before stopping with the objective unmet, account for each viable primitive and pursue any concrete path that could still close it. Stop and summarize when the objective is met, credible leads are genuinely exhausted, or human input is needed. Stay in scope and never trade verification for speed.`;
     }
 
     if (opts?.approvedPlanContent) {


### PR DESCRIPTION
## Summary
- guide Fast Strike to externalize complex security research into editable session-scratchpad scripts
- preserve viable primitives and extend them through longer exploit chains
- require a structured response after success or genuine exhaustion
- keep temporary scripts out of the target repository

## Testing
- bun run test: 91 passed files, 1,416 passed tests; 6 files and 18 tests skipped
- bun run build
- focused Biome check passes with two pre-existing noNonNullAssertion warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to LLM system-prompt text and test expectations; no runtime security, auth, or data-path logic is modified.
> 
> **Overview**
> **Fast Strike** and **operator Strike Mode** prompts now steer the agent away from minimal one-off commands toward **session-scratchpad scripts** for stateful, multi-stage work, with an explicit rule **not** to create `scratchpad/` inside the target repo.
> 
> The **ACT**, **EXPLOIT**, and **finish** steps emphasize **extending working scripts** through exploit chains, **accounting for viable primitives** before giving up, and always ending via the **response tool** with the correct solved value after success or genuine exhaustion. `FAST_STRIKE_SYSTEM_PROMPT` is **exported** and covered by new **Vitest** assertions; operator dashboard tests assert the same strings in `buildOperatorSystemPrompt` for `fast-strike`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c884e487fe555a5a685f5383fe489f89085adfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->