### PR TITLE
refactor(operator): encapsulate run tracing

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -46,7 +46,6 @@ import {
   isSensitiveHeaderName,
   renderHeaderValue,
 } from "../../../core/http/types";
-import { attachWandbToEventBus } from "../../../core/integrations/wandb/upload";
 import type { OperatorMode, PendingApproval } from "../../../core/operator";
 import {
   ApprovalGate,
@@ -128,6 +127,7 @@ import {
   selectionAfterRemove,
 } from "./queue";
 import { QueuedMessages } from "./queued-messages";
+import { RunTraceSession } from "./run-tracing";
 import SubagentDialog from "./subagent-dialog";
 import {
   createSubagentSessionHelpers,
@@ -816,6 +816,15 @@ export default function OperatorDashboard({
 
       const eventBus = new AgentEventBus();
 
+      // W&B trace upload — buffer early records so none are lost for new sessions.
+      // For resumed sessions, we attach before the agent starts.
+      // For new sessions, onSessionReady fires mid-construction; we replay
+      // any buffered records once the handler attaches.
+      const runTrace = new RunTraceSession(eventBus, {
+        isCurrent: () => gen === generationRef.current,
+        recordTokenUsage,
+      });
+
       // Patch the workflowData on the active run_pentest_workflow tool message.
       const updateWorkflowData = (
         updater: (wd: WorkflowData) => WorkflowData,
@@ -1049,71 +1058,13 @@ export default function OperatorDashboard({
           setSessionCwd(s.rootPath);
           sessionRef.current = s;
           setSession((prev) => prev ?? s);
-          tryAttachWandb(s);
+          runTrace.tryAttach(s);
         },
-      };
-
-      // W&B trace upload — buffer early records so none are lost for new sessions.
-      // For resumed sessions, we attach before the agent starts.
-      // For new sessions, onSessionReady fires mid-construction; we replay
-      // any buffered records once the handler attaches.
-      type TraceEvent = {
-        record: import("../../../core/agents/offSecAgent").TraceRecord;
-        subagentId?: string;
-      };
-      let wandbCleanup: (() => Promise<void>) | null = null;
-      let earlyBuffer: TraceEvent[] | null = [];
-
-      const earlyBufferHandler = (e: TraceEvent) => {
-        earlyBuffer?.push(e);
-      };
-      eventBus.on("trace-record", earlyBufferHandler);
-
-      // Subagent steps (orchestrator ones lack subagentId, counted above).
-      // Key dedupes the W&B early-buffer replay.
-      const countedSubagentSteps = new Set<string>();
-      eventBus.on("trace-record", ({ record, subagentId }) => {
-        if (gen !== generationRef.current) return;
-        if (!subagentId || record.type !== "step") return;
-        const key = `${subagentId}:${record.stepIndex}:${record.timestamp}`;
-        if (countedSubagentSteps.has(key)) return;
-        countedSubagentSteps.add(key);
-        recordTokenUsage(
-          record.usage.inputTokens,
-          record.usage.outputTokens,
-          record.usage.cacheReadTokens ?? 0,
-          record.usage.cacheWriteTokens ?? 0,
-        );
-      });
-
-      const tryAttachWandb = async (s: SessionInfo) => {
-        if (wandbCleanup) return;
-        const cleanup = await attachWandbToEventBus(s, eventBus).catch(
-          (e: unknown) => {
-            console.error("[wandb] Attach failed:", e);
-            return null;
-          },
-        );
-        if (cleanup) {
-          wandbCleanup = cleanup;
-          // Replay any records captured before the handler attached
-          const buffered = earlyBuffer;
-          earlyBuffer = null;
-          eventBus.off("trace-record", earlyBufferHandler);
-          if (buffered) {
-            for (const e of buffered) {
-              eventBus.emit("trace-record", e);
-            }
-          }
-        } else {
-          earlyBuffer = null;
-          eventBus.off("trace-record", earlyBufferHandler);
-        }
       };
 
       const wandbSession = session ?? sessionRef.current;
       if (wandbSession) {
-        await tryAttachWandb(wandbSession);
+        await runTrace.tryAttach(wandbSession);
       }
 
       try {
@@ -1256,16 +1207,9 @@ export default function OperatorDashboard({
           ]);
         }
       } finally {
-        // Clean up early buffer listener on all paths (abort, error, success)
-        earlyBuffer = null;
-        eventBus.off("trace-record", earlyBufferHandler);
-
-        if (wandbCleanup) {
-          const fn = wandbCleanup as () => Promise<void>;
-          await fn().catch((e: unknown) =>
-            console.error("[wandb] Flush failed:", e),
-          );
-        }
+        // Detach trace listeners and flush the uploader on all paths
+        // (abort, error, success).
+        await runTrace.cleanupRun();
         if (gen === generationRef.current) {
           setStatus(pendingToolCallIdRef.current ? "waiting" : "idle");
           setThinking(false);

--- a/src/tui/components/operator-dashboard/run-tracing.test.ts
+++ b/src/tui/components/operator-dashboard/run-tracing.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TraceRecord } from "../../../core/agents/offSecAgent";
+import { AgentEventBus } from "../../../core/eventBus";
+import type { SessionInfo } from "../../../core/session";
+import { RunTraceSession } from "./run-tracing";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeStepRecord(
+  stepIndex: number,
+  timestamp: string,
+  usage = { inputTokens: 10, outputTokens: 5 },
+): TraceRecord {
+  return {
+    type: "step",
+    stepIndex,
+    timestamp,
+    agentId: "pentest-agent-1",
+    observations: null,
+    reasoning: null,
+    text: null,
+    toolCalls: [],
+    usage,
+    cumulativeUsage: { ...usage },
+    durationMs: 1,
+  } as unknown as TraceRecord;
+}
+
+function makeSession(): SessionInfo {
+  return {
+    id: "ses_test",
+    rootPath: "/tmp/ses_test",
+  } as unknown as SessionInfo;
+}
+
+// ---------------------------------------------------------------------------
+// RunTraceSession
+// ---------------------------------------------------------------------------
+
+describe("RunTraceSession", () => {
+  it("counts deduped subagent step tokens, ignoring orchestrator steps", () => {
+    const bus = new AgentEventBus();
+    const recordTokenUsage = vi.fn();
+    const trace = new RunTraceSession(bus, {
+      isCurrent: () => true,
+      recordTokenUsage,
+      attach: async () => async () => {},
+    });
+
+    bus.emit("trace-record", {
+      record: makeStepRecord(0, "t0"),
+      subagentId: "pentest-agent-1",
+    });
+    // Orchestrator step (no subagentId) — not counted here.
+    bus.emit("trace-record", { record: makeStepRecord(0, "t0") });
+    // Non-step record — ignored.
+    bus.emit("trace-record", {
+      record: { type: "checkpoint" } as unknown as TraceRecord,
+      subagentId: "pentest-agent-1",
+    });
+
+    expect(recordTokenUsage).toHaveBeenCalledTimes(1);
+    expect(recordTokenUsage).toHaveBeenCalledWith(10, 5, 0, 0);
+  });
+
+  it("dedupes a replayed early-buffer step so it is not double-counted", async () => {
+    const bus = new AgentEventBus();
+    const recordTokenUsage = vi.fn();
+    let attached: ((e: { record: TraceRecord }) => void) | null = null;
+    const trace = new RunTraceSession(bus, {
+      isCurrent: () => true,
+      recordTokenUsage,
+      attach: async (_s, eventBus) => {
+        attached = (e) => {
+          // Real attach re-emits through the bus; here we just observe.
+          void eventBus;
+          void e;
+        };
+        return async () => {};
+      },
+    });
+
+    // Emit before attach — buffered.
+    const rec = makeStepRecord(1, "t1");
+    bus.emit("trace-record", { record: rec, subagentId: "pentest-agent-1" });
+    expect(recordTokenUsage).toHaveBeenCalledTimes(1);
+
+    await trace.tryAttach(makeSession());
+
+    // The early-buffer replay re-emits the same step — dedup key suppresses it.
+    bus.emit("trace-record", { record: rec, subagentId: "pentest-agent-1" });
+    expect(recordTokenUsage).toHaveBeenCalledTimes(1);
+    expect(attached).not.toBeNull();
+  });
+
+  it("replays buffered records to the uploader on attach", async () => {
+    const bus = new AgentEventBus();
+    const received: TraceRecord[] = [];
+    // Faithful to attachWandbToEventBus: the uploader subscribes inside attach
+    // (before returning its cleanup), then tryAttach replays the buffer.
+    const trace = new RunTraceSession(bus, {
+      isCurrent: () => true,
+      recordTokenUsage: () => {},
+      attach: async (_s, eventBus) => {
+        const handler = (e: { record: TraceRecord }) => received.push(e.record);
+        eventBus.on("trace-record", handler);
+        return async () => {
+          eventBus.off("trace-record", handler);
+        };
+      },
+    });
+
+    const rec = makeStepRecord(2, "t2");
+    bus.emit("trace-record", { record: rec, subagentId: "pentest-agent-1" });
+
+    await trace.tryAttach(makeSession());
+
+    expect(received).toContain(rec);
+  });
+
+  it("is idempotent — a second tryAttach is a no-op", async () => {
+    const bus = new AgentEventBus();
+    const attach = vi.fn(async () => async () => {});
+    const trace = new RunTraceSession(bus, {
+      isCurrent: () => true,
+      recordTokenUsage: () => {},
+      attach,
+    });
+
+    await trace.tryAttach(makeSession());
+    await trace.tryAttach(makeSession());
+
+    expect(attach).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops records when the generation guard fails", () => {
+    const bus = new AgentEventBus();
+    const recordTokenUsage = vi.fn();
+    const trace = new RunTraceSession(bus, {
+      isCurrent: () => false, // stale generation
+      recordTokenUsage,
+      attach: async () => async () => {},
+    });
+
+    bus.emit("trace-record", {
+      record: makeStepRecord(0, "t0"),
+      subagentId: "pentest-agent-1",
+    });
+
+    expect(recordTokenUsage).not.toHaveBeenCalled();
+  });
+
+  it("cleanup detaches listeners and flushes the uploader exactly once", async () => {
+    const bus = new AgentEventBus();
+    const recordTokenUsage = vi.fn();
+    const flush = vi.fn(async () => {});
+    const trace = new RunTraceSession(bus, {
+      isCurrent: () => true,
+      recordTokenUsage,
+      attach: async () => flush,
+    });
+
+    await trace.tryAttach(makeSession());
+    await trace.cleanupRun();
+    await trace.cleanupRun(); // second call is safe
+
+    expect(flush).toHaveBeenCalledTimes(1);
+
+    // After cleanup, the token listener is detached.
+    bus.emit("trace-record", {
+      record: makeStepRecord(3, "t3"),
+      subagentId: "pentest-agent-1",
+    });
+    expect(recordTokenUsage).not.toHaveBeenCalled();
+  });
+
+  it("survives attach failure — buffers stop and cleanup is safe", async () => {
+    const bus = new AgentEventBus();
+    const trace = new RunTraceSession(bus, {
+      isCurrent: () => true,
+      recordTokenUsage: () => {},
+      attach: async () => {
+        throw new Error("attach boom");
+      },
+    });
+
+    await trace.tryAttach(makeSession()); // swallow + log
+    await expect(trace.cleanupRun()).resolves.toBeUndefined();
+  });
+
+  it("survives flush failure in cleanup without throwing", async () => {
+    const bus = new AgentEventBus();
+    const trace = new RunTraceSession(bus, {
+      isCurrent: () => true,
+      recordTokenUsage: () => {},
+      attach: async () => async () => {
+        throw new Error("flush boom");
+      },
+    });
+
+    await trace.tryAttach(makeSession());
+    await expect(trace.cleanupRun()).resolves.toBeUndefined();
+  });
+});

--- a/src/tui/components/operator-dashboard/run-tracing.ts
+++ b/src/tui/components/operator-dashboard/run-tracing.ts
@@ -1,0 +1,105 @@
+import type { TraceRecord } from "../../../core/agents/offSecAgent";
+import type { AgentEventBus } from "../../../core/eventBus";
+import { attachWandbToEventBus } from "../../../core/integrations/wandb/upload";
+import type { SessionInfo } from "../../../core/session";
+
+type TraceEvent = {
+  record: TraceRecord;
+  subagentId?: string;
+};
+
+export type RunTraceOptions = {
+  /** Generation guard — called on every trace-record; return false to drop it. */
+  isCurrent: () => boolean;
+  /** Accumulate deduped subagent step token usage. */
+  recordTokenUsage: (
+    inputTokens: number,
+    outputTokens: number,
+    cacheReadTokens: number,
+    cacheWriteTokens: number,
+  ) => void;
+  /** Optional uploader override for tests; defaults to the real W&B attach. */
+  attach?: (
+    session: SessionInfo,
+    eventBus: AgentEventBus,
+  ) => Promise<(() => Promise<void>) | null>;
+};
+
+/**
+ * Owns the W&B trace-upload lifecycle for a single agent run: buffers records
+ * emitted before the uploader attaches (new sessions fire onSessionReady
+ * mid-construction), dedupes subagent step tokens against the early-buffer
+ * replay, and flushes on cleanup. Construct once per run; call `cleanup()` on
+ * every exit path.
+ */
+export class RunTraceSession {
+  private cleanup: (() => Promise<void>) | null = null;
+  private earlyBuffer: TraceEvent[] | null = [];
+  private readonly countedSubagentSteps = new Set<string>();
+  private readonly earlyBufferHandler = (e: TraceEvent) => {
+    this.earlyBuffer?.push(e);
+  };
+
+  constructor(
+    private readonly eventBus: AgentEventBus,
+    private readonly options: RunTraceOptions,
+  ) {
+    eventBus.on("trace-record", this.earlyBufferHandler);
+    eventBus.on("trace-record", this.countSubagentStep);
+  }
+
+  /** Idempotent: only the first successful attach takes effect. */
+  async tryAttach(session: SessionInfo): Promise<void> {
+    if (this.cleanup) return;
+    const attach = this.options.attach ?? attachWandbToEventBus;
+    const cleanup = await attach(session, this.eventBus).catch((e: unknown) => {
+      console.error("[wandb] Attach failed:", e);
+      return null;
+    });
+    // Capture the buffer before detaching the early handler.
+    const buffered = this.earlyBuffer;
+    this.stopBuffering();
+    if (cleanup) {
+      this.cleanup = cleanup;
+      // Replay records captured before the handler attached.
+      if (buffered) {
+        for (const e of buffered) this.eventBus.emit("trace-record", e);
+      }
+    }
+  }
+
+  /** Flush the uploader and detach all listeners. Safe to call repeatedly. */
+  async cleanupRun(): Promise<void> {
+    this.stopBuffering();
+    this.eventBus.off("trace-record", this.countSubagentStep);
+    if (this.cleanup) {
+      const fn = this.cleanup;
+      this.cleanup = null;
+      await fn().catch((e: unknown) =>
+        console.error("[wandb] Flush failed:", e),
+      );
+    }
+  }
+
+  private stopBuffering(): void {
+    this.earlyBuffer = null;
+    this.eventBus.off("trace-record", this.earlyBufferHandler);
+  }
+
+  // Subagent steps (orchestrator ones lack subagentId, counted elsewhere). The
+  // key dedupes the W&B early-buffer replay.
+  private countSubagentStep = (e: TraceEvent): void => {
+    if (!this.options.isCurrent()) return;
+    const { record, subagentId } = e;
+    if (!subagentId || record.type !== "step") return;
+    const key = `${subagentId}:${record.stepIndex}:${record.timestamp}`;
+    if (this.countedSubagentSteps.has(key)) return;
+    this.countedSubagentSteps.add(key);
+    this.options.recordTokenUsage(
+      record.usage.inputTokens,
+      record.usage.outputTokens,
+      record.usage.cacheReadTokens ?? 0,
+      record.usage.cacheWriteTokens ?? 0,
+    );
+  };
+}


### PR DESCRIPTION
## Stack

**6 of 6** — stacked on #969 (`refactor/workflow-projections`) ← #968 ← #967 ← #965 ← #964. Merge order: #964 → #965 → #967 → #968 → #969 → this PR, retargeting to `canary` at each step.

## Summary

- encapsulate the W&B run-tracing lifecycle from `runAgent` into a `RunTraceSession` class in `run-tracing.ts`
- own the early-record buffer, the subagent-step token dedup, and the W&B attach/replay/cleanup in one place
- add characterization coverage for buffering, replay, token dedup, the generation guard, attach idempotency, and cleanup

## Motivation

Next slice of the `OperatorDashboard` decomposition (after #965, #967, #968, #969). The W&B logic in `runAgent` was spread across ~60 lines mixing three concerns: an early-record buffer (so records emitted before `onSessionReady` aren't lost for new sessions), a subagent-step token dedup (so the early-buffer replay isn't double-counted), and the W&B attach/replay/cleanup lifecycle. Those are a single cohesive collaborator — they own no rendering, only the trace pipeline — so they belong behind a tested boundary.

## What changed

**New module: `src/tui/components/operator-dashboard/run-tracing.ts`** — a `RunTraceSession` class, constructed once per `runAgent` call:

- **Constructor** wires two `trace-record` listeners: the early-record buffer and the subagent-step token counter.
- **`tryAttach(session)`** — idempotent (no-op after the first successful attach). Calls `attachWandbToEventBus` (injectable for tests), captures the buffer, stops buffering, then replays buffered records so the just-attached uploader sees them.
- **`cleanupRun()`** — detaches both listeners and flushes the uploader exactly once; safe to call repeatedly. Both attach and flush failures are caught and logged, matching the original behavior.
- **Token counting** — only subagent `step` records (orchestrator steps lack a `subagentId` and are counted elsewhere), deduped by `subagentId:stepIndex:timestamp` so the early-buffer replay doesn't double-count.

**`index.tsx`:** the `TraceEvent` type, `wandbCleanup`/`earlyBuffer` state, `earlyBufferHandler`, `countedSubagentSteps`, the inline `tryAttachWandb`, and the `finally` cleanup all collapse into constructing one `RunTraceSession`, calling `tryAttach` for the resumed-session path and from `onSessionReady` for the new-session path, and `await runTrace.cleanupRun()` in the `finally`. The unused `attachWandbToEventBus` import is dropped. Net −71/+15 in the component.

## Two things the tests caught

- **Replay-ordering bug (mine, caught before merge).** My first cut called `stopBuffering()` (which nulls `earlyBuffer`) *before* reading the buffer for the replay, so buffered records were silently dropped. The original captured the buffer first. The replay test failed on this; fixed by capturing `buffered` before `stopBuffering()`. This is exactly the failure mode the early-buffer exists to prevent, so it was good to catch it here.
- **Declaration-order hazard.** `onSessionReady` (inside `commonInput`, line ~1057) references the trace session, but `runTrace` was initially declared *after* `commonInput`. The original worked because `tryAttachWandb` was a hoisted `function` declaration; a `const` class instance is not hoisted. `runTrace` is now declared right after `eventBus` (line ~823), before `commonInput`. TSC passed either way (it's a runtime TDZ, not a type error), but a synchronous `onSessionReady` would have thrown.

## Behavior preserved

- early records buffer until attach; replayed in order once the uploader subscribes
- the resumed-session path attaches before the agent starts; the new-session path attaches from `onSessionReady`
- subagent step tokens are deduped across the replay; orchestrator steps are untouched
- attach and flush failures are logged, not thrown; cleanup runs on every exit path (success, error, abort)
- the generation guard (`isCurrent: () => gen === generationRef.current`) drops stale records exactly as the inline handler did

## Test coverage

8 tests in `run-tracing.test.ts`, driving a real `AgentEventBus` with an injected fake `attach`:

- counts deduped subagent step tokens (ignores orchestrator steps and non-step records)
- does not double-count a replayed early-buffer step
- replays buffered records to the uploader on attach (the faithful `attach` subscribes before returning cleanup)
- `tryAttach` is idempotent across two calls
- the generation guard drops records when stale
- `cleanupRun` detaches listeners and flushes exactly once (second call is a safe no-op)
- attach failure and flush failure are both swallowed + logged, cleanup stays safe

## Validation

- `bun run test` (1,594 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check src/tui/components/operator-dashboard/run-tracing.ts src/tui/components/operator-dashboard/run-tracing.test.ts src/tui/components/operator-dashboard/index.tsx`

## Notes

- no behavior change intended; this completes the four decomposition PRs (display state, conversation, workflow, run tracing). Step 5 (agent event bindings) and the `runAgent` reassessment are the remaining planned work, but those touch the live event-ingress path and are worth a fresh look once this stack lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with characterization tests and preserved attach/replay/cleanup semantics; risk is limited to observability/token accounting edge cases if wiring regressed.
> 
> **Overview**
> Moves **Weights & Biases trace upload** out of `runAgent` in the operator dashboard into a dedicated **`RunTraceSession`** module (`run-tracing.ts`).
> 
> The dashboard now constructs one session per agent run, calls **`tryAttach`** when resuming (before the agent starts) and from **`onSessionReady`** for new sessions, and **`cleanupRun`** in the `finally` block. Inline logic for early `trace-record` buffering, subagent step token dedup (including replay after attach), and W&B attach/flush is removed from `index.tsx` (~60 lines → a small wiring block).
> 
> **`RunTraceSession`** centralizes: buffering records until the uploader attaches, idempotent attach with ordered replay, generation-guarded subagent step token counting, and safe teardown (listeners off, flush once; attach/flush errors logged). Tests in **`run-tracing.test.ts`** cover dedup, replay, idempotency, stale generation, and failure paths via an injectable `attach` hook.
> 
> **No intended behavior change** for trace upload or token metrics; this is a decomposition step for `OperatorDashboard`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e112e61ddb4a7a98911bda3eff1664033e73135b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->