### PR TITLE
fix(browser): match Camoufox window to Xvfb display tier

### DIFF
--- a/src/core/agents/offSecAgent/tools/camoufox.test.ts
+++ b/src/core/agents/offSecAgent/tools/camoufox.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CAMOUFOX_OPTIONS,
+  COMPUTER_USE_VIEWPORT_SIZE,
+  camoufoxWindowOptions,
+  ENDPOINT_DISPLAY_BASE,
+  ENDPOINT_VIEWPORT_SIZE,
   MEMORY_FIREFOX_PREFS,
+  parseDisplayNumber,
+  parseViewportSize,
   resolveCamoufoxLaunchOptions,
+  viewportSizeForDisplay,
 } from "./camoufox";
 
 const launchOptionsMock = vi.fn();
@@ -13,6 +20,44 @@ vi.mock("camoufox-js", () => ({
 
 afterEach(() => {
   launchOptionsMock.mockReset();
+});
+
+describe("display-tier viewport helpers", () => {
+  it("parses WIDTH,HEIGHT viewport strings", () => {
+    expect(parseViewportSize("1280,720")).toEqual([1280, 720]);
+    expect(parseViewportSize(" 1920,1080 ")).toEqual([1920, 1080]);
+    expect(parseViewportSize("bad")).toBeUndefined();
+    expect(parseViewportSize("0,720")).toBeUndefined();
+  });
+
+  it("parses :N display strings", () => {
+    expect(parseDisplayNumber(":0")).toBe(0);
+    expect(parseDisplayNumber(":11")).toBe(11);
+    expect(parseDisplayNumber(":10.0")).toBe(10);
+    expect(parseDisplayNumber(undefined)).toBeUndefined();
+    expect(parseDisplayNumber("DISPLAY")).toBeUndefined();
+  });
+
+  it("maps endpoint-tier displays to 720p and everything else to 1080p", () => {
+    expect(ENDPOINT_DISPLAY_BASE).toBe(10);
+    expect(viewportSizeForDisplay(":11")).toBe(ENDPOINT_VIEWPORT_SIZE);
+    expect(viewportSizeForDisplay(":10")).toBe(ENDPOINT_VIEWPORT_SIZE);
+    expect(viewportSizeForDisplay(":0")).toBe(COMPUTER_USE_VIEWPORT_SIZE);
+    expect(viewportSizeForDisplay(":9")).toBe(COMPUTER_USE_VIEWPORT_SIZE);
+    expect(viewportSizeForDisplay(undefined)).toBe(COMPUTER_USE_VIEWPORT_SIZE);
+  });
+
+  it("builds fingerprint-coherent window + screen constraints", () => {
+    expect(camoufoxWindowOptions([1280, 720])).toEqual({
+      window: [1280, 720],
+      screen: {
+        minWidth: 1280,
+        maxWidth: 1280,
+        minHeight: 720,
+        maxHeight: 720,
+      },
+    });
+  });
 });
 
 describe("resolveCamoufoxLaunchOptions", () => {
@@ -67,6 +112,30 @@ describe("resolveCamoufoxLaunchOptions", () => {
     expect(launchOptionsMock).toHaveBeenCalledWith({
       ...CAMOUFOX_OPTIONS,
       headless: true,
+    });
+  });
+
+  it("forwards a fixed window and matching screen constraints when provided", async () => {
+    launchOptionsMock.mockResolvedValue({
+      executablePath: "/opt/camoufox/camoufox-bin",
+      args: [],
+      env: {},
+      firefoxUserPrefs: {},
+      headless: false,
+    });
+
+    await resolveCamoufoxLaunchOptions(false, { window: [1280, 720] });
+
+    expect(launchOptionsMock).toHaveBeenCalledWith({
+      ...CAMOUFOX_OPTIONS,
+      headless: false,
+      window: [1280, 720],
+      screen: {
+        minWidth: 1280,
+        maxWidth: 1280,
+        minHeight: 720,
+        maxHeight: 720,
+      },
     });
   });
 });

--- a/src/core/agents/offSecAgent/tools/camoufox.ts
+++ b/src/core/agents/offSecAgent/tools/camoufox.ts
@@ -59,6 +59,84 @@ export const MEMORY_FIREFOX_PREFS: Record<string, unknown> = {
   "browser.sessionhistory.max_total_viewers": 0, // disable bfcache page retention
 };
 
+/**
+ * Display-tier viewport geometry for headed Camoufox.
+ *
+ * Console's per-endpoint desktops (`packages/agents/desktopSession.ts`) and the
+ * agent-image Xvfb shim (`packages/cluster-services/gen-purpose/desktop/Xvfb`)
+ * use `DISPLAY_BASE = 10`: displays `:0`–`:9` are the shared computer-use
+ * desktop at 1920x1080; `:10+` are per-endpoint desktops at 1280x720 (memory
+ * cap under concurrency). Keep these in sync — a mismatch makes the browser
+ * overflow/letterbox on the streamed desktop.
+ */
+export const ENDPOINT_DISPLAY_BASE = 10;
+export const COMPUTER_USE_VIEWPORT_SIZE = "1920,1080";
+export const ENDPOINT_VIEWPORT_SIZE = "1280,720";
+
+/** Parse `"WIDTH,HEIGHT"` into a Camoufox `window` tuple; undefined if invalid. */
+export function parseViewportSize(
+  viewportSize: string,
+): [number, number] | undefined {
+  const match = /^(\d+),(\d+)$/.exec(viewportSize.trim());
+  if (!match) return undefined;
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  if (
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    return undefined;
+  }
+  return [width, height];
+}
+
+/** Parse `":N"` / `":N.0"` display strings into N; undefined if unparseable. */
+export function parseDisplayNumber(
+  display: string | undefined,
+): number | undefined {
+  if (!display) return undefined;
+  const match = /^:(\d+)/.exec(display.trim());
+  if (!match) return undefined;
+  const num = Number(match[1]);
+  return Number.isFinite(num) ? num : undefined;
+}
+
+/**
+ * Default viewport for a bound X display. Endpoint desktops (`:10+`) are 720p;
+ * everything else (including no display / headless) stays at 1080p.
+ */
+export function viewportSizeForDisplay(display: string | undefined): string {
+  const num = parseDisplayNumber(display);
+  if (num !== undefined && num >= ENDPOINT_DISPLAY_BASE) {
+    return ENDPOINT_VIEWPORT_SIZE;
+  }
+  return COMPUTER_USE_VIEWPORT_SIZE;
+}
+
+/** Camoufox `window` + matching `screen` constraints (fingerprint-coherent). */
+export function camoufoxWindowOptions(window: [number, number]): {
+  window: [number, number];
+  screen: {
+    minWidth: number;
+    maxWidth: number;
+    minHeight: number;
+    maxHeight: number;
+  };
+} {
+  const [width, height] = window;
+  return {
+    window: [width, height],
+    screen: {
+      minWidth: width,
+      maxWidth: width,
+      minHeight: height,
+      maxHeight: height,
+    },
+  };
+}
+
 /** What camoufox-js `launchOptions()` returns: Playwright-firefox launch opts. */
 export interface CamoufoxLaunchOptions {
   executablePath: string;
@@ -74,6 +152,11 @@ export interface CamoufoxLaunchOptions {
   };
 }
 
+export interface ResolveCamoufoxLaunchOptionsOpts {
+  /** Fixed browser window size — must match the Xvfb geometry when headed. */
+  readonly window?: [number, number];
+}
+
 /**
  * Resolve Playwright-firefox launch options for the host (MCP) path.
  * `headless` is a plain boolean here — the host runtime has no virtual display,
@@ -81,21 +164,24 @@ export interface CamoufoxLaunchOptions {
  */
 export async function resolveCamoufoxLaunchOptions(
   headless: boolean,
+  opts?: ResolveCamoufoxLaunchOptionsOpts,
 ): Promise<CamoufoxLaunchOptions> {
   // Loaded lazily (and kept external from the bundle) so the CLI's startup
   // commands (--version/--help) don't pull camoufox-js + its data-file deps
   // (fingerprint-generator/territoryInfo.xml) at module load.
   const { launchOptions: camoufoxLaunchOptions } = await import("camoufox-js");
-  const opts = (await camoufoxLaunchOptions({
+  const windowOpts = opts?.window ? camoufoxWindowOptions(opts.window) : {};
+  const resolved = (await camoufoxLaunchOptions({
     ...CAMOUFOX_OPTIONS,
     headless,
+    ...windowOpts,
   })) as CamoufoxLaunchOptions;
   // Layer our memory prefs over Camoufox's fingerprint prefs (ours win).
-  opts.firefoxUserPrefs = {
-    ...opts.firefoxUserPrefs,
+  resolved.firefoxUserPrefs = {
+    ...resolved.firefoxUserPrefs,
     ...MEMORY_FIREFOX_PREFS,
   };
-  return opts;
+  return resolved;
 }
 
 let ensurePromise: Promise<void> | null = null;

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.test.ts
@@ -269,6 +269,45 @@ describe("PlaywrightMcpSession — constructor defaults", () => {
     });
   });
 
+  describe("display-tier viewport defaults", () => {
+    const originalDisplay = process.env.DISPLAY;
+    afterEach(() => {
+      if (originalDisplay === undefined) delete process.env.DISPLAY;
+      else process.env.DISPLAY = originalDisplay;
+      setViewportSize("1920,1080");
+    });
+
+    it("defaults endpoint-tier displays (:10+) to 1280x720", () => {
+      delete process.env.DISPLAY;
+      const session = new PlaywrightMcpSession({
+        display: ":11",
+      }) as unknown as InternalShape;
+      expect(session.viewportSize).toBe("1280,720");
+    });
+
+    it("defaults computer-use displays (:0–:9) to 1920x1080", () => {
+      delete process.env.DISPLAY;
+      const session = new PlaywrightMcpSession({
+        display: ":0",
+      }) as unknown as InternalShape;
+      expect(session.viewportSize).toBe("1920,1080");
+    });
+
+    it("uses process.env.DISPLAY for the tier when no explicit display is given", () => {
+      process.env.DISPLAY = ":12";
+      const session = new PlaywrightMcpSession() as unknown as InternalShape;
+      expect(session.viewportSize).toBe("1280,720");
+    });
+
+    it("lets an explicit viewportSize win over the display-tier default", () => {
+      const session = new PlaywrightMcpSession({
+        display: ":11",
+        viewportSize: "800,600",
+      }) as unknown as InternalShape;
+      expect(session.viewportSize).toBe("800,600");
+    });
+  });
+
   it("falls back to a hardcoded 1920x1080 floor for viewport even if the module default was cleared (regression: don't ship a Chromium-tiny viewport just because someone called setViewportSize(undefined))", () => {
     const original = "1920,1080";
     try {

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -25,7 +25,12 @@ import { z } from "zod";
 import type { Logger } from "../../../logger";
 import {
   type CamoufoxLaunchOptions,
+  COMPUTER_USE_VIEWPORT_SIZE,
+  ENDPOINT_DISPLAY_BASE,
+  ENDPOINT_VIEWPORT_SIZE,
   ensureCamoufox,
+  parseDisplayNumber,
+  parseViewportSize,
   resolveCamoufoxLaunchOptions,
 } from "./camoufox";
 
@@ -413,19 +418,20 @@ let defaultUserAgent: string | undefined =
 
 /**
  * Hard floor for viewport size — used when both the explicit constructor
- * arg and the module-level default are `undefined`. Guarantees that
- * `new PlaywrightMcpSession()` always launches Chromium at a real desktop
- * resolution and never silently falls back to Chromium's tiny built-in
- * default just because someone called `setViewportSize(undefined)`.
+ * arg and the module-level default are `undefined`, and the session is not
+ * on an endpoint-tier display. Guarantees that `new PlaywrightMcpSession()`
+ * always launches at a real desktop resolution and never silently falls
+ * back to Chromium's tiny built-in just because someone called
+ * `setViewportSize(undefined)`. Must match computer-use Xvfb (Console shim).
  *
  * The only way to opt out is to pass `null` explicitly to the constructor.
  */
-const HARDCODED_VIEWPORT_FALLBACK = "1920,1080";
+const HARDCODED_VIEWPORT_FALLBACK = COMPUTER_USE_VIEWPORT_SIZE;
 
 /**
  * Default viewport size (format: `WIDTH,HEIGHT`) for new browser sessions.
- * 1920x1080 matches a standard desktop resolution and avoids the small
- * default viewport that some SPAs use as a mobile/bot signal.
+ * 1920x1080 matches computer-use desktops; endpoint displays (`:10+`) override
+ * to 1280x720 in the constructor so Camoufox fills the streamed Xvfb.
  */
 let defaultViewportSize: string | undefined = HARDCODED_VIEWPORT_FALLBACK;
 
@@ -527,10 +533,23 @@ export class PlaywrightMcpSession {
     this.headless = headless ?? (this.display ? false : defaultHeadless);
     this.userAgent =
       userAgent === null ? undefined : (userAgent ?? defaultUserAgent);
-    this.viewportSize =
-      viewportSize === null
-        ? undefined
-        : (viewportSize ?? defaultViewportSize ?? HARDCODED_VIEWPORT_FALLBACK);
+    // Viewport resolution:
+    //   1. explicit `viewportSize` / `null` opt-out
+    //   2. endpoint-tier display (`:10+`) → 1280x720 (matches Console Xvfb)
+    //   3. module default / 1920x1080 floor (matches computer-use `:0`–`:9`)
+    // `ENDPOINT_DISPLAY_BASE` must stay aligned with Console desktopSession.ts
+    // and the agent-image Xvfb shim.
+    if (viewportSize === null) {
+      this.viewportSize = undefined;
+    } else if (viewportSize !== undefined) {
+      this.viewportSize = viewportSize;
+    } else {
+      const displayNum = parseDisplayNumber(this.display);
+      this.viewportSize =
+        displayNum !== undefined && displayNum >= ENDPOINT_DISPLAY_BASE
+          ? ENDPOINT_VIEWPORT_SIZE
+          : (defaultViewportSize ?? HARDCODED_VIEWPORT_FALLBACK);
+    }
 
     // Snapshot headers so post-construction mutations don't leak in.
     const headerSource =
@@ -675,8 +694,15 @@ export class PlaywrightMcpSession {
         // Resolve once per session lifetime so reconnects keep the same fingerprint.
         await ensureCamoufox();
         if (!this.cachedCamouOptions) {
+          // Apply viewportSize as Camoufox `window` so the headed browser fills
+          // the bound Xvfb desktop (previously stored but never forwarded —
+          // Camoufox randomised the window and overflowed 720p endpoint streams).
+          const window = this.viewportSize
+            ? parseViewportSize(this.viewportSize)
+            : undefined;
           this.cachedCamouOptions = await resolveCamoufoxLaunchOptions(
             this.headless,
+            window ? { window } : undefined,
           );
         }
         const camou = this.cachedCamouOptions;

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -26,7 +26,14 @@ import {
   resolveEffectiveHeaders,
   stripBrowserManagedHeaders,
 } from "../../../http/targetHeaders";
-import { CAMOUFOX_OPTIONS, MEMORY_FIREFOX_PREFS } from "./camoufox";
+import {
+  CAMOUFOX_OPTIONS,
+  COMPUTER_USE_VIEWPORT_SIZE,
+  ENDPOINT_DISPLAY_BASE,
+  ENDPOINT_VIEWPORT_SIZE,
+  MEMORY_FIREFOX_PREFS,
+  parseViewportSize,
+} from "./camoufox";
 import type {
   BrowserClickResult,
   BrowserConsoleResult,
@@ -305,13 +312,35 @@ const fs = require('fs');
   // detectable headful. Falls back to plain headless, which is still fully
   // fingerprint-spoofed (just a weaker stealth posture, never vanilla Chromium).
   const __headless = process.env.DISPLAY ? false : true;
+  // Match Camoufox window to the bound Xvfb tier (Console desktopSession /
+  // Xvfb shim: :0–:9 → 1920x1080, :10+ → 1280x720). Constants are inlined
+  // from ./camoufox so host + sandbox stay lockstep.
+  const __ENDPOINT_DISPLAY_BASE = ${ENDPOINT_DISPLAY_BASE};
+  const __endpointWindow = ${JSON.stringify(parseViewportSize(ENDPOINT_VIEWPORT_SIZE))};
+  const __computerUseWindow = ${JSON.stringify(parseViewportSize(COMPUTER_USE_VIEWPORT_SIZE))};
+  const __displayMatch = /^:(\\d+)/.exec(process.env.DISPLAY || '');
+  const __displayNum = __displayMatch ? Number(__displayMatch[1]) : undefined;
+  const __window =
+    __displayNum !== undefined && __displayNum >= __ENDPOINT_DISPLAY_BASE
+      ? __endpointWindow
+      : __computerUseWindow;
   // Resolve Camoufox options once per sandbox session and cache to disk so
   // every tool call presents the same fingerprint on the shared profile dir.
   let __camou;
   try {
     __camou = JSON.parse(fs.readFileSync('${SANDBOX_CAMOU_CACHE}', 'utf-8'));
   } catch {
-    __camou = await launchOptions({ ...${JSON.stringify(CAMOUFOX_OPTIONS)}, headless: __headless });
+    __camou = await launchOptions({
+      ...${JSON.stringify(CAMOUFOX_OPTIONS)},
+      headless: __headless,
+      window: __window,
+      screen: {
+        minWidth: __window[0],
+        maxWidth: __window[0],
+        minHeight: __window[1],
+        maxHeight: __window[1],
+      },
+    });
     fs.writeFileSync('${SANDBOX_CAMOU_CACHE}', JSON.stringify(__camou));
   }
 


### PR DESCRIPTION
viewportSize was stored on PlaywrightMcpSession but never applied to Camoufox launch, so headed browsers got a random fingerprint window on per-endpoint 720p desktops and overflowed the stream/recording.

Wire viewportSize into camoufox-js window/screen options, default endpoint-tier displays (:10+) to 1280x720, and keep computer-use (:0–:9) at 1920x1080. Mirror the same geometry on the sandbox launch path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Browser launch and viewport defaults only; no auth or data-path changes. Main operational risk is `ENDPOINT_DISPLAY_BASE` drifting from Console/Xvfb if those are changed elsewhere without updating `camoufox.ts`.
> 
> **Overview**
> Fixes headed Camoufox sessions overflowing or letterboxing on streamed desktops by **applying** `viewportSize` to Camoufox launch (it was stored on `PlaywrightMcpSession` but never forwarded, so Camoufox used a random fingerprint window).
> 
> **Display-tier defaults** (aligned with Console `desktopSession` / Xvfb `DISPLAY_BASE = 10`): `:10+` → **1280×720**, `:0`–`:9` and no display → **1920×1080**. Explicit `viewportSize` still wins.
> 
> **`camoufox.ts`** adds shared helpers (`parseViewportSize`, `parseDisplayNumber`, `viewportSizeForDisplay`, `camoufoxWindowOptions`) and extends `resolveCamoufoxLaunchOptions` with optional fixed `window` + matching `screen` constraints.
> 
> **MCP path** (`playwrightMcp.ts`): constructor picks tier from `DISPLAY`; launch passes parsed window into Camoufox. **Sandbox path** (`sandboxPlaywright.ts`): generated scripts pick window from `process.env.DISPLAY` with the same inlined constants.
> 
> Tests cover helpers, launch option forwarding, and session viewport defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5984ea866e61c05fa65dea0637a1e7e98b8d26d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->