### PR TITLE
Enforce host capabilities for embedded Apex agents

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -11,6 +11,10 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
+const promptMocks = vi.hoisted(() => ({
+  buildSessionWorkspaceSection: vi.fn(() => "workspace-section"),
+}));
+
 // ---------------------------------------------------------------------------
 // Module stubs — prevent the full tool/AI/zod import chain from loading.
 //
@@ -48,10 +52,11 @@ vi.mock("../specialized/utils", () => ({
 }));
 vi.mock("./prompt", () => ({
   buildBaseSystemPrompt: () => "system",
-  buildSessionWorkspaceSection: () => "",
+  buildSessionWorkspaceSection: promptMocks.buildSessionWorkspaceSection,
 }));
 vi.mock("./trace", () => ({
   StepTraceWriter: class {
+    writeInit() {}
     onStepFinish() {}
   },
 }));
@@ -154,6 +159,33 @@ async function* yieldThenThrow(
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe("OffensiveSecurityAgent system prompt", () => {
+  it("omits shell workspace guidance for a filesystem-less host", () => {
+    const rootPath = join("/tmp", `apex-no-filesystem-prompt-${Date.now()}`);
+    mkdirSync(rootPath, { recursive: true });
+    promptMocks.buildSessionWorkspaceSection.mockClear();
+    try {
+      new OffensiveSecurityAgent({
+        system: "profile prompt",
+        prompt: "continue",
+        model: "global.anthropic.claude-opus-4-6-v1",
+        session: {
+          id: "ses_prompt_test",
+          rootPath,
+          config: { agentCwd: rootPath },
+        },
+        activeTools: [],
+        sandbox: {},
+        includeSessionWorkspace: false,
+      } as never);
+
+      expect(promptMocks.buildSessionWorkspaceSection).not.toHaveBeenCalled();
+    } finally {
+      rmSync(rootPath, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("OffensiveSecurityAgent.consume()", () => {
   const textDelta = { type: "text-delta", text: "hi" };

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -14,6 +14,15 @@ import { describe, expect, it, vi } from "vitest";
 const promptMocks = vi.hoisted(() => ({
   buildSessionWorkspaceSection: vi.fn(() => "workspace-section"),
 }));
+const capabilityMocks = vi.hoisted(() => ({
+  createAllTools: vi.fn(() => ({
+    safe_tool: {},
+    execute_command: {},
+  })),
+  streamResponse: vi.fn((_opts: { tools: Record<string, unknown> }) => ({})),
+  persistentShell: vi.fn(),
+  browserSession: vi.fn(),
+}));
 
 // ---------------------------------------------------------------------------
 // Module stubs — prevent the full tool/AI/zod import chain from loading.
@@ -36,16 +45,25 @@ vi.mock("zod", () => {
 });
 
 vi.mock("./tools", () => ({
-  createAllTools: () => ({}),
+  createAllTools: capabilityMocks.createAllTools,
   EMAIL_TOOL_NAMES_ACTIVE: [],
   SEND_EMAIL_TOOL_NAME: "send_email",
   PLAN_MODE_TOOL_NAMES: [],
   createResponseTool: () => {},
   RESPONSE_TOOL_NAME: "response",
   ASK_USER_QUESTIONS_TOOL_NAME: "ask_user_questions",
-  PersistentShell: class {},
+  PersistentShell: class {
+    constructor() {
+      capabilityMocks.persistentShell();
+    }
+  },
+  PlaywrightMcpSession: class {
+    constructor() {
+      capabilityMocks.browserSession();
+    }
+  },
 }));
-vi.mock("../../ai", () => ({ streamResponse: () => {} }));
+vi.mock("../../ai", () => ({ streamResponse: capabilityMocks.streamResponse }));
 vi.mock("../../session", () => ({ create: () => {} }));
 vi.mock("../specialized/utils", () => ({
   detectOSAndEnhancePrompt: (p: string) => p,
@@ -181,6 +199,47 @@ describe("OffensiveSecurityAgent system prompt", () => {
       } as never);
 
       expect(promptMocks.buildSessionWorkspaceSection).not.toHaveBeenCalled();
+    } finally {
+      rmSync(rootPath, { recursive: true, force: true });
+    }
+  });
+
+  it("hard-removes inactive tools and skips local capabilities when requested", () => {
+    const rootPath = join("/tmp", `apex-restricted-tools-${Date.now()}`);
+    mkdirSync(rootPath, { recursive: true });
+    capabilityMocks.streamResponse.mockClear();
+    capabilityMocks.persistentShell.mockClear();
+    capabilityMocks.browserSession.mockClear();
+    try {
+      const agent = new OffensiveSecurityAgent({
+        system: "profile prompt",
+        prompt: "continue",
+        model: "global.anthropic.claude-opus-4-6-v1",
+        session: {
+          id: "ses_tool_test",
+          rootPath,
+          config: { agentCwd: rootPath },
+        },
+        activeTools: ["safe_tool", "allowed_custom"],
+        extraTools: {
+          allowed_custom: {},
+          inactive_custom: {},
+        },
+        allowLocalToolExecution: false,
+        restrictToolsToActiveSet: true,
+      } as never);
+
+      void agent.streamResult;
+
+      expect(capabilityMocks.persistentShell).not.toHaveBeenCalled();
+      expect(capabilityMocks.browserSession).not.toHaveBeenCalled();
+      const streamCall = capabilityMocks.streamResponse.mock.calls.at(0);
+      expect(streamCall).toBeDefined();
+      if (!streamCall) throw new Error("streamResponse was not called");
+      expect(Object.keys(streamCall[0].tools)).toEqual([
+        "safe_tool",
+        "allowed_custom",
+      ]);
     } finally {
       rmSync(rootPath, { recursive: true, force: true });
     }

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -534,7 +534,10 @@ export class OffensiveSecurityAgent<TResult = void> {
         }),
       );
     const systemPrompt =
-      baseSystemPrompt + buildSessionWorkspaceSection(input.session, agentCwd);
+      baseSystemPrompt +
+      (input.includeSessionWorkspace === false
+        ? ""
+        : buildSessionWorkspaceSection(input.session, agentCwd));
 
     traceWriter.writeInit({
       model: input.model,

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -251,7 +251,7 @@ export class OffensiveSecurityAgent<TResult = void> {
     // -- Persistent shell (local mode only) -----------------------------------
     // Shell survives command cancellation; only disposed in consume() after the
     // stream ends, or when the agent is fully killed.
-    if (!input.sandbox) {
+    if (!input.sandbox && input.allowLocalToolExecution !== false) {
       this.persistentShell = new PersistentShell({
         cwd: agentCwd,
         env: input.environmentVariables,
@@ -270,7 +270,7 @@ export class OffensiveSecurityAgent<TResult = void> {
     // for agents that never use browser tools. Sandbox-mode agents already
     // share browser state via the sandbox's per-sandbox Playwright user-data
     // dir, so they don't need a session object on the host.
-    if (!input.sandbox) {
+    if (!input.sandbox && input.allowLocalToolExecution !== false) {
       // Snapshot resolved headers into the browser session. Later mutations
       // require a browser restart to take effect.
       const sessionHeaders = input.target
@@ -478,6 +478,13 @@ export class OffensiveSecurityAgent<TResult = void> {
         if (t === SEND_EMAIL_TOOL_NAME) return hasSmtp;
         return hasEmail;
       });
+    }
+
+    if (input.restrictToolsToActiveSet) {
+      const activeToolSet = new Set(activeTools);
+      tools = Object.fromEntries(
+        Object.entries(tools).filter(([name]) => activeToolSet.has(name)),
+      );
     }
 
     // -- Messages persistence -------------------------------------------------

--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -396,6 +396,25 @@ describe("PersistentShell — long-running stability", () => {
     expect(b.stdout).toContain("apex-call-b-stdout");
   }, 15_000);
 
+  it("captures stderr when its pipe delivery trails stdout completion", async () => {
+    const shell = make();
+    await shell.execute("echo warm", 5);
+    const stderr = (
+      shell as unknown as {
+        proc: { stderr: { pause: () => void; resume: () => void } };
+      }
+    ).proc.stderr;
+
+    stderr.pause();
+    try {
+      const result = await shell.execute(">&2 echo delayed-stderr", 5);
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain("delayed-stderr");
+    } finally {
+      stderr.resume();
+    }
+  });
+
   it("isolates parallel-call timeouts (no marker or kill-message leakage)", async () => {
     const shell = make();
     const [timedOut, ok] = await Promise.all([

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -344,9 +344,10 @@ export class PersistentShell {
           : Number.isNaN(naturalExitCode)
             ? 1
             : naturalExitCode;
+      const diskStderr = readTempfileCapped(cmd.errPath);
       const effectiveStderr = cmd.forcedStderrSuffix
-        ? (cmd.stderr || "") + cmd.forcedStderrSuffix
-        : cmd.stderr || "";
+        ? (diskStderr || cmd.stderr || "") + cmd.forcedStderrSuffix
+        : diskStderr || cmd.stderr || "";
 
       // Cleanup is owned by Node now that the wrapper no longer rm's.
       unlinkSafe(cmd.outPath);

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -83,6 +83,12 @@ export type OffensiveSecurityAgentInput<TResult = void> = {
   /** Append shell/filesystem session guidance. Defaults to true. */
   includeSessionWorkspace?: boolean;
 
+  /** Construct local shell/browser capabilities when no sandbox is supplied. Defaults to true. */
+  allowLocalToolExecution?: boolean;
+
+  /** Remove inactive tools from the executable tool map, not only the model-visible definitions. */
+  restrictToolsToActiveSet?: boolean;
+
   /** Initial user prompt that kicks off the agent */
   prompt: string;
 

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -80,6 +80,9 @@ export type OffensiveSecurityAgentInput<TResult = void> = {
   /** System prompt defining agent persona and behavior. Defaults to BASE_SYSTEM_PROMPT when omitted. */
   system?: string;
 
+  /** Append shell/filesystem session guidance. Defaults to true. */
+  includeSessionWorkspace?: boolean;
+
   /** Initial user prompt that kicks off the agent */
   prompt: string;
 

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -18,7 +18,10 @@ import {
 } from "ai";
 import type { z } from "zod";
 import { createLogger } from "../logger/structured";
-import { shouldRecordAiPayloads } from "../observability";
+import {
+  shouldEnableAiTelemetry,
+  shouldRecordAiPayloads,
+} from "../observability";
 import { scopedLogger } from "../util/lazyLogger";
 import { withCachedLastMessage, withCachedSystemPrompt } from "./caching";
 import { fitMessagesToContext, truncateWithMarker } from "./contextManagement";
@@ -1074,7 +1077,7 @@ export function streamResponse(
       maxRetries: 3,
       providerOptions,
       experimental_telemetry: {
-        isEnabled: true,
+        isEnabled: shouldEnableAiTelemetry(),
         recordInputs: recordPayloads,
         recordOutputs: recordPayloads,
         functionId: `apex.stream.${model}`,
@@ -1223,7 +1226,7 @@ export function streamResponse(
               ].join("\n"),
               abortSignal,
               experimental_telemetry: {
-                isEnabled: true,
+                isEnabled: shouldEnableAiTelemetry(),
                 recordInputs: recordPayloads,
                 recordOutputs: recordPayloads,
                 functionId: "apex.tool_repair",
@@ -1402,7 +1405,7 @@ export async function generateObjectResponse<T extends z.ZodType>(
         maxRetries: 0,
         abortSignal,
         experimental_telemetry: {
-          isEnabled: true,
+          isEnabled: shouldEnableAiTelemetry(),
           recordInputs: recordPayloads,
           recordOutputs: recordPayloads,
           functionId: "apex.generate_object",

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -19,6 +19,10 @@ import { getPensarGatewayUrl } from "../api/constants";
 import { ensureValidToken } from "../auth";
 import { config } from "../config";
 import { createLogger } from "../logger/structured";
+import {
+  shouldEnableAiTelemetry,
+  shouldRecordAiPayloads,
+} from "../observability";
 import { scopedLogger } from "../util/lazyLogger";
 import { type AIModel, type StreamResponseOpts, streamResponse } from "./ai";
 import {
@@ -419,6 +423,13 @@ async function summarizeConversation(
     system: `You are a helpful assistant that summarizes conversations to pass to another agent. Review the conversation and system prompt at the end provided by the user.`,
     messages: summarizedMessages,
     abortSignal: opts.abortSignal,
+    experimental_telemetry: {
+      isEnabled: shouldEnableAiTelemetry(),
+      recordInputs: shouldRecordAiPayloads(),
+      recordOutputs: shouldRecordAiPayloads(),
+      functionId: "apex.summarize_conversation",
+      ...(opts.sessionId ? { metadata: { sessionId: opts.sessionId } } : {}),
+    },
   });
 
   // Report summarization token usage if onStepFinish callback is provided

--- a/src/core/observability.test.ts
+++ b/src/core/observability.test.ts
@@ -9,6 +9,8 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { newSessionId } from "./id/id";
 import {
   SESSION_BAGGAGE_KEY,
+  shouldEnableAiTelemetry,
+  shouldRecordAiPayloads,
   withSubagentSessionBaggage,
 } from "./observability";
 
@@ -48,6 +50,39 @@ beforeAll(() => {
 });
 
 const ROOT_BAGGAGE_KEY = "pensar.root_session.id";
+
+describe("AI telemetry environment", () => {
+  it("defaults traces on and payloads off", () => {
+    const traces = process.env.AGENT_TRACES_ENABLED;
+    const payloads = process.env.AI_TRACE_RECORD_PAYLOADS;
+    delete process.env.AGENT_TRACES_ENABLED;
+    delete process.env.AI_TRACE_RECORD_PAYLOADS;
+    try {
+      expect(shouldEnableAiTelemetry()).toBe(true);
+      expect(shouldRecordAiPayloads()).toBe(false);
+    } finally {
+      if (traces !== undefined) process.env.AGENT_TRACES_ENABLED = traces;
+      if (payloads !== undefined)
+        process.env.AI_TRACE_RECORD_PAYLOADS = payloads;
+    }
+  });
+
+  it("honors host-resolved trace and payload flags", () => {
+    const traces = process.env.AGENT_TRACES_ENABLED;
+    const payloads = process.env.AI_TRACE_RECORD_PAYLOADS;
+    process.env.AGENT_TRACES_ENABLED = "false";
+    process.env.AI_TRACE_RECORD_PAYLOADS = "true";
+    try {
+      expect(shouldEnableAiTelemetry()).toBe(false);
+      expect(shouldRecordAiPayloads()).toBe(true);
+    } finally {
+      if (traces === undefined) delete process.env.AGENT_TRACES_ENABLED;
+      else process.env.AGENT_TRACES_ENABLED = traces;
+      if (payloads === undefined) delete process.env.AI_TRACE_RECORD_PAYLOADS;
+      else process.env.AI_TRACE_RECORD_PAYLOADS = payloads;
+    }
+  });
+});
 
 function activeSessionId(): string | undefined {
   return propagation.getActiveBaggage()?.getEntry(SESSION_BAGGAGE_KEY)?.value;

--- a/src/core/observability.ts
+++ b/src/core/observability.ts
@@ -15,6 +15,10 @@ export function shouldRecordAiPayloads(): boolean {
   return process.env.AI_TRACE_RECORD_PAYLOADS === "true";
 }
 
+export function shouldEnableAiTelemetry(): boolean {
+  return process.env.AGENT_TRACES_ENABLED !== "false";
+}
+
 /**
  * OTel baggage key for the execution-session id. Console's SpanProcessor copies
  * `pensar.*` baggage onto every span — must stay in sync with it.


### PR DESCRIPTION
## Summary

- Honor host-provided trace and payload telemetry settings across Apex AI calls.
- Allow filesystem-less hosts to omit workspace prompt guidance.
- Skip agent-owned local shell and browser sessions when the host disables local execution.
- Physically remove inactive tools from the executable tool map.

## Why

`activeTools` controls what the model sees, but is not an execution boundary by itself. Embedded hosts such as inline workspace chat need Apex to enforce the host's tool and filesystem capabilities.

## Verification

- 1,384 tests passed
- `bun run tsc`
- `bun run build`
- Touched-file Biome checks passed with pre-existing warnings only

## Development

No dedicated GitHub issue exists for this capability layer.