### PR TITLE
feat(models): add Ox Alpha to OpenRouter

### DIFF
--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -190,6 +190,13 @@ function lookupOutputBudgetByPattern(modelId: string): number {
     return 131_072;
   }
 
+  // Ox Alpha (stealth) ships a ~131K (128Ki) max-output window over its 1M
+  // context — reasoning tokens share this budget, so don't let it fall to the
+  // 4,096 catch-all.
+  if (modelId.includes("ox-alpha")) {
+    return 131_072;
+  }
+
   // DeepSeek (V3.1, R1, chat). Bedrock documents an 8K output window for
   // DeepSeek V3.1; the rest of the family is no larger, so this is a safe floor
   // that keeps new `deepseek.*` ids off the 4,096 catch-all.

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -56,6 +56,10 @@ describe("getMaxOutputTokens", () => {
     expect(getMaxOutputTokens("zai.glm-5")).toBe(131_072);
   });
 
+  it("recognizes Ox Alpha's 131.1K max-output window", () => {
+    expect(getMaxOutputTokens("stealth/ox-alpha")).toBe(131_072);
+  });
+
   it("recognizes the new Bedrock DeepSeek / Qwen output budgets", () => {
     // These three were silently inheriting the 4,096 catch-all, capping
     // replies far below each model's documented Bedrock limit.

--- a/src/core/ai/models/openrouter.ts
+++ b/src/core/ai/models/openrouter.ts
@@ -231,4 +231,10 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
     provider: "openrouter",
     contextLength: 1000000,
   },
+  {
+    id: "stealth/ox-alpha",
+    name: "Ox Alpha",
+    provider: "openrouter",
+    contextLength: 1000000,
+  },
 ];


### PR DESCRIPTION
## Summary
- Register `stealth/ox-alpha` (Ox Alpha), 1M context, in `OPENROUTER_MODELS`
- Follows the existing pattern for OpenRouter model additions (e.g. Kimi K3)

## Verification
- `tsc --noEmit` clean
- `src/core/ai/models/models.test.ts` — 23 tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry and output-token lookup changes only; no auth, routing, or runtime behavior beyond correct max-token limits for the new model ID.
> 
> **Overview**
> Adds **Ox Alpha** (`stealth/ox-alpha`) to the curated OpenRouter model list with a **1M** context window so it appears in `AVAILABLE_MODELS` like other manually registered OpenRouter IDs.
> 
> Extends **`getMaxOutputTokens`** with an `ox-alpha` pattern returning **131,072** tokens (same tier as GLM 5), so streaming and context budgeting do not fall through to the **4,096** default—important because reasoning tokens share that output cap.
> 
> Includes a regression test that pins `stealth/ox-alpha` to the **131.1K** output budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac33861b452997182271cdd80c1b9f6ac59033a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->