### PR TITLE
Prevent invalid tool history when truncating long conversations

### DIFF
--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -786,34 +786,33 @@ export function hasOperatorState(session: SessionInfo): boolean {
 }
 
 /**
- * Maximum number of model messages to pass to the AI when resuming a session.
+ * Target number of model messages to pass to the AI when resuming a session.
  *
  * Keeps enough context for the agent to continue effectively without hitting
  * the model's context window and triggering an immediate summarization cycle.
- * The value is conservative; tool-heavy conversations can produce many messages
- * per logical "turn" (assistant → tool × N), so 200 messages ≈ 20–50 turns.
+ * This is a replay-size target, not a token or turn budget. A single tool-heavy
+ * turn can exceed it.
  */
-const MAX_RESUME_MESSAGES = 200;
+const RESUME_MESSAGE_WINDOW = 200;
 
 /**
  * Return the tail subset of model messages suitable for resuming an agent.
  *
  * The full message array may be very long after an extended session. Feeding
  * it all back to the model on resume would immediately exceed the context
- * window and force an expensive summarization pass. Instead we keep only the
- * most recent messages, cutting at a clean "user" message boundary so that no
- * tool-call / tool-result pairs are orphaned.
+ * window and force an expensive summarization pass. Instead we prefer the most
+ * recent messages, cutting at a clean "user" message boundary so that no
+ * tool-call / tool-result pairs are orphaned. When the latest turn is larger
+ * than the target window, preserving the complete turn takes precedence.
  */
 export function getResumeMessages(
   messages: ModelMessage[],
-  limit: number = MAX_RESUME_MESSAGES,
+  limit: number = RESUME_MESSAGE_WINDOW,
 ): ModelMessage[] {
   if (messages.length <= limit) return messages;
 
-  // Walk backward from `limit` positions before the end to find the nearest
-  // "user" message — that is a safe boundary because every tool-call /
-  // tool-result exchange that follows it will be complete.
-  let cutIndex = messages.length - limit;
+  const roughCutIndex = messages.length - limit;
+  let cutIndex = roughCutIndex;
 
   // Search forward from the rough cut point for the next user message.
   // This guarantees we don't start mid-turn (e.g. on an orphaned tool
@@ -823,9 +822,13 @@ export function getResumeMessages(
     cutIndex++;
   }
 
-  // If we couldn't find a user message (unlikely), fall back to the raw cut.
+  // A single autonomous turn can exceed the target window. In that case,
+  // include the preceding user message rather than splitting the turn.
   if (cutIndex >= messages.length) {
-    cutIndex = messages.length - limit;
+    cutIndex = roughCutIndex;
+    while (cutIndex > 0 && messages[cutIndex].role !== "user") {
+      cutIndex--;
+    }
   }
 
   return messages.slice(cutIndex);

--- a/src/core/session/persistence.test.ts
+++ b/src/core/session/persistence.test.ts
@@ -906,18 +906,19 @@ describe("getResumeMessages", () => {
     expect(result.length).toBe(2);
   });
 
-  it("handles conversations with no user messages after cut point", () => {
-    // All assistant messages except the first
-    const msgs: ModelMessage[] = [
-      makeMsg("user", "go"),
-      ...Array.from({ length: 20 }, (_, i) =>
-        makeMsg("assistant", `step-${i}`),
-      ),
-    ];
+  it("keeps a complete tool-heavy turn when it exceeds the target window", () => {
+    const msgs: ModelMessage[] = [makeMsg("user", "start")];
+    for (let i = 0; i < 101; i++) {
+      const toolName = `tool-${i}`;
+      msgs.push(
+        makeMsg("assistant", [makeToolCallPart(toolName, {})]),
+        makeMsg("tool", [makeToolResultPart(toolName, "ok")]),
+      );
+    }
+    msgs.push(makeMsg("assistant", "done"));
 
-    // Limit 5 → rough cut at index 16, no user message after that → fallback
-    const result = getResumeMessages(msgs, 5);
-    expect(result.length).toBe(5);
+    const result = getResumeMessages(msgs, 200);
+    expect(result).toEqual(msgs);
   });
 
   it("returns empty array for empty input", () => {


### PR DESCRIPTION
## Why this change is needed

Apex limits the conversation history replayed to the model to a target of 200 internal ModelMessage entries. The limit exists to avoid sending an arbitrarily large persisted history back to the model and immediately forcing context compaction.

When a history exceeded that target, getResumeMessages started near the 200-message cutoff and searched forward for the next user message. A user message is a safe boundary because every tool call and tool result after it belongs to the same complete turn.

The fallback was unsafe when one autonomous turn itself exceeded 200 messages. In that case there was no newer user boundary, so the code retained exactly the last 200 messages. That raw slice could remove an assistant tool call while retaining its corresponding tool result. Model APIs require those records to remain paired, so the next request could be rejected and the conversation could no longer progress. This can happen during an internally reloaded autonomous session; it does not require a manual session resume.

## What changed

- Keep the existing forward search when a user boundary exists inside the target window.
- When no such boundary exists, search backward to the user message that started the current turn.
- Allow the replayed history to exceed 200 messages when necessary to preserve a complete turn.
- Continue relying on the existing token-aware context fitter to compact oversized valid histories for the selected model.
- Rename the constant to describe 200 as a target window rather than a hard maximum.

The invariant is now: history truncation may discard complete turns, but it must never split a tool-call and tool-result sequence.

## Regression coverage

The regression test constructs a 204-message turn containing 101 paired tool calls and results. The previous fallback returned the final 200 messages and began with an orphaned tool result. The new behavior retains the complete turn.

## Scope

- This change prevents new malformed replay windows.
- It does not modify or repair already-persisted malformed histories.
- It does not add provider-specific recovery or change the persistence format.

## Validation

- bun run test src/core/session/persistence.test.ts: 55 passed
- bun run test: 1,431 passed, 18 skipped
- bun run build: passed
- bunx biome check src/core/session/index.ts src/core/session/persistence.test.ts: passed with one existing warning outside the changed lines

## Existing repository checks

- TypeScript reports existing type mismatches in the Surface integration and related tests.
- The repository-wide format check reports existing Markdown formatting issues under .pi.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core conversation replay logic on resume/reload; incorrect truncation could still break sessions, but the fix is localized and covered by a targeted regression test.
> 
> **Overview**
> Fixes **session resume** truncation so replayed history never splits assistant tool calls from their tool results—a case that could make the next model request fail when a single autonomous turn exceeded the ~200-message replay target.
> 
> **`getResumeMessages`** still advances the cut to the next `user` message when one exists inside the window. When no such boundary exists (tool-heavy turn larger than the window), it now walks **backward** to the user message that started the current turn instead of falling back to a raw last-N slice. Replay may exceed 200 messages when needed to keep the turn intact; docs rename the constant to **`RESUME_MESSAGE_WINDOW`** to reflect that 200 is a target, not a hard cap.
> 
> Tests replace the old “no user after cut” fallback case with a **204-message** turn (101 tool pairs) asserting the full history is retained.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bf152c55c684db6a0bacdbd53745546c2289fc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->