### PR TITLE
chore(tui): hide deprecated models from picker

### DIFF
--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -147,15 +147,21 @@ export function ModelPicker({
     setLocalModelName(config?.localModelName ?? "");
   }, [config?.localModelUrl, config?.localModelName]);
 
-  // Load models when config changes
+  // Load models when config changes. The selected model stays visible even
+  // when lifecycle-hidden, so an existing config's selection can be seen.
   useEffect(() => {
     if (!config) {
       setAvailableModels([]);
       return;
     }
 
-    setAvailableModels(getVisiblePickerModels(getAvailableModels(config)));
-  }, [config]);
+    setAvailableModels(
+      getVisiblePickerModels(getAvailableModels(config), {
+        id: selectedModel.id,
+        provider: selectedModel.provider,
+      }),
+    );
+  }, [config, selectedModel.id, selectedModel.provider]);
 
   useEffect(() => {
     const availableProviders = new Set<AIModelProvider>(

--- a/src/tui/components/model-picker/ModelPicker.tsx
+++ b/src/tui/components/model-picker/ModelPicker.tsx
@@ -28,6 +28,7 @@ import {
   retainAvailableProviders,
 } from "./model-navigation";
 import { filterModels, getProviderDisplayName } from "./model-search";
+import { getVisiblePickerModels } from "./model-visibility";
 
 const providerOrder: AIModelProvider[] = [
   "pensar",
@@ -153,7 +154,7 @@ export function ModelPicker({
       return;
     }
 
-    setAvailableModels(getAvailableModels(config));
+    setAvailableModels(getVisiblePickerModels(getAvailableModels(config)));
   }, [config]);
 
   useEffect(() => {

--- a/src/tui/components/model-picker/model-visibility.test.ts
+++ b/src/tui/components/model-picker/model-visibility.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { AIModelProvider, ModelInfo } from "../../../core/ai";
+import { getVisiblePickerModels } from "./model-visibility";
+
+function model(id: string, provider: AIModelProvider): ModelInfo {
+  return { id, name: id, provider };
+}
+
+describe("getVisiblePickerModels", () => {
+  it("hides deprecated direct-provider models", () => {
+    const models = [
+      model("claude-3-haiku-20240307", "anthropic"),
+      model("claude-opus-4-8", "anthropic"),
+      model("gpt-3.5-turbo", "openai"),
+      model("gpt-5.6-sol", "openai"),
+      model("gemini-2.0-flash", "google"),
+      model("gemini-3.1-pro-preview", "google"),
+    ];
+
+    expect(getVisiblePickerModels(models)).toEqual([
+      models[1],
+      models[3],
+      models[5],
+    ]);
+  });
+
+  it("does not apply one provider's lifecycle to another provider", () => {
+    const models = [
+      model("gpt-3.5-turbo", "local"),
+      model("openai/gpt-3.5-turbo", "openrouter"),
+      model("anthropic.claude-3-haiku-20240307-v1:0", "bedrock"),
+    ];
+
+    expect(getVisiblePickerModels(models)).toEqual(models);
+  });
+});

--- a/src/tui/components/model-picker/model-visibility.test.ts
+++ b/src/tui/components/model-picker/model-visibility.test.ts
@@ -12,6 +12,7 @@ describe("getVisiblePickerModels", () => {
       model("claude-3-haiku-20240307", "anthropic"),
       model("claude-opus-4-8", "anthropic"),
       model("gpt-3.5-turbo", "openai"),
+      model("gpt-4o-2024-05-13", "openai"),
       model("gpt-5.6-sol", "openai"),
       model("gemini-2.0-flash", "google"),
       model("gemini-3.1-pro-preview", "google"),
@@ -19,9 +20,37 @@ describe("getVisiblePickerModels", () => {
 
     expect(getVisiblePickerModels(models)).toEqual([
       models[1],
-      models[3],
-      models[5],
+      models[4],
+      models[6],
     ]);
+  });
+
+  it("keeps a hidden model visible while it is the selected model", () => {
+    const models = [
+      model("gpt-3.5-turbo", "openai"),
+      model("gpt-5.6-sol", "openai"),
+    ];
+
+    expect(
+      getVisiblePickerModels(models, {
+        id: "gpt-3.5-turbo",
+        provider: "openai",
+      }),
+    ).toEqual(models);
+  });
+
+  it("does not exempt a hidden model selected on a different provider", () => {
+    const models = [
+      model("gpt-3.5-turbo", "openai"),
+      model("gpt-3.5-turbo", "local"),
+    ];
+
+    expect(
+      getVisiblePickerModels(models, {
+        id: "gpt-3.5-turbo",
+        provider: "local",
+      }),
+    ).toEqual([models[1]]);
   });
 
   it("does not apply one provider's lifecycle to another provider", () => {

--- a/src/tui/components/model-picker/model-visibility.ts
+++ b/src/tui/components/model-picker/model-visibility.ts
@@ -1,0 +1,54 @@
+import type { AIModelProvider, ModelInfo } from "../../../core/ai";
+
+// Lifecycle status is provider-specific; gateway and local models are intentionally unaffected.
+const HIDDEN_MODEL_IDS: Partial<Record<AIModelProvider, ReadonlySet<string>>> =
+  {
+    anthropic: new Set([
+      "claude-3-haiku-20240307",
+      "claude-opus-4-0",
+      "claude-opus-4-20250514",
+      "claude-opus-4-1",
+      "claude-opus-4-1-20250805",
+      "claude-sonnet-4-0",
+      "claude-sonnet-4-20250514",
+    ]),
+    openai: new Set([
+      "gpt-5.3-chat-latest",
+      "gpt-5.2-chat-latest",
+      "gpt-5.2-codex",
+      "gpt-5.1-chat-latest",
+      "gpt-5.1-codex-mini",
+      "gpt-5.1-codex",
+      "gpt-5.1-codex-max",
+      "gpt-5-chat-latest",
+      "gpt-5-codex",
+      "gpt-4.1-nano",
+      "gpt-4.1-nano-2025-04-14",
+      "gpt-3.5-turbo",
+      "gpt-3.5-turbo-0125",
+      "gpt-3.5-turbo-1106",
+      "o4-mini",
+      "o4-mini-2025-04-16",
+      "o3-mini",
+      "o3-mini-2025-01-31",
+      "o1",
+      "o1-2024-12-17",
+    ]),
+    google: new Set([
+      "gemini-2.0-flash",
+      "gemini-2.0-flash-001",
+      "gemini-2.0-flash-lite",
+      "gemini-2.0-flash-lite-001",
+      "gemini-3-pro-preview",
+      "gemini-3.1-flash-lite-preview",
+      "gemini-robotics-er-1.5-preview",
+    ]),
+  };
+
+export function getVisiblePickerModels(
+  models: readonly ModelInfo[],
+): ModelInfo[] {
+  return models.filter(
+    (model) => !HIDDEN_MODEL_IDS[model.provider]?.has(model.id),
+  );
+}

--- a/src/tui/components/model-picker/model-visibility.ts
+++ b/src/tui/components/model-picker/model-visibility.ts
@@ -24,6 +24,7 @@ const HIDDEN_MODEL_IDS: Partial<Record<AIModelProvider, ReadonlySet<string>>> =
       "gpt-5-codex",
       "gpt-4.1-nano",
       "gpt-4.1-nano-2025-04-14",
+      "gpt-4o-2024-05-13",
       "gpt-3.5-turbo",
       "gpt-3.5-turbo-0125",
       "gpt-3.5-turbo-1106",
@@ -47,8 +48,12 @@ const HIDDEN_MODEL_IDS: Partial<Record<AIModelProvider, ReadonlySet<string>>> =
 
 export function getVisiblePickerModels(
   models: readonly ModelInfo[],
+  selectedModel?: Pick<ModelInfo, "id" | "provider">,
 ): ModelInfo[] {
   return models.filter(
-    (model) => !HIDDEN_MODEL_IDS[model.provider]?.has(model.id),
+    (model) =>
+      !HIDDEN_MODEL_IDS[model.provider]?.has(model.id) ||
+      (model.id === selectedModel?.id &&
+        model.provider === selectedModel.provider),
   );
 }


### PR DESCRIPTION
## Stack

- Depends on #982
- Base: feat/model-search

## Summary

- hide 34 deprecated, retired, or shut-down direct-provider models from the picker
- scope lifecycle exclusions by provider so Bedrock, gateways, and local models are unaffected
- keep the full runtime registry intact so existing configs and direct model IDs remain compatible
- cover visibility behavior and provider isolation with unit tests

Lifecycle references:
- https://platform.claude.com/docs/en/about-claude/model-deprecations
- https://developers.openai.com/api/docs/models/all
- https://ai.google.dev/gemini-api/docs/deprecations

## Validation

- bun run test (1607 passed, 22 skipped)
- bun run tsc
- bun run build
- bun run lint
- bun run format:check
- picker visibility audit: 34 hidden, 230 remaining

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only picker filtering with no changes to runtime model resolution or config; selected-model exemption limits disruption for existing setups.
> 
> **Overview**
> The TUI model picker now filters out **34 deprecated/retired direct-provider models** (Anthropic, OpenAI, Google) via a new `getVisiblePickerModels` helper with provider-scoped ID blocklists. **Bedrock, gateways, and local** entries are unchanged because lifecycle rules apply only to those three providers.
> 
> `ModelPicker` runs `getAvailableModels(config)` through this filter when building the list, and **recomputes when the selected model changes** so a user’s current choice stays visible even if it would otherwise be hidden. The core model registry is untouched—this is display-only.
> 
> Unit tests cover default hiding, selected-model exemption (matching id **and** provider), and that other providers are not affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cf0a399893781feb2cfb079f8269732f1287ee8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->