### PR TITLE
feat(pentest): support Fast Strike in targeted agents

### DIFF
--- a/src/core/agents/specialized/pentest/agent.test.ts
+++ b/src/core/agents/specialized/pentest/agent.test.ts
@@ -8,6 +8,7 @@ import {
   buildPentestSystemPrompt,
   PentestResponseSchema,
   resolvePentestAgentRole,
+  type TargetedPentestMode,
 } from "./agent";
 
 const session = {
@@ -231,6 +232,99 @@ describe("TargetedPentestAgent prompt contracts", () => {
 
     expect(userPrompt).toContain("newObjectives");
     expect(userPrompt).toContain("ZERO open objectives");
+  });
+
+  describe("Fast Strike task-driven suppression", () => {
+    const taskDrivenSession = {
+      rootPath: "/tmp/apex-test-session",
+      config: { taskDriven: true },
+    };
+
+    it("does not emit task-driven instructions for a fast-strike worker even when taskDriven is set", () => {
+      // Fast Strike runs as a single focused worker with create_task /
+      // update_task / list_tasks excluded at the harness boundary
+      // (FAST_STRIKE_EXCLUDED_TOOL_NAMES). The user prompt must not tell the
+      // agent to use tools it does not have.
+      const fastStrikePrompt = buildPentestPrompt(
+        "https://example.com/api/users",
+        ["Test /api/users id param for SQL injection"],
+        taskDrivenSession,
+        undefined, // findingsRegistry
+        undefined, // context
+        undefined, // envVarNames
+        undefined, // subagentId
+        "worker", // resolvePentestAgentRole("fast-strike", …) → worker
+        undefined, // credentialContext
+        undefined, // grpc
+        "fast-strike",
+      );
+
+      expect(fastStrikePrompt).not.toContain("create_task");
+      expect(fastStrikePrompt).not.toContain("update_task");
+      expect(fastStrikePrompt).not.toContain("list_tasks");
+      // It still emits the ordinary focused-worker testing loop.
+      expect(fastStrikePrompt).toContain("outline your testing plan");
+    });
+
+    it("still emits task-driven instructions for a default-mode worker with taskDriven set", () => {
+      const defaultWorkerPrompt = buildPentestPrompt(
+        "https://example.com/api/users",
+        ["Test /api/users id param for SQL injection"],
+        taskDrivenSession,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "worker",
+        // mode defaults to "default" — the task-driven worker keeps its
+        // create_task/update_task/list_tasks decomposition flow.
+      );
+
+      expect(defaultWorkerPrompt).toContain("create_task");
+      expect(defaultWorkerPrompt).toContain("update_task");
+      expect(defaultWorkerPrompt).toContain("list_tasks");
+    });
+
+    it("also suppresses the task-driven system prompt for fast-strike + taskDriven", () => {
+      const system = buildPentestSystemPrompt(
+        taskDrivenSession,
+        "worker",
+        "fast-strike",
+      );
+
+      expect(system).toContain("Strike assessment");
+      expect(system).not.toContain("TASK-DRIVEN TESTING");
+      expect(system).not.toContain("Task Coverage Rules");
+    });
+
+    it("leaves no-mode/default behavior unchanged: a plain worker emits neither task nor strike instructions", () => {
+      const prompt = buildPentestPrompt(
+        "https://example.com/api/users",
+        ["Test /api/users id param for SQL injection"],
+        { rootPath: "/tmp/apex-test-session", config: {} },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "worker",
+      );
+
+      expect(prompt).toContain("outline your testing plan");
+      expect(prompt).not.toContain("create_task");
+    });
+  });
+
+  it("narrows the harness AgentMode to exactly default | fast-strike (excludes plan)", () => {
+    // Compile-time contract: if TargetedPentestMode ever widens to re-admit
+    // "plan" (or any other AgentMode), `isExact` stops resolving to `true` and
+    // this assignment fails to compile — the test can't be edited to paper over
+    // the regression without also changing the type.
+    type Equal<A, B> =
+      (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+        ? true
+        : false;
+    const isExact: Equal<TargetedPentestMode, "default" | "fast-strike"> = true;
+    expect(isExact).toBe(true);
   });
 
   describe("PentestResponseSchema", () => {

--- a/src/core/agents/specialized/pentest/agent.test.ts
+++ b/src/core/agents/specialized/pentest/agent.test.ts
@@ -7,6 +7,7 @@ import {
   buildPentestPrompt,
   buildPentestSystemPrompt,
   PentestResponseSchema,
+  resolvePentestAgentRole,
 } from "./agent";
 
 const session = {
@@ -15,6 +16,30 @@ const session = {
 };
 
 describe("TargetedPentestAgent prompt contracts", () => {
+  it("forces Fast Strike into the single-worker role", () => {
+    expect(resolvePentestAgentRole("fast-strike", "orchestrator")).toBe(
+      "worker",
+    );
+    expect(resolvePentestAgentRole("default", "orchestrator")).toBe(
+      "orchestrator",
+    );
+  });
+
+  it("uses the focused Strike loop without orchestrator fan-out", () => {
+    const prompt = buildPentestSystemPrompt(
+      session,
+      "orchestrator",
+      "fast-strike",
+    );
+
+    expect(prompt).toContain("Strike assessment");
+    expect(prompt).toContain("OBSERVE");
+    expect(prompt).toContain("HYPOTHESIZE");
+    expect(prompt).toContain("document_vulnerability");
+    expect(prompt).toContain("objectiveResults");
+    expect(prompt).not.toContain("CHAIN & EXPLORE");
+  });
+
   it("keeps document_vulnerability out of the orchestrator toolset", () => {
     const tools = buildPentestActiveTools("orchestrator", session);
 

--- a/src/core/agents/specialized/pentest/agent.test.ts
+++ b/src/core/agents/specialized/pentest/agent.test.ts
@@ -40,6 +40,32 @@ describe("TargetedPentestAgent prompt contracts", () => {
     expect(prompt).not.toContain("CHAIN & EXPLORE");
   });
 
+  it("preserves rate-limit and live-delivery guardrails in Fast Strike", () => {
+    const blocked = buildPentestSystemPrompt(
+      session,
+      "orchestrator",
+      "fast-strike",
+    );
+    expect(blocked).toContain(
+      "Rate-Limit / Anti-Automation Testing (OUT OF SCOPE)",
+    );
+    expect(blocked).toContain(
+      "Real-World Side Effects — Prove Once, Never Loop",
+    );
+
+    const authorized = buildPentestSystemPrompt(
+      { ...session, config: { allowRateLimitTesting: true } },
+      "orchestrator",
+      "fast-strike",
+    );
+    expect(authorized).toContain(
+      "Testing for Rate Limiting Deficiencies (AUTHORIZED)",
+    );
+    expect(authorized).not.toContain(
+      "Rate-Limit / Anti-Automation Testing (OUT OF SCOPE)",
+    );
+  });
+
   it("keeps document_vulnerability out of the orchestrator toolset", () => {
     const tools = buildPentestActiveTools("orchestrator", session);
 

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -44,8 +44,21 @@ const log = scopedLogger(() => createLogger("pentest-agent"));
  */
 export type PentestAgentRole = "orchestrator" | "worker";
 
+/**
+ * Operating mode for a {@link TargetedPentestAgent}.
+ *
+ * A deliberately narrower subset of the harness-level {@link AgentMode}: this
+ * agent only implements the `"default"` (orchestrator/worker methodology) and
+ * `"fast-strike"` (single focused worker) prompt + tool contracts. `"plan"` is
+ * intentionally excluded — there is no plan-mode prompt or tool wiring here, so
+ * accepting it would be a type-level lie. Deriving from {@link AgentMode} via
+ * `Extract` keeps the two in lockstep: if the harness ever renames or drops one
+ * of these modes, this type stops compiling.
+ */
+export type TargetedPentestMode = Extract<AgentMode, "default" | "fast-strike">;
+
 export function resolvePentestAgentRole(
-  mode: AgentMode = "default",
+  mode: TargetedPentestMode = "default",
   role: PentestAgentRole = "orchestrator",
 ): PentestAgentRole {
   return mode === "fast-strike" ? "worker" : role;
@@ -76,8 +89,9 @@ export interface PentestAgentInput extends SpecializedAgentInput {
   context?: string;
 
   /** Harness mode. Fast Strike always runs as one focused worker and disables
-   * orchestration, planning, and task-decomposition tools. */
-  mode?: AgentMode;
+   * orchestration, planning, and task-decomposition tools. Narrowed to the
+   * modes this agent actually implements — see {@link TargetedPentestMode}. */
+  mode?: TargetedPentestMode;
 
   /**
    * Operating role. Defaults to `"orchestrator"`.
@@ -260,6 +274,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
         // those resolve at tool-execution time via credentialId/credentialField.
         session.credentialManager?.formatForPrompt(),
         grpc,
+        mode,
       ),
       model,
       session,
@@ -772,7 +787,7 @@ export function buildPentestSystemPrompt(
     };
   },
   role: PentestAgentRole = "orchestrator",
-  mode: AgentMode = "default",
+  mode: TargetedPentestMode = "default",
 ): string {
   const destructive = destructiveSection(
     session.config?.allowDestructiveActions,
@@ -888,15 +903,20 @@ export function buildPentestPrompt(
   // `session` param intentionally omits the (non-serializable) credentialManager.
   credentialContext?: string,
   grpc?: GrpcPentestContext,
+  mode: TargetedPentestMode = "default",
 ): string {
   const sessionRootPath = session.rootPath;
   const exfilMode = session.config?.exfilMode ?? false;
   // Orchestrator does not own a task-driven decomposition flow — it
-  // delegates to workers. Force taskDriven off when role==='orchestrator'
-  // so the prompt directs the agent to spawn_pentest_agent rather than
-  // create_task.
+  // delegates to workers. Fast Strike runs as a single focused worker with the
+  // task tools excluded at the harness boundary (FAST_STRIKE_EXCLUDED_TOOL_NAMES),
+  // so it must not emit create_task/update_task/list_tasks instructions even when
+  // the session opted into taskDriven. Force taskDriven off in both cases so the
+  // prompt never references tools the agent doesn't have.
   const taskDriven =
-    role === "orchestrator" ? false : (session.config?.taskDriven ?? false);
+    mode === "fast-strike" || role === "orchestrator"
+      ? false
+      : (session.config?.taskDriven ?? false);
   const outcomeGuidance = session.config?.outcomeGuidance;
   const objectiveList = objectives.map((o, i) => `${i + 1}. ${o}`).join("\n");
 

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -543,8 +543,6 @@ ${SECTION_SOURCE_CODE_PROHIBITION}
 
 ${SECTION_RATE_LIMITING}
 
-${SECTION_RATE_LIMITING_TESTING}
-
 ${SECTION_DOCUMENT_VULNERABILITY_RULES}
 
 ${SECTION_MATERIALITY_GUIDANCE}
@@ -787,10 +785,10 @@ export function buildPentestSystemPrompt(
   const guardrails = `${destructive}\n\n${rateLimitTesting}\n\n${SECTION_SIDE_EFFECT_SAFETY}`;
 
   if (mode === "fast-strike") {
-    const withDestructive = `${PENTEST_SYSTEM_PROMPT_STRIKE}\n\n${destructive}`;
+    const withGuardrails = `${PENTEST_SYSTEM_PROMPT_STRIKE}\n\n${guardrails}`;
     return session.config?.promptInjectionLibrarySource
-      ? `${withDestructive}\n\n${SECTION_PROMPT_INJECTION}`
-      : withDestructive;
+      ? `${withGuardrails}\n\n${SECTION_PROMPT_INJECTION}`
+      : withGuardrails;
   }
 
   if (role === "orchestrator") {

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -8,6 +8,7 @@ import { isMemoryEnabled } from "../../../memory";
 import { readPlan } from "../../../plan";
 import { scopedLogger } from "../../../util/lazyLogger";
 import {
+  type AgentMode,
   createReportErrorTool,
   type Finding,
   OffensiveSecurityAgent,
@@ -43,6 +44,13 @@ const log = scopedLogger(() => createLogger("pentest-agent"));
  */
 export type PentestAgentRole = "orchestrator" | "worker";
 
+export function resolvePentestAgentRole(
+  mode: AgentMode = "default",
+  role: PentestAgentRole = "orchestrator",
+): PentestAgentRole {
+  return mode === "fast-strike" ? "worker" : role;
+}
+
 export type { GrpcPentestContext };
 
 export interface PentestAgentInput extends SpecializedAgentInput {
@@ -66,6 +74,10 @@ export interface PentestAgentInput extends SpecializedAgentInput {
    * The agent will treat non-malicious instructions within the context as guidance.
    */
   context?: string;
+
+  /** Harness mode. Fast Strike always runs as one focused worker and disables
+   * orchestration, planning, and task-decomposition tools. */
+  mode?: AgentMode;
 
   /**
    * Operating role. Defaults to `"orchestrator"`.
@@ -201,9 +213,11 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       thinkingEffort,
       openAIReasoningEffort,
       role = "orchestrator",
+      mode = "default",
       browserSession,
       display,
     } = opts;
+    const effectiveRole = resolvePentestAgentRole(mode, role);
 
     // The base class creates the response tool from responseSchema and
     // invokes onResult with the validated data. We intercept that via
@@ -230,7 +244,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
     let reportedError: ReportedError | null = null;
 
     super({
-      system: buildPentestSystemPrompt(session, role),
+      system: buildPentestSystemPrompt(session, effectiveRole, mode),
       prompt: buildPentestPrompt(
         target,
         objectives,
@@ -239,7 +253,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
         context,
         environmentVariables ? Object.keys(environmentVariables) : undefined,
         subagentId,
-        role,
+        effectiveRole,
         // Surface the operator-provided credentials (IDs / usernames / login
         // URLs / context) into the prompt so the agent knows what to log in
         // with. `formatForPrompt()` is safe — it never emits secret values;
@@ -270,7 +284,8 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       openAIReasoningEffort,
       browserSession,
       display,
-      activeTools: buildPentestActiveTools(role, session),
+      mode,
+      activeTools: buildPentestActiveTools(effectiveRole, session),
 
       responseSchema: PentestResponseSchema,
 
@@ -507,6 +522,47 @@ const SECTION_PROMPT_INJECTION = `Prompt-Injection Testing (payload library conf
 // Assembled system prompts
 // ---------------------------------------------------------------------------
 
+const PENTEST_SYSTEM_PROMPT_STRIKE = `You are an elite penetration tester running a focused Strike assessment against one target. Work ALONE and finish the objectives yourself — do not delegate, spawn agents, map the entire attack surface, or create task lists.
+
+You are given a specific target and specific objectives. Reconnaissance and exploitation are one tight loop:
+1. OBSERVE — Read every response for signal: stack details, headers, cookies, tokens, form fields, errors, redirects, disabled controls, and identifier patterns.
+2. HYPOTHESIZE — Choose the strongest vulnerability lead supported by that evidence and explain why it is the best next move.
+3. ACT — Test that hypothesis directly. For stateful, repetitive, concurrent, protocol-heavy, or multi-stage work, build an editable script in the session scratchpad directory, run it, inspect it, and iterate.
+4. PRUNE — Drop disproven leads instead of repeating them or grinding through generic enumeration.
+5. EXPLOIT — Confirm impact and build on viable primitives. Prefer extending a working script into an end-to-end exploit over restarting with disconnected one-off commands.
+6. DOCUMENT & FINISH — Call document_vulnerability for every confirmed issue. When the supplied objectives are complete or every credible lead is exhausted, call response with a concise summary, objectiveResults for every objective, and any high-signal newObjectives for a future run.
+
+Rules:
+- Stay focused on the supplied target and objectives. Do not perform broad service or endpoint discovery.
+- Spend reasoning on choosing techniques and interpreting evidence; use scripts for deterministic mechanics.
+- Bias toward the shortest path that proves impact, but never trade verification for speed.
+- Before stopping with an objective incomplete, account for every viable primitive and pursue any concrete path that could still close it.
+- Never create a scratchpad/ directory inside the target repository.
+
+${SECTION_SOURCE_CODE_PROHIBITION}
+
+${SECTION_RATE_LIMITING}
+
+${SECTION_RATE_LIMITING_TESTING}
+
+${SECTION_DOCUMENT_VULNERABILITY_RULES}
+
+${SECTION_MATERIALITY_GUIDANCE}
+
+${SECTION_POC_PORTABILITY}
+
+${SECTION_BROWSER_INTERACTION}
+
+${SECTION_AUTHENTICATION}
+
+${SECTION_CREDENTIAL_DISCOVERY}
+
+${SECTION_SECURITY_HEADERS_CORS}
+
+${SECTION_FINDING_QUALITY}
+
+${SECTION_STATE_CHECKPOINTING}`;
+
 const PENTEST_SYSTEM_PROMPT_BASE = `You are an expert penetration tester performing a targeted security assessment.
 
 You are given a specific target and specific objectives. Do NOT perform broad reconnaissance or service/endpoint discovery — that has already been done for you. Your job is to deeply test the provided target against the provided objectives.
@@ -718,6 +774,7 @@ export function buildPentestSystemPrompt(
     };
   },
   role: PentestAgentRole = "orchestrator",
+  mode: AgentMode = "default",
 ): string {
   const destructive = destructiveSection(
     session.config?.allowDestructiveActions,
@@ -728,6 +785,13 @@ export function buildPentestSystemPrompt(
   // SECTION_SIDE_EFFECT_SAFETY is unconditional — a live-delivery endpoint is
   // never looped regardless of the rate-limit / destructive opt-ins.
   const guardrails = `${destructive}\n\n${rateLimitTesting}\n\n${SECTION_SIDE_EFFECT_SAFETY}`;
+
+  if (mode === "fast-strike") {
+    const withDestructive = `${PENTEST_SYSTEM_PROMPT_STRIKE}\n\n${destructive}`;
+    return session.config?.promptInjectionLibrarySource
+      ? `${withDestructive}\n\n${SECTION_PROMPT_INJECTION}`
+      : withDestructive;
+  }
 
   if (role === "orchestrator") {
     return `${PENTEST_SYSTEM_PROMPT_ORCHESTRATOR}\n\n${guardrails}`;


### PR DESCRIPTION
## Summary
- allow `TargetedPentestAgent` callers to select the existing `fast-strike` harness mode
- force targeted Fast Strike runs into the single-worker role while preserving findings, objective results, browser use, and event-bus contracts
- add a focused Strike prompt while retaining canary's destructive-action, rate-limit opt-in, and live-delivery safety guardrails

## Test plan
- [x] `bun run tsc`
- [x] `bun run test` (1,515 passed; 22 skipped)
- [x] `bun run lint`
- [x] `bun run format:check`

## Related
Unblocks [Console Strike Mode PR #2445](https://github.com/pensarai/console/pull/2445).

Made with [Cursor](https://cursor.com)