### PR TITLE
refactor(operator): extract abort subagent transition

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -133,6 +133,7 @@ import {
   createSubagentSessionHelpers,
   createSubagentStore,
   loadSubagentSessionsFromDisk,
+  markSubagentsInterrupted,
 } from "./subagent-state";
 import { SubagentStatusBar } from "./subagent-status-bar";
 import {
@@ -1660,31 +1661,7 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
     setMessages((prev) => markInFlightToolsErrored(prev, "Interrupted"));
 
     // Mark any in-flight subagent tool messages as interrupted too
-    subagentStore.setState((prev) => {
-      let changed = false;
-      const next = new Map(prev);
-      for (const [id, session] of next) {
-        const hasInFlight = session.messages.some(
-          (m) =>
-            m.role === "tool" &&
-            (m.status === "pending" || m.status === "streaming"),
-        );
-        if (hasInFlight || session.status === "running") {
-          changed = true;
-          next.set(id, {
-            ...session,
-            status: session.status === "running" ? "cancelled" : session.status,
-            messages: session.messages.map((m) =>
-              m.role === "tool" &&
-              (m.status === "pending" || m.status === "streaming")
-                ? { ...m, status: "error" as const, result: "Interrupted" }
-                : m,
-            ),
-          });
-        }
-      }
-      return changed ? next : prev;
-    });
+    subagentStore.setState(markSubagentsInterrupted);
 
     // Read back persisted messages so the next run has full context.
     // Only keep a recent subset to avoid blowing the context window.

--- a/src/tui/components/operator-dashboard/subagent-state.test.ts
+++ b/src/tui/components/operator-dashboard/subagent-state.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import type { DisplayMessage } from "../agent-display";
+import {
+  markSubagentsInterrupted,
+  type SubagentSession,
+} from "./subagent-state";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function toolMessage(
+  status: "streaming" | "pending" | "completed" | "error",
+  toolCallId = "tc-1",
+): DisplayMessage {
+  return {
+    role: "tool",
+    content: "execute_command",
+    createdAt: new Date("2026-08-25T00:00:00Z"),
+    toolCallId,
+    toolName: "execute_command",
+    args: {},
+    status,
+  };
+}
+
+function textMessage(text: string): DisplayMessage {
+  return {
+    role: "assistant",
+    content: text,
+    createdAt: new Date("2026-08-25T00:00:01Z"),
+  };
+}
+
+function makeSession(
+  overrides: Partial<SubagentSession> = {},
+): SubagentSession {
+  return {
+    id: "sub-1",
+    name: "Subagent 1",
+    status: "running",
+    spawnedAt: new Date("2026-08-25T00:00:00Z"),
+    input: null,
+    messages: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// markSubagentsInterrupted
+// ---------------------------------------------------------------------------
+
+describe("markSubagentsInterrupted", () => {
+  it("marks a running session cancelled, leaving its settled messages untouched", () => {
+    const msg = textMessage("working");
+    const sessions = new Map([["sub-1", makeSession({ messages: [msg] })]]);
+
+    const result = markSubagentsInterrupted(sessions);
+
+    const session = result.get("sub-1");
+    expect(session?.status).toBe("cancelled");
+    // Settled messages pass through by reference.
+    expect(session?.messages[0]).toBe(msg);
+  });
+
+  it("leaves settled sessions without in-flight tools untouched by reference", () => {
+    const settled = makeSession({
+      id: "sub-2",
+      status: "completed",
+      completedAt: new Date("2026-08-25T00:00:05Z"),
+      messages: [toolMessage("completed")],
+    });
+    const sessions = new Map([["sub-2", settled]]);
+
+    const result = markSubagentsInterrupted(sessions);
+
+    expect(result.get("sub-2")).toBe(settled);
+  });
+
+  it("interrupts in-flight tools on a session that already settled", () => {
+    const completedTool = toolMessage("completed", "tc-done");
+    const pendingTool = toolMessage("pending", "tc-pending");
+    const streamingTool = toolMessage("streaming", "tc-streaming");
+    const sessions = new Map([
+      [
+        "sub-1",
+        makeSession({
+          status: "failed",
+          messages: [completedTool, pendingTool, streamingTool],
+        }),
+      ],
+    ]);
+
+    const result = markSubagentsInterrupted(sessions);
+
+    const session = result.get("sub-1");
+    // Status is preserved — only the "running → cancelled" flip happens.
+    expect(session?.status).toBe("failed");
+    expect(session?.messages[0]).toBe(completedTool);
+    expect(session?.messages[1]).toMatchObject({
+      status: "error",
+      result: "Interrupted",
+      toolCallId: "tc-pending",
+    });
+    expect(session?.messages[2]).toMatchObject({
+      status: "error",
+      result: "Interrupted",
+      toolCallId: "tc-streaming",
+    });
+  });
+
+  it("flips status and interrupts tools together for a running session", () => {
+    const sessions = new Map([
+      [
+        "sub-1",
+        makeSession({
+          messages: [textMessage("hi"), toolMessage("streaming")],
+        }),
+      ],
+    ]);
+
+    const result = markSubagentsInterrupted(sessions);
+
+    const session = result.get("sub-1");
+    expect(session?.status).toBe("cancelled");
+    expect(session?.messages[1]).toMatchObject({
+      status: "error",
+      result: "Interrupted",
+    });
+  });
+
+  it("returns the identical reference for an empty store", () => {
+    const sessions = new Map<string, SubagentSession>();
+
+    const result = markSubagentsInterrupted(sessions);
+
+    expect(result).toBe(sessions);
+  });
+
+  it("returns the identical reference when nothing needs changing", () => {
+    const sessions = new Map([
+      ["sub-1", makeSession({ status: "completed", messages: [] })],
+    ]);
+
+    const result = markSubagentsInterrupted(sessions);
+
+    expect(result).toBe(sessions);
+  });
+
+  it("preserves insertion order across changed and unchanged sessions", () => {
+    const sessions = new Map([
+      ["sub-a", makeSession({ id: "sub-a", status: "running" })],
+      ["sub-b", makeSession({ id: "sub-b", status: "completed" })],
+      ["sub-c", makeSession({ id: "sub-c", status: "failed" })],
+    ]);
+
+    const result = markSubagentsInterrupted(sessions);
+
+    expect(Array.from(result.keys())).toEqual(["sub-a", "sub-b", "sub-c"]);
+  });
+
+  it("does not mutate the input map, sessions, or messages", () => {
+    const pendingTool = toolMessage("pending");
+    const session = makeSession({
+      messages: [textMessage("working"), pendingTool],
+    });
+    const sessions = new Map([["sub-1", session]]);
+    const originalMap = structuredClone(Object.fromEntries(sessions.entries()));
+
+    markSubagentsInterrupted(sessions);
+
+    expect(Object.fromEntries(sessions.entries())).toEqual(originalMap);
+    expect(session.status).toBe("running");
+    expect(pendingTool.status).toBe("pending");
+    expect(pendingTool.result).toBeUndefined();
+  });
+});

--- a/src/tui/components/operator-dashboard/subagent-state.ts
+++ b/src/tui/components/operator-dashboard/subagent-state.ts
@@ -113,6 +113,39 @@ export function createSubagentStore(): SubagentStore {
 }
 
 /**
+ * Abort-path transition: mark running subagent sessions cancelled and any
+ * in-flight subagent tool messages interrupted. Settled sessions without
+ * in-flight tools pass through untouched. Returns the input reference when
+ * nothing needed changing.
+ */
+export function markSubagentsInterrupted(
+  prev: Map<string, SubagentSession>,
+): Map<string, SubagentSession> {
+  let changed = false;
+  const next = new Map(prev);
+  for (const [id, session] of next) {
+    const hasInFlight = session.messages.some(
+      (m) =>
+        m.role === "tool" &&
+        (m.status === "pending" || m.status === "streaming"),
+    );
+    if (!hasInFlight && session.status !== "running") continue;
+    changed = true;
+    next.set(id, {
+      ...session,
+      status: session.status === "running" ? "cancelled" : session.status,
+      messages: session.messages.map((m) =>
+        m.role === "tool" &&
+        (m.status === "pending" || m.status === "streaming")
+          ? { ...m, status: "error" as const, result: "Interrupted" }
+          : m,
+      ),
+    });
+  }
+  return changed ? next : prev;
+}
+
+/**
  * Creates helper functions for managing per-subagent session state.
  *
  * All helpers follow the React `setState(prev => ...)` pattern with


### PR DESCRIPTION
## Stack

**1 of 5 (Stack A: OperatorDashboard)** — base PR. Stack: #975 (this PR) → #976 abort transcript recovery → #977 run-event subscription lifecycle → #978 display event projections → #980 workflow/subagent/question projections. Merge bottom-up, retargeting to `canary` at each step.

## Summary

- move the immutable "mark running subagents interrupted" transformation from the dashboard's abort handler into `subagent-state.ts` as a pure `markSubagentsInterrupted` store transition
- add characterization coverage: running, settled, in-flight-tool, empty-state, ordering, and input immutability

## Motivation

First slice of Stack A, continuing the `OperatorDashboard` decomposition after the display-state / conversation / workflow-data / run-tracing extractions. The abort handler carried an anonymous 25-line `Map` transformation inline — exactly the kind of state logic that belongs with the other subagent store transitions in `subagent-state.ts`, testable without the component.

## What changed

**`subagent-state.ts`** — new exported `markSubagentsInterrupted(prev)`:

- a session is rewritten when it is `running` **or** has in-flight (`pending`/`streaming`) tool messages
- `running` → `cancelled`; every other status passes through
- in-flight tool messages become `status: "error"`, `result: "Interrupted"`
- returns the **identical reference** when nothing changed (keeps the external store's no-op semantics)
- immutable: new `Map`, new session objects, new messages array

**`index.tsx`** — the inline `subagentStore.setState((prev) => {...})` block becomes `subagentStore.setState(markSubagentsInterrupted)`.

**Non-goals honored** — abort controllers, persistence, and UI notifications are untouched; the root-level `markInFlightToolsErrored` display-message pass is a separate concern and stays in place.

## Test coverage

8 tests in `subagent-state.test.ts` (new file):

- running session with settled messages → `cancelled`, messages pass through by reference
- settled session without in-flight tools → identical session object preserved
- settled session **with** in-flight tools → tools interrupted, status preserved
- running session with streaming tool → both flips together
- empty store → identical map reference
- nothing-to-change → identical map reference
- insertion order preserved across changed and unchanged entries
- no mutation of the input map, sessions, or message objects

## Validation

- `bun run test` (1,602 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the three touched files

## Notes

- behavior-preserving; no functional change intended

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with unit tests; abort wiring in the dashboard is a one-line substitution with no auth or persistence changes.
> 
> **Overview**
> Moves the operator **abort** path’s subagent-store update out of `OperatorDashboard` into a pure **`markSubagentsInterrupted`** transition in `subagent-state.ts`, alongside the other subagent store helpers.
> 
> On user stop, **`handleAbort`** now calls `subagentStore.setState(markSubagentsInterrupted)` instead of an inline `Map` rewrite. Behavior is unchanged: **`running`** sessions become **`cancelled`**, **`pending`/`streaming`** subagent tool messages get **`error`** with **`Interrupted`**, settled sessions with no in-flight tools are skipped, and the store returns the **same map reference** when nothing changes.
> 
> Adds **`subagent-state.test.ts`** with characterization tests for running vs settled sessions, in-flight tools on non-running sessions, reference equality for no-ops, map order, and input immutability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 895905ca41e565d1aa23ebc84df22d796ce8bd00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
