### PR TITLE
feat(tui): improve model search and recents

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Professional pentesters, security engineers, and developers use Apex from local terminals, remote hosts, containers, and CI environments to run and steer authorized security testing.
+
+## Product Purpose
+
+Apex makes continuous, automated pentesting as routine as running unit tests. Its terminal UI keeps agent activity interpretable and steerable while its headless CLI supports automation and integrations.
+
+## Brand Personality
+
+Technical, focused, trustworthy.
+
+## Anti-references
+
+Avoid browser-first interaction patterns that weaken terminal workflows, decorative TUI chrome that competes with operational data, opaque automation that hides agent state, and novel controls that diverge from established Apex dialogs.
+
+## Design Principles
+
+- Keep security workflows keyboard-first and context-preserving.
+- Make autonomous activity visible, interpretable, and steerable.
+- Preserve local-first and air-gapped operation.
+- Guide users toward capable defaults while supporting provider choice.
+- Prefer consistent, restrained controls over decorative novelty.
+
+## Accessibility & Inclusion
+
+Support both dark and light themes, maintain readable contrast, never rely on color alone for state, and keep every view usable in constrained terminal dimensions without clipping essential controls.

--- a/src/core/ai/index.ts
+++ b/src/core/ai/index.ts
@@ -19,6 +19,11 @@ export {
   normalizeOpenAIReasoningEffort,
   streamResponse,
 } from "./ai";
+export {
+  addRecentModelId,
+  getRecentModels,
+  MAX_RECENT_MODELS,
+} from "./model-history";
 export { AVAILABLE_MODELS } from "./models";
 export type { AIAuthConfig } from "./utils";
 export { buildAuthConfig } from "./utils";

--- a/src/core/ai/model-history.test.ts
+++ b/src/core/ai/model-history.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { ModelInfo } from "./ai";
+import {
+  addRecentModelId,
+  getRecentModels,
+  MAX_RECENT_MODELS,
+} from "./model-history";
+
+const models: ModelInfo[] = [
+  { id: "model-a", name: "Model A", provider: "anthropic" },
+  { id: "model-b", name: "Model B", provider: "openai" },
+  { id: "model-c", name: "Model C", provider: "google" },
+];
+
+describe("addRecentModelId", () => {
+  it("puts the latest model first without duplicates", () => {
+    expect(
+      addRecentModelId(["model-a", "model-a", "model-b"], "model-b"),
+    ).toEqual(["model-b", "model-a"]);
+  });
+
+  it("keeps at most five models", () => {
+    const recent = addRecentModelId(
+      ["model-a", "model-b", "model-c", "model-d", "model-e"],
+      "model-f",
+    );
+
+    expect(recent).toHaveLength(MAX_RECENT_MODELS);
+    expect(recent).toEqual([
+      "model-f",
+      "model-a",
+      "model-b",
+      "model-c",
+      "model-d",
+    ]);
+  });
+});
+
+describe("getRecentModels", () => {
+  it("preserves history order and omits unavailable models", () => {
+    expect(getRecentModels(models, ["model-c", "missing", "model-a"])).toEqual([
+      models[2],
+      models[0],
+    ]);
+  });
+
+  it("deduplicates legacy history entries", () => {
+    expect(getRecentModels(models, ["model-b", "model-b", "model-a"])).toEqual([
+      models[1],
+      models[0],
+    ]);
+  });
+});

--- a/src/core/ai/model-history.ts
+++ b/src/core/ai/model-history.ts
@@ -1,0 +1,38 @@
+import type { ModelInfo } from "./ai";
+
+export const MAX_RECENT_MODELS = 5;
+
+export function addRecentModelId(
+  recentModelIds: readonly string[],
+  modelId: string,
+): string[] {
+  const nextRecentModelIds: string[] = [];
+
+  for (const id of [modelId, ...recentModelIds]) {
+    if (nextRecentModelIds.includes(id)) continue;
+    nextRecentModelIds.push(id);
+    if (nextRecentModelIds.length === MAX_RECENT_MODELS) break;
+  }
+
+  return nextRecentModelIds;
+}
+
+export function getRecentModels(
+  availableModels: readonly ModelInfo[],
+  recentModelIds: readonly string[],
+): ModelInfo[] {
+  const modelsById = new Map(availableModels.map((model) => [model.id, model]));
+  const seen = new Set<string>();
+  const recentModels: ModelInfo[] = [];
+
+  for (const id of recentModelIds) {
+    const model = modelsById.get(id);
+    if (!model || seen.has(id)) continue;
+
+    seen.add(id);
+    recentModels.push(model);
+    if (recentModels.length === MAX_RECENT_MODELS) break;
+  }
+
+  return recentModels;
+}

--- a/src/core/config/config.test.ts
+++ b/src/core/config/config.test.ts
@@ -73,3 +73,16 @@ describe("Strike Mode config", () => {
     expect(persisted.strikeMode).toBe(true);
   });
 });
+
+describe("recent model config", () => {
+  it("persists model history across a fresh config load", async () => {
+    await init();
+    await update({ recentModelIds: ["model-b", "model-a"] });
+
+    vi.resetModules();
+    const { get: getReloadedConfig } = await import("./config");
+    const reloaded = await getReloadedConfig();
+
+    expect(reloaded.recentModelIds).toEqual(["model-b", "model-a"]);
+  });
+});

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -36,6 +36,7 @@ export interface Config {
   transparentBackground?: boolean;
   // Model preference
   selectedModelId?: string | null;
+  recentModelIds?: string[];
   // Extended thinking / reasoning
   reasoningEnabled?: boolean;
   openAIReasoningEffort?:

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -1,4 +1,4 @@
-import type { ScrollBoxRenderable } from "@opentui/core";
+import type { RGBA, ScrollBoxRenderable } from "@opentui/core";
 import { useKeyboard } from "@opentui/react";
 import {
   type ReactNode,
@@ -9,7 +9,9 @@ import {
   useState,
 } from "react";
 import {
+  type AIModelProvider,
   getOpenAIReasoningEfforts,
+  getRecentModels,
   type ModelInfo,
   modelSupportsOpenAIReasoning,
   modelSupportsThinking,
@@ -20,19 +22,9 @@ import { getAvailableModels } from "../../../core/providers/utils";
 import { useTheme } from "../../theme";
 import { getPasteText } from "../../utils/paste";
 import { scrollToChild } from "../../utils/scroll";
+import { filterModels, getProviderDisplayName } from "./model-search";
 
-const providerNames: Record<string, string> = {
-  anthropic: "Claude",
-  openai: "OpenAI",
-  google: "Gemini",
-  openrouter: "OpenRouter",
-  concentrate: "Concentrate",
-  bedrock: "Bedrock",
-  pensar: "Pensar",
-  local: "Local LLM",
-};
-
-const providerOrder = [
+const providerOrder: AIModelProvider[] = [
   "pensar",
   "anthropic",
   "openai",
@@ -40,10 +32,12 @@ const providerOrder = [
   "openrouter",
   "concentrate",
   "bedrock",
+  "bedrock-mantle",
+  "inception",
   "local",
 ];
 
-function setsAreEqual(a: Set<string>, b: Set<string>) {
+function setsAreEqual<T>(a: Set<T>, b: Set<T>) {
   return a.size === b.size && [...a].every((value) => b.has(value));
 }
 
@@ -60,7 +54,7 @@ function PickerRow({
   id?: string;
   paddingLeft?: number;
   paddingRight?: number;
-  backgroundColor?: string;
+  backgroundColor?: string | RGBA;
   flexDirection?: "row" | "column";
   gap?: number;
 }) {
@@ -81,8 +75,9 @@ function PickerRow({
 }
 
 type NavigationItem =
-  | { type: "provider"; provider: string }
+  | { type: "provider"; provider: AIModelProvider }
   | { type: "model"; model: ModelInfo }
+  | { type: "recent-model"; model: ModelInfo }
   | { type: "local-input"; field: LocalInputField }
   | { type: "reasoning" }
   | { type: "openai-reasoning" };
@@ -92,6 +87,7 @@ type LocalInputField = "url" | "model";
 function getNavItemId(item: NavigationItem): string {
   if (item.type === "provider") return `provider-${item.provider}`;
   if (item.type === "model") return `model-${item.model.id}`;
+  if (item.type === "recent-model") return `recent-model-${item.model.id}`;
   if (item.type === "reasoning") return "reasoning-toggle";
   if (item.type === "openai-reasoning") return "openai-reasoning-effort";
   return `local-input-${item.field}`;
@@ -130,9 +126,9 @@ export function ModelPicker({
   const scrollBoxRef = useRef<ScrollBoxRenderable | null>(null);
   const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
-  const [expandedProviders, setExpandedProviders] = useState<Set<string>>(
-    new Set(["anthropic"]),
-  );
+  const [expandedProviders, setExpandedProviders] = useState<
+    Set<AIModelProvider>
+  >(new Set(["anthropic"]));
   const [focusedIndex, setFocusedIndex] = useState(0);
 
   const [localUrl, setLocalUrl] = useState(config?.localModelUrl ?? "");
@@ -158,7 +154,7 @@ export function ModelPicker({
   }, [config]);
 
   useEffect(() => {
-    const availableProviders = new Set<string>(
+    const availableProviders = new Set<AIModelProvider>(
       availableModels.map((model) => model.provider),
     );
 
@@ -191,59 +187,73 @@ export function ModelPicker({
     });
   }, [availableModels, selectedModel.provider]);
 
-  // Group models by provider and filter by search
+  const filteredModels = useMemo(
+    () => filterModels(availableModels, searchQuery),
+    [availableModels, searchQuery],
+  );
+  const isSearching = searchQuery.trim().length > 0;
+  const recentModels = useMemo(
+    () => getRecentModels(availableModels, config?.recentModelIds ?? []),
+    [availableModels, config?.recentModelIds],
+  );
+
+  // Group models by provider for the unfiltered browsing view.
   const groupedModels = useMemo(() => {
     const groups: Record<string, ModelInfo[]> = {};
-    const query = searchQuery.toLowerCase().trim();
-
     for (const m of availableModels) {
-      // Fuzzy match: check if query matches model name or id
-      if (
-        query &&
-        !m.name.toLowerCase().includes(query) &&
-        !m.id.toLowerCase().includes(query)
-      ) {
-        continue;
-      }
       if (!groups[m.provider]) {
         groups[m.provider] = [];
       }
       groups[m.provider].push(m);
     }
     return groups;
-  }, [availableModels, searchQuery]);
+  }, [availableModels]);
 
   // Flat navigation list: provider headers + expanded models
   const navigationItems = useMemo(() => {
     const items: NavigationItem[] = [];
-    for (const provider of providerOrder) {
-      if (provider === "local") {
-        items.push({ type: "provider", provider: "local" });
-        if (expandedProviders.has("local")) {
-          items.push({ type: "local-input", field: "url" });
-          items.push({ type: "local-input", field: "model" });
-          const localModels = groupedModels.local;
-          if (localModels) {
-            for (const m of localModels) {
-              items.push({ type: "model", model: m });
+    if (isSearching) {
+      for (const model of filteredModels) {
+        items.push({ type: "model", model });
+      }
+    } else {
+      for (const model of recentModels) {
+        items.push({ type: "recent-model", model });
+      }
+      for (const provider of providerOrder) {
+        if (provider === "local") {
+          items.push({ type: "provider", provider: "local" });
+          if (expandedProviders.has("local")) {
+            items.push({ type: "local-input", field: "url" });
+            items.push({ type: "local-input", field: "model" });
+            const localModels = groupedModels.local;
+            if (localModels) {
+              for (const m of localModels) {
+                items.push({ type: "model", model: m });
+              }
             }
           }
+          continue;
         }
-        continue;
-      }
-      const models = groupedModels[provider];
-      if (!models || models.length === 0) continue;
-      items.push({ type: "provider", provider });
-      if (expandedProviders.has(provider)) {
-        for (const m of models) {
-          items.push({ type: "model", model: m });
+        const models = groupedModels[provider];
+        if (!models || models.length === 0) continue;
+        items.push({ type: "provider", provider });
+        if (expandedProviders.has(provider)) {
+          for (const m of models) {
+            items.push({ type: "model", model: m });
+          }
         }
       }
     }
-    if (onReasoningToggle && modelSupportsThinking(selectedModel.id)) {
+    if (
+      !isSearching &&
+      onReasoningToggle &&
+      modelSupportsThinking(selectedModel.id)
+    ) {
       items.push({ type: "reasoning" });
     }
     if (
+      !isSearching &&
       onOpenAIReasoningEffortChange &&
       modelSupportsOpenAIReasoning(selectedModel.id)
     ) {
@@ -252,21 +262,14 @@ export function ModelPicker({
     return items;
   }, [
     groupedModels,
+    filteredModels,
+    recentModels,
+    isSearching,
     expandedProviders,
     onReasoningToggle,
     onOpenAIReasoningEffortChange,
     selectedModel.id,
   ]);
-
-  // Sync focusedIndex when selected model changes (e.g. on initial load)
-  useEffect(() => {
-    const idx = navigationItems.findIndex(
-      (item) => item.type === "model" && item.model.id === selectedModel.id,
-    );
-    if (idx !== -1) {
-      setFocusedIndex(idx);
-    }
-  }, [selectedModel.id, navigationItems]);
 
   // Clamp focusedIndex when navigation items change
   useEffect(() => {
@@ -343,25 +346,14 @@ export function ModelPicker({
         return false;
       }
 
-      if (navigationItems.length === 0) return false;
-
       // Up/Down - navigate through items
       if (key.name === "up" || key.name === "down") {
+        if (navigationItems.length === 0) return false;
+        const direction = key.name === "up" ? -1 : 1;
         const newIndex =
-          key.name === "up"
-            ? Math.max(0, focusedIndex - 1)
-            : Math.min(navigationItems.length - 1, focusedIndex + 1);
+          (focusedIndex + direction + navigationItems.length) %
+          navigationItems.length;
         setFocusedIndex(newIndex);
-        const item = navigationItems[newIndex];
-        if (item && item.type === "model") {
-          onSelectModel(item.model);
-        }
-        return true;
-      }
-
-      // Backspace - remove last char from search
-      if (key.name === "backspace") {
-        setSearchQuery((prev) => prev.slice(0, -1));
         return true;
       }
 
@@ -369,6 +361,7 @@ export function ModelPicker({
       if (key.name === "escape") {
         if (searchQuery) {
           setSearchQuery("");
+          setFocusedIndex(0);
           return true;
         }
         if (onCancel) {
@@ -378,13 +371,20 @@ export function ModelPicker({
         return false;
       }
 
-      // Space - toggle reasoning checkbox from any row
-      if (key.name === "space" && onReasoningToggle && thinkingSupported) {
+      const currentItem = navigationItems[focusedIndex];
+
+      if (
+        key.name === "space" &&
+        currentItem?.type === "reasoning" &&
+        onReasoningToggle &&
+        thinkingSupported
+      ) {
         onReasoningToggle(!reasoningEnabled);
         return true;
       }
       if (
         key.name === "space" &&
+        currentItem?.type === "openai-reasoning" &&
         onOpenAIReasoningEffortChange &&
         openAIReasoningSupported
       ) {
@@ -394,7 +394,6 @@ export function ModelPicker({
 
       // Enter - confirm model selection, toggle provider, or start editing local input
       if (key.name === "return") {
-        const currentItem = navigationItems[focusedIndex];
         if (!currentItem) return false;
 
         if (currentItem.type === "local-input") {
@@ -417,7 +416,11 @@ export function ModelPicker({
             }
             return next;
           });
-        } else {
+        } else if (
+          currentItem.type === "model" ||
+          currentItem.type === "recent-model"
+        ) {
+          onSelectModel(currentItem.model);
           onConfirm?.();
         }
         return true;
@@ -425,9 +428,11 @@ export function ModelPicker({
 
       // Left/Right - collapse/expand provider
       if (key.name === "left" || key.name === "right") {
+        if (isSearching) return false;
         const currentItem = navigationItems[focusedIndex];
         if (
           !currentItem ||
+          currentItem.type === "recent-model" ||
           currentItem.type === "reasoning" ||
           currentItem.type === "openai-reasoning"
         ) {
@@ -460,19 +465,6 @@ export function ModelPicker({
         return true;
       }
 
-      // Printable character - add to search
-      if (
-        key.sequence &&
-        key.sequence.length === 1 &&
-        /[a-zA-Z0-9\-_.]/.test(key.sequence)
-      ) {
-        setSearchQuery((prev) => prev + key.sequence);
-        if (!searchQuery) {
-          setExpandedProviders(new Set(providerOrder));
-        }
-        return true;
-      }
-
       return false;
     },
     [
@@ -491,6 +483,7 @@ export function ModelPicker({
       onOpenAIReasoningEffortChange,
       openAIReasoningSupported,
       cycleOpenAIReasoningEffort,
+      isSearching,
     ],
   );
 
@@ -505,16 +498,16 @@ export function ModelPicker({
   });
 
   // Helper to check if a navigation item at focusedIndex matches a provider
-  const isProviderFocused = (provider: string) =>
+  const isProviderFocused = (provider: AIModelProvider) =>
     navigationItems[focusedIndex]?.type === "provider" &&
-    (navigationItems[focusedIndex] as { type: "provider"; provider: string })
-      .provider === provider;
+    navigationItems[focusedIndex].provider === provider;
 
   // Helper to check if a model is focused
-  const isModelFocused = (modelId: string) =>
-    navigationItems[focusedIndex]?.type === "model" &&
-    (navigationItems[focusedIndex] as { type: "model"; model: ModelInfo }).model
-      .id === modelId;
+  const isModelFocused = (modelId: string, recent = false) => {
+    const item = navigationItems[focusedIndex];
+    const expectedType = recent ? "recent-model" : "model";
+    return item?.type === expectedType && item.model.id === modelId;
+  };
 
   // Helper to check if a local input field is focused
   const isLocalFieldFocused = (field: LocalInputField) =>
@@ -534,41 +527,121 @@ export function ModelPicker({
       flexShrink={1}
       overflow="hidden"
     >
-      {/* Search indicator */}
-      <box flexShrink={0}>
-        {searchQuery ? (
+      {/* Search input */}
+      <box flexShrink={0} marginBottom={1}>
+        <PickerRow>
+          <text fg={colors.primary}>Search </text>
+          <input
+            flexGrow={1}
+            value={searchQuery}
+            onInput={(value) => {
+              setSearchQuery(value);
+              setFocusedIndex(0);
+            }}
+            focused={focused && editingLocalField === null}
+            placeholder="family, model name, or provider..."
+            textColor={colors.text}
+            focusedTextColor={colors.text}
+            backgroundColor="transparent"
+            cursorColor={colors.textMuted}
+          />
+        </PickerRow>
+        {isSearching && (
           <PickerRow>
-            <text fg={colors.text}>Search: {searchQuery}</text>
-          </PickerRow>
-        ) : (
-          <PickerRow>
-            <text fg={colors.textMuted}>Type to search models...</text>
+            <text fg={colors.primary}>Results ({filteredModels.length})</text>
           </PickerRow>
         )}
       </box>
 
-      {/* Scrollable provider/model list */}
+      {/* Remount when the list shape changes to reset OpenTUI's cached geometry. */}
       <scrollbox
+        key={isSearching ? "search-results" : "model-browser"}
         ref={scrollBoxRef}
         style={{
           rootOptions: {
             flexShrink: 1,
             width: "100%",
             overflow: "hidden",
-            maxHeight: navigationItems.length,
+            maxHeight: Math.max(
+              1,
+              navigationItems.length +
+                (!isSearching && recentModels.length > 0 ? 1 : 0),
+            ),
           },
           contentOptions: {
             flexDirection: "column",
           },
           scrollbarOptions: {
-            visible: false,
+            trackOptions: {
+              foregroundColor: colors.textMuted,
+              backgroundColor: colors.backgroundElement,
+            },
           },
         }}
         stickyScroll={false}
       >
+        {!isSearching && recentModels.length > 0 && (
+          <>
+            <PickerRow>
+              <text fg={colors.primary}>Recent</text>
+            </PickerRow>
+            {recentModels.map((model) => {
+              const isSelected = model.id === selectedModel.id;
+              const isFocused = isModelFocused(model.id, true);
+              return (
+                <PickerRow
+                  key={`recent-${model.id}`}
+                  id={`recent-model-${model.id}`}
+                  backgroundColor={
+                    isFocused ? colors.backgroundSelected : undefined
+                  }
+                >
+                  <text>
+                    <span fg={isFocused ? colors.primary : colors.text}>
+                      {isSelected ? "●" : "○"} {model.name}
+                    </span>
+                    <span fg={colors.textMuted}>
+                      {`  ${getProviderDisplayName(model.provider)}`}
+                    </span>
+                  </text>
+                </PickerRow>
+              );
+            })}
+          </>
+        )}
+        {isSearching &&
+          (filteredModels.length === 0 ? (
+            <PickerRow>
+              <text fg={colors.textMuted}>No matching models</text>
+            </PickerRow>
+          ) : (
+            filteredModels.map((model) => {
+              const isSelected = model.id === selectedModel.id;
+              const isFocused = isModelFocused(model.id);
+              return (
+                <PickerRow
+                  key={model.id}
+                  id={`model-${model.id}`}
+                  backgroundColor={
+                    isFocused ? colors.backgroundSelected : undefined
+                  }
+                >
+                  <text>
+                    <span fg={isFocused ? colors.primary : colors.text}>
+                      {isSelected ? "●" : "○"} {model.name}
+                    </span>
+                    <span fg={colors.textMuted}>
+                      {`  ${getProviderDisplayName(model.provider)}`}
+                    </span>
+                  </text>
+                </PickerRow>
+              );
+            })
+          ))}
         {providerOrder.flatMap((provider) => {
+          if (isSearching) return [];
           const isExpanded = expandedProviders.has(provider);
-          const providerName = providerNames[provider] || provider;
+          const providerName = getProviderDisplayName(provider);
           const isFocused = isProviderFocused(provider);
 
           if (provider === "local") {
@@ -754,7 +827,7 @@ export function ModelPicker({
       </scrollbox>
 
       {/* Reasoning toggle */}
-      {onReasoningToggle && thinkingSupported && (
+      {!isSearching && onReasoningToggle && thinkingSupported && (
         <box flexShrink={0} paddingTop={1}>
           <PickerRow id="reasoning-toggle">
             <text fg={isReasoningFocused ? colors.primary : colors.text}>
@@ -765,18 +838,22 @@ export function ModelPicker({
         </box>
       )}
 
-      {onOpenAIReasoningEffortChange && openAIReasoningSupported && (
-        <box flexShrink={0} paddingTop={1}>
-          <PickerRow id="openai-reasoning-effort">
-            <text fg={isOpenAIReasoningFocused ? colors.primary : colors.text}>
-              Reasoning Effort:{" "}
-              {openAIReasoningEffort === "xhigh"
-                ? "extra high"
-                : openAIReasoningEffort}
-            </text>
-          </PickerRow>
-        </box>
-      )}
+      {!isSearching &&
+        onOpenAIReasoningEffortChange &&
+        openAIReasoningSupported && (
+          <box flexShrink={0} paddingTop={1}>
+            <PickerRow id="openai-reasoning-effort">
+              <text
+                fg={isOpenAIReasoningFocused ? colors.primary : colors.text}
+              >
+                Reasoning Effort:{" "}
+                {openAIReasoningEffort === "xhigh"
+                  ? "extra high"
+                  : openAIReasoningEffort}
+              </text>
+            </PickerRow>
+          </box>
+        )}
 
       {/* Help text for inline editing only — general controls are in ModelPickerDialog */}
       {editingLocalField && (

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -24,6 +24,7 @@ import { getPasteText } from "../../utils/paste";
 import { scrollToChild } from "../../utils/scroll";
 import {
   findSelectedModelIndex,
+  getSelectedModelRevealKey,
   retainAvailableProviders,
 } from "./model-navigation";
 import { filterModels, getProviderDisplayName } from "./model-search";
@@ -168,8 +169,16 @@ export function ModelPicker({
 
   // A genuine model change should reveal its provider exactly once.
   useEffect(() => {
-    const selectedModelKey = `${selectedModel.provider}:${selectedModel.id}`;
-    if (lastRevealedSelectedModelRef.current === selectedModelKey) return;
+    const selectedModelKey = getSelectedModelRevealKey({
+      availableModels,
+      selectedModel: {
+        id: selectedModel.id,
+        provider: selectedModel.provider,
+      },
+      lastRevealedSelectedModelKey: lastRevealedSelectedModelRef.current,
+    });
+    if (!selectedModelKey) return;
+
     lastRevealedSelectedModelRef.current = selectedModelKey;
 
     setExpandedProviders((prev) =>
@@ -177,7 +186,7 @@ export function ModelPicker({
         ? prev
         : new Set([...prev, selectedModel.provider]),
     );
-  }, [selectedModel.id, selectedModel.provider]);
+  }, [availableModels, selectedModel.id, selectedModel.provider]);
 
   const filteredModels = useMemo(
     () => filterModels(availableModels, searchQuery),

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -22,7 +22,10 @@ import { getAvailableModels } from "../../../core/providers/utils";
 import { useTheme } from "../../theme";
 import { getPasteText } from "../../utils/paste";
 import { scrollToChild } from "../../utils/scroll";
-import { findSelectedModelIndex } from "./model-navigation";
+import {
+  findSelectedModelIndex,
+  retainAvailableProviders,
+} from "./model-navigation";
 import { filterModels, getProviderDisplayName } from "./model-search";
 
 const providerOrder: AIModelProvider[] = [
@@ -37,10 +40,6 @@ const providerOrder: AIModelProvider[] = [
   "inception",
   "local",
 ];
-
-function setsAreEqual<T>(a: Set<T>, b: Set<T>) {
-  return a.size === b.size && [...a].every((value) => b.has(value));
-}
 
 function PickerRow({
   children,
@@ -131,6 +130,7 @@ export function ModelPicker({
     Set<AIModelProvider>
   >(new Set([selectedModel.provider]));
   const [focusedIndex, setFocusedIndex] = useState(0);
+  const lastRevealedSelectedModelRef = useRef<string | null>(null);
   const lastFocusedSelectedModelIdRef = useRef<string | null>(null);
 
   const [localUrl, setLocalUrl] = useState(config?.localModelUrl ?? "");
@@ -160,37 +160,24 @@ export function ModelPicker({
       availableModels.map((model) => model.provider),
     );
 
-    setExpandedProviders((prev) => {
-      if (availableProviders.size === 0) {
-        return prev.size === 0 ? prev : new Set();
-      }
+    // Config refreshes may prune expansions, but must not reopen a provider.
+    setExpandedProviders((prev) =>
+      retainAvailableProviders(prev, availableProviders),
+    );
+  }, [availableModels]);
 
-      const preservedProviders = new Set(
-        [...prev].filter((provider) => availableProviders.has(provider)),
-      );
-      if (availableProviders.has(selectedModel.provider)) {
-        preservedProviders.add(selectedModel.provider);
-      }
+  // A genuine model change should reveal its provider exactly once.
+  useEffect(() => {
+    const selectedModelKey = `${selectedModel.provider}:${selectedModel.id}`;
+    if (lastRevealedSelectedModelRef.current === selectedModelKey) return;
+    lastRevealedSelectedModelRef.current = selectedModelKey;
 
-      if (preservedProviders.size > 0) {
-        return setsAreEqual(prev, preservedProviders)
-          ? prev
-          : preservedProviders;
-      }
-
-      const fallbackProvider = availableProviders.has(selectedModel.provider)
-        ? selectedModel.provider
-        : availableModels[0]?.provider;
-
-      if (!fallbackProvider) {
-        return prev.size === 0 ? prev : new Set();
-      }
-
-      return prev.size === 1 && prev.has(fallbackProvider)
+    setExpandedProviders((prev) =>
+      prev.has(selectedModel.provider)
         ? prev
-        : new Set([fallbackProvider]);
-    });
-  }, [availableModels, selectedModel.provider]);
+        : new Set([...prev, selectedModel.provider]),
+    );
+  }, [selectedModel.id, selectedModel.provider]);
 
   const filteredModels = useMemo(
     () => filterModels(availableModels, searchQuery),

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -22,6 +22,7 @@ import { getAvailableModels } from "../../../core/providers/utils";
 import { useTheme } from "../../theme";
 import { getPasteText } from "../../utils/paste";
 import { scrollToChild } from "../../utils/scroll";
+import { findSelectedModelIndex } from "./model-navigation";
 import { filterModels, getProviderDisplayName } from "./model-search";
 
 const providerOrder: AIModelProvider[] = [
@@ -128,8 +129,9 @@ export function ModelPicker({
   const [searchQuery, setSearchQuery] = useState("");
   const [expandedProviders, setExpandedProviders] = useState<
     Set<AIModelProvider>
-  >(new Set(["anthropic"]));
+  >(new Set([selectedModel.provider]));
   const [focusedIndex, setFocusedIndex] = useState(0);
+  const lastFocusedSelectedModelIdRef = useRef<string | null>(null);
 
   const [localUrl, setLocalUrl] = useState(config?.localModelUrl ?? "");
   const [localModelName, setLocalModelName] = useState(
@@ -166,6 +168,9 @@ export function ModelPicker({
       const preservedProviders = new Set(
         [...prev].filter((provider) => availableProviders.has(provider)),
       );
+      if (availableProviders.has(selectedModel.provider)) {
+        preservedProviders.add(selectedModel.provider);
+      }
 
       if (preservedProviders.size > 0) {
         return setsAreEqual(prev, preservedProviders)
@@ -270,6 +275,21 @@ export function ModelPicker({
     onOpenAIReasoningEffortChange,
     selectedModel.id,
   ]);
+
+  useEffect(() => {
+    if (
+      isSearching ||
+      lastFocusedSelectedModelIdRef.current === selectedModel.id
+    ) {
+      return;
+    }
+
+    const index = findSelectedModelIndex(navigationItems, selectedModel.id);
+    if (index === -1) return;
+
+    lastFocusedSelectedModelIdRef.current = selectedModel.id;
+    setFocusedIndex(index);
+  }, [isSearching, navigationItems, selectedModel.id]);
 
   // Clamp focusedIndex when navigation items change
   useEffect(() => {

--- a/src/tui/components/model-picker/ModelPickerDialog.tsx
+++ b/src/tui/components/model-picker/ModelPickerDialog.tsx
@@ -5,10 +5,6 @@
  * Used from both home page and operator mode.
  */
 
-import {
-  modelSupportsOpenAIReasoning,
-  modelSupportsThinking,
-} from "../../../core/ai";
 import { useAgent } from "../../context/agent";
 import { useConfig } from "../../context/config";
 import { Dialog } from "../../context/dialog";
@@ -34,18 +30,9 @@ export default function ModelPickerDialog({ onClose }: ModelPickerDialogProps) {
     setOpenAIReasoningEffort,
   } = useAgent();
 
-  const thinkingSupported = modelSupportsThinking(model.id);
-  const openAIReasoningSupported = modelSupportsOpenAIReasoning(model.id);
-
   const footerActions: FooterAction[] = [
     { key: "Enter", label: "confirm", variant: "primary" },
   ];
-  if (thinkingSupported) {
-    footerActions.push({ key: "Space", label: "Extended Thinking" });
-  }
-  if (openAIReasoningSupported) {
-    footerActions.push({ key: "Space", label: "Reasoning Effort" });
-  }
 
   const title = (
     <text>

--- a/src/tui/components/model-picker/model-navigation.test.ts
+++ b/src/tui/components/model-picker/model-navigation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AIModelProvider } from "../../../core/ai";
 import {
   findSelectedModelIndex,
+  getSelectedModelRevealKey,
   retainAvailableProviders,
 } from "./model-navigation";
 
@@ -65,5 +66,37 @@ describe("retainAvailableProviders", () => {
         new Set<AIModelProvider>(["openai"]),
       ),
     ).toEqual(new Set<AIModelProvider>(["openai"]));
+  });
+});
+
+describe("getSelectedModelRevealKey", () => {
+  it("waits for availability and reveals each selection only once", () => {
+    const selectedModel = {
+      id: "model-b" as const,
+      provider: "anthropic" as const,
+    };
+
+    expect(
+      getSelectedModelRevealKey({
+        availableModels: [],
+        selectedModel,
+        lastRevealedSelectedModelKey: null,
+      }),
+    ).toBeNull();
+
+    const selectedModelKey = getSelectedModelRevealKey({
+      availableModels: [selectedModel],
+      selectedModel,
+      lastRevealedSelectedModelKey: null,
+    });
+    expect(selectedModelKey).toBe("anthropic:model-b");
+
+    expect(
+      getSelectedModelRevealKey({
+        availableModels: [{ ...selectedModel }],
+        selectedModel,
+        lastRevealedSelectedModelKey: selectedModelKey,
+      }),
+    ).toBeNull();
   });
 });

--- a/src/tui/components/model-picker/model-navigation.test.ts
+++ b/src/tui/components/model-picker/model-navigation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { findSelectedModelIndex } from "./model-navigation";
+import type { AIModelProvider } from "../../../core/ai";
+import {
+  findSelectedModelIndex,
+  retainAvailableProviders,
+} from "./model-navigation";
 
 describe("findSelectedModelIndex", () => {
   it("focuses the selected recent model instead of the first recent model", () => {
@@ -39,5 +43,27 @@ describe("findSelectedModelIndex", () => {
         "model-b",
       ),
     ).toBe(-1);
+  });
+});
+
+describe("retainAvailableProviders", () => {
+  it("keeps an available provider collapsed after a model refresh", () => {
+    const collapsedProviders = new Set<AIModelProvider>();
+
+    expect(
+      retainAvailableProviders(
+        collapsedProviders,
+        new Set<AIModelProvider>(["anthropic"]),
+      ),
+    ).toBe(collapsedProviders);
+  });
+
+  it("removes providers that are no longer available", () => {
+    expect(
+      retainAvailableProviders(
+        new Set<AIModelProvider>(["anthropic", "openai"]),
+        new Set<AIModelProvider>(["openai"]),
+      ),
+    ).toEqual(new Set<AIModelProvider>(["openai"]));
   });
 });

--- a/src/tui/components/model-picker/model-navigation.test.ts
+++ b/src/tui/components/model-picker/model-navigation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { findSelectedModelIndex } from "./model-navigation";
+
+describe("findSelectedModelIndex", () => {
+  it("focuses the selected recent model instead of the first recent model", () => {
+    expect(
+      findSelectedModelIndex(
+        [
+          { type: "recent-model", model: { id: "model-a" } },
+          { type: "recent-model", model: { id: "model-b" } },
+          { type: "provider" },
+          { type: "model", model: { id: "model-b" } },
+        ],
+        "model-b",
+      ),
+    ).toBe(1);
+  });
+
+  it("finds the selected model outside recent history", () => {
+    expect(
+      findSelectedModelIndex(
+        [
+          { type: "recent-model", model: { id: "model-a" } },
+          { type: "provider" },
+          { type: "model", model: { id: "model-b" } },
+        ],
+        "model-b",
+      ),
+    ).toBe(2);
+  });
+
+  it("returns -1 when the selected model is not visible", () => {
+    expect(
+      findSelectedModelIndex(
+        [
+          { type: "recent-model", model: { id: "model-a" } },
+          { type: "provider" },
+        ],
+        "model-b",
+      ),
+    ).toBe(-1);
+  });
+});

--- a/src/tui/components/model-picker/model-navigation.ts
+++ b/src/tui/components/model-picker/model-navigation.ts
@@ -1,4 +1,4 @@
-import type { ModelInfo } from "../../../core/ai";
+import type { AIModelProvider, ModelInfo } from "../../../core/ai";
 
 type NavigationItem = {
   type: string;
@@ -14,4 +14,19 @@ export function findSelectedModelIndex(
       (item.type === "model" || item.type === "recent-model") &&
       item.model?.id === selectedModelId,
   );
+}
+
+export function retainAvailableProviders(
+  expandedProviders: Set<AIModelProvider>,
+  availableProviders: ReadonlySet<AIModelProvider>,
+): Set<AIModelProvider> {
+  const retainedProviders = new Set(
+    [...expandedProviders].filter((provider) =>
+      availableProviders.has(provider),
+    ),
+  );
+
+  return retainedProviders.size === expandedProviders.size
+    ? expandedProviders
+    : retainedProviders;
 }

--- a/src/tui/components/model-picker/model-navigation.ts
+++ b/src/tui/components/model-picker/model-navigation.ts
@@ -5,6 +5,8 @@ type NavigationItem = {
   model?: Pick<ModelInfo, "id">;
 };
 
+type ModelIdentity = Pick<ModelInfo, "id" | "provider">;
+
 export function findSelectedModelIndex(
   navigationItems: readonly NavigationItem[],
   selectedModelId: string,
@@ -29,4 +31,24 @@ export function retainAvailableProviders(
   return retainedProviders.size === expandedProviders.size
     ? expandedProviders
     : retainedProviders;
+}
+
+export function getSelectedModelRevealKey({
+  availableModels,
+  selectedModel,
+  lastRevealedSelectedModelKey,
+}: {
+  availableModels: readonly ModelIdentity[];
+  selectedModel: ModelIdentity;
+  lastRevealedSelectedModelKey: string | null;
+}): string | null {
+  const selectedModelKey = `${selectedModel.provider}:${selectedModel.id}`;
+  if (lastRevealedSelectedModelKey === selectedModelKey) return null;
+
+  const selectedModelIsAvailable = availableModels.some(
+    (model) =>
+      model.id === selectedModel.id &&
+      model.provider === selectedModel.provider,
+  );
+  return selectedModelIsAvailable ? selectedModelKey : null;
 }

--- a/src/tui/components/model-picker/model-navigation.ts
+++ b/src/tui/components/model-picker/model-navigation.ts
@@ -1,0 +1,17 @@
+import type { ModelInfo } from "../../../core/ai";
+
+type NavigationItem = {
+  type: string;
+  model?: Pick<ModelInfo, "id">;
+};
+
+export function findSelectedModelIndex(
+  navigationItems: readonly NavigationItem[],
+  selectedModelId: string,
+): number {
+  return navigationItems.findIndex(
+    (item) =>
+      (item.type === "model" || item.type === "recent-model") &&
+      item.model?.id === selectedModelId,
+  );
+}

--- a/src/tui/components/model-picker/model-search.test.ts
+++ b/src/tui/components/model-picker/model-search.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { ModelInfo } from "../../../core/ai";
+import { filterModels } from "./model-search";
+
+const models: ModelInfo[] = [
+  {
+    id: "claude-opus-4-6",
+    name: "Claude Opus 4.6",
+    provider: "anthropic",
+  },
+  {
+    id: "anthropic/claude-opus-4.6",
+    name: "Claude Opus 4.6",
+    provider: "openrouter",
+  },
+  {
+    id: "moonshotai/kimi-k3",
+    name: "Kimi K3",
+    provider: "openrouter",
+  },
+  {
+    id: "z-ai/glm-5.3",
+    name: "GLM 5.3",
+    provider: "openrouter",
+  },
+  {
+    id: "gpt-5.6-sol",
+    name: "GPT-5.6-sol",
+    provider: "openai",
+  },
+];
+
+describe("filterModels", () => {
+  it("matches a model family", () => {
+    expect(filterModels(models, "kimi")).toEqual([models[2]]);
+  });
+
+  it("matches a model name across punctuation", () => {
+    expect(filterModels(models, "opus 4.6")).toEqual([models[0], models[1]]);
+    expect(filterModels(models, "glm-5.3")).toEqual([models[3]]);
+  });
+
+  it("matches provider names", () => {
+    expect(filterModels(models, "open router")).toEqual([
+      models[1],
+      models[2],
+      models[3],
+    ]);
+  });
+
+  it("combines family and provider terms", () => {
+    expect(filterModels(models, "claude openrouter")).toEqual([models[1]]);
+  });
+
+  it("matches model IDs case-insensitively", () => {
+    expect(filterModels(models, "GPT-5.6-SOL")).toEqual([models[4]]);
+  });
+
+  it("returns every model for an empty query", () => {
+    expect(filterModels(models, "   ")).toBe(models);
+  });
+});

--- a/src/tui/components/model-picker/model-search.ts
+++ b/src/tui/components/model-picker/model-search.ts
@@ -1,0 +1,40 @@
+import type { AIModelProvider, ModelInfo } from "../../../core/ai";
+
+const PROVIDER_DISPLAY_NAMES: Record<AIModelProvider, string> = {
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  google: "Google",
+  openrouter: "OpenRouter",
+  concentrate: "Concentrate",
+  bedrock: "AWS Bedrock",
+  "bedrock-mantle": "Bedrock Mantle",
+  pensar: "Pensar",
+  inception: "Inception",
+  local: "Local LLM",
+};
+
+export function getProviderDisplayName(provider: AIModelProvider): string {
+  return PROVIDER_DISPLAY_NAMES[provider];
+}
+
+function normalizeSearchText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+export function filterModels(
+  models: ModelInfo[],
+  searchQuery: string,
+): ModelInfo[] {
+  const terms = normalizeSearchText(searchQuery).split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return models;
+
+  return models.filter((model) => {
+    const searchableText = normalizeSearchText(
+      `${model.name} ${model.id} ${model.provider} ${getProviderDisplayName(model.provider)}`,
+    );
+    return terms.every((term) => searchableText.includes(term));
+  });
+}

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -10,13 +10,13 @@ import {
 } from "react";
 import {
   AVAILABLE_MODELS,
+  addRecentModelId,
   DEFAULT_OPENAI_REASONING_EFFORT,
   getOpenAIReasoningEfforts,
   type ModelInfo,
   modelSupportsThinking,
   type OpenAIReasoningEffort,
 } from "../../core/ai";
-import { update as updateConfig } from "../../core/config/config";
 import { writeErrorLog } from "../../core/logger";
 import {
   getAvailableModels,
@@ -107,45 +107,64 @@ export function AgentProvider({ children }: AgentProviderProps) {
   reasoningEnabledRef.current = reasoningEnabled;
   const openAIReasoningEffortRef = useRef(openAIReasoningEffort);
   openAIReasoningEffortRef.current = openAIReasoningEffort;
+  const recentModelIdsRef = useRef(appConfig.data.recentModelIds ?? []);
+  const updateConfig = appConfig.update;
 
   // Wrapper that marks model as user-selected and persists to config.
   // Pass `persist = false` for programmatic/initialization calls so the
   // user's previously saved preference is not silently overwritten.
-  const setModel = useCallback((newModel: ModelInfo, persist = true) => {
-    setModelInternal(newModel);
-    if (persist) {
-      setIsModelUserSelected(true);
-      const configUpdate: {
-        selectedModelId: string;
-        reasoningEnabled?: boolean;
-        openAIReasoningEffort?: OpenAIReasoningEffort;
-      } = {
-        selectedModelId: newModel.id,
-      };
-      if (reasoningEnabledRef.current && !modelSupportsThinking(newModel.id)) {
-        configUpdate.reasoningEnabled = false;
-        setReasoningEnabledInternal(false);
+  const setModel = useCallback(
+    (newModel: ModelInfo, persist = true) => {
+      setModelInternal(newModel);
+      if (persist) {
+        setIsModelUserSelected(true);
+        const nextRecentModelIds = addRecentModelId(
+          recentModelIdsRef.current,
+          newModel.id,
+        );
+        recentModelIdsRef.current = nextRecentModelIds;
+
+        const configUpdate: {
+          selectedModelId: string;
+          recentModelIds: string[];
+          reasoningEnabled?: boolean;
+          openAIReasoningEffort?: OpenAIReasoningEffort;
+        } = {
+          selectedModelId: newModel.id,
+          recentModelIds: nextRecentModelIds,
+        };
+        if (
+          reasoningEnabledRef.current &&
+          !modelSupportsThinking(newModel.id)
+        ) {
+          configUpdate.reasoningEnabled = false;
+          setReasoningEnabledInternal(false);
+        }
+        const supportedOpenAIEfforts = getOpenAIReasoningEfforts(newModel.id);
+        if (
+          supportedOpenAIEfforts.length > 0 &&
+          !supportedOpenAIEfforts.includes(openAIReasoningEffortRef.current)
+        ) {
+          configUpdate.openAIReasoningEffort = DEFAULT_OPENAI_REASONING_EFFORT;
+          setOpenAIReasoningEffortInternal(DEFAULT_OPENAI_REASONING_EFFORT);
+        }
+        updateConfig(configUpdate).catch((err) => {
+          writeErrorLog(err, "AGENT_CONTEXT");
+        });
       }
-      const supportedOpenAIEfforts = getOpenAIReasoningEfforts(newModel.id);
-      if (
-        supportedOpenAIEfforts.length > 0 &&
-        !supportedOpenAIEfforts.includes(openAIReasoningEffortRef.current)
-      ) {
-        configUpdate.openAIReasoningEffort = DEFAULT_OPENAI_REASONING_EFFORT;
-        setOpenAIReasoningEffortInternal(DEFAULT_OPENAI_REASONING_EFFORT);
-      }
-      updateConfig(configUpdate).catch((err) => {
+    },
+    [updateConfig],
+  );
+
+  const setReasoningEnabled = useCallback(
+    (enabled: boolean) => {
+      setReasoningEnabledInternal(enabled);
+      updateConfig({ reasoningEnabled: enabled }).catch((err) => {
         writeErrorLog(err, "AGENT_CONTEXT");
       });
-    }
-  }, []);
-
-  const setReasoningEnabled = useCallback((enabled: boolean) => {
-    setReasoningEnabledInternal(enabled);
-    updateConfig({ reasoningEnabled: enabled }).catch((err) => {
-      writeErrorLog(err, "AGENT_CONTEXT");
-    });
-  }, []);
+    },
+    [updateConfig],
+  );
 
   const setOpenAIReasoningEffort = useCallback(
     (effort: OpenAIReasoningEffort) => {
@@ -154,8 +173,12 @@ export function AgentProvider({ children }: AgentProviderProps) {
         writeErrorLog(err, "AGENT_CONTEXT");
       });
     },
-    [],
+    [updateConfig],
   );
+
+  useEffect(() => {
+    recentModelIdsRef.current = appConfig.data.recentModelIds ?? [];
+  }, [appConfig.data.recentModelIds]);
 
   // Sync reasoningEnabled when config loads asynchronously
   useEffect(() => {

--- a/src/tui/context/config.tsx
+++ b/src/tui/context/config.tsx
@@ -1,6 +1,7 @@
 import {
   createContext,
   type ReactNode,
+  useCallback,
   useContext,
   useMemo,
   useState,
@@ -24,22 +25,26 @@ type ConfigProviderProps = {
 export function ConfigProvider({ children, config }: ConfigProviderProps) {
   const [appConfig, setAppConfig] = useState<Config>(config);
 
+  const update = useCallback(async (newConfig: Partial<Config>) => {
+    await _config.update(newConfig);
+    setAppConfig((current) => ({
+      ...current,
+      ...newConfig,
+    }));
+  }, []);
+
+  const reload = useCallback(async () => {
+    const freshConfig = await _config.get();
+    setAppConfig(freshConfig);
+  }, []);
+
   const value = useMemo(
     () => ({
       data: appConfig,
-      update: async (newConfig: Partial<Config>) => {
-        await _config.update(newConfig);
-        setAppConfig({
-          ...appConfig,
-          ...newConfig,
-        });
-      },
-      reload: async () => {
-        const freshConfig = await _config.get();
-        setAppConfig(freshConfig);
-      },
+      update,
+      reload,
     }),
-    [appConfig],
+    [appConfig, reload, update],
   );
 
   return <ctx.Provider value={value}>{children}</ctx.Provider>;


### PR DESCRIPTION
## Summary

- focus the /models dialog search input immediately
- add persisted, provider-aware recent models with a five-model cap
- match queries against model names, IDs, families, and provider labels
- keep arrow navigation non-destructive until selection is confirmed

## Validation

- bun run test (1605 passed, 22 skipped)
- bun run tsc
- bun run build
- bun run lint
- bun run format:check
- local OpenTUI renderer smoke test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI and local config preference changes only; model selection still goes through existing `setModel` persistence with tests for recents and filtering.
> 
> **Overview**
> **Improves the `/models` picker** with a dedicated search field, persisted **Recent** models (up to five IDs in config), and safer keyboard behavior.
> 
> Search no longer hijacks printable keys: queries run through normalized multi-term matching on names, IDs, and provider labels, with a flat results list while searching. Browse mode shows a **Recent** section (from `recentModelIds` via `addRecentModelId` / `getRecentModels`) above the provider tree; **↑/↓** only move focus and **Enter** applies the model and closes the dialog, so previewing no longer overwrites the active model or config.
> 
> Provider expansion is refactored (`retainAvailableProviders`, one-time reveal for the selected model’s provider) and display names/order now include **bedrock-mantle** and **inception**. `AgentProvider` writes `recentModelIds` on persisted selection; `ConfigProvider` uses stable `update`/`reload` callbacks. Adds `PRODUCT.md` and unit tests for history, search, and navigation helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97cdfce3d2a945d684c21736843fba9e279e4fce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->