### PR TITLE
fix(browser): floor the Camoufox screen constraint instead of exact-pinning it

### DIFF
--- a/src/core/agents/offSecAgent/tools/camoufox.test.ts
+++ b/src/core/agents/offSecAgent/tools/camoufox.test.ts
@@ -47,15 +47,11 @@ describe("display-tier viewport helpers", () => {
     expect(viewportSizeForDisplay(undefined)).toBe(COMPUTER_USE_VIEWPORT_SIZE);
   });
 
-  it("builds fingerprint-coherent window + screen constraints", () => {
+  it("floors the screen at the window without an exact pin", () => {
+    // Guard: an exact (min==max) pin wedged the 720p tier in browserforge.
     expect(camoufoxWindowOptions([1280, 720])).toEqual({
       window: [1280, 720],
-      screen: {
-        minWidth: 1280,
-        maxWidth: 1280,
-        minHeight: 720,
-        maxHeight: 720,
-      },
+      screen: { minWidth: 1280, minHeight: 720 },
     });
   });
 });
@@ -115,7 +111,7 @@ describe("resolveCamoufoxLaunchOptions", () => {
     });
   });
 
-  it("forwards a fixed window and matching screen constraints when provided", async () => {
+  it("forwards a fixed window and a screen floor when provided", async () => {
     launchOptionsMock.mockResolvedValue({
       executablePath: "/opt/camoufox/camoufox-bin",
       args: [],
@@ -130,12 +126,7 @@ describe("resolveCamoufoxLaunchOptions", () => {
       ...CAMOUFOX_OPTIONS,
       headless: false,
       window: [1280, 720],
-      screen: {
-        minWidth: 1280,
-        maxWidth: 1280,
-        minHeight: 720,
-        maxHeight: 720,
-      },
+      screen: { minWidth: 1280, minHeight: 720 },
     });
   });
 });

--- a/src/core/agents/offSecAgent/tools/camoufox.ts
+++ b/src/core/agents/offSecAgent/tools/camoufox.ts
@@ -115,25 +115,21 @@ export function viewportSizeForDisplay(display: string | undefined): string {
   return COMPUTER_USE_VIEWPORT_SIZE;
 }
 
-/** Camoufox `window` + matching `screen` constraints (fingerprint-coherent). */
+/**
+ * Camoufox `window` + a `screen` floor (min only, never an exact pin).
+ *
+ * browserforge has no Firefox fingerprint at 720px height, so exact-pinning the
+ * 720p endpoint tier made header generation throw for every browser call. A
+ * min-only floor keeps `screen >= window` while staying in a covered bucket.
+ */
 export function camoufoxWindowOptions(window: [number, number]): {
   window: [number, number];
-  screen: {
-    minWidth: number;
-    maxWidth: number;
-    minHeight: number;
-    maxHeight: number;
-  };
+  screen: { minWidth: number; minHeight: number };
 } {
   const [width, height] = window;
   return {
     window: [width, height],
-    screen: {
-      minWidth: width,
-      maxWidth: width,
-      minHeight: height,
-      maxHeight: height,
-    },
+    screen: { minWidth: width, minHeight: height },
   };
 }
 

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -334,12 +334,8 @@ const fs = require('fs');
       ...${JSON.stringify(CAMOUFOX_OPTIONS)},
       headless: __headless,
       window: __window,
-      screen: {
-        minWidth: __window[0],
-        maxWidth: __window[0],
-        minHeight: __window[1],
-        maxHeight: __window[1],
-      },
+      // Floor only — exact-pinning a 720px height throws in browserforge.
+      screen: { minWidth: __window[0], minHeight: __window[1] },
     });
     fs.writeFileSync('${SANDBOX_CAMOU_CACHE}', JSON.stringify(__camou));
   }


### PR DESCRIPTION
## Problem

Camoufox-backed browser tools (`browser_navigate`, etc.) fail for **every URL** on the pentest per-endpoint (720p) desktop tier with:

> No headers based on this input can be generated. Please relax or change some of the requirements you specified.

`launchOptions()` throws before any page loads, and the result is cached per sandbox, so one bad draw wedges the whole browser flow. Browser-based auth/testing goes dark and the agent falls back to raw HTTP — credentialed objectives get reported as unfinishable. The 1080p computer-use tier (credential-test/auth agent) is unaffected, which is why auth succeeds while endpoint pentests report "browser navigation completely broken."

## Root cause

`camoufoxWindowOptions` (and the inlined block in `sandboxPlaywright.ts`) pinned the fingerprint's reported `screen` to **exactly** the browser window (`min==max`). The per-endpoint desktops run at **1280×720**, and browserforge (behind `fingerprint-generator`) has **no Firefox fingerprint at 720px height** — so `getFingerprint`/`getHeaders` throws 100% of the time on that tier. Introduced by #946 ("match Camoufox window to Xvfb display tier"); latent until a pentest drove a per-endpoint browser against a browser-dependent target (authenticated SPA / OAuth).

Measured against the pinned `fingerprint-generator@2.1.82`:

| scenario | fail |
|---|---|
| exact 1280×720 screen pin (what camoufox does on endpoints) | **100%** |
| force FF≥148, no screen pin (version-drift mode) | 100% |
| baseline (no screen pin, any FF) | ~1% |
| **min-only screen floor (this PR)** | **0%** |

> Note: this is **not** the Firefox-version-drift mode that console#2592 pinned the fingerprint suite for. `launchOptions()` feeds only screen + OS into header generation (the FF binary version is applied to the UA afterward), so that mode never fires in the real camoufox path. That pin is still worth keeping for reproducibility — it just doesn't touch this screen pin.

## Change

Stop exact-pinning `screen`; use a **min-only floor** so the reported screen stays `>= window` (also more realistic — a real monitor is never smaller than its window) without landing in the empty 720 bucket. `window` is unchanged, so the actual browser size / streamed desktop / recordings are identical.

- `camoufox.ts` — `camoufoxWindowOptions` returns `{ minWidth, minHeight }` (no `max*`)
- `sandboxPlaywright.ts` — same in the generated sandbox script
- `camoufox.test.ts` — asserts the floor shape (guards against re-adding the exact pin)

## Validation

- 0% failure at 720p on both `fingerprint-generator@2.1.82` and `2.1.88` (vs 100% / 3% for the exact pin).
- `bun run tsc`: 0 errors. `vitest camoufox.test.ts`: 8/8 pass.

Refs pensarai/console#2591

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Camoufox fingerprint launch options on the pentest browser path; behavior is validated but alters how screen constraints are passed to browserforge.
> 
> **Overview**
> Fixes **720p per-endpoint** Camoufox launches where `launchOptions()` failed every time with browserforge header generation errors, wedging cached sandbox browser sessions.
> 
> **`camoufoxWindowOptions`** (and the matching inline logic in **`sandboxPlaywright`**) no longer sets `screen` with `min==max` to match the window. They pass a **min-only floor** (`minWidth` / `minHeight`) so reported screen stays ≥ window without forcing a 720px-tall fingerprint bucket browserforge does not cover. Actual **`window`** size is unchanged (still 1280×720 on endpoint displays).
> 
> Tests now assert the floor shape and document the regression guard against re-introducing exact pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddb5b3224f5b8e7a10e46149da6c8825efb35968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->