### PR TITLE
fix(browser): reap orphaned Camoufox when the MCP node dies

### DIFF
--- a/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   collectDescendantPids,
+  collectPidsByEnvMarker,
   createBrowserTools,
   PlaywrightMcpSession,
   parseStorageStateResult,
@@ -356,6 +357,94 @@ describe("collectDescendantPids", () => {
   (hasProc ? it : it.skip)("returns [] for a leaf pid with no children", () => {
     // A made-up high pid that almost certainly has no children.
     expect(collectDescendantPids(2_147_483_646)).toEqual([]);
+  });
+});
+
+// Regression: when the MCP node exits unexpectedly its Camoufox reparents to
+// init, so no ancestry lookup can reach it — ~1.5 GiB stranded per occurrence
+// until the sandbox OOM'd. The env marker survives reparenting.
+describe("collectPidsByEnvMarker — orphan reaping", () => {
+  const hasProc = existsSync("/proc/self");
+  const ENV_KEY = "PENSAR_BROWSER_LAUNCH_ID";
+
+  const killPids = (pids: number[]) => {
+    for (const pid of pids) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        /* already gone */
+      }
+    }
+  };
+
+  /** `sh` backgrounds a sleep then exits, orphaning it as a dying node orphans
+   *  Camoufox. Returns the (now dead) parent pid. */
+  const spawnOrphan = async (marker: string): Promise<number> => {
+    const parent = spawn("sh", ["-c", "sleep 30 &"], {
+      stdio: "ignore",
+      env: { ...process.env, [ENV_KEY]: marker },
+    });
+    await new Promise((r) => setTimeout(r, 500));
+    return parent.pid!;
+  };
+
+  (hasProc ? it : it.skip)(
+    "finds an orphan by marker after its parent is gone, where ancestry finds nothing",
+    async () => {
+      const marker = `test-${process.pid}-${Date.now()}`;
+      const parentPid = await spawnOrphan(marker);
+      try {
+        // The parent exited, so the ancestry walk is blind to the orphan...
+        expect(collectDescendantPids(parentPid)).toEqual([]);
+        // ...but it still carries the launch marker.
+        expect(
+          collectPidsByEnvMarker(ENV_KEY, marker).length,
+        ).toBeGreaterThanOrEqual(1);
+      } finally {
+        killPids([parentPid, ...collectPidsByEnvMarker(ENV_KEY, marker)]);
+      }
+    },
+  );
+
+  (hasProc ? it : it.skip)(
+    "forceKillProcess still reaps when the child handle is already dead (the early-return bug)",
+    async () => {
+      const marker = `test-dead-handle-${process.pid}-${Date.now()}`;
+      const parentPid = await spawnOrphan(marker);
+      try {
+        expect(
+          collectPidsByEnvMarker(ENV_KEY, marker).length,
+        ).toBeGreaterThanOrEqual(1);
+
+        const session = new PlaywrightMcpSession();
+        Object.assign(session as unknown as Record<string, unknown>, {
+          // A non-null exitCode used to short-circuit the whole method.
+          mcpProcess: { exitCode: 0, pid: parentPid, kill: () => {} },
+          currentLaunchId: marker,
+        });
+        (
+          session as unknown as { forceKillProcess: () => void }
+        ).forceKillProcess();
+
+        await new Promise((r) => setTimeout(r, 400));
+        expect(collectPidsByEnvMarker(ENV_KEY, marker)).toEqual([]);
+      } finally {
+        killPids([parentPid, ...collectPidsByEnvMarker(ENV_KEY, marker)]);
+      }
+    },
+  );
+
+  (hasProc ? it : it.skip)("does not match an unrelated marker value", () => {
+    expect(collectPidsByEnvMarker(ENV_KEY, `absent-${Date.now()}`)).toEqual([]);
+  });
+
+  it("is a no-op when the session has no launch marker yet", () => {
+    const session = new PlaywrightMcpSession();
+    expect(() =>
+      (
+        session as unknown as { forceKillProcess: () => void }
+      ).forceKillProcess(),
+    ).not.toThrow();
   });
 });
 

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
@@ -434,6 +434,44 @@ describe("collectPidsByEnvMarker — orphan reaping", () => {
     },
   );
 
+  // A relaunch overwrites currentLaunchId. If teardown swept "whatever is
+  // current" rather than its own generation, a late onclose from the previous
+  // generation would kill the freshly launched browser.
+  (hasProc ? it : it.skip)(
+    "sweeps only the generation it was given, leaving a newer launch alone",
+    async () => {
+      const oldMarker = `gen1-${process.pid}-${Date.now()}`;
+      const newMarker = `gen2-${process.pid}-${Date.now()}`;
+      const oldPid = await spawnOrphan(oldMarker);
+      const newPid = await spawnOrphan(newMarker);
+      try {
+        const session = new PlaywrightMcpSession();
+        Object.assign(session as unknown as Record<string, unknown>, {
+          mcpProcess: null,
+          currentLaunchId: newMarker, // a relaunch already moved this on
+        });
+        (
+          session as unknown as {
+            forceKillProcess: (p: unknown, l: string) => void;
+          }
+        ).forceKillProcess(null, oldMarker);
+
+        await new Promise((r) => setTimeout(r, 400));
+        expect(collectPidsByEnvMarker(ENV_KEY, oldMarker)).toEqual([]);
+        expect(
+          collectPidsByEnvMarker(ENV_KEY, newMarker).length,
+        ).toBeGreaterThanOrEqual(1);
+      } finally {
+        killPids([
+          oldPid,
+          newPid,
+          ...collectPidsByEnvMarker(ENV_KEY, oldMarker),
+          ...collectPidsByEnvMarker(ENV_KEY, newMarker),
+        ]);
+      }
+    },
+  );
+
   (hasProc ? it : it.skip)("does not match an unrelated marker value", () => {
     expect(collectPidsByEnvMarker(ENV_KEY, `absent-${Date.now()}`)).toEqual([]);
   });

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -577,6 +577,10 @@ export class PlaywrightMcpSession {
    */
   private forceKillProcess(
     proc: import("child_process").ChildProcess | null = this.mcpProcess,
+    // Bind the sweep to a specific launch. `onclose` passes its own generation
+    // so a relaunch that has already overwritten `currentLaunchId` can never
+    // have its fresh browser killed by the previous generation's teardown.
+    launchId: string | null = this.currentLaunchId,
   ): void {
     // Was an early `return`, which skipped the sweep below in exactly the case
     // that needs it — a node that already exited.
@@ -619,15 +623,14 @@ export class PlaywrightMcpSession {
       }
     }
 
-    this.reapLaunchedProcesses();
+    this.reapLaunchedProcesses(launchId);
   }
 
   /**
-   * SIGKILL anything still carrying this launch's marker. Idempotent, and can
-   * only ever target processes this session launched.
+   * SIGKILL anything still carrying the given launch's marker. Idempotent, and
+   * can only ever target processes this session launched.
    */
-  private reapLaunchedProcesses(): void {
-    const launchId = this.currentLaunchId;
+  private reapLaunchedProcesses(launchId: string | null): void {
     if (!launchId) return;
     for (const pid of collectPidsByEnvMarker(BROWSER_LAUNCH_ENV, launchId)) {
       try {
@@ -765,7 +768,7 @@ export class PlaywrightMcpSession {
           if (this.mcpClient === client) {
             // Must run before resetState() nulls the handle. This path used to
             // drop it without killing anything, stranding one Camoufox each time.
-            this.forceKillProcess();
+            this.forceKillProcess(this.mcpProcess, launchId);
             this.resetState();
           }
         };

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -8,6 +8,7 @@
  * - "operator": User-driven operator mode - SPA reconnaissance, authenticated flows, attack surface mapping
  */
 
+import { randomUUID } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
@@ -355,6 +356,43 @@ export function collectDescendantPids(rootPid: number): number[] {
   return descendants;
 }
 
+/**
+ * Per-launch UUID inherited by the node child, Camoufox, and its content
+ * processes. Lets teardown find the tree by identity rather than ancestry,
+ * which breaks the moment the node dies and its browser reparents to init.
+ */
+const BROWSER_LAUNCH_ENV = "PENSAR_BROWSER_LAUNCH_ID";
+
+/** Live pids stamped with `key=value`; `/proc/<pid>/environ` is fixed at exec. */
+export function collectPidsByEnvMarker(key: string, value: string): number[] {
+  let entries: string[];
+  try {
+    entries = readdirSync("/proc");
+  } catch {
+    return [];
+  }
+
+  const needle = `${key}=${value}`;
+  const pids: number[] = [];
+  for (const name of entries) {
+    if (!/^\d+$/.test(name)) continue;
+    const pid = Number(name);
+    if (pid === process.pid) continue;
+    try {
+      if (
+        readFileSync(`/proc/${pid}/environ`, "utf8")
+          .split("\0")
+          .includes(needle)
+      ) {
+        pids.push(pid);
+      }
+    } catch {
+      // exited, or not ours to inspect
+    }
+  }
+  return pids;
+}
+
 // ---------------------------------------------------------------------------
 // Module-level defaults (used when not explicitly provided)
 // ---------------------------------------------------------------------------
@@ -459,6 +497,11 @@ export class PlaywrightMcpSession {
   private mcpConfigPath: string | null = null;
   /** Cached Camoufox launch options — resolved once, reused on reconnect. */
   private cachedCamouOptions: CamoufoxLaunchOptions | null = null;
+  /**
+   * Deliberately NOT cleared by `resetState()` — `disconnect()` resets before
+   * it kills, so clearing there would blind the sweep. A new launch overwrites.
+   */
+  private currentLaunchId: string | null = null;
 
   /**
    * Each option is three-state: `undefined` → module default, value → use it,
@@ -535,41 +578,58 @@ export class PlaywrightMcpSession {
   private forceKillProcess(
     proc: import("child_process").ChildProcess | null = this.mcpProcess,
   ): void {
-    if (!proc || proc.exitCode !== null) return;
+    // Was an early `return`, which skipped the sweep below in exactly the case
+    // that needs it — a node that already exited.
+    if (proc && proc.exitCode === null) {
+      // Snapshot descendants BEFORE the node dies; afterwards they reparent to
+      // init. The group-kill misses them because the node isn't a group leader.
+      const rootPid = proc.pid ?? null;
+      const descendants = rootPid != null ? collectDescendantPids(rootPid) : [];
+      // Snapshot starttimes before kill so we refuse PID-reuse kills after reparent.
+      const descendantStarts = new Map<number, number | null>();
+      for (const pid of descendants) {
+        descendantStarts.set(pid, readProcStartTime(pid));
+      }
 
-    // Snapshot the descendant tree (Chromium browser + renderers) BEFORE the
-    // node dies — afterwards they reparent to init and can't be found via its
-    // pid. The group-kill below misses them because the MCP node isn't spawned
-    // as a process-group leader, which orphaned Chromium and leaked memory
-    // across endpoints until the sandbox OOM'd.
-    const rootPid = proc.pid ?? null;
-    const descendants = rootPid != null ? collectDescendantPids(rootPid) : [];
-    // Snapshot starttimes before kill so we refuse PID-reuse kills after reparent.
-    const descendantStarts = new Map<number, number | null>();
-    for (const pid of descendants) {
-      descendantStarts.set(pid, readProcStartTime(pid));
-    }
-
-    try {
-      if (rootPid != null) {
-        try {
-          process.kill(-rootPid, "SIGKILL");
-        } catch {
+      try {
+        if (rootPid != null) {
+          try {
+            process.kill(-rootPid, "SIGKILL");
+          } catch {
+            proc.kill("SIGKILL");
+          }
+        } else {
           proc.kill("SIGKILL");
         }
-      } else {
-        proc.kill("SIGKILL");
+      } catch {
+        // Already dead — fine
       }
-    } catch {
-      // Already dead — fine
+
+      for (const pid of descendants) {
+        // An unverifiable starttime can't rule out PID reuse, so decline the
+        // kill; the marker sweep below covers anything skipped here.
+        const expected = descendantStarts.get(pid);
+        const now = readProcStartTime(pid);
+        if (expected == null || now == null || now !== expected) continue;
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          // Already gone — fine
+        }
+      }
     }
 
-    for (const pid of descendants) {
-      const expected = descendantStarts.get(pid);
-      if (expected != null) {
-        const now = readProcStartTime(pid);
-        if (now == null || now !== expected) continue;
-      }
+    this.reapLaunchedProcesses();
+  }
+
+  /**
+   * SIGKILL anything still carrying this launch's marker. Idempotent, and can
+   * only ever target processes this session launched.
+   */
+  private reapLaunchedProcesses(): void {
+    const launchId = this.currentLaunchId;
+    if (!launchId) return;
+    for (const pid of collectPidsByEnvMarker(BROWSER_LAUNCH_ENV, launchId)) {
       try {
         process.kill(pid, "SIGKILL");
       } catch {
@@ -649,6 +709,11 @@ export class PlaywrightMcpSession {
         // UA / viewport / fingerprint — a hand-set Chrome UA on Firefox would
         // itself be a detection tell.
 
+        // Stamped before the process exists so a failure inside connect() can
+        // still sweep the tree.
+        const launchId = randomUUID();
+        this.currentLaunchId = launchId;
+
         const transport = new StdioClientTransport({
           command: "node",
           args,
@@ -666,6 +731,7 @@ export class PlaywrightMcpSession {
               Object.entries(camou.env).map(([k, v]) => [k, String(v)]),
             ),
             ...(this.display ? { DISPLAY: this.display } : {}),
+            [BROWSER_LAUNCH_ENV]: launchId,
           },
         });
 
@@ -697,6 +763,9 @@ export class PlaywrightMcpSession {
 
         client.onclose = () => {
           if (this.mcpClient === client) {
+            // Must run before resetState() nulls the handle. This path used to
+            // drop it without killing anything, stranding one Camoufox each time.
+            this.forceKillProcess();
             this.resetState();
           }
         };


### PR DESCRIPTION
Fixes the orphaned-Camoufox leak that OOM-kills pentest sandboxes and surfaces to users as "Scan run ended prematurely" (console#2315 context).

## The bug

Camoufox teardown is gated behind a live `ChildProcess` handle, and the one case that strands a browser is the case that never reaps.

- `forceKillProcess()` opened with `if (!proc || proc.exitCode !== null) return;` — *above* the descendant walk. Once the node had exited, nothing was reaped.
- `client.onclose` called only `resetState()`, which nulls `mcpProcess`. The single signal that the node died was also the only path that killed nothing, and it discarded the handle every other recovery path (`initialize()`'s dead-transport branch, `callTool`'s `isConnectionDead` branch) depends on — silently turning those into no-ops too.

When the node exits unexpectedly (crash, OOM, self-exit, pipe break) its Camoufox reparents to init, so `collectDescendantPids` can never reach it again.

## Evidence

From production telemetry, comparing max `camoufoxParents` at endpoint teardown against each scan's concurrency (expected max is `concurrency - 1`, since sibling endpoints are legitimately running):

| scan | concurrency | max parents | orphans | OOM'd + reaped? |
|---|---|---|---|---|
| `a8339323` | 8 | 13 | +6 | yes |
| `b03cd7ea` | 6 | 9 | +4 | yes |
| all others | 5-8 | <= concurrency-1 | 0 | no |

Only the scans accumulating orphans died. Each stranded browser measures ~1.4-1.8 GiB (p50/p90 over 312 samples) against a 16 GiB sandbox, and the pressure is anonymous memory, not reclaimable cache (p50 anon 13.7 GB vs file 1.0 GB above 12 GB).

## The fix

Stamp a per-launch UUID (`PENSAR_BROWSER_LAUNCH_ID`) into the transport env. The node child, Camoufox, and Firefox's content processes all inherit it, and `/proc/<pid>/environ` is fixed at exec — so the tree stays findable by *identity* after ancestry is gone. Teardown sweeps by that marker.

Chosen over the two alternatives:

- **Process-group kill** would be cleaner, but the SDK's `StdioServerParameters` (`@modelcontextprotocol/sdk@1.29.0`) exposes only `command`/`args`/`env`/`stderr`/`cwd` — no `detached`, so the node can't be made a group leader without wrapping the spawn.
- **Recording pids eagerly** and killing them later widens the PID-reuse window from microseconds to minutes. A UUID in the environment can't mistarget: a recycled pid doesn't carry it.

Also tightened the existing descendant kill — an unverifiable starttime now declines the kill instead of killing unchecked (the `if (expected != null)` guard previously fell through to an unconditional `process.kill`). Anything skipped is covered by the marker sweep.

## Risk

Low, and deliberately additive. The marker sweep can only ever target processes this session launched. The `forceKillProcess` restructure is re-indentation — the live-handle path is byte-for-byte the same logic, now wrapped in `if (proc && proc.exitCode === null)` so the sweep runs either way. Reaping on `onclose` is safe because a closed transport means the browser is already unusable.

Worth a reviewer's eye on: `onclose` now kills a shared browser session for the orchestrator *and* every subagent sharing it — but that session was already dead, so this strands nothing new.

## Verification

- 1436 tests pass (91 files); `biome check` clean on changed files.
- Two new `/proc`-gated tests spawn a real orphan (`sh -c "sleep 30 &"`, parent exits) and assert (a) ancestry finds nothing while the marker finds it, and (b) `forceKillProcess` reaps it even with an already-exited handle — which fails on `canary`.

**Now verified on a live stage — see below.**


---

## Verified end-to-end on a live stage

Deployed to an isolated SST stage (`jraad-camoufox`) with this branch pinned, and verified three independent ways.

### 1. Controlled A/B in real sandboxes

A clean MCP-node kill is **not** a faithful repro — Camoufox notices its juggler pipe close and self-exits, so both fixed and pre-fix images reap. Real orphaning needs a browser that *cannot service* that shutdown, which is what a sandbox thrashing at its cgroup ceiling produces. `SIGSTOP` models that state (alive, unschedulable), so only an external kill can remove it.

Same script, same 8 GiB sandbox spec, only the image differs:

| image | fix present | markedProcs after launch | survivors after node kill | verdict |
|---|---|---|---|---|
| `pensar-agent-jraad-e59377cab377` (pre-fix) | no | 0 | **6** | **ORPHANED** |
| `pensar-agent-jraad-camoufox-36a037a4e15a` (this branch) | yes | 7 | **0** | **REAPED** |

Pre-fix survivors show the mechanism exactly:
```
orphan pid=484 ppid=1  /opt/camoufox/camoufox-bin -no-remote -headless -profile /tm
orphan pid=551 ppid=484 ... -contentproc ...   (+4 more)
```
`ppid=1` — reparented to init, unreachable by any ancestry-based reap. On this branch the same six are gone within 2 s.

### 2. Full pentest, 79 minutes, 3 endpoints

| time | camoufoxTotal | mcpNode | markedProcs |
|---|---|---|---|
| 04:13:57 | 28 | 4 | 32 |
| 04:54:45 | 21 | 3 | 24 |
| 04:55:46 | 14 | 2 | 16 |
| 05:05:55 | 7 | 1 | 8 |
| 05:31:19 | completed, sandbox torn down | | |

Each finishing endpoint dropped exactly one full browser tree (1 parent + 6 content), with `markedProcs` tracking precisely (= camoufoxTotal + mcpNode). Peak 4 concurrent trees.

Memory stayed **flat at ~1.2 GB of 8 GB for the entire run, `oom=0`**. For contrast, the production failure reached 13 GB within an hour and rode the 16 GB ceiling for 13 hours.

Scan finalized on its own — `errorMessage = (none)`, which is where a reaped run writes REAP_REASON. `pentest_targets`: 4 total, 4 completed, 0 errored.

### 3. Marker propagation on the production dispatch path

`markedProcs` = MCP node + Camoufox parent + all content processes, in both a live `blackbox-recon` run and the pentest. Content processes are precisely what the old ancestry walk could not reach after reparenting.

### Not covered

Production sandboxes are 16 GiB; this stage is 8 GiB. That doesn't affect the reaping logic under test, but a production-sized memory-pressure run is still untested. The `wedged` death class (~26% of reaps) remains separately un-root-caused.

---

## Does this fix the "sandbox stopped responding" errors?

Probably most of them — but not all, and worth being precise about which part.

### What it does address

Orphaned browsers were the *discriminator* in the production data. The two scans that OOM'd and got reaped were exactly the two carrying orphans beyond what concurrency explains (13 Camoufox parents at concurrency 8; 9 at concurrency 6). Every scan without orphans survived. This branch removes that mechanism.

`cgroup-oom` was **68% of reaps** over 30 days (13 of 19; `wedged` 5, `sandbox-gone` 1). If orphans drove that bucket, this should remove most of the error volume.

### What it does NOT address

**Baseline capacity is untouched.** The sandbox that died reached **10.5 GB within its first 30 minutes** — before orphans had meaningful time to accumulate. That early climb was legitimate concurrent browsers. Orphans then pushed it from ~65% to the ceiling. This fix removes what pushed it over; the edge is still close. At concurrency 8 a 16 GiB sandbox sits near 89% with zero orphans, so a heavy enough target can still OOM with no leak at all.

**The `wedged` bucket (26%) is un-root-caused.** Plausibly the same memory pressure — a thrashing process makes no forward progress — but that is unconfirmed. If it is something else, this branch does nothing for it.

**The OOM itself was never reproduced.** Verification ran on 8 GiB against a light target and peaked at 1.2 GB, nowhere near pressure. This proves the leak mechanism is gone; it does not prove a production-scale run stays under the ceiling. Different claims.

### Recommended rollout

Ship this, but not as the whole fix. Pair it with lowering platform `agentConcurrency.maxConcurrency` (currently 6-8) — that addresses the baseline margin, needs no deploy, and is instantly reversible.

Then measure: re-run the reap death-class breakdown a week out. If `cgroup-oom` drops toward zero, orphans were the story and concurrency can go back up. If it doesn't, baseline capacity is the dominant term and the answer is a larger sandbox — the same call already made once when it went 8 → 16 GiB.

### Note on the error wording

The generic string "the agent sandbox stopped responding and was reclaimed by the reliability backstop" stopped being generated on 2026-07-26, when `formatReapReason` shipped in console#2146. Current reaps name the cause (e.g. "sandbox out-of-memory (cgroup OOM)"). Older scans keep the legacy wording in their stored `errorMessage`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Teardown now SIGKILLs processes by env marker and on every transport close; scope is limited to this session’s launch IDs, but mis-tagged or shared-session edge cases warrant a quick review.
> 
> **Overview**
> Fixes **orphaned Camoufox** processes when the Playwright MCP node exits unexpectedly (crash, pipe break, etc.). Browsers that reparent to init were no longer reachable via `collectDescendantPids`, and **`forceKillProcess` used to return early** when the child handle already had a non-null `exitCode`, so teardown never ran in that case. **`client.onclose` only called `resetState()`** and did not kill anything.
> 
> Each browser launch now gets a **`PENSAR_BROWSER_LAUNCH_ID` UUID** in the MCP transport env (inherited by the node, Camoufox, and content processes). Teardown scans `/proc` with **`collectPidsByEnvMarker`** and SIGKILLs anything still carrying that launch’s marker via **`reapLaunchedProcesses`**, including after the node is gone. **`forceKillProcess`** always runs the marker sweep and accepts an explicit **`launchId`** so a late `onclose` from an old generation cannot kill a relaunched browser. **`onclose`** now calls **`forceKillProcess`** before **`resetState`**. Descendant kills skip PIDs when starttime cannot be verified (marker sweep covers the rest).
> 
> New **`/proc`-gated tests** cover orphan discovery, reaping with a dead handle, generation-scoped sweeps, and no-marker no-ops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 656eb5a16be572ec80a99d7a33c9e19473e72d7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->