### PR TITLE
refactor(operator): extract abort transcript recovery

### DIFF
--- a/src/tui/components/operator-dashboard/conversation.test.ts
+++ b/src/tui/components/operator-dashboard/conversation.test.ts
@@ -1,8 +1,18 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { ModelMessage } from "ai";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { DisplayMessage } from "../agent-display";
 import {
   recoverAbortedConversation,
+  recoverAbortedTranscript,
   rewriteToolResultOutput,
 } from "./conversation";
 
@@ -251,5 +261,171 @@ describe("rewriteToolResultOutput", () => {
     rewriteToolResultOutput(toolConversation, "q1", { answers: [] });
 
     expect(toolConversation).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recoverAbortedTranscript
+// ---------------------------------------------------------------------------
+
+describe("recoverAbortedTranscript", () => {
+  let rootPath: string;
+
+  beforeEach(() => {
+    rootPath = mkdtempSync(join(tmpdir(), "abort-transcript-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(rootPath, { recursive: true, force: true });
+  });
+
+  const messagesPath = () => join(rootPath, "messages.json");
+
+  function readDisk(): unknown {
+    return JSON.parse(readFileSync(messagesPath(), "utf-8"));
+  }
+
+  function writeDisk(value: unknown): void {
+    writeFileSync(messagesPath(), JSON.stringify(value, null, 2), "utf-8");
+  }
+
+  const userMessage: ModelMessage = {
+    role: "user",
+    content: [{ type: "text", text: "scan the target" }],
+  };
+
+  const pendingTool: DisplayMessage = {
+    role: "tool",
+    content: "",
+    createdAt: new Date("2026-08-25T00:00:00Z"),
+    toolCallId: "tc-1",
+    toolName: "execute_command",
+    args: { command: "nmap example.com" },
+    status: "pending",
+  };
+
+  it("missing file: recovers from the in-memory conversation and persists it", () => {
+    const result = recoverAbortedTranscript({
+      rootPath,
+      conversation: [userMessage],
+      partialText: "partial",
+      displayMessages: [],
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({ role: "assistant" });
+    // The recovered transcript is written even though no file existed before.
+    expect(readDisk()).toEqual(result);
+  });
+
+  it("missing file with nothing to recover: returns the input, writes nothing", () => {
+    const conversation: ModelMessage[] = [
+      userMessage,
+      { role: "assistant", content: [{ type: "text", text: "done" }] },
+    ];
+
+    const result = recoverAbortedTranscript({
+      rootPath,
+      conversation,
+      partialText: "",
+      displayMessages: [],
+    });
+
+    expect(result).toBe(conversation);
+    expect(existsSync(messagesPath())).toBe(false);
+  });
+
+  it("malformed file: keeps the in-memory conversation and leaves the file alone", () => {
+    writeFileSync(messagesPath(), "{ not json", "utf-8");
+    const conversation: ModelMessage[] = [userMessage];
+
+    const result = recoverAbortedTranscript({
+      rootPath,
+      conversation,
+      partialText: "partial",
+      displayMessages: [],
+    });
+
+    // Read failed → no recovery attempted → input returned unchanged.
+    expect(result).toBe(conversation);
+    expect(readFileSync(messagesPath(), "utf-8")).toBe("{ not json");
+  });
+
+  it("empty transcript on disk: falls back to the in-memory conversation", () => {
+    writeDisk([]);
+    const conversation: ModelMessage[] = [userMessage];
+
+    const result = recoverAbortedTranscript({
+      rootPath,
+      conversation,
+      partialText: "partial",
+      displayMessages: [],
+    });
+
+    // The empty persisted transcript must not clobber the in-memory base.
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(userMessage);
+  });
+
+  it("already-complete transcript: reloads it and writes nothing", () => {
+    const persisted: ModelMessage[] = [
+      userMessage,
+      { role: "assistant", content: [{ type: "text", text: "done" }] },
+    ];
+    writeDisk(persisted);
+
+    const result = recoverAbortedTranscript({
+      rootPath,
+      conversation: [],
+      partialText: "ignored",
+      displayMessages: [pendingTool],
+    });
+
+    // Recovery gated off (transcript ends in an assistant turn) → the
+    // reloaded transcript is returned and the file is left byte-identical.
+    expect(result).toEqual(persisted);
+    expect(readDisk()).toEqual(persisted);
+  });
+
+  it("partial text: recovers a trimmed assistant turn and persists it", () => {
+    writeDisk([userMessage]);
+
+    const result = recoverAbortedTranscript({
+      rootPath,
+      conversation: [],
+      partialText: "  partial response\n",
+      displayMessages: [],
+    });
+
+    expect(result[1]).toEqual({
+      role: "assistant",
+      content: [{ type: "text", text: "partial response" }],
+    });
+    expect(readDisk()).toEqual(result);
+  });
+
+  it("pending tool: pairs the cancelled tool-call/result and persists it", () => {
+    writeDisk([userMessage]);
+
+    const result = recoverAbortedTranscript({
+      rootPath,
+      conversation: [],
+      partialText: "working",
+      displayMessages: [pendingTool],
+    });
+
+    expect(result).toHaveLength(3);
+    const assistant = result[1] as { content: Array<Record<string, unknown>> };
+    expect(assistant.content[1]).toMatchObject({
+      type: "tool-call",
+      toolCallId: "tc-1",
+    });
+    const tool = result[2] as { content: Array<Record<string, unknown>> };
+    expect(tool.content[0]).toMatchObject({
+      type: "tool-result",
+      toolCallId: "tc-1",
+      output: { type: "text", value: "Cancelled by user." },
+    });
+    expect(readDisk()).toEqual(result);
   });
 });

--- a/src/tui/components/operator-dashboard/conversation.ts
+++ b/src/tui/components/operator-dashboard/conversation.ts
@@ -1,8 +1,12 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type { ModelMessage } from "ai";
+import { getResumeMessages, normalizeMessages } from "../../../core/session";
 import type { DisplayMessage } from "../agent-display";
 
 // ---------------------------------------------------------------------------
-// Conversation transitions over ModelMessage[] — pure, immutable, testable
+// Conversation transitions over ModelMessage[] — pure, immutable, testable —
+// plus the one concrete abort transcript operation that orchestrates them.
 // ---------------------------------------------------------------------------
 
 /**
@@ -113,4 +117,63 @@ export function rewriteToolResultOutput(
   });
 
   return changed ? next : (conversation as ModelMessage[]);
+}
+
+// ---------------------------------------------------------------------------
+// Abort transcript recovery operation
+// ---------------------------------------------------------------------------
+
+export interface RecoverAbortedTranscriptInput {
+  /** Session root — `messages.json` is read from and written here. */
+  rootPath: string;
+  /** In-memory conversation — the base when no usable transcript is on disk. */
+  conversation: readonly ModelMessage[];
+  /** Partial streamed assistant text at abort time. */
+  partialText: string;
+  /** Display messages — the source of pending/streaming tool state. */
+  displayMessages: readonly DisplayMessage[];
+}
+
+/**
+ * The abort-path transcript operation: read the persisted messages, reload the
+ * resumable window into a normalized conversation, recover the aborted turn
+ * via {@link recoverAbortedConversation}, and persist the corrected transcript
+ * when recovery produced one. Best-effort throughout — read and write failures
+ * keep whatever conversation is already available.
+ *
+ * Returns the conversation the caller should hold next: the recovered
+ * transcript when recovery fired, otherwise the (possibly reloaded) input.
+ */
+export function recoverAbortedTranscript(
+  input: RecoverAbortedTranscriptInput,
+): ModelMessage[] {
+  const messagesPath = join(input.rootPath, "messages.json");
+  let conversation = input.conversation as ModelMessage[];
+  let recovered: ModelMessage[] | null = null;
+
+  try {
+    if (existsSync(messagesPath)) {
+      const raw = JSON.parse(readFileSync(messagesPath, "utf-8"));
+      if (Array.isArray(raw) && raw.length > 0) {
+        conversation = normalizeMessages(getResumeMessages(raw));
+      }
+    }
+    recovered = recoverAbortedConversation(
+      conversation,
+      input.partialText,
+      input.displayMessages,
+    );
+  } catch {
+    // Best-effort read — keep whatever conversation we already have.
+  }
+
+  if (!recovered) return conversation;
+  conversation = recovered;
+  try {
+    // Persist so session resume also sees the corrected state.
+    writeFileSync(messagesPath, JSON.stringify(recovered, null, 2));
+  } catch {
+    // Best-effort write — the in-memory conversation is still recovered.
+  }
+  return conversation;
 }

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -95,7 +95,7 @@ import {
   tryParsePartialJson,
 } from "../shared";
 import {
-  recoverAbortedConversation,
+  recoverAbortedTranscript,
   rewriteToolResultOutput,
 } from "./conversation";
 import {
@@ -1664,39 +1664,17 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
     subagentStore.setState(markSubagentsInterrupted);
 
     // Read back persisted messages so the next run has full context.
-    // Only keep a recent subset to avoid blowing the context window.
     // Use sessionRef (not the `session` state) so we see the session even
     // when it was just created via onSessionReady but React hasn't
     // re-rendered yet (e.g. aborting on the very first message).
     const activeSession = sessionRef.current;
     if (activeSession) {
-      try {
-        const messagesPath = join(activeSession.rootPath, "messages.json");
-        if (existsSync(messagesPath)) {
-          const raw = JSON.parse(readFileSync(messagesPath, "utf-8"));
-          if (Array.isArray(raw) && raw.length > 0) {
-            conversationRef.current = normalizeMessages(
-              sessions.getResumeMessages(raw as ModelMessage[]),
-            );
-          }
-        }
-
-        const recovered = recoverAbortedConversation(
-          conversationRef.current,
-          textRef.current,
-          displayMessagesRef.current,
-        );
-        if (recovered) {
-          conversationRef.current = recovered;
-          // Persist so session resume also sees the corrected state.
-          writeFileSync(
-            messagesPath,
-            JSON.stringify(conversationRef.current, null, 2),
-          );
-        }
-      } catch {
-        // Best-effort — keep whatever conversationRef already has
-      }
+      conversationRef.current = recoverAbortedTranscript({
+        rootPath: activeSession.rootPath,
+        conversation: conversationRef.current,
+        partialText: textRef.current,
+        displayMessages: displayMessagesRef.current,
+      });
     }
 
     setMessages((prev) => {


### PR DESCRIPTION
## Stack

**2 of 5 (Stack A: OperatorDashboard)** — stacked on #975 (`refactor/abort-subagent-transition`). Merge order: #975 → this PR → O3 → O4 → O5, retargeting to `canary` at each step.

## Summary

- extract the abort handler's transcript operation into one concrete `recoverAbortedTranscript` function in `conversation.ts`
- it reads persisted `messages.json`, reloads the resumable window (normalized), calls the existing `recoverAbortedConversation`, writes the corrected transcript when recovery produced one, and returns the conversation to hold next
- add characterization coverage: missing, malformed, empty, already-complete, partial-text, and pending-tool cases

## Motivation

O2 of Stack A. The abort handler carried ~35 lines of read → normalize → recover → write I/O inline. That sequence is the exact "abort transcript recovery" operation — cohesive, reusable by other abort paths, and testable with a temp dir once named. The pure `recoverAbortedConversation` (from the earlier conversation-transitions PR) stays untouched underneath.

## What changed

**`conversation.ts`** — new exported `recoverAbortedTranscript(input)`:

1. **Read** `messages.json` under `rootPath`; if it holds a non-empty array, reload `normalizeMessages(getResumeMessages(raw))` as the working conversation — otherwise keep the in-memory base
2. **Recover** via `recoverAbortedConversation(conversation, partialText, displayMessages)`
3. **Write** the recovered transcript back to `messages.json` when recovery fired (so session resume sees the corrected state)
4. **Return** the recovered transcript, or the (possibly reloaded) input when recovery was gated off

Best-effort semantics preserved exactly from the inline block, with the two failure windows made explicit:

- read/parse failure → skip recovery entirely, return the caller's conversation (the inline code's single `catch` aborted the whole sequence on a malformed file)
- write failure → still return the recovered conversation (the inline code assigned `conversationRef` *before* writing, so a write throw did not undo the in-memory recovery)

**`index.tsx`** — the inline block becomes one call. The `sessionRef`-vs-`session` comment (first-message abort races React's re-render) stays at the call site; `recoverAbortedConversation` is no longer imported by the component.

**Non-goals honored** — no generic transcript repository, no session-persistence framework; one concrete function.

## Test coverage

7 new tests in `conversation.test.ts` (temp-dir based):

- **missing file** — recovers from the in-memory conversation *and persists the recovered transcript* (documents the write-on-missing behavior)
- **missing file, nothing to recover** — returns the input by reference, writes nothing
- **malformed file** — returns the input by reference, leaves the file byte-identical, no recovery attempted
- **empty transcript** — `[]` on disk does not clobber the in-memory base; recovery proceeds from it
- **already-complete transcript** — returns the reloaded transcript, file left byte-identical (recovery gated off)
- **partial text** — trimmed assistant turn recovered and persisted
- **pending tool** — tool-call + `Cancelled by user.` tool-result pair recovered and persisted

## Validation

- `bun run test` (1,609 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the three touched files

## Notes

- behavior-preserving; the module header now notes `conversation.ts` holds the pure transitions *plus* this one concrete abort I/O operation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of abort-path session transcript handling with explicit tests; no new auth or external API surface beyond the same `messages.json` I/O.
> 
> **Overview**
> **Pulls the operator abort handler’s transcript read → normalize → recover → persist sequence into `recoverAbortedTranscript` in `conversation.ts`, and replaces the inline block in `index.tsx` with a single call.**
> 
> The new helper optionally reloads a non-empty `messages.json` via `getResumeMessages` / `normalizeMessages`, runs the existing `recoverAbortedConversation` on partial text and pending tools, writes the corrected transcript when recovery applies, and returns the conversation the UI should keep—still best-effort on read/write failures.
> 
> **Seven temp-dir tests** cover missing/malformed/empty disk state, already-complete transcripts, partial assistant text, and cancelled pending tools (including when recovery creates `messages.json` from memory).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ff1dc89185ffc9245cf9027c1c91867d1adbb64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->