### PR TITLE
refactor(operator): extract conversation transitions

### DIFF
--- a/src/tui/components/operator-dashboard/conversation.test.ts
+++ b/src/tui/components/operator-dashboard/conversation.test.ts
@@ -1,0 +1,255 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import type { DisplayMessage } from "../agent-display";
+import {
+  recoverAbortedConversation,
+  rewriteToolResultOutput,
+} from "./conversation";
+
+// ---------------------------------------------------------------------------
+// recoverAbortedConversation
+// ---------------------------------------------------------------------------
+
+describe("recoverAbortedConversation", () => {
+  const userConversation: ModelMessage[] = [
+    {
+      role: "user",
+      content: [{ type: "text", text: "scan the target" }],
+    },
+  ];
+
+  it("does not recover a conversation that already has an assistant response", () => {
+    const conversation: ModelMessage[] = [
+      ...userConversation,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Scan complete" }],
+      },
+    ];
+    const original = structuredClone(conversation);
+
+    expect(recoverAbortedConversation(conversation, "partial", [])).toBeNull();
+    expect(conversation).toEqual(original);
+  });
+
+  it("appends the interruption placeholder when no response was streamed", () => {
+    const recovered = recoverAbortedConversation(userConversation, "  \n ", []);
+
+    expect(recovered).toEqual([
+      ...userConversation,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[Response interrupted by user.]" }],
+      },
+    ]);
+  });
+
+  it("trims and preserves a partial assistant response", () => {
+    const recovered = recoverAbortedConversation(
+      userConversation,
+      "  partial response\n",
+      [],
+    );
+
+    expect(recovered?.at(-1)).toEqual({
+      role: "assistant",
+      content: [{ type: "text", text: "partial response" }],
+    });
+  });
+
+  it("pairs pending tools and ignores settled display messages", () => {
+    const createdAt = new Date("2026-08-24T00:00:00Z");
+    const displayMessages: DisplayMessage[] = [
+      {
+        role: "assistant",
+        content: "Working",
+        createdAt,
+      },
+      {
+        role: "tool",
+        content: "",
+        createdAt,
+        toolCallId: "pending-tool",
+        toolName: "execute_command",
+        args: { command: "nmap example.com" },
+        status: "pending",
+      },
+      {
+        role: "tool",
+        content: "",
+        createdAt,
+        toolCallId: "streaming-tool",
+        toolName: "http_request",
+        status: "streaming",
+      },
+      {
+        role: "tool",
+        content: "",
+        createdAt,
+        toolCallId: "completed-tool",
+        toolName: "read_file",
+        args: { path: "notes.txt" },
+        status: "completed",
+      },
+      {
+        role: "tool",
+        content: "",
+        createdAt,
+        toolCallId: "failed-tool",
+        toolName: "glob",
+        args: { pattern: "*.ts" },
+        status: "error",
+      },
+    ];
+    const originalConversation = structuredClone(userConversation);
+    const originalDisplayMessages = structuredClone(displayMessages);
+
+    const recovered = recoverAbortedConversation(
+      userConversation,
+      "Checking tools",
+      displayMessages,
+    );
+
+    expect(recovered).toEqual([
+      ...userConversation,
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Checking tools" },
+          {
+            type: "tool-call",
+            toolCallId: "pending-tool",
+            toolName: "execute_command",
+            input: { command: "nmap example.com" },
+          },
+          {
+            type: "tool-call",
+            toolCallId: "streaming-tool",
+            toolName: "http_request",
+            input: {},
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "pending-tool",
+            toolName: "execute_command",
+            output: { type: "text", value: "Cancelled by user." },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "streaming-tool",
+            toolName: "http_request",
+            output: { type: "text", value: "Cancelled by user." },
+          },
+        ],
+      },
+    ]);
+    expect(recovered).not.toBe(userConversation);
+    expect(userConversation).toEqual(originalConversation);
+    expect(displayMessages).toEqual(originalDisplayMessages);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rewriteToolResultOutput
+// ---------------------------------------------------------------------------
+
+describe("rewriteToolResultOutput", () => {
+  const toolConversation: ModelMessage[] = [
+    {
+      role: "user",
+      content: [{ type: "text", text: "run the scan" }],
+    },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "q1",
+          toolName: "ask_user_questions",
+          input: { questions: [] },
+        },
+      ],
+    } as ModelMessage,
+    {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "q1",
+          toolName: "ask_user_questions",
+          output: { type: "text", value: "pending" },
+        },
+      ],
+    } as ModelMessage,
+  ];
+
+  it("replaces the matching tool-result output with the json wrapper", () => {
+    const result = rewriteToolResultOutput(toolConversation, "q1", {
+      answers: [],
+      skipped: true,
+    });
+
+    const toolMsg = result.at(-1);
+    expect(toolMsg?.role).toBe("tool");
+    const part = (toolMsg?.content as Array<Record<string, unknown>>)[0];
+    expect(part.output).toEqual({
+      type: "json",
+      value: { answers: [], skipped: true },
+    });
+  });
+
+  it("returns the identical reference when no tool-result matches", () => {
+    const result = rewriteToolResultOutput(toolConversation, "missing", {
+      answers: [],
+    });
+
+    expect(result).toBe(toolConversation);
+  });
+
+  it("only rewrites the matching toolCallId, leaving other parts intact", () => {
+    const multi: ModelMessage[] = [
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "a",
+            toolName: "t",
+            output: { type: "text", value: "keep-a" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "b",
+            toolName: "t",
+            output: { type: "text", value: "keep-b" },
+          },
+        ],
+      } as ModelMessage,
+    ];
+
+    const result = rewriteToolResultOutput(multi, "b", { v: 1 });
+    const parts = result[0].content as Array<{
+      toolCallId: string;
+      output: unknown;
+    }>;
+
+    expect(parts[0]).toMatchObject({
+      toolCallId: "a",
+      output: { type: "text", value: "keep-a" },
+    });
+    expect(parts[1].output).toEqual({ type: "json", value: { v: 1 } });
+  });
+
+  it("does not mutate the input conversation", () => {
+    const original = structuredClone(toolConversation);
+
+    rewriteToolResultOutput(toolConversation, "q1", { answers: [] });
+
+    expect(toolConversation).toEqual(original);
+  });
+});

--- a/src/tui/components/operator-dashboard/conversation.ts
+++ b/src/tui/components/operator-dashboard/conversation.ts
@@ -1,0 +1,116 @@
+import type { ModelMessage } from "ai";
+import type { DisplayMessage } from "../agent-display";
+
+// ---------------------------------------------------------------------------
+// Conversation transitions over ModelMessage[] — pure, immutable, testable
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconstruct a resumable assistant turn after an abort that landed before the
+ * agent completed its first inference step (no assistant message persisted).
+ * Returns null when the conversation already ends in an assistant response.
+ */
+export function recoverAbortedConversation(
+  conversation: readonly ModelMessage[],
+  partialText: string,
+  displayMessages: readonly DisplayMessage[],
+): ModelMessage[] | null {
+  if (conversation.at(-1)?.role !== "user") return null;
+
+  const pendingTools = displayMessages.filter(
+    (
+      message,
+    ): message is DisplayMessage & {
+      toolCallId: string;
+      toolName: string;
+      status: "pending" | "streaming";
+    } =>
+      message.role === "tool" &&
+      typeof message.toolCallId === "string" &&
+      typeof message.toolName === "string" &&
+      (message.status === "pending" || message.status === "streaming"),
+  );
+  const assistantContent: Array<Record<string, unknown>> = [
+    {
+      type: "text" as const,
+      text: partialText.trim() || "[Response interrupted by user.]",
+    },
+    ...pendingTools.map((tool) => ({
+      type: "tool-call" as const,
+      toolCallId: tool.toolCallId,
+      toolName: tool.toolName,
+      input: tool.args ?? {},
+    })),
+  ];
+  const recovered: ModelMessage[] = [
+    ...conversation,
+    {
+      role: "assistant",
+      content: assistantContent,
+    } as ModelMessage,
+  ];
+
+  if (pendingTools.length === 0) return recovered;
+
+  return [
+    ...recovered,
+    {
+      role: "tool",
+      content: pendingTools.map((tool) => ({
+        type: "tool-result" as const,
+        toolCallId: tool.toolCallId,
+        toolName: tool.toolName ?? "unknown",
+        output: {
+          type: "text" as const,
+          value: "Cancelled by user.",
+        },
+      })),
+    } as unknown as ModelMessage,
+  ];
+}
+
+/**
+ * Overwrite the output of the tool-result part matching `toolCallId` with a
+ * JSON-wrapped value, leaving every other message and part untouched. Used for
+ * ask-user-question answers, where Bedrock/Anthropic require the
+ * `{ type: 'json', value }` wrapper. Returns the input unchanged (same
+ * reference) when no part matches.
+ */
+export function rewriteToolResultOutput(
+  conversation: readonly ModelMessage[],
+  toolCallId: string,
+  value: Record<string, unknown>,
+): ModelMessage[] {
+  const wrappedOutput = {
+    type: "json" as const,
+    value,
+  };
+
+  let changed = false;
+  const next = conversation.map((msg) => {
+    if (msg.role !== "tool") return msg;
+    if (!Array.isArray(msg.content)) return msg;
+    let mutated = false;
+    const nextContent = msg.content.map((part) => {
+      if (
+        part &&
+        typeof part === "object" &&
+        "type" in part &&
+        (part as { type?: unknown }).type === "tool-result" &&
+        (part as { toolCallId?: unknown }).toolCallId === toolCallId
+      ) {
+        mutated = true;
+        return {
+          ...(part as Record<string, unknown>),
+          output: wrappedOutput,
+        };
+      }
+      return part;
+    });
+    if (!mutated) return msg;
+    changed = true;
+    return { ...msg, content: nextContent } as ModelMessage;
+  });
+
+  return changed ? next : (conversation as ModelMessage[]);
+}

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -96,6 +96,10 @@ import {
   tryParsePartialJson,
 } from "../shared";
 import {
+  recoverAbortedConversation,
+  rewriteToolResultOutput,
+} from "./conversation";
+import {
   appendStreamedText,
   applyToolCall,
   applyToolCallDelta,
@@ -108,7 +112,6 @@ import {
   buildOperatorSystemPrompt,
   type DashboardStatus,
   filterOperatorAutocomplete,
-  recoverAbortedConversation,
   resolveAbortAction,
   resolveInputFocused,
   resolveKeyboardShortcut,
@@ -1881,36 +1884,13 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
       const toolCallId = pendingToolCallIdRef.current;
       if (!toolCallId) return;
 
-      // Bedrock Converse / Anthropic requires { type: 'json', value: ... } wrapper.
-      const wrappedOutput = {
-        type: "json" as const,
-        value: result as unknown as Record<string, unknown>,
-      };
-
-      const updated: ModelMessage[] = conversationRef.current.map((msg) => {
-        if (msg.role !== "tool") return msg;
-        if (!Array.isArray(msg.content)) return msg;
-        let mutated = false;
-        const nextContent = msg.content.map((part) => {
-          if (
-            part &&
-            typeof part === "object" &&
-            "type" in part &&
-            (part as { type?: unknown }).type === "tool-result" &&
-            (part as { toolCallId?: unknown }).toolCallId === toolCallId
-          ) {
-            mutated = true;
-            return {
-              ...(part as Record<string, unknown>),
-              output: wrappedOutput,
-            };
-          }
-          return part;
-        });
-        return mutated
-          ? ({ ...msg, content: nextContent } as ModelMessage)
-          : msg;
-      });
+      // Bedrock Converse / Anthropic requires the { type: 'json', value }
+      // wrapper around the answers payload.
+      const updated = rewriteToolResultOutput(
+        conversationRef.current,
+        toolCallId,
+        result as unknown as Record<string, unknown>,
+      );
 
       conversationRef.current = updated;
 
@@ -2100,37 +2080,15 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
       key.preventDefault?.();
       const toolCallId = pendingToolCallIdRef.current;
       if (toolCallId) {
-        const abortedResult = {
-          type: "json" as const,
-          value: {
+        conversationRef.current = rewriteToolResultOutput(
+          conversationRef.current,
+          toolCallId,
+          {
             answers: [],
             skipped: true,
             aborted: true,
           } as unknown as Record<string, unknown>,
-        };
-        conversationRef.current = conversationRef.current.map((msg) => {
-          if (msg.role !== "tool" || !Array.isArray(msg.content)) return msg;
-          let mutated = false;
-          const nextContent = msg.content.map((part) => {
-            if (
-              part &&
-              typeof part === "object" &&
-              "type" in part &&
-              (part as { type?: unknown }).type === "tool-result" &&
-              (part as { toolCallId?: unknown }).toolCallId === toolCallId
-            ) {
-              mutated = true;
-              return {
-                ...(part as Record<string, unknown>),
-                output: abortedResult,
-              };
-            }
-            return part;
-          });
-          return mutated
-            ? ({ ...msg, content: nextContent } as ModelMessage)
-            : msg;
-        });
+        );
         const activeSession = sessionRef.current;
         if (activeSession) {
           try {

--- a/src/tui/components/operator-dashboard/logic.test.ts
+++ b/src/tui/components/operator-dashboard/logic.test.ts
@@ -1,14 +1,11 @@
-import type { ModelMessage } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import type { OperatorSessionState } from "../../../core/operator";
-import type { DisplayMessage } from "../agent-display";
 import type { AutocompleteOption } from "../shared";
 import {
   accumulateTokenUsage,
   buildOperatorSystemPrompt,
   type DashboardStatus,
   filterOperatorAutocomplete,
-  recoverAbortedConversation,
   resolveAbortAction,
   resolveInputFocused,
   resolveKeyboardShortcut,
@@ -528,150 +525,6 @@ describe("resolveAbortAction", () => {
   it("returns kill-agent when cancel returns false (no command running)", () => {
     const result = resolveAbortAction(false, () => false);
     expect(result).toEqual({ type: "kill-agent" });
-  });
-});
-
-describe("recoverAbortedConversation", () => {
-  const userConversation: ModelMessage[] = [
-    {
-      role: "user",
-      content: [{ type: "text", text: "scan the target" }],
-    },
-  ];
-
-  it("does not recover a conversation that already has an assistant response", () => {
-    const conversation: ModelMessage[] = [
-      ...userConversation,
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Scan complete" }],
-      },
-    ];
-    const original = structuredClone(conversation);
-
-    expect(recoverAbortedConversation(conversation, "partial", [])).toBeNull();
-    expect(conversation).toEqual(original);
-  });
-
-  it("appends the interruption placeholder when no response was streamed", () => {
-    const recovered = recoverAbortedConversation(userConversation, "  \n ", []);
-
-    expect(recovered).toEqual([
-      ...userConversation,
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "[Response interrupted by user.]" }],
-      },
-    ]);
-  });
-
-  it("trims and preserves a partial assistant response", () => {
-    const recovered = recoverAbortedConversation(
-      userConversation,
-      "  partial response\n",
-      [],
-    );
-
-    expect(recovered?.at(-1)).toEqual({
-      role: "assistant",
-      content: [{ type: "text", text: "partial response" }],
-    });
-  });
-
-  it("pairs pending tools and ignores settled display messages", () => {
-    const createdAt = new Date("2026-08-24T00:00:00Z");
-    const displayMessages: DisplayMessage[] = [
-      {
-        role: "assistant",
-        content: "Working",
-        createdAt,
-      },
-      {
-        role: "tool",
-        content: "",
-        createdAt,
-        toolCallId: "pending-tool",
-        toolName: "execute_command",
-        args: { command: "nmap example.com" },
-        status: "pending",
-      },
-      {
-        role: "tool",
-        content: "",
-        createdAt,
-        toolCallId: "streaming-tool",
-        toolName: "http_request",
-        status: "streaming",
-      },
-      {
-        role: "tool",
-        content: "",
-        createdAt,
-        toolCallId: "completed-tool",
-        toolName: "read_file",
-        args: { path: "notes.txt" },
-        status: "completed",
-      },
-      {
-        role: "tool",
-        content: "",
-        createdAt,
-        toolCallId: "failed-tool",
-        toolName: "glob",
-        args: { pattern: "*.ts" },
-        status: "error",
-      },
-    ];
-    const originalConversation = structuredClone(userConversation);
-    const originalDisplayMessages = structuredClone(displayMessages);
-
-    const recovered = recoverAbortedConversation(
-      userConversation,
-      "Checking tools",
-      displayMessages,
-    );
-
-    expect(recovered).toEqual([
-      ...userConversation,
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: "Checking tools" },
-          {
-            type: "tool-call",
-            toolCallId: "pending-tool",
-            toolName: "execute_command",
-            input: { command: "nmap example.com" },
-          },
-          {
-            type: "tool-call",
-            toolCallId: "streaming-tool",
-            toolName: "http_request",
-            input: {},
-          },
-        ],
-      },
-      {
-        role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: "pending-tool",
-            toolName: "execute_command",
-            output: { type: "text", value: "Cancelled by user." },
-          },
-          {
-            type: "tool-result",
-            toolCallId: "streaming-tool",
-            toolName: "http_request",
-            output: { type: "text", value: "Cancelled by user." },
-          },
-        ],
-      },
-    ]);
-    expect(recovered).not.toBe(userConversation);
-    expect(userConversation).toEqual(originalConversation);
-    expect(displayMessages).toEqual(originalDisplayMessages);
   });
 });
 

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -1,4 +1,3 @@
-import type { ModelMessage } from "ai";
 import {
   type AgentMode,
   buildBaseSystemPrompt,
@@ -8,7 +7,6 @@ import type {
   OperatorMode,
   OperatorSessionState,
 } from "../../../core/operator";
-import type { DisplayMessage } from "../agent-display";
 import type { AutocompleteOption } from "../shared";
 
 // ---------------------------------------------------------------------------
@@ -270,65 +268,6 @@ export function resolveAbortAction(
     return { type: "cancel-command" };
   }
   return { type: "kill-agent" };
-}
-
-export function recoverAbortedConversation(
-  conversation: readonly ModelMessage[],
-  partialText: string,
-  displayMessages: readonly DisplayMessage[],
-): ModelMessage[] | null {
-  if (conversation.at(-1)?.role !== "user") return null;
-
-  const pendingTools = displayMessages.filter(
-    (
-      message,
-    ): message is DisplayMessage & {
-      toolCallId: string;
-      toolName: string;
-      status: "pending" | "streaming";
-    } =>
-      message.role === "tool" &&
-      typeof message.toolCallId === "string" &&
-      typeof message.toolName === "string" &&
-      (message.status === "pending" || message.status === "streaming"),
-  );
-  const assistantContent: Array<Record<string, unknown>> = [
-    {
-      type: "text" as const,
-      text: partialText.trim() || "[Response interrupted by user.]",
-    },
-    ...pendingTools.map((tool) => ({
-      type: "tool-call" as const,
-      toolCallId: tool.toolCallId,
-      toolName: tool.toolName,
-      input: tool.args ?? {},
-    })),
-  ];
-  const recovered: ModelMessage[] = [
-    ...conversation,
-    {
-      role: "assistant",
-      content: assistantContent,
-    } as ModelMessage,
-  ];
-
-  if (pendingTools.length === 0) return recovered;
-
-  return [
-    ...recovered,
-    {
-      role: "tool",
-      content: pendingTools.map((tool) => ({
-        type: "tool-result" as const,
-        toolCallId: tool.toolCallId,
-        toolName: tool.toolName ?? "unknown",
-        output: {
-          type: "text" as const,
-          value: "Cancelled by user.",
-        },
-      })),
-    } as unknown as ModelMessage,
-  ];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stack

**4 of 6** — stacked on #967 (`refactor/display-state-transitions`); #969 → #970 sit above. Merge order: …→ this PR → #969 → #970, retargeting to `canary` at each step.

## Summary

- move `recoverAbortedConversation` from the catch-all `logic.ts` into a dedicated `conversation.ts` domain module
- extract the duplicated question-result rewriting from `resumeWithQuestionResult` and the Ctrl+C abort handler into a single pure `rewriteToolResultOutput`
- move the recovery characterization tests into `conversation.test.ts` and add coverage for the question-result rewrite

## Motivation

This is the next slice of the `OperatorDashboard` decomposition (after #965's abort-recovery extraction and #967's display-state reducers). Two distinct changes, both behavior-preserving:

1. **Domain placement.** `recoverAbortedConversation` was extracted into `logic.ts` in #965, but `logic.ts` is a grab-bag (autocomplete, keyboard routing, prompt building, abort resolution). Conversation reconstruction is its own concern — this gives it a home that step 5 (agent event bindings) can build on.

2. **Duplication.** The "overwrite a tool-result part's output, wrapped as `{ type: 'json', value }`, preserving every other message and part" map existed verbatim in two places: `resumeWithQuestionResult` (the answer-submit/skip path) and the Ctrl+C-while-questions-pending abort handler. They differed only in the value written. That duplication is exactly the kind that drifts.

## What changed

**New module: `src/tui/components/operator-dashboard/conversation.ts`.**

- `recoverAbortedConversation(conversation, partialText, displayMessages)` — moved verbatim from `logic.ts`. No behavior change.
- `rewriteToolResultOutput(conversation, toolCallId, value)` — new pure function. Overwrites the output of the tool-result part matching `toolCallId` with the JSON-wrapped value, leaves all other messages/parts untouched, and returns the *identical reference* when nothing matches (so callers can rely on reference equality for the no-op case).

**`index.tsx`:**

- `resumeWithQuestionResult` now calls `rewriteToolResultOutput(conversationRef.current, toolCallId, result)` — the inline map is gone.
- The Ctrl+C handler calls `rewriteToolResultOutput(...)` with `{ answers: [], skipped: true, aborted: true }` — the second inline map is gone.
- Both keep their existing surrounding side effects: the `messages.json` `writeFileSync`, the `pendingToolCallIdRef` reset, `setPendingQuestions(null)`, and (on the abort path) `setStatus("idle")` + the "Aborted" system message.
- Import for `recoverAbortedConversation` repointed from `./logic` to `./conversation`; `rewriteToolResultOutput` added.

**`logic.ts` / `logic.test.ts`:** the recovery function and its tests are removed (now in `conversation.ts` / `conversation.test.ts`); the now-unused `ModelMessage` and `DisplayMessage` type imports are dropped from both.

**Behavior preserved:**

- the Bedrock/Anthropic `{ type: 'json', value }` wrapper is still applied to question answers
- only the part matching the pending `toolCallId` is rewritten; sibling parts and non-tool messages are untouched
- non-array `content` and non-`tool` roles are passed through unchanged
- abort recovery gating, placeholder text, tool-call pairing, and the `Cancelled by user.` synthetic results are all unchanged (tests moved, not rewritten)

## Test coverage

8 tests in `conversation.test.ts`:

- **recovery** (moved from `logic.test.ts`, unchanged): no-recover-when-assistant-exists, interruption placeholder, partial-text trimming, pending/streaming tool pairing with settled-message exclusion, input immutability
- **`rewriteToolResultOutput`** (new): applies the json wrapper to the matching part, returns the identical reference on no match, rewrites only the matching `toolCallId` among multiple parts, does not mutate the input

## Validation

- `bun run test` (1,567 passed, 22 skipped)
- `bun run tsc`
- `bunx biome check src/tui/components/operator-dashboard/conversation.ts src/tui/components/operator-dashboard/conversation.test.ts src/tui/components/operator-dashboard/logic.ts src/tui/components/operator-dashboard/logic.test.ts src/tui/components/operator-dashboard/index.tsx`

## Notes

- no behavior change intended; next slice after this is step 3 (workflow projections into `workflow-data.ts`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with moved logic and consolidated helpers; conversation persistence paths are unchanged aside from shared implementation.
> 
> **Overview**
> Introduces **`conversation.ts`** for pure `ModelMessage[]` transitions as part of the operator dashboard decomposition.
> 
> **`recoverAbortedConversation`** moves out of `logic.ts` unchanged; **`rewriteToolResultOutput`** centralizes the duplicated logic that rewrites a tool-result part with a Bedrock/Anthropic `{ type: 'json', value }` wrapper. The operator dashboard now calls it from **`resumeWithQuestionResult`** and the Ctrl+C-while-questions-pending path instead of inline `map` over the conversation.
> 
> Recovery tests relocate to **`conversation.test.ts`**; new tests cover the rewrite helper (no-op reference equality, immutability, selective `toolCallId` updates). **`logic.ts`** drops the recovery implementation and related imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f899ab6f9c5caee0fa9c8bbca459b78c13cd6a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
