### PR TITLE
refactor(operator): extract workflow projections

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -135,6 +135,14 @@ import {
   loadSubagentSessionsFromDisk,
 } from "./subagent-state";
 import { SubagentStatusBar } from "./subagent-status-bar";
+import {
+  applyWorkflowPhaseComplete,
+  applyWorkflowPhaseStart,
+  applyWorkflowSubagentComplete,
+  applyWorkflowSubagentSpawn,
+  isPentestAgent,
+  updateWorkflowDataMessage,
+} from "./workflow-data";
 
 function markInFlightToolsErrored(
   messages: DisplayMessage[],
@@ -808,39 +816,11 @@ export default function OperatorDashboard({
 
       const eventBus = new AgentEventBus();
 
-      // Only pentest swarm agents (pentest-agent-*) get entries in
-      // WorkflowData.pentesting.subagents. All others (discovery, risk
-      // scorers, whitebox analyzers) are excluded.
-      const isPentestAgent = (id?: string) =>
-        id !== undefined && /^pentest-agent-\d+$/.test(id);
-
       // Patch the workflowData on the active run_pentest_workflow tool message.
       const updateWorkflowData = (
         updater: (wd: WorkflowData) => WorkflowData,
       ) => {
-        setMessages((prev) => {
-          const idx = prev.findLastIndex(
-            (m) =>
-              isToolMessage(m) &&
-              m.toolName === "run_pentest_workflow" &&
-              (m.status === "pending" || m.status === "streaming"),
-          );
-          if (idx === -1) return prev;
-          const msg = prev[idx];
-          const wd = msg.workflowData ?? {
-            currentPhase: "discovery" as const,
-            discovery: { label: "", status: "pending" as const, logs: [] },
-            pentesting: {
-              label: "",
-              status: "idle" as const,
-              subagents: {},
-            },
-            reporting: { label: "", status: "idle" as const },
-          };
-          const updated = [...prev];
-          updated[idx] = { ...msg, workflowData: updater(wd) };
-          return updated;
-        });
+        setMessages((prev) => updateWorkflowDataMessage(prev, updater));
       };
 
       eventBus.on("text-delta", (d) => {
@@ -978,20 +958,9 @@ export default function OperatorDashboard({
         subagentHelpers.spawnSession(subagentId, name);
         if (!isPentestAgent(subagentId)) return;
         // Pentest swarm agents → workflowData.pentesting.subagents
-        updateWorkflowData((wd) => ({
-          ...wd,
-          pentesting: {
-            ...wd.pentesting,
-            subagents: {
-              ...wd.pentesting.subagents,
-              [subagentId]: {
-                name,
-                status: "pending" as const,
-                logs: [],
-              },
-            },
-          },
-        }));
+        updateWorkflowData((wd) =>
+          applyWorkflowSubagentSpawn(wd, subagentId, name),
+        );
       });
 
       eventBus.on("subagent-complete", ({ subagentId, status }) => {
@@ -1002,20 +971,9 @@ export default function OperatorDashboard({
         subagentHelpers.completeSession(subagentId, status);
         if (!isPentestAgent(subagentId)) return;
         // Update workflowData swarm status
-        updateWorkflowData((wd) => {
-          const entry = wd.pentesting.subagents[subagentId];
-          if (!entry) return wd;
-          return {
-            ...wd,
-            pentesting: {
-              ...wd.pentesting,
-              subagents: {
-                ...wd.pentesting.subagents,
-                [subagentId]: { ...entry, status },
-              },
-            },
-          };
-        });
+        updateWorkflowData((wd) =>
+          applyWorkflowSubagentComplete(wd, subagentId, status),
+        );
       });
 
       // Workflow phase events → update workflowData on the tool message
@@ -1027,67 +985,25 @@ export default function OperatorDashboard({
         if (d.phase === "discovery") {
           subagentStore.setState(new Map());
         }
-        updateWorkflowData((wd) => {
-          const next = {
-            ...wd,
-            currentPhase: d.phase as WorkflowData["currentPhase"],
-          };
-          if (d.phase === "discovery") {
-            next.discovery = {
-              ...wd.discovery,
-              label: d.label,
-              status: "pending",
-              logs: [],
-            };
-          } else if (d.phase === "pentesting") {
-            next.pentesting = {
-              ...wd.pentesting,
-              label: d.label,
-              status: "pending",
-            };
-          } else if (d.phase === "reporting") {
-            next.reporting = {
-              ...wd.reporting,
-              label: d.label,
-              status: "pending",
-            };
-          }
-          return next;
-        });
+        updateWorkflowData((wd) =>
+          applyWorkflowPhaseStart(
+            wd,
+            d.phase as WorkflowData["currentPhase"],
+            d.label,
+          ),
+        );
       });
 
       eventBus.on("workflow-phase-complete", (d) => {
         if (gen !== generationRef.current) return;
         textRef.current = "";
-        updateWorkflowData((wd) => {
-          const next = { ...wd };
-          if (d.phase === "discovery") {
-            const targets = (d.summary.targets ?? []) as {
-              target: string;
-              objectives: string[];
-            }[];
-            next.discovery = {
-              ...wd.discovery,
-              status: "complete",
-              targets,
-              cached: d.summary.cached as boolean | undefined,
-            };
-          } else if (d.phase === "pentesting") {
-            next.pentesting = { ...wd.pentesting, status: "complete" };
-          } else if (d.phase === "reporting") {
-            next.reporting = {
-              ...wd.reporting,
-              status: "complete",
-              findingsCount: d.summary.findingsCount as number | undefined,
-              findingsBySeverity: d.summary.findingsBySeverity as
-                | Record<string, number>
-                | undefined,
-              reportPath: d.summary.reportPath as string | undefined,
-            };
-            next.currentPhase = "complete";
-          }
-          return next;
-        });
+        updateWorkflowData((wd) =>
+          applyWorkflowPhaseComplete(
+            wd,
+            d.phase as WorkflowData["currentPhase"],
+            d.summary,
+          ),
+        );
       });
 
       const skillsCatalog = skillsRegistry.buildCatalog() || undefined;

--- a/src/tui/components/operator-dashboard/workflow-data.test.ts
+++ b/src/tui/components/operator-dashboard/workflow-data.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "vitest";
+import type { DisplayMessage, WorkflowData } from "../agent-display";
+import {
+  applyWorkflowPhaseComplete,
+  applyWorkflowPhaseStart,
+  applyWorkflowSubagentComplete,
+  applyWorkflowSubagentSpawn,
+  initialWorkflowData,
+  isPentestAgent,
+  updateWorkflowDataMessage,
+} from "./workflow-data";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+function baseWorkflow(): WorkflowData {
+  return initialWorkflowData();
+}
+
+function workflowToolMessage(overrides: {
+  status?: "pending" | "streaming" | "completed";
+  workflowData?: WorkflowData;
+}): DisplayMessage {
+  return {
+    role: "tool",
+    content: "",
+    createdAt: new Date("2026-08-24T00:00:00Z"),
+    toolCallId: "wf1",
+    toolName: "run_pentest_workflow",
+    status: overrides.status ?? "pending",
+    workflowData: overrides.workflowData,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// isPentestAgent
+// ---------------------------------------------------------------------------
+
+describe("isPentestAgent", () => {
+  it("matches numbered pentest swarm agents", () => {
+    expect(isPentestAgent("pentest-agent-1")).toBe(true);
+    expect(isPentestAgent("pentest-agent-42")).toBe(true);
+  });
+
+  it("rejects non-swarm agents and undefined", () => {
+    expect(isPentestAgent("discovery")).toBe(false);
+    expect(isPentestAgent("pentest-agent")).toBe(false);
+    expect(isPentestAgent("pentest-agent-x")).toBe(false);
+    expect(isPentestAgent("app:foo")).toBe(false);
+    expect(isPentestAgent(undefined)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateWorkflowDataMessage
+// ---------------------------------------------------------------------------
+
+describe("updateWorkflowDataMessage", () => {
+  it("patches the active run_pentest_workflow tool message", () => {
+    const messages: DisplayMessage[] = [
+      { role: "user", content: "go", createdAt: new Date() },
+      workflowToolMessage({ status: "pending" }),
+    ];
+    const result = updateWorkflowDataMessage(messages, (wd) => ({
+      ...wd,
+      currentPhase: "pentesting",
+    }));
+
+    expect(result).toHaveLength(2);
+    const tool = result[1];
+    expect(tool.workflowData?.currentPhase).toBe("pentesting");
+  });
+
+  it("initializes default workflowData when the message has none", () => {
+    const messages = [workflowToolMessage({ status: "streaming" })];
+    const result = updateWorkflowDataMessage(messages, (wd) => wd);
+
+    expect(result[0].workflowData).toEqual(initialWorkflowData());
+  });
+
+  it("targets the most recent active workflow tool, ignoring completed ones", () => {
+    const older = workflowToolMessage({
+      status: "completed",
+      workflowData: baseWorkflow(),
+    });
+    const active = workflowToolMessage({ status: "pending" });
+    const messages: DisplayMessage[] = [older, active];
+
+    const result = updateWorkflowDataMessage(messages, (wd) => ({
+      ...wd,
+      currentPhase: "reporting",
+    }));
+
+    expect(result[0].workflowData?.currentPhase).toBe("discovery"); // untouched
+    expect(result[1].workflowData?.currentPhase).toBe("reporting");
+  });
+
+  it("returns the input unchanged when no active workflow tool exists", () => {
+    const messages: DisplayMessage[] = [
+      { role: "user", content: "go", createdAt: new Date() },
+    ];
+    const result = updateWorkflowDataMessage(messages, (wd) => wd);
+
+    expect(result).toBe(messages);
+  });
+
+  it("does not mutate the input list or message", () => {
+    const msg = workflowToolMessage({ status: "pending" });
+    const messages: DisplayMessage[] = [msg];
+    const original = structuredClone(messages);
+
+    updateWorkflowDataMessage(messages, (wd) => ({
+      ...wd,
+      currentPhase: "pentesting",
+    }));
+
+    expect(messages).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyWorkflowSubagentSpawn / Complete
+// ---------------------------------------------------------------------------
+
+describe("applyWorkflowSubagentSpawn", () => {
+  it("registers a pending subagent entry", () => {
+    const result = applyWorkflowSubagentSpawn(
+      baseWorkflow(),
+      "pentest-agent-1",
+      "nmap-scan",
+    );
+
+    expect(result.pentesting.subagents["pentest-agent-1"]).toEqual({
+      name: "nmap-scan",
+      status: "pending",
+      logs: [],
+    });
+  });
+
+  it("does not mutate the input workflow data", () => {
+    const wd = baseWorkflow();
+    const original = structuredClone(wd);
+
+    applyWorkflowSubagentSpawn(wd, "pentest-agent-1", "nmap-scan");
+
+    expect(wd).toEqual(original);
+  });
+});
+
+describe("applyWorkflowSubagentComplete", () => {
+  it("updates an existing subagent's status", () => {
+    const spawned = applyWorkflowSubagentSpawn(
+      baseWorkflow(),
+      "pentest-agent-1",
+      "nmap-scan",
+    );
+    const result = applyWorkflowSubagentComplete(
+      spawned,
+      "pentest-agent-1",
+      "completed",
+    );
+
+    expect(result.pentesting.subagents["pentest-agent-1"].status).toBe(
+      "completed",
+    );
+    expect(result.pentesting.subagents["pentest-agent-1"].name).toBe(
+      "nmap-scan",
+    );
+  });
+
+  it("returns the input unchanged for an unknown subagent", () => {
+    const wd = baseWorkflow();
+    const result = applyWorkflowSubagentComplete(
+      wd,
+      "pentest-agent-9",
+      "failed",
+    );
+
+    expect(result).toBe(wd);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyWorkflowPhaseStart
+// ---------------------------------------------------------------------------
+
+describe("applyWorkflowPhaseStart", () => {
+  it("marks discovery pending with label and resets logs", () => {
+    const result = applyWorkflowPhaseStart(
+      baseWorkflow(),
+      "discovery",
+      "Recon",
+    );
+
+    expect(result.currentPhase).toBe("discovery");
+    expect(result.discovery).toMatchObject({
+      label: "Recon",
+      status: "pending",
+      logs: [],
+    });
+  });
+
+  it("marks pentesting pending and sets it current", () => {
+    const result = applyWorkflowPhaseStart(
+      baseWorkflow(),
+      "pentesting",
+      "Exploit",
+    );
+
+    expect(result.currentPhase).toBe("pentesting");
+    expect(result.pentesting).toMatchObject({
+      label: "Exploit",
+      status: "pending",
+    });
+  });
+
+  it("marks reporting pending", () => {
+    const result = applyWorkflowPhaseStart(
+      baseWorkflow(),
+      "reporting",
+      "Write-up",
+    );
+
+    expect(result.reporting).toMatchObject({
+      label: "Write-up",
+      status: "pending",
+    });
+  });
+
+  it("does not mutate the input", () => {
+    const wd = baseWorkflow();
+    const original = structuredClone(wd);
+
+    applyWorkflowPhaseStart(wd, "pentesting", "Exploit");
+
+    expect(wd).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyWorkflowPhaseComplete
+// ---------------------------------------------------------------------------
+
+describe("applyWorkflowPhaseComplete", () => {
+  it("completes discovery with targets and cached flag", () => {
+    const targets = [{ target: "https://a", objectives: ["enum"] }];
+    const result = applyWorkflowPhaseComplete(baseWorkflow(), "discovery", {
+      targets,
+      cached: true,
+    });
+
+    expect(result.discovery).toMatchObject({
+      status: "complete",
+      targets,
+      cached: true,
+    });
+  });
+
+  it("completes pentesting without touching currentPhase", () => {
+    const result = applyWorkflowPhaseComplete(baseWorkflow(), "pentesting", {});
+
+    expect(result.pentesting.status).toBe("complete");
+    expect(result.currentPhase).toBe("discovery"); // unchanged
+  });
+
+  it("completes reporting, records findings, and flips currentPhase to complete", () => {
+    const result = applyWorkflowPhaseComplete(baseWorkflow(), "reporting", {
+      findingsCount: 3,
+      findingsBySeverity: { high: 1, medium: 2 },
+      reportPath: "/tmp/report.md",
+    });
+
+    expect(result.reporting).toMatchObject({
+      status: "complete",
+      findingsCount: 3,
+      findingsBySeverity: { high: 1, medium: 2 },
+      reportPath: "/tmp/report.md",
+    });
+    expect(result.currentPhase).toBe("complete");
+  });
+
+  it("does not mutate the input", () => {
+    const wd = baseWorkflow();
+    const original = structuredClone(wd);
+
+    applyWorkflowPhaseComplete(wd, "pentesting", {});
+
+    expect(wd).toEqual(original);
+  });
+});

--- a/src/tui/components/operator-dashboard/workflow-data.ts
+++ b/src/tui/components/operator-dashboard/workflow-data.ts
@@ -1,0 +1,130 @@
+import type { DisplayMessage, WorkflowData } from "../agent-display";
+import { isToolMessage } from "../shared/type-guards";
+
+// ---------------------------------------------------------------------------
+// Pentest workflow projections — pure, immutable WorkflowData transitions.
+// ---------------------------------------------------------------------------
+
+/** Only pentest swarm agents (pentest-agent-*) appear in WorkflowData. */
+export function isPentestAgent(id?: string): boolean {
+  return id !== undefined && /^pentest-agent-\d+$/.test(id);
+}
+
+/** Default WorkflowData for a fresh run_pentest_workflow tool message. */
+export function initialWorkflowData(): WorkflowData {
+  return {
+    currentPhase: "discovery",
+    discovery: { label: "", status: "pending", logs: [] },
+    pentesting: { label: "", status: "idle", subagents: {} },
+    reporting: { label: "", status: "idle" },
+  };
+}
+
+/** Patch the workflowData on the active run_pentest_workflow tool message. */
+export function updateWorkflowDataMessage(
+  messages: readonly DisplayMessage[],
+  updater: (wd: WorkflowData) => WorkflowData,
+): DisplayMessage[] {
+  const idx = messages.findLastIndex(
+    (m) =>
+      isToolMessage(m) &&
+      m.toolName === "run_pentest_workflow" &&
+      (m.status === "pending" || m.status === "streaming"),
+  );
+  if (idx === -1) return messages as DisplayMessage[];
+  const msg = messages[idx];
+  const wd = msg.workflowData ?? initialWorkflowData();
+  const updated = [...messages];
+  updated[idx] = { ...msg, workflowData: updater(wd) };
+  return updated;
+}
+
+/** Register a pentest swarm agent in the workflow's subagent map. */
+export function applyWorkflowSubagentSpawn(
+  wd: WorkflowData,
+  subagentId: string,
+  name?: string,
+): WorkflowData {
+  return {
+    ...wd,
+    pentesting: {
+      ...wd.pentesting,
+      subagents: {
+        ...wd.pentesting.subagents,
+        [subagentId]: { name, status: "pending", logs: [] },
+      },
+    },
+  };
+}
+
+/** Record a pentest swarm agent's terminal status. */
+export function applyWorkflowSubagentComplete(
+  wd: WorkflowData,
+  subagentId: string,
+  status: "completed" | "failed",
+): WorkflowData {
+  const entry = wd.pentesting.subagents[subagentId];
+  if (!entry) return wd;
+  return {
+    ...wd,
+    pentesting: {
+      ...wd.pentesting,
+      subagents: {
+        ...wd.pentesting.subagents,
+        [subagentId]: { ...entry, status },
+      },
+    },
+  };
+}
+
+/** Mark a workflow phase in-flight and label it. */
+export function applyWorkflowPhaseStart(
+  wd: WorkflowData,
+  phase: WorkflowData["currentPhase"],
+  label: string,
+): WorkflowData {
+  const next: WorkflowData = { ...wd, currentPhase: phase };
+  if (phase === "discovery") {
+    next.discovery = { ...wd.discovery, label, status: "pending", logs: [] };
+  } else if (phase === "pentesting") {
+    next.pentesting = { ...wd.pentesting, label, status: "pending" };
+  } else if (phase === "reporting") {
+    next.reporting = { ...wd.reporting, label, status: "pending" };
+  }
+  return next;
+}
+
+/** Mark a workflow phase complete and record its summary. */
+export function applyWorkflowPhaseComplete(
+  wd: WorkflowData,
+  phase: WorkflowData["currentPhase"],
+  summary: Record<string, unknown>,
+): WorkflowData {
+  const next: WorkflowData = { ...wd };
+  if (phase === "discovery") {
+    const targets = (summary.targets ?? []) as {
+      target: string;
+      objectives: string[];
+    }[];
+    next.discovery = {
+      ...wd.discovery,
+      status: "complete",
+      targets,
+      cached: summary.cached as boolean | undefined,
+    };
+  } else if (phase === "pentesting") {
+    next.pentesting = { ...wd.pentesting, status: "complete" };
+  } else if (phase === "reporting") {
+    next.reporting = {
+      ...wd.reporting,
+      status: "complete",
+      findingsCount: summary.findingsCount as number | undefined,
+      findingsBySeverity: summary.findingsBySeverity as
+        | Record<string, number>
+        | undefined,
+      reportPath: summary.reportPath as string | undefined,
+    };
+    next.currentPhase = "complete";
+  }
+  return next;
+}


### PR DESCRIPTION
## Stack

**5 of 6** — stacked on #968 (`refactor/conversation-transitions`); #970 (`refactor/run-tracing`) is stacked on this PR. Merge order: …→ this PR → #970, retargeting to `canary` at each step.

## Summary

- move the pentest workflow state transformations out of the dashboard's event handlers into a pure `workflow-data.ts` module
- extract the `updateWorkflowData` patch mechanism (locate the active `run_pentest_workflow` tool message + default `WorkflowData` init)
- add characterization coverage for every projection, including the pentest-swarm-agent filter and per-phase start/complete transitions

## Motivation

Next slice of the `OperatorDashboard` decomposition (after #965's abort recovery, #967's display-state reducers, #968's conversation transitions). The four workflow event handlers (`subagent-spawn`, `subagent-complete`, `workflow-phase-start`, `workflow-phase-complete`) each carried an inline `WorkflowData` transformation — the same spread-and-patch shape repeated four times. Those are deterministic projections of an event onto workflow state; they belong behind pure, directly testable functions.

## What changed

**New module: `src/tui/components/operator-dashboard/workflow-data.ts`.** All pure and immutable:

- `isPentestAgent(id)` — the `pentest-agent-\d+` predicate that gates which subagents appear in `WorkflowData` (moved verbatim)
- `initialWorkflowData()` — the default `WorkflowData` for a fresh `run_pentest_workflow` tool message (previously an inline literal inside `updateWorkflowData`)
- `updateWorkflowDataMessage(messages, updater)` — locate the *most recent active* `run_pentest_workflow` tool message (pending/streaming), seed its `workflowData` from `initialWorkflowData()` if absent, apply `updater`, return a new list
- `applyWorkflowSubagentSpawn(wd, subagentId, name?)` — register a pending subagent entry
- `applyWorkflowSubagentComplete(wd, subagentId, status)` — record terminal status; identical-reference no-op for unknown ids
- `applyWorkflowPhaseStart(wd, phase, label)` — set `currentPhase`, mark the phase `pending` + label it; discovery also resets `logs`
- `applyWorkflowPhaseComplete(wd, phase, summary)` — mark the phase `complete` and record its summary (discovery targets/cached, reporting findings/reportPath); reporting also flips `currentPhase` to `complete`

**`index.tsx`:** the inline `isPentestAgent` and the ~27-line `updateWorkflowData` are replaced by the imported helpers; each event handler keeps its side effects (generation guard, `textRef` reset, the discovery-phase `subagentStore.setState(new Map())` clear, the `app:` synthetic-node filter, `subagentHelpers` session calls) and now delegates the `WorkflowData` transformation. Net −113/+29 in the component.

**Behavior preserved:**

- only `pentest-agent-\d+` ids enter `WorkflowData.pentesting.subagents`; discovery/risk/whitebox agents stay excluded
- the `app:` synthetic grouping nodes are filtered *before* the pentest-agent check (unchanged order)
- `updateWorkflowData` no-ops when no active workflow tool message exists
- discovery-phase start clears subagent sessions *and* resets discovery logs; reporting complete flips `currentPhase` to `complete`
- summary fields are read defensively (`summary.targets ?? []`, typed casts) exactly as before

## Type notes

Two places where I initially over-constrained the signatures and TSC caught it:

- `applyWorkflowSubagentComplete`'s `status` is `"completed" | "failed"` (matching the `subagent-complete` event payload and `SubagentLogEntry.status`), not `| "cancelled"`
- `applyWorkflowSubagentSpawn`'s `name` is `name?: string` (matching the optional `name` on the `subagent-spawn` event and `SubagentLogEntry.name`)

## Test coverage

19 tests in `workflow-data.test.ts`:

- **`isPentestAgent`** — matches numbered swarm agents; rejects `discovery`, `pentest-agent` (no number), `pentest-agent-x`, `app:foo`, `undefined`
- **`updateWorkflowDataMessage`** — patches the active tool message, seeds default `workflowData` when absent, targets the most recent active message while leaving a completed one untouched, identical-reference no-op when none, input immutability
- **subagent spawn/complete** — registers pending entry, updates status while preserving name, no-op for unknown id, input immutability
- **phase start/complete** — per-phase pending/complete labeling, discovery log reset + targets/cached, reporting findings + `currentPhase` flip, input immutability

## Validation

- `bun run test` (1,586 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check src/tui/components/operator-dashboard/workflow-data.ts src/tui/components/operator-dashboard/workflow-data.test.ts src/tui/components/operator-dashboard/index.tsx`

## Notes

- no behavior change intended; next slice after this is step 4 (W&B run tracing into `run-tracing.ts`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only extraction with tests locking prior behavior; no auth, persistence, or API surface changes beyond moving TUI workflow projection logic.
> 
> **Overview**
> **Moves pentest `WorkflowData` updates out of `OperatorDashboard` event handlers** into a pure `workflow-data` module so the dashboard only wires side effects (generation guards, subagent store, `app:` filters) and calls small updaters.
> 
> The inline `isPentestAgent` check, the “find active `run_pentest_workflow` tool message and patch `workflowData`” logic, and the spread-heavy handlers for `subagent-spawn`, `subagent-complete`, `workflow-phase-start`, and `workflow-phase-complete` are replaced by **`updateWorkflowDataMessage`**, **`initialWorkflowData`**, and **`applyWorkflow*`** helpers. Behavior is intended unchanged: only `pentest-agent-\d+` ids land in `pentesting.subagents`, discovery start still resets logs, reporting complete still sets `currentPhase` to `complete`, and there is a no-op when no active workflow tool exists.
> 
> Adds **`workflow-data.test.ts`** with characterization tests for the predicate, message patching (including “most recent active” vs completed), subagent spawn/complete, and per-phase start/complete transitions, plus immutability checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a060e087259d3c46f11de1b27f7eb2644a636bac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
