### PR TITLE
fix(agent): preserve abort state during teardown

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -102,6 +102,7 @@ function buildStubAgent(overrides: {
   ownsBrowserSession?: boolean;
   messagesPath?: string | null;
   latestMessages?: unknown[] | null;
+  persistenceTail?: Promise<void>;
   responseCaptured?: Promise<unknown>;
 }): OffensiveSecurityAgent<unknown> {
   const agent = Object.create(
@@ -152,6 +153,10 @@ function buildStubAgent(overrides: {
   });
   Object.defineProperty(agent, "cancelPersistTimer", {
     value: () => {},
+  });
+  Object.defineProperty(agent, "persistenceTail", {
+    value: overrides.persistenceTail ?? Promise.resolve(),
+    writable: true,
   });
 
   return agent;
@@ -941,6 +946,59 @@ describe("OffensiveSecurityAgent.consume()", () => {
       rmSync(tmpDir, { recursive: true, force: true });
     });
 
+    it("waits for an in-flight persist before writing the abort snapshot", async () => {
+      const tmpDir = join("/tmp", `pensar-test-${Date.now()}-persist-race`);
+      mkdirSync(tmpDir, { recursive: true });
+      const messagesPath = join(tmpDir, "messages.json");
+
+      const staleMessages = [
+        { role: "user", content: [{ type: "text", text: "scan target" }] },
+      ];
+      const persistedMessages = [
+        ...staleMessages,
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Starting scan" }],
+        },
+      ];
+      writeFileSync(messagesPath, JSON.stringify(staleMessages));
+
+      let finishPersist!: () => void;
+      const persistenceTail = new Promise<void>((resolve) => {
+        finishPersist = () => {
+          writeFileSync(messagesPath, JSON.stringify(persistedMessages));
+          resolve();
+        };
+      });
+
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow([toolCallChunk], new Error("timeout")),
+        messagesPath,
+        latestMessages: null,
+        persistenceTail,
+      });
+
+      const consume = agent.consume().catch(() => {});
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      finishPersist();
+      await consume;
+
+      const written = JSON.parse(readFileSync(messagesPath, "utf-8"));
+      expect(written.slice(0, persistedMessages.length)).toEqual(
+        persistedMessages,
+      );
+      expect(written.at(-2)).toMatchObject({
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "tc1" }],
+      });
+      expect(written.at(-1)).toMatchObject({
+        role: "tool",
+        content: [{ type: "tool-result", toolCallId: "tc1" }],
+      });
+
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
     it("does not add assistant tool-call msg when base already contains them", async () => {
       const tmpDir = join("/tmp", `pensar-test-${Date.now()}-nodup`);
       mkdirSync(tmpDir, { recursive: true });
@@ -1207,6 +1265,58 @@ describe("OffensiveSecurityAgent.consume()", () => {
 
       await expect(agent.consume()).rejects.toThrow("stream broke");
       expect(dispose).toHaveBeenCalledOnce();
+    });
+
+    it("preserves the stream error and disposes resources when deferred emission throws", async () => {
+      const tmpDir = join("/tmp", `pensar-test-${Date.now()}-listener-error`);
+      mkdirSync(tmpDir, { recursive: true });
+      const messagesPath = join(tmpDir, "messages.json");
+      const existingMessages = [
+        { role: "user", content: [{ type: "text", text: "scan" }] },
+      ];
+      writeFileSync(messagesPath, JSON.stringify(existingMessages));
+
+      const streamError = new Error("original stream error");
+      const dispose = vi.fn();
+      const disconnect = vi.fn().mockResolvedValue(undefined);
+      const agent = buildStubAgent({
+        fullStream: yieldThenThrow(
+          [
+            {
+              type: "tool-error",
+              toolCallId: "tc1",
+              toolName: "execute_command",
+              error: new Error("tool validation failed"),
+            },
+          ],
+          streamError,
+        ),
+        persistentShell: { dispose },
+        browserSession: { disconnect },
+        ownsBrowserSession: true,
+        messagesPath,
+        latestMessages: existingMessages,
+      });
+
+      agent.eventBus.on("tool-result", () => {
+        throw new Error("listener explosion");
+      });
+
+      await expect(agent.consume()).rejects.toBe(streamError);
+      expect(dispose).toHaveBeenCalledOnce();
+      expect(disconnect).toHaveBeenCalledOnce();
+
+      const written = JSON.parse(readFileSync(messagesPath, "utf-8"));
+      expect(written.at(-2)).toMatchObject({
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "tc1" }],
+      });
+      expect(written.at(-1)).toMatchObject({
+        role: "tool",
+        content: [{ type: "tool-result", toolCallId: "tc1" }],
+      });
+
+      rmSync(tmpDir, { recursive: true, force: true });
     });
   });
 });

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -322,7 +322,10 @@ export class OffensiveSecurityAgent<TResult = void> {
 
   private messagesPath: string | null = null;
 
-  /** Cancels the debounced persist timer so abort writes don't race it. */
+  /** Serializes agent-owned messages.json writes in enqueue order. */
+  private persistenceTail: Promise<void> = Promise.resolve();
+
+  /** Cancels a pending debounce; already-started writes remain in persistenceTail. */
   private cancelPersistTimer: (() => void) | null = null;
 
   private syntheticsPersisted = false;
@@ -617,7 +620,6 @@ export class OffensiveSecurityAgent<TResult = void> {
       mkdirSync(messagesDir, { recursive: true });
     }
     this.messagesPath = join(messagesDir, "messages.json");
-    const messagesPath = this.messagesPath;
 
     // Mutable so that summarization can clear stale history.
     const initialMessagesRef: { current: ModelMessage[] } = {
@@ -642,8 +644,11 @@ export class OffensiveSecurityAgent<TResult = void> {
         persistTimer = null;
         if (this.latestMessages) {
           const toWrite = this.latestMessages;
-          this.latestMessages = null;
-          writeFile(messagesPath, JSON.stringify(toWrite)).catch(() => {});
+          void this.enqueueMessagesWrite(toWrite)
+            .then(() => {
+              if (this.latestMessages === toWrite) this.latestMessages = null;
+            })
+            .catch(() => {});
         }
       }, PERSIST_INTERVAL_MS);
     };
@@ -743,9 +748,8 @@ export class OffensiveSecurityAgent<TResult = void> {
               ...initialMessagesRef.current,
               ...event.response.messages,
             ];
-            await writeFile(messagesPath, JSON.stringify(finalMessages)).catch(
-              () => {},
-            );
+            this.latestMessages = finalMessages;
+            await this.enqueueMessagesWrite(finalMessages).catch(() => {});
           }
           await input.onFinish?.(event);
         },
@@ -1113,57 +1117,82 @@ export class OffensiveSecurityAgent<TResult = void> {
       } finally {
         // Stop the stall watchdog so it never leaks past stream end / throw.
         if (stallTimer) clearInterval(stallTimer);
-        // Dispose first — don't block on persistence I/O.
-        this.persistentShell?.dispose();
-        // Flush tool-errors that never reached a finish-step into the snapshot.
-        for (const [toolCallId, info] of toolErrors) {
-          const result = {
-            type: "error-text" as const,
-            value: `Tool call failed: ${info.message}`,
-          };
-          bus.emit("tool-result", {
-            toolCallId,
-            toolName: info.toolName,
-            result,
-            sessionId: this.busSessionId,
-            subagentId: sid,
-            partId: ids.toolPartId?.(toolCallId),
-            messageId: ids.messageId,
-          });
-          completedResults.push({
-            type: "tool-result",
-            toolCallId,
-            toolName: info.toolName,
-            output: result,
-          });
-        }
-        toolErrors.clear();
-        // Snapshot unpersisted step state: open tools get synthetic closes, completed/errored results get written.
-        if (inFlightTools.size > 0 || completedResults.length > 0) {
-          const reason = this.abortSignal?.aborted
-            ? "Agent aborted by user"
-            : streamError instanceof Error && streamError.message
-              ? streamError.message
-              : "Stream terminated unexpectedly";
+        let finalizationError: unknown;
+        let hasFinalizationError = false;
+        const recordFinalizationError = (error: unknown) => {
+          if (hasFinalizationError) return;
+          finalizationError = error;
+          hasFinalizationError = true;
+        };
+
+        try {
+          // Dispose first — don't block on persistence I/O.
           try {
-            await this.emitSyntheticToolResults(
-              inFlightTools,
-              completedResults,
-              reason,
-              ids.toolPartId,
-              ids.messageId,
-              streamedArgText,
-            );
-          } catch {
-            // Never mask the original streamError with a listener error.
+            this.persistentShell?.dispose();
+          } catch (error) {
+            recordFinalizationError(error);
           }
+          // Flush tool-errors that never reached a finish-step into the snapshot.
+          for (const [toolCallId, info] of toolErrors) {
+            const result = {
+              type: "error-text" as const,
+              value: `Tool call failed: ${info.message}`,
+            };
+            completedResults.push({
+              type: "tool-result",
+              toolCallId,
+              toolName: info.toolName,
+              output: result,
+            });
+            try {
+              bus.emit("tool-result", {
+                toolCallId,
+                toolName: info.toolName,
+                result,
+                sessionId: this.busSessionId,
+                subagentId: sid,
+                partId: ids.toolPartId?.(toolCallId),
+                messageId: ids.messageId,
+              });
+            } catch (error) {
+              recordFinalizationError(error);
+            }
+          }
+          toolErrors.clear();
+          // Snapshot unpersisted step state: open tools get synthetic closes, completed/errored results get written.
+          if (inFlightTools.size > 0 || completedResults.length > 0) {
+            const reason = this.abortSignal?.aborted
+              ? "Agent aborted by user"
+              : streamError instanceof Error && streamError.message
+                ? streamError.message
+                : "Stream terminated unexpectedly";
+            try {
+              await this.emitSyntheticToolResults(
+                inFlightTools,
+                completedResults,
+                reason,
+                ids.toolPartId,
+                ids.messageId,
+                streamedArgText,
+              );
+            } catch (error) {
+              recordFinalizationError(error);
+            }
+          }
+        } catch (error) {
+          recordFinalizationError(error);
+        } finally {
+          // Tear down the Chromium child process we own. Without this, a
+          // naturally-finishing agent leaks its Playwright MCP browser — over a
+          // long single-process scan (many endpoints) the leaked Chromium
+          // processes exhaust memory and OOM the run. disconnect() force-kills
+          // and never hangs, so awaiting here is safe.
+          await this.disconnectOwnedBrowser();
         }
-        // Tear down the Chromium child process we own. Without this, a
-        // naturally-finishing agent leaks its Playwright MCP browser — over a
-        // long single-process scan (many endpoints) the leaked Chromium
-        // processes exhaust memory and OOM the run. disconnect() force-kills
-        // and never hangs, so awaiting here is safe.
-        await this.disconnectOwnedBrowser();
+        // Teardown failures must not replace the provider/stream failure.
+        if (streamError === null && hasFinalizationError) {
+          streamError = finalizationError;
+        }
       }
 
       if (streamError) {
@@ -1253,6 +1282,26 @@ export class OffensiveSecurityAgent<TResult = void> {
     await this.browserSession.disconnect().catch(() => {});
   }
 
+  private async enqueueMessagesWrite(messages: ModelMessage[]): Promise<void> {
+    const messagesPath = this.messagesPath;
+    if (!messagesPath) return;
+
+    const contents = JSON.stringify(messages);
+    const write = this.persistenceTail.then(() =>
+      writeFile(messagesPath, contents),
+    );
+    this.persistenceTail = write.catch(() => {});
+    await write;
+  }
+
+  private async waitForPendingMessagesWrites(): Promise<void> {
+    let pending: Promise<void>;
+    do {
+      pending = this.persistenceTail;
+      await pending;
+    } while (pending !== this.persistenceTail);
+  }
+
   /**
    * Idempotent teardown for hosts that abort before `consume()` settles
    * (Console `settleOnAbort` on timeout/pause). Force-disconnects the owned
@@ -1286,6 +1335,8 @@ export class OffensiveSecurityAgent<TResult = void> {
       value: `Tool execution aborted: ${reason}`,
     };
     const syntheticParts: ToolResultPart[] = [];
+    let emissionError: unknown;
+    let hasEmissionError = false;
 
     if (RESPONSE_DEBUG) {
       const responseInFlight = [...inFlightTools.entries()].filter(
@@ -1306,28 +1357,39 @@ export class OffensiveSecurityAgent<TResult = void> {
         toolName === RESPONSE_TOOL_NAME && this._responseToolFired
           ? { type: "text" as const, value: "Response submitted." }
           : output;
-      this.eventBus.emit("tool-result", {
-        toolCallId,
-        toolName,
-        result,
-        // Canonical session id, not just the legacy subagentId alias, so the translator routes to THIS subagent's session.
-        sessionId: this.busSessionId,
-        subagentId: sid,
-        partId: partIdFor?.(toolCallId),
-        messageId,
-      });
       syntheticParts.push({
         type: "tool-result",
         toolCallId,
         toolName,
         output: result,
       });
+      try {
+        this.eventBus.emit("tool-result", {
+          toolCallId,
+          toolName,
+          result,
+          // Canonical session id, not just the legacy subagentId alias, so the translator routes to THIS subagent's session.
+          sessionId: this.busSessionId,
+          subagentId: sid,
+          partId: partIdFor?.(toolCallId),
+          messageId,
+        });
+      } catch (error) {
+        if (!hasEmissionError) {
+          emissionError = error;
+          hasEmissionError = true;
+        }
+      }
     }
 
-    if (!this.messagesPath) return;
+    if (!this.messagesPath) {
+      if (hasEmissionError) throw emissionError;
+      return;
+    }
 
-    // Cancel the debounced timer so its writeFile can't race the write below.
+    // Cancel an unfired debounce and drain writes that already started.
     this.cancelPersistTimer?.();
+    await this.waitForPendingMessagesWrites();
 
     // Fall back to the on-disk snapshot once the debounced timer has flushed latestMessages, so we don't overwrite history.
     let base: ModelMessage[] = this.latestMessages ?? [];
@@ -1401,12 +1463,14 @@ export class OffensiveSecurityAgent<TResult = void> {
     const next: ModelMessage[] = [...base, ...appended];
     this.latestMessages = next;
     try {
-      await writeFile(this.messagesPath, JSON.stringify(next));
+      await this.enqueueMessagesWrite(next);
       // Only suppress onFinish's write once the snapshot is safely on disk.
       this.syntheticsPersisted = true;
     } catch {
       // Write failed — leave the flag false so onFinish still attempts a write.
     }
+
+    if (hasEmissionError) throw emissionError;
   }
 
   private baseContainsToolCalls(

--- a/src/core/api/targetedPentest.ts
+++ b/src/core/api/targetedPentest.ts
@@ -43,7 +43,7 @@ function normalizeResult(result: unknown): TargetedPentestResult {
   };
 }
 
-/** Start a targeted pentest and return a handle for result + bounded teardown. */
+/** Start a targeted pentest and return a handle for result + explicit teardown. */
 export function startTargetedPentestAgent(
   input: PentestAgentInput,
 ): TargetedPentestHandle {


### PR DESCRIPTION
## Stack

**1 of 6** — base of the stack: #964 → #965 → #967 (`refactor/display-state-transitions`) → #968 (`refactor/conversation-transitions`) → #969 (`refactor/workflow-projections`) → #970 (`refactor/run-tracing`).

## Summary

Fixes a class of abort-path failures in `OffensiveSecurityAgent.consume()` where agent-owned `messages.json` writes could race each other and teardown errors could mask the real stream failure:

- serialize agent-owned message persistence so abort snapshots cannot be overwritten by older writes
- isolate finalization listener failures so synthetic state persists and browser teardown always runs
- preserve the original stream failure and correct the teardown contract documentation

## Root causes

**Persistence race.** The debounced persist timer fired a detached `writeFile`, and the abort snapshot path (`emitSyntheticToolResults`) wrote directly after only cancelling the *pending* timer. A write that had already started could land *after* the abort snapshot and overwrite it with stale state — losing the synthetic tool-call/tool-result pairs that make an aborted conversation resumable.

**Fragile finalization.** The `finally` block ran shell disposal, tool-error flushing, synthetic-result emission, and browser teardown as one undifferentiated sequence. A single throwing `tool-result` listener (or a throwing `dispose()`) would skip everything after it: no abort snapshot persisted, and the owned Chromium process never disconnected.

**Error masking.** A teardown failure could replace the original provider/stream error as the thrown value, hiding the actual cause of the run's failure.

## What changed

**Serialized writes** — a new `persistenceTail` promise chain serializes all agent-owned `messages.json` writes in enqueue order. The debounced timer and `onFinish` now both route through `enqueueMessagesWrite` instead of issuing their own `writeFile` calls.

**Abort snapshot drains the queue** — `emitSyntheticToolResults` still cancels the unfired debounce, but now also awaits `waitForPendingMessagesWrites()` before reading the base state and writing, so the snapshot always builds on the newest persisted history.

**Guarded `latestMessages` clearing** — the debounced flush only nulls `latestMessages` if it still references the exact array that was written, so a newer snapshot recorded in the meantime is not silently dropped. `onFinish` now records `latestMessages` too, giving the abort path the freshest possible base.

**Isolated finalization** — shell disposal, per-tool error flushing, and synthetic-result emission are each individually wrapped: the first failure is recorded, the rest still run. `disconnectOwnedBrowser()` moved into a nested `finally` so the owned Chromium process is always torn down. A finalization error only becomes the thrown error when the stream itself ended cleanly; otherwise the original stream error is always preserved.

**Emit-then-persist ordering** — synthetic tool-result parts are assembled before any event emission; a throwing listener is recorded and rethrown only after the snapshot write is attempted, so listener bugs cannot cost us the persisted state.

**Docs** — `startTargetedPentestAgent`'s teardown contract comment corrected from "bounded teardown" to "explicit teardown" to match actual behavior.

## Test coverage

Two regression tests added to `offensiveSecurityAgent.test.ts`:

- **in-flight persist vs. abort snapshot** — starts a persist, triggers the abort path while it is suspended, then releases it; asserts the snapshot appends *after* the in-flight write (both the persisted history and the synthetic tool-call/tool-result pair survive)
- **throwing deferred-emission listener** — a `tool-result` listener that throws during finalization; asserts the rejection is the original stream error (object identity), `dispose` and `disconnect` each ran exactly once, and the synthetic pair still landed on disk

## Validation

- `bun run test` (1,535 passed, 22 skipped)
- `bun run tsc`
- `bunx biome check src/core/agents/offSecAgent/offensiveSecurityAgent.ts src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts src/core/api/targetedPentest.ts`

## Notes

- repository-wide `bun run lint` completes with 193 pre-existing warnings unrelated to this change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches abort persistence and stream teardown in a core agent path; mistakes could corrupt conversation resume state or mask errors, but behavior is regression-tested.
> 
> **Overview**
> Fixes **abort and error teardown** in `OffensiveSecurityAgent` so `messages.json` stays consistent and failures stay attributable.
> 
> **Serialized persistence** — debounced step saves, `onFinish`, and abort snapshots all go through a `persistenceTail` queue (`enqueueMessagesWrite` / `waitForPendingMessagesWrites`). Abort snapshots **wait for in-flight writes** before reading base history, so stale async `writeFile` calls cannot overwrite synthetic tool-call/tool-result pairs. Debounced flushes only clear `latestMessages` when it still matches what was written.
> 
> **Safer finalization** — `consume()`’s `finally` isolates shell dispose, deferred tool-error emission, and synthetic persistence; **owned browser disconnect** runs in a nested `finally` even when listeners throw. The **original stream error** is kept when the provider already failed; listener errors are deferred until after the snapshot write is attempted.
> 
> **Tests** cover persist-vs-abort ordering and throwing `tool-result` listeners (stream error identity, dispose/disconnect, disk snapshot). `startTargetedPentestAgent` doc comment only: “explicit teardown” vs “bounded teardown”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ea41060d91f98dde2fa3755bd349cc7a423f6d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



