### PR TITLE
refactor(operator): isolate run event subscription lifecycle

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -127,6 +127,7 @@ import {
   selectionAfterRemove,
 } from "./queue";
 import { QueuedMessages } from "./queued-messages";
+import { bindOperatorRunEvents } from "./run-events";
 import { RunTraceSession } from "./run-tracing";
 import SubagentDialog from "./subagent-dialog";
 import {
@@ -833,187 +834,171 @@ export default function OperatorDashboard({
         setMessages((prev) => updateWorkflowDataMessage(prev, updater));
       };
 
-      eventBus.on("text-delta", (d) => {
-        if (gen !== generationRef.current) return;
-        if (d.subagentId) {
-          subagentHelpers.appendText(d.subagentId, d.text);
-          return;
-        }
-        setThinking(false);
-        appendText(d.text);
-      });
+      const unbindRunEvents = bindOperatorRunEvents(eventBus, {
+        isCurrent: () => gen === generationRef.current,
+        handlers: {
+          onTextDelta: (d) => {
+            if (d.subagentId) {
+              subagentHelpers.appendText(d.subagentId, d.text);
+              return;
+            }
+            setThinking(false);
+            appendText(d.text);
+          },
+          onToolCallStart: (d) => {
+            if (d.subagentId) {
+              subagentHelpers.addStreamingToolCall(
+                d.subagentId,
+                d.toolCallId,
+                d.toolName,
+              );
+              return;
+            }
+            setThinking(false);
+            addStreamingToolCall(d.toolCallId, d.toolName);
+          },
+          onToolCallDelta: (d) => {
+            if (d.subagentId) {
+              subagentHelpers.appendToolCallDelta(
+                d.subagentId,
+                d.toolCallId,
+                d.argsTextDelta,
+              );
+              return;
+            }
+            appendToolCallDelta(d.toolCallId, d.argsTextDelta);
+          },
+          onToolCallComplete: (d) => {
+            if (d.subagentId) {
+              const args =
+                d.args &&
+                typeof d.args === "object" &&
+                !Array.isArray(d.args) &&
+                d.args !== null
+                  ? (d.args as Record<string, unknown>)
+                  : {};
+              subagentHelpers.addToolCall(
+                d.subagentId,
+                d.toolCallId,
+                d.toolName,
+                args,
+              );
+              return;
+            }
+            setThinking(false);
+            commandCancelledRef.current = false;
+            const args =
+              d.args &&
+              typeof d.args === "object" &&
+              !Array.isArray(d.args) &&
+              d.args !== null
+                ? (d.args as Record<string, unknown>)
+                : undefined;
+            addToolCall(d.toolCallId, d.toolName, args);
 
-      eventBus.on("tool-call-start", (d) => {
-        if (gen !== generationRef.current) return;
-        if (d.subagentId) {
-          subagentHelpers.addStreamingToolCall(
-            d.subagentId,
-            d.toolCallId,
-            d.toolName,
-          );
-          return;
-        }
-        setThinking(false);
-        addStreamingToolCall(d.toolCallId, d.toolName);
-      });
+            if (d.toolName === ASK_USER_QUESTIONS_TOOL_NAME && args) {
+              const rawQuestions = args.questions;
+              if (Array.isArray(rawQuestions) && rawQuestions.length > 0) {
+                pendingToolCallIdRef.current = d.toolCallId;
+                setPendingQuestions(rawQuestions as AskUserQuestion[]);
+              }
+            }
+          },
+          onToolResult: (d) => {
+            if (d.subagentId) {
+              subagentHelpers.updateToolResult(
+                d.subagentId,
+                d.toolCallId,
+                d.result,
+              );
+              return;
+            }
+            flushCommandOutput();
+            if (cmdFlushTimerRef.current) {
+              clearInterval(cmdFlushTimerRef.current);
+              cmdFlushTimerRef.current = null;
+            }
+            setThinking(true);
+            updateToolResult(d.toolCallId, d.toolName, d.result);
 
-      eventBus.on("tool-call-delta", (d) => {
-        if (gen !== generationRef.current) return;
-        if (d.subagentId) {
-          subagentHelpers.appendToolCallDelta(
-            d.subagentId,
-            d.toolCallId,
-            d.argsTextDelta,
-          );
-          return;
-        }
-        appendToolCallDelta(d.toolCallId, d.argsTextDelta);
-      });
-
-      eventBus.on("tool-call-complete", (d) => {
-        if (gen !== generationRef.current) return;
-        if (d.subagentId) {
-          const args =
-            d.args &&
-            typeof d.args === "object" &&
-            !Array.isArray(d.args) &&
-            d.args !== null
-              ? (d.args as Record<string, unknown>)
-              : {};
-          subagentHelpers.addToolCall(
-            d.subagentId,
-            d.toolCallId,
-            d.toolName,
-            args,
-          );
-          return;
-        }
-        setThinking(false);
-        commandCancelledRef.current = false;
-        const args =
-          d.args &&
-          typeof d.args === "object" &&
-          !Array.isArray(d.args) &&
-          d.args !== null
-            ? (d.args as Record<string, unknown>)
-            : undefined;
-        addToolCall(d.toolCallId, d.toolName, args);
-
-        if (d.toolName === ASK_USER_QUESTIONS_TOOL_NAME && args) {
-          const rawQuestions = args.questions;
-          if (Array.isArray(rawQuestions) && rawQuestions.length > 0) {
-            pendingToolCallIdRef.current = d.toolCallId;
-            setPendingQuestions(rawQuestions as AskUserQuestion[]);
-          }
-        }
-      });
-
-      eventBus.on("tool-result", (d) => {
-        if (gen !== generationRef.current) return;
-        if (d.subagentId) {
-          subagentHelpers.updateToolResult(
-            d.subagentId,
-            d.toolCallId,
-            d.result,
-          );
-          return;
-        }
-        flushCommandOutput();
-        if (cmdFlushTimerRef.current) {
-          clearInterval(cmdFlushTimerRef.current);
-          cmdFlushTimerRef.current = null;
-        }
-        setThinking(true);
-        updateToolResult(d.toolCallId, d.toolName, d.result);
-
-        // Track submit_plan success — review triggers after the run completes
-        if (
-          d.toolName === "submit_plan" &&
-          (d.result as Record<string, unknown> | null)?.success === true
-        ) {
-          planSubmittedRef.current = true;
-          planGateBypassedOnResumeRef.current = false;
-        }
-      });
-
-      eventBus.on("command-output", (d) => {
-        if (gen !== generationRef.current) return;
-        if (d.subagentId) return;
-        onCommandOutput(d.data);
-      });
-
-      eventBus.on("error", (d) => {
-        if (gen !== generationRef.current) return;
-        if (d.subagentId) {
-          const errMsg =
-            d.error instanceof Error ? d.error.message : "Unknown error";
-          subagentHelpers.appendText(d.subagentId, `\nError: ${errMsg}\n`);
-          return;
-        }
-        console.error("Agent error:", d.error);
-        // Clear pending-questions state so an error after the tool-call event
-        // doesn't leave the questions form stuck over a failed conversation.
-        pendingToolCallIdRef.current = null;
-        setPendingQuestions(null);
-        const errorMessage =
-          d.error instanceof Error ? d.error.message : "Unknown error";
-        setError(errorMessage);
-        setMessages((prev) => markInFlightToolsErrored(prev, errorMessage));
-      });
-
-      eventBus.on("subagent-spawn", ({ subagentId, name }) => {
-        if (gen !== generationRef.current) return;
-        // Hide whitebox per-app synthetic grouping nodes until #744 lands a hierarchical view.
-        if (subagentId.startsWith("app:")) return;
-        subagentHelpers.spawnSession(subagentId, name);
-        if (!isPentestAgent(subagentId)) return;
-        // Pentest swarm agents → workflowData.pentesting.subagents
-        updateWorkflowData((wd) =>
-          applyWorkflowSubagentSpawn(wd, subagentId, name),
-        );
-      });
-
-      eventBus.on("subagent-complete", ({ subagentId, status }) => {
-        if (gen !== generationRef.current) return;
-        // Mirror the spawn-handler filter: synthetic per-app grouping nodes
-        // were never registered as sessions, so don't try to complete them.
-        if (subagentId.startsWith("app:")) return;
-        subagentHelpers.completeSession(subagentId, status);
-        if (!isPentestAgent(subagentId)) return;
-        // Update workflowData swarm status
-        updateWorkflowData((wd) =>
-          applyWorkflowSubagentComplete(wd, subagentId, status),
-        );
-      });
-
-      // Workflow phase events → update workflowData on the tool message
-      eventBus.on("workflow-phase-start", (d) => {
-        if (gen !== generationRef.current) return;
-        textRef.current = "";
-        // New workflow run — clear old subagent sessions so the hub
-        // shows only the current batch.
-        if (d.phase === "discovery") {
-          subagentStore.setState(new Map());
-        }
-        updateWorkflowData((wd) =>
-          applyWorkflowPhaseStart(
-            wd,
-            d.phase as WorkflowData["currentPhase"],
-            d.label,
-          ),
-        );
-      });
-
-      eventBus.on("workflow-phase-complete", (d) => {
-        if (gen !== generationRef.current) return;
-        textRef.current = "";
-        updateWorkflowData((wd) =>
-          applyWorkflowPhaseComplete(
-            wd,
-            d.phase as WorkflowData["currentPhase"],
-            d.summary,
-          ),
-        );
+            // Track submit_plan success — review triggers after the run completes
+            if (
+              d.toolName === "submit_plan" &&
+              (d.result as Record<string, unknown> | null)?.success === true
+            ) {
+              planSubmittedRef.current = true;
+              planGateBypassedOnResumeRef.current = false;
+            }
+          },
+          onCommandOutput: (d) => {
+            if (d.subagentId) return;
+            onCommandOutput(d.data);
+          },
+          onError: (d) => {
+            if (d.subagentId) {
+              const errMsg =
+                d.error instanceof Error ? d.error.message : "Unknown error";
+              subagentHelpers.appendText(d.subagentId, `\nError: ${errMsg}\n`);
+              return;
+            }
+            console.error("Agent error:", d.error);
+            // Clear pending-questions state so an error after the tool-call event
+            // doesn't leave the questions form stuck over a failed conversation.
+            pendingToolCallIdRef.current = null;
+            setPendingQuestions(null);
+            const errorMessage =
+              d.error instanceof Error ? d.error.message : "Unknown error";
+            setError(errorMessage);
+            setMessages((prev) => markInFlightToolsErrored(prev, errorMessage));
+          },
+          onSubagentSpawn: ({ subagentId, name }) => {
+            // Hide whitebox per-app synthetic grouping nodes until #744 lands a hierarchical view.
+            if (subagentId.startsWith("app:")) return;
+            subagentHelpers.spawnSession(subagentId, name);
+            if (!isPentestAgent(subagentId)) return;
+            // Pentest swarm agents → workflowData.pentesting.subagents
+            updateWorkflowData((wd) =>
+              applyWorkflowSubagentSpawn(wd, subagentId, name),
+            );
+          },
+          onSubagentComplete: ({ subagentId, status }) => {
+            // Mirror the spawn-handler filter: synthetic per-app grouping nodes
+            // were never registered as sessions, so don't try to complete them.
+            if (subagentId.startsWith("app:")) return;
+            subagentHelpers.completeSession(subagentId, status);
+            if (!isPentestAgent(subagentId)) return;
+            // Update workflowData swarm status
+            updateWorkflowData((wd) =>
+              applyWorkflowSubagentComplete(wd, subagentId, status),
+            );
+          },
+          // Workflow phase events → update workflowData on the tool message
+          onWorkflowPhaseStart: (d) => {
+            textRef.current = "";
+            // New workflow run — clear old subagent sessions so the hub
+            // shows only the current batch.
+            if (d.phase === "discovery") {
+              subagentStore.setState(new Map());
+            }
+            updateWorkflowData((wd) =>
+              applyWorkflowPhaseStart(
+                wd,
+                d.phase as WorkflowData["currentPhase"],
+                d.label,
+              ),
+            );
+          },
+          onWorkflowPhaseComplete: (d) => {
+            textRef.current = "";
+            updateWorkflowData((wd) =>
+              applyWorkflowPhaseComplete(
+                wd,
+                d.phase as WorkflowData["currentPhase"],
+                d.summary,
+              ),
+            );
+          },
+        },
       });
 
       const skillsCatalog = skillsRegistry.buildCatalog() || undefined;
@@ -1208,6 +1193,9 @@ export default function OperatorDashboard({
           ]);
         }
       } finally {
+        // Detach run-event listeners on all paths (abort, error, success) —
+        // post-run stragglers must not mutate display state.
+        unbindRunEvents();
         // Detach trace listeners and flush the uploader on all paths
         // (abort, error, success).
         await runTrace.cleanupRun();

--- a/src/tui/components/operator-dashboard/run-events.test.ts
+++ b/src/tui/components/operator-dashboard/run-events.test.ts
@@ -202,4 +202,39 @@ describe("bindOperatorRunEvents", () => {
     // The raw sibling listener is unaffected by our unbind — 3 emissions, 3 calls.
     expect(sibling).toHaveBeenCalledTimes(3);
   });
+
+  it("a straggler error emitted after unbind does not crash the process", () => {
+    // Node's EventEmitter throws when `error` is emitted with no listeners.
+    // Unbinding must leave a no-op error listener so a late emission (e.g.
+    // forwarded from a subagent bus that outlived the run) is dropped.
+    const bus = new Bus();
+    const onError = vi.fn();
+    const unbind = bindOperatorRunEvents(bus, {
+      isCurrent: () => true,
+      handlers: { onError },
+    });
+
+    unbind();
+
+    expect(() =>
+      bus.emit("error", { error: new Error("straggler") }),
+    ).not.toThrow();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("unbind does not add an error listener when none was bound", () => {
+    const bus = new Bus();
+    const unbind = bindOperatorRunEvents(bus, {
+      isCurrent: () => true,
+      handlers: { onTextDelta: vi.fn() },
+    });
+
+    unbind();
+
+    // The binding only manages the listeners it subscribed — no error
+    // handler was bound, so unbind must not leave a no-op behind. Node
+    // still throws on a listenerless error emission, which is exactly
+    // what happens if this contract is violated.
+    expect(() => bus.emit("error", { error: new Error("x") })).toThrow();
+  });
 });

--- a/src/tui/components/operator-dashboard/run-events.test.ts
+++ b/src/tui/components/operator-dashboard/run-events.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentEventBus, AgentEventMap } from "../../../core/eventBus";
+import { AgentEventBus as Bus } from "../../../core/eventBus";
+import {
+  bindOperatorRunEvents,
+  type OperatorRunEventHandlers,
+} from "./run-events";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+type EventCase = readonly [
+  event: keyof AgentEventMap,
+  handlerKey: keyof OperatorRunEventHandlers,
+  payload: unknown,
+];
+
+const EVENT_CASES: readonly EventCase[] = [
+  ["text-delta", "onTextDelta", { text: "hello" }],
+  [
+    "tool-call-start",
+    "onToolCallStart",
+    { toolCallId: "tc-1", toolName: "execute_command" },
+  ],
+  [
+    "tool-call-delta",
+    "onToolCallDelta",
+    { toolCallId: "tc-1", argsTextDelta: '{"command":' },
+  ],
+  [
+    "tool-call-complete",
+    "onToolCallComplete",
+    { toolCallId: "tc-1", toolName: "execute_command", args: { a: 1 } },
+  ],
+  [
+    "tool-result",
+    "onToolResult",
+    { toolCallId: "tc-1", toolName: "execute_command", result: "done" },
+  ],
+  ["command-output", "onCommandOutput", { data: "line\n" }],
+  ["error", "onError", { error: new Error("boom") }],
+  [
+    "subagent-spawn",
+    "onSubagentSpawn",
+    { subagentId: "pentest-agent-1", input: {} },
+  ],
+  [
+    "subagent-complete",
+    "onSubagentComplete",
+    { subagentId: "pentest-agent-1", status: "completed" },
+  ],
+  [
+    "workflow-phase-start",
+    "onWorkflowPhaseStart",
+    { phase: "discovery", label: "Recon" },
+  ],
+  [
+    "workflow-phase-complete",
+    "onWorkflowPhaseComplete",
+    { phase: "reporting", summary: { findingsCount: 2 } },
+  ],
+] as const;
+
+/** Untyped emit helper for the table-driven test. */
+function emit(bus: AgentEventBus, event: string, payload: unknown): void {
+  (bus.emit as (event: string, payload: unknown) => boolean)(event, payload);
+}
+
+// ---------------------------------------------------------------------------
+// bindOperatorRunEvents
+// ---------------------------------------------------------------------------
+
+describe("bindOperatorRunEvents", () => {
+  it("forwards each event to its handler exactly once with the payload", () => {
+    for (const [event, handlerKey, payload] of EVENT_CASES) {
+      const bus = new Bus();
+      const handler = vi.fn();
+      const unbind = bindOperatorRunEvents(bus, {
+        isCurrent: () => true,
+        handlers: { [handlerKey]: handler } as OperatorRunEventHandlers,
+      });
+
+      emit(bus, event, payload);
+
+      expect(handler, event).toHaveBeenCalledTimes(1);
+      expect(handler, event).toHaveBeenCalledWith(payload);
+      unbind();
+    }
+  });
+
+  it("does not subscribe events whose handlers are omitted", () => {
+    const bus = new Bus();
+    const handler = vi.fn();
+    const unbind = bindOperatorRunEvents(bus, {
+      isCurrent: () => true,
+      handlers: { onTextDelta: handler },
+    });
+
+    emit(bus, "tool-result", {
+      toolCallId: "tc-1",
+      toolName: "t",
+      result: null,
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    unbind();
+  });
+
+  it("drops events when the generation guard reports stale", () => {
+    const bus = new Bus();
+    const handler = vi.fn();
+    let current = true;
+    const unbind = bindOperatorRunEvents(bus, {
+      isCurrent: () => current,
+      handlers: { onTextDelta: handler },
+    });
+
+    emit(bus, "text-delta", { text: "fresh" });
+    current = false;
+    emit(bus, "text-delta", { text: "stale" });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ text: "fresh" });
+    unbind();
+  });
+
+  it("cleanup detaches every listener; idempotent", () => {
+    const bus = new Bus();
+    const textHandler = vi.fn();
+    const resultHandler = vi.fn();
+    const unbind = bindOperatorRunEvents(bus, {
+      isCurrent: () => true,
+      handlers: {
+        onTextDelta: textHandler,
+        onToolResult: resultHandler,
+      },
+    });
+
+    unbind();
+    unbind(); // second call is a safe no-op
+
+    emit(bus, "text-delta", { text: "after" });
+    emit(bus, "tool-result", {
+      toolCallId: "tc-1",
+      toolName: "t",
+      result: null,
+    });
+
+    expect(textHandler).not.toHaveBeenCalled();
+    expect(resultHandler).not.toHaveBeenCalled();
+  });
+
+  it("repeated binding: unbinding one binding leaves the other intact", () => {
+    const bus = new Bus();
+    const first = vi.fn();
+    const second = vi.fn();
+    const unbindFirst = bindOperatorRunEvents(bus, {
+      isCurrent: () => true,
+      handlers: { onTextDelta: first },
+    });
+    const unbindSecond = bindOperatorRunEvents(bus, {
+      isCurrent: () => true,
+      handlers: { onTextDelta: second },
+    });
+
+    emit(bus, "text-delta", { text: "both" });
+    unbindFirst();
+    emit(bus, "text-delta", { text: "second only" });
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(2);
+    expect(second).toHaveBeenLastCalledWith({ text: "second only" });
+    unbindSecond();
+  });
+
+  it("isolates listener exceptions from the emitter, siblings, and later events", () => {
+    const bus = new Bus();
+    const throwing = vi.fn(() => {
+      throw new Error("handler boom");
+    });
+    const sibling = vi.fn();
+    bus.on("text-delta", sibling);
+
+    const unbind = bindOperatorRunEvents(bus, {
+      isCurrent: () => true,
+      handlers: { onTextDelta: throwing },
+    });
+
+    expect(() => emit(bus, "text-delta", { text: "one" })).not.toThrow();
+
+    // The sibling listener on the same emission still ran...
+    expect(sibling).toHaveBeenCalledTimes(1);
+    // ...and the throwing handler is still bound for later events.
+    emit(bus, "text-delta", { text: "two" });
+    expect(throwing).toHaveBeenCalledTimes(2);
+
+    // Cleanup still works after the exceptions.
+    unbind();
+    emit(bus, "text-delta", { text: "three" });
+    expect(throwing).toHaveBeenCalledTimes(2);
+    // The raw sibling listener is unaffected by our unbind — 3 emissions, 3 calls.
+    expect(sibling).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/tui/components/operator-dashboard/run-events.ts
+++ b/src/tui/components/operator-dashboard/run-events.ts
@@ -1,0 +1,82 @@
+import type { AgentEventBus, AgentEventMap } from "../../../core/eventBus";
+
+// ---------------------------------------------------------------------------
+// Run event subscription lifecycle — owns subscription, generation filtering,
+// and cleanup for one agent run's bus listeners. Handler behavior stays with
+// the caller (O4/O5 will move the projections in behind this boundary).
+// ---------------------------------------------------------------------------
+
+export interface OperatorRunEventHandlers {
+  onTextDelta?: (e: AgentEventMap["text-delta"]) => void;
+  onToolCallStart?: (e: AgentEventMap["tool-call-start"]) => void;
+  onToolCallDelta?: (e: AgentEventMap["tool-call-delta"]) => void;
+  onToolCallComplete?: (e: AgentEventMap["tool-call-complete"]) => void;
+  onToolResult?: (e: AgentEventMap["tool-result"]) => void;
+  onCommandOutput?: (e: AgentEventMap["command-output"]) => void;
+  onError?: (e: AgentEventMap["error"]) => void;
+  onSubagentSpawn?: (e: AgentEventMap["subagent-spawn"]) => void;
+  onSubagentComplete?: (e: AgentEventMap["subagent-complete"]) => void;
+  onWorkflowPhaseStart?: (e: AgentEventMap["workflow-phase-start"]) => void;
+  onWorkflowPhaseComplete?: (
+    e: AgentEventMap["workflow-phase-complete"],
+  ) => void;
+}
+
+export interface BindOperatorRunEventsOptions {
+  /** Generation guard — stale generations never reach the handlers. */
+  isCurrent: () => boolean;
+  handlers: OperatorRunEventHandlers;
+}
+
+/**
+ * Subscribe the provided handlers to the run bus. The generation guard is
+ * applied uniformly at ingress, and each handler is isolated: a throwing
+ * handler is logged and neither prevents sibling listeners on the same
+ * emission nor affects later events or cleanup.
+ *
+ * Returns an unbind function that detaches every listener; idempotent.
+ */
+export function bindOperatorRunEvents(
+  bus: AgentEventBus,
+  options: BindOperatorRunEventsOptions,
+): () => void {
+  const { isCurrent, handlers } = options;
+  const offs: Array<() => void> = [];
+
+  const bind = <K extends keyof AgentEventMap>(
+    event: K,
+    handler: ((e: AgentEventMap[K]) => void) | undefined,
+  ): void => {
+    if (!handler) return;
+    const wrapped = (e: AgentEventMap[K]): void => {
+      if (!isCurrent()) return;
+      try {
+        handler(e);
+      } catch (err) {
+        console.error(`[operator] ${event} handler failed:`, err);
+      }
+    };
+    bus.on(event, wrapped);
+    offs.push(() => bus.off(event, wrapped));
+  };
+
+  bind("text-delta", handlers.onTextDelta);
+  bind("tool-call-start", handlers.onToolCallStart);
+  bind("tool-call-delta", handlers.onToolCallDelta);
+  bind("tool-call-complete", handlers.onToolCallComplete);
+  bind("tool-result", handlers.onToolResult);
+  bind("command-output", handlers.onCommandOutput);
+  bind("error", handlers.onError);
+  bind("subagent-spawn", handlers.onSubagentSpawn);
+  bind("subagent-complete", handlers.onSubagentComplete);
+  bind("workflow-phase-start", handlers.onWorkflowPhaseStart);
+  bind("workflow-phase-complete", handlers.onWorkflowPhaseComplete);
+
+  let unbound = false;
+  return () => {
+    if (unbound) return;
+    unbound = true;
+    for (const off of offs) off();
+    offs.length = 0;
+  };
+}

--- a/src/tui/components/operator-dashboard/run-events.ts
+++ b/src/tui/components/operator-dashboard/run-events.ts
@@ -35,6 +35,10 @@ export interface BindOperatorRunEventsOptions {
  * emission nor affects later events or cleanup.
  *
  * Returns an unbind function that detaches every listener; idempotent.
+ * Unbinding swaps the error listener for a no-op rather than removing it —
+ * Node's EventEmitter throws on an `error` emission with no listeners, and a
+ * straggler error (e.g. forwarded from a subagent bus that outlived the run)
+ * must be dropped like any other post-run event, not crash the process.
  */
 export function bindOperatorRunEvents(
   bus: AgentEventBus,
@@ -42,12 +46,14 @@ export function bindOperatorRunEvents(
 ): () => void {
   const { isCurrent, handlers } = options;
   const offs: Array<() => void> = [];
+  let boundError = false;
 
   const bind = <K extends keyof AgentEventMap>(
     event: K,
     handler: ((e: AgentEventMap[K]) => void) | undefined,
   ): void => {
     if (!handler) return;
+    if (event === "error") boundError = true;
     const wrapped = (e: AgentEventMap[K]): void => {
       if (!isCurrent()) return;
       try {
@@ -78,5 +84,10 @@ export function bindOperatorRunEvents(
     unbound = true;
     for (const off of offs) off();
     offs.length = 0;
+    // Node's EventEmitter throws on an `error` emission with no listeners.
+    // Leave a no-op behind so a straggler error on this bus is dropped like
+    // any other post-run event instead of crashing the process. The bus is
+    // per-run and unreferenced after the run, so the listener dies with it.
+    if (boundError) bus.on("error", () => {});
   };
 }


### PR DESCRIPTION
## Stack

**3 of 5 (Stack A: OperatorDashboard)** — stacked on #976 (`refactor/abort-transcript-recovery`) ← #975. Merge order: #975 → #976 → this PR → O4 → O5, retargeting to `canary` at each step.

## Summary

- extract `bindOperatorRunEvents(bus, { isCurrent, handlers })` into a new `run-events.ts` — it owns **subscription, generation filtering, and cleanup** for the run's 11 bus listeners
- handler behavior stays in the component: the closures move into a typed `handlers` object, bodies unchanged
- the run `finally` now explicitly unbinds all run-event listeners on every exit path

## Motivation

O3 of Stack A. Each of the 11 `eventBus.on(...)` calls in `runAgent` opened with the same `if (gen !== generationRef.current) return;` guard, and none of them were ever detached — the per-run bus simply got GC'd. This PR moves that mechanical lifecycle behind one tested boundary so O4/O5 can slide the projections in behind it without touching subscription mechanics again.

## What changed

**New module: `run-events.ts`**

- `bindOperatorRunEvents(bus, options)` subscribes each provided handler (omitted handlers are not subscribed), applying the generation guard uniformly at ingress
- returns an idempotent unbind that detaches every listener it created
- handlers are optional per-event, typed off `AgentEventMap` payloads

**`index.tsx`**

- the 11 inline `eventBus.on` calls become one `bindOperatorRunEvents` call with an 11-entry `handlers` object — handler bodies are verbatim, including the subagent/root routing, the `app:` synthetic-node filter, the submit-plan tracking, and the questions interception
- the `finally` block now calls `unbindRunEvents()` before flushing W&B tracing

## Two deliberate behavior changes (called out for review)

1. **Listener exception isolation.** Each wrapped handler catches and logs (`[operator] <event> handler failed:`). Previously a throwing handler propagated through `emit()` and broke the emitter's listener loop — a UI-handler bug could kill the agent run mid-stream. This mirrors the teardown-failure isolation landed for `OffensiveSecurityAgent` in #964. The spec's "listener exceptions" test target implies the binding must be robust to them.
2. **Explicit unbind in `finally`.** Previously listeners lived as long as the bus, so a straggler event arriving after the run ended (while the generation was still "current") could still mutate display state. Now post-run events are dropped. This also satisfies the stack's standing invariant: *every listener has cleanup on every path*.

Everything else — guard semantics, handler order, payload routing — is unchanged.

## Test coverage

6 tests in `run-events.test.ts`, driving a real `AgentEventBus`:

- **exact-once forwarding** — table-driven over all 11 events: one emission → one call with the exact payload
- omitted handlers are not subscribed
- **stale generations** — guard flip mid-run drops only the stale event
- **cleanup** — unbind detaches everything; second call is a safe no-op
- **repeated binding** — two bindings coexist; unbinding the first leaves the second fully intact
- **listener exceptions** — a throwing handler does not break `emit`, does not prevent a sibling listener on the same emission, remains bound for later events, and cleanup still works

## Validation

- `bun run test` (1,615 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the three touched files

## Notes

- handler bodies are intentionally still component closures (per the O3 scope: "leave handler behavior in the component"); O4 moves the display projections behind a narrow sink, O5 moves workflow/subagent/questions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live agent-run event wiring and changes teardown/exception behavior for the operator TUI; logic is largely moved verbatim but explicit unbind and handler isolation can alter edge-case timing.
> 
> **Overview**
> Extracts **`bindOperatorRunEvents`** into `run-events.ts` so the operator dashboard’s eleven per-run `AgentEventBus` listeners share one boundary for subscribe, **generation guard** (`isCurrent`), and teardown instead of repeated inline `eventBus.on` calls.
> 
> `runAgent` now passes the same handler logic through a typed `handlers` object and calls **`unbindRunEvents()` in `finally`**, so post-run stragglers no longer update UI state. Wrapped handlers **catch and log** failures instead of breaking `emit`, and unbind leaves a **no-op `error` listener** when an error handler was bound so late errors do not crash Node.
> 
> Adds **`run-events.test.ts`** covering forwarding, stale-generation drops, cleanup/idempotency, multi-bind, exception isolation, and straggler-error behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 053056e2c5d9084715d772f1f45d81e76609ef3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->