### PR TITLE
refactor(operator): isolate abort recovery logic

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -101,6 +101,7 @@ import {
   buildOperatorSystemPrompt,
   type DashboardStatus,
   filterOperatorAutocomplete,
+  recoverAbortedConversation,
   resolveAbortAction,
   resolveInputFocused,
   resolveKeyboardShortcut,
@@ -1929,70 +1930,16 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
           }
         }
 
-        // If the conversation now ends with a user message it means the agent
-        // was aborted before completing its first inference step (onStepFinish
-        // never fired, so no assistant turn was persisted).  Reconstruct the
-        // partial assistant response — including any in-flight tool calls — so
-        // the context survives abort and session resume.
-        const last =
-          conversationRef.current[conversationRef.current.length - 1];
-        if (last?.role === "user") {
-          const partial = textRef.current.trim();
-
-          // Collect pending/streaming tool calls from the UI messages.
-          const pendingTools = displayMessagesRef.current.filter(
-            (m) =>
-              isToolMessage(m) &&
-              (m.status === "pending" || m.status === "streaming"),
-          );
-
-          // Build assistant content parts: text + tool-call entries.
-          const assistantContent: Array<Record<string, unknown>> = [
-            {
-              type: "text" as const,
-              text: partial || "[Response interrupted by user.]",
-            },
-          ];
-          for (const t of pendingTools) {
-            assistantContent.push({
-              type: "tool-call" as const,
-              toolCallId: t.toolCallId,
-              toolName: t.toolName,
-              input: t.args ?? {},
-            });
-          }
-
-          conversationRef.current = [
-            ...conversationRef.current,
-            {
-              role: "assistant" as const,
-              content: assistantContent,
-            } as ModelMessage,
-          ];
-
-          // For each tool call, add a tool-result so the conversation stays
-          // valid (every tool-call must be paired with a tool-result).
-          if (pendingTools.length > 0) {
-            conversationRef.current = [
-              ...conversationRef.current,
-              {
-                role: "tool" as const,
-                content: pendingTools.map((t) => ({
-                  type: "tool-result" as const,
-                  toolCallId: t.toolCallId,
-                  toolName: t.toolName ?? "unknown",
-                  output: {
-                    type: "text" as const,
-                    value: "Cancelled by user.",
-                  },
-                })),
-              } as unknown as ModelMessage,
-            ];
-          }
-
+        const recovered = recoverAbortedConversation(
+          conversationRef.current,
+          textRef.current,
+          displayMessagesRef.current,
+        );
+        if (recovered) {
+          conversationRef.current = recovered;
           // Persist so session resume also sees the corrected state.
           writeFileSync(
-            join(activeSession.rootPath, "messages.json"),
+            messagesPath,
             JSON.stringify(conversationRef.current, null, 2),
           );
         }

--- a/src/tui/components/operator-dashboard/logic.test.ts
+++ b/src/tui/components/operator-dashboard/logic.test.ts
@@ -1,11 +1,14 @@
+import type { ModelMessage } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import type { OperatorSessionState } from "../../../core/operator";
+import type { DisplayMessage } from "../agent-display";
 import type { AutocompleteOption } from "../shared";
 import {
   accumulateTokenUsage,
   buildOperatorSystemPrompt,
   type DashboardStatus,
   filterOperatorAutocomplete,
+  recoverAbortedConversation,
   resolveAbortAction,
   resolveInputFocused,
   resolveKeyboardShortcut,
@@ -525,6 +528,150 @@ describe("resolveAbortAction", () => {
   it("returns kill-agent when cancel returns false (no command running)", () => {
     const result = resolveAbortAction(false, () => false);
     expect(result).toEqual({ type: "kill-agent" });
+  });
+});
+
+describe("recoverAbortedConversation", () => {
+  const userConversation: ModelMessage[] = [
+    {
+      role: "user",
+      content: [{ type: "text", text: "scan the target" }],
+    },
+  ];
+
+  it("does not recover a conversation that already has an assistant response", () => {
+    const conversation: ModelMessage[] = [
+      ...userConversation,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Scan complete" }],
+      },
+    ];
+    const original = structuredClone(conversation);
+
+    expect(recoverAbortedConversation(conversation, "partial", [])).toBeNull();
+    expect(conversation).toEqual(original);
+  });
+
+  it("appends the interruption placeholder when no response was streamed", () => {
+    const recovered = recoverAbortedConversation(userConversation, "  \n ", []);
+
+    expect(recovered).toEqual([
+      ...userConversation,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[Response interrupted by user.]" }],
+      },
+    ]);
+  });
+
+  it("trims and preserves a partial assistant response", () => {
+    const recovered = recoverAbortedConversation(
+      userConversation,
+      "  partial response\n",
+      [],
+    );
+
+    expect(recovered?.at(-1)).toEqual({
+      role: "assistant",
+      content: [{ type: "text", text: "partial response" }],
+    });
+  });
+
+  it("pairs pending tools and ignores settled display messages", () => {
+    const createdAt = new Date("2026-08-24T00:00:00Z");
+    const displayMessages: DisplayMessage[] = [
+      {
+        role: "assistant",
+        content: "Working",
+        createdAt,
+      },
+      {
+        role: "tool",
+        content: "",
+        createdAt,
+        toolCallId: "pending-tool",
+        toolName: "execute_command",
+        args: { command: "nmap example.com" },
+        status: "pending",
+      },
+      {
+        role: "tool",
+        content: "",
+        createdAt,
+        toolCallId: "streaming-tool",
+        toolName: "http_request",
+        status: "streaming",
+      },
+      {
+        role: "tool",
+        content: "",
+        createdAt,
+        toolCallId: "completed-tool",
+        toolName: "read_file",
+        args: { path: "notes.txt" },
+        status: "completed",
+      },
+      {
+        role: "tool",
+        content: "",
+        createdAt,
+        toolCallId: "failed-tool",
+        toolName: "glob",
+        args: { pattern: "*.ts" },
+        status: "error",
+      },
+    ];
+    const originalConversation = structuredClone(userConversation);
+    const originalDisplayMessages = structuredClone(displayMessages);
+
+    const recovered = recoverAbortedConversation(
+      userConversation,
+      "Checking tools",
+      displayMessages,
+    );
+
+    expect(recovered).toEqual([
+      ...userConversation,
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Checking tools" },
+          {
+            type: "tool-call",
+            toolCallId: "pending-tool",
+            toolName: "execute_command",
+            input: { command: "nmap example.com" },
+          },
+          {
+            type: "tool-call",
+            toolCallId: "streaming-tool",
+            toolName: "http_request",
+            input: {},
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "pending-tool",
+            toolName: "execute_command",
+            output: { type: "text", value: "Cancelled by user." },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "streaming-tool",
+            toolName: "http_request",
+            output: { type: "text", value: "Cancelled by user." },
+          },
+        ],
+      },
+    ]);
+    expect(recovered).not.toBe(userConversation);
+    expect(userConversation).toEqual(originalConversation);
+    expect(displayMessages).toEqual(originalDisplayMessages);
   });
 });
 

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -1,3 +1,4 @@
+import type { ModelMessage } from "ai";
 import {
   type AgentMode,
   buildBaseSystemPrompt,
@@ -7,6 +8,7 @@ import type {
   OperatorMode,
   OperatorSessionState,
 } from "../../../core/operator";
+import type { DisplayMessage } from "../agent-display";
 import type { AutocompleteOption } from "../shared";
 
 // ---------------------------------------------------------------------------
@@ -268,6 +270,65 @@ export function resolveAbortAction(
     return { type: "cancel-command" };
   }
   return { type: "kill-agent" };
+}
+
+export function recoverAbortedConversation(
+  conversation: readonly ModelMessage[],
+  partialText: string,
+  displayMessages: readonly DisplayMessage[],
+): ModelMessage[] | null {
+  if (conversation.at(-1)?.role !== "user") return null;
+
+  const pendingTools = displayMessages.filter(
+    (
+      message,
+    ): message is DisplayMessage & {
+      toolCallId: string;
+      toolName: string;
+      status: "pending" | "streaming";
+    } =>
+      message.role === "tool" &&
+      typeof message.toolCallId === "string" &&
+      typeof message.toolName === "string" &&
+      (message.status === "pending" || message.status === "streaming"),
+  );
+  const assistantContent: Array<Record<string, unknown>> = [
+    {
+      type: "text" as const,
+      text: partialText.trim() || "[Response interrupted by user.]",
+    },
+    ...pendingTools.map((tool) => ({
+      type: "tool-call" as const,
+      toolCallId: tool.toolCallId,
+      toolName: tool.toolName,
+      input: tool.args ?? {},
+    })),
+  ];
+  const recovered: ModelMessage[] = [
+    ...conversation,
+    {
+      role: "assistant",
+      content: assistantContent,
+    } as ModelMessage,
+  ];
+
+  if (pendingTools.length === 0) return recovered;
+
+  return [
+    ...recovered,
+    {
+      role: "tool",
+      content: pendingTools.map((tool) => ({
+        type: "tool-result" as const,
+        toolCallId: tool.toolCallId,
+        toolName: tool.toolName ?? "unknown",
+        output: {
+          type: "text" as const,
+          value: "Cancelled by user.",
+        },
+      })),
+    } as unknown as ModelMessage,
+  ];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stack

**2 of 6** — stacked on #964 (`fix/agent-persistence-teardown`); #967 → #968 → #969 → #970 sit above. Merge order: #964 → this PR → …→ #970, retargeting to `canary` at each step.

## Summary

- extract deterministic abort-conversation reconstruction from `OperatorDashboard`
- preserve existing partial-text, pending-tool pairing, and session persistence behavior
- add characterization coverage for recovery gating, interruption fallback, streamed text, tool arguments, pairing, and input immutability

## Motivation

`OperatorDashboard` (`src/tui/components/operator-dashboard/index.tsx`, ~2,500 lines) is the highest-complexity unit in the codebase (measured cyclomatic complexity of 506 in a recent audit). It mixes rendering with agent-run lifecycle, streaming, persistence, and abort recovery, which makes behavior-preserving changes risky. This PR is a deliberately small first step: pull the *deterministic, non-visual* abort-recovery logic into a pure function behind characterization tests, before any larger extraction.

## What changed

**Extraction.** The ~56-line inline abort-recovery block in the dashboard's abort handler moved to a new exported pure function, `recoverAbortedConversation(conversation, partialText, displayMessages)`, in `src/tui/components/operator-dashboard/logic.ts` — alongside the existing dashboard logic helpers (`resolveAbortAction`, `filterOperatorAutocomplete`, etc.). The call site now invokes it and only persists (`writeFileSync` to the session's `messages.json`) when the function returns a recovered conversation.

**Behavior preserved.** The function replicates the previous inline semantics exactly:

- recovery only fires when the conversation's last message is a `user` turn (i.e. the agent was aborted before `onStepFinish` persisted any assistant response) — otherwise it returns `null` and nothing is written
- the assistant message carries the trimmed partial streamed text, or the `[Response interrupted by user.]` placeholder when nothing was streamed
- display messages in `pending` or `streaming` status become `tool-call` parts with their args; settled (`completed`/`error`) display messages are ignored
- every recovered tool call is paired with a synthetic `tool-result` reading `Cancelled by user.`, keeping the conversation valid for the model and for session resume
- the write path, format, and target (`<session>/messages.json`) are unchanged

**Purity.** The function returns a new array and does not mutate the input conversation or display messages, which the tests assert explicitly. This makes the recovery behavior independently testable without mounting the dashboard.

## Test coverage

Four characterization tests added to `logic.test.ts`:

- **recovery gating** — a conversation already ending in an assistant response returns `null` and is left untouched
- **interruption fallback** — whitespace-only partial text produces the placeholder message
- **partial text preservation** — streamed text is trimmed and carried into the assistant turn
- **tool pairing** — pending + streaming tools become tool calls (with args), completed/errored display messages are excluded, each call gets a `Cancelled by user.` result, and neither input is mutated

## Validation

- `bun run test` (1,537 passed, 22 skipped)
- `bun run tsc`
- `bunx biome check src/tui/components/operator-dashboard/logic.ts src/tui/components/operator-dashboard/logic.test.ts src/tui/components/operator-dashboard/index.tsx`

## Notes

- this PR touches disjoint files from #964 (no functional dependency) but is stacked on it for merge ordering; it remains intentionally limited to one behavior-preserving extraction — larger dashboard decomposition should follow this pattern (characterization tests first, one responsibility at a time)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with unit tests; session persistence still runs only on the same abort path, with no auth or API surface changes.
> 
> **Overview**
> Moves **abort-time conversation repair** out of `OperatorDashboard` into a pure helper, `recoverAbortedConversation`, in `logic.ts`. The dashboard’s kill-agent path now calls that helper instead of ~56 lines of inline reconstruction, and still writes `messages.json` only when recovery returns a new history.
> 
> **Behavior is unchanged:** recovery runs only when the persisted thread ends on a user turn; it appends trimmed partial assistant text (or `[Response interrupted by user.]`), turns pending/streaming UI tools into `tool-call` parts with synthetic `Cancelled by user.` results, and skips conversations that already have an assistant reply. The helper returns a new array without mutating inputs.
> 
> **Tests:** Four characterization cases in `logic.test.ts` cover gating, placeholder text, partial stream text, and tool pairing/immutability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d73dd08a1331ae1f791c6210573bc22688fa7c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



