### PR TITLE
refactor(operator): extract streamed display transitions

### DIFF
--- a/src/tui/components/operator-dashboard/display-state.test.ts
+++ b/src/tui/components/operator-dashboard/display-state.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, it } from "vitest";
+import type { DisplayMessage } from "../agent-display";
+import {
+  appendStreamedText,
+  applyToolCall,
+  applyToolCallDelta,
+  applyToolResult,
+  MAX_LOG_LINES,
+  mergeCommandOutput,
+  startStreamingToolCall,
+} from "./display-state";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const userMessage: DisplayMessage = {
+  role: "user",
+  content: "scan the target",
+  createdAt: new Date("2026-08-24T00:00:00Z"),
+};
+
+const streamingTool: DisplayMessage = {
+  role: "tool",
+  content: "",
+  createdAt: new Date("2026-08-24T00:00:01Z"),
+  toolCallId: "tc1",
+  toolName: "execute_command",
+  args: {},
+  status: "streaming",
+};
+
+const pendingTool: DisplayMessage = {
+  ...streamingTool,
+  toolCallId: "tc2",
+  toolName: "http_request",
+  status: "pending",
+};
+
+const completedTool: DisplayMessage = {
+  ...streamingTool,
+  toolCallId: "tc3",
+  toolName: "read_file",
+  status: "completed",
+};
+
+// ---------------------------------------------------------------------------
+// appendStreamedText
+// ---------------------------------------------------------------------------
+
+describe("appendStreamedText", () => {
+  it("appends a new assistant message when the list ends with a user message", () => {
+    const result = appendStreamedText([userMessage], "hello");
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({ role: "assistant", content: "hello" });
+  });
+
+  it("updates the trailing assistant message with the full accumulated text", () => {
+    const assistant: DisplayMessage = {
+      role: "assistant",
+      content: "hel",
+      createdAt: new Date("2026-08-24T00:00:02Z"),
+    };
+    const result = appendStreamedText([userMessage, assistant], "hello");
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toEqual({ ...assistant, content: "hello" });
+  });
+
+  it("starts a new assistant message after a tool message", () => {
+    const result = appendStreamedText([userMessage, pendingTool], "next step");
+
+    expect(result).toHaveLength(3);
+    expect(result[2]).toMatchObject({
+      role: "assistant",
+      content: "next step",
+    });
+  });
+
+  it("does not mutate the input list or trailing assistant message", () => {
+    const assistant: DisplayMessage = {
+      role: "assistant",
+      content: "hel",
+      createdAt: new Date("2026-08-24T00:00:02Z"),
+    };
+    const messages = [userMessage, assistant];
+    const original = structuredClone(messages);
+
+    const result = appendStreamedText(messages, "hello");
+
+    expect(messages).toEqual(original);
+    expect(result).not.toBe(messages);
+    expect(result[1]).not.toBe(assistant);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startStreamingToolCall
+// ---------------------------------------------------------------------------
+
+describe("startStreamingToolCall", () => {
+  it("appends a streaming tool message with empty args", () => {
+    const result = startStreamingToolCall([userMessage], "tc1", "nmap");
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({
+      role: "tool",
+      toolCallId: "tc1",
+      toolName: "nmap",
+      args: {},
+      status: "streaming",
+    });
+  });
+
+  it("does not mutate the input list", () => {
+    const messages = [userMessage];
+    const original = structuredClone(messages);
+
+    startStreamingToolCall(messages, "tc1", "nmap");
+
+    expect(messages).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyToolCallDelta
+// ---------------------------------------------------------------------------
+
+describe("applyToolCallDelta", () => {
+  it("updates args on the matching streaming tool message", () => {
+    const parsed = { command: "nmap example.com" };
+    const result = applyToolCallDelta(
+      [userMessage, streamingTool],
+      "tc1",
+      parsed,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({ args: parsed });
+  });
+
+  it("derives logs from streamable content in the parsed args", () => {
+    const parsed = { content: "line1\nline2" };
+    const result = applyToolCallDelta(
+      [userMessage, streamingTool],
+      "tc1",
+      parsed,
+    );
+
+    expect(result[1].logs).toEqual(["line1", "line2"]);
+  });
+
+  it("omits logs when the parsed args carry no streamable content", () => {
+    const parsed = { path: "/etc/hosts" };
+    const result = applyToolCallDelta(
+      [userMessage, streamingTool],
+      "tc1",
+      parsed,
+    );
+
+    expect(result[1].args).toEqual(parsed);
+    expect(result[1].logs).toBeUndefined();
+  });
+
+  it("returns the input unchanged when no tool message matches", () => {
+    const messages = [userMessage, streamingTool];
+    const result = applyToolCallDelta(messages, "unknown", { a: 1 });
+
+    expect(result).toBe(messages);
+  });
+
+  it("does not mutate the input list", () => {
+    const messages = [userMessage, streamingTool];
+    const original = structuredClone(messages);
+
+    applyToolCallDelta(messages, "tc1", { command: "ls" });
+
+    expect(messages).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyToolCall
+// ---------------------------------------------------------------------------
+
+describe("applyToolCall", () => {
+  it("transitions a streaming tool to pending with final args and clears logs", () => {
+    const withLogs: DisplayMessage = { ...streamingTool, logs: ["partial"] };
+    const args = { command: "nmap example.com" };
+    const result = applyToolCall(
+      [userMessage, withLogs],
+      "tc1",
+      "execute_command",
+      args,
+    );
+
+    expect(result[1]).toMatchObject({
+      toolCallId: "tc1",
+      args,
+      status: "pending",
+      logs: undefined,
+    });
+  });
+
+  it("appends a pending tool message when none exists", () => {
+    const result = applyToolCall([userMessage], "tc9", "execute_command", {
+      command: "ls",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({
+      role: "tool",
+      toolCallId: "tc9",
+      toolName: "execute_command",
+      args: { command: "ls" },
+      status: "pending",
+    });
+  });
+
+  it("does not mutate the input list", () => {
+    const messages = [userMessage, streamingTool];
+    const original = structuredClone(messages);
+
+    applyToolCall(messages, "tc1", "execute_command", { command: "ls" });
+
+    expect(messages).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyToolResult
+// ---------------------------------------------------------------------------
+
+describe("applyToolResult", () => {
+  it("marks the matching tool completed with the result", () => {
+    const result = applyToolResult([userMessage, pendingTool], "tc2", {
+      out: 1,
+    });
+
+    expect(result[1]).toMatchObject({
+      toolCallId: "tc2",
+      status: "completed",
+      result: { out: 1 },
+    });
+  });
+
+  it("returns the input unchanged when no tool message matches", () => {
+    const messages = [userMessage, pendingTool];
+    const result = applyToolResult(messages, "unknown", null);
+
+    expect(result).toBe(messages);
+  });
+
+  it("does not mutate the input list", () => {
+    const messages = [userMessage, pendingTool];
+    const original = structuredClone(messages);
+
+    applyToolResult(messages, "tc2", "done");
+
+    expect(messages).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeCommandOutput
+// ---------------------------------------------------------------------------
+
+describe("mergeCommandOutput", () => {
+  it("appends output lines to the last active tool message", () => {
+    const messages = [userMessage, pendingTool, completedTool];
+    const result = mergeCommandOutput(messages, "line1\nline2");
+
+    expect(result[1].logs).toEqual(["line1", "line2"]);
+    expect(result[2]).toBe(completedTool);
+  });
+
+  it("targets the most recent pending or streaming tool only", () => {
+    const laterPending: DisplayMessage = {
+      ...pendingTool,
+      toolCallId: "tc4",
+      createdAt: new Date("2026-08-24T00:00:05Z"),
+    };
+    const messages = [userMessage, streamingTool, laterPending];
+    const result = mergeCommandOutput(messages, "hello");
+
+    expect(result[1].logs).toBeUndefined();
+    expect(result[2].logs).toEqual(["hello"]);
+  });
+
+  it("merges a trailing partial line with the first incoming line", () => {
+    const withPartial: DisplayMessage = { ...pendingTool, logs: ["partial"] };
+    const result = mergeCommandOutput([withPartial], " continued\nnext");
+
+    expect(result[0].logs).toEqual(["partial continued", "next"]);
+  });
+
+  it("does not merge the last line when the buffer starts with a newline", () => {
+    const withLine: DisplayMessage = { ...pendingTool, logs: ["complete"] };
+    const result = mergeCommandOutput([withLine], "\nnext");
+
+    expect(result[0].logs).toEqual(["complete", "", "next"]);
+  });
+
+  it("returns the input unchanged when no tool is active", () => {
+    const messages = [userMessage, completedTool];
+    const result = mergeCommandOutput(messages, "orphaned output");
+
+    expect(result).toBe(messages);
+  });
+
+  it("caps retained logs at MAX_LOG_LINES, keeping the newest lines", () => {
+    const bigLogs = Array.from({ length: MAX_LOG_LINES }, (_, i) => `old-${i}`);
+    const withLogs: DisplayMessage = { ...pendingTool, logs: bigLogs };
+    const result = mergeCommandOutput([withLogs], "new-0\nnew-1");
+
+    // The last existing line was partial, so "new-0" merges into it; the cap
+    // then trims the single oldest line.
+    expect(result[0].logs).toHaveLength(MAX_LOG_LINES);
+    expect(result[0].logs?.at(-2)).toBe("old-199new-0");
+    expect(result[0].logs?.at(-1)).toBe("new-1");
+    expect(result[0].logs?.[0]).toBe("old-1");
+  });
+
+  it("does not mutate the input list or existing logs array", () => {
+    const withLogs: DisplayMessage = { ...pendingTool, logs: ["a"] };
+    const messages = [withLogs];
+    const original = structuredClone(messages);
+
+    mergeCommandOutput(messages, "b");
+
+    expect(messages).toEqual(original);
+    expect(withLogs.logs).toEqual(["a"]);
+  });
+});

--- a/src/tui/components/operator-dashboard/display-state.ts
+++ b/src/tui/components/operator-dashboard/display-state.ts
@@ -1,0 +1,137 @@
+import type { DisplayMessage } from "../agent-display";
+import { extractStreamableContent } from "../shared/message-utils";
+import { isToolMessage } from "../shared/type-guards";
+
+/** Cap on retained command-output lines per tool message. */
+export const MAX_LOG_LINES = 200;
+
+export function appendStreamedText(
+  messages: readonly DisplayMessage[],
+  accumulated: string,
+): DisplayMessage[] {
+  const last = messages[messages.length - 1];
+  if (last && last.role === "assistant") {
+    const updated = [...messages];
+    updated[updated.length - 1] = { ...last, content: accumulated };
+    return updated;
+  }
+  return [
+    ...messages,
+    { role: "assistant", content: accumulated, createdAt: new Date() },
+  ];
+}
+
+export function startStreamingToolCall(
+  messages: readonly DisplayMessage[],
+  toolCallId: string,
+  toolName: string,
+): DisplayMessage[] {
+  return [
+    ...messages,
+    {
+      role: "tool" as const,
+      content: "",
+      createdAt: new Date(),
+      toolCallId,
+      toolName,
+      args: {},
+      status: "streaming" as const,
+    },
+  ];
+}
+
+export function applyToolCallDelta(
+  messages: readonly DisplayMessage[],
+  toolCallId: string,
+  parsed: Record<string, unknown>,
+): DisplayMessage[] {
+  const contentText = extractStreamableContent(parsed);
+  const logs = contentText ? contentText.split("\n") : undefined;
+
+  const idx = messages.findIndex(
+    (m) => isToolMessage(m) && m.toolCallId === toolCallId,
+  );
+  if (idx === -1) return messages as DisplayMessage[];
+  const updated = [...messages];
+  updated[idx] = { ...updated[idx], args: parsed, ...(logs && { logs }) };
+  return updated;
+}
+
+export function applyToolCall(
+  messages: readonly DisplayMessage[],
+  toolCallId: string,
+  toolName: string,
+  args?: Record<string, unknown>,
+): DisplayMessage[] {
+  const idx = messages.findIndex(
+    (m) => isToolMessage(m) && m.toolCallId === toolCallId,
+  );
+  if (idx !== -1) {
+    const updated = [...messages];
+    updated[idx] = {
+      ...updated[idx],
+      args,
+      logs: undefined,
+      status: "pending" as const,
+    };
+    return updated;
+  }
+  return [
+    ...messages,
+    {
+      role: "tool" as const,
+      content: "",
+      createdAt: new Date(),
+      toolCallId,
+      toolName,
+      args,
+      status: "pending" as const,
+    },
+  ];
+}
+
+export function applyToolResult(
+  messages: readonly DisplayMessage[],
+  toolCallId: string,
+  result?: unknown,
+): DisplayMessage[] {
+  const idx = messages.findIndex(
+    (m) => isToolMessage(m) && m.toolCallId === toolCallId,
+  );
+  if (idx === -1) return messages as DisplayMessage[];
+  const updated = [...messages];
+  updated[idx] = { ...updated[idx], status: "completed", result };
+  return updated;
+}
+
+export function mergeCommandOutput(
+  messages: readonly DisplayMessage[],
+  buf: string,
+): DisplayMessage[] {
+  const idx = messages.findLastIndex(
+    (m) =>
+      isToolMessage(m) && (m.status === "pending" || m.status === "streaming"),
+  );
+  if (idx === -1) return messages as DisplayMessage[];
+
+  const msg = messages[idx];
+  const existing = msg.logs ?? [];
+  const incoming = buf.split("\n");
+  // If last existing line was partial (no trailing newline), merge it
+  let merged: string[];
+  if (existing.length > 0 && !buf.startsWith("\n")) {
+    merged = [...existing];
+    merged[merged.length - 1] += incoming[0];
+    merged.push(...incoming.slice(1));
+  } else {
+    merged = [...existing, ...incoming];
+  }
+  // Cap to last MAX_LOG_LINES
+  if (merged.length > MAX_LOG_LINES) {
+    merged = merged.slice(-MAX_LOG_LINES);
+  }
+
+  const updated = [...messages];
+  updated[idx] = { ...msg, logs: merged };
+  return updated;
+}

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -92,10 +92,17 @@ import { QuestionsForm } from "../chat/questions-form";
 import { collectScreenshotPaths, ScreenshotModal } from "../screenshot-modal";
 import {
   deriveApprovedActionLabel,
-  extractStreamableContent,
   isToolMessage,
   tryParsePartialJson,
 } from "../shared";
+import {
+  appendStreamedText,
+  applyToolCall,
+  applyToolCallDelta,
+  applyToolResult,
+  mergeCommandOutput,
+  startStreamingToolCall,
+} from "./display-state";
 import {
   accumulateTokenUsage,
   buildOperatorSystemPrompt,
@@ -586,18 +593,7 @@ export default function OperatorDashboard({
   const appendText = useCallback((text: string) => {
     textRef.current += text;
     const accumulated = textRef.current;
-    setMessages((prev) => {
-      const last = prev[prev.length - 1];
-      if (last && last.role === "assistant") {
-        const updated = [...prev];
-        updated[updated.length - 1] = { ...last, content: accumulated };
-        return updated;
-      }
-      return [
-        ...prev,
-        { role: "assistant", content: accumulated, createdAt: new Date() },
-      ];
-    });
+    setMessages((prev) => appendStreamedText(prev, accumulated));
   }, []);
 
   // Ref to accumulate partial tool args JSON per toolCallId
@@ -612,18 +608,7 @@ export default function OperatorDashboard({
         toolName,
         accumulated: "",
       });
-      setMessages((prev) => [
-        ...prev,
-        {
-          role: "tool" as const,
-          content: "",
-          createdAt: new Date(),
-          toolCallId,
-          toolName,
-          args: {},
-          status: "streaming" as const,
-        },
-      ]);
+      setMessages((prev) => startStreamingToolCall(prev, toolCallId, toolName));
     },
     [],
   );
@@ -640,18 +625,7 @@ export default function OperatorDashboard({
       const parsed = tryParsePartialJson(accumulated);
       if (!parsed) return;
 
-      const contentText = extractStreamableContent(parsed);
-      const logs = contentText ? contentText.split("\n") : undefined;
-
-      setMessages((msgs) => {
-        const idx = msgs.findIndex(
-          (m) => isToolMessage(m) && m.toolCallId === toolCallId,
-        );
-        if (idx === -1) return msgs;
-        const updated = [...msgs];
-        updated[idx] = { ...updated[idx], args: parsed, ...(logs && { logs }) };
-        return updated;
-      });
+      setMessages((msgs) => applyToolCallDelta(msgs, toolCallId, parsed));
     },
     [],
   );
@@ -660,33 +634,7 @@ export default function OperatorDashboard({
     (toolCallId: string, toolName: string, args?: Record<string, unknown>) => {
       textRef.current = "";
       toolArgsDeltaRef.current.delete(toolCallId);
-      setMessages((prev) => {
-        const idx = prev.findIndex(
-          (m) => isToolMessage(m) && m.toolCallId === toolCallId,
-        );
-        if (idx !== -1) {
-          const updated = [...prev];
-          updated[idx] = {
-            ...updated[idx],
-            args,
-            logs: undefined,
-            status: "pending" as const,
-          };
-          return updated;
-        }
-        return [
-          ...prev,
-          {
-            role: "tool" as const,
-            content: "",
-            createdAt: new Date(),
-            toolCallId,
-            toolName,
-            args,
-            status: "pending" as const,
-          },
-        ];
-      });
+      setMessages((prev) => applyToolCall(prev, toolCallId, toolName, args));
     },
     [],
   );
@@ -694,15 +642,7 @@ export default function OperatorDashboard({
   const updateToolResult = useCallback(
     (toolCallId: string, _toolName: string, result?: unknown) => {
       textRef.current = "";
-      setMessages((prev) => {
-        const idx = prev.findIndex(
-          (m) => isToolMessage(m) && m.toolCallId === toolCallId,
-        );
-        if (idx === -1) return prev;
-        const updated = [...prev];
-        updated[idx] = { ...updated[idx], status: "completed", result };
-        return updated;
-      });
+      setMessages((prev) => applyToolResult(prev, toolCallId, result));
     },
     [],
   );
@@ -713,42 +653,13 @@ export default function OperatorDashboard({
 
   const cmdOutputBufRef = useRef("");
   const cmdFlushTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const MAX_LOG_LINES = 200;
 
   const flushCommandOutput = useCallback(() => {
     const buf = cmdOutputBufRef.current;
     if (!buf) return;
     cmdOutputBufRef.current = "";
 
-    setMessages((prev) => {
-      const idx = prev.findLastIndex(
-        (m) =>
-          isToolMessage(m) &&
-          (m.status === "pending" || m.status === "streaming"),
-      );
-      if (idx === -1) return prev;
-
-      const msg = prev[idx];
-      const existing = msg.logs ?? [];
-      const incoming = buf.split("\n");
-      // If last existing line was partial (no trailing newline), merge it
-      let merged: string[];
-      if (existing.length > 0 && !buf.startsWith("\n")) {
-        merged = [...existing];
-        merged[merged.length - 1] += incoming[0];
-        merged.push(...incoming.slice(1));
-      } else {
-        merged = [...existing, ...incoming];
-      }
-      // Cap to last MAX_LOG_LINES
-      if (merged.length > MAX_LOG_LINES) {
-        merged = merged.slice(-MAX_LOG_LINES);
-      }
-
-      const updated = [...prev];
-      updated[idx] = { ...msg, logs: merged };
-      return updated;
-    });
+    setMessages((prev) => mergeCommandOutput(prev, buf));
   }, []);
 
   const onCommandOutput = useCallback(

--- a/src/tui/components/shared/index.ts
+++ b/src/tui/components/shared/index.ts
@@ -20,11 +20,7 @@ export {
 } from "./markdown-viewer";
 export { MessageRenderer } from "./message-renderer";
 // Message utilities
-export {
-  extractStreamableContent,
-  getStableMessageKey,
-  tryParsePartialJson,
-} from "./message-utils";
+export { getStableMessageKey, tryParsePartialJson } from "./message-utils";
 // Input components
 export {
   type AutocompleteOption,


### PR DESCRIPTION
## Stack

**3 of 6** — stacked on #965 (`refactor/operator-abort-recovery`); #968 → #969 → #970 sit above. Merge order: …→ this PR → #968 → #969 → #970, retargeting to `canary` at each step.

## Summary

- extract the pure display-list transitions behind the dashboard's stream callbacks from `index.tsx` into `display-state.ts`
- preserve all streaming behavior: partial-text accumulation, streaming→pending→completed tool lifecycle, partial-JSON arg parsing, and the 200-line command-log cap
- add characterization coverage for every extracted reducer, including partial-line merging, cap trimming, and input immutability

## Motivation

`OperatorDashboard` (~2,500 lines, measured cyclomatic complexity 506) mixes rendering with every streamed display transition inline. Following the same pattern as #965 (which extracted abort-conversation reconstruction), this PR pulls the *deterministic, non-visual* message-list updates out of the stream callbacks and behind pure, directly testable functions — while the callbacks keep ownership of the mutable refs, the partial-args accumulator, and the flush timer.

## What changed

**New module: `src/tui/components/operator-dashboard/display-state.ts`.** Six pure functions over the `DisplayMessage` list, each returning a new array without mutating inputs:

- `appendStreamedText(messages, accumulated)` — update the trailing assistant message with the full accumulated text, or open a new one after a user/tool message
- `startStreamingToolCall(messages, toolCallId, toolName)` — append a `streaming` tool message with empty args
- `applyToolCallDelta(messages, toolCallId, parsed)` — write partially-parsed args onto the matching tool message and derive live `logs` from streamable content (`extractStreamableContent`)
- `applyToolCall(messages, toolCallId, toolName, args)` — transition streaming → pending with final args and clear the live logs; append a pending message if the tool wasn't streaming
- `applyToolResult(messages, toolCallId, result)` — mark the matching tool `completed` with its result
- `mergeCommandOutput(messages, buf)` — merge throttled command output into the *most recent* pending/streaming tool's `logs`, joining the trailing partial line and capping at `MAX_LOG_LINES = 200` (exported)

**`index.tsx`** — the six stream callbacks keep their side effects (accumulating `textRef`, the `toolArgsDeltaRef` partial-args map, the command-output buffer and 150 ms flush interval) and now delegate the `setMessages` update to the matching reducer. `MAX_LOG_LINES` is imported from the new module instead of declared inline. Net: −103/+14 lines in the component.

**Behavior preserved**, including the subtle paths:

- partial-JSON deltas that don't yet parse are dropped in the callback before any state update (unchanged)
- deltas for unknown tool calls and results for unknown tool calls return the list untouched
- command output targets only the *last* pending/streaming tool; output with no active tool is dropped
- a buffer that doesn't start with `\n` merges its first line into the previous partial line before capping
- the cap keeps the newest 200 lines after merging

**Import note.** `display-state.ts` imports `isToolMessage` / `extractStreamableContent` directly from `shared/message-utils` and `shared/type-guards` rather than the `shared` barrel — the same pattern `subagent-state.ts` already uses (documented there): the barrel statically evaluates component modules whose transitive imports reach `@opentui/core`'s `.scm` assets, which vitest can't load in the node environment. Since this removed the barrel's last runtime consumer of `extractStreamableContent`, the now-unused re-export was dropped from `shared/index.ts` (knip `dead-code` was failing on it). `getStableMessageKey` and `tryParsePartialJson` remain re-exported.

## Test coverage

24 characterization tests in `display-state.test.ts`, exercising the exact production reducers:

- **text accumulation** — append vs. update-in-place by trailing role, no mutation of input
- **streaming tool lifecycle** — open streaming, delta args + live logs (present only when args carry streamable content), settle to pending with logs cleared, complete with result
- **unknown-id no-ops** — deltas and results for missing tool calls return the identical list reference
- **command output** — last-active-tool targeting, partial-line merge, newline-prefixed buffers, no-active-tool drop, 200-line cap keeping the newest lines, input immutability

The cap test initially failed because I hadn't accounted for the partial-line merge inside the cap accounting — the tests now document that interaction explicitly.

## Validation

- `bun run test` (1,563 passed, 22 skipped)
- `bun run tsc`
- `bunx biome check src/tui/components/operator-dashboard/display-state.ts src/tui/components/operator-dashboard/display-state.test.ts src/tui/components/operator-dashboard/index.tsx`

## Notes

- no behavior change intended; this is the next slice of the dashboard decomposition started in #965 — reducers first, then event bindings can sit behind narrow tested sinks in a follow-up

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with explicit test lock-in; runtime behavior is intended to be unchanged aside from code organization.
> 
> **Overview**
> Pulls **pure `DisplayMessage` list reducers** out of `OperatorDashboard` into new `display-state.ts`, so stream callbacks only keep refs, timers, and partial-JSON accumulation while `setMessages` delegates to tested helpers.
> 
> The module covers **assistant text streaming**, the **streaming → pending → completed** tool lifecycle (including live logs from partial args), and **throttled command output** merged into the latest active tool with partial-line joining and **`MAX_LOG_LINES` (200)**. `index.tsx` wires the same six paths through these functions with no intended behavior change.
> 
> Adds **`display-state.test.ts`** with characterization tests for immutability, unknown tool no-ops, and log-cap edge cases. **`display-state.ts`** imports shared utils directly (not the barrel) so Vitest stays hermetic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f85db1f4ad4eaf4be9c7bb544952bf469fe9567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


