### PR TITLE
fix(eventBus): stamp sessionId/messageId on reasoning events

### DIFF
--- a/src/core/eventBus.test.ts
+++ b/src/core/eventBus.test.ts
@@ -231,6 +231,33 @@ describe("emitStreamPart — native id threading", () => {
     expect(results[0].partId).toBe(toolPartId);
   });
 
+  it("stamps sessionId/messageId on reasoning events", () => {
+    // Reasoning opens each step's message before any text flows, so downstream
+    // consumers need the ids to attach the thinking block to the right message
+    // instead of minting a fallback.
+    const bus = new AgentEventBus();
+    const sessionId = newSessionId();
+    const messageId = newMessageId();
+    const received: Array<{ sessionId?: string; messageId?: string }> = [];
+    bus.on("reasoning-start", (e) => received.push(e));
+    bus.on("reasoning-delta", (e) => received.push(e));
+    bus.on("reasoning-end", (e) => received.push(e));
+
+    const ids: StreamIdContext = { sessionId, messageId };
+    bus.emitStreamPart(part({ type: "reasoning-start", id: "r1" }), ids);
+    bus.emitStreamPart(
+      part({ type: "reasoning-delta", id: "r1", text: "hm" }),
+      ids,
+    );
+    bus.emitStreamPart(part({ type: "reasoning-end", id: "r1" }), ids);
+
+    expect(received).toHaveLength(3);
+    for (const e of received) {
+      expect(e.sessionId).toBe(sessionId);
+      expect(e.messageId).toBe(messageId);
+    }
+  });
+
   it("accepts a bare subagentId string for backward compatibility", () => {
     const bus = new AgentEventBus();
     const received: AgentEventMapText[] = [];

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -24,11 +24,24 @@ export type AgentEventMap = {
    * extended thinking, OpenAI reasoning) so consumers can surface a
    * "thinking" indicator instead of appearing to hang between tool calls.
    */
-  "reasoning-delta": { text: string; subagentId?: string };
+  "reasoning-delta": {
+    text: string;
+    subagentId?: string;
+    sessionId?: string;
+    messageId?: string;
+  };
   /** A reasoning block opened. Lets consumers time the thinking window. */
-  "reasoning-start": { subagentId?: string };
+  "reasoning-start": {
+    subagentId?: string;
+    sessionId?: string;
+    messageId?: string;
+  };
   /** A reasoning block closed. Paired with `reasoning-start` to derive duration. */
-  "reasoning-end": { subagentId?: string };
+  "reasoning-end": {
+    subagentId?: string;
+    sessionId?: string;
+    messageId?: string;
+  };
   "tool-call-start": {
     toolCallId: string;
     toolName: string;
@@ -300,13 +313,18 @@ export class AgentEventBus {
         });
         break;
       case "reasoning-start":
-        this.emit("reasoning-start", { subagentId });
+        this.emit("reasoning-start", { subagentId, sessionId, messageId });
         break;
       case "reasoning-delta":
-        this.emit("reasoning-delta", { text: chunk.text, subagentId });
+        this.emit("reasoning-delta", {
+          text: chunk.text,
+          subagentId,
+          sessionId,
+          messageId,
+        });
         break;
       case "reasoning-end":
-        this.emit("reasoning-end", { subagentId });
+        this.emit("reasoning-end", { subagentId, sessionId, messageId });
         break;
       case "tool-input-start":
         this.emit("tool-call-start", {


### PR DESCRIPTION
emitStreamPart already holds the step's StreamIdContext when reasoning chunks flow through, but the reasoning-start/-delta/-end bus events only carried subagentId — so bus consumers couldn't attach a thinking block to the message it belongs to. The session's first reasoning block forced consumers to fall back to minting their own message id, and every later step's reasoning got attributed to the previous step's still-open message.

The ids were already in scope — this just stamps them on the three reasoning events, same as text and tool events.