### PR TITLE
perf: bound typecheck and test resource usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "url": "https://github.com/pensarai/apex.git"
   },
   "scripts": {
-    "build": "bun build src/cli.ts --outdir build --target node --format esm --splitting --external @opentui/core --external @opentui/react --external @opentui/react/* --external react --external react/jsx-runtime --external react/jsx-dev-runtime --external react-reconciler --external weave --external electron --external chromium-bidi --external camoufox-js",
+    "build": "rm -rf build && bun build src/cli.ts --outdir build --target node --format esm --splitting --external @opentui/core --external @opentui/react --external @opentui/react/* --external react --external react/jsx-runtime --external react/jsx-dev-runtime --external react-reconciler --external weave --external electron --external chromium-bidi --external camoufox-js",
     "build:binaries": "bun run generate:ascii && mkdir -p dist && bun run build:binary:macos-arm64 && bun run build:binary:macos-x64 && bun run build:binary:linux-x64 && bun run build:binary:linux-arm64",
     "build:binary": "bun run generate:ascii && bun build src/cli.ts --compile --external electron --external chromium-bidi --external camoufox-js --outfile pensar",
     "build:binary:linux-arm64": "bun build src/cli.ts --compile --external electron --external chromium-bidi --external camoufox-js --target=bun-linux-arm64 --outfile dist/pensar-linux-arm64",

--- a/src/core/agents/offSecAgent/tools/persistentShell.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 
 import {
   extractFallbackStdout,
@@ -21,22 +21,17 @@ const HAS_STDBUF =
 describe("PersistentShell — long-running stability", () => {
   const shells: PersistentShell[] = [];
   const make = () => {
-    const s = new PersistentShell();
-    shells.push(s);
-    return s;
+    const shell = new PersistentShell();
+    shells.push(shell);
+    return shell;
   };
 
-  afterEach(() => {
-    while (shells.length) {
-      try {
-        shells.pop()?.dispose();
-      } catch {
-        // ignore
-      }
-    }
+  // Process-group cleanup can race sibling shells, so wait for concurrent cases.
+  afterAll(() => {
+    for (const shell of shells) shell.dispose();
   });
 
-  it("basic smoke: sequential commands return quickly", async () => {
+  it.concurrent("basic smoke: sequential commands return quickly", async () => {
     const shell = make();
     const r1 = await shell.execute("echo one", 5);
     expect(r1.exitCode).toBe(0);
@@ -47,7 +42,7 @@ describe("PersistentShell — long-running stability", () => {
     expect(r2.stdout).toContain("two");
   });
 
-  it("captures short stdout (no-stdbuf safe)", async () => {
+  it.concurrent("captures short stdout (no-stdbuf safe)", async () => {
     const shell = make();
     const r = await shell.execute("printf 'hello\\nworld\\n'", 5);
     expect(r.exitCode).toBe(0);
@@ -55,7 +50,7 @@ describe("PersistentShell — long-running stability", () => {
     expect(r.stdout).toContain("world");
   });
 
-  it("captures trivial stdout even when tail block-buffers", async () => {
+  it.concurrent("captures trivial stdout even when tail block-buffers", async () => {
     const shell = make();
     const echo = await shell.execute("echo hello", 5);
     expect(echo.exitCode).toBe(0);
@@ -70,7 +65,7 @@ describe("PersistentShell — long-running stability", () => {
     expect(seq.stdout.trim()).toBe("1\n2\n3\n4\n5");
   });
 
-  it("captures output across the 8 KiB block-buffer boundary", async () => {
+  it.concurrent("captures output across the 8 KiB block-buffer boundary", async () => {
     const shell = make();
     // 9000 > 8192 to exceed tail's default block-buffer.
     const r = await shell.execute(
@@ -81,7 +76,7 @@ describe("PersistentShell — long-running stability", () => {
     expect(r.stdout.replace(/\n$/, "").length).toBe(9000);
   });
 
-  it("stays responsive after a command that normally reads stdin", async () => {
+  it.concurrent("stays responsive after a command that normally reads stdin", async () => {
     const shell = make();
 
     const warm = await shell.execute("echo warm", 5);
@@ -99,7 +94,7 @@ describe("PersistentShell — long-running stability", () => {
     expect(after.stdout).toContain("after-cat");
   }, 20_000);
 
-  it("cleans up pipeline grandchildren when a command times out", async () => {
+  it.concurrent("cleans up pipeline grandchildren when a command times out", async () => {
     const shell = make();
     await shell.execute("echo prime", 5);
     const bashPid = (shell as unknown as { proc: { pid: number } }).proc.pid;
@@ -124,7 +119,7 @@ describe("PersistentShell — long-running stability", () => {
     expect(remaining.find((l) => l.includes("sleep"))).toBeUndefined();
   }, 20_000);
 
-  it("does not leak background-process output into the next command's stdout", async () => {
+  it.concurrent("does not leak background-process output into the next command's stdout", async () => {
     const shell = make();
 
     // Background a generator whose fd 1 is NOT redirected (`nmap -v &`).
@@ -147,7 +142,7 @@ describe("PersistentShell — long-running stability", () => {
     expect(quick.stdout.includes("spam-")).toBe(false);
   }, 20_000);
 
-  it("persists cd and export across commands (documented contract)", async () => {
+  it.concurrent("persists cd and export across commands (documented contract)", async () => {
     const shell = make();
     const mk = await shell.execute(
       "mkdir -p /tmp/apex-persistent-shell-test-2ef1",
@@ -172,7 +167,7 @@ describe("PersistentShell — long-running stability", () => {
     expect(echo.stdout).toContain("hello");
   });
 
-  it("reports exit code 124 on timeout and kills descendants", async () => {
+  it.concurrent("reports exit code 124 on timeout and kills descendants", async () => {
     const shell = make();
     const r = await shell.execute("sleep 30", 1);
     expect(r.exitCode).toBe(124);
@@ -182,14 +177,14 @@ describe("PersistentShell — long-running stability", () => {
     expect(after.stdout).toContain("ok");
   }, 10_000);
 
-  it("does not leak nonce markers on timeout", async () => {
+  it.concurrent("does not leak nonce markers on timeout", async () => {
     const shell = make();
     const r = await shell.execute(`printf 'hello\\n'; sleep 10`, 1);
     expect(r.exitCode).toBe(124);
     expect(r.stdout).not.toMatch(/__APEX_[0-9a-f]+___(CUTOVER|EXIT_)/);
   }, 10_000);
 
-  it("does not leak nonce markers on abort", async () => {
+  it.concurrent("does not leak nonce markers on abort", async () => {
     const shell = make();
     const ac = new AbortController();
     setTimeout(() => ac.abort(), 200);
@@ -213,7 +208,7 @@ describe("PersistentShell — long-running stability", () => {
    * bash's children and killed `cat` mid-flush, dropping partial output
    * to `(no output)`.
    */
-  it("preserves partial stdout when a command is killed by timeout", async () => {
+  it.concurrent("preserves partial stdout when a command is killed by timeout", async () => {
     const shell = make();
     const r = await shell.execute(
       `printf 'hit-1\\n'; printf 'hit-2\\n'; sleep 30`,
@@ -230,7 +225,7 @@ describe("PersistentShell — long-running stability", () => {
     expect(after.stdout).toContain("ok");
   }, 15_000);
 
-  it("preserves partial stdout when a command is aborted", async () => {
+  it.concurrent("preserves partial stdout when a command is aborted", async () => {
     const shell = make();
     const ac = new AbortController();
     setTimeout(() => ac.abort(), 200);
@@ -252,7 +247,7 @@ describe("PersistentShell — long-running stability", () => {
    * so anything the tool had already written reaches the agent — and
    * SIGKILL reliably ends it afterward.
    */
-  it("salvages stdout from a SIGTERM-resistant command", async () => {
+  it.concurrent("salvages stdout from a SIGTERM-resistant command", async () => {
     const shell = make();
     const r = await shell.execute(
       `bash -c "trap '' TERM; printf hit-trapped; sleep 30"`,
@@ -268,7 +263,7 @@ describe("PersistentShell — long-running stability", () => {
    * The pre-fix in-pipe approach would block `cat` once the pipe filled and
    * SIGKILL would truncate. Disk reads are unaffected by pipe state.
    */
-  it("salvages large partial output (>64 KB) on timeout", async () => {
+  it.concurrent("salvages large partial output (>64 KB) on timeout", async () => {
     const shell = make();
     const r = await shell.execute(
       `for i in $(seq 1 4000); do printf 'line-%05d\\n' $i; done; sleep 30`,
@@ -280,7 +275,7 @@ describe("PersistentShell — long-running stability", () => {
     expect(r.stdout).not.toMatch(/__APEX_[0-9a-f]+__/);
   }, 15_000);
 
-  it("returns (no output) when an empty-output command times out", async () => {
+  it.concurrent("returns (no output) when an empty-output command times out", async () => {
     const shell = make();
     const r = await shell.execute("sleep 30", 1);
     expect(r.exitCode).toBe(124);
@@ -365,7 +360,7 @@ describe("PersistentShell — long-running stability", () => {
     },
   );
 
-  it("does not cross-contaminate stdout across parallel execute() calls", async () => {
+  it.concurrent("does not cross-contaminate stdout across parallel execute() calls", async () => {
     const shell = make();
     const [a, b] = await Promise.all([
       shell.execute("echo apex-call-a-output", 5),
@@ -382,7 +377,7 @@ describe("PersistentShell — long-running stability", () => {
     expect(b.stdout).not.toMatch(/__APEX_[0-9a-f]+___(CUTOVER|EXIT_)/);
   }, 15_000);
 
-  it("does not cross-contaminate stderr across parallel execute() calls", async () => {
+  it.concurrent("does not cross-contaminate stderr across parallel execute() calls", async () => {
     const shell = make();
     const [a, b] = await Promise.all([
       shell.execute(">&2 echo apex-call-a-stderr", 5),
@@ -396,7 +391,7 @@ describe("PersistentShell — long-running stability", () => {
     expect(b.stdout).toContain("apex-call-b-stdout");
   }, 15_000);
 
-  it("isolates parallel-call timeouts (no marker or kill-message leakage)", async () => {
+  it.concurrent("isolates parallel-call timeouts (no marker or kill-message leakage)", async () => {
     const shell = make();
     const [timedOut, ok] = await Promise.all([
       shell.execute("sleep 30", 1),
@@ -415,7 +410,7 @@ describe("PersistentShell — long-running stability", () => {
     expect(ok.stderr).not.toMatch(/Terminated|Killed/);
   }, 15_000);
 
-  it("preserves FIFO ordering for parallel execute() calls", async () => {
+  it.concurrent("preserves FIFO ordering for parallel execute() calls", async () => {
     const shell = make();
     const results = await Promise.all([
       shell.execute("echo 1", 5),
@@ -429,7 +424,7 @@ describe("PersistentShell — long-running stability", () => {
     for (const r of results) expect(r.exitCode).toBe(0);
   }, 15_000);
 
-  it("aborts a queued execute() without running its bash command", async () => {
+  it.concurrent("aborts a queued execute() without running its bash command", async () => {
     const shell = make();
     const ac = new AbortController();
 
@@ -452,7 +447,7 @@ describe("PersistentShell — long-running stability", () => {
     expect(firstResult.exitCode).toBe(0);
   }, 15_000);
 
-  it("stays responsive after a mixed workload of 30 commands", async () => {
+  it.concurrent("stays responsive after a mixed workload of 30 commands", async () => {
     const shell = make();
 
     for (let i = 0; i < 10; i++) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,13 +7,15 @@
     "moduleDetection": "force",
     "jsx": "react-jsx",
     "jsxImportSource": "@opentui/react",
-    "allowJs": true,
+    "allowJs": false,
 
     // Bundler mode
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
+    "incremental": true,
+    "tsBuildInfoFile": ".cache/tsc.tsbuildinfo",
 
     // Best practices
     "strict": true,
@@ -26,5 +28,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
-  }
+  },
+  "include": ["src", "scripts", "*.ts", "*.tsx"],
+  "exclude": ["build", "dist", "node_modules", "coverage"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,5 +11,9 @@ export default defineConfig({
     testTimeout: 120000, // 2 minutes for API calls
     hookTimeout: 120000,
     pool: "forks",
+    // Agent imports make each fork expensive; cap aggregate heap usage.
+    maxWorkers: 4,
+    minWorkers: 1,
+    maxConcurrency: 4,
   },
 });


### PR DESCRIPTION
## Summary
- scope TypeScript to source inputs, disable JavaScript discovery, and cache incremental compiler state so generated bundles cannot trigger heap exhaustion
- clean stale split chunks before builds and cap Vitest fork concurrency to bound aggregate memory
- run independent persistent-shell stability cases concurrently, reducing the full suite from about 28.6s to 14.3s

## Performance
- typecheck with a 366 MB build directory: 4.8 GB RSS OOM to 3.5s at about 834 MB RSS
- warm incremental typecheck: about 1s at about 548 MB RSS
- full test suite: 28.6s to 14.3s

## Verification
- `bun run build`
- `bun run tsc`
- `bun run format:check`
- `bun run test -- --reporter=dot` (1,594 passed, 22 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect build, typecheck, and test configuration only; production CLI behavior is unchanged aside from a cleaner `build` output directory.
> 
> **Overview**
> This PR tightens **developer-tooling performance and memory** without changing runtime agent/shell behavior.
> 
> **TypeScript** (`tsconfig.json`) now limits the project to `src`, `scripts`, and root `*.ts`/`*.tsx`, excludes `build`/`dist`, turns off `allowJs`, and enables **incremental** compilation with cache at `.cache/tsc.tsbuildinfo` so large generated bundles are not typechecked (addressing OOM during `tsc`).
> 
> **Build** prepends `rm -rf build` to the `build` script so stale ESM split chunks are removed before each bundle.
> 
> **Vitest** caps fork workers and concurrency (`maxWorkers`/`maxConcurrency` of 4) to limit aggregate heap from heavy agent imports.
> 
> **PersistentShell stability tests** run most cases with `it.concurrent` and dispose shells in `afterAll` instead of `afterEach` to avoid process-group cleanup races while roughly halving that suite’s wall time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1a8c906a16fc1869f1f2a0728e8caec4bafcf75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->