### PR TITLE
refactor(operator): move display event projections into run event adapter

### DIFF
--- a/src/tui/components/operator-dashboard/display-state.ts
+++ b/src/tui/components/operator-dashboard/display-state.ts
@@ -135,3 +135,15 @@ export function mergeCommandOutput(
   updated[idx] = { ...msg, logs: merged };
   return updated;
 }
+
+/** Mark every in-flight tool message errored with the given result label. */
+export function markInFlightToolsErrored(
+  messages: readonly DisplayMessage[],
+  result: string,
+): DisplayMessage[] {
+  return messages.map((m) =>
+    isToolMessage(m) && (m.status === "pending" || m.status === "streaming")
+      ? { ...m, status: "error" as const, result }
+      : m,
+  );
+}

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -89,23 +89,12 @@ import { InputArea } from "../chat/input-area";
 import { MessageList } from "../chat/message-list";
 import { QuestionsForm } from "../chat/questions-form";
 import { collectScreenshotPaths, ScreenshotModal } from "../screenshot-modal";
-import {
-  deriveApprovedActionLabel,
-  isToolMessage,
-  tryParsePartialJson,
-} from "../shared";
+import { deriveApprovedActionLabel, isToolMessage } from "../shared";
 import {
   recoverAbortedTranscript,
   rewriteToolResultOutput,
 } from "./conversation";
-import {
-  appendStreamedText,
-  applyToolCall,
-  applyToolCallDelta,
-  applyToolResult,
-  mergeCommandOutput,
-  startStreamingToolCall,
-} from "./display-state";
+import { markInFlightToolsErrored } from "./display-state";
 import {
   accumulateTokenUsage,
   buildOperatorSystemPrompt,
@@ -127,7 +116,10 @@ import {
   selectionAfterRemove,
 } from "./queue";
 import { QueuedMessages } from "./queued-messages";
-import { bindOperatorRunEvents } from "./run-events";
+import {
+  bindOperatorRunEvents,
+  createDisplayEventHandlers,
+} from "./run-events";
 import { RunTraceSession } from "./run-tracing";
 import SubagentDialog from "./subagent-dialog";
 import {
@@ -145,17 +137,6 @@ import {
   isPentestAgent,
   updateWorkflowDataMessage,
 } from "./workflow-data";
-
-function markInFlightToolsErrored(
-  messages: DisplayMessage[],
-  result: string,
-): DisplayMessage[] {
-  return messages.map((m) =>
-    isToolMessage(m) && (m.status === "pending" || m.status === "streaming")
-      ? { ...m, status: "error" as const, result }
-      : m,
-  );
-}
 
 /**
  * Operator Dashboard - interactive chat interface with the offensive security agent
@@ -317,7 +298,6 @@ export default function OperatorDashboard({
   // without a ref).
   const displayMessagesRef = useRef<DisplayMessage[]>([]);
   displayMessagesRef.current = messages;
-  const textRef = useRef("");
   // AI SDK conversation history for multi-turn continuity
   const conversationRef = useRef<ModelMessage[]>([]);
   // Input state
@@ -600,103 +580,27 @@ export default function OperatorDashboard({
   }, [session, sessionId, addTokenUsage, resetTokenUsage]);
 
   // ---------------------------------------------------------------------------
-  // Message helpers — same pattern as pentest component
+  // Display event adapter — root display projections (partial text, tool-arg
+  // deltas, throttled command output) behind the run-event binding. React
+  // setters stay behind the narrow sink.
   // ---------------------------------------------------------------------------
 
-  const appendText = useCallback((text: string) => {
-    textRef.current += text;
-    const accumulated = textRef.current;
-    setMessages((prev) => appendStreamedText(prev, accumulated));
-  }, []);
-
-  // Ref to accumulate partial tool args JSON per toolCallId
-  const toolArgsDeltaRef = useRef<
-    Map<string, { toolName: string; accumulated: string }>
-  >(new Map());
-
-  const addStreamingToolCall = useCallback(
-    (toolCallId: string, toolName: string) => {
-      textRef.current = "";
-      toolArgsDeltaRef.current.set(toolCallId, {
-        toolName,
-        accumulated: "",
-      });
-      setMessages((prev) => startStreamingToolCall(prev, toolCallId, toolName));
-    },
-    [],
+  const displayEvents = useMemo(
+    () =>
+      createDisplayEventHandlers({
+        updateMessages: setMessages,
+        setThinking,
+        setError,
+      }),
+    [setThinking],
   );
 
-  const appendToolCallDelta = useCallback(
-    (toolCallId: string, argsTextDelta: string) => {
-      const entry = toolArgsDeltaRef.current.get(toolCallId);
-      const accumulated = (entry?.accumulated ?? "") + argsTextDelta;
-      toolArgsDeltaRef.current.set(toolCallId, {
-        toolName: entry?.toolName ?? "",
-        accumulated,
-      });
-
-      const parsed = tryParsePartialJson(accumulated);
-      if (!parsed) return;
-
-      setMessages((msgs) => applyToolCallDelta(msgs, toolCallId, parsed));
-    },
-    [],
-  );
-
-  const addToolCall = useCallback(
-    (toolCallId: string, toolName: string, args?: Record<string, unknown>) => {
-      textRef.current = "";
-      toolArgsDeltaRef.current.delete(toolCallId);
-      setMessages((prev) => applyToolCall(prev, toolCallId, toolName, args));
-    },
-    [],
-  );
-
-  const updateToolResult = useCallback(
-    (toolCallId: string, _toolName: string, result?: unknown) => {
-      textRef.current = "";
-      setMessages((prev) => applyToolResult(prev, toolCallId, result));
-    },
-    [],
-  );
-
-  // ---------------------------------------------------------------------------
-  // Streaming command output — throttled to avoid excessive re-renders
-  // ---------------------------------------------------------------------------
-
-  const cmdOutputBufRef = useRef("");
-  const cmdFlushTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  const flushCommandOutput = useCallback(() => {
-    const buf = cmdOutputBufRef.current;
-    if (!buf) return;
-    cmdOutputBufRef.current = "";
-
-    setMessages((prev) => mergeCommandOutput(prev, buf));
-  }, []);
-
-  const onCommandOutput = useCallback(
-    (data: string) => {
-      cmdOutputBufRef.current += data;
-
-      if (!cmdFlushTimerRef.current) {
-        cmdFlushTimerRef.current = setInterval(() => {
-          flushCommandOutput();
-        }, 150);
-      }
-    },
-    [flushCommandOutput],
-  );
-
-  // Clean up the flush timer when the component unmounts or agent stops
+  // Clean up the command-output flush timer when the component unmounts
   useEffect(() => {
     return () => {
-      if (cmdFlushTimerRef.current) {
-        clearInterval(cmdFlushTimerRef.current);
-        cmdFlushTimerRef.current = null;
-      }
+      displayEvents.dispose();
     };
-  }, []);
+  }, [displayEvents]);
 
   // ---------------------------------------------------------------------------
   // Approval handlers
@@ -744,7 +648,7 @@ export default function OperatorDashboard({
       setThinking(true);
       setIsExecuting(true);
       setError(null);
-      textRef.current = "";
+      displayEvents.resetPartialText();
 
       const controller = new AbortController();
       abortControllerRef.current = controller;
@@ -842,8 +746,7 @@ export default function OperatorDashboard({
               subagentHelpers.appendText(d.subagentId, d.text);
               return;
             }
-            setThinking(false);
-            appendText(d.text);
+            displayEvents.onTextDelta(d);
           },
           onToolCallStart: (d) => {
             if (d.subagentId) {
@@ -854,8 +757,7 @@ export default function OperatorDashboard({
               );
               return;
             }
-            setThinking(false);
-            addStreamingToolCall(d.toolCallId, d.toolName);
+            displayEvents.onToolCallStart(d);
           },
           onToolCallDelta: (d) => {
             if (d.subagentId) {
@@ -866,7 +768,7 @@ export default function OperatorDashboard({
               );
               return;
             }
-            appendToolCallDelta(d.toolCallId, d.argsTextDelta);
+            displayEvents.onToolCallDelta(d);
           },
           onToolCallComplete: (d) => {
             if (d.subagentId) {
@@ -885,19 +787,18 @@ export default function OperatorDashboard({
               );
               return;
             }
-            setThinking(false);
+            displayEvents.onToolCallComplete(d);
             commandCancelledRef.current = false;
-            const args =
-              d.args &&
-              typeof d.args === "object" &&
-              !Array.isArray(d.args) &&
-              d.args !== null
-                ? (d.args as Record<string, unknown>)
-                : undefined;
-            addToolCall(d.toolCallId, d.toolName, args);
 
-            if (d.toolName === ASK_USER_QUESTIONS_TOOL_NAME && args) {
-              const rawQuestions = args.questions;
+            if (d.toolName === ASK_USER_QUESTIONS_TOOL_NAME) {
+              const args =
+                d.args &&
+                typeof d.args === "object" &&
+                !Array.isArray(d.args) &&
+                d.args !== null
+                  ? (d.args as Record<string, unknown>)
+                  : undefined;
+              const rawQuestions = args?.questions;
               if (Array.isArray(rawQuestions) && rawQuestions.length > 0) {
                 pendingToolCallIdRef.current = d.toolCallId;
                 setPendingQuestions(rawQuestions as AskUserQuestion[]);
@@ -913,13 +814,7 @@ export default function OperatorDashboard({
               );
               return;
             }
-            flushCommandOutput();
-            if (cmdFlushTimerRef.current) {
-              clearInterval(cmdFlushTimerRef.current);
-              cmdFlushTimerRef.current = null;
-            }
-            setThinking(true);
-            updateToolResult(d.toolCallId, d.toolName, d.result);
+            displayEvents.onToolResult(d);
 
             // Track submit_plan success — review triggers after the run completes
             if (
@@ -932,7 +827,7 @@ export default function OperatorDashboard({
           },
           onCommandOutput: (d) => {
             if (d.subagentId) return;
-            onCommandOutput(d.data);
+            displayEvents.onCommandOutput(d);
           },
           onError: (d) => {
             if (d.subagentId) {
@@ -941,15 +836,11 @@ export default function OperatorDashboard({
               subagentHelpers.appendText(d.subagentId, `\nError: ${errMsg}\n`);
               return;
             }
-            console.error("Agent error:", d.error);
+            displayEvents.onError(d);
             // Clear pending-questions state so an error after the tool-call event
             // doesn't leave the questions form stuck over a failed conversation.
             pendingToolCallIdRef.current = null;
             setPendingQuestions(null);
-            const errorMessage =
-              d.error instanceof Error ? d.error.message : "Unknown error";
-            setError(errorMessage);
-            setMessages((prev) => markInFlightToolsErrored(prev, errorMessage));
           },
           onSubagentSpawn: ({ subagentId, name }) => {
             // Hide whitebox per-app synthetic grouping nodes until #744 lands a hierarchical view.
@@ -974,7 +865,7 @@ export default function OperatorDashboard({
           },
           // Workflow phase events → update workflowData on the tool message
           onWorkflowPhaseStart: (d) => {
-            textRef.current = "";
+            displayEvents.resetPartialText();
             // New workflow run — clear old subagent sessions so the hub
             // shows only the current batch.
             if (d.phase === "discovery") {
@@ -989,7 +880,7 @@ export default function OperatorDashboard({
             );
           },
           onWorkflowPhaseComplete: (d) => {
-            textRef.current = "";
+            displayEvents.resetPartialText();
             updateWorkflowData((wd) =>
               applyWorkflowPhaseComplete(
                 wd,
@@ -1221,13 +1112,7 @@ export default function OperatorDashboard({
       operatorMode,
       agentMode,
       addTokenUsage,
-      appendText,
-      addStreamingToolCall,
-      appendToolCallDelta,
-      addToolCall,
-      updateToolResult,
-      flushCommandOutput,
-      onCommandOutput,
+      displayEvents,
       subagentHelpers,
       setThinking,
       setIsExecuting,
@@ -1660,7 +1545,7 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
       conversationRef.current = recoverAbortedTranscript({
         rootPath: activeSession.rootPath,
         conversation: conversationRef.current,
-        partialText: textRef.current,
+        partialText: displayEvents.getPartialText(),
         displayMessages: displayMessagesRef.current,
       });
     }
@@ -1680,7 +1565,7 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
         },
       ];
     });
-  }, [setThinking, setIsExecuting, subagentStore.setState]);
+  }, [setThinking, setIsExecuting, subagentStore.setState, displayEvents]);
 
   const resumeWithQuestionResult = useCallback(
     (result: AskUserQuestionsResult) => {
@@ -1816,11 +1701,8 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
           setQueuedMessages((prev) => prev.filter((_, i) => i !== removeIdx));
           setSelectedQueueIndex(-1);
 
-          flushCommandOutput();
-          if (cmdFlushTimerRef.current) {
-            clearInterval(cmdFlushTimerRef.current);
-            cmdFlushTimerRef.current = null;
-          }
+          displayEvents.flushCommandOutput();
+          displayEvents.stopCommandOutputFlush();
           setMessages((prev) =>
             prev.map((m) =>
               isToolMessage(m) && m.status === "pending"

--- a/src/tui/components/operator-dashboard/run-events.test.ts
+++ b/src/tui/components/operator-dashboard/run-events.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AgentEventBus, AgentEventMap } from "../../../core/eventBus";
 import { AgentEventBus as Bus } from "../../../core/eventBus";
+import type { DisplayMessage } from "../agent-display";
 import {
   bindOperatorRunEvents,
+  createDisplayEventHandlers,
   type OperatorRunEventHandlers,
 } from "./run-events";
 
@@ -236,5 +238,196 @@ describe("bindOperatorRunEvents", () => {
     // still throws on a listenerless error emission, which is exactly
     // what happens if this contract is violated.
     expect(() => bus.emit("error", { error: new Error("x") })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createDisplayEventHandlers — display projections
+// ---------------------------------------------------------------------------
+
+describe("createDisplayEventHandlers", () => {
+  function createRecordingSink() {
+    let messages: DisplayMessage[] = [];
+    const thinking: boolean[] = [];
+    const errors: string[] = [];
+    const sink = {
+      updateMessages: (updater: (m: typeof messages) => typeof messages) => {
+        messages = updater(messages);
+      },
+      setThinking: (v: boolean) => thinking.push(v),
+      setError: (m: string) => errors.push(m),
+    };
+    return {
+      sink,
+      getMessages: () => messages,
+      getThinking: () => thinking,
+      getErrors: () => errors,
+    };
+  }
+
+  it("replays a full streaming trace: text → tool-input → tool-call → command-output → tool-result", () => {
+    const recording = createRecordingSink();
+    const display = createDisplayEventHandlers(recording.sink);
+    const bus = new Bus();
+    bindOperatorRunEvents(bus, {
+      isCurrent: () => true,
+      handlers: {
+        onTextDelta: display.onTextDelta,
+        onToolCallStart: display.onToolCallStart,
+        onToolCallDelta: display.onToolCallDelta,
+        onToolCallComplete: display.onToolCallComplete,
+        onCommandOutput: display.onCommandOutput,
+        onToolResult: display.onToolResult,
+      },
+    });
+
+    // Partial assistant text streams in.
+    bus.emit("text-delta", { text: "Let me " });
+    bus.emit("text-delta", { text: "run a scan." });
+    expect(display.getPartialText()).toBe("Let me run a scan.");
+
+    // Tool input starts streaming.
+    bus.emit("tool-call-start", {
+      toolCallId: "tc-1",
+      toolName: "execute_command",
+    });
+    expect(display.getPartialText()).toBe("");
+
+    // Args JSON arrives in fragments; only complete parses project.
+    bus.emit("tool-call-delta", {
+      toolCallId: "tc-1",
+      argsTextDelta: '{"command":"nmap -p 443 ',
+    });
+    bus.emit("tool-call-delta", {
+      toolCallId: "tc-1",
+      argsTextDelta: 'example.com"}',
+    });
+
+    // The call completes with final args.
+    bus.emit("tool-call-complete", {
+      toolCallId: "tc-1",
+      toolName: "execute_command",
+      args: { command: "nmap -p 443 example.com" },
+    });
+
+    // Command output streams (buffered, throttled).
+    bus.emit("command-output", { data: "Starting Nmap 7.94\n" });
+
+    // The tool produces its result — output flushes first, then completion.
+    bus.emit("tool-result", {
+      toolCallId: "tc-1",
+      toolName: "execute_command",
+      result: { exitCode: 0 },
+    });
+
+    const messages = recording.getMessages();
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({
+      role: "assistant",
+      content: "Let me run a scan.",
+    });
+    expect(messages[1]).toMatchObject({
+      role: "tool",
+      toolCallId: "tc-1",
+      toolName: "execute_command",
+      status: "completed",
+      args: { command: "nmap -p 443 example.com" },
+      result: { exitCode: 0 },
+    });
+    expect(messages[1].logs).toEqual(["Starting Nmap 7.94", ""]);
+    // Thinking toggles: text/tool events clear it; a tool result restores it.
+    // (Two text deltas → two false entries.)
+    expect(recording.getThinking()).toEqual([false, false, false, false, true]);
+    // Partial text is reset by the tool lifecycle.
+    expect(display.getPartialText()).toBe("");
+    display.dispose();
+  });
+
+  it("buffers command output and flushes on the 150ms throttle timer", () => {
+    vi.useFakeTimers();
+    try {
+      const recording = createRecordingSink();
+      const display = createDisplayEventHandlers(recording.sink);
+      display.onToolCallStart({ toolCallId: "tc-1", toolName: "t" });
+
+      display.onCommandOutput({ data: "line-1\n" });
+      display.onCommandOutput({ data: "line-2\n" });
+      expect(recording.getMessages()).toHaveLength(1);
+
+      vi.advanceTimersByTime(150);
+      const messages = recording.getMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].logs).toEqual(["line-1", "line-2", ""]);
+
+      // Buffer drained — a later timer tick flushes nothing new.
+      vi.advanceTimersByTime(150);
+      expect(recording.getMessages()).toHaveLength(1);
+
+      display.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stopCommandOutputFlush halts the throttle; dispose clears the timer", () => {
+    vi.useFakeTimers();
+    try {
+      const recording = createRecordingSink();
+      const display = createDisplayEventHandlers(recording.sink);
+      display.onToolCallStart({ toolCallId: "tc-1", toolName: "t" });
+
+      display.onCommandOutput({ data: "buffered\n" });
+      display.stopCommandOutputFlush();
+      vi.advanceTimersByTime(1000);
+      // Timer stopped — nothing flushed into the active tool's logs.
+      expect(recording.getMessages()[0].logs).toBeUndefined();
+
+      // Explicit flush still drains the buffer.
+      display.flushCommandOutput();
+      expect(recording.getMessages()[0].logs).toEqual(["buffered", ""]);
+
+      // dispose clears an active timer without flushing.
+      display.onCommandOutput({ data: "more\n" });
+      display.dispose();
+      vi.advanceTimersByTime(1000);
+      expect(recording.getMessages()[0].logs).toEqual(["buffered", ""]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("error projection sets the error and marks in-flight tools errored", () => {
+    const recording = createRecordingSink();
+    const display = createDisplayEventHandlers(recording.sink);
+    display.onToolCallStart({ toolCallId: "tc-1", toolName: "t" });
+
+    display.onError({ error: new Error("stream died") });
+
+    expect(recording.getErrors()).toEqual(["stream died"]);
+    const messages = recording.getMessages();
+    expect(messages[0]).toMatchObject({
+      status: "error",
+      result: "stream died",
+    });
+    display.dispose();
+  });
+
+  it("unparseable args deltas do not touch the display", () => {
+    const recording = createRecordingSink();
+    const display = createDisplayEventHandlers(recording.sink);
+    let updates = 0;
+    const countingSink = {
+      ...recording.sink,
+      updateMessages: (u: (m: DisplayMessage[]) => DisplayMessage[]) => {
+        updates++;
+        recording.sink.updateMessages(u);
+      },
+    };
+    const display2 = createDisplayEventHandlers(countingSink);
+
+    display2.onToolCallDelta({ toolCallId: "tc-1", argsTextDelta: '{"comm' });
+    expect(updates).toBe(0);
+
+    display.dispose();
   });
 });

--- a/src/tui/components/operator-dashboard/run-events.ts
+++ b/src/tui/components/operator-dashboard/run-events.ts
@@ -1,9 +1,21 @@
 import type { AgentEventBus, AgentEventMap } from "../../../core/eventBus";
+import type { DisplayMessage } from "../agent-display";
+import { tryParsePartialJson } from "../shared/message-utils";
+import {
+  appendStreamedText,
+  applyToolCall,
+  applyToolCallDelta,
+  applyToolResult,
+  markInFlightToolsErrored,
+  mergeCommandOutput,
+  startStreamingToolCall,
+} from "./display-state";
 
 // ---------------------------------------------------------------------------
 // Run event subscription lifecycle — owns subscription, generation filtering,
-// and cleanup for one agent run's bus listeners. Handler behavior stays with
-// the caller (O4/O5 will move the projections in behind this boundary).
+// and cleanup for one agent run's bus listeners. Display projections live
+// here too (createDisplayEventHandlers); workflow/subagent/question
+// projections follow in later slices.
 // ---------------------------------------------------------------------------
 
 export interface OperatorRunEventHandlers {
@@ -89,5 +101,150 @@ export function bindOperatorRunEvents(
     // any other post-run event instead of crashing the process. The bus is
     // per-run and unreferenced after the run, so the listener dies with it.
     if (boundError) bus.on("error", () => {});
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Display event projections — root-level text, tool, error, and command-output
+// projections over a narrow display sink. Subagent routing, questions
+// interception, and workflow phases stay with the caller.
+// ---------------------------------------------------------------------------
+
+/** Narrow sink: the only ways run events may touch display state. */
+export interface DisplayEventSink {
+  /** Apply an immutable update to the display message list. */
+  updateMessages: (
+    updater: (messages: DisplayMessage[]) => DisplayMessage[],
+  ) => void;
+  setThinking: (thinking: boolean) => void;
+  setError: (message: string) => void;
+}
+
+export interface DisplayEventAdapter {
+  onTextDelta(e: AgentEventMap["text-delta"]): void;
+  onToolCallStart(e: AgentEventMap["tool-call-start"]): void;
+  onToolCallDelta(e: AgentEventMap["tool-call-delta"]): void;
+  onToolCallComplete(e: AgentEventMap["tool-call-complete"]): void;
+  onToolResult(e: AgentEventMap["tool-result"]): void;
+  onCommandOutput(e: AgentEventMap["command-output"]): void;
+  onError(e: AgentEventMap["error"]): void;
+  /** Partial streamed assistant text so far — abort recovery reads it. */
+  getPartialText(): string;
+  resetPartialText(): void;
+  /** Flush buffered command output into the display immediately. */
+  flushCommandOutput(): void;
+  /** Stop the throttled command-output flush timer. */
+  stopCommandOutputFlush(): void;
+  /** Clear the flush timer (unmount). */
+  dispose(): void;
+}
+
+const COMMAND_OUTPUT_FLUSH_MS = 150;
+
+/**
+ * Root display projections with their accumulation state: the partial text
+ * buffer, per-tool-call args-delta buffers, and the throttled command-output
+ * buffer. Component-lifetime — create once, hand the handlers to
+ * {@link bindOperatorRunEvents}, dispose on unmount.
+ */
+export function createDisplayEventHandlers(
+  sink: DisplayEventSink,
+): DisplayEventAdapter {
+  let partialText = "";
+  const toolArgsDeltas = new Map<string, { accumulated: string }>();
+  let commandOutputBuf = "";
+  let flushTimer: ReturnType<typeof setInterval> | null = null;
+
+  const flushCommandOutput = (): void => {
+    if (!commandOutputBuf) return;
+    const buf = commandOutputBuf;
+    commandOutputBuf = "";
+    sink.updateMessages((messages) => mergeCommandOutput(messages, buf));
+  };
+
+  const stopCommandOutputFlush = (): void => {
+    if (flushTimer) {
+      clearInterval(flushTimer);
+      flushTimer = null;
+    }
+  };
+
+  return {
+    onTextDelta(e) {
+      sink.setThinking(false);
+      partialText += e.text;
+      const accumulated = partialText;
+      sink.updateMessages((messages) =>
+        appendStreamedText(messages, accumulated),
+      );
+    },
+    onToolCallStart(e) {
+      sink.setThinking(false);
+      partialText = "";
+      toolArgsDeltas.set(e.toolCallId, { accumulated: "" });
+      sink.updateMessages((messages) =>
+        startStreamingToolCall(messages, e.toolCallId, e.toolName),
+      );
+    },
+    onToolCallDelta(e) {
+      const entry = toolArgsDeltas.get(e.toolCallId);
+      const accumulated = (entry?.accumulated ?? "") + e.argsTextDelta;
+      toolArgsDeltas.set(e.toolCallId, { accumulated });
+
+      const parsed = tryParsePartialJson(accumulated);
+      if (!parsed) return;
+
+      sink.updateMessages((messages) =>
+        applyToolCallDelta(messages, e.toolCallId, parsed),
+      );
+    },
+    onToolCallComplete(e) {
+      sink.setThinking(false);
+      partialText = "";
+      toolArgsDeltas.delete(e.toolCallId);
+      const args =
+        e.args &&
+        typeof e.args === "object" &&
+        !Array.isArray(e.args) &&
+        e.args !== null
+          ? (e.args as Record<string, unknown>)
+          : undefined;
+      sink.updateMessages((messages) =>
+        applyToolCall(messages, e.toolCallId, e.toolName, args),
+      );
+    },
+    onToolResult(e) {
+      flushCommandOutput();
+      stopCommandOutputFlush();
+      sink.setThinking(true);
+      partialText = "";
+      sink.updateMessages((messages) =>
+        applyToolResult(messages, e.toolCallId, e.result),
+      );
+    },
+    onCommandOutput(e) {
+      commandOutputBuf += e.data;
+      if (!flushTimer) {
+        flushTimer = setInterval(flushCommandOutput, COMMAND_OUTPUT_FLUSH_MS);
+      }
+    },
+    onError(e) {
+      console.error("Agent error:", e.error);
+      const errorMessage =
+        e.error instanceof Error ? e.error.message : "Unknown error";
+      sink.setError(errorMessage);
+      sink.updateMessages((messages) =>
+        markInFlightToolsErrored(messages, errorMessage),
+      );
+    },
+    getPartialText() {
+      return partialText;
+    },
+    resetPartialText() {
+      partialText = "";
+    },
+    flushCommandOutput,
+    stopCommandOutputFlush,
+    dispose: stopCommandOutputFlush,
   };
 }

--- a/src/tui/components/shared/index.ts
+++ b/src/tui/components/shared/index.ts
@@ -20,7 +20,7 @@ export {
 } from "./markdown-viewer";
 export { MessageRenderer } from "./message-renderer";
 // Message utilities
-export { getStableMessageKey, tryParsePartialJson } from "./message-utils";
+export { getStableMessageKey } from "./message-utils";
 // Input components
 export {
   type AutocompleteOption,


### PR DESCRIPTION
## Stack

**4 of 5 (Stack A: OperatorDashboard)** — stacked on #977 (`refactor/run-event-binding`) ← #976 ← #975. Merge order: #975 → #976 → #977 → this PR → O5, retargeting to `canary` at each step.

## Summary

- move the root display projections (text, tool-input, tool-result, error, command-output) into the run-event adapter as `createDisplayEventHandlers(sink)`
- React setters stay behind a narrow 3-method `DisplayEventSink` (`updateMessages` / `setThinking` / `setError`); the adapter owns the partial-text buffer, per-tool args-delta buffers, and the throttled command-output buffer + 150 ms flush timer
- `markInFlightToolsErrored` moves to `display-state.ts` (it is a display transition; the abort path and error rollback import it from there)
- one full replay-trace test drives text → tool-input-start → deltas → tool-call → command-output → tool-result through the real bus + binding

## Motivation

O4 of Stack A. After O3 gave the subscriptions a tested boundary, the display projections were still component closures over four refs (`textRef`, `toolArgsDeltaRef`, `cmdOutputBufRef`, `cmdFlushTimerRef`) and seven `useCallback`s. The projections are deterministic event → display-state translations using the `display-state.ts` reducers from the earlier extraction — they belong behind the adapter boundary, testable without React.

## What changed

**`run-events.ts`** — new `createDisplayEventHandlers(sink)`:

- the seven root display handlers (`onTextDelta`, `onToolCallStart`, `onToolCallDelta`, `onToolCallComplete`, `onToolResult`, `onCommandOutput`, `onError`), each delegating to the existing `display-state.ts` production functions
- adapter-owned state: partial text (with `getPartialText`/`resetPartialText` for the abort path, workflow phase resets, and run starts), args-delta buffers, command-output buffer + flush timer
- exposed lifecycle: `flushCommandOutput` / `stopCommandOutputFlush` (used by the queue-return key handler), `dispose` (unmount)
- thinking toggles move with the projections: text/tool events clear, tool results set

**`index.tsx`:**

- one component-lifetime adapter instance behind a `useMemo` (the `useAgent()` `setThinking` is a stable `useState` setter, so the memo never re-runs); unmount effect disposes
- the handlers object now routes: subagent branch → `subagentHelpers` (unchanged), root branch → adapter; questions interception, submit-plan tracking, and `commandCancelledRef` stay in the component (per O4 non-goals)
- the seven callbacks, four refs, and their deps entries are deleted; `textRef` is gone entirely

**`display-state.ts`** — `markInFlightToolsErrored` moved here from `index.tsx`.

**`shared/index.ts`** — the `tryParsePartialJson` barrel re-export is dropped: its last barrel consumer was the component callback that moved into the adapter (which imports the leaf module directly, per the established vitest/barrel constraint). Same treatment as `extractStreamableContent` in #967.

## Behavior preserved

- partial text accumulates across deltas, resets on tool lifecycle events, run start, and workflow phase transitions
- unparseable args deltas never touch the display
- command output buffers and flushes on the 150 ms throttle; tool-result flushes + stops the timer before completing; the queue-return handler flushes + stops before starting a new run; unmount clears the timer
- command output with no active tool message is drained-and-dropped (pre-existing `mergeCommandOutput` semantics, now pinned by a test)
- error projection: `setError` + in-flight tools marked errored with the message

## Test coverage

5 new tests in `run-events.test.ts` (11 total in the file):

- **the replay trace** — two text deltas → tool-call-start → two args deltas (partial JSON) → tool-call-complete → command-output → tool-result, driven through a real `AgentEventBus` + `bindOperatorRunEvents`; asserts the final two-message display state (assistant text, completed tool with args/logs/result) and the full thinking-toggle sequence
- command output buffers and flushes on the 150 ms timer (fake timers); a drained buffer flushes nothing on later ticks
- `stopCommandOutputFlush` halts the throttle; explicit flush still drains; `dispose` clears an active timer without flushing
- error projection sets the error and marks in-flight tools errored
- unparseable args deltas produce zero display updates

## Validation

- `bun run test` (1,620 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the touched files

## Notes

- non-goals honored: subagents, questions, and workflow phases remain component-side and land in O5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior-preserving tests and no auth or persistence changes; risk is limited to operator TUI display timing during agent runs.
> 
> **Overview**
> **Operator dashboard streaming UI logic** is extracted out of the React component into a testable **`createDisplayEventHandlers`** adapter in `run-events.ts`, wired through a narrow sink (`updateMessages`, `setThinking`, `setError`).
> 
> The adapter now owns partial assistant text, per-tool args JSON buffers, and **150ms-throttled command output** (with flush/stop/dispose hooks used on abort, queue-return, and unmount). `OperatorDashboard` delegates root bus events to this adapter while **subagent routing, questions, and workflow** handling stay in the component.
> 
> **`markInFlightToolsErrored`** moves to `display-state.ts`; **`tryParsePartialJson`** is no longer re-exported from the shared barrel. Five new unit tests cover full streaming replay, command-output timing, errors, and partial JSON behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 060e55d5912ff467c0e0c1bca354d360b2f6e39f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->