### PR TITLE
fix(session): prevent credential persistence

### DIFF
--- a/src/core/session/credentials-persistence.test.ts
+++ b/src/core/session/credentials-persistence.test.ts
@@ -1,0 +1,258 @@
+// Contract tests for WI-1: raw authentication credentials must never enter the
+// persisted session.json. Verifies the runtime → persisted conversion, the
+// in-memory credential retention on create(), and the legacy-session migration
+// that hydrates CredentialManager and strips credentials on the next write.
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CredentialManager } from "../credentials";
+import {
+  create,
+  get,
+  sessions,
+  toPersistedSession,
+  updateOperatorSettings,
+} from "./index";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(tmpdir(), "session-cred-test-"));
+  process.env.PENSAR_DATA_DIR = tmpDir;
+});
+
+afterEach(() => {
+  delete process.env.PENSAR_DATA_DIR;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Read the raw on-disk session.json for a session id. */
+function readPersisted(id: string): Record<string, unknown> {
+  const file = path.join(tmpDir, "sessions", id, "session.json");
+  return JSON.parse(readFileSync(file, "utf-8"));
+}
+
+const CREDS = {
+  username: "admin",
+  password: "s3cret-password",
+  apiKey: "sk-test-key-123",
+  loginUrl: "https://example.com/login",
+  tokens: { bearerToken: "bearer-abc", cookies: "session=xyz" },
+};
+
+/** Assert the runtime session has a live CredentialManager and return it. */
+function expectManager(session: {
+  credentialManager?: unknown;
+}): CredentialManager {
+  const cm = session.credentialManager;
+  if (!cm || typeof (cm as { resolve?: unknown }).resolve !== "function") {
+    throw new Error("expected a live CredentialManager on the session");
+  }
+  return cm as CredentialManager;
+}
+
+// ---------------------------------------------------------------------------
+// toPersistedSession
+// ---------------------------------------------------------------------------
+
+describe("toPersistedSession", () => {
+  it("strips runtime-only fields and config.authCredentials", async () => {
+    const session = await create({
+      targets: ["https://example.com"],
+      config: { authCredentials: CREDS },
+    });
+
+    const persisted = toPersistedSession(session);
+
+    expect("_rateLimiter" in persisted).toBe(false);
+    expect("credentialManager" in persisted).toBe(false);
+    expect(persisted.config).toBeDefined();
+    expect("authCredentials" in (persisted.config as object)).toBe(false);
+  });
+
+  it("keeps tokensIn/tokensOut (deliberately persisted for benchmark tooling)", async () => {
+    const session = await create({ targets: ["https://example.com"] });
+    session.tokensIn = 123;
+    session.tokensOut = 456;
+
+    const persisted = toPersistedSession(session);
+
+    expect(persisted.tokensIn).toBe(123);
+    expect(persisted.tokensOut).toBe(456);
+  });
+
+  it("does not mutate the runtime session", async () => {
+    const session = await create({
+      targets: ["https://example.com"],
+      config: { authCredentials: CREDS },
+    });
+
+    toPersistedSession(session);
+
+    // Runtime object still has its live credentialManager and config creds.
+    expect(session.credentialManager).toBeDefined();
+    expect(session.config?.authCredentials).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// create(): secrets absent from disk, retained in memory
+// ---------------------------------------------------------------------------
+
+describe("create() — credential persistence", () => {
+  it("omits authCredentials and credentialManager from session.json", async () => {
+    const session = await create({
+      targets: ["https://example.com"],
+      config: { authCredentials: CREDS },
+    });
+
+    const persisted = readPersisted(session.id);
+    const persistedConfig = persisted.config as Record<string, unknown>;
+
+    expect("authCredentials" in persistedConfig).toBe(false);
+    expect("credentialManager" in persisted).toBe(false);
+    expect("_rateLimiter" in persisted).toBe(false);
+
+    // No secret values anywhere in the serialized file.
+    const serialized = JSON.stringify(persisted);
+    for (const secret of [
+      CREDS.password,
+      CREDS.apiKey,
+      CREDS.tokens.bearerToken,
+      CREDS.tokens.cookies,
+    ]) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it("retains a working in-memory CredentialManager for new sessions", async () => {
+    const session = await create({
+      targets: ["https://example.com"],
+      config: { authCredentials: CREDS },
+    });
+
+    const cm = expectManager(session);
+    const ids = cm.listReferences();
+    expect(ids.length).toBeGreaterThan(0);
+
+    const resolved = cm.resolve(ids[0].id);
+    expect(resolved?.username).toBe("admin");
+    expect(resolved?.password).toBe(CREDS.password);
+    expect(resolved?.apiKey).toBe(CREDS.apiKey);
+  });
+
+  it("handles an array of auth credentials", async () => {
+    const session = await create({
+      targets: ["https://example.com"],
+      config: {
+        authCredentials: [
+          { username: "admin", password: "pw1" },
+          { apiKey: "key-2" },
+        ],
+      },
+    });
+
+    expect(expectManager(session).size).toBe(2);
+    const persisted = readPersisted(session.id);
+    expect("authCredentials" in (persisted.config as object)).toBe(false);
+    expect(JSON.stringify(persisted)).not.toContain("pw1");
+    expect(JSON.stringify(persisted)).not.toContain("key-2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy migration: hydrate in memory, strip on next write
+// ---------------------------------------------------------------------------
+
+describe("legacy session migration", () => {
+  it("hydrates CredentialManager deterministically from on-disk credentials", async () => {
+    // Create a session, then plant legacy credentials directly on disk.
+    const session = await create({ targets: ["https://example.com"] });
+    const persisted = readPersisted(session.id);
+    (persisted.config as Record<string, unknown>).authCredentials = CREDS;
+    const file = path.join(tmpDir, "sessions", session.id, "session.json");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(file, JSON.stringify(persisted, null, 2));
+
+    const loaded = await get(session.id);
+
+    // In-memory manager is hydrated from the legacy creds.
+    const cm = expectManager(loaded);
+    const refs = cm.listReferences();
+    expect(refs.length).toBeGreaterThan(0);
+    const resolved = cm.resolve(refs[0].id);
+    expect(resolved?.username).toBe("admin");
+    expect(resolved?.password).toBe(CREDS.password);
+
+    // The in-memory read still sees the legacy config field (runtime path).
+    expect(loaded.config?.authCredentials).toBeDefined();
+  });
+
+  it("strips credentials from session.json on the next write", async () => {
+    // Plant a legacy session with credentials on disk.
+    const session = await create({ targets: ["https://example.com"] });
+    const file = path.join(tmpDir, "sessions", session.id, "session.json");
+    const persisted = readPersisted(session.id);
+    (persisted.config as Record<string, unknown>).authCredentials = CREDS;
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(file, JSON.stringify(persisted, null, 2));
+
+    // Sanity: credentials are on disk before the write.
+    expect(JSON.stringify(readPersisted(session.id))).toContain(CREDS.password);
+
+    // Any update triggers a rewrite that strips runtime-only fields.
+    await updateOperatorSettings(session.id, { requireApproval: false });
+
+    const rewritten = readPersisted(session.id);
+    expect("authCredentials" in (rewritten.config as object)).toBe(false);
+    expect(JSON.stringify(rewritten)).not.toContain(CREDS.password);
+    expect(JSON.stringify(rewritten)).not.toContain(CREDS.apiKey);
+  });
+
+  it("discards a stale serialized credentialManager plain object on read", async () => {
+    const session = await create({ targets: ["https://example.com"] });
+    const file = path.join(tmpDir, "sessions", session.id, "session.json");
+    const persisted = readPersisted(session.id);
+    // Legacy file: raw creds present AND a stale serialized manager object.
+    (persisted.config as Record<string, unknown>).authCredentials = CREDS;
+    persisted.credentialManager = { store: {} };
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(file, JSON.stringify(persisted, null, 2));
+
+    const loaded = await get(session.id);
+
+    // Rehydrated from authCredentials into a real manager, not the stale
+    // plain object left on disk.
+    const cm = expectManager(loaded);
+    const refs = cm.listReferences();
+    expect(refs.length).toBeGreaterThan(0);
+    expect(cm.resolve(refs[0].id)?.password).toBe(CREDS.password);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sessions without credentials remain unaffected
+// ---------------------------------------------------------------------------
+
+describe("sessions without credentials", () => {
+  it("persists and reloads cleanly with no credential fields", async () => {
+    const session = await create({ targets: ["https://example.com"] });
+
+    const persisted = readPersisted(session.id);
+    expect("credentialManager" in persisted).toBe(false);
+    expect("authCredentials" in (persisted.config as object)).toBe(false);
+
+    const loaded = await get(session.id);
+    expect(loaded.credentialManager).toBeUndefined();
+    expect(loaded.targets).toEqual(["https://example.com"]);
+  });
+
+  it("exposes toPersistedSession on the public sessions namespace via module", () => {
+    // sessions namespace re-exports create/get/etc.; toPersistedSession is a
+    // direct module export used by the create() write path.
+    expect(typeof toPersistedSession).toBe("function");
+    expect(typeof sessions.create).toBe("function");
+  });
+});

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -507,6 +507,52 @@ export interface CreateInputProps {
   onNameGenerated?: (name: string) => void;
 }
 
+// ============================================================================
+// Runtime → persisted conversion
+// ============================================================================
+
+/** Persisted session config: SessionConfig minus raw auth credentials. */
+export type PersistedSessionConfig = Omit<SessionConfig, "authCredentials">;
+
+/** Persisted session metadata: SessionInfo minus runtime-only fields. */
+export type PersistedSessionInfo = Omit<
+  SessionInfo,
+  "_rateLimiter" | "credentialManager"
+> & {
+  config?: PersistedSessionConfig;
+};
+
+/**
+ * Convert a runtime session into its persisted shape. Raw auth credentials
+ * and the class instances built from them (`credentialManager`) plus the
+ * `_rateLimiter` live only in memory. `tokensIn`/`tokensOut` are kept —
+ * execution-metrics deliberately persists them for the benchmark tooling.
+ */
+export function toPersistedSession(session: SessionInfo): PersistedSessionInfo {
+  const { _rateLimiter, credentialManager: _cm, ...rest } = session;
+  if (!rest.config) return rest;
+  const { authCredentials: _ac, ...config } = rest.config;
+  return { ...rest, config };
+}
+
+/**
+ * Build the in-memory credential store from session auth credentials.
+ * Shared by create() and the legacy-session migration in get().
+ */
+function hydrateCredentialManager(
+  authCredentials: SessionConfig["authCredentials"],
+): CredentialManager | undefined {
+  if (!authCredentials) return undefined;
+  const manager = new CredentialManager();
+  const creds = Array.isArray(authCredentials)
+    ? authCredentials
+    : [authCredentials];
+  for (const cred of creds) {
+    manager.addFromAuthCredentials(cred);
+  }
+  return manager;
+}
+
 export async function create(input: CreateInputProps) {
   const name = input.name ?? generateRandomName();
 
@@ -531,16 +577,9 @@ export async function create(input: CreateInputProps) {
 
   // Auto-create CredentialManager when authCredentials are provided.
   // Secrets live only in memory — they are never serialized to disk.
-  let credentialManager: CredentialManager | undefined;
-  if (normalizedConfig?.authCredentials) {
-    credentialManager = new CredentialManager();
-    const creds = Array.isArray(normalizedConfig.authCredentials)
-      ? normalizedConfig.authCredentials
-      : [normalizedConfig.authCredentials];
-    for (const cred of creds) {
-      credentialManager.addFromAuthCredentials(cred);
-    }
-  }
+  const credentialManager = hydrateCredentialManager(
+    normalizedConfig?.authCredentials,
+  );
 
   const smtpConfig = resolveSmtpConfig(normalizedConfig?.smtpConfig);
 
@@ -586,10 +625,11 @@ export async function create(input: CreateInputProps) {
     findingsPath,
   };
 
-  // Exclude non-serializable fields (class instances with methods)
-  const { _rateLimiter, credentialManager: _cm, ...sessionData } = result;
   await createSessionDirs({ session: result });
-  await Storage.write(["sessions", result.id, "session"], sessionData);
+  await Storage.write(
+    ["sessions", result.id, "session"],
+    toPersistedSession(result),
+  );
 
   // Fire-and-forget AI name generation — updates persisted session in the background
   if (!input.name && input.model) {
@@ -627,6 +667,19 @@ export const get = async (id: string) => {
     delete read._rateLimiter;
   }
 
+  // Legacy sessions may carry raw auth credentials on disk. Hydrate the
+  // in-memory CredentialManager from them; the next update() write strips
+  // them from session.json. A stale serialized `credentialManager` plain
+  // object is discarded rather than treated as a live instance.
+  if (!(read.credentialManager instanceof CredentialManager)) {
+    const hydrated = hydrateCredentialManager(read.config?.authCredentials);
+    if (hydrated) {
+      read.credentialManager = hydrated;
+    } else {
+      delete read.credentialManager;
+    }
+  }
+
   return read;
 };
 
@@ -638,6 +691,12 @@ async function update(id: string, editor: (session: SessionInfo) => void) {
     (draft) => {
       editor(draft);
       draft.time.updated = Date.now();
+      // Storage.update writes the draft object itself, so mirror
+      // toPersistedSession in place. Also strips raw credentials left on
+      // disk by legacy sessions on their next write.
+      delete draft._rateLimiter;
+      delete draft.credentialManager;
+      if (draft.config) delete draft.config.authCredentials;
     },
   );
   return result;


### PR DESCRIPTION
## Summary

- add an explicit runtime → persisted conversion for session metadata so raw auth credentials never reach `session.json`
- exclude `authCredentials`, `credentialManager`, `_rateLimiter`, and other runtime-only fields from every write path
- migrate legacy sessions that already carry on-disk credentials by hydrating `CredentialManager` in memory and stripping credentials on the next write
- no new encrypted-secret store — secrets stay in-memory only

## Motivation

Today, `session.json` can carry raw `config.authCredentials` (username/password/apiKey/tokens). That is a secret-leak surface: anything that reads or copies the session tree (benchmark exports, rehydration, debugging, support bundles) picks up live credentials. The intended model is that secrets live only in an in-memory `CredentialManager`, referenced by opaque IDs — but the persistence layer never enforced it. This PR makes the boundary explicit and self-healing.

## What changed

**`src/core/session/index.ts`:**

- **`toPersistedSession(session)`** — new exported pure function. Strips `_rateLimiter`, `credentialManager`, and `config.authCredentials`; returns the persisted shape (`PersistedSessionInfo`). `tokensIn`/`tokensOut` are intentionally kept — `execution-metrics.ts` persists them to `session.json` for the benchmark tooling, and they are counts, not secrets.
- **`hydrateCredentialManager(authCredentials)`** — shared helper that builds the in-memory store from session credentials (single or array). Extracted from `create()` so the legacy migration reuses the exact same path.
- **`create()`** — the initial `Storage.write` now goes through `toPersistedSession` instead of an ad-hoc destructure, so `config.authCredentials` is excluded from the very first write.
- **`update()`** — strips `draft._rateLimiter`, `draft.credentialManager`, and `draft.config.authCredentials` in place before `Storage.update` writes. Because `Storage.update` serializes the draft object it returns, this also **removes credentials that legacy sessions left on disk** on their next write.
- **`get()`** — legacy migration: if the deserialized `credentialManager` is not a live `CredentialManager` instance (it is a stale plain object from disk), rebuild one from `config.authCredentials` via `hydrateCredentialManager`, or drop the stale object when no credentials exist. In-memory credentials keep working; the file is cleaned on the next `update()`.

**`src/core/session/credentials-persistence.test.ts`** — new contract tests.

## Acceptance criteria coverage

- **Secret values absent from serialized files** — `create()` with credentials writes a `session.json` with no `authCredentials`/`credentialManager`/`_rateLimiter`, and a byte-level scan asserts none of the password, API key, bearer token, or cookie values appear in the serialized JSON. Also covers the array-of-credentials shape.
- **Newly created sessions retain working in-memory credentials** — `create()` returns a session whose `credentialManager` resolves the full secret set (`username`/`password`/`apiKey`).
- **Legacy sessions hydrate deterministically** — a session.json with planted legacy `authCredentials` loads via `get()` into a working in-memory manager, and a stale serialized `credentialManager` plain object is discarded in favor of rehydration. The next `update()` write strips the credentials from disk (verified byte-level).
- **`bun run test`, `bun run tsc`, Biome pass** — see Validation.

## Design notes

- `update()` strips in place rather than routing through `toPersistedSession` because `Storage.update` reads the file, mutates the draft, and writes that same object — a returned converted copy would be ignored. The two paths strip the same field set; the comment in `update()` points at `toPersistedSession` to keep them from drifting.
- Existing in-memory consumers are untouched: `create()` still returns a session with a live `credentialManager`, and `delegateAuth` still reads `session.config.authCredentials` at runtime from the in-memory config.
- No encrypted-secret store — per the work item, secrets are simply never written.

## Validation

- `bun run test` (1,605 passed, 22 skipped) — including the 11 new credential-persistence tests
- `bun run tsc`
- `bun run knip`
- `bunx biome check src/core/session/index.ts src/core/session/credentials-persistence.test.ts` (one pre-existing `noNonNullAssertion` warning at `index.ts:1081` in untouched `toggleTool` code)

## Notes

- Biome warning at `index.ts:1081` predates this change; left alone to keep the diff surgical.
- Follow-up (separate PR): decide whether `delegateAuth`'s runtime read of `session.config.authCredentials` should instead resolve through the `CredentialManager` now that the persisted field is gone on rewrite — that is a behavioral change, not part of this WI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session persistence and credential hydration on load/save; incorrect stripping or migration could break auth for legacy sessions or change restart behavior now that new sessions no longer persist secrets to disk.
> 
> **Overview**
> **Stops raw auth secrets from being written to `session.json`** by introducing an explicit runtime → persisted conversion and applying it on every session metadata write.
> 
> Adds **`toPersistedSession`** (and `PersistedSessionInfo` types) to strip `_rateLimiter`, `credentialManager`, and `config.authCredentials` while still persisting non-secret fields like `tokensIn`/`tokensOut` for benchmarks. **`create()`** now persists through that helper instead of ad-hoc destructuring. **`update()`** deletes the same runtime-only fields on the draft before `Storage.update` serializes it, which also **cleans legacy files** that still had credentials on disk.
> 
> **Legacy load path:** **`get()`** rebuilds a live `CredentialManager` from on-disk `authCredentials` when the deserialized manager isn’t a real instance (discarding stale plain objects). Secrets stay usable in memory until the next update rewrites the file without them. Credential hydration is centralized in **`hydrateCredentialManager`**, shared by `create()` and `get()`.
> 
> Adds **`credentials-persistence.test.ts`** contract tests for conversion, create-time disk absence, in-memory resolution, array credentials, legacy hydrate/strip, and sessions without credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad8e368bed3f62ece635851fc09f4eaa6443d31a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->