### PR TITLE
refactor(agent): extract tool lifecycle tracker

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -27,6 +27,7 @@ import { scopedLogger } from "../../util/lazyLogger";
 import { detectOSAndEnhancePrompt } from "../specialized/utils";
 import { buildBaseSystemPrompt, buildSessionWorkspaceSection } from "./prompt";
 import { responseArgBytes, StreamDiagnostics } from "./streamDiagnostics";
+import { ToolLifecycleTracker } from "./toolLifecycle";
 import {
   ASK_USER_QUESTIONS_TOOL_NAME,
   createAllTools,
@@ -828,24 +829,17 @@ export class OffensiveSecurityAgent<TResult = void> {
         },
       };
 
-      // inFlightTools = calls awaiting a result; completedResults = streamed but not yet persisted by onStepFinish (PR #779).
-      const inFlightTools = new Map<string, string>();
-      const completedResults: ToolResultPart[] = [];
+      // Tool lifecycle state: in-flight calls awaiting a result, completed but
+      // unpersisted results (PR #779), streamed arg text, and deferred tool
+      // errors — all owned by the tracker (see ./toolLifecycle).
+      const tracker = new ToolLifecycleTracker();
       let streamError: unknown = null;
-
-      // Raw streamed arg text per tool-call id, kept so a `tool-error` can persist the real (possibly truncated) payload instead of `{}`.
-      const streamedArgText = new Map<string, string>();
-      // Tool errors observed mid-stream, surfaced at finish-step (where finishReason is known) instead of a generic "did not complete".
-      const toolErrors = new Map<
-        string,
-        { message: string; input: unknown; toolName: string }
-      >();
 
       // Opt-in stall watchdog + response-tool tracer (see ./streamDiagnostics).
       const diagnostics = new StreamDiagnostics({
         sessionId: this._session.id,
         subagentId: sid,
-        inFlightTools: () => inFlightTools,
+        inFlightTools: () => tracker.inFlightTools,
         responseToolFired: () => this._responseToolFired,
         responseToolName: RESPONSE_TOOL_NAME,
       });
@@ -866,86 +860,20 @@ export class OffensiveSecurityAgent<TResult = void> {
             case "text-end":
               ids.textPartId = undefined;
               break;
-            case "tool-input-start":
-              // Track from the start so a truncated call still gets closed instead of left "running".
-              inFlightTools.set(chunk.id, chunk.toolName);
-              streamedArgText.set(chunk.id, "");
-              break;
-            case "tool-input-delta": {
-              const d = chunk as { id: string; delta?: string };
-              streamedArgText.set(
-                d.id,
-                (streamedArgText.get(d.id) ?? "") + (d.delta ?? ""),
-              );
-              break;
-            }
-            case "tool-call":
-              inFlightTools.set(chunk.toolCallId, chunk.toolName);
-              break;
-            case "tool-error": {
-              // `execute` never runs for an errored call, so it must be cleared here or finish-step would fabricate a bogus "did not complete".
-              const te = chunk as {
-                toolCallId: string;
-                toolName: string;
-                input?: unknown;
-                error?: unknown;
-              };
-              inFlightTools.delete(te.toolCallId);
-              const errMsg =
-                te.error instanceof Error
-                  ? te.error.message
-                  : typeof te.error === "string"
-                    ? te.error
-                    : (() => {
-                        try {
-                          return JSON.stringify(te.error);
-                        } catch {
-                          return String(te.error);
-                        }
-                      })();
-              const partialArgs =
-                te.input !== undefined &&
-                te.input !== null &&
-                responseArgBytes(te.input) > 2
-                  ? te.input
-                  : (streamedArgText.get(te.toolCallId) ?? "");
-              toolErrors.set(te.toolCallId, {
-                message: errMsg,
-                input: partialArgs,
-                toolName: te.toolName,
-              });
-              break;
-            }
-            case "tool-result": {
-              const tc = chunk as {
-                toolCallId: string;
-                toolName: string;
-                result?: unknown;
-                output?: unknown;
-              };
-              inFlightTools.delete(tc.toolCallId);
-              completedResults.push({
-                type: "tool-result",
-                toolCallId: tc.toolCallId,
-                toolName: tc.toolName,
-                output: (tc.result ?? tc.output) as ToolResultPart["output"],
-              });
-              break;
-            }
             case "finish-step": {
-              // onStepFinish has persisted this step; drop its results so a later abort doesn't re-append them.
-              completedResults.length = 0;
+              tracker.onStepPersisted();
               const finishReason = (chunk as { finishReason?: string })
                 .finishReason;
               const truncated = finishReason === "length";
 
-              for (const [toolCallId, info] of toolErrors) {
+              for (const [toolCallId, info] of tracker.toolErrors) {
                 diagnostics.logSurfacedToolError({
                   toolCallId,
                   toolName: info.toolName,
                   message: info.message,
-                  streamedArgChars: (streamedArgText.get(toolCallId) ?? "")
-                    .length,
+                  streamedArgChars: (
+                    tracker.streamedArgText.get(toolCallId) ?? ""
+                  ).length,
                   finishReason,
                   truncated,
                 });
@@ -964,10 +892,10 @@ export class OffensiveSecurityAgent<TResult = void> {
                   messageId: ids.messageId,
                 });
               }
-              toolErrors.clear();
+              tracker.clearToolErrors();
 
               // Close any call still in flight (args never finalized) so it doesn't render stuck "running".
-              for (const [toolCallId, toolName] of inFlightTools) {
+              for (const [toolCallId, toolName] of tracker.inFlightTools) {
                 diagnostics.logClosingInFlightTool({
                   toolCallId,
                   toolName,
@@ -994,9 +922,12 @@ export class OffensiveSecurityAgent<TResult = void> {
                   messageId: ids.messageId,
                 });
               }
-              inFlightTools.clear();
+              tracker.clearInFlight();
               break;
             }
+            default:
+              // Tool-input/delta, tool-call, tool-error, tool-result → tracker.
+              tracker.observePart(chunk);
           }
           bus.emitStreamPart(chunk, ids);
         }
@@ -1022,17 +953,11 @@ export class OffensiveSecurityAgent<TResult = void> {
             recordFinalizationError(error);
           }
           // Flush tool-errors that never reached a finish-step into the snapshot.
-          for (const [toolCallId, info] of toolErrors) {
+          for (const [toolCallId, info] of tracker.flushToolErrorsToResults()) {
             const result = {
               type: "error-text" as const,
               value: `Tool call failed: ${info.message}`,
             };
-            completedResults.push({
-              type: "tool-result",
-              toolCallId,
-              toolName: info.toolName,
-              output: result,
-            });
             try {
               bus.emit("tool-result", {
                 toolCallId,
@@ -1047,9 +972,8 @@ export class OffensiveSecurityAgent<TResult = void> {
               recordFinalizationError(error);
             }
           }
-          toolErrors.clear();
           // Snapshot unpersisted step state: open tools get synthetic closes, completed/errored results get written.
-          if (inFlightTools.size > 0 || completedResults.length > 0) {
+          if (tracker.hasUnpersistedState()) {
             const reason = this.abortSignal?.aborted
               ? "Agent aborted by user"
               : streamError instanceof Error && streamError.message
@@ -1057,12 +981,12 @@ export class OffensiveSecurityAgent<TResult = void> {
                 : "Stream terminated unexpectedly";
             try {
               await this.emitSyntheticToolResults(
-                inFlightTools,
-                completedResults,
+                tracker.inFlightTools,
+                [...tracker.completedResults],
                 reason,
                 ids.toolPartId,
                 ids.messageId,
-                streamedArgText,
+                tracker.streamedArgText,
               );
             } catch (error) {
               recordFinalizationError(error);
@@ -1211,12 +1135,12 @@ export class OffensiveSecurityAgent<TResult = void> {
   }
 
   private async emitSyntheticToolResults(
-    inFlightTools: Map<string, string>,
-    completedResults: ToolResultPart[],
+    inFlightTools: ReadonlyMap<string, string>,
+    completedResults: readonly ToolResultPart[],
     reason: string,
     partIdFor?: (toolCallId: string) => string,
     messageId?: string,
-    streamedArgText?: Map<string, string>,
+    streamedArgText?: ReadonlyMap<string, string>,
   ): Promise<void> {
     const sid = this.subagentId;
     const output = {

--- a/src/core/agents/offSecAgent/toolLifecycle.test.ts
+++ b/src/core/agents/offSecAgent/toolLifecycle.test.ts
@@ -1,0 +1,199 @@
+import type { ToolResultPart } from "ai";
+import { describe, expect, it } from "vitest";
+import { ToolLifecycleTracker } from "./toolLifecycle";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function inputStart(id: string, toolName: string) {
+  return { type: "tool-input-start", id, toolName };
+}
+function inputDelta(id: string, delta: string) {
+  return { type: "tool-input-delta", id, delta };
+}
+function toolCall(id: string, toolName: string) {
+  return { type: "tool-call", toolCallId: id, toolName };
+}
+function toolResult(id: string, toolName: string, output: unknown) {
+  return { type: "tool-result", toolCallId: id, toolName, output };
+}
+
+// ---------------------------------------------------------------------------
+// ToolLifecycleTracker
+// ---------------------------------------------------------------------------
+
+describe("ToolLifecycleTracker", () => {
+  it("tracks a normal completion: in-flight → result, kept until step persisted", () => {
+    const t = new ToolLifecycleTracker();
+    t.observePart(inputStart("tc-1", "execute_command"));
+    t.observePart(inputDelta("tc-1", '{"command":"ls"}'));
+    t.observePart(toolCall("tc-1", "execute_command"));
+    expect(t.inFlightTools.get("tc-1")).toBe("execute_command");
+
+    t.observePart(toolResult("tc-1", "execute_command", { ok: true }));
+    expect(t.inFlightTools.size).toBe(0);
+    expect(t.completedResults).toHaveLength(1);
+    expect(t.completedResults[0]).toMatchObject({
+      toolCallId: "tc-1",
+      output: { ok: true },
+    });
+    expect(t.hasUnpersistedState()).toBe(true);
+
+    t.onStepPersisted();
+    expect(t.completedResults).toHaveLength(0);
+    expect(t.hasUnpersistedState()).toBe(false);
+  });
+
+  it("accumulates streamed argument text across deltas", () => {
+    const t = new ToolLifecycleTracker();
+    t.observePart(inputStart("tc-1", "t"));
+    t.observePart(inputDelta("tc-1", '{"a":'));
+    t.observePart(inputDelta("tc-1", "1}"));
+    expect(t.streamedArgText.get("tc-1")).toBe('{"a":1}');
+  });
+
+  it("records tool errors with parsed input preferred over streamed text", () => {
+    const t = new ToolLifecycleTracker();
+    t.observePart(inputStart("tc-1", "response"));
+    t.observePart(inputDelta("tc-1", '{"partial'));
+    t.observePart(toolCall("tc-1", "response"));
+    t.observePart({
+      type: "tool-error",
+      toolCallId: "tc-1",
+      toolName: "response",
+      input: { real: "args" },
+      error: new Error("schema mismatch"),
+    });
+
+    expect(t.inFlightTools.size).toBe(0);
+    const err = t.toolErrors.get("tc-1");
+    expect(err?.message).toBe("schema mismatch");
+    expect(err?.input).toEqual({ real: "args" });
+    expect(err?.toolName).toBe("response");
+  });
+
+  it("falls back to streamed arg text when the error input is tiny or absent", () => {
+    const t = new ToolLifecycleTracker();
+    t.observePart(inputStart("tc-1", "t"));
+    t.observePart(inputDelta("tc-1", '{"trunc'));
+    t.observePart({
+      type: "tool-error",
+      toolCallId: "tc-1",
+      toolName: "t",
+      input: {},
+      error: "boom",
+    });
+    expect(t.toolErrors.get("tc-1")?.input).toBe('{"trunc');
+
+    const t2 = new ToolLifecycleTracker();
+    t2.observePart({
+      type: "tool-error",
+      toolCallId: "tc-2",
+      toolName: "t",
+      error: { code: 500 },
+    });
+    expect(t2.toolErrors.get("tc-2")?.message).toBe(
+      JSON.stringify({ code: 500 }),
+    );
+    expect(t2.toolErrors.get("tc-2")?.input).toBe("");
+  });
+
+  it("handles duplicate parts idempotently for in-flight tracking", () => {
+    const t = new ToolLifecycleTracker();
+    t.observePart(inputStart("tc-1", "t"));
+    t.observePart(toolCall("tc-1", "t")); // duplicate registration
+    expect(t.inFlightTools.size).toBe(1);
+
+    t.observePart(toolResult("tc-1", "t", "a"));
+    t.observePart(toolResult("tc-1", "t", "b")); // duplicate result
+    expect(t.inFlightTools.size).toBe(0);
+    // Completed results append verbatim — dedup is not the tracker's call.
+    expect(t.completedResults).toHaveLength(2);
+  });
+
+  it("flushToolErrorsToResults records error-text results and clears the map", () => {
+    const t = new ToolLifecycleTracker();
+    t.observePart({
+      type: "tool-error",
+      toolCallId: "tc-1",
+      toolName: "t",
+      error: "late failure",
+    });
+
+    const flushed = t.flushToolErrorsToResults();
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0]?.[0]).toBe("tc-1");
+    expect(t.completedResults).toHaveLength(1);
+    expect(t.completedResults[0]).toMatchObject({
+      toolCallId: "tc-1",
+      output: {
+        type: "error-text",
+        value: "Tool call failed: late failure",
+      },
+    });
+    expect(t.toolErrors.size).toBe(0);
+
+    // Second flush is empty.
+    expect(t.flushToolErrorsToResults()).toHaveLength(0);
+    expect(t.completedResults).toHaveLength(1);
+  });
+
+  it("clearToolErrors / clearInFlight drop state without recording results", () => {
+    const t = new ToolLifecycleTracker();
+    t.observePart(inputStart("tc-1", "t"));
+    t.observePart({
+      type: "tool-error",
+      toolCallId: "tc-2",
+      toolName: "t",
+      error: "x",
+    });
+
+    t.clearToolErrors();
+    t.clearInFlight();
+    expect(t.toolErrors.size).toBe(0);
+    expect(t.inFlightTools.size).toBe(0);
+    expect(t.completedResults).toHaveLength(0);
+  });
+
+  it("snapshot() is an independent copy — mutation and later parts never alter it", () => {
+    const t = new ToolLifecycleTracker();
+    t.observePart(inputStart("tc-1", "t"));
+    t.observePart(inputDelta("tc-1", '{"a":1}'));
+
+    const snap = t.snapshot();
+    // Mutate the snapshot's maps like a hostile consumer that bypasses the
+    // readonly types — the tracker must not see any of it.
+    (snap.inFlightTools as Map<string, string>).set("tc-hack", "hacked");
+    (snap.streamedArgText as Map<string, string>).set("tc-hack", "hacked");
+    (snap.completedResults as ToolResultPart[]).push({
+      type: "tool-result",
+      toolCallId: "tc-hack",
+      toolName: "h",
+      output: { type: "text", value: "x" },
+    });
+    expect(t.inFlightTools.has("tc-hack")).toBe(false);
+    expect(t.completedResults).toHaveLength(0);
+
+    // Further stream parts don't alter the earlier snapshot.
+    t.observePart(toolResult("tc-1", "t", "done"));
+    expect(snap.inFlightTools.get("tc-1")).toBe("t");
+    expect(snap.completedResults).toHaveLength(1); // the hacked entry only
+    expect(snap.streamedArgText.get("tc-1")).toBe('{"a":1}');
+
+    const snap2 = t.snapshot();
+    expect(snap2.inFlightTools.size).toBe(0);
+    expect(snap2.completedResults).toHaveLength(1);
+    expect(snap2).not.toBe(snap);
+  });
+
+  it("ignores non-tool parts", () => {
+    const t = new ToolLifecycleTracker();
+    t.observePart({ type: "text-delta", delta: "hi" });
+    t.observePart({ type: "start-step" });
+    t.observePart({ type: "finish-step" });
+    expect(t.hasUnpersistedState()).toBe(false);
+    expect(t.inFlightTools.size).toBe(0);
+    expect(t.completedResults).toHaveLength(0);
+  });
+});

--- a/src/core/agents/offSecAgent/toolLifecycle.ts
+++ b/src/core/agents/offSecAgent/toolLifecycle.ts
@@ -1,0 +1,171 @@
+import type { ToolResultPart } from "ai";
+import { responseArgBytes } from "./streamDiagnostics";
+
+// ---------------------------------------------------------------------------
+// Tool lifecycle tracker — owns the per-stream view of tool-call state:
+// in-flight calls, completed-but-unpersisted results, streamed argument text,
+// and deferred tool errors. Purely stateful; event emission, persistence,
+// and disposal live elsewhere.
+// ---------------------------------------------------------------------------
+
+export interface TrackedToolError {
+  message: string;
+  input: unknown;
+  toolName: string;
+}
+
+/** Immutable point-in-time view used by the interrupted-step finalization. */
+export interface ToolRecoverySnapshot {
+  readonly inFlightTools: ReadonlyMap<string, string>;
+  readonly completedResults: readonly ToolResultPart[];
+  readonly streamedArgText: ReadonlyMap<string, string>;
+  readonly toolErrors: ReadonlyMap<string, TrackedToolError>;
+}
+
+/** Structural stream-part view the tracker observes. */
+export interface LifecycleChunk {
+  type: string;
+  id?: string;
+  toolCallId?: string;
+  toolName?: string;
+  delta?: string;
+  input?: unknown;
+  error?: unknown;
+  result?: unknown;
+  output?: unknown;
+}
+
+export class ToolLifecycleTracker {
+  private readonly inFlight = new Map<string, string>();
+  private readonly completed: ToolResultPart[] = [];
+  private readonly streamedArgs = new Map<string, string>();
+  private readonly errors = new Map<string, TrackedToolError>();
+
+  /** Update tracker state from one stream part. */
+  observePart(chunk: LifecycleChunk): void {
+    switch (chunk.type) {
+      case "tool-input-start":
+        // Track from the start so a truncated call still gets closed instead of left "running".
+        this.inFlight.set(chunk.id as string, chunk.toolName as string);
+        this.streamedArgs.set(chunk.id as string, "");
+        break;
+      case "tool-input-delta":
+        this.streamedArgs.set(
+          chunk.id as string,
+          (this.streamedArgs.get(chunk.id as string) ?? "") +
+            (chunk.delta ?? ""),
+        );
+        break;
+      case "tool-call":
+        this.inFlight.set(chunk.toolCallId as string, chunk.toolName as string);
+        break;
+      case "tool-error": {
+        // `execute` never runs for an errored call, so it must be cleared here or finish-step would fabricate a bogus "did not complete".
+        const toolCallId = chunk.toolCallId as string;
+        this.inFlight.delete(toolCallId);
+        const errMsg =
+          chunk.error instanceof Error
+            ? chunk.error.message
+            : typeof chunk.error === "string"
+              ? chunk.error
+              : (() => {
+                  try {
+                    return JSON.stringify(chunk.error);
+                  } catch {
+                    return String(chunk.error);
+                  }
+                })();
+        const partialArgs =
+          chunk.input !== undefined &&
+          chunk.input !== null &&
+          responseArgBytes(chunk.input) > 2
+            ? chunk.input
+            : (this.streamedArgs.get(toolCallId) ?? "");
+        this.errors.set(toolCallId, {
+          message: errMsg,
+          input: partialArgs,
+          toolName: chunk.toolName as string,
+        });
+        break;
+      }
+      case "tool-result":
+        this.inFlight.delete(chunk.toolCallId as string);
+        this.completed.push({
+          type: "tool-result",
+          toolCallId: chunk.toolCallId as string,
+          toolName: chunk.toolName as string,
+          output: (chunk.result ?? chunk.output) as ToolResultPart["output"],
+        });
+        break;
+    }
+  }
+
+  /** finish-step: onStepFinish has persisted this step; drop its results so a later abort doesn't re-append them. */
+  onStepPersisted(): void {
+    this.completed.length = 0;
+  }
+
+  /**
+   * Flush deferred tool errors into completed error-text results (the
+   * interrupted-step path — they never reached a finish-step). Returns the
+   * flushed entries so the caller can emit them; clears the error map.
+   */
+  flushToolErrorsToResults(): Array<
+    [toolCallId: string, error: TrackedToolError]
+  > {
+    const flushed: Array<[string, TrackedToolError]> = [];
+    for (const [toolCallId, info] of this.errors) {
+      this.completed.push({
+        type: "tool-result",
+        toolCallId,
+        toolName: info.toolName,
+        output: {
+          type: "error-text",
+          value: `Tool call failed: ${info.message}`,
+        },
+      });
+      flushed.push([toolCallId, info]);
+    }
+    this.errors.clear();
+    return flushed;
+  }
+
+  clearToolErrors(): void {
+    this.errors.clear();
+  }
+
+  clearInFlight(): void {
+    this.inFlight.clear();
+  }
+
+  /** Whether an interrupted step has state worth persisting (open tools or unpersisted results). */
+  hasUnpersistedState(): boolean {
+    return this.inFlight.size > 0 || this.completed.length > 0;
+  }
+
+  get inFlightTools(): ReadonlyMap<string, string> {
+    return this.inFlight;
+  }
+
+  get toolErrors(): ReadonlyMap<string, TrackedToolError> {
+    return this.errors;
+  }
+
+  get completedResults(): readonly ToolResultPart[] {
+    return this.completed;
+  }
+
+  get streamedArgText(): ReadonlyMap<string, string> {
+    return this.streamedArgs;
+  }
+
+  /** Independent point-in-time copy; mutating it never affects the tracker. */
+  snapshot(): ToolRecoverySnapshot {
+    return {
+      inFlightTools: new Map(this.inFlight),
+      completedResults: this.completed.map((r) => ({ ...r })),
+      streamedArgText: new Map(this.streamedArgs),
+      toolErrors: new Map(this.errors),
+    };
+  }
+}


### PR DESCRIPTION
## Stack

> [!NOTE]
> **OffensiveSecurityAgent refactor · PR 2 of 7**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#986](https://github.com/pensarai/apex/pull/986) | Stream diagnostics |
| **2** | **[#987](https://github.com/pensarai/apex/pull/987)** | **Tool lifecycle** · `Current` |
| 3 | [#988](https://github.com/pensarai/apex/pull/988) | Interrupted-step messages |
| 4 | [#989](https://github.com/pensarai/apex/pull/989) | Message persistence |
| 5 | [#990](https://github.com/pensarai/apex/pull/990) | Interrupted-step finalization |
| 6 | [#991](https://github.com/pensarai/apex/pull/991) | Resource disposal |
| 7 | [#992](https://github.com/pensarai/apex/pull/992) | `consume()` simplification |

## Summary

- move the four tool-lifecycle state structures out of `consume()` into a `ToolLifecycleTracker` (`toolLifecycle.ts`): in-flight tool calls, completed-but-unpersisted results, streamed argument text, and deferred tool errors
- `observePart(chunk)` owns the stream-part → state transitions (tool-input-start/delta, tool-call, tool-error, tool-result); `onStepPersisted()` is the finish-step cleanup; `flushToolErrorsToResults()` is the interrupted-path error flush; `snapshot()` is an independent recovery copy
- `consume()` keeps only the emission logic (bus events, response-tool special cases) and reads the tracker's readonly views

## Motivation

A2 of Stack B. The tracker state was six inline closures' worth of `Map`/array mutation interleaved with the stream switch — invisible to tests except through full agent runs. The tracker is the recovery model for the interrupted-step finalization (A3/A5 build directly on `snapshot()`), and extracting it makes the duplication rules (duplicate results append, in-flight sets idempotent) explicit and pinned.

## What changed

**New module: `src/core/agents/offSecAgent/toolLifecycle.ts`**

- `observePart` — the tool-part transitions, verbatim from the switch, including the tool-error partial-args rule (parsed `input` wins when `responseArgBytes > 2`, streamed text otherwise) and error-message normalization (Error → message, string → itself, else JSON.stringify with String fallback)
- `onStepPersisted()` — drops completed results once onStepFinish has persisted the step, so a later abort doesn't re-append them
- `flushToolErrorsToResults()` — records each deferred tool error as an `error-text` completed result and returns the entries for emission (the interrupted path's flush, previously inline in the `finally`)
- `clearToolErrors()` / `clearInFlight()` — the finish-step post-emission clears
- `hasUnpersistedState()` — the abort-snapshot gate (`inFlight.size > 0 || completed.length > 0`)
- readonly live views (`inFlightTools`, `toolErrors`, `completedResults`, `streamedArgText`) for the emission loops and diagnostics accessors
- `snapshot()` — copies of all four structures; mutating the snapshot (even via type-casting) never affects the tracker, and later stream parts never alter a taken snapshot

**`offensiveSecurityAgent.ts`** — the state decls and four switch cases collapse to `tracker.observePart(chunk)` under `default:`; the finish-step case keeps its emissions but reads tracker views; the `finally` uses `flushToolErrorsToResults()`, `hasUnpersistedState()`, and passes tracker views to `emitSyntheticToolResults` (signature widened to `ReadonlyMap`/readonly arrays). Net −101 lines.

## Behavior preserved

- duplicate tool-results append verbatim (dedup is deliberately not the tracker's call — matches today)
- `tool-input-start` registers in-flight immediately so truncated calls still get closed
- tool-error clears in-flight (execute never ran) and defers surfacing to finish-step
- finish-step order: results dropped → errors emitted+cleared → in-flight closed+cleared
- the abort path flushes deferred errors into the snapshot before the synthetic-close write

## Test coverage

9 tests in `toolLifecycle.test.ts` (new file, zero mocks):

- normal completion lifecycle, results retained until `onStepPersisted`
- streamed arg accumulation across deltas
- tool-error input preference (parsed > streamed) and fallbacks (tiny `{}` input → streamed text; no text → `""`), error-message normalization
- duplicate-part idempotency (in-flight) and verbatim append (results)
- `flushToolErrorsToResults` records + clears; second flush empty
- clears drop state without recording
- snapshot independence — hostile mutation via type-cast, later parts don't alter a taken snapshot, two snapshots are distinct
- non-tool parts ignored

## Validation

- `bun run test` (1,648 passed, 22 skipped — all 34 agent tests green)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the three touched files

## Notes

- non-goals honored: no event emission, persistence, or disposal in the tracker
- A3 consumes `ToolRecoverySnapshot` directly to build the interrupted-step messages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical extraction with dedicated tests; agent stream semantics are unchanged, though regressions would affect tool UI and abort persistence.
> 
> **Overview**
> Pulls per-stream tool state out of `OffensiveSecurityAgent.consume()` into a new **`ToolLifecycleTracker`** (`toolLifecycle.ts`), so the stream loop only handles bus emission and finish-step special cases.
> 
> The tracker owns in-flight calls, completed-but-unpersisted results (PR #779), streamed argument text, and deferred `tool-error` state. Tool stream parts are handled via **`observePart()`**; **`onStepPersisted()`**, **`flushToolErrorsToResults()`**, and **`hasUnpersistedState()`** replace the inline maps/arrays in finish-step and abort finalization. **`snapshot()`** adds an immutable recovery view for follow-on stack PRs.
> 
> Adds **`toolLifecycle.test.ts`** (9 unit tests, no mocks). **`emitSyntheticToolResults`** now takes `ReadonlyMap`/readonly arrays. Intended behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f2b7008c2cedb7b277cf7db26d2efb4f58c79e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

