### PR TITLE
fix(shell): cap execute_command runtime so a hung command can't freeze the agent

### DIFF
--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -73,7 +73,7 @@ const executeCommandInputSchema = z.object({
     .number()
     .optional()
     .describe(
-      "Timeout in seconds. If omitted, the command runs until completion or abort.",
+      "Timeout in seconds. If omitted, a hard maximum is applied so a hung command cannot stall the session; set an explicit, conservative value for long scans.",
     ),
   allow_unprotected: z
     .boolean()

--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  DEFAULT_MAX_EXECUTE_TIMEOUT_SECONDS,
   extractFallbackStdout,
   getApexTmpRoot,
   PersistentShell,
@@ -481,6 +482,60 @@ describe("PersistentShell — long-running stability", () => {
     expect(final.stdout).toContain("final");
     expect(elapsed).toBeLessThan(3_000);
   }, 60_000);
+
+  // Regression: a command with no explicit timeout must not run unbounded.
+  // Before the ceiling, `execute(cmd)` with no timeout armed no timer, so a
+  // hung command held the shell mutex forever and froze the agent.
+  it("force-kills a no-timeout command at the ceiling", async () => {
+    const shell = new PersistentShell({ maxExecuteTimeoutSeconds: 2 });
+    shells.push(shell);
+
+    const start = Date.now();
+    const result = await shell.execute("sleep 30"); // no timeout arg
+    const elapsed = Date.now() - start;
+
+    expect(result.exitCode).toBe(124); // timed out at the ceiling
+    expect(elapsed).toBeLessThan(6_000); // ~2s + salvage grace, not 30s
+  }, 15_000);
+
+  // Regression for the production freeze: a no-timeout hang must not starve the
+  // next queued command. Before the fix, cmd2 (no timeout) held the mutex
+  // forever and cmd3 never ran, even though cmd3 had its own timeout — a queued
+  // command can't arm its timer until it acquires the turn.
+  it("a no-timeout hang does not permanently starve the next command", async () => {
+    const shell = new PersistentShell({ maxExecuteTimeoutSeconds: 2 });
+    shells.push(shell);
+
+    const start = Date.now();
+    const [hung, next] = await Promise.all([
+      shell.execute("sleep 30"), // no timeout -> ceiling-killed
+      shell.execute("echo after-hang", 10),
+    ]);
+    const elapsed = Date.now() - start;
+
+    expect(hung.exitCode).toBe(124);
+    expect(next.exitCode).toBe(0);
+    expect(next.stdout).toContain("after-hang");
+    expect(elapsed).toBeLessThan(8_000); // both done shortly after the ceiling
+  }, 20_000);
+
+  // An explicit timeout above the ceiling is clamped down to it.
+  it("clamps an explicit timeout above the ceiling", async () => {
+    const shell = new PersistentShell({ maxExecuteTimeoutSeconds: 2 });
+    shells.push(shell);
+
+    const start = Date.now();
+    const result = await shell.execute("sleep 30", 60); // asks 60s, capped at 2s
+    const elapsed = Date.now() - start;
+
+    expect(result.exitCode).toBe(124);
+    expect(elapsed).toBeLessThan(6_000);
+  }, 15_000);
+
+  it("exposes a finite, positive default ceiling", () => {
+    expect(Number.isFinite(DEFAULT_MAX_EXECUTE_TIMEOUT_SECONDS)).toBe(true);
+    expect(DEFAULT_MAX_EXECUTE_TIMEOUT_SECONDS).toBeGreaterThan(0);
+  });
 });
 
 describe("extractFallbackStdout", () => {

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -14,6 +14,14 @@ import { join } from "node:path";
 
 const MAX_BUFFER = 5_000_000;
 
+// Hard ceiling on how long a single command may hold the shell. Commands are
+// serialized through one mutex (see `writeChain`), so a command that never
+// resolves — a no-timeout network probe against a black-holed host — would hold
+// the mutex forever and starve every later command, freezing the whole agent.
+// An always-armed ceiling guarantees the mutex is always released. 600s sits
+// well under the sandbox's 3600s budget; tune via the constructor option.
+export const DEFAULT_MAX_EXECUTE_TIMEOUT_SECONDS = 600;
+
 // Node-owned per-PID tempfile root. Paths are substituted into the wrapper
 // (not `mktemp` inside bash) so kill paths can fs.readFileSync directly —
 // Bun's child_process pipe drops bytes written after a descendant signal.
@@ -198,6 +206,7 @@ export class PersistentShell {
   private disposed = false;
   private readonly cwd?: string;
   private readonly extraEnv?: Record<string, string>;
+  private readonly maxExecuteTimeoutSeconds: number;
 
   private current: PendingCommand | null = null;
   private pendingCancel: ((result: ShellExecuteResult) => void) | null = null;
@@ -207,9 +216,19 @@ export class PersistentShell {
   // `this.current` and cross-contaminate output.
   private writeChain: Promise<void> = Promise.resolve();
 
-  constructor(opts?: { cwd?: string; env?: Record<string, string> }) {
+  constructor(opts?: {
+    cwd?: string;
+    env?: Record<string, string>;
+    // Hard ceiling (seconds) a single command may run before it is force-killed
+    // and its turn released. Defaults to DEFAULT_MAX_EXECUTE_TIMEOUT_SECONDS.
+    maxExecuteTimeoutSeconds?: number;
+  }) {
     this.cwd = opts?.cwd;
     this.extraEnv = opts?.env;
+    this.maxExecuteTimeoutSeconds =
+      opts?.maxExecuteTimeoutSeconds && opts.maxExecuteTimeoutSeconds > 0
+        ? opts.maxExecuteTimeoutSeconds
+        : DEFAULT_MAX_EXECUTE_TIMEOUT_SECONDS;
   }
 
   private spawn(): void {
@@ -504,17 +523,26 @@ export class PersistentShell {
             abortSignal.removeEventListener("abort", onAbort);
         }
 
-        if (timeoutSeconds != null && timeoutSeconds > 0) {
-          timeoutTimer = setTimeout(() => {
-            if (resolved) return;
-            pending.forcedExitCode = 124;
-            pending.killEscalationTimer = scheduleSalvageKill(
-              proc.pid,
-              pending,
-              124,
-            );
-          }, timeoutSeconds * 1_000);
-        }
+        // Always arm a timeout, clamped to the hard ceiling. A missing/invalid
+        // per-command timeout falls back to the ceiling rather than running
+        // unbounded — an unbounded command holds the shell mutex forever and
+        // starves every later command (frozen agent). An explicit timeout above
+        // the ceiling is clamped down.
+        const effectiveTimeoutSeconds = Math.min(
+          timeoutSeconds != null && timeoutSeconds > 0
+            ? timeoutSeconds
+            : this.maxExecuteTimeoutSeconds,
+          this.maxExecuteTimeoutSeconds,
+        );
+        timeoutTimer = setTimeout(() => {
+          if (resolved) return;
+          pending.forcedExitCode = 124;
+          pending.killEscalationTimer = scheduleSalvageKill(
+            proc.pid,
+            pending,
+            124,
+          );
+        }, effectiveTimeoutSeconds * 1_000);
 
         // Wrap command:
         //   - brace group `{ ...; }` (NOT a subshell) so cd/export/aliases persist;


### PR DESCRIPTION
## Problem

Blackbox recon / offensive-security agents froze mid-run in production (jobs stuck showing `RUNNING` for hours), always right after the model fired shell commands against an unreachable/filtered host. The process stayed alive (memory heartbeat kept logging), but no further tool calls executed.

**Root cause.** The agent runs every shell command through one per-agent persistent bash shell (`PersistentShell`). Concurrent `execute()` calls are serialized by a single async mutex (`writeChain`/`acquireTurn`); a command's turn is released only in `execute`'s `finally`, after its promise resolves. But the timeout timer was armed **only** when a positive `timeoutSeconds` was passed:

```ts
if (timeoutSeconds != null && timeoutSeconds > 0) { /* arm timer */ }
```

…and the `execute_command` tool's `timeout` arg is `optional` with no default and no ceiling ("If omitted, the command runs until completion or abort"). So a command sent without a timeout, against a black-holed host that never returns, ran unbounded, **held the mutex forever, and starved every later command** — a permanent agent freeze. A queued command couldn't save itself: its own timeout is armed only *after* it acquires the turn, so it waited behind the wedged command with its timer never started.

Two independent ceilings were missing (the second — a recon-job reaper — is tracked separately on the console side); this PR fixes the tool-level one, which is the actual deadlock.

## Fix

Always arm the timeout, clamped to a hard ceiling:

- `DEFAULT_MAX_EXECUTE_TIMEOUT_SECONDS = 600` (well under the sandbox's 3600s budget), overridable via a new `maxExecuteTimeoutSeconds` constructor option.
- A missing/invalid per-command timeout falls back to the ceiling instead of running unbounded.
- An explicit timeout above the ceiling is clamped down.

This guarantees the mutex is always released, so one hung command can never freeze the shell. Tool-schema description updated to match; `normalizeExecuteCommandTimeout` semantics are unchanged (still returns `undefined` for "no explicit timeout" — the ceiling lives at the single choke point in `PersistentShell.execute`).

## Verification — this is the important part

Three regression tests reproduce the production freeze and are proven to fail without the fix:

| Test | Without fix | With fix |
|------|-------------|----------|
| `force-kills a no-timeout command at the ceiling` | times out (15s) | ✅ killed at ceiling, exit 124 |
| `a no-timeout hang does not permanently starve the next command` | times out (20s) | ✅ next command runs |
| `clamps an explicit timeout above the ceiling` | times out (15s) | ✅ killed at ceiling |

Confirmed locally by reverting only the timer-arming change (keeping the ceiling plumbing so it compiles) and watching all three time out, then restoring:

```
BEFORE:  Tests  3 failed  (all time out — the deadlock)
AFTER:   Tests  47 passed (full persistentShell suite)
```

- `bunx vitest run …/persistentShell.test.ts` → **47 passed** (44 existing + 3 regressions + 1 constant assertion)
- `bunx vitest run …/executeCommand.test.ts` → **14 passed**
- `bun run tsc` → exit 0
- `biome check` on the three files → no new warnings (base commit already carries the same 4 pre-existing warnings on unchanged lines)

Tests use a small `maxExecuteTimeoutSeconds` (2s) via the new constructor option, so they run in a few seconds.

## Follow-ups (not in this PR)
- Console-side: add a recon-job reaper (mirroring `stuckScanReaper`) so any future wedge — from any cause — self-recovers instead of showing `RUNNING` forever.
- Console-side: submodule bump to pick this up once merged.