### PR TITLE
2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,5 +113,5 @@
     "tsc": "tsc --noEmit"
   },
   "type": "module",
-  "version": "2.3.0"
+  "version": "2.4.0"
 }


### PR DESCRIPTION
Version bump for the 2.4.0 release. Only changes `package.json`.

Once this lands on `canary`, the release is cut by opening a `canary` → `release` PR and merging it with a merge commit — that fires `.github/workflows/release.yml`, which tags `v2.4.0`, builds the five platform binaries, publishes npm `latest`, updates the Homebrew formula, and posts to Discord.

### What ships in 2.4.0

14 commits since `v2.3.0` (2026-07-28).

**Features**
- #955 workspace domain and endpoint tools for the agent
- #954 Fast Strike support in targeted agents
- #950 human-gated Console workspace management
- #949 resolve operator-named extra secrets without exposing values
- #948 Concentrate provider support
- #934 improved Fast Strike scripted exploit workflow

**Fixes**
- #952 gate burst testing on the rate-limit opt-in, never loop live-delivery endpoints
- #943 prompt caching was off on Bedrock and partial on the gateway
- #947 announce and complete every subagent carrying a `subagentId`
- #946 match Camoufox window to Xvfb display tier
- #940 reap orphaned Camoufox when the MCP node dies
- #939 preserve tool pairs when trimming session history
- #938 stamp `sessionId`/`messageId` on reasoning events
- #935 stop the repo's `AGENTS.md` from corrupting the patching prompt

New features, no breaking changes — minor bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version bump with no code, auth, or data-handling changes.
> 
> **Overview**
> Bumps the package version from `2.3.0` to `2.4.0` in `package.json` so the canary→release merge can tag, publish, and ship the 2.4.0 release. No other files change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98d743263d5d5c8bb44ba2ab7b0c83a9d8e74ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->