### PR TITLE
fix(build): pin AI SDK for reliable npm installs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@opentui/react": "^0.1.107",
         "@pensar/surface": "0.3.0",
         "@playwright/mcp": "^0.0.54",
-        "ai": "^6.0.208",
+        "ai": "6.0.208",
         "camoufox-js": "^0.11.1",
         "glob": "^13.0.6",
         "highlight.js": "^11.11.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@opentui/react": "^0.1.107",
     "@pensar/surface": "0.3.0",
     "@playwright/mcp": "^0.0.54",
-    "ai": "^6.0.208",
+    "ai": "6.0.208",
     "camoufox-js": "^0.11.1",
     "glob": "^13.0.6",
     "highlight.js": "^11.11.1",


### PR DESCRIPTION
## Summary
- Pin `ai` to the tested `6.0.208` version in `package.json` and `bun.lock`.
- Keep packed npm installs from resolving a just-published AI SDK release before its exact gateway dependency is available.

The failed build resolved the caret range to `ai@6.0.256`, which requires `@ai-sdk/gateway@3.0.174`. That gateway version reached npm roughly two seconds after the install failed, exposing a package-publication race.

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] `bun run generate:ascii && bun run build`
- [x] `npm pack`
- [x] Install the tarball into an isolated global npm prefix
- [x] Run Node CLI smoke tests for version and help commands

Made with [Cursor](https://cursor.com)