### PR TITLE
fix(ai): prompt caching was off on Bedrock and partial on the gateway

### DIFF
--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -20,7 +20,11 @@ import type { z } from "zod";
 import { createLogger } from "../logger/structured";
 import { shouldRecordAiPayloads } from "../observability";
 import { scopedLogger } from "../util/lazyLogger";
-import { withCachedLastMessage, withCachedSystemPrompt } from "./caching";
+import {
+  cacheBreakpointFor,
+  withCachedLastMessage,
+  withCachedSystemPrompt,
+} from "./caching";
 import { fitMessagesToContext, truncateWithMarker } from "./contextManagement";
 import {
   getMaxOutputTokens,
@@ -966,7 +970,9 @@ export function streamResponse(
     }
   };
   const providerModel = getProviderModel(model, authConfig);
-  const useAnthropicCaching = isAnthropicProvider(model);
+  // Undefined when the model has no cache breakpoint we can express (non-Claude
+  // Bedrock models, OpenAI/Google/OpenRouter) — those run uncached.
+  const cacheBreakpoint = cacheBreakpointFor(model);
 
   // Models that mis-parse multiple tool calls per turn (DeepSeek V3.1 on
   // Bedrock) are constrained to one tool call per turn via system prompt —
@@ -1032,25 +1038,27 @@ export function streamResponse(
     );
   }
 
-  // For Anthropic models, move the system prompt into messages with cache_control.
-  // This caches tools + system prompt across multi-turn conversations (~90% cost reduction on cache hits).
+  // For cacheable models, move the system prompt into messages behind a cache
+  // breakpoint. This caches tools + system prompt across multi-turn
+  // conversations (~90% cost reduction on cache hits).
   let effectiveSystem: string | undefined = systemWithToolPolicy;
   let effectiveMessages: ModelMessage[] | undefined = fittedMessages;
 
-  if (useAnthropicCaching && systemWithToolPolicy) {
+  if (cacheBreakpoint && systemWithToolPolicy) {
     const baseMessages: ModelMessage[] = fittedMessages ?? [
       { role: "user" as const, content: prompt },
     ];
     effectiveMessages = withCachedSystemPrompt(
       systemWithToolPolicy,
       baseMessages,
+      cacheBreakpoint,
     );
     effectiveSystem = undefined;
   }
 
   // Build providerOptions for extended thinking when enabled on a supported model.
-  // Caching uses message-level cache_control (withCachedSystemPrompt / withCachedLastMessage),
-  // not providerOptions, so there is no collision.
+  // Caching uses message-level breakpoints (withCachedSystemPrompt / withCachedLastMessage),
+  // not top-level providerOptions, so there is no collision.
   // Note: when thinking is enabled, temperature must not be set (Anthropic rejects it);
   // this path never sets temperature, so there is nothing to clear.
   const providerOptions = buildReasoningProviderOptions(model, {
@@ -1089,9 +1097,11 @@ export function streamResponse(
       prepareStep: (opts) => {
         // Update the container with the latest messages
         messagesContainer.current = opts.messages;
-        // For Anthropic, add cache_control to the last message for incremental caching
-        if (useAnthropicCaching) {
-          return { messages: withCachedLastMessage(opts.messages) };
+        // Mark the last message so the growing conversation caches incrementally
+        if (cacheBreakpoint) {
+          return {
+            messages: withCachedLastMessage(opts.messages, cacheBreakpoint),
+          };
         }
         return undefined;
       },

--- a/src/core/ai/caching.test.ts
+++ b/src/core/ai/caching.test.ts
@@ -5,6 +5,7 @@ import {
   withCachedLastMessage,
   withCachedSystemPrompt,
 } from "./caching";
+import { AVAILABLE_MODELS } from "./models";
 
 const BEDROCK_BREAKPOINT = { bedrock: { cachePoint: { type: "default" } } };
 const ANTHROPIC_BREAKPOINT = {
@@ -16,10 +17,7 @@ describe("cacheBreakpointFor", () => {
     "global.anthropic.claude-opus-4-6-v1",
     "global.anthropic.claude-opus-4-8",
     "us.anthropic.claude-haiku-4-5-20251001-v1:0",
-    "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
     "anthropic.claude-sonnet-4-6-v1",
-    "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
-    "us.anthropic.claude-3-5-haiku-20241022-v1:0",
   ])("uses the bedrock cachePoint namespace for %s", (model) => {
     expect(cacheBreakpointFor(model)).toEqual(BEDROCK_BREAKPOINT);
   });
@@ -45,10 +43,33 @@ describe("cacheBreakpointFor", () => {
     "anthropic.claude-3-5-sonnet-20240620-v1:0",
     "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
     "global.anthropic.claude-3-5-sonnet-20240620-v1:0",
+    // Rest of the claude-3 line: cache support was uneven and all of it is
+    // end-of-life on Bedrock, so none of it may carry a cache point.
+    "global.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+    "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
   ])("returns undefined for Bedrock model %s", (model) => {
     // Bedrock rejects a cache point outright on models that don't support
     // prompt caching, so these must stay uncached rather than 400.
     expect(cacheBreakpointFor(model)).toBeUndefined();
+  });
+
+  it("caches every Claude 4+ id in the registry and no earlier one", () => {
+    // Guards the generation boundary wholesale rather than by sampled id:
+    // 3.x put the generation first (claude-3-5-sonnet-…), 4.x puts the tier
+    // first (claude-sonnet-4-…), and only the latter may carry a cache point.
+    const bedrockClaude = AVAILABLE_MODELS.filter(
+      (m) => m.provider === "bedrock" && m.id.includes("anthropic.claude"),
+    );
+    expect(bedrockClaude.length).toBeGreaterThan(0);
+    for (const { id } of bedrockClaude) {
+      const base = id.replace(/^(?:[a-z]{2,6}\.)?anthropic\./, "");
+      const isGen4Plus = /^claude-(?:opus|sonnet|haiku)-\d/.test(base);
+      expect({ id, cached: cacheBreakpointFor(id) !== undefined }).toEqual({
+        id,
+        cached: isGen4Plus,
+      });
+    }
   });
 
   it("uses the anthropic namespace for direct Anthropic models", () => {

--- a/src/core/ai/caching.test.ts
+++ b/src/core/ai/caching.test.ts
@@ -1,0 +1,130 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import {
+  cacheBreakpointFor,
+  withCachedLastMessage,
+  withCachedSystemPrompt,
+} from "./caching";
+
+const BEDROCK_BREAKPOINT = { bedrock: { cachePoint: { type: "default" } } };
+const ANTHROPIC_BREAKPOINT = {
+  anthropic: { cacheControl: { type: "ephemeral" } },
+};
+
+describe("cacheBreakpointFor", () => {
+  it.each([
+    "global.anthropic.claude-opus-4-6-v1",
+    "global.anthropic.claude-opus-4-8",
+    "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+    "anthropic.claude-sonnet-4-6-v1",
+  ])("uses the bedrock cachePoint namespace for %s", (model) => {
+    expect(cacheBreakpointFor(model)).toEqual(BEDROCK_BREAKPOINT);
+  });
+
+  it("never emits an anthropic key on Bedrock", () => {
+    // The bug this guards: @ai-sdk/amazon-bedrock only reads
+    // providerOptions.bedrock.cachePoint, so an `anthropic` key is dropped with
+    // no error and every request bills the full prefix.
+    expect(
+      cacheBreakpointFor("global.anthropic.claude-opus-4-6-v1"),
+    ).not.toHaveProperty("anthropic");
+  });
+
+  it.each([
+    "us.deepseek.r1-v1:0",
+    "us.amazon.nova-lite-v1:0",
+    "amazon.titan-text-express-v1",
+    "anthropic.claude-v2",
+  ])("returns undefined for Bedrock model %s", (model) => {
+    // Bedrock rejects a cache point outright on models that don't support
+    // prompt caching, so these must stay uncached rather than 400.
+    expect(cacheBreakpointFor(model)).toBeUndefined();
+  });
+
+  it("uses the anthropic namespace for direct Anthropic models", () => {
+    expect(cacheBreakpointFor("claude-haiku-4-5")).toEqual(
+      ANTHROPIC_BREAKPOINT,
+    );
+  });
+
+  it("uses the anthropic namespace for Pensar gateway models", () => {
+    // The gateway hand-builds native Anthropic cache_control blocks — see
+    // providers/pensarFormatters.ts.
+    expect(cacheBreakpointFor("pensar:anthropic.claude-opus-4-8")).toEqual(
+      ANTHROPIC_BREAKPOINT,
+    );
+  });
+
+  it.each([
+    "gpt-5.6-sol",
+    "some-unknown-model",
+  ])("returns undefined for %s", (model) => {
+    expect(cacheBreakpointFor(model)).toBeUndefined();
+  });
+});
+
+describe("withCachedSystemPrompt", () => {
+  const messages: ModelMessage[] = [{ role: "user", content: "hi" }];
+
+  it("prepends a system message carrying the breakpoint", () => {
+    const result = withCachedSystemPrompt(
+      "be helpful",
+      messages,
+      BEDROCK_BREAKPOINT,
+    );
+    expect(result[0]).toEqual({
+      role: "system",
+      content: "be helpful",
+      providerOptions: BEDROCK_BREAKPOINT,
+    });
+    expect(result.slice(1)).toEqual(messages);
+  });
+
+  it("omits providerOptions when the model has no breakpoint", () => {
+    const result = withCachedSystemPrompt("be helpful", messages, undefined);
+    expect(result[0]).not.toHaveProperty("providerOptions");
+  });
+});
+
+describe("withCachedLastMessage", () => {
+  it("marks only the last message", () => {
+    const result = withCachedLastMessage(
+      [
+        { role: "user", content: "first" },
+        { role: "assistant", content: "second" },
+        { role: "user", content: "third" },
+      ],
+      BEDROCK_BREAKPOINT,
+    );
+    expect(result[0].providerOptions).toBeUndefined();
+    expect(result[1].providerOptions).toBeUndefined();
+    expect(result[2].providerOptions).toEqual(BEDROCK_BREAKPOINT);
+  });
+
+  it("merges with providerOptions already on the message", () => {
+    const result = withCachedLastMessage(
+      [
+        {
+          role: "user",
+          content: "hi",
+          providerOptions: { anthropic: { signature: "abc" } },
+        },
+      ],
+      BEDROCK_BREAKPOINT,
+    );
+    expect(result[0].providerOptions).toEqual({
+      anthropic: { signature: "abc" },
+      ...BEDROCK_BREAKPOINT,
+    });
+  });
+
+  it("is a no-op without a breakpoint", () => {
+    const messages: ModelMessage[] = [{ role: "user", content: "hi" }];
+    expect(withCachedLastMessage(messages, undefined)).toBe(messages);
+  });
+
+  it("is a no-op on an empty list", () => {
+    expect(withCachedLastMessage([], BEDROCK_BREAKPOINT)).toEqual([]);
+  });
+});

--- a/src/core/ai/caching.test.ts
+++ b/src/core/ai/caching.test.ts
@@ -36,6 +36,10 @@ describe("cacheBreakpointFor", () => {
     "us.amazon.nova-lite-v1:0",
     "amazon.titan-text-express-v1",
     "anthropic.claude-v2",
+    "anthropic.claude-v2:1",
+    "anthropic.claude-instant-v1",
+    "global.anthropic.claude-3-opus-20240229-v1:0",
+    "us.anthropic.claude-3-haiku-20240307-v1:0",
   ])("returns undefined for Bedrock model %s", (model) => {
     // Bedrock rejects a cache point outright on models that don't support
     // prompt caching, so these must stay uncached rather than 400.
@@ -116,6 +120,25 @@ describe("withCachedLastMessage", () => {
     expect(result[0].providerOptions).toEqual({
       anthropic: { signature: "abc" },
       ...BEDROCK_BREAKPOINT,
+    });
+  });
+
+  it("keeps sibling options within the same provider namespace", () => {
+    const result = withCachedLastMessage(
+      [
+        {
+          role: "user",
+          content: "hi",
+          providerOptions: { bedrock: { citations: { enabled: true } } },
+        },
+      ],
+      BEDROCK_BREAKPOINT,
+    );
+    expect(result[0].providerOptions).toEqual({
+      bedrock: {
+        citations: { enabled: true },
+        cachePoint: { type: "default" },
+      },
     });
   });
 

--- a/src/core/ai/caching.test.ts
+++ b/src/core/ai/caching.test.ts
@@ -18,6 +18,8 @@ describe("cacheBreakpointFor", () => {
     "us.anthropic.claude-haiku-4-5-20251001-v1:0",
     "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
     "anthropic.claude-sonnet-4-6-v1",
+    "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "us.anthropic.claude-3-5-haiku-20241022-v1:0",
   ])("uses the bedrock cachePoint namespace for %s", (model) => {
     expect(cacheBreakpointFor(model)).toEqual(BEDROCK_BREAKPOINT);
   });
@@ -40,6 +42,9 @@ describe("cacheBreakpointFor", () => {
     "anthropic.claude-instant-v1",
     "global.anthropic.claude-3-opus-20240229-v1:0",
     "us.anthropic.claude-3-haiku-20240307-v1:0",
+    "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "global.anthropic.claude-3-5-sonnet-20240620-v1:0",
   ])("returns undefined for Bedrock model %s", (model) => {
     // Bedrock rejects a cache point outright on models that don't support
     // prompt caching, so these must stay uncached rather than 400.

--- a/src/core/ai/caching.ts
+++ b/src/core/ai/caching.ts
@@ -20,13 +20,14 @@ const BEDROCK_CACHE_POINT: CacheBreakpoint = {
 };
 
 /**
- * Legacy Claude on Bedrock — v2, instant, and the Claude 3 line — predates
- * prompt caching; 3.5 onward supports it. Kept as a deny-list so a new Claude
- * generation picks caching up the moment `generate:models` adds it, rather than
- * silently losing it again, which is the failure this whole fix is about.
+ * Legacy Claude on Bedrock — v2, instant, the Claude 3 line, and 3.5 Sonnet v1
+ * (`20240620`) — predates prompt caching; 3.5 Sonnet v2, 3.5 Haiku, and 3.7
+ * onward support it. Kept as a deny-list so a new Claude generation picks
+ * caching up the moment `generate:models` adds it, rather than silently losing
+ * it again, which is the failure this whole fix is about.
  */
 const BEDROCK_UNCACHEABLE_CLAUDE =
-  /^claude-(?:v2|instant|3-(?:opus|sonnet|haiku))/;
+  /^claude-(?:v2|instant|3-(?:opus|sonnet|haiku)|3-5-sonnet-20240620)/;
 
 /**
  * Bedrock *rejects* a cache point on models that don't support prompt caching

--- a/src/core/ai/caching.ts
+++ b/src/core/ai/caching.ts
@@ -1,41 +1,91 @@
 import type { ModelMessage } from "ai";
+import type { AIModel } from "./ai";
+import { getModelInfo } from "./models";
 
-const ANTHROPIC_CACHE_CONTROL = {
+type CacheBreakpoint = NonNullable<ModelMessage["providerOptions"]>;
+
+const ANTHROPIC_CACHE_CONTROL: CacheBreakpoint = {
   anthropic: { cacheControl: { type: "ephemeral" as const } },
 };
 
 /**
- * Prepend a system message with cache_control to the messages array.
+ * Bedrock's Converse API namespaces the breakpoint under `bedrock.cachePoint`.
+ * Provider options are keyed by provider id, so an `anthropic` key is dropped
+ * with no error and no warning — which is how caching stayed silently off on
+ * every Bedrock model. Confirmed against live Bedrock: `anthropic.cacheControl`
+ * reports cacheWrite/cacheRead of 0, `bedrock.cachePoint` caches the prefix.
+ */
+const BEDROCK_CACHE_POINT: CacheBreakpoint = {
+  bedrock: { cachePoint: { type: "default" as const } },
+};
+
+/**
+ * Bedrock *rejects* a cache point on models that don't support prompt caching
+ * ("You invoked an unsupported model or your request did not allow prompt
+ * caching" — observed on `us.deepseek.r1-v1:0`), so this is an allowlist rather
+ * than best-effort. Models outside it keep running uncached instead of failing.
+ */
+function bedrockSupportsCachePoint(modelId: string): boolean {
+  const base = modelId.replace(/^(?:[a-z]{2,6}\.)?anthropic\./, "");
+  return /^claude-(?:3-7-sonnet|sonnet-4|opus-4|haiku-4)/.test(base);
+}
+
+/**
+ * Provider options marking a cache breakpoint for `model`, or `undefined` when
+ * the model has no breakpoint we can express.
+ */
+export function cacheBreakpointFor(
+  model: AIModel,
+): CacheBreakpoint | undefined {
+  const { provider } = getModelInfo(model);
+  switch (provider) {
+    case "anthropic":
+    // The Pensar gateway speaks the native Anthropic Messages API and reads
+    // this same key — see providers/pensarFormatters.ts.
+    case "pensar":
+      return ANTHROPIC_CACHE_CONTROL;
+    case "bedrock":
+      return bedrockSupportsCachePoint(model) ? BEDROCK_CACHE_POINT : undefined;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Prepend a system message carrying a cache breakpoint to the messages array.
  * This ensures tools + system prompt are cached on every request.
  *
  * The system prompt is placed as a system-role message at the start of
- * the messages array with providerOptions containing cacheControl,
- * so Anthropic caches the entire prefix (tools + system) and reads
- * it from cache on subsequent turns (~90% cost reduction).
+ * the messages array with providerOptions containing the breakpoint, so the
+ * provider caches the entire prefix (tools + system) and reads it from cache
+ * on subsequent turns (~90% cost reduction).
  */
 export function withCachedSystemPrompt(
   system: string,
   messages: ModelMessage[],
+  breakpoint: CacheBreakpoint | undefined,
 ): ModelMessage[] {
   return [
     {
       role: "system" as const,
       content: system,
-      providerOptions: ANTHROPIC_CACHE_CONTROL,
+      ...(breakpoint ? { providerOptions: breakpoint } : {}),
     },
     ...messages,
   ];
 }
 
 /**
- * Add cache_control to the last message for incremental conversation caching.
- * On each turn, everything up to (and including) the last message is read from cache,
- * so only the new content after the cache breakpoint is billed at full price.
+ * Add a cache breakpoint to the last message for incremental conversation
+ * caching. On each turn, everything up to (and including) the last message is
+ * read from cache, so only the new content after the breakpoint is billed at
+ * full price.
  */
 export function withCachedLastMessage(
   messages: ModelMessage[],
+  breakpoint: CacheBreakpoint | undefined,
 ): ModelMessage[] {
-  if (messages.length === 0) return messages;
+  if (messages.length === 0 || !breakpoint) return messages;
 
   return messages.map((msg, i) => {
     if (i === messages.length - 1) {
@@ -43,7 +93,7 @@ export function withCachedLastMessage(
         ...msg,
         providerOptions: {
           ...msg.providerOptions,
-          ...ANTHROPIC_CACHE_CONTROL,
+          ...breakpoint,
         },
       };
     }

--- a/src/core/ai/caching.ts
+++ b/src/core/ai/caching.ts
@@ -20,14 +20,20 @@ const BEDROCK_CACHE_POINT: CacheBreakpoint = {
 };
 
 /**
- * Legacy Claude on Bedrock — v2, instant, the Claude 3 line, and 3.5 Sonnet v1
- * (`20240620`) — predates prompt caching; 3.5 Sonnet v2, 3.5 Haiku, and 3.7
- * onward support it. Kept as a deny-list so a new Claude generation picks
- * caching up the moment `generate:models` adds it, rather than silently losing
- * it again, which is the failure this whole fix is about.
+ * Legacy Claude on Bedrock — v2, instant, and the whole `claude-3-…` line.
+ * Cache-point support was uneven across it (3.5 Sonnet v1 never had it), and
+ * that is now moot: every `claude-3-…` id is end-of-life on Bedrock and fails
+ * with "This model version has reached the end of its life" before caching is
+ * reached. Denying the line wholesale beats enumerating per-snapshot support
+ * for models that can no longer be invoked.
+ *
+ * The generation boundary is legible in the id itself — 3.x puts the generation
+ * first (`claude-3-5-sonnet-…`), 4.x onward puts the tier first
+ * (`claude-sonnet-4-…`) — so this stays a deny-list: a new Claude picks caching
+ * up the moment `generate:models` adds it, rather than silently losing it,
+ * which is the failure this whole fix is about.
  */
-const BEDROCK_UNCACHEABLE_CLAUDE =
-  /^claude-(?:v2|instant|3-(?:opus|sonnet|haiku)|3-5-sonnet-20240620)/;
+const BEDROCK_UNCACHEABLE_CLAUDE = /^claude-(?:v2|instant|3[-.])/;
 
 /**
  * Bedrock *rejects* a cache point on models that don't support prompt caching

--- a/src/core/ai/caching.ts
+++ b/src/core/ai/caching.ts
@@ -20,14 +20,24 @@ const BEDROCK_CACHE_POINT: CacheBreakpoint = {
 };
 
 /**
+ * Legacy Claude on Bedrock — v2, instant, and the Claude 3 line — predates
+ * prompt caching; 3.5 onward supports it. Kept as a deny-list so a new Claude
+ * generation picks caching up the moment `generate:models` adds it, rather than
+ * silently losing it again, which is the failure this whole fix is about.
+ */
+const BEDROCK_UNCACHEABLE_CLAUDE =
+  /^claude-(?:v2|instant|3-(?:opus|sonnet|haiku))/;
+
+/**
  * Bedrock *rejects* a cache point on models that don't support prompt caching
  * ("You invoked an unsupported model or your request did not allow prompt
- * caching" — observed on `us.deepseek.r1-v1:0`), so this is an allowlist rather
- * than best-effort. Models outside it keep running uncached instead of failing.
+ * caching" — observed on `us.deepseek.r1-v1:0`), so this gate is load-bearing:
+ * non-Claude Bedrock models must stay uncached rather than fail.
  */
 function bedrockSupportsCachePoint(modelId: string): boolean {
+  // Strip the cross-region inference-profile prefix (`global.`, `us.`, `eu.`, …).
   const base = modelId.replace(/^(?:[a-z]{2,6}\.)?anthropic\./, "");
-  return /^claude-(?:3-7-sonnet|sonnet-4|opus-4|haiku-4)/.test(base);
+  return base.startsWith("claude-") && !BEDROCK_UNCACHEABLE_CLAUDE.test(base);
 }
 
 /**
@@ -89,13 +99,13 @@ export function withCachedLastMessage(
 
   return messages.map((msg, i) => {
     if (i === messages.length - 1) {
-      return {
-        ...msg,
-        providerOptions: {
-          ...msg.providerOptions,
-          ...breakpoint,
-        },
-      };
+      // Merge inside the provider's namespace — a top-level spread would drop
+      // any sibling options the message already carries for that provider.
+      const merged = { ...msg.providerOptions };
+      for (const [provider, options] of Object.entries(breakpoint)) {
+        merged[provider] = { ...merged[provider], ...options };
+      }
+      return { ...msg, providerOptions: merged };
     }
     return msg;
   });

--- a/src/core/ai/providers/pensarFormatters.test.ts
+++ b/src/core/ai/providers/pensarFormatters.test.ts
@@ -112,3 +112,161 @@ describe("convertToBedrockFormat → Responses API (GPT 5.5)", () => {
     expect(Array.isArray(body.messages)).toBe(true);
   });
 });
+
+describe("convertToBedrockFormat → Anthropic cache breakpoints", () => {
+  const CLAUDE = "anthropic.claude-opus-4-6-v1";
+  const CACHED = {
+    providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
+  };
+  const EPHEMERAL = { type: "ephemeral" };
+
+  it("puts cache_control on the system block", () => {
+    const body = convertToBedrockFormat(
+      CLAUDE,
+      baseOptions({
+        prompt: [
+          { role: "system", content: "You are a pentester.", ...CACHED },
+          { role: "user", content: [{ type: "text", text: "Scan this." }] },
+        ],
+      } as unknown as Partial<LanguageModelV3CallOptions>),
+    );
+    expect(body.system).toEqual([
+      {
+        type: "text",
+        text: "You are a pentester.",
+        cache_control: EPHEMERAL,
+      },
+    ]);
+  });
+
+  it("keeps the system prompt a bare string when uncached", () => {
+    const body = convertToBedrockFormat(CLAUDE, baseOptions());
+    expect(body.system).toBe("You are a pentester.");
+  });
+
+  it("puts cache_control on a cached user message", () => {
+    const body = convertToBedrockFormat(
+      CLAUDE,
+      baseOptions({
+        prompt: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Scan this." }],
+            ...CACHED,
+          },
+        ],
+      } as unknown as Partial<LanguageModelV3CallOptions>),
+    );
+    expect(body.messages).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Scan this.", cache_control: EPHEMERAL },
+        ],
+      },
+    ]);
+  });
+
+  it("puts cache_control on the last tool_result block", () => {
+    // The incremental breakpoint lands on a tool-result turn for most of an
+    // agent loop; without this it was silently dropped.
+    const body = convertToBedrockFormat(
+      CLAUDE,
+      baseOptions({
+        prompt: [
+          { role: "user", content: [{ type: "text", text: "Scan this." }] },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "call_1",
+                toolName: "http_get",
+                input: { url: "https://example.com" },
+              },
+            ],
+          },
+          {
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: "call_1",
+                toolName: "http_get",
+                output: { type: "text", value: "200 OK" },
+              },
+            ],
+            ...CACHED,
+          },
+        ],
+      } as unknown as Partial<LanguageModelV3CallOptions>),
+    );
+    const messages = body.messages as Array<{
+      role: string;
+      content: Array<Record<string, unknown>>;
+    }>;
+    expect(messages[2]).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_1",
+          content: "200 OK",
+          cache_control: EPHEMERAL,
+        },
+      ],
+    });
+  });
+
+  it("puts cache_control on a text-only assistant message", () => {
+    const body = convertToBedrockFormat(
+      CLAUDE,
+      baseOptions({
+        prompt: [
+          { role: "user", content: [{ type: "text", text: "Scan this." }] },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "On it." }],
+            ...CACHED,
+          },
+        ],
+      } as unknown as Partial<LanguageModelV3CallOptions>),
+    );
+    const messages = body.messages as Array<Record<string, unknown>>;
+    expect(messages[1]).toEqual({
+      role: "assistant",
+      content: [{ type: "text", text: "On it.", cache_control: EPHEMERAL }],
+    });
+  });
+
+  it("skips a trailing thinking block, which rejects cache_control", () => {
+    const body = convertToBedrockFormat(
+      CLAUDE,
+      baseOptions({
+        prompt: [
+          { role: "user", content: [{ type: "text", text: "Scan this." }] },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "call_1",
+                toolName: "http_get",
+                input: {},
+              },
+              { type: "reasoning", text: "thinking out loud" },
+            ],
+            ...CACHED,
+          },
+        ],
+      } as unknown as Partial<LanguageModelV3CallOptions>),
+    );
+    const messages = body.messages as Array<{
+      content: Array<Record<string, unknown>>;
+    }>;
+    expect(messages[1].content.at(-1)).toEqual({
+      type: "thinking",
+      thinking: "thinking out loud",
+    });
+  });
+});

--- a/src/core/ai/providers/pensarFormatters.ts
+++ b/src/core/ai/providers/pensarFormatters.ts
@@ -172,6 +172,34 @@ function hasCacheControl(part: Record<string, unknown>): boolean {
   return !!opts?.anthropic?.cacheControl;
 }
 
+/**
+ * Anthropic carries the breakpoint on a content block, so mirror the part's
+ * cache_control onto the last block emitted for it. Without this the
+ * incremental breakpoint `withCachedLastMessage` sets is dropped on every
+ * assistant and tool-result turn — i.e. most of an agent loop.
+ */
+function applyCacheControl(message: {
+  role: string;
+  content: string | Array<Record<string, unknown>>;
+}): void {
+  if (typeof message.content === "string") {
+    // An empty text block is rejected outright; leave it alone.
+    if (message.content === "") return;
+    message.content = [
+      {
+        type: "text",
+        text: message.content,
+        cache_control: EPHEMERAL_CACHE_CONTROL,
+      },
+    ];
+    return;
+  }
+  const last = message.content[message.content.length - 1];
+  // cache_control is not accepted on thinking blocks.
+  if (!last || last.type === "thinking") return;
+  last.cache_control = EPHEMERAL_CACHE_CONTROL;
+}
+
 function convertToAnthropicFormat(
   modelId: string,
   options: LanguageModelV3CallOptions,
@@ -192,9 +220,6 @@ function convertToAnthropicFormat(
           part as unknown as Record<string, unknown>,
         );
       } else if (part.role === "user") {
-        const partHasCache = hasCacheControl(
-          part as unknown as Record<string, unknown>,
-        );
         const text = (part.content as Array<LanguageModelV3TextPart>)
           .map((c: LanguageModelV3TextPart) => {
             if (c.type === "text") return c.text;
@@ -202,16 +227,7 @@ function convertToAnthropicFormat(
             return "";
           })
           .join("");
-        if (partHasCache) {
-          messages.push({
-            role: "user",
-            content: [
-              { type: "text", text, cache_control: EPHEMERAL_CACHE_CONTROL },
-            ],
-          });
-        } else {
-          messages.push({ role: "user", content: text });
-        }
+        messages.push({ role: "user", content: text });
       } else if (part.role === "assistant") {
         const assistantContent = part.content as unknown as Array<
           Record<string, unknown>
@@ -281,6 +297,15 @@ function convertToAnthropicFormat(
           };
         });
         messages.push({ role: "user", content: toolResults });
+      }
+
+      const pushed = messages[messages.length - 1];
+      if (
+        part.role !== "system" &&
+        pushed &&
+        hasCacheControl(part as unknown as Record<string, unknown>)
+      ) {
+        applyCacheControl(pushed);
       }
     }
   }

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -32,8 +32,13 @@ import { createPensarModel } from "./providers/pensar";
 const log = scopedLogger(() => createLogger("ai:utils"));
 
 /**
- * Check if a model uses an Anthropic-compatible provider that supports prompt caching.
- * Direct Anthropic, AWS Bedrock (Claude), and Pensar gateway (routes to Bedrock) all support cache_control.
+ * Check if a model is served by a provider that speaks Anthropic's thinking
+ * options — direct Anthropic, AWS Bedrock, and the Pensar gateway (which routes
+ * to Bedrock). Callers pair this with a model-level capability check, since the
+ * Bedrock provider also serves non-Claude models.
+ *
+ * Not a prompt-caching check: cache breakpoints are namespaced per provider and
+ * live in `cacheBreakpointFor` (see caching.ts).
  */
 export function isAnthropicProvider(model: AIModel): boolean {
   const { provider } = getModelInfo(model);


### PR DESCRIPTION
Prompt caching was configured everywhere and engaging almost nowhere. Two separate failures, both silent.

## What was broken

**Bedrock — no caching at all.** `caching.ts` set `providerOptions.anthropic.cacheControl` for every provider it treated as Anthropic-compatible. Provider options are namespaced by provider id, and `@ai-sdk/amazon-bedrock` reads only `providerOptions.bedrock.cachePoint`. The key was dropped with no error and no warning, so no breakpoint ever reached the API.

**Pensar gateway — caching stopped after the prefix.** The gateway speaks the native Anthropic Messages API and hand-builds `cache_control`, but `convertToAnthropicFormat` only honoured it on system and user parts. The incremental breakpoint `withCachedLastMessage` sets lands on an assistant or tool-result turn for most of an agent loop, so it was discarded on nearly every turn. The static prefix cached; the growing conversation never did.

## Effects

| Path | Before | After |
|---|---|---|
| Bedrock (Claude) | Zero breakpoints — the full prefix re-billed at full input rate on **every** turn | Prefix cached; cache reads bill at ~10% of input rate |
| Pensar gateway | System prefix cached; conversation re-billed every turn | Prefix **and** conversation cache incrementally |
| Direct Anthropic API | Working | Unchanged |
| Non-Claude Bedrock (DeepSeek, …) | Uncached | Uncached — now deliberately, see below |

The cost shape matters more than the percentage: an agent loop re-sends a growing conversation on every step, so the same system prompt and tool definitions were paying full price dozens of times per run. On the probe below that prefix is ~26k tokens.

## The fix

`cacheBreakpointFor(model)` resolves the breakpoint **per model** instead of per provider:

- `anthropic` / `pensar` → `anthropic.cacheControl`
- `bedrock` → `bedrock.cachePoint`, but only when the model supports it
- anything else → `undefined`, and the model runs uncached

`withCachedSystemPrompt` / `withCachedLastMessage` now take that breakpoint and no-op when it is `undefined`. `withCachedLastMessage` also merges *inside* the provider namespace — the previous top-level spread would have dropped any sibling options the message already carried for that provider.

On the gateway side, `applyCacheControl` mirrors a part's `cache_control` onto the last content block it emits, so assistant and tool-result turns keep the breakpoint. Trailing `thinking` blocks are skipped because they reject `cache_control`.

### Why not just swap the key

That was the obvious one-line fix and it would have broken models. `isAnthropicProvider()` is true for *every* Bedrock model, and Bedrock rejects a cache point outright on models that don't support caching — `us.deepseek.r1-v1:0` returns *"You invoked an unsupported model or your request did not allow prompt caching."* Blanket-swapping the namespace would have turned a silent cost bug into hard failures on non-Claude Bedrock models.

Model support is a **deny-list** (`claude-v2`, `claude-instant`, the `claude-3-…` line) rather than an allow-list, so a newly added Claude picks caching up automatically instead of silently losing it — which is the exact failure mode this PR exists to fix. Those legacy ids are end-of-life on Bedrock anyway and fail before caching is reached.

`isAnthropicProvider` keeps its thinking-options role and its doc comment now says it is not a caching check.

## Verification

Measured against live Bedrock (`global.anthropic.claude-haiku-4-5-20251001-v1:0`, us-east-1) by sending an identical ~26k-token prompt twice under each namespace:

| `providerOptions` namespace | call 1 | call 2 |
|---|---|---|
| `anthropic.cacheControl` (before) | `cacheWrite=0`, `cacheRead=0` | `cacheWrite=0`, `cacheRead=0` |
| `bedrock.cachePoint` (after) | `cacheWrite=25812`, `cacheRead=0` | `cacheWrite=0`, `cacheRead=25812` |

Reproduced independently of the branch, so it confirms the diagnosis rather than just the patch.

One thing worth knowing for anyone reading usage numbers: `usage.inputTokens` was **25825 on all four calls**. Bedrock still counts cached tokens there — the split lives only in `providerMetadata.bedrock` and the SDK's normalized `usage.inputTokenDetails`. Total input tokens will not visibly drop when caching starts working, so it cannot be used as a signal that this fix is live.

Unit coverage in `caching.test.ts` and `pensarFormatters.test.ts`: namespace per provider, the DeepSeek/non-Claude and legacy-Claude gates, namespace-scoped merging, and gateway `cache_control` placement on system, user, assistant, tool-result and trailing-thinking cases.

The live A/B covers the Bedrock path. The gateway change is covered at the formatter boundary by unit tests, not by a live gateway call.

Full suite green: 1470 passed, 17 skipped. `tsc --noEmit` and `biome check` clean on the touched files.

## Confirming it in a running deployment

Total input tokens are the wrong thing to watch — as above, `usage.inputTokens` still counts cached tokens, so it does not drop when caching starts working.

On Bedrock the signal is in CloudWatch. The `AWS/Bedrock` namespace publishes `CacheReadInputTokenCount` and `CacheWriteInputTokenCount` alongside `InputTokenCount`, so:

```
hit ratio = CacheRead / (CacheRead + InputTokenCount)
```

That ratio is volume-independent, which makes a before/after comparison across the deploy meaningful even if traffic changes in between. On an agent workload it should move by an order of magnitude or more once breakpoints are actually going out — the system prompt and tool definitions are re-sent on every turn, so they dominate the cacheable prefix.

Cost Explorer exposes the same split as separate `…CacheReadInputTokenCount…` / `…CacheWriteInputTokenCount…` usage types for the dollar view. Note that cache writes bill at 1.25× input, so a workload that writes far more than it reads (very short sessions, or a prefix that changes every turn) can cost more rather than less — the hit ratio is the number to watch, not the write count.
