### PR TITLE
refactor(agent): extract stream diagnostics collaborator

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -26,6 +26,7 @@ import { create as createSession, type SessionInfo } from "../../session";
 import { scopedLogger } from "../../util/lazyLogger";
 import { detectOSAndEnhancePrompt } from "../specialized/utils";
 import { buildBaseSystemPrompt, buildSessionWorkspaceSection } from "./prompt";
+import { responseArgBytes, StreamDiagnostics } from "./streamDiagnostics";
 import {
   ASK_USER_QUESTIONS_TOOL_NAME,
   createAllTools,
@@ -171,24 +172,6 @@ export function filterWorkspaceToolsForRun(
     if (WORKSPACE_TOOL_NAME_SET.has(name)) return readRequested;
     return true;
   });
-}
-
-// Opt-in stall watchdog (STREAM_STALL_DEBUG=1): warns when fullStream goes byte-silent, catching a Bedrock wedge.
-const STREAM_STALL_DEBUG =
-  process.env.STREAM_STALL_DEBUG === "1" ||
-  process.env.STREAM_STALL_DEBUG === "true";
-const STREAM_STALL_TICK_MS = 15_000;
-const STREAM_STALL_WARN_MS = 20_000;
-const STREAM_GAP_RECOVERED_MS = 10_000;
-
-function responseArgBytes(input: unknown): number {
-  if (input == null) return 0;
-  if (typeof input === "string") return input.length;
-  try {
-    return JSON.stringify(input).length;
-  } catch {
-    return -1;
-  }
 }
 
 /**
@@ -850,9 +833,6 @@ export class OffensiveSecurityAgent<TResult = void> {
       const completedResults: ToolResultPart[] = [];
       let streamError: unknown = null;
 
-      const responseArgChars = new Map<string, number>();
-      const responseSawTerminal = new Map<string, string>();
-
       // Raw streamed arg text per tool-call id, kept so a `tool-error` can persist the real (possibly truncated) payload instead of `{}`.
       const streamedArgText = new Map<string, string>();
       // Tool errors observed mid-stream, surfaced at finish-step (where finishReason is known) instead of a generic "did not complete".
@@ -861,108 +841,19 @@ export class OffensiveSecurityAgent<TResult = void> {
         { message: string; input: unknown; toolName: string }
       >();
 
-      let lastChunkAt = Date.now();
-      let lastChunkType = "none";
-      let stallStepIndex = -1;
-      let stallTimer: ReturnType<typeof setInterval> | undefined;
-      if (STREAM_STALL_DEBUG) {
-        const label = this._session.id;
-        stallTimer = setInterval(() => {
-          const gap = Date.now() - lastChunkAt;
-          if (gap > STREAM_STALL_WARN_MS) {
-            rlog.warn(
-              `[stream-stall] no chunk for ${Math.round(gap / 1000)}s ` +
-                `session=${label} subagent=${sid ?? "-"} step=${stallStepIndex} ` +
-                `lastChunkType=${lastChunkType} ` +
-                `inFlightTools=${[...inFlightTools.values()].join(",")} ` +
-                `responseToolFired=${this._responseToolFired}`,
-            );
-          }
-        }, STREAM_STALL_TICK_MS);
-      }
+      // Opt-in stall watchdog + response-tool tracer (see ./streamDiagnostics).
+      const diagnostics = new StreamDiagnostics({
+        sessionId: this._session.id,
+        subagentId: sid,
+        inFlightTools: () => inFlightTools,
+        responseToolFired: () => this._responseToolFired,
+        responseToolName: RESPONSE_TOOL_NAME,
+      });
+      diagnostics.start();
 
       try {
         for await (const chunk of this.streamResult.fullStream) {
-          if (STREAM_STALL_DEBUG) {
-            const now = Date.now();
-            const gap = now - lastChunkAt;
-            lastChunkAt = now;
-            lastChunkType = chunk.type;
-            if (chunk.type === "start-step") stallStepIndex++;
-            if (gap > STREAM_GAP_RECOVERED_MS) {
-              rlog.warn(
-                `[stream-gap] recovered after ${Math.round(gap / 1000)}s ` +
-                  `session=${this._session.id} chunkType=${chunk.type}`,
-              );
-            }
-          }
-          if (RESPONSE_DEBUG) {
-            const c = chunk as {
-              type: string;
-              id?: string;
-              toolCallId?: string;
-              toolName?: string;
-              delta?: string;
-              input?: unknown;
-              args?: unknown;
-              error?: unknown;
-            };
-            const idForChunk = c.toolCallId ?? c.id;
-            const nameForChunk =
-              c.toolName ??
-              (idForChunk ? inFlightTools.get(idForChunk) : undefined);
-            if (nameForChunk === RESPONSE_TOOL_NAME && idForChunk) {
-              if (chunk.type === "tool-input-start") {
-                responseArgChars.set(idForChunk, 0);
-                rlog.warn(
-                  `[response-debug] tool-input-start id=${idForChunk} session=${this.busSessionId}`,
-                );
-              } else if (chunk.type === "tool-input-delta") {
-                responseArgChars.set(
-                  idForChunk,
-                  (responseArgChars.get(idForChunk) ?? 0) +
-                    (c.delta?.length ?? 0),
-                );
-              } else if (chunk.type === "tool-input-end") {
-                rlog.warn(
-                  `[response-debug] tool-input-end id=${idForChunk} argChars=${responseArgChars.get(idForChunk) ?? 0}`,
-                );
-              } else if (chunk.type === "tool-call") {
-                responseSawTerminal.set(idForChunk, "tool-call");
-                const inputBytes = responseArgBytes(c.input ?? c.args);
-                const invalid = (c as { invalid?: boolean }).invalid === true;
-                rlog.warn(
-                  `[response-debug] tool-call id=${idForChunk} streamedArgChars=${responseArgChars.get(idForChunk) ?? 0} parsedInputBytes=${inputBytes} invalid=${invalid}`,
-                );
-              } else if (chunk.type === "tool-error") {
-                responseSawTerminal.set(idForChunk, "tool-error");
-                const errMsg =
-                  c.error instanceof Error
-                    ? c.error.message
-                    : typeof c.error === "string"
-                      ? c.error
-                      : JSON.stringify(c.error)?.slice(0, 300);
-                rlog.warn(
-                  `[response-debug] tool-error id=${idForChunk} streamedArgChars=${responseArgChars.get(idForChunk) ?? 0} stillInFlight=${inFlightTools.has(idForChunk)} error=${errMsg}`,
-                );
-              } else if (chunk.type === "tool-result") {
-                responseSawTerminal.set(idForChunk, "tool-result");
-                rlog.warn(
-                  `[response-debug] tool-result id=${idForChunk} streamedArgChars=${responseArgChars.get(idForChunk) ?? 0}`,
-                );
-              } else if (chunk.type === "finish-step") {
-                const fr = (c as { finishReason?: string }).finishReason;
-                rlog.warn(
-                  `[response-debug] finish-step finishReason=${fr} responseInFlight=${[
-                    ...inFlightTools.entries(),
-                  ]
-                    .filter(([, n]) => n === RESPONSE_TOOL_NAME)
-                    .map(([id]) => id)
-                    .join(",")} responseToolFired=${this._responseToolFired}`,
-                );
-              }
-            }
-          }
+          diagnostics.observeChunk(chunk);
           switch (chunk.type) {
             case "start-step":
               ids.messageId = newMessageId();
@@ -1049,14 +940,15 @@ export class OffensiveSecurityAgent<TResult = void> {
               const truncated = finishReason === "length";
 
               for (const [toolCallId, info] of toolErrors) {
-                if (RESPONSE_DEBUG && info.toolName === RESPONSE_TOOL_NAME) {
-                  rlog.warn(
-                    `[response-debug] tool-error SURFACED id=${toolCallId} ` +
-                      `streamedArgChars=${(streamedArgText.get(toolCallId) ?? "").length} ` +
-                      `finishReason=${finishReason ?? "unknown"} ` +
-                      `outputTokenTruncated=${truncated} error=${info.message.slice(0, 300)}`,
-                  );
-                }
+                diagnostics.logSurfacedToolError({
+                  toolCallId,
+                  toolName: info.toolName,
+                  message: info.message,
+                  streamedArgChars: (streamedArgText.get(toolCallId) ?? "")
+                    .length,
+                  finishReason,
+                  truncated,
+                });
                 bus.emit("tool-result", {
                   toolCallId,
                   toolName: info.toolName,
@@ -1076,15 +968,12 @@ export class OffensiveSecurityAgent<TResult = void> {
 
               // Close any call still in flight (args never finalized) so it doesn't render stuck "running".
               for (const [toolCallId, toolName] of inFlightTools) {
-                if (RESPONSE_DEBUG && toolName === RESPONSE_TOOL_NAME) {
-                  rlog.warn(
-                    `[response-debug] CLOSING response as "did not complete" id=${toolCallId} ` +
-                      `streamedArgChars=${responseArgChars.get(toolCallId) ?? 0} ` +
-                      `sawTerminalChunk=${responseSawTerminal.get(toolCallId) ?? "none"} ` +
-                      `finishReason=${finishReason ?? "unknown"} outputTokenTruncated=${truncated} ` +
-                      `responseToolFired=${this._responseToolFired}`,
-                  );
-                }
+                diagnostics.logClosingInFlightTool({
+                  toolCallId,
+                  toolName,
+                  finishReason,
+                  truncated,
+                });
                 // Already-fired response: mark submitted, not "did not complete".
                 const result =
                   toolName === RESPONSE_TOOL_NAME && this._responseToolFired
@@ -1116,7 +1005,7 @@ export class OffensiveSecurityAgent<TResult = void> {
         streamError = err;
       } finally {
         // Stop the stall watchdog so it never leaks past stream end / throw.
-        if (stallTimer) clearInterval(stallTimer);
+        diagnostics.stop();
         let finalizationError: unknown;
         let hasFinalizationError = false;
         const recordFinalizationError = (error: unknown) => {

--- a/src/core/agents/offSecAgent/streamDiagnostics.test.ts
+++ b/src/core/agents/offSecAgent/streamDiagnostics.test.ts
@@ -178,8 +178,8 @@ describe("StreamDiagnostics response-tool tracer", () => {
       delta: '"x"}',
     });
     diagnostics.observeChunk({ type: "tool-input-end", id: "tc-r" });
-    expect(warns.some((w) => w.includes("tool-input-start id=tc-r"))).toBe(
-      true,
+    expect(warns).toContain(
+      "[response-debug] tool-input-start id=tc-r session=sub_1",
     );
     expect(
       warns.some((w) => w.includes("tool-input-end id=tc-r argChars=15")),

--- a/src/core/agents/offSecAgent/streamDiagnostics.test.ts
+++ b/src/core/agents/offSecAgent/streamDiagnostics.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it, vi } from "vitest";
+import { responseArgBytes, StreamDiagnostics } from "./streamDiagnostics";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeDiagnostics(overrides?: {
+  stallEnabled?: boolean;
+  responseDebugEnabled?: boolean;
+  inFlightTools?: Map<string, string>;
+  responseToolFired?: boolean;
+}) {
+  const warns: string[] = [];
+  const inFlightTools = overrides?.inFlightTools ?? new Map<string, string>();
+  const diagnostics = new StreamDiagnostics({
+    sessionId: "ses_test",
+    subagentId: "sub_1",
+    inFlightTools: () => inFlightTools,
+    responseToolFired: () => overrides?.responseToolFired ?? false,
+    responseToolName: "response",
+    stallEnabled: overrides?.stallEnabled ?? false,
+    responseDebugEnabled: overrides?.responseDebugEnabled ?? false,
+    warn: (m) => warns.push(m),
+  });
+  return { diagnostics, warns, inFlightTools };
+}
+
+// ---------------------------------------------------------------------------
+// Stall watchdog
+// ---------------------------------------------------------------------------
+
+describe("StreamDiagnostics stall watchdog", () => {
+  it("warns when no chunk arrives within the stall window, reporting step/type/in-flight state", () => {
+    vi.useFakeTimers();
+    try {
+      const { diagnostics, warns, inFlightTools } = makeDiagnostics({
+        stallEnabled: true,
+      });
+      inFlightTools.set("tc-1", "response");
+      diagnostics.start();
+
+      diagnostics.observeChunk({ type: "start-step" });
+      diagnostics.observeChunk({ type: "text-delta", delta: "hi" });
+
+      // 20s warn threshold, 15s tick — the second tick crosses it.
+      vi.advanceTimersByTime(15_000);
+      expect(warns).toHaveLength(0);
+      vi.advanceTimersByTime(15_000);
+
+      expect(warns).toHaveLength(1);
+      const warn = warns[0] ?? "";
+      expect(warn).toContain("[stream-stall]");
+      expect(warn).toContain("session=ses_test");
+      expect(warn).toContain("subagent=sub_1");
+      expect(warn).toContain("step=0");
+      expect(warn).toContain("lastChunkType=text-delta");
+      expect(warn).toContain("inFlightTools=response");
+      expect(warn).toContain("responseToolFired=false");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stop() clears the interval and is idempotent", () => {
+    vi.useFakeTimers();
+    try {
+      const { diagnostics, warns } = makeDiagnostics({
+        stallEnabled: true,
+      });
+      diagnostics.start();
+      diagnostics.stop();
+      diagnostics.stop();
+
+      vi.advanceTimersByTime(120_000);
+      expect(warns).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("start() is a no-op when the watchdog is disabled", () => {
+    vi.useFakeTimers();
+    try {
+      const { diagnostics, warns } = makeDiagnostics({ stallEnabled: false });
+      diagnostics.start();
+      vi.advanceTimersByTime(120_000);
+      expect(warns).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stream-gap tracking
+// ---------------------------------------------------------------------------
+
+describe("StreamDiagnostics gap tracking", () => {
+  it("warns when a chunk arrives after a long silence", () => {
+    vi.useFakeTimers();
+    try {
+      const { diagnostics, warns } = makeDiagnostics({
+        stallEnabled: true,
+      });
+      diagnostics.start();
+      diagnostics.observeChunk({ type: "text-delta", delta: "first" });
+
+      vi.advanceTimersByTime(11_000);
+      diagnostics.observeChunk({ type: "tool-call", toolCallId: "tc-1" });
+
+      expect(warns).toHaveLength(1);
+      expect(warns[0]).toContain("[stream-gap]");
+      expect(warns[0]).toContain("recovered after 11s");
+      expect(warns[0]).toContain("session=ses_test");
+      expect(warns[0]).toContain("chunkType=tool-call");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not warn for short gaps", () => {
+    vi.useFakeTimers();
+    try {
+      const { diagnostics, warns } = makeDiagnostics({
+        stallEnabled: true,
+      });
+      diagnostics.observeChunk({ type: "text-delta", delta: "a" });
+      vi.advanceTimersByTime(5_000);
+      diagnostics.observeChunk({ type: "text-delta", delta: "b" });
+      expect(warns).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gap tracking is disabled with the watchdog", () => {
+    vi.useFakeTimers();
+    try {
+      const { diagnostics, warns } = makeDiagnostics({
+        stallEnabled: false,
+      });
+      diagnostics.observeChunk({ type: "text-delta", delta: "a" });
+      vi.advanceTimersByTime(60_000);
+      diagnostics.observeChunk({ type: "text-delta", delta: "b" });
+      expect(warns).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response-tool tracer
+// ---------------------------------------------------------------------------
+
+describe("StreamDiagnostics response-tool tracer", () => {
+  it("traces the full response-tool lifecycle with arg-char accumulation", () => {
+    const inFlight = new Map<string, string>([["tc-r", "response"]]);
+    const { diagnostics, warns } = makeDiagnostics({
+      responseDebugEnabled: true,
+      inFlightTools: inFlight,
+    });
+
+    diagnostics.observeChunk({
+      type: "tool-input-start",
+      id: "tc-r",
+      toolName: "response",
+    });
+    diagnostics.observeChunk({
+      type: "tool-input-delta",
+      id: "tc-r",
+      delta: '{"summary":',
+    });
+    diagnostics.observeChunk({
+      type: "tool-input-delta",
+      id: "tc-r",
+      delta: '"x"}',
+    });
+    diagnostics.observeChunk({ type: "tool-input-end", id: "tc-r" });
+    expect(warns.some((w) => w.includes("tool-input-start id=tc-r"))).toBe(
+      true,
+    );
+    expect(
+      warns.some((w) => w.includes("tool-input-end id=tc-r argChars=15")),
+    ).toBe(true);
+
+    diagnostics.observeChunk({
+      type: "tool-call",
+      id: "tc-r",
+      toolName: "response",
+      input: { summary: "x" },
+    });
+    expect(
+      warns.some(
+        (w) =>
+          w.includes("tool-call id=tc-r") &&
+          w.includes("streamedArgChars=15") &&
+          w.includes("invalid=false"),
+      ),
+    ).toBe(true);
+
+    diagnostics.observeChunk({
+      type: "tool-result",
+      id: "tc-r",
+      toolName: "response",
+    });
+    expect(warns.some((w) => w.includes("tool-result id=tc-r"))).toBe(true);
+  });
+
+  it("resolves the tool name via in-flight state when the chunk omits it", () => {
+    const inFlight = new Map<string, string>([["tc-r", "response"]]);
+    const { diagnostics, warns } = makeDiagnostics({
+      responseDebugEnabled: true,
+      inFlightTools: inFlight,
+    });
+
+    diagnostics.observeChunk({ type: "tool-error", id: "tc-r", error: "boom" });
+
+    expect(
+      warns.some(
+        (w) =>
+          w.includes("tool-error id=tc-r") &&
+          w.includes("stillInFlight=true") &&
+          w.includes("error=boom"),
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores non-response tools and stays silent when disabled", () => {
+    const silent = makeDiagnostics({ responseDebugEnabled: false });
+    silent.diagnostics.observeChunk({
+      type: "tool-call",
+      id: "tc-1",
+      toolName: "response",
+    });
+    expect(silent.warns).toHaveLength(0);
+
+    const enabled = makeDiagnostics({ responseDebugEnabled: true });
+    enabled.diagnostics.observeChunk({
+      type: "tool-call",
+      id: "tc-1",
+      toolName: "execute_command",
+    });
+    enabled.diagnostics.observeChunk({
+      type: "tool-result",
+      id: "tc-1",
+      toolName: "execute_command",
+    });
+    expect(enabled.warns).toHaveLength(0);
+  });
+
+  it("logSurfacedToolError and logClosingInFlightTool only trace the response tool", () => {
+    const { diagnostics, warns } = makeDiagnostics({
+      responseDebugEnabled: true,
+    });
+
+    diagnostics.logSurfacedToolError({
+      toolCallId: "tc-1",
+      toolName: "execute_command",
+      message: "failed",
+      streamedArgChars: 5,
+      truncated: false,
+    });
+    diagnostics.logClosingInFlightTool({
+      toolCallId: "tc-2",
+      toolName: "execute_command",
+      truncated: false,
+    });
+    expect(warns).toHaveLength(0);
+
+    diagnostics.logSurfacedToolError({
+      toolCallId: "tc-r",
+      toolName: "response",
+      message: "args never completed",
+      streamedArgChars: 42,
+      finishReason: "length",
+      truncated: true,
+    });
+    diagnostics.logClosingInFlightTool({
+      toolCallId: "tc-r2",
+      toolName: "response",
+      finishReason: "stop",
+      truncated: false,
+    });
+    expect(warns).toHaveLength(2);
+    expect(warns[0]).toContain("tool-error SURFACED id=tc-r");
+    expect(warns[0]).toContain("finishReason=length");
+    expect(warns[0]).toContain("outputTokenTruncated=true");
+    expect(warns[1]).toContain(
+      'CLOSING response as "did not complete" id=tc-r2',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// responseArgBytes
+// ---------------------------------------------------------------------------
+
+describe("responseArgBytes", () => {
+  it("measures strings, objects, and edge cases", () => {
+    expect(responseArgBytes(null)).toBe(0);
+    expect(responseArgBytes(undefined)).toBe(0);
+    expect(responseArgBytes("abc")).toBe(3);
+    expect(responseArgBytes({ a: 1 })).toBe(JSON.stringify({ a: 1 }).length);
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(responseArgBytes(cyclic)).toBe(-1);
+  });
+});

--- a/src/core/agents/offSecAgent/streamDiagnostics.ts
+++ b/src/core/agents/offSecAgent/streamDiagnostics.ts
@@ -1,0 +1,237 @@
+import { createLogger } from "../../logger/structured";
+import { scopedLogger } from "../../util/lazyLogger";
+
+// ---------------------------------------------------------------------------
+// Stream diagnostics — opt-in observability for the agent stream: a stall
+// watchdog (byte-silent streams), stream-gap recovery warnings, and the
+// `response` tool lifecycle tracer. Purely observational; never touches tool
+// state or stream iteration.
+// ---------------------------------------------------------------------------
+
+const STREAM_STALL_DEBUG =
+  process.env.STREAM_STALL_DEBUG === "1" ||
+  process.env.STREAM_STALL_DEBUG === "true";
+const STREAM_STALL_TICK_MS = 15_000;
+const STREAM_STALL_WARN_MS = 20_000;
+const STREAM_GAP_RECOVERED_MS = 10_000;
+
+const RESPONSE_DEBUG =
+  process.env.RESPONSE_DEBUG === "1" || process.env.RESPONSE_DEBUG === "true";
+
+const rlog = scopedLogger(() => createLogger("response-debug"));
+
+/** Byte size of a streamed tool input, for the response-debug tracer. */
+export function responseArgBytes(input: unknown): number {
+  if (input == null) return 0;
+  if (typeof input === "string") return input.length;
+  try {
+    return JSON.stringify(input).length;
+  } catch {
+    return -1;
+  }
+}
+
+/** Structural chunk view the diagnostics read. */
+export interface DiagnosticsChunk {
+  type: string;
+  id?: string;
+  toolCallId?: string;
+  toolName?: string;
+  delta?: string;
+  input?: unknown;
+  args?: unknown;
+  error?: unknown;
+  invalid?: boolean;
+  finishReason?: string;
+}
+
+export interface StreamDiagnosticsOptions {
+  sessionId: string;
+  subagentId?: string;
+  /** Live in-flight tool view (owned by the lifecycle tracker). */
+  inFlightTools: () => ReadonlyMap<string, string>;
+  /** Whether the `response` tool has fired (owned by the agent). */
+  responseToolFired: () => boolean;
+  /** Tool name treated as the structured-response tool. */
+  responseToolName: string;
+  /** Stall watchdog + gap tracking; defaults to STREAM_STALL_DEBUG. */
+  stallEnabled?: boolean;
+  /** Response-tool lifecycle tracing; defaults to RESPONSE_DEBUG. */
+  responseDebugEnabled?: boolean;
+  /** Warn sink; defaults to the scoped response-debug logger. */
+  warn?: (message: string) => void;
+}
+
+export class StreamDiagnostics {
+  private readonly opts: StreamDiagnosticsOptions;
+  private readonly stallEnabled: boolean;
+  private readonly responseDebugEnabled: boolean;
+  private readonly warn: (message: string) => void;
+  private readonly responseArgChars = new Map<string, number>();
+  private readonly responseSawTerminal = new Map<string, string>();
+
+  private lastChunkAt = Date.now();
+  private lastChunkType = "none";
+  private stallStepIndex = -1;
+  private stallTimer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(options: StreamDiagnosticsOptions) {
+    this.opts = options;
+    this.stallEnabled = options.stallEnabled ?? STREAM_STALL_DEBUG;
+    this.responseDebugEnabled = options.responseDebugEnabled ?? RESPONSE_DEBUG;
+    this.warn = options.warn ?? ((message: string) => rlog.warn(message));
+  }
+
+  /** Start the stall watchdog interval (no-op when disabled). */
+  start(): void {
+    if (!this.stallEnabled || this.stallTimer) return;
+    const label = this.opts.sessionId;
+    const sid = this.opts.subagentId;
+    this.stallTimer = setInterval(() => {
+      const gap = Date.now() - this.lastChunkAt;
+      if (gap > STREAM_STALL_WARN_MS) {
+        this.warn(
+          `[stream-stall] no chunk for ${Math.round(gap / 1000)}s ` +
+            `session=${label} subagent=${sid ?? "-"} step=${this.stallStepIndex} ` +
+            `lastChunkType=${this.lastChunkType} ` +
+            `inFlightTools=${[...this.opts.inFlightTools().values()].join(",")} ` +
+            `responseToolFired=${this.opts.responseToolFired()}`,
+        );
+      }
+    }, STREAM_STALL_TICK_MS);
+  }
+
+  /** Observe one stream chunk: gap tracking plus response-debug tracing. */
+  observeChunk(chunk: DiagnosticsChunk): void {
+    if (this.stallEnabled) {
+      const now = Date.now();
+      const gap = now - this.lastChunkAt;
+      this.lastChunkAt = now;
+      this.lastChunkType = chunk.type;
+      if (chunk.type === "start-step") this.stallStepIndex++;
+      if (gap > STREAM_GAP_RECOVERED_MS) {
+        this.warn(
+          `[stream-gap] recovered after ${Math.round(gap / 1000)}s ` +
+            `session=${this.opts.sessionId} chunkType=${chunk.type}`,
+        );
+      }
+    }
+    if (this.responseDebugEnabled) {
+      this.traceResponseTool(chunk);
+    }
+  }
+
+  /** Response-debug: a deferred tool-error surfaced at finish-step. */
+  logSurfacedToolError(info: {
+    toolCallId: string;
+    toolName: string;
+    message: string;
+    streamedArgChars: number;
+    finishReason?: string;
+    truncated: boolean;
+  }): void {
+    if (!this.responseDebugEnabled) return;
+    if (info.toolName !== this.opts.responseToolName) return;
+    this.warn(
+      `[response-debug] tool-error SURFACED id=${info.toolCallId} ` +
+        `streamedArgChars=${info.streamedArgChars} ` +
+        `finishReason=${info.finishReason ?? "unknown"} ` +
+        `outputTokenTruncated=${info.truncated} error=${info.message.slice(0, 300)}`,
+    );
+  }
+
+  /** Response-debug: an in-flight call closed at finish-step. */
+  logClosingInFlightTool(info: {
+    toolCallId: string;
+    toolName: string;
+    finishReason?: string;
+    truncated: boolean;
+  }): void {
+    if (!this.responseDebugEnabled) return;
+    if (info.toolName !== this.opts.responseToolName) return;
+    this.warn(
+      `[response-debug] CLOSING response as "did not complete" id=${info.toolCallId} ` +
+        `streamedArgChars=${this.responseArgChars.get(info.toolCallId) ?? 0} ` +
+        `sawTerminalChunk=${this.responseSawTerminal.get(info.toolCallId) ?? "none"} ` +
+        `finishReason=${info.finishReason ?? "unknown"} outputTokenTruncated=${info.truncated} ` +
+        `responseToolFired=${this.opts.responseToolFired()}`,
+    );
+  }
+
+  /** Stop the stall watchdog so it never leaks past stream end / throw. */
+  stop(): void {
+    if (this.stallTimer) clearInterval(this.stallTimer);
+    this.stallTimer = undefined;
+  }
+
+  private traceResponseTool(chunk: DiagnosticsChunk): void {
+    const idForChunk = chunk.toolCallId ?? chunk.id;
+    const nameForChunk =
+      chunk.toolName ??
+      (idForChunk ? this.opts.inFlightTools().get(idForChunk) : undefined);
+    if (nameForChunk !== this.opts.responseToolName || !idForChunk) {
+      if (chunk.type === "finish-step") {
+        // finish-step has no tool id; report every response call still in flight.
+        const responseInFlight = [...this.opts.inFlightTools().entries()]
+          .filter(([, n]) => n === this.opts.responseToolName)
+          .map(([id]) => id)
+          .join(",");
+        if (responseInFlight) {
+          this.warn(
+            `[response-debug] finish-step finishReason=${chunk.finishReason} ` +
+              `responseInFlight=${responseInFlight} ` +
+              `responseToolFired=${this.opts.responseToolFired()}`,
+          );
+        }
+      }
+      return;
+    }
+    switch (chunk.type) {
+      case "tool-input-start":
+        this.responseArgChars.set(idForChunk, 0);
+        this.warn(
+          `[response-debug] tool-input-start id=${idForChunk} session=${this.opts.sessionId}`,
+        );
+        break;
+      case "tool-input-delta":
+        this.responseArgChars.set(
+          idForChunk,
+          (this.responseArgChars.get(idForChunk) ?? 0) +
+            (chunk.delta?.length ?? 0),
+        );
+        break;
+      case "tool-input-end":
+        this.warn(
+          `[response-debug] tool-input-end id=${idForChunk} argChars=${this.responseArgChars.get(idForChunk) ?? 0}`,
+        );
+        break;
+      case "tool-call": {
+        this.responseSawTerminal.set(idForChunk, "tool-call");
+        const inputBytes = responseArgBytes(chunk.input ?? chunk.args);
+        this.warn(
+          `[response-debug] tool-call id=${idForChunk} streamedArgChars=${this.responseArgChars.get(idForChunk) ?? 0} parsedInputBytes=${inputBytes} invalid=${chunk.invalid === true}`,
+        );
+        break;
+      }
+      case "tool-error": {
+        this.responseSawTerminal.set(idForChunk, "tool-error");
+        const errMsg =
+          chunk.error instanceof Error
+            ? chunk.error.message
+            : typeof chunk.error === "string"
+              ? chunk.error
+              : JSON.stringify(chunk.error)?.slice(0, 300);
+        this.warn(
+          `[response-debug] tool-error id=${idForChunk} streamedArgChars=${this.responseArgChars.get(idForChunk) ?? 0} stillInFlight=${this.opts.inFlightTools().has(idForChunk)} error=${errMsg}`,
+        );
+        break;
+      }
+      case "tool-result":
+        this.responseSawTerminal.set(idForChunk, "tool-result");
+        this.warn(
+          `[response-debug] tool-result id=${idForChunk} streamedArgChars=${this.responseArgChars.get(idForChunk) ?? 0}`,
+        );
+        break;
+    }
+  }
+}

--- a/src/core/agents/offSecAgent/streamDiagnostics.ts
+++ b/src/core/agents/offSecAgent/streamDiagnostics.ts
@@ -190,7 +190,7 @@ export class StreamDiagnostics {
       case "tool-input-start":
         this.responseArgChars.set(idForChunk, 0);
         this.warn(
-          `[response-debug] tool-input-start id=${idForChunk} session=${this.opts.sessionId}`,
+          `[response-debug] tool-input-start id=${idForChunk} session=${this.opts.subagentId ?? this.opts.sessionId}`,
         );
         break;
       case "tool-input-delta":


### PR DESCRIPTION
## Stack

> [!NOTE]
> **OffensiveSecurityAgent refactor · PR 1 of 7**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| **1** | **[#986](https://github.com/pensarai/apex/pull/986)** | **Stream diagnostics** · `Current` |
| 2 | [#987](https://github.com/pensarai/apex/pull/987) | Tool lifecycle |
| 3 | [#988](https://github.com/pensarai/apex/pull/988) | Interrupted-step messages |
| 4 | [#989](https://github.com/pensarai/apex/pull/989) | Message persistence |
| 5 | [#990](https://github.com/pensarai/apex/pull/990) | Interrupted-step finalization |
| 6 | [#991](https://github.com/pensarai/apex/pull/991) | Resource disposal |
| 7 | [#992](https://github.com/pensarai/apex/pull/992) | `consume()` simplification |

## Summary

- move the stall watchdog, stream-gap tracking, and `response`-tool lifecycle tracing out of `consume()` into a focused `StreamDiagnostics` collaborator (`streamDiagnostics.ts`)
- the collaborator is purely observational: it owns the stall interval, last-chunk/gap state, and the response-debug arg-char/terminal-chunk maps; live tracker state (`inFlightTools`, `responseToolFired`) is injected via accessors
- `consume()`'s ~90 lines of inline debug blocks become `diagnostics.start()` / `observeChunk(chunk)` / `stop()`, plus two named log methods used by the finish-step projections

## Motivation

A1 of Stack B. `consume()` mixed three opt-in diagnostics regimes (STREAM_STALL_DEBUG, stream-gap, RESPONSE_DEBUG) into the stream loop, interleaved with real lifecycle logic. The diagnostics never touch tool state or iteration — extracting them shrinks the loop to its actual concerns and makes the debug tooling directly testable for the first time.

## What changed

**New module: `src/core/agents/offSecAgent/streamDiagnostics.ts`**

- `StreamDiagnostics` — constructor takes `sessionId`, `subagentId`, accessor `inFlightTools()`, accessor `responseToolFired()`, `responseToolName`, optional `stallEnabled`/`responseDebugEnabled` (default to the same env flags), and an injectable `warn` sink (defaults to the scoped `response-debug` logger)
- `start()` / `stop()` — the stall watchdog interval; `stop()` idempotent
- `observeChunk(chunk)` — gap tracking (warns when a chunk arrives after >10s silence) and the full response-tool trace (`tool-input-start`/`delta`/`end`, `tool-call`, `tool-error`, `tool-result`, `finish-step`), with arg-char accumulation and terminal-chunk tracking owned internally
- `logSurfacedToolError(...)` / `logClosingInFlightTool(...)` — the two finish-step debug logs, internally gated on the response tool name
- `responseArgBytes` moved here (exported) — still used by the tool-error partial-args logic in the agent
- all log message formats are byte-identical to the originals

**`offensiveSecurityAgent.ts`** — the four stall/gap constants, `responseArgBytes`, the stream-loop debug blocks, and the finish-step inline debug logs are replaced by the collaborator; `diagnostics.stop()` replaces the raw `clearInterval` in the `finally`. Net −138 lines.

## One deliberate debug-only behavior fix (flagged)

The original `finish-step` response-debug log sat behind `if (nameForChunk === RESPONSE_TOOL_NAME && idForChunk)` — but finish-step chunks carry no id, so the branch was dead and the log could never fire. The extracted version fires it when response calls are actually still in flight (`responseInFlight` non-empty), which was clearly the intent. Opt-in debug output only; all other logs are byte-identical.

## Test coverage

11 tests in `streamDiagnostics.test.ts` (new file, no mocks needed — the module is dependency-free):

- **stall watchdog** — warns after the 20s threshold on the 15s tick with step/type/in-flight/response-fired state; `stop()` clears and is idempotent; disabled → no interval
- **gap tracking** — warns on a chunk after 11s silence with session + chunkType; short gaps silent; disabled with the watchdog
- **response tracer** — full lifecycle trace with arg-char accumulation (15 chars across two deltas), name resolution via in-flight state, `stillInFlight` reporting, non-response tools ignored, disabled → silent; the two finish-step log methods gate on the response tool name
- **`responseArgBytes`** — string/object/null/cyclic cases

## Validation

- `bun run test` (1,639 passed, 22 skipped — all 34 existing agent tests green)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the three touched files

## Notes

- non-goals honored: tool state and stream iteration stay in `consume()` (A2's target)
- `RESPONSE_DEBUG`/`rlog` remain in the agent for the construction-time response-tool log and the interrupted-step debug blocks; those move in A3/A5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability refactor with no change to tool lifecycle or persistence; only opt-in env-flag logging behavior differs slightly for finish-step response-debug.
> 
> **Overview**
> **PR 1 of 7** in the OffensiveSecurityAgent refactor: pulls opt-in stream observability out of `consume()` into a dedicated `StreamDiagnostics` module.
> 
> `offensiveSecurityAgent.ts` no longer embeds stall watchdog timers, stream-gap warnings, or `RESPONSE_DEBUG` chunk tracing in the stream loop. Those behaviors live in `streamDiagnostics.ts` as a **read-only** collaborator that receives `inFlightTools` and `responseToolFired` via accessors. The loop now calls `diagnostics.start()`, `observeChunk(chunk)`, `stop()`, and two finish-step helpers (`logSurfacedToolError`, `logClosingInFlightTool`). **`responseArgBytes`** moves to the new module but stays imported for tool-error partial-arg handling and the response-tool capture log.
> 
> Adds **`streamDiagnostics.test.ts`** (stall interval, gap recovery, response-tool lifecycle, `responseArgBytes`) so diagnostics are testable without running the full agent.
> 
> One **debug-only** fix: `finish-step` response-debug logging now runs when response calls are still in flight (the old branch required a tool id that `finish-step` chunks never carry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4a102451750fd8b86c87c67af89b5aca2b28dc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


