### PR TITLE
refactor(operator): move remaining event projections into run event adapter

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -119,6 +119,7 @@ import { QueuedMessages } from "./queued-messages";
 import {
   bindOperatorRunEvents,
   createDisplayEventHandlers,
+  createRunEventProjections,
 } from "./run-events";
 import { RunTraceSession } from "./run-tracing";
 import SubagentDialog from "./subagent-dialog";
@@ -129,14 +130,7 @@ import {
   markSubagentsInterrupted,
 } from "./subagent-state";
 import { SubagentStatusBar } from "./subagent-status-bar";
-import {
-  applyWorkflowPhaseComplete,
-  applyWorkflowPhaseStart,
-  applyWorkflowSubagentComplete,
-  applyWorkflowSubagentSpawn,
-  isPentestAgent,
-  updateWorkflowDataMessage,
-} from "./workflow-data";
+import { updateWorkflowDataMessage } from "./workflow-data";
 
 /**
  * Operator Dashboard - interactive chat interface with the offensive security agent
@@ -603,6 +597,47 @@ export default function OperatorDashboard({
   }, [displayEvents]);
 
   // ---------------------------------------------------------------------------
+  // Run event projections — subagent routing, questions interception, and
+  // workflow phases layered over the display projections. Component state
+  // changes stay behind the injected callbacks.
+  // ---------------------------------------------------------------------------
+
+  const updateWorkflowData = useCallback(
+    (updater: (wd: WorkflowData) => WorkflowData) => {
+      setMessages((prev) => updateWorkflowDataMessage(prev, updater));
+    },
+    [],
+  );
+
+  const runEventProjections = useMemo(
+    () =>
+      createRunEventProjections({
+        display: displayEvents,
+        subagents: subagentHelpers,
+        updateWorkflowData,
+        clearSubagentSessions: () => subagentStore.setState(new Map()),
+        questions: {
+          onAsked: (toolCallId, questions) => {
+            pendingToolCallIdRef.current = toolCallId;
+            setPendingQuestions(questions);
+          },
+          onCleared: () => {
+            pendingToolCallIdRef.current = null;
+            setPendingQuestions(null);
+          },
+        },
+        onRootToolCallStarted: () => {
+          commandCancelledRef.current = false;
+        },
+        onPlanSubmitted: () => {
+          planSubmittedRef.current = true;
+          planGateBypassedOnResumeRef.current = false;
+        },
+      }),
+    [displayEvents, subagentHelpers, updateWorkflowData, subagentStore],
+  );
+
+  // ---------------------------------------------------------------------------
   // Approval handlers
   // ---------------------------------------------------------------------------
 
@@ -731,165 +766,9 @@ export default function OperatorDashboard({
         recordTokenUsage,
       });
 
-      // Patch the workflowData on the active run_pentest_workflow tool message.
-      const updateWorkflowData = (
-        updater: (wd: WorkflowData) => WorkflowData,
-      ) => {
-        setMessages((prev) => updateWorkflowDataMessage(prev, updater));
-      };
-
       const unbindRunEvents = bindOperatorRunEvents(eventBus, {
         isCurrent: () => gen === generationRef.current,
-        handlers: {
-          onTextDelta: (d) => {
-            if (d.subagentId) {
-              subagentHelpers.appendText(d.subagentId, d.text);
-              return;
-            }
-            displayEvents.onTextDelta(d);
-          },
-          onToolCallStart: (d) => {
-            if (d.subagentId) {
-              subagentHelpers.addStreamingToolCall(
-                d.subagentId,
-                d.toolCallId,
-                d.toolName,
-              );
-              return;
-            }
-            displayEvents.onToolCallStart(d);
-          },
-          onToolCallDelta: (d) => {
-            if (d.subagentId) {
-              subagentHelpers.appendToolCallDelta(
-                d.subagentId,
-                d.toolCallId,
-                d.argsTextDelta,
-              );
-              return;
-            }
-            displayEvents.onToolCallDelta(d);
-          },
-          onToolCallComplete: (d) => {
-            if (d.subagentId) {
-              const args =
-                d.args &&
-                typeof d.args === "object" &&
-                !Array.isArray(d.args) &&
-                d.args !== null
-                  ? (d.args as Record<string, unknown>)
-                  : {};
-              subagentHelpers.addToolCall(
-                d.subagentId,
-                d.toolCallId,
-                d.toolName,
-                args,
-              );
-              return;
-            }
-            displayEvents.onToolCallComplete(d);
-            commandCancelledRef.current = false;
-
-            if (d.toolName === ASK_USER_QUESTIONS_TOOL_NAME) {
-              const args =
-                d.args &&
-                typeof d.args === "object" &&
-                !Array.isArray(d.args) &&
-                d.args !== null
-                  ? (d.args as Record<string, unknown>)
-                  : undefined;
-              const rawQuestions = args?.questions;
-              if (Array.isArray(rawQuestions) && rawQuestions.length > 0) {
-                pendingToolCallIdRef.current = d.toolCallId;
-                setPendingQuestions(rawQuestions as AskUserQuestion[]);
-              }
-            }
-          },
-          onToolResult: (d) => {
-            if (d.subagentId) {
-              subagentHelpers.updateToolResult(
-                d.subagentId,
-                d.toolCallId,
-                d.result,
-              );
-              return;
-            }
-            displayEvents.onToolResult(d);
-
-            // Track submit_plan success — review triggers after the run completes
-            if (
-              d.toolName === "submit_plan" &&
-              (d.result as Record<string, unknown> | null)?.success === true
-            ) {
-              planSubmittedRef.current = true;
-              planGateBypassedOnResumeRef.current = false;
-            }
-          },
-          onCommandOutput: (d) => {
-            if (d.subagentId) return;
-            displayEvents.onCommandOutput(d);
-          },
-          onError: (d) => {
-            if (d.subagentId) {
-              const errMsg =
-                d.error instanceof Error ? d.error.message : "Unknown error";
-              subagentHelpers.appendText(d.subagentId, `\nError: ${errMsg}\n`);
-              return;
-            }
-            displayEvents.onError(d);
-            // Clear pending-questions state so an error after the tool-call event
-            // doesn't leave the questions form stuck over a failed conversation.
-            pendingToolCallIdRef.current = null;
-            setPendingQuestions(null);
-          },
-          onSubagentSpawn: ({ subagentId, name }) => {
-            // Hide whitebox per-app synthetic grouping nodes until #744 lands a hierarchical view.
-            if (subagentId.startsWith("app:")) return;
-            subagentHelpers.spawnSession(subagentId, name);
-            if (!isPentestAgent(subagentId)) return;
-            // Pentest swarm agents → workflowData.pentesting.subagents
-            updateWorkflowData((wd) =>
-              applyWorkflowSubagentSpawn(wd, subagentId, name),
-            );
-          },
-          onSubagentComplete: ({ subagentId, status }) => {
-            // Mirror the spawn-handler filter: synthetic per-app grouping nodes
-            // were never registered as sessions, so don't try to complete them.
-            if (subagentId.startsWith("app:")) return;
-            subagentHelpers.completeSession(subagentId, status);
-            if (!isPentestAgent(subagentId)) return;
-            // Update workflowData swarm status
-            updateWorkflowData((wd) =>
-              applyWorkflowSubagentComplete(wd, subagentId, status),
-            );
-          },
-          // Workflow phase events → update workflowData on the tool message
-          onWorkflowPhaseStart: (d) => {
-            displayEvents.resetPartialText();
-            // New workflow run — clear old subagent sessions so the hub
-            // shows only the current batch.
-            if (d.phase === "discovery") {
-              subagentStore.setState(new Map());
-            }
-            updateWorkflowData((wd) =>
-              applyWorkflowPhaseStart(
-                wd,
-                d.phase as WorkflowData["currentPhase"],
-                d.label,
-              ),
-            );
-          },
-          onWorkflowPhaseComplete: (d) => {
-            displayEvents.resetPartialText();
-            updateWorkflowData((wd) =>
-              applyWorkflowPhaseComplete(
-                wd,
-                d.phase as WorkflowData["currentPhase"],
-                d.summary,
-              ),
-            );
-          },
-        },
+        handlers: runEventProjections.handlers,
       });
 
       const skillsCatalog = skillsRegistry.buildCatalog() || undefined;
@@ -1113,7 +992,7 @@ export default function OperatorDashboard({
       agentMode,
       addTokenUsage,
       displayEvents,
-      subagentHelpers,
+      runEventProjections,
       setThinking,
       setIsExecuting,
       addCacheUsage,
@@ -1125,7 +1004,6 @@ export default function OperatorDashboard({
       strikeMode,
       route.data,
       setSessionCwd,
-      subagentStore.setState,
       skillsRegistry.buildCatalog,
       requireApproval,
       skillsRegistry,

--- a/src/tui/components/operator-dashboard/run-events.test.ts
+++ b/src/tui/components/operator-dashboard/run-events.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AgentEventBus, AgentEventMap } from "../../../core/eventBus";
 import { AgentEventBus as Bus } from "../../../core/eventBus";
-import type { DisplayMessage } from "../agent-display";
+import type { DisplayMessage, WorkflowData } from "../agent-display";
 import {
   bindOperatorRunEvents,
   createDisplayEventHandlers,
+  createRunEventProjections,
   type OperatorRunEventHandlers,
+  type SubagentEventSink,
 } from "./run-events";
+import { initialWorkflowData } from "./workflow-data";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -429,5 +432,275 @@ describe("createDisplayEventHandlers", () => {
     expect(updates).toBe(0);
 
     display.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createRunEventProjections — subagent routing, questions, workflow phases
+// ---------------------------------------------------------------------------
+
+describe("createRunEventProjections", () => {
+  function setup(current = true) {
+    let messages: DisplayMessage[] = [];
+    const display = createDisplayEventHandlers({
+      updateMessages: (u) => {
+        messages = u(messages);
+      },
+      setThinking: () => {},
+      setError: () => {},
+    });
+    const subagents: SubagentEventSink = {
+      appendText: vi.fn(),
+      addStreamingToolCall: vi.fn(),
+      appendToolCallDelta: vi.fn(),
+      addToolCall: vi.fn(),
+      updateToolResult: vi.fn(),
+      spawnSession: vi.fn(),
+      completeSession: vi.fn(),
+    };
+    const workflowUpdaters: Array<(wd: WorkflowData) => WorkflowData> = [];
+    const clearSubagentSessions = vi.fn();
+    const onAsked = vi.fn();
+    const onCleared = vi.fn();
+    const onRootToolCallStarted = vi.fn();
+    const onPlanSubmitted = vi.fn();
+    const projections = createRunEventProjections({
+      display,
+      subagents,
+      updateWorkflowData: (u) => workflowUpdaters.push(u),
+      clearSubagentSessions,
+      questions: { onAsked, onCleared },
+      onRootToolCallStarted,
+      onPlanSubmitted,
+    });
+    const bus = new Bus();
+    const unbind = bindOperatorRunEvents(bus, {
+      isCurrent: () => current,
+      handlers: projections.handlers,
+    });
+    return {
+      display,
+      subagents,
+      workflowUpdaters,
+      clearSubagentSessions,
+      onAsked,
+      onCleared,
+      onRootToolCallStarted,
+      onPlanSubmitted,
+      bus,
+      unbind,
+      getMessages: () => messages,
+    };
+  }
+
+  it("routes root events to the display and subagent events to the sink", () => {
+    const s = setup();
+
+    s.bus.emit("text-delta", { text: "root text" });
+    s.bus.emit("text-delta", { text: " sub", subagentId: "pentest-agent-1" });
+    expect(s.getMessages()).toHaveLength(1);
+    expect(s.getMessages()[0]).toMatchObject({
+      role: "assistant",
+      content: "root text",
+    });
+    expect(s.subagents.appendText).toHaveBeenCalledWith(
+      "pentest-agent-1",
+      " sub",
+    );
+
+    s.bus.emit("tool-call-start", {
+      toolCallId: "tc-sub",
+      toolName: "t",
+      subagentId: "pentest-agent-1",
+    });
+    expect(s.subagents.addStreamingToolCall).toHaveBeenCalledWith(
+      "pentest-agent-1",
+      "tc-sub",
+      "t",
+    );
+    expect(s.getMessages()).toHaveLength(1);
+
+    // Subagent command output is dropped entirely.
+    s.bus.emit("command-output", { data: "x", subagentId: "pentest-agent-1" });
+    expect(s.getMessages()).toHaveLength(1);
+
+    s.bus.emit("error", {
+      error: new Error("sub fail"),
+      subagentId: "pentest-agent-1",
+    });
+    expect(s.subagents.appendText).toHaveBeenCalledWith(
+      "pentest-agent-1",
+      expect.stringContaining("sub fail"),
+    );
+    expect(s.getMessages()).toHaveLength(1);
+
+    // Subagent tool-call-complete falls back to {} args.
+    s.bus.emit("tool-call-complete", {
+      toolCallId: "tc-sub",
+      toolName: "t",
+      args: undefined,
+      subagentId: "pentest-agent-1",
+    });
+    expect(s.subagents.addToolCall).toHaveBeenCalledWith(
+      "pentest-agent-1",
+      "tc-sub",
+      "t",
+      {},
+    );
+    s.unbind();
+  });
+
+  it("drops every projection for stale generations", () => {
+    const s = setup(false);
+
+    s.bus.emit("text-delta", { text: "stale" });
+    s.bus.emit("subagent-spawn", {
+      subagentId: "pentest-agent-1",
+      input: {},
+    });
+    s.bus.emit("workflow-phase-start", { phase: "discovery", label: "Recon" });
+
+    expect(s.getMessages()).toHaveLength(0);
+    expect(s.subagents.spawnSession).not.toHaveBeenCalled();
+    expect(s.clearSubagentSessions).not.toHaveBeenCalled();
+    expect(s.workflowUpdaters).toHaveLength(0);
+    s.unbind();
+  });
+
+  it("intercepts ask_user_questions and fires root tool-call hooks", () => {
+    const s = setup();
+
+    s.bus.emit("tool-call-complete", {
+      toolCallId: "q1",
+      toolName: "ask_user_questions",
+      args: { questions: [{ id: "x", question: "which?" }] },
+    });
+    expect(s.onAsked).toHaveBeenCalledWith("q1", [
+      { id: "x", question: "which?" },
+    ]);
+    expect(s.onRootToolCallStarted).toHaveBeenCalledTimes(1);
+
+    // Empty questions batch — no interception.
+    s.bus.emit("tool-call-complete", {
+      toolCallId: "q2",
+      toolName: "ask_user_questions",
+      args: { questions: [] },
+    });
+    expect(s.onAsked).toHaveBeenCalledTimes(1);
+
+    // Non-question tool — no interception, hook still fires.
+    s.bus.emit("tool-call-complete", {
+      toolCallId: "tc-1",
+      toolName: "execute_command",
+      args: { command: "ls" },
+    });
+    expect(s.onAsked).toHaveBeenCalledTimes(1);
+    // Three root tool-call-completes total (q1, empty q2, tc-1).
+    expect(s.onRootToolCallStarted).toHaveBeenCalledTimes(3);
+    s.unbind();
+  });
+
+  it("clears questions on root error and tracks submit_plan success", () => {
+    const s = setup();
+
+    s.bus.emit("error", { error: new Error("boom") });
+    expect(s.onCleared).toHaveBeenCalledTimes(1);
+
+    s.bus.emit("tool-result", {
+      toolCallId: "p1",
+      toolName: "submit_plan",
+      result: { success: true },
+    });
+    expect(s.onPlanSubmitted).toHaveBeenCalledTimes(1);
+
+    // Unsuccessful submit_plan — no gating flip.
+    s.bus.emit("tool-result", {
+      toolCallId: "p2",
+      toolName: "submit_plan",
+      result: { success: false },
+    });
+    expect(s.onPlanSubmitted).toHaveBeenCalledTimes(1);
+    s.unbind();
+  });
+
+  it("projects workflow phases and the subagent swarm", () => {
+    const s = setup();
+
+    s.bus.emit("text-delta", { text: "partial" });
+    s.bus.emit("workflow-phase-start", { phase: "discovery", label: "Recon" });
+    expect(s.display.getPartialText()).toBe("");
+    expect(s.clearSubagentSessions).toHaveBeenCalledTimes(1);
+    const discovery = s.workflowUpdaters[0](initialWorkflowData());
+    expect(discovery.currentPhase).toBe("discovery");
+    expect(discovery.discovery.label).toBe("Recon");
+
+    // Non-discovery phase start does not clear sessions again.
+    s.bus.emit("workflow-phase-start", {
+      phase: "pentesting",
+      label: "Exploit",
+    });
+    expect(s.clearSubagentSessions).toHaveBeenCalledTimes(1);
+
+    // Synthetic app: nodes are dropped before any bookkeeping.
+    s.bus.emit("subagent-spawn", { subagentId: "app:foo", input: {} });
+    expect(s.subagents.spawnSession).not.toHaveBeenCalled();
+
+    // Swarm agents register in the workflow; other subagents do not.
+    s.bus.emit("subagent-spawn", {
+      subagentId: "pentest-agent-1",
+      name: "A1",
+      input: {},
+    });
+    expect(s.subagents.spawnSession).toHaveBeenCalledWith(
+      "pentest-agent-1",
+      "A1",
+    );
+    const spawned = s.workflowUpdaters.at(-1)?.(initialWorkflowData());
+    expect(spawned?.pentesting.subagents["pentest-agent-1"]).toMatchObject({
+      name: "A1",
+      status: "pending",
+    });
+
+    s.bus.emit("subagent-spawn", { subagentId: "discovery-agent", input: {} });
+    expect(s.subagents.spawnSession).toHaveBeenCalledWith(
+      "discovery-agent",
+      undefined,
+    );
+    expect(s.workflowUpdaters).toHaveLength(3);
+
+    s.bus.emit("subagent-complete", {
+      subagentId: "pentest-agent-1",
+      status: "completed",
+    });
+    expect(s.subagents.completeSession).toHaveBeenCalledWith(
+      "pentest-agent-1",
+      "completed",
+    );
+    const completed = s.workflowUpdaters.at(-1)?.(spawned as WorkflowData);
+    expect(completed?.pentesting.subagents["pentest-agent-1"].status).toBe(
+      "completed",
+    );
+
+    s.bus.emit("workflow-phase-complete", {
+      phase: "reporting",
+      summary: { findingsCount: 2 },
+    });
+    const reported = s.workflowUpdaters.at(-1)?.(completed as WorkflowData);
+    expect(reported?.currentPhase).toBe("complete");
+    expect(reported?.reporting.findingsCount).toBe(2);
+    s.unbind();
+  });
+
+  it("cleanup stops all forwarding", () => {
+    const s = setup();
+    s.unbind();
+
+    s.bus.emit("text-delta", { text: "after" });
+    s.bus.emit("subagent-spawn", { subagentId: "pentest-agent-1", input: {} });
+    s.bus.emit("workflow-phase-start", { phase: "discovery", label: "R" });
+
+    expect(s.getMessages()).toHaveLength(0);
+    expect(s.subagents.spawnSession).not.toHaveBeenCalled();
+    expect(s.workflowUpdaters).toHaveLength(0);
   });
 });

--- a/src/tui/components/operator-dashboard/run-events.ts
+++ b/src/tui/components/operator-dashboard/run-events.ts
@@ -1,5 +1,9 @@
+import {
+  ASK_USER_QUESTIONS_TOOL_NAME,
+  type AskUserQuestion,
+} from "../../../core/agents/offSecAgent";
 import type { AgentEventBus, AgentEventMap } from "../../../core/eventBus";
-import type { DisplayMessage } from "../agent-display";
+import type { DisplayMessage, WorkflowData } from "../agent-display";
 import { tryParsePartialJson } from "../shared/message-utils";
 import {
   appendStreamedText,
@@ -10,6 +14,13 @@ import {
   mergeCommandOutput,
   startStreamingToolCall,
 } from "./display-state";
+import {
+  applyWorkflowPhaseComplete,
+  applyWorkflowPhaseStart,
+  applyWorkflowSubagentComplete,
+  applyWorkflowSubagentSpawn,
+  isPentestAgent,
+} from "./workflow-data";
 
 // ---------------------------------------------------------------------------
 // Run event subscription lifecycle — owns subscription, generation filtering,
@@ -246,5 +257,206 @@ export function createDisplayEventHandlers(
     flushCommandOutput,
     stopCommandOutputFlush,
     dispose: stopCommandOutputFlush,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Run event projections — the full handler set: root-vs-subagent routing,
+// questions interception, workflow phases, and subagent swarm bookkeeping,
+// layered over the display projections. Component-specific state changes
+// (questions state, command-cancel flag, plan-review gating) stay behind
+// injected callbacks.
+// ---------------------------------------------------------------------------
+
+/** Structural subset of createSubagentSessionHelpers used by the projections. */
+export interface SubagentEventSink {
+  appendText(id: string, text: string): void;
+  addStreamingToolCall(id: string, toolCallId: string, toolName: string): void;
+  appendToolCallDelta(
+    id: string,
+    toolCallId: string,
+    argsTextDelta: string,
+  ): void;
+  addToolCall(
+    id: string,
+    toolCallId: string,
+    toolName: string,
+    args?: Record<string, unknown>,
+  ): void;
+  updateToolResult(id: string, toolCallId: string, result: unknown): void;
+  spawnSession(id: string, name?: string, input?: unknown): void;
+  completeSession(id: string, status: "completed" | "failed"): void;
+}
+
+export interface RunEventProjectionDeps {
+  display: DisplayEventAdapter;
+  subagents: SubagentEventSink;
+  /** Patch the active run_pentest_workflow tool message's workflowData. */
+  updateWorkflowData: (updater: (wd: WorkflowData) => WorkflowData) => void;
+  /** Clear all subagent sessions (new discovery phase). */
+  clearSubagentSessions: () => void;
+  /** Ask-user-questions lifecycle, wired to component state. */
+  questions: {
+    onAsked: (toolCallId: string, questions: AskUserQuestion[]) => void;
+    onCleared: () => void;
+  };
+  /** A root tool call began executing (resets the command-cancel flag). */
+  onRootToolCallStarted?: () => void;
+  /** A submit_plan tool result reported success (plan-review gating). */
+  onPlanSubmitted?: () => void;
+}
+
+function toRecordArgs(args: unknown): Record<string, unknown> | undefined {
+  return args &&
+    typeof args === "object" &&
+    !Array.isArray(args) &&
+    args !== null
+    ? (args as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * The complete run-event handler set for {@link bindOperatorRunEvents}.
+ * Routing: events carrying a `subagentId` project into that subagent's
+ * session; root events project into the display. Generation filtering and
+ * cleanup are owned by the binding, not the projections.
+ */
+export function createRunEventProjections(deps: RunEventProjectionDeps): {
+  handlers: OperatorRunEventHandlers;
+} {
+  const { display, subagents, updateWorkflowData } = deps;
+
+  return {
+    handlers: {
+      onTextDelta: (d) => {
+        if (d.subagentId) {
+          subagents.appendText(d.subagentId, d.text);
+          return;
+        }
+        display.onTextDelta(d);
+      },
+      onToolCallStart: (d) => {
+        if (d.subagentId) {
+          subagents.addStreamingToolCall(
+            d.subagentId,
+            d.toolCallId,
+            d.toolName,
+          );
+          return;
+        }
+        display.onToolCallStart(d);
+      },
+      onToolCallDelta: (d) => {
+        if (d.subagentId) {
+          subagents.appendToolCallDelta(
+            d.subagentId,
+            d.toolCallId,
+            d.argsTextDelta,
+          );
+          return;
+        }
+        display.onToolCallDelta(d);
+      },
+      onToolCallComplete: (d) => {
+        if (d.subagentId) {
+          subagents.addToolCall(
+            d.subagentId,
+            d.toolCallId,
+            d.toolName,
+            toRecordArgs(d.args) ?? {},
+          );
+          return;
+        }
+        display.onToolCallComplete(d);
+        deps.onRootToolCallStarted?.();
+
+        if (d.toolName === ASK_USER_QUESTIONS_TOOL_NAME) {
+          const rawQuestions = toRecordArgs(d.args)?.questions;
+          if (Array.isArray(rawQuestions) && rawQuestions.length > 0) {
+            deps.questions.onAsked(
+              d.toolCallId,
+              rawQuestions as AskUserQuestion[],
+            );
+          }
+        }
+      },
+      onToolResult: (d) => {
+        if (d.subagentId) {
+          subagents.updateToolResult(d.subagentId, d.toolCallId, d.result);
+          return;
+        }
+        display.onToolResult(d);
+
+        if (
+          d.toolName === "submit_plan" &&
+          (d.result as Record<string, unknown> | null)?.success === true
+        ) {
+          deps.onPlanSubmitted?.();
+        }
+      },
+      onCommandOutput: (d) => {
+        if (d.subagentId) return;
+        display.onCommandOutput(d);
+      },
+      onError: (d) => {
+        if (d.subagentId) {
+          const errMsg =
+            d.error instanceof Error ? d.error.message : "Unknown error";
+          subagents.appendText(d.subagentId, `\nError: ${errMsg}\n`);
+          return;
+        }
+        display.onError(d);
+        // Clear pending-questions state so an error after the tool-call event
+        // doesn't leave the questions form stuck over a failed conversation.
+        deps.questions.onCleared();
+      },
+      onSubagentSpawn: ({ subagentId, name }) => {
+        // Hide whitebox per-app synthetic grouping nodes until #744 lands a hierarchical view.
+        if (subagentId.startsWith("app:")) return;
+        subagents.spawnSession(subagentId, name);
+        if (!isPentestAgent(subagentId)) return;
+        // Pentest swarm agents → workflowData.pentesting.subagents
+        updateWorkflowData((wd) =>
+          applyWorkflowSubagentSpawn(wd, subagentId, name),
+        );
+      },
+      onSubagentComplete: ({ subagentId, status }) => {
+        // Mirror the spawn-handler filter: synthetic per-app grouping nodes
+        // were never registered as sessions, so don't try to complete them.
+        if (subagentId.startsWith("app:")) return;
+        subagents.completeSession(subagentId, status);
+        if (!isPentestAgent(subagentId)) return;
+        // Update workflowData swarm status
+        updateWorkflowData((wd) =>
+          applyWorkflowSubagentComplete(wd, subagentId, status),
+        );
+      },
+      // Workflow phase events → update workflowData on the tool message
+      onWorkflowPhaseStart: (d) => {
+        display.resetPartialText();
+        // New workflow run — clear old subagent sessions so the hub
+        // shows only the current batch.
+        if (d.phase === "discovery") {
+          deps.clearSubagentSessions();
+        }
+        updateWorkflowData((wd) =>
+          applyWorkflowPhaseStart(
+            wd,
+            d.phase as WorkflowData["currentPhase"],
+            d.label,
+          ),
+        );
+      },
+      onWorkflowPhaseComplete: (d) => {
+        display.resetPartialText();
+        updateWorkflowData((wd) =>
+          applyWorkflowPhaseComplete(
+            wd,
+            d.phase as WorkflowData["currentPhase"],
+            d.summary,
+          ),
+        );
+      },
+    },
   };
 }


### PR DESCRIPTION
## Stack

**5 of 5 (Stack A: OperatorDashboard)** — stacked on #978 (`refactor/display-event-projections`) ← #977 ← #976 ← #975. Merge order: #975 → #976 → #977 → #978 → this PR, retargeting to `canary` at each step.

## Summary

- move the remaining run-event handlers into the adapter as `createRunEventProjections(deps)`: root-vs-subagent routing, questions interception, workflow phases, and subagent swarm bookkeeping
- component state changes stay behind injected callbacks — `questions.onAsked/onCleared` (pending questions state), `onRootToolCallStarted` (command-cancel flag reset), `onPlanSubmitted` (plan-review gating), `clearSubagentSessions` (discovery-phase hub reset)
- `runAgent`'s ~150-line handlers object collapses to `handlers: runEventProjections.handlers`

## Motivation

O5 closes Stack A. After O3 (subscription lifecycle) and O4 (display projections), the only handler logic left in the component was routing and component-state wiring. With the full projection set behind the adapter boundary, `runAgent` no longer contains any event-handler bodies — it is agent construction, run I/O, and result persistence only, which were this slice's stated non-goals.

## What changed

**`run-events.ts`** — new `createRunEventProjections(deps)` returning the complete `OperatorRunEventHandlers`:

- **routing** — every event carrying a `subagentId` projects into that subagent's session via a structural `SubagentEventSink` (satisfied by `createSubagentSessionHelpers`); root events project into the O4 display adapter. Subagent `command-output` is dropped; subagent tool-call-complete falls back to `{}` args.
- **questions** — root `ask_user_questions` tool-call-complete with a non-empty questions batch fires `questions.onAsked(toolCallId, questions)`; root errors fire `questions.onCleared()`.
- **workflow** — phase start/complete project through the `workflow-data.ts` functions; discovery start also resets the partial text and clears subagent sessions; swarm agents (`pentest-agent-N`) register/complete in `workflowData.pentesting.subagents` with the `app:` synthetic-node filter preserved.
- **hooks** — `onRootToolCallStarted` fires on every root tool-call-complete (command-cancel flag reset); `onPlanSubmitted` fires only on a successful `submit_plan` result.

**`index.tsx`** — `updateWorkflowData` moves to component scope; a component-lifetime `runEventProjections` memo wires the deps to the real state setters/refs; `runAgent` binds `runEventProjections.handlers` and drops its inline handlers object entirely (−212/+44 net in the component across this PR). Unused `workflow-data` imports leave the component.

**Non-goals honored** — agent construction and run-result persistence are untouched.

## Behavior preserved

- subagent routing precedence (`subagentId` first, root fallback) and the `app:` filter order in spawn/complete
- questions interception only for non-empty batches of `ask_user_questions` args
- `submit_plan` success gating (`result.success === true`)
- discovery-phase session clear + partial-text reset; reporting completion flips `currentPhase` to `complete`
- the generation guard and cleanup remain owned by `bindOperatorRunEvents` (O3)

## Test coverage

6 new tests in `run-events.test.ts` (17 total in the file), all driving a real `AgentEventBus` through `bindOperatorRunEvents` + the projections:

- **root-vs-subagent routing** — text/tool-start/command-output/error/tool-call-complete route to the right sink (subagent args `{}` fallback included)
- **stale generations** — every projection is dropped when the guard reports stale
- **question interception** — `onAsked` fires with the toolCallId + questions only for non-empty batches; `onRootToolCallStarted` fires per root tool call
- **error + plan hooks** — root error clears questions; only successful `submit_plan` results fire `onPlanSubmitted`
- **workflow phases + swarm** — discovery start (reset + clear + projection), pentesting start (no re-clear), `app:` drop, swarm registration/completion in `workflowData`, reporting completion with findings
- **cleanup** — unbind stops all forwarding

## Validation

- `bun run test` (1,626 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the touched files

## Notes

- Stack A complete: `index.tsx` is now composition + lifecycle glue over tested domains — `display-state.ts`, `conversation.ts`, `workflow-data.ts`, `run-tracing.ts`, `subagent-state.ts`, and `run-events.ts` (binding + all projections). The three separate bugs called out in the original plan (command-output intervals surviving abort, async W&B attachment after teardown, rapid mode cycling stale ref) remain open for dedicated bug-fix PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the operator run streaming event path (subagent routing, questions UI, workflow state) but keeps behavior equivalent and adds targeted bus-level tests.
> 
> **Overview**
> **Completes Stack A** by moving the last inline run-event handlers out of `OperatorDashboard` into `createRunEventProjections` in `run-events.ts`.
> 
> `runAgent` no longer defines ~150 lines of handler bodies; it passes `runEventProjections.handlers` into `bindOperatorRunEvents`. The dashboard wires a component-lifetime memo with injected callbacks for React-specific side effects (pending questions, command-cancel reset, plan-review gating, discovery-phase subagent hub clear) and a scoped `updateWorkflowData` helper.
> 
> The new adapter owns **root vs `subagentId` routing** (display vs `SubagentEventSink`), **`ask_user_questions` interception**, **`submit_plan` success hook**, **workflow phase / pentest swarm updates** (including `app:` filtering), and the same subagent command-output drop and args `{}` fallback. Six integration tests drive a real bus through bind + projections.
> 
> Intended behavior is unchanged; generation guarding and unbind cleanup stay in `bindOperatorRunEvents`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d060fc81922b317ca376191aab66e163a506cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->