### PR TITLE
docs(fern): bring the CLI reference level with 2.4.0

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -90,6 +90,8 @@ navigation:
             path: ./docs/cli/auth.mdx
           - page: pensar pentests
             path: ./docs/cli/pentests.mdx
+          - page: pensar targets
+            path: ./docs/cli/targets.mdx
           - page: pensar issues
             path: ./docs/cli/issues.mdx
           - page: pensar apps

--- a/fern/docs/cli/apps.mdx
+++ b/fern/docs/cli/apps.mdx
@@ -5,7 +5,7 @@ description: "Manage the workspace attack surface — apps and endpoints — via
 
 ## Overview
 
-The `pensar apps` command lets you manage your **attack surface** — the applications and endpoints Pensar knows about — through the Pensar Console API. You can list, view, create, update, and delete apps, and do the same for the endpoints that belong to them.
+The `pensar apps` command lets you manage your **attack surface** — the applications and endpoints Pensar knows about — through the Pensar Console API. You can list, view, create, update, and delete apps, and do the same for the endpoints that belong to them. It also exposes the workspace's domains, so you can resolve the domain an app links to without leaving the terminal.
 
 All commands operate on the **selected workspace**, which is chosen when you connect with [`pensar login`](/apex/cli-commands/pensar-login). Apps and endpoints are scoped to that workspace — there is no project argument.
 
@@ -17,6 +17,8 @@ pensar apps get <appId>                        # Show app details
 pensar apps create [options]                   # Create an app
 pensar apps update <appId> [options]           # Update an app
 pensar apps delete <appId>                     # Delete an app
+pensar apps domains                            # List workspace domains
+pensar apps domain-create <domain>             # Create/resolve a domain
 pensar apps endpoints <appId> [filters]        # List an app's endpoints
 pensar apps endpoint <endpointId>              # Show endpoint details
 pensar apps endpoint-create <appId> [options]  # Create an endpoint
@@ -69,7 +71,7 @@ Creates a new app in the workspace. `--name` and `--description` are required.
 | `--description <text>`        | Application description (**required**)       |
 | `--type <type>`               | Application type (see [App types](#app-types)) |
 | `--framework <text>`          | Framework / runtime hint                     |
-| `--domain <id>`               | Linked domain UUID                           |
+| `--domain <id>`               | Linked domain UUID (see [Domain Subcommands](#domain-subcommands)) |
 | `--disallowed-actions <text>` | Free-form disallowed-actions notes           |
 
 ### Update an App
@@ -86,7 +88,7 @@ Updates one or more fields on an existing app. Only the flags you pass are chang
 | `--description <text>`        | New description                              |
 | `--type <type>`               | New application type                         |
 | `--framework <text>`          | New framework / runtime hint                 |
-| `--domain <id>`               | New linked domain UUID                       |
+| `--domain <id>`               | New linked domain UUID (see [Domain Subcommands](#domain-subcommands)) |
 | `--disallowed-actions <text>` | New disallowed-actions notes                 |
 
 ### Delete an App
@@ -96,6 +98,30 @@ pensar apps delete <appId>
 ```
 
 Deletes an app from the workspace. Returns `{ success, appId }`.
+
+## Domain Subcommands
+
+Apps link to a domain by UUID via `--domain`. These two subcommands are how you find or mint that UUID.
+
+### List Domains
+
+```bash
+pensar apps domains
+```
+
+Lists the domains in the selected workspace as `{ domains }`, where each entry is `{ id, url, verified }`. Use the `id` as the `--domain` value on `apps create` or `apps update`.
+
+### Create a Domain
+
+```bash
+pensar apps domain-create <domain>
+```
+
+Creates a domain in the workspace and returns `{ id, url, verified }`.
+
+<Note>
+Domains created through the API are canonicalized and created idempotently — passing a domain that already exists returns the existing record rather than failing. They stay **unverified** and do not start reconnaissance. Verification happens in Console.
+</Note>
 
 ## Endpoint Subcommands
 
@@ -135,6 +161,7 @@ Creates an endpoint under the given app. `--endpoint` and `--description` are re
 | `--endpoint <text>`     | Endpoint path / URL / route (**required**)          |
 | `--description <text>`  | Endpoint description (**required**)                  |
 | `--type <type>`         | Endpoint type (see [Endpoint types](#endpoint-types)) |
+| `--transport <transport>` | Wire transport (see [Endpoint transports](#endpoint-transports)); defaults to `http` |
 | `--location <text>`     | Source file (whitebox)                              |
 | `--start-line <n>`      | Start line number                                   |
 | `--end-line <n>`        | End line number                                     |
@@ -153,7 +180,13 @@ Pass `--objective` more than once to attach multiple objectives. `--auth-require
 pensar apps endpoint-update <endpointId> [options]
 ```
 
-Updates one or more fields on an existing endpoint. Only the flags you pass are changed; the same field flags as `endpoint-create` are accepted (all optional here).
+Updates one or more fields on an existing endpoint. Only the flags you pass are changed; every field flag from `endpoint-create` is accepted here (all optional), plus one that is update-only:
+
+| Flag           | Description                                                          |
+| -------------- | -------------------------------------------------------------------- |
+| `--app <id>`   | **Update only.** Move the endpoint to a different app in the workspace |
+
+`--app` is not a valid flag on `endpoint-create` — the parent app is the positional `<appId>` argument there.
 
 ### Delete an Endpoint
 
@@ -203,6 +236,10 @@ pensar apps search-endpoints <query> [options]
 
 `--type` on an endpoint accepts one of: `api-endpoint`, `web-endpoint`, `auth-endpoint`, `database`, `file-storage`, `asset`.
 
+## Endpoint transports
+
+`--transport` on an endpoint accepts one of: `http`, `grpc`, `grpc_web`, `connect`. Endpoints created without it default to `http`.
+
 ## Examples
 
 ```bash
@@ -229,6 +266,24 @@ pensar apps endpoint-create app_abc123 \
   --auth-required \
   --objective "Test for IDOR on invoice id" \
   --objective "Check auth bypass"
+
+# Create a gRPC endpoint
+pensar apps endpoint-create app_abc123 \
+  --endpoint "orders.v1.OrderService/GetOrder" \
+  --description "Fetch an order over gRPC" \
+  --type api-endpoint \
+  --transport grpc
+
+# Correct an endpoint's transport after the fact
+pensar apps endpoint-update endpoint_xyz789 --transport grpc_web
+
+# Move an endpoint to a different app
+pensar apps endpoint-update endpoint_xyz789 --app app_def456
+
+# Resolve a domain, then link a new app to it
+pensar apps domains
+pensar apps domain-create billing.example.com
+pensar apps create --name "Billing API" --description "Customer billing service" --domain <domainId>
 
 # Search endpoints across the workspace for "login"
 pensar apps search-endpoints login --auth-required

--- a/fern/docs/cli/issues.mdx
+++ b/fern/docs/cli/issues.mdx
@@ -1,11 +1,11 @@
 ---
 title: "pensar issues"
-description: "List, view, update, and retest security issues via the Pensar Console API"
+description: "List, view, update, retest, and link pull requests to security issues via the Pensar Console API"
 ---
 
 ## Overview
 
-The `pensar issues` command lets you manage security issues discovered by pentests. You can list issues with filters, view detailed information, update issue statuses, and queue retests.
+The `pensar issues` command lets you manage security issues discovered by pentests. You can list issues with filters, view detailed information, update issue statuses, queue retests, and link the pull requests that fix them.
 
 All commands operate on the **selected workspace**, which is chosen when you connect with [`pensar login`](/apex/cli-commands/pensar-login). There is no longer a project argument.
 
@@ -16,7 +16,13 @@ pensar issues [filters]                        # List issues in the workspace (a
 pensar issues get <issueId>                    # Get issue details
 pensar issues update <issueId> [options]       # Update an issue
 pensar issues retest <issueId>                 # Queue an issue retest
+pensar issues link-pr <issueId> --url <url>    # Link a pull request to an issue
+pensar issues prs <issueId>                    # List pull requests linked to an issue
 ```
+
+<Note>
+`<issueId>` accepts either the issue UUID or its label — e.g. `VULN-000123`.
+</Note>
 
 ## Prerequisites
 
@@ -69,6 +75,28 @@ pensar issues retest <issueId>
 
 Queues an asynchronous retest of the issue against its original target. The JSON response includes the agent session ID for the queued run.
 
+### Link a Pull Request
+
+```bash
+pensar issues link-pr <issueId> --url <prUrl>
+```
+
+Links a pull request to the issue. `--url` is required.
+
+| Option        | Description                                          |
+| ------------- | ---------------------------------------------------- |
+| `--url <url>` | URL of the pull request to link (**required**)       |
+
+Returns `{ success, created, pullRequest, issue }`. `created` distinguishes a newly linked PR from one that was already attached, so re-running the command is safe.
+
+### List Linked Pull Requests
+
+```bash
+pensar issues prs <issueId>
+```
+
+Returns the pull requests linked to the issue as an array of `{ id, url, status, createMethod, createdAt }`. `createMethod` tells you whether the link came from an agent or from a person.
+
 ## Examples
 
 ```bash
@@ -86,6 +114,13 @@ pensar issues update issue_ghi789 --false-positive --fp-reason "Test environment
 
 # Retest an issue after deploying a fix
 pensar issues retest issue_ghi789
+
+# Reference an issue by its label instead of its UUID
+pensar issues get VULN-000123
+
+# Link the PR that fixes an issue, then confirm the link
+pensar issues link-pr VULN-000123 --url https://github.com/acme/api/pull/42
+pensar issues prs VULN-000123
 ```
 
 ## Related Commands

--- a/fern/docs/cli/targets.mdx
+++ b/fern/docs/cli/targets.mdx
@@ -1,0 +1,89 @@
+---
+title: "pensar targets"
+description: "List pentest targets and query their agent execution logs via the Pensar Console API"
+---
+
+## Overview
+
+A **target** is a single attack-surface endpoint exercised during a pentest. Pentest execution logs are persisted against the target rather than against the issues it produced, so `pensar targets` is how you query the full activity for an endpoint — **including runs that found nothing**.
+
+That distinction matters: [`pensar logs`](/apex/cli-commands/pensar-logs) is keyed by issue, so it can only show you work that ended in a finding. If you want to know what the agent tried against an endpoint that came back clean, you need the target.
+
+All commands operate on the **selected workspace**, which is chosen when you connect with [`pensar login`](/apex/cli-commands/pensar-login).
+
+## Usage
+
+```bash
+pensar targets <pentestId>                       # List targets for a pentest
+pensar targets logs <targetId> [filters]         # List agent logs for a target
+pensar targets search <targetId> <query> [opts]  # Search agent logs for a target
+```
+
+## Prerequisites
+
+You must be connected to Pensar Console via [`pensar login`](/apex/cli-commands/pensar-login) before using this command.
+
+## Subcommands
+
+### List Targets
+
+```bash
+pensar targets <pentestId>
+```
+
+Lists every target exercised by the given pentest. Use the returned target IDs with the `logs` and `search` subcommands.
+
+### List Target Logs
+
+```bash
+pensar targets logs <targetId> [filters]
+```
+
+Lists agent execution logs recorded against a target.
+
+| Filter            | Description                                                          |
+| ----------------- | -------------------------------------------------------------------- |
+| `--level <level>` | Filter by: `debug`, `info`, `warn`, `error`                          |
+| `--role <role>`   | Filter by: `assistant`, `user`, `system`, `tool-call`, `tool-result` |
+| `--limit <n>`     | Max entries to return (default: 100, max: 500)                       |
+
+### Search Target Logs
+
+```bash
+pensar targets search <targetId> <query> [options]
+```
+
+Searches a target's log entries for a query string.
+
+| Option            | Description                                                          |
+| ----------------- | -------------------------------------------------------------------- |
+| `--level <level>` | Filter by: `debug`, `info`, `warn`, `error`                          |
+| `--role <role>`   | Filter by: `assistant`, `user`, `system`, `tool-call`, `tool-result` |
+| `--context <n>`   | Context lines around matches (default: 3)                            |
+
+## Examples
+
+```bash
+# List the targets a pentest exercised
+pensar targets scan_abc123
+
+# Everything the agent did against one target
+pensar targets logs target_def456
+
+# Just the tool calls, capped at 50
+pensar targets logs target_def456 --role tool-call --limit 50
+
+# Find where the agent tried SQL injection against this target
+pensar targets search target_def456 "sqlmap" --context 5
+```
+
+## Related Commands
+
+<CardGroup cols={2}>
+  <Card title="pensar pentests" icon="shield" href="/apex/cli-commands/pensar-pentests">
+    List the pentests these targets belong to
+  </Card>
+  <Card title="pensar logs" icon="file-lines" href="/apex/cli-commands/pensar-logs">
+    Agent logs keyed by issue instead of by target
+  </Card>
+</CardGroup>


### PR DESCRIPTION
### What does this PR do?

`fern/` hadn't been touched since #920 (pre-2.2.0), and `apps.mdx` not since #822, so several shipped commands were undocumented and one section was actively wrong.

**`apps.mdx`**
- New "Endpoint transports" reference section and `--transport` on the endpoint-create flag table
- New "Domain Subcommands" section for `apps domains` / `apps domain-create`, with the canonicalization + unverified caveat from `src/core/api/domains.ts`. Both `--domain <id>` rows now link to it, so the flag is no longer a dead end
- Fixed the endpoint-update section. It said "the same field flags as `endpoint-create` are accepted", but `--app` (move an endpoint between apps, #865) is update-only and isn't a create flag at all — the parent app is positional there. Now documented in its own table with that called out
- Examples for gRPC endpoint creation, transport correction, moving an endpoint, and the domain → app linking flow

**`targets.mdx`** — new page for `pensar targets` (#864), which had no docs and no nav entry. Covers all three subcommands and their filters, and explains why it exists alongside `pensar logs`: logs are keyed by issue, so they can't show you runs that found nothing, while targets can.

**`issues.mdx`** — `link-pr` and `prs` (#925), including the `created` flag that makes re-linking safe and what `createMethod` tells you. Also documents that `<issueId>` accepts an issue label like `VULN-000123`, which the CLI has supported without ever saying so.

**`docs.yml`** — nav entry for the targets page.

### How did you verify your code works?

`fern check` reports 0 errors. The 2 warnings it prints are pre-existing — the href-only `blog` and `console` tabs have empty `layout:` blocks on `canary` too. `bun run format:check` passes. Every flag, subcommand, and response shape here was read off the CLI sources and `src/core/api/` rather than inferred.

Closes #959

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Fern CLI reference updates; no runtime, auth, or API behavior changes.
> 
> **Overview**
> Brings the Fern CLI reference in line with shipped 2.4.0 commands. No product code changes.
> 
> Adds a `pensar targets` page (and nav entry) so users can list pentest targets and query agent logs by target — including clean runs that `pensar logs` cannot show because it is issue-keyed.
> 
> Updates `pensar apps` with domain list/create, `--transport` (`http`/`grpc`/`grpc_web`/`connect`), and the update-only `--app` flag to move endpoints. Documents that API-created domains are idempotent, unverified, and do not start recon.
> 
> Updates `pensar issues` with `link-pr` / `prs` and notes that `<issueId>` accepts labels like `VULN-000123`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76669380a4d055cac6c0201a11321092b746643d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

