### PR TITLE
feat(cli): expose endpoint transport and workspace domains in pensar apps

### DIFF
--- a/src/cli/apps.test.ts
+++ b/src/cli/apps.test.ts
@@ -1,0 +1,63 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CLI = join(import.meta.dirname, "apps.ts");
+
+// Every case below fails before any API call, so these stay offline.
+function runApps(args: string[]) {
+  const result = spawnSync("bun", [CLI, ...args], { encoding: "utf8" });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+describe("pensar apps CLI", () => {
+  it("advertises the domain subcommands and transport flag", () => {
+    const { status, stdout } = runApps(["--help"]);
+
+    expect(status).toBe(0);
+    expect(stdout).toContain("pensar apps domains");
+    expect(stdout).toContain("pensar apps domain-create <domain>");
+    expect(stdout).toContain("--transport <transport>");
+    expect(stdout).toContain("http, grpc, grpc_web, connect");
+  });
+
+  it("rejects an unknown endpoint transport", () => {
+    const { status, stderr } = runApps([
+      "endpoint-create",
+      "app-1",
+      "--endpoint",
+      "/v1/orders",
+      "--description",
+      "Orders",
+      "--transport",
+      "carrier-pigeon",
+    ]);
+
+    expect(status).toBe(1);
+    expect(stderr).toContain('Invalid --transport "carrier-pigeon"');
+    expect(stderr).toContain("http, grpc, grpc_web, connect");
+  });
+
+  it("rejects an unknown transport on endpoint-update", () => {
+    const { status, stderr } = runApps([
+      "endpoint-update",
+      "endpoint-1",
+      "--transport",
+      "smoke-signal",
+    ]);
+
+    expect(status).toBe(1);
+    expect(stderr).toContain('Invalid --transport "smoke-signal"');
+  });
+
+  it("requires a domain argument for domain-create", () => {
+    const { status, stderr } = runApps(["domain-create"]);
+
+    expect(status).toBe(1);
+    expect(stderr).toContain("Usage: pensar apps domain-create <domain>");
+  });
+});

--- a/src/cli/apps.ts
+++ b/src/cli/apps.ts
@@ -11,6 +11,8 @@
  *   pensar apps create --name N --description D [opts]      Create an app
  *   pensar apps update <appId> [opts]                       Update app fields
  *   pensar apps delete <appId>                              Delete an app
+ *   pensar apps domains                                     List domains
+ *   pensar apps domain-create <domain>                      Create a domain
  *   pensar apps endpoints <appId> [filters]                 List endpoints
  *   pensar apps endpoint <endpointId>                       Show endpoint
  *   pensar apps endpoint-create <appId> --endpoint E ...    Create endpoint
@@ -23,13 +25,17 @@ import {
   type CreateAppInput,
   type CreateEndpointInput,
   createApp,
+  createDomain,
   createEndpoint,
   deleteApp,
   deleteEndpoint,
+  ENDPOINT_TRANSPORTS,
+  type EndpointTransport,
   type EndpointType,
   getApp,
   getEndpoint,
   listApps,
+  listDomains,
   listEndpoints,
   searchApps,
   searchEndpoints,
@@ -102,6 +108,18 @@ function parseEndpointType(
   return value as EndpointType;
 }
 
+function parseTransport(
+  value: string | undefined,
+): EndpointTransport | undefined {
+  if (value === undefined) return undefined;
+  if (!ENDPOINT_TRANSPORTS.includes(value as EndpointTransport)) {
+    throw new Error(
+      `Invalid --transport "${value}". Must be one of: ${ENDPOINT_TRANSPORTS.join(", ")}`,
+    );
+  }
+  return value as EndpointTransport;
+}
+
 function parseInteger(
   flag: string,
   value: string | undefined,
@@ -137,6 +155,8 @@ Usage:
   pensar apps create [options]                             Create an app
   pensar apps update <appId> [options]                     Update an app
   pensar apps delete <appId>                               Delete an app
+  pensar apps domains                                      List workspace domains
+  pensar apps domain-create <domain>                       Create/resolve a domain
   pensar apps endpoints <appId> [filters]                  List endpoints
   pensar apps endpoint <endpointId>                        Show endpoint details
   pensar apps endpoint-create <appId> [options]            Create an endpoint
@@ -150,8 +170,12 @@ App fields (create requires --name and --description):
   --description <text>         Application description
   --type <type>                One of: ${APPLICATION_TYPES.join(", ")}
   --framework <text>           Framework / runtime hint
-  --domain <id>                Linked domain UUID
+  --domain <id>                Linked domain UUID (see "apps domains")
   --disallowed-actions <text>  Free-form disallowed actions notes
+
+Domains:
+  API-created domains are canonicalized and created idempotently by Console.
+  They stay unverified and do not start reconnaissance.
 
 List pagination (for "apps" and "endpoints <appId>"):
   --limit <n>                  Page size (default 100, max 200)
@@ -178,6 +202,8 @@ Endpoint fields (create requires --endpoint and --description):
   --endpoint <text>            Endpoint path / URL / route
   --description <text>         Endpoint description
   --type <type>                One of: ${ENDPOINT_TYPES.join(", ")}
+  --transport <transport>      One of: ${ENDPOINT_TRANSPORTS.join(", ")}
+                               (defaults to http when omitted)
   --location <text>            Source file (whitebox)
   --start-line <n>             Start line number
   --end-line <n>               End line number
@@ -255,6 +281,7 @@ function parseEndpointCreateOptions(argv: string[]): CreateEndpointInput {
   if (description === undefined) throw new Error("--description is required");
 
   const type = parseEndpointType(getFlag("--type", argv));
+  const transport = parseTransport(getFlag("--transport", argv));
   const location = getFlag("--location", argv);
   const startLineNumber = parseInteger(
     "--start-line",
@@ -270,6 +297,7 @@ function parseEndpointCreateOptions(argv: string[]): CreateEndpointInput {
     endpoint,
     description,
     ...(type !== undefined ? { type } : {}),
+    ...(transport !== undefined ? { transport } : {}),
     ...(location !== undefined ? { location } : {}),
     ...(startLineNumber !== undefined ? { startLineNumber } : {}),
     ...(endLineNumber !== undefined ? { endLineNumber } : {}),
@@ -290,6 +318,8 @@ function parseEndpointUpdateOptions(argv: string[]): UpdateEndpointInput {
   if (description !== undefined) update.description = description;
   const type = parseEndpointType(getFlag("--type", argv));
   if (type !== undefined) update.type = type;
+  const transport = parseTransport(getFlag("--transport", argv));
+  if (transport !== undefined) update.transport = transport;
   const location = getFlag("--location", argv);
   if (location !== undefined) update.location = location;
   const startLine = parseInteger("--start-line", getFlag("--start-line", argv));
@@ -348,6 +378,18 @@ async function main(): Promise<void> {
         process.exit(1);
       }
       const result = await deleteApp(appId);
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub === "domains") {
+      const result = await listDomains();
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub === "domain-create") {
+      const url = args[1];
+      if (!url) {
+        console.error("Error: domain is required");
+        console.error("Usage: pensar apps domain-create <domain>");
+        process.exit(1);
+      }
+      const result = await createDomain({ url });
       console.log(JSON.stringify(result, null, 2));
     } else if (sub === "endpoints") {
       const appId = args[1];


### PR DESCRIPTION
### What does this PR do?

#955 added `transport` (`http`, `grpc`, `grpc_web`, `connect`) to the endpoint API and the agent tools, and #950 wired up the workspace domain tools — but neither reached `pensar apps`. The agent could create a gRPC endpoint and the CLI could not, and while `pensar apps create --domain <id>` accepted a domain UUID, there was no way to discover or create that UUID without opening Console.

Three additions, all thin wrappers over API functions that already existed:

- `--transport <transport>` on `endpoint-create` and `endpoint-update`, validated against `ENDPOINT_TRANSPORTS` (the same shape as the existing `--type` validation)
- `pensar apps domains` → `listDomains()`
- `pensar apps domain-create <domain>` → `createDomain()`

`--domain <id>` now points at `apps domains` in the help text, and the help notes that API-created domains are canonicalized, idempotent, and stay unverified — matching the contract documented in `src/core/api/domains.ts`.

### How did you verify your code works?

Added `src/cli/apps.test.ts` — four subprocess tests that all fail before any API call, so they stay offline:

- `--help` advertises both domain subcommands and the transport flag with its value list
- a bogus `--transport` is rejected on `endpoint-create` and on `endpoint-update`
- `domain-create` with no argument prints usage and exits 1

Full suite passes locally (1538 passed, 17 skipped), plus `tsc --noEmit`, `bun run lint`, `format:check`, and `knip` all clean.

Docs for this land in #961, stacked on this branch. Closing #959.

Closes #958

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin CLI wrappers over existing APIs with local flag validation only; no auth, data-model, or backend changes.
> 
> **Overview**
> Wires existing API support into `pensar apps` so the CLI can set endpoint transport and manage workspace domains without Console.
> 
> Adds `--transport` on `endpoint-create` / `endpoint-update`, validated against `ENDPOINT_TRANSPORTS` (`http`, `grpc`, `grpc_web`, `connect`). Adds `apps domains` and `apps domain-create <domain>` as thin wrappers over `listDomains` / `createDomain`. Help text now points `--domain` at those commands and notes that API-created domains stay unverified.
> 
> Offline CLI tests cover help advertising, invalid transport rejection, and a missing domain argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff3fdcc36ff96fc68424169fe97c586990e67851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

