### PR TITLE
feat(credentials): resolve operator-named extra secrets without exposing values

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -350,6 +350,7 @@ export class OffensiveSecurityAgent<TResult = void> {
       attackSurfaceRegistry: input.attackSurfaceRegistry,
       credentialManager,
       secretValues: input.secretValues,
+      environmentVariables: input.environmentVariables,
       persistentShell: this.persistentShell,
       skillsRegistry: input.skillsRegistry,
       promptInjectionLibrary: input.promptInjectionLibrary,

--- a/src/core/agents/offSecAgent/tools/browserTools.ts
+++ b/src/core/agents/offSecAgent/tools/browserTools.ts
@@ -138,17 +138,12 @@ export function createBrowserToolset(ctx: ToolContext) {
         "ID of a stored credential. When provided with credentialField, the secret is resolved automatically.",
       );
     shape.credentialField = z
-      .enum([
-        "password",
-        "username",
-        "apiKey",
-        "bearerToken",
-        "cookies",
-        "sessionToken",
-      ])
+      .string()
       .optional()
       .describe(
-        "Which field to extract from the credential (e.g. 'password'). Required when credentialId is set.",
+        "Which field to extract from the credential. One of: password, username, apiKey, " +
+          "bearerToken, cookies, sessionToken — or the name of one of the credential's " +
+          "extra secret fields. Required when credentialId is set.",
       );
   }
 
@@ -186,13 +181,7 @@ export function createBrowserToolset(ctx: ToolContext) {
         toolCallDescription: string;
         promptInjection?: { id?: string };
         credentialId?: string;
-        credentialField?:
-          | "password"
-          | "username"
-          | "apiKey"
-          | "bearerToken"
-          | "cookies"
-          | "sessionToken";
+        credentialField?: string;
       };
       const { element, ref, toolCallDescription } = params;
       let value = params.value;
@@ -252,8 +241,14 @@ export function createBrowserToolset(ctx: ToolContext) {
           credentialField === "sessionToken"
         ) {
           value = stored.tokens?.[credentialField] ?? "";
-        } else {
+        } else if (
+          credentialField === "password" ||
+          credentialField === "username" ||
+          credentialField === "apiKey"
+        ) {
           value = stored[credentialField] ?? "";
+        } else {
+          value = stored.additionalFields?.[credentialField] ?? "";
         }
         if (!value) {
           return {

--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -309,6 +309,7 @@ IMPORTANT: Pass protectedEndpoints in authHints when you've discovered 401/403 e
           eventBus: localBus,
           subagentId,
           subagentName,
+          environmentVariables: ctx.environmentVariables,
           secretValues: ctx.secretValues,
         });
 

--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -18,8 +18,12 @@ const log = scopedLogger(() => createLogger("delegate_auth"));
 /**
  * Merge session-level credentials with explicitly passed credentials.
  * Explicit values take precedence over session defaults.
+ *
+ * Every secret-bearing field must be carried through: the merged result is
+ * re-added to the credential manager, which dedupes on those fields, so a
+ * dropped one produces a twin credential rather than a match.
  */
-function mergeAuthCredentials(
+export function mergeAuthCredentials(
   sessionCreds: AuthCredentials | undefined,
   explicit: {
     username?: string;
@@ -32,6 +36,7 @@ function mergeAuthCredentials(
       sessionToken?: string;
       customHeaders?: Record<string, string>;
     };
+    additionalFields?: Record<string, string>;
   },
 ): AuthCredentials | undefined {
   const hasExplicit =
@@ -55,6 +60,7 @@ function mergeAuthCredentials(
     password: sessionCreds?.password,
     apiKey: sessionCreds?.apiKey,
     loginUrl: sessionCreds?.loginUrl,
+    additionalFields: sessionCreds?.additionalFields,
     tokens: sessionCreds?.tokens
       ? {
           bearerToken: sessionCreds.tokens.bearerToken,
@@ -67,6 +73,9 @@ function mergeAuthCredentials(
     ...(explicit.password && { password: explicit.password }),
     ...(explicit.apiKey && { apiKey: explicit.apiKey }),
     ...(explicit.loginUrl && { loginUrl: explicit.loginUrl }),
+    ...(explicit.additionalFields && {
+      additionalFields: explicit.additionalFields,
+    }),
     ...(explicit.tokens && {
       tokens: {
         bearerToken: explicit.tokens.bearerToken,
@@ -186,6 +195,8 @@ IMPORTANT: Pass protectedEndpoints in authHints when you've discovered 401/403 e
       authHints,
       reason,
     }) => {
+      // Resolved from a stored credential only — agents never pass raw secrets.
+      let additionalFields: Record<string, string> | undefined;
       // Outside the try so the failure-path subagent-complete reuses this id.
       const subagentId = newSessionId();
       const subagentName = "Authentication Agent";
@@ -213,6 +224,7 @@ IMPORTANT: Pass protectedEndpoints in authHints when you've discovered 401/403 e
           password = stored.password ?? password;
           apiKey = stored.apiKey ?? apiKey;
           loginUrl = stored.loginUrl ?? loginUrl;
+          additionalFields = stored.additionalFields;
           if (stored.tokens && !tokens) {
             tokens = { ...stored.tokens };
           }
@@ -276,6 +288,7 @@ IMPORTANT: Pass protectedEndpoints in authHints when you've discovered 401/403 e
           apiKey,
           loginUrl,
           tokens,
+          additionalFields,
         });
 
         // Ensure the session has a credential manager with the resolved credentials.

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -81,6 +81,13 @@ export type ToolContext = {
   secretValues?: string[];
 
   /**
+   * Shell env this agent runs with. Tools that spawn a sub-agent forward it so
+   * the child's shell resolves the same variables (credential secrets among
+   * them) as the parent's.
+   */
+  environmentVariables?: Record<string, string>;
+
+  /**
    * Long-lived bash process shared across execute_command calls.
    * Environment variables, working directory, and background processes
    * persist between invocations. Only used in local (non-sandbox) mode.

--- a/src/core/agents/specialized/authenticationAgent/agent.ts
+++ b/src/core/agents/specialized/authenticationAgent/agent.ts
@@ -333,8 +333,9 @@ The credentials above were provided to you and have already been verified — th
 do not modify them or their account settings. NEVER change the password, complete a password reset /
 forced-password-change / account-recovery flow, or modify MFA/2FA settings (enrolling, disabling, or
 resetting a second factor) for this account. If they do not authenticate (rejected, locked out, forced
-password change required, MFA required, email not confirmed), call complete_authentication with
-success=false and a clear summary of why — do not attempt to recover, reset, or rotate them. Do NOT
+password change required, email not confirmed, or an MFA prompt with no TOTP seed available), call
+complete_authentication with success=false and a clear summary of why — do not attempt to recover, reset,
+or rotate them. When a TOTP seed IS available, generate the code and continue; that is not a barrier. Do NOT
 register a new account or self-sign-up to work around a failed login: that is not the credential under test
 and only pollutes results — fail fast with success=false instead.`);
   } else {

--- a/src/core/agents/specialized/authenticationAgent/agent.ts
+++ b/src/core/agents/specialized/authenticationAgent/agent.ts
@@ -167,7 +167,13 @@ export class AuthenticationAgent extends OffensiveSecurityAgent<AuthenticationRe
 
     super({
       system: detectOSAndEnhancePrompt(AUTH_SUBAGENT_SYSTEM_PROMPT),
-      prompt: buildAuthPrompt(target, authHints, cm, context),
+      prompt: buildAuthPrompt(
+        target,
+        authHints,
+        cm,
+        context,
+        environmentVariables ? Object.keys(environmentVariables) : undefined,
+      ),
       model,
       session,
       target,
@@ -267,6 +273,7 @@ function buildAuthPrompt(
   authHints?: AuthenticationAgentInput["authHints"],
   credentialManager?: import("../../../credentials").CredentialManager,
   context?: string,
+  envVarNames?: string[],
 ): string {
   const parts: string[] = [`TARGET: ${target}\n`];
 
@@ -287,6 +294,15 @@ function buildAuthPrompt(
     parts.push(
       "No credentials provided. Probe the target to discover auth requirements.\n",
     );
+  }
+
+  if (envVarNames?.length) {
+    parts.push("ENVIRONMENT VARIABLES:");
+    parts.push(
+      `These are pre-loaded in your shell and available in every execute_command call. Reference them (e.g. $${envVarNames[0]}) — their values are hidden from you and redacted from command output, so never try to print one.`,
+    );
+    parts.push(envVarNames.map((n) => `- ${n}`).join("\n"));
+    parts.push("");
   }
 
   if (authHints) {

--- a/src/core/agents/specialized/authenticationAgent/prompts.ts
+++ b/src/core/agents/specialized/authenticationAgent/prompts.ts
@@ -18,7 +18,7 @@ Obtain valid credentials/sessions that other agents can use for authenticated te
 # Operating Mode
 
 - Fully autonomous — no human intervention
-- If you encounter barriers (CAPTCHA, MFA), report failure with details
+- If you encounter barriers (CAPTCHA, or MFA with no TOTP seed available), report failure with details
 - Call \`complete_authentication\` when done (success or failure)
 
 # Available Tools
@@ -112,6 +112,22 @@ These are the ONLY way downstream agents receive the session credentials.
 
 **Then**, call the \`response\` tool with your final summary to end the run. This is required — complete_authentication persists the data, response terminates the agent.
 
+# MFA / TOTP Codes
+
+If the login asks for a 6-digit authenticator code, check whether a TOTP seed was provided for this
+account — it appears as an extra secret field on the credential and as a matching environment variable
+(look for a name containing TOTP, MFA, OTP, or 2FA). If one exists, do NOT report an MFA barrier —
+compute the code yourself:
+
+\`\`\`
+python3 -c "import base64,hmac,hashlib,struct,time,os;s=os.environ['<ENV_VAR>'].replace(' ','').upper();k=base64.b32decode(s+'='*(-len(s)%8));d=hmac.new(k,struct.pack('>Q',int(time.time())//30),hashlib.sha1).digest();o=d[-1]&15;print('%06d'%((struct.unpack('>I',d[o:o+4])[0]&0x7fffffff)%1000000))"
+\`\`\`
+
+Read the seed from the environment variable — never paste a seed literal into a command. Codes rotate
+every 30 seconds, so run this immediately before filling the field. If the code is rejected, re-run and
+retry once (you may have crossed a period boundary). Only report an MFA barrier if no seed is available
+or two fresh codes are both rejected.
+
 # Error Recovery
 
 If authentication fails, try these mechanical fixes (they are login mechanics, not credential changes):
@@ -123,7 +139,8 @@ If authentication fails, try these mechanical fixes (they are login mechanics, n
 
 If credentials were provided to you, they are already verified and SHARED — do not modify them or their
 account settings. When such provided credentials are genuinely rejected — wrong password, account locked, a
-forced password change is required, MFA is required, or the email is not confirmed — do NOT try to recover by resetting or changing
+forced password change is required, MFA is required and no TOTP seed was provided, or the email is not
+confirmed — do NOT try to recover by resetting or changing
 the password, modifying MFA/2FA settings, or running any account-recovery flow. Fail fast: call
 \`complete_authentication\` with success=false and a summary naming the reason. Do NOT register a new account
 or self-sign-up to get around a rejected provided credential — that is a different account than the one

--- a/src/core/credentials/manager.ts
+++ b/src/core/credentials/manager.ts
@@ -256,7 +256,7 @@ export class CredentialManager {
       }
       if (ref.additionalFieldKeys?.length) {
         parts.push(
-          `  Extra secret fields: ${ref.additionalFieldKeys.join(", ")}`,
+          `  Additional secret fields: ${ref.additionalFieldKeys.join(", ")}`,
         );
       }
       if (ref.context) parts.push(`  Context: ${ref.context}`);
@@ -266,7 +266,7 @@ export class CredentialManager {
     return `<available_credentials>
 The following credentials are available. To use a credential, pass its ID to the appropriate tool.
 Do NOT ask the user for passwords or secrets — they are resolved automatically from the credential ID.
-"Extra secret fields" are operator-supplied named secrets: pass the name as "credentialField"
+"Additional secret fields" are operator-supplied named secrets: pass the name as "credentialField"
 to browser_fill, or read the matching environment variable in execute_command. Their values are
 never shown to you and are redacted from command output.
 

--- a/src/core/credentials/manager.ts
+++ b/src/core/credentials/manager.ts
@@ -61,6 +61,10 @@ function toReference(stored: StoredCredential): CredentialReference {
   if (stored.tokens?.customHeaders) {
     ref.customHeaderKeys = Object.keys(stored.tokens.customHeaders);
   }
+  if (stored.additionalFields) {
+    const keys = Object.keys(stored.additionalFields);
+    if (keys.length > 0) ref.additionalFieldKeys = keys;
+  }
   const ctx = stored.metadata?.context;
   if (typeof ctx === "string" && ctx) ref.context = ctx;
   return ref;
@@ -90,7 +94,9 @@ export class CredentialManager {
         existing.tokens?.cookies === candidate.tokens?.cookies &&
         existing.tokens?.sessionToken === candidate.tokens?.sessionToken &&
         JSON.stringify(existing.tokens?.customHeaders) ===
-          JSON.stringify(candidate.tokens?.customHeaders)
+          JSON.stringify(candidate.tokens?.customHeaders) &&
+        JSON.stringify(existing.additionalFields) ===
+          JSON.stringify(candidate.additionalFields)
       ) {
         return id;
       }
@@ -248,6 +254,11 @@ export class CredentialManager {
       if (ref.customHeaderKeys?.length) {
         parts.push(`  Header keys: ${ref.customHeaderKeys.join(", ")}`);
       }
+      if (ref.additionalFieldKeys?.length) {
+        parts.push(
+          `  Extra secret fields: ${ref.additionalFieldKeys.join(", ")}`,
+        );
+      }
       if (ref.context) parts.push(`  Context: ${ref.context}`);
       return parts.join("\n");
     });
@@ -255,6 +266,9 @@ export class CredentialManager {
     return `<available_credentials>
 The following credentials are available. To use a credential, pass its ID to the appropriate tool.
 Do NOT ask the user for passwords or secrets — they are resolved automatically from the credential ID.
+"Extra secret fields" are operator-supplied named secrets: pass the name as "credentialField"
+to browser_fill, or read the matching environment variable in execute_command. Their values are
+never shown to you and are redacted from command output.
 
 ${lines.join("\n\n")}
 </available_credentials>`;

--- a/src/core/credentials/types.ts
+++ b/src/core/credentials/types.ts
@@ -92,6 +92,9 @@ export interface CredentialReference {
   /** Names of custom header keys (values redacted) */
   customHeaderKeys?: string[];
 
+  /** Names of operator-defined extra secret fields (values redacted) */
+  additionalFieldKeys?: string[];
+
   /** Usage context / notes about when and how to use this credential */
   context?: string;
 }

--- a/src/tests/credentialManager.test.ts
+++ b/src/tests/credentialManager.test.ts
@@ -361,7 +361,7 @@ describe("CredentialManager", () => {
       expect(prompt).not.toContain("secret-value-123");
     });
 
-    it("includes extra secret field names but not values", () => {
+    it("includes additional secret field names but not values", () => {
       cm.add({
         id: "cred-mfa",
         username: "pentest@agents.pensar.dev",
@@ -376,7 +376,7 @@ describe("CredentialManager", () => {
     });
   });
 
-  describe("extra secret fields", () => {
+  describe("additional secret fields", () => {
     it("exposes only the field names on the reference", () => {
       const id = cm.add({
         username: "admin",
@@ -397,7 +397,7 @@ describe("CredentialManager", () => {
       expect(cm.getReference(id)!.additionalFieldKeys).toBeUndefined();
     });
 
-    it("keeps credentials that differ only by extra fields distinct", () => {
+    it("keeps credentials that differ only by additional fields distinct", () => {
       const a = cm.addFromAuthCredentials({
         username: "admin",
         password: "pw",

--- a/src/tests/credentialManager.test.ts
+++ b/src/tests/credentialManager.test.ts
@@ -360,6 +360,56 @@ describe("CredentialManager", () => {
       expect(prompt).toContain("X-API-Key");
       expect(prompt).not.toContain("secret-value-123");
     });
+
+    it("includes extra secret field names but not values", () => {
+      cm.add({
+        id: "cred-mfa",
+        username: "pentest@agents.pensar.dev",
+        password: "pw_secret_1",
+        role: "github",
+        additionalFields: { TOTP_SEED: "JBSWY3DPEHPK3PXP" },
+      });
+
+      const prompt = cm.formatForPrompt();
+      expect(prompt).toContain("TOTP_SEED");
+      expect(prompt).not.toContain("JBSWY3DPEHPK3PXP");
+    });
+  });
+
+  describe("extra secret fields", () => {
+    it("exposes only the field names on the reference", () => {
+      const id = cm.add({
+        username: "admin",
+        password: "pw",
+        additionalFields: { TOTP_SEED: "JBSWY3DPEHPK3PXP", PIN: "4821" },
+      });
+
+      const ref = cm.getReference(id)!;
+      expect(ref.additionalFieldKeys).toEqual(["TOTP_SEED", "PIN"]);
+      expect(JSON.stringify(ref)).not.toContain("JBSWY3DPEHPK3PXP");
+      expect(cm.resolve(id)!.additionalFields!.TOTP_SEED).toBe(
+        "JBSWY3DPEHPK3PXP",
+      );
+    });
+
+    it("omits the key list when there are no extra fields", () => {
+      const id = cm.add({ username: "admin", password: "pw" });
+      expect(cm.getReference(id)!.additionalFieldKeys).toBeUndefined();
+    });
+
+    it("keeps credentials that differ only by extra fields distinct", () => {
+      const a = cm.addFromAuthCredentials({
+        username: "admin",
+        password: "pw",
+        additionalFields: { TOTP_SEED: "SEED_A" },
+      });
+      const b = cm.addFromAuthCredentials({
+        username: "admin",
+        password: "pw",
+        additionalFields: { TOTP_SEED: "SEED_B" },
+      });
+      expect(a).not.toBe(b);
+    });
   });
 
   // =========================================================================

--- a/src/tests/delegateAuthMerge.test.ts
+++ b/src/tests/delegateAuthMerge.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { mergeAuthCredentials } from "../core/agents/offSecAgent/tools/delegateAuth";
+import { CredentialManager } from "../core/credentials";
+
+describe("mergeAuthCredentials", () => {
+  it("carries additional fields from the session credentials", () => {
+    const merged = mergeAuthCredentials(
+      {
+        username: "admin",
+        password: "pw",
+        additionalFields: { TOTP_SEED: "JBSWY3DPEHPK3PXP" },
+      },
+      {},
+    );
+    expect(merged?.additionalFields).toEqual({ TOTP_SEED: "JBSWY3DPEHPK3PXP" });
+  });
+
+  it("prefers explicitly resolved additional fields", () => {
+    const merged = mergeAuthCredentials(
+      { username: "admin", password: "pw", additionalFields: { PIN: "1111" } },
+      { username: "admin", additionalFields: { PIN: "2222" } },
+    );
+    expect(merged?.additionalFields).toEqual({ PIN: "2222" });
+  });
+
+  // The delegation path re-adds the merged credential to the manager, which
+  // dedupes on every secret field. Dropping one here silently spawns a twin
+  // credential that shares the login but is missing its extra secrets.
+  it("re-adds onto the original credential instead of creating a twin", () => {
+    const cm = new CredentialManager();
+    const original = cm.addFromAuthCredentials({
+      username: "admin",
+      password: "pw",
+      additionalFields: { TOTP_SEED: "JBSWY3DPEHPK3PXP" },
+    });
+
+    const stored = cm.resolve(original)!;
+    const rebuilt = mergeAuthCredentials(undefined, {
+      username: stored.username,
+      password: stored.password,
+      additionalFields: stored.additionalFields,
+    });
+
+    expect(cm.addFromAuthCredentials(rebuilt!)).toBe(original);
+    expect(cm.size).toBe(1);
+  });
+});

--- a/src/tests/delegateAuthMerge.test.ts
+++ b/src/tests/delegateAuthMerge.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { mergeAuthCredentials } from "../core/agents/offSecAgent/tools/delegateAuth";
 import { CredentialManager } from "../core/credentials";
 
@@ -34,14 +34,15 @@ describe("mergeAuthCredentials", () => {
       additionalFields: { TOTP_SEED: "JBSWY3DPEHPK3PXP" },
     });
 
-    const stored = cm.resolve(original)!;
+    const stored = cm.resolve(original);
     const rebuilt = mergeAuthCredentials(undefined, {
-      username: stored.username,
-      password: stored.password,
-      additionalFields: stored.additionalFields,
+      username: stored?.username,
+      password: stored?.password,
+      additionalFields: stored?.additionalFields,
     });
+    expect(rebuilt).toBeDefined();
 
-    expect(cm.addFromAuthCredentials(rebuilt!)).toBe(original);
+    expect(cm.addFromAuthCredentials(rebuilt ?? {})).toBe(original);
     expect(cm.size).toBe(1);
   });
 });


### PR DESCRIPTION
## Why

Operators sometimes need to hand an agent a secret that isn't a password, token, or header — the motivating case is an **MFA TOTP seed** so an agent can get past a GitHub-style authenticator prompt on its own. Today the only place to put one is the credential's free-text `context`, which means pasting the seed in plaintext straight into the model's prompt.

## What

Credentials can carry arbitrary named secrets. Agents get the **names**, never the values.

- `CredentialReference.additionalFieldKeys` lists the field names; `formatForPrompt` renders them as `Extra secret fields: …` and explains the two ways to use one. Values stay inside `CredentialManager`.
- `browser_fill`'s `credentialField` now accepts a custom field name in addition to the built-ins, resolved at execution time like any other secret.
- `findDuplicate` compares `additionalFields`, so two credentials differing only by their extra secrets stay distinct.

The auth agent was missing the shell env entirely, which is what made the TOTP case impossible:

- `delegate_to_auth_subagent` forwards `environmentVariables` (it already forwarded `secretValues`).
- The auth prompt gained an `ENVIRONMENT VARIABLES` section listing names only — same shape the pentest agent already uses.
- With a seed reachable that way, an authenticator-code page is no longer a hard barrier: the system prompt tells the agent to compute the code from the env var, and to report an MFA block only when no seed exists or two fresh codes are rejected.

The console side of this (storage, encryption, UI, env-var mapping) is in pensarai/console.

## Test

`src/tests/credentialManager.test.ts` — extra field names appear on the reference and in the prompt block, values never do; the no-extra-fields case stays `undefined`; credentials differing only by extra fields don't dedupe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential resolution, auth delegation, and MFA handling—security-sensitive paths—but values remain out of prompts and changes are narrowly scoped with new tests.
> 
> **Overview**
> Credentials can now carry **operator-defined named secrets** (`additionalFields`). Agents only see field **names** via `additionalFieldKeys` in prompts and references; values stay in `CredentialManager`. **`browser_fill`** accepts any `credentialField` string (built-ins or extra field names) and resolves extras at execution time. **Dedup/merge** includes `additionalFields` so delegation does not spawn twin credentials missing TOTP seeds.
> 
> **`delegate_to_auth_subagent`** forwards **`environmentVariables`** (with existing `secretValues`) into the authentication agent. The auth prompt lists env var **names** only and documents TOTP: compute a 6-digit code from the seed env var via shell, retry once on boundary rejection, and treat MFA as a barrier only when no seed exists or two fresh codes fail.
> 
> Tests cover prompt/reference redaction, distinct dedupe on extra fields, and **`mergeAuthCredentials`** carrying extras through re-add.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62e6d656a98cc1babe5ef1c86802e2fe9c6ca0c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->