### PR TITLE
fix(workflows): announce and complete every subagent that carries a subagentId

### DIFF
--- a/src/core/workflows/fastStrike.ts
+++ b/src/core/workflows/fastStrike.ts
@@ -135,16 +135,24 @@ export async function runFastStrike(
     input: { target },
   });
 
-  const strikeResult = await agent.consume();
+  let strikeResult: FastStrikeOutcome;
+  try {
+    strikeResult = await agent.consume();
+    eventBus?.emit("subagent-complete", {
+      subagentId: "fast-strike",
+      status: "completed",
+    });
+  } catch (e) {
+    eventBus?.emit("subagent-complete", {
+      subagentId: "fast-strike",
+      status: "failed",
+    });
+    throw e;
+  }
 
   if (abortSignal?.aborted) {
     throw new DOMException("Pentest aborted by user", "AbortError");
   }
-
-  eventBus?.emit("subagent-complete", {
-    subagentId: "fast-strike",
-    status: "completed",
-  });
 
   await findingsRegistry.groupByRootCause();
   const findings = [...findingsRegistry.getFindings()];

--- a/src/core/workflows/fastStrike.ts
+++ b/src/core/workflows/fastStrike.ts
@@ -141,6 +141,11 @@ export async function runFastStrike(
     throw new DOMException("Pentest aborted by user", "AbortError");
   }
 
+  eventBus?.emit("subagent-complete", {
+    subagentId: "fast-strike",
+    status: "completed",
+  });
+
   await findingsRegistry.groupByRootCause();
   const findings = [...findingsRegistry.getFindings()];
 

--- a/src/core/workflows/fastStrike.ts
+++ b/src/core/workflows/fastStrike.ts
@@ -129,6 +129,12 @@ export async function runFastStrike(
     openAIReasoningEffort,
   });
 
+  eventBus?.emit("subagent-spawn", {
+    subagentId: "fast-strike",
+    name: "Fast Strike",
+    input: { target },
+  });
+
   const strikeResult = await agent.consume();
 
   if (abortSignal?.aborted) {

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -306,6 +306,14 @@ export async function runPentestSwarm(
             openAIReasoningEffort,
             display,
           });
+
+          eventBus?.emit("subagent-spawn", {
+            subagentId: `${subagentId}-plan`,
+            name: `${subagentName} (plan)`,
+            input: { target: target.target, objectives: target.objectives },
+            parentSubagentId: subagentId,
+          });
+
           await planAgent.consume();
         } catch (planErr) {
           // Plan phase failure is non-fatal — execution agent proceeds without plan

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -315,9 +315,21 @@ export async function runPentestSwarm(
           });
 
           await planAgent.consume();
+
+          eventBus?.emit("subagent-complete", {
+            subagentId: `${subagentId}-plan`,
+            status: "completed",
+            parentSubagentId: subagentId,
+          });
         } catch (planErr) {
           // Plan phase failure is non-fatal — execution agent proceeds without plan
           log.warn(`Plan phase failed for ${subagentId}: ${planErr}`);
+
+          eventBus?.emit("subagent-complete", {
+            subagentId: `${subagentId}-plan`,
+            status: "failed",
+            parentSubagentId: subagentId,
+          });
         }
       }
 

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -272,6 +272,13 @@ export async function runPentestSwarm(
         previousMessages.length === 0 // Skip on resume
       ) {
         try {
+          eventBus?.emit("subagent-spawn", {
+            subagentId: `${subagentId}-plan`,
+            name: `${subagentName} (plan)`,
+            input: { target: target.target, objectives: target.objectives },
+            parentSubagentId: subagentId,
+          });
+
           // Plan agent writes tasks to the execution agent's directory
           // so the execution agent can see them.
           const executionTasksDir = join(
@@ -307,13 +314,6 @@ export async function runPentestSwarm(
             display,
           });
 
-          eventBus?.emit("subagent-spawn", {
-            subagentId: `${subagentId}-plan`,
-            name: `${subagentName} (plan)`,
-            input: { target: target.target, objectives: target.objectives },
-            parentSubagentId: subagentId,
-          });
-
           await planAgent.consume();
 
           eventBus?.emit("subagent-complete", {
@@ -322,14 +322,13 @@ export async function runPentestSwarm(
             parentSubagentId: subagentId,
           });
         } catch (planErr) {
-          // Plan phase failure is non-fatal — execution agent proceeds without plan
-          log.warn(`Plan phase failed for ${subagentId}: ${planErr}`);
-
           eventBus?.emit("subagent-complete", {
             subagentId: `${subagentId}-plan`,
             status: "failed",
             parentSubagentId: subagentId,
           });
+          // Plan phase failure is non-fatal — execution agent proceeds without plan
+          log.warn(`Plan phase failed for ${subagentId}: ${planErr}`);
         }
       }
 

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -1227,6 +1227,11 @@ export async function runIncrementalWhiteboxAttackSurfaceWorkflow(
 
   const agentResult = await agent.consume();
 
+  eventBus?.emit("subagent-complete", {
+    subagentId: incrementalSubagentId,
+    status: "completed",
+  });
+
   log.info(
     `Incremental agent finished: ${agentResult?.summary ?? "no summary"}`,
   );

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -1198,6 +1198,7 @@ export async function runIncrementalWhiteboxAttackSurfaceWorkflow(
     input.environments,
   );
 
+  const incrementalSubagentId = newSessionId();
   const agent = new CodeAgent<IncrementalResult>({
     codebasePath,
     objective,
@@ -1208,7 +1209,7 @@ export async function runIncrementalWhiteboxAttackSurfaceWorkflow(
     abortSignal,
     attackSurfaceRegistry,
     eventBus,
-    subagentId: newSessionId(),
+    subagentId: incrementalSubagentId,
     subagentName: "Incremental Recon",
     onStepFinish: (event) => onStepFinish?.(event),
     openAIReasoningEffort: input.openAIReasoningEffort,
@@ -1216,6 +1217,12 @@ export async function runIncrementalWhiteboxAttackSurfaceWorkflow(
     thinkingEffort: input.thinkingEffort,
     responseSchema: IncrementalResultSchema,
     projectThreatModel,
+  });
+
+  eventBus?.emit("subagent-spawn", {
+    subagentId: incrementalSubagentId,
+    name: "Incremental Recon",
+    input: { codebasePath },
   });
 
   const agentResult = await agent.consume();

--- a/src/core/workflows/whiteboxAttackSurface.ts
+++ b/src/core/workflows/whiteboxAttackSurface.ts
@@ -1225,12 +1225,20 @@ export async function runIncrementalWhiteboxAttackSurfaceWorkflow(
     input: { codebasePath },
   });
 
-  const agentResult = await agent.consume();
-
-  eventBus?.emit("subagent-complete", {
-    subagentId: incrementalSubagentId,
-    status: "completed",
-  });
+  let agentResult: IncrementalResult;
+  try {
+    agentResult = await agent.consume();
+    eventBus?.emit("subagent-complete", {
+      subagentId: incrementalSubagentId,
+      status: "completed",
+    });
+  } catch (e) {
+    eventBus?.emit("subagent-complete", {
+      subagentId: incrementalSubagentId,
+      status: "failed",
+    });
+    throw e;
+  }
 
   log.info(
     `Incremental agent finished: ${agentResult?.summary ?? "no summary"}`,


### PR DESCRIPTION
An agent constructed with a `subagentId` publishes every one of its bus events under that id — `busSessionId` is `subagentId ?? session.id`. `subagent-spawn` is what tells a consumer that id exists and where it belongs in the tree.

Three agents carried a `subagentId` and never announced it:

| Agent | id | Reached via |
|---|---|---|
| `runFastStrike` | `"fast-strike"` | CLI only — `input.fastStrike` is set at `cli.ts:346`, behind `--fast-strike` |
| swarm plan phase (`pentest.ts`) | `` `${subagentId}-plan` `` | only when a caller sets `requirePlan` **and** `taskDriven` on the session config |
| incremental whitebox recon (`whiteboxAttackSurface.ts`) | `newSessionId()` | any headless/automated recon run |

Their text, tool calls, and reasoning all arrived under a session the consumer had never seen opened, so that work could not be attributed to an agent or nested under its parent. For fast strike that is the entire run — it is the only agent in the workflow.

Each now emits `subagent-spawn` immediately after construction and before `consume()`, matching the five existing spawn sites. The plan agent passes `parentSubagentId: subagentId` so it nests under its execution agent rather than sitting at the top level; the other two are genuinely top-level.

Each announcement is paired with a `subagent-complete` on both the success and failure paths, as every existing announce site does. `spawnSession` seeds `status: "running"` and only `subagent-complete` clears it, and that event is also where a consumer flushes the session's trailing durable text — so an unpaired spawn would strand fast strike's final output, not merely leave a spinner. The plan agent's spawn sits at the top of its `try` so a construction failure still completes what it opened.

**Ordering is load-bearing.** `subagent-spawn` initialises the consumer's session state — the dashboard's `spawnSession` seeds a fresh entry with `messages: []` — so an announcement that lands after the first event discards everything before it. Announcing before `consume()` is what keeps that safe.

## Priority: hardening, not urgent

Worth knowing for review order. Of the three, only **incremental recon** runs in automated/headless deployments; fast strike and the plan phase are interactive-only by construction (see the table above). Telemetry over the last 14 days agrees — across 898,902 AI spans there were **0** fast-strike spans and **0** plan-phase spans, against 198 `invoke_agent Incremental Recon`.

So this is a correctness fix that closes a real gap for one automated path and prevents the other two from misbehaving for CLI users — it is not gating any live incident.

## Audit

I checked every site that passes a `subagentId` into an agent, including shorthand. The remaining ones already announce and are unchanged: `attack-surface-agent`, the whitebox umbrella / per-app / per-task nodes, the pentest swarm workers, `spawnPentestAgent`, `delegateAuth`, `endpointDocumentationAgent`, and the finding judge. These three were the only gaps.

## Known limitation, not addressed here

Two id conventions coexist: real `ses_` ids (`spawnPentestAgent`, `delegateAuth`, the finding judge, incremental recon) and stable slot slugs (`pentest-agent-N`, `fast-strike`, `attack-surface-agent`, the whitebox nodes, `<slug>-plan`). That's deliberate — `persistence.ts:10` calls the slug a "stable slot id … for the swarm", and `id.test.ts:66` pins `isSessionId("pentest-agent-1") === false`.

This PR preserves each site's existing convention rather than migrating any of them. The consequence is at **resume**: a consumer that maps slug → minted session id does so in memory, so a resumed run mints a different id for the same slot and writes a second session row instead of continuing the first. On-disk continuity is preserved by the manifest; downstream continuity is not.

The fix would be to mint a `ses_` id per manifest entry, persist it alongside the slot (the manifest already survives resume), and pass it as `sessionId` on the spawn event — `AgentEventMap["subagent-spawn"]` already carries that field. That's a real change and deserves its own PR.

## Verification

`bun run tsc` clean, `bun run test` 1448 passed / 17 skipped, and `biome lint` reports the same 4 pre-existing warnings on the touched files as it does on `canary`.

No test added: these are announce/complete pairs mirroring existing call sites in the same files, with no logic of their own beyond the success/failure split. Covering them would mean mocking the whole agent stack for each workflow, which buys less than it costs.
