### PR TITLE
feat(ai): add Concentrate provider support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -185,6 +185,7 @@ async function resolveCliModel(): Promise<AIModel> {
         "  ANTHROPIC_API_KEY  — Anthropic direct\n" +
         "  OPENAI_API_KEY     — OpenAI\n" +
         "  OPENROUTER_API_KEY — OpenRouter\n" +
+        "  CONCENTRATE_API_KEY — Concentrate\n" +
         "\nOr run 'pensar login' to connect to Pensar Console.",
     );
     process.exit(1);

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -43,7 +43,7 @@ const RESPONSE_DEBUG =
   process.env.RESPONSE_DEBUG === "1" || process.env.RESPONSE_DEBUG === "true";
 const RESPONSE_TOOL_NAME = "response";
 
-export type AIModel = AnthropicMessagesModelId | OpenAIChatModelId | string; // For OpenRouter and Bedrock models
+export type AIModel = AnthropicMessagesModelId | OpenAIChatModelId | string; // For gateway and Bedrock model IDs
 
 export type OpenAIReasoningEffort =
   | "none"
@@ -142,6 +142,7 @@ export type AIModelProvider =
   | "openai"
   | "google"
   | "openrouter"
+  | "concentrate"
   | "bedrock"
   | "bedrock-mantle"
   | "pensar"

--- a/src/core/ai/concentrate.test.ts
+++ b/src/core/ai/concentrate.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { getModelInfo } from "./models";
+import { buildAuthConfig, getProviderModel } from "./utils";
+
+describe("Concentrate provider", () => {
+  it("registers namespaced model IDs", () => {
+    const info = getModelInfo("concentrate:claude-opus-4-6");
+
+    expect(info.provider).toBe("concentrate");
+    expect(info.contextLength).toBe(200000);
+  });
+
+  it("passes the unprefixed model ID to the compatible provider", () => {
+    const model = getProviderModel("concentrate:gpt-5.4", {
+      concentrateAPIKey: "sk-cn-test",
+    }) as unknown as { modelId: string; provider: string };
+
+    expect(model.modelId).toBe("gpt-5.4");
+    expect(model.provider).toBe("concentrate.chat");
+  });
+
+  it("includes the persisted key in auth config", () => {
+    expect(
+      buildAuthConfig({ concentrateAPIKey: "sk-cn-persisted" }),
+    ).toMatchObject({ concentrateAPIKey: "sk-cn-persisted" });
+  });
+});

--- a/src/core/ai/models/concentrate.ts
+++ b/src/core/ai/models/concentrate.ts
@@ -1,0 +1,114 @@
+import type { ModelInfo } from "../ai";
+
+// Curated from Concentrate's public model catalog. The local prefix keeps
+// gateway selections distinct from direct-provider models and is not sent.
+export const CONCENTRATE_MODELS: ModelInfo[] = [
+  {
+    id: "concentrate:claude-opus-4-6",
+    name: "Claude Opus 4.6",
+    provider: "concentrate",
+    contextLength: 200000,
+  },
+  {
+    id: "concentrate:claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
+    provider: "concentrate",
+    contextLength: 200000,
+  },
+  {
+    id: "concentrate:claude-sonnet-4-5",
+    name: "Claude Sonnet 4.5",
+    provider: "concentrate",
+    contextLength: 200000,
+  },
+  {
+    id: "concentrate:claude-haiku-4-5",
+    name: "Claude Haiku 4.5",
+    provider: "concentrate",
+    contextLength: 200000,
+  },
+  {
+    id: "concentrate:gpt-5.6-sol",
+    name: "GPT 5.6 Sol",
+    provider: "concentrate",
+    contextLength: 1050000,
+  },
+  {
+    id: "concentrate:gpt-5.6-terra",
+    name: "GPT 5.6 Terra",
+    provider: "concentrate",
+    contextLength: 1050000,
+  },
+  {
+    id: "concentrate:gpt-5.6-luna",
+    name: "GPT 5.6 Luna",
+    provider: "concentrate",
+    contextLength: 1050000,
+  },
+  {
+    id: "concentrate:gpt-5.5",
+    name: "GPT 5.5",
+    provider: "concentrate",
+    contextLength: 1050000,
+  },
+  {
+    id: "concentrate:gpt-5.4",
+    name: "GPT 5.4",
+    provider: "concentrate",
+    contextLength: 1050000,
+  },
+  {
+    id: "concentrate:gpt-5.3-codex",
+    name: "GPT 5.3 Codex",
+    provider: "concentrate",
+    contextLength: 400000,
+  },
+  {
+    id: "concentrate:gemini-3.6-flash",
+    name: "Gemini 3.6 Flash",
+    provider: "concentrate",
+    contextLength: 1048576,
+  },
+  {
+    id: "concentrate:gemini-3.1-pro-preview",
+    name: "Gemini 3.1 Pro Preview",
+    provider: "concentrate",
+    contextLength: 1000000,
+  },
+  {
+    id: "concentrate:gemini-2.5-pro",
+    name: "Gemini 2.5 Pro",
+    provider: "concentrate",
+    contextLength: 1000000,
+  },
+  {
+    id: "concentrate:deepseek-v3-2",
+    name: "DeepSeek V3.2",
+    provider: "concentrate",
+    contextLength: 163840,
+  },
+  {
+    id: "concentrate:mistral-large-3",
+    name: "Mistral Large 3",
+    provider: "concentrate",
+    contextLength: 256000,
+  },
+  {
+    id: "concentrate:kimi-k2-thinking",
+    name: "Kimi K2 Thinking",
+    provider: "concentrate",
+    contextLength: 262144,
+  },
+  {
+    id: "concentrate:minimax-m2-7",
+    name: "MiniMax M2.7",
+    provider: "concentrate",
+    contextLength: 204800,
+  },
+  {
+    id: "concentrate:glm-5",
+    name: "GLM-5",
+    provider: "concentrate",
+    contextLength: 202800,
+  },
+];

--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -4,6 +4,7 @@ import type { AIModel, ModelInfo } from "../ai";
 // Re-generate after bumping SDK packages: bun run generate:models
 import { ANTHROPIC_MODELS } from "./anthropic";
 import { BEDROCK_MODELS } from "./bedrock";
+import { CONCENTRATE_MODELS } from "./concentrate";
 import { GOOGLE_MODELS } from "./google";
 import { INCEPTION_MODELS } from "./inception";
 // Bedrock Mantle (OpenAI Responses API) — curated manually.
@@ -20,6 +21,7 @@ export const AVAILABLE_MODELS: ModelInfo[] = [
   ...BEDROCK_MODELS,
   ...MANTLE_MODELS,
   ...OPENROUTER_MODELS,
+  ...CONCENTRATE_MODELS,
   ...PENSAR_MODELS,
   ...INCEPTION_MODELS,
 ];

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -60,6 +60,7 @@ export type AIAuthConfig = {
   anthropicAPIKey?: string;
   googleAPIKey?: string;
   openRouterAPIKey?: string;
+  concentrateAPIKey?: string;
   inceptionAPIKey?: string;
   pensarAPIKey?: string;
   // WorkOS CLI auth
@@ -92,6 +93,7 @@ export function buildAuthConfig(cfg: {
   openAiAPIKey?: string | null;
   googleAPIKey?: string | null;
   openRouterAPIKey?: string | null;
+  concentrateAPIKey?: string | null;
   inceptionAPIKey?: string | null;
   pensarAPIKey?: string | null;
   accessToken?: string | null;
@@ -107,6 +109,7 @@ export function buildAuthConfig(cfg: {
     openAiAPIKey: cfg.openAiAPIKey ?? undefined,
     googleAPIKey: cfg.googleAPIKey ?? undefined,
     openRouterAPIKey: cfg.openRouterAPIKey ?? undefined,
+    concentrateAPIKey: cfg.concentrateAPIKey ?? undefined,
     inceptionAPIKey: cfg.inceptionAPIKey ?? undefined,
     pensarAPIKey: cfg.pensarAPIKey ?? undefined,
     accessToken: cfg.accessToken ?? undefined,
@@ -132,6 +135,8 @@ export function getProviderModel(
     authConfig?.googleAPIKey || process.env.GOOGLE_GENERATIVE_AI_API_KEY;
   const openRouterAPIKey =
     authConfig?.openRouterAPIKey || process.env.OPENROUTER_API_KEY;
+  const concentrateAPIKey =
+    authConfig?.concentrateAPIKey || process.env.CONCENTRATE_API_KEY;
   const bedrockApiKey =
     authConfig?.bedrock?.apiKey || process.env.BEDROCK_API_KEY;
   const bedrockAccessKeyId =
@@ -164,6 +169,16 @@ export function getProviderModel(
         apiKey: openRouterAPIKey,
       });
       providerModel = openrouter(model);
+      break;
+    }
+
+    case "concentrate": {
+      const concentrate = createOpenAICompatible({
+        name: "concentrate",
+        apiKey: concentrateAPIKey,
+        baseURL: "https://api.concentrate.ai/v1",
+      });
+      providerModel = concentrate(model.replace(/^concentrate:/, ""));
       break;
     }
 

--- a/src/core/config/config.test.ts
+++ b/src/core/config/config.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { get, init, update } from "./config";
 
 let homeDirectory: string;
+const originalConcentrateAPIKey = process.env.CONCENTRATE_API_KEY;
 
 beforeEach(() => {
   homeDirectory = mkdtempSync(path.join(os.tmpdir(), "apex-config-test-"));
@@ -19,7 +20,22 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  if (originalConcentrateAPIKey === undefined) {
+    delete process.env.CONCENTRATE_API_KEY;
+  } else {
+    process.env.CONCENTRATE_API_KEY = originalConcentrateAPIKey;
+  }
   rmSync(homeDirectory, { recursive: true, force: true });
+});
+
+describe("provider environment fallbacks", () => {
+  it("loads a Concentrate API key from the environment", async () => {
+    process.env.CONCENTRATE_API_KEY = "sk-cn-env";
+
+    const config = await get();
+
+    expect(config.concentrateAPIKey).toBe("sk-cn-env");
+  });
 });
 
 describe("Strike Mode config", () => {

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -15,6 +15,7 @@ export interface Config {
   anthropicAPIKey?: string | null;
   googleAPIKey?: string | null;
   openRouterAPIKey?: string | null;
+  concentrateAPIKey?: string | null;
   inceptionAPIKey?: string | null;
   bedrockAPIKey?: string | null;
   pensarAPIKey?: string | null;
@@ -123,6 +124,8 @@ function applyEnvFallbacks(parsedConfig: Partial<Config>): Config {
       parsedConfig.googleAPIKey ?? process.env.GOOGLE_GENERATIVE_AI_API_KEY,
     openRouterAPIKey:
       parsedConfig.openRouterAPIKey ?? process.env.OPENROUTER_API_KEY,
+    concentrateAPIKey:
+      parsedConfig.concentrateAPIKey ?? process.env.CONCENTRATE_API_KEY,
     inceptionAPIKey:
       parsedConfig.inceptionAPIKey ?? process.env.INCEPTION_API_KEY,
     bedrockAPIKey: parsedConfig.bedrockAPIKey ?? process.env.BEDROCK_API_KEY,

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -42,6 +42,7 @@ function checkApiKeys(): { provider: string; configured: boolean }[] {
     { provider: "OpenAI", env: "OPENAI_API_KEY" },
     { provider: "Google", env: "GOOGLE_GENERATIVE_AI_API_KEY" },
     { provider: "OpenRouter", env: "OPENROUTER_API_KEY" },
+    { provider: "Concentrate", env: "CONCENTRATE_API_KEY" },
     { provider: "AWS Bedrock", env: "BEDROCK_API_KEY" },
     { provider: "AWS IAM", env: "AWS_ACCESS_KEY_ID" },
     { provider: "vLLM (local)", env: "LOCAL_MODEL_URL" },

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -4,6 +4,7 @@ export type ProviderType =
   | "google"
   | "bedrock"
   | "openrouter"
+  | "concentrate"
   | "inception"
   | "pensar"
   | "local";
@@ -43,6 +44,12 @@ export const AVAILABLE_PROVIDERS: Provider[] = [
   {
     id: "openrouter",
     name: "OpenRouter",
+    description: "Access multiple AI models through one API",
+    requiresAPIKey: true,
+  },
+  {
+    id: "concentrate",
+    name: "Concentrate",
     description: "Access multiple AI models through one API",
     requiresAPIKey: true,
   },

--- a/src/core/providers/utils.test.ts
+++ b/src/core/providers/utils.test.ts
@@ -75,6 +75,20 @@ describe("getDefaultModelForConfig", () => {
     expect(model?.id).toBe("anthropic/claude-opus-4.6");
   });
 
+  it("returns Concentrate models when only Concentrate is configured", () => {
+    const config = makeConfig({ concentrateAPIKey: "sk-cn-123" });
+    const model = getDefaultModelForConfig(config);
+    const available = getAvailableModels(config);
+
+    expect(model).not.toBeNull();
+    expect(model?.provider).toBe("concentrate");
+    expect(model?.id).toBe("concentrate:claude-opus-4-6");
+    expect(available.length).toBeGreaterThan(1);
+    expect(available.every((item) => item.provider === "concentrate")).toBe(
+      true,
+    );
+  });
+
   it("prefers Anthropic over OpenAI when both are configured", () => {
     const config = makeConfig({
       anthropicAPIKey: "sk-ant-123",

--- a/src/core/providers/utils.ts
+++ b/src/core/providers/utils.ts
@@ -12,6 +12,7 @@ const PROVIDER_PREFERENCE_ORDER: ProviderType[] = [
   "openai",
   "google",
   "openrouter",
+  "concentrate",
   "bedrock",
 ];
 
@@ -21,6 +22,7 @@ const PREFERRED_MODEL_BY_PROVIDER: Record<string, string> = {
   openai: "gpt-5.6-sol",
   google: "gemini-3.1-pro-preview",
   openrouter: "anthropic/claude-opus-4.6",
+  concentrate: "concentrate:claude-opus-4-6",
   bedrock: "anthropic.claude-opus-4-6-v1",
 };
 
@@ -48,6 +50,8 @@ function isProviderConfigured(
       return !!config.googleAPIKey;
     case "openrouter":
       return !!config.openRouterAPIKey;
+    case "concentrate":
+      return !!config.concentrateAPIKey;
     case "inception":
       return !!config.inceptionAPIKey;
     case "bedrock":
@@ -71,6 +75,7 @@ export function hasAnyProviderConfigured(config: Config): boolean {
     !!config.openAiAPIKey ||
     !!config.googleAPIKey ||
     !!config.openRouterAPIKey ||
+    !!config.concentrateAPIKey ||
     !!config.inceptionAPIKey ||
     !!config.bedrockAPIKey ||
     !!config.localModelUrl ||
@@ -104,7 +109,7 @@ export function getAvailableModels(config: Config): ModelInfo[] {
 /**
  * Dynamically select the best default model based on which providers are
  * configured.  Priority order: Pensar → Anthropic → OpenAI → Google →
- * OpenRouter → Bedrock.  Within each provider the preferred model is an
+ * OpenRouter → Concentrate → Bedrock. Within each provider the preferred model is an
  * opus-class / flagship model; falls back to the first available model for
  * that provider if the preferred one isn't found.
  */

--- a/src/core/providers/verify.test.ts
+++ b/src/core/providers/verify.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { verifyApiKey } from "./verify";
+
+describe("verifyApiKey Concentrate key format", () => {
+  it("accepts the documented key prefix", async () => {
+    await expect(verifyApiKey("concentrate", "sk-cn-test")).resolves.toEqual({
+      valid: true,
+    });
+  });
+
+  it("rejects keys without the documented prefix", async () => {
+    await expect(verifyApiKey("concentrate", "sk-test")).resolves.toEqual({
+      valid: false,
+      error: "Concentrate API keys start with sk-cn",
+    });
+  });
+});

--- a/src/core/providers/verify.ts
+++ b/src/core/providers/verify.ts
@@ -165,6 +165,13 @@ export async function verifyApiKey(
       return verifyGoogle(apiKey);
     case "openrouter":
       return verifyOpenRouter(apiKey);
+    case "concentrate":
+      return apiKey.startsWith("sk-cn")
+        ? { valid: true }
+        : {
+            valid: false,
+            error: "Concentrate API keys start with sk-cn",
+          };
     case "inception":
       return verifyInception(apiKey);
     case "bedrock":

--- a/src/tui/components/chat/input-area.tsx
+++ b/src/tui/components/chat/input-area.tsx
@@ -25,6 +25,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   openai: "OpenAI",
   google: "Google",
   openrouter: "OpenRouter",
+  concentrate: "Concentrate",
   bedrock: "Bedrock",
   pensar: "Pensar",
   inception: "Inception",

--- a/src/tui/components/commands/api-key-input.tsx
+++ b/src/tui/components/commands/api-key-input.tsx
@@ -63,6 +63,8 @@ export default function APIKeyInput({
         return "Get your API key from aistudio.google.com/apikey";
       case "openrouter":
         return "Get your API key from openrouter.ai/keys";
+      case "concentrate":
+        return "Create your API key at concentrate.ai";
       case "bedrock":
         return "Enter your AWS Access Key ID (configure region separately) or AWS Bedrock API Key";
       default:

--- a/src/tui/components/commands/operator-wizard.tsx
+++ b/src/tui/components/commands/operator-wizard.tsx
@@ -28,9 +28,16 @@ const providerNames: Record<string, string> = {
   anthropic: "Claude",
   openai: "OpenAI",
   openrouter: "OpenRouter",
+  concentrate: "Concentrate",
   bedrock: "Bedrock",
 };
-const providerOrder = ["anthropic", "openai", "openrouter", "bedrock"];
+const providerOrder = [
+  "anthropic",
+  "openai",
+  "openrouter",
+  "concentrate",
+  "bedrock",
+];
 
 export default function HITLWizard(props: HITLWizardProps) {
   const { colors } = useTheme();

--- a/src/tui/components/commands/provider-manager.tsx
+++ b/src/tui/components/commands/provider-manager.tsx
@@ -63,6 +63,9 @@ export default function ProviderManager({
       case "openrouter":
         configUpdate.openRouterAPIKey = apiKey;
         break;
+      case "concentrate":
+        configUpdate.concentrateAPIKey = apiKey;
+        break;
       case "bedrock":
         configUpdate.bedrockAPIKey = apiKey;
         break;

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -26,6 +26,7 @@ const providerNames: Record<string, string> = {
   openai: "OpenAI",
   google: "Gemini",
   openrouter: "OpenRouter",
+  concentrate: "Concentrate",
   bedrock: "Bedrock",
   pensar: "Pensar",
   local: "Local LLM",
@@ -37,6 +38,7 @@ const providerOrder = [
   "openai",
   "google",
   "openrouter",
+  "concentrate",
   "bedrock",
   "local",
 ];


### PR DESCRIPTION
### What does this PR do?

Adds Concentrate as a first-class AI provider using its OpenAI-compatible API.

- Persists `CONCENTRATE_API_KEY` from settings or the environment.
- Adds Concentrate to provider setup, model selection, operator UI, CLI help, and doctor output.
- Registers 18 curated Concentrate models with internal `concentrate:` IDs so they cannot collide with direct-provider model IDs.
- Strips the internal prefix and routes requests through `https://api.concentrate.ai/v1` using the existing OpenAI-compatible adapter.
- Checks the documented `sk-cn` key prefix without making a billable inference request.
- Adds focused coverage for config fallback, key format, model availability, auth propagation, and request routing.

No new dependency is introduced.

### How did you verify your code works?

- `bun run test` — 1,450 passed, 22 skipped.
- `bun run build` — passed.
- `bun run lint` — passed with existing warnings.
- Focused provider/config tests — 23 passed.
- Changed-file Biome check and `git diff --check` — passed.

Known pre-existing repository checks remain unchanged: source typechecking reports the existing `@pensar/surface` gRPC type drift, and `format:check` reports three existing `.pi/self-learning-memory` Markdown files. No live billed Concentrate inference request was made.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider integration following existing OpenRouter/Inception patterns; no auth or data-path changes beyond new API key handling and outbound calls to Concentrate.
> 
> **Overview**
> Adds **Concentrate** as a first-class AI provider alongside OpenRouter-style gateways, using Concentrate’s OpenAI-compatible API at `https://api.concentrate.ai/v1`.
> 
> **Configuration & routing:** `concentrateAPIKey` is persisted and loaded from `CONCENTRATE_API_KEY`; auth flows through `buildAuthConfig` / `getProviderModel`, which strips the internal `concentrate:` prefix before calling the API. Eighteen curated models are registered with `concentrate:` IDs so they don’t collide with direct-provider IDs.
> 
> **Product surfaces:** Concentrate appears in provider setup (API key save + `sk-cn` prefix validation without a billed inference call), default-model preference (after OpenRouter), CLI “no provider” help, `doctor`, and TUI labels (model picker, operator wizard, input area).
> 
> **Tests** cover env fallback, routing, model registry, default model selection, and key format verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 488d264ac843e153ce676f520cd2ca42809dd960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->