### PR TITLE
refactor(agent): extract interrupted-step message builder

### DIFF
--- a/src/core/agents/offSecAgent/interruptedStepMessages.test.ts
+++ b/src/core/agents/offSecAgent/interruptedStepMessages.test.ts
@@ -1,0 +1,296 @@
+import type { ModelMessage, ToolResultPart } from "ai";
+import { describe, expect, it } from "vitest";
+import {
+  baseContainsToolCalls,
+  buildInterruptedStepMessages,
+  buildSyntheticToolResults,
+} from "./interruptedStepMessages";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const inFlight = new Map<string, string>([
+  ["tc-open-1", "execute_command"],
+  ["tc-open-2", "response"],
+]);
+
+function completed(ids: string[]): ToolResultPart[] {
+  return ids.map((id) => ({
+    type: "tool-result",
+    toolCallId: id,
+    toolName: `tool-${id}`,
+    output: { type: "text", value: `done-${id}` },
+  }));
+}
+
+const userBase: ModelMessage[] = [
+  { role: "user", content: [{ type: "text", text: "go" }] },
+];
+
+function assistantBaseWith(ids: string[]): ModelMessage[] {
+  return [
+    ...userBase,
+    {
+      role: "assistant",
+      content: ids.map((id) => ({
+        type: "tool-call" as const,
+        toolCallId: id,
+        toolName: `tool-${id}`,
+        input: {},
+      })),
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// buildSyntheticToolResults
+// ---------------------------------------------------------------------------
+
+describe("buildSyntheticToolResults", () => {
+  it("closes every open tool with the aborted reason", () => {
+    const parts = buildSyntheticToolResults({
+      inFlightTools: inFlight,
+      reason: "Agent aborted by user",
+      responseToolName: "response",
+      responseSubmitted: false,
+    });
+
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toMatchObject({
+      toolCallId: "tc-open-1",
+      toolName: "execute_command",
+      output: {
+        type: "error-text",
+        value: "Tool execution aborted: Agent aborted by user",
+      },
+    });
+    expect(parts[1]?.output).toMatchObject({
+      type: "error-text",
+      value: "Tool execution aborted: Agent aborted by user",
+    });
+  });
+
+  it("marks an already-fired response tool as submitted, not aborted", () => {
+    const parts = buildSyntheticToolResults({
+      inFlightTools: inFlight,
+      reason: "stream wedged",
+      responseToolName: "response",
+      responseSubmitted: true,
+    });
+
+    expect(parts[1]?.output).toEqual({
+      type: "text",
+      value: "Response submitted.",
+    });
+    // Non-response tools still read as aborted.
+    expect(parts[0]?.output).toMatchObject({ type: "error-text" });
+  });
+
+  it("returns empty for no open tools", () => {
+    expect(
+      buildSyntheticToolResults({
+        inFlightTools: new Map(),
+        reason: "x",
+        responseToolName: "response",
+        responseSubmitted: false,
+      }),
+    ).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// baseContainsToolCalls
+// ---------------------------------------------------------------------------
+
+describe("baseContainsToolCalls", () => {
+  it("true only when every id is present in the assistant content", () => {
+    const base = assistantBaseWith(["tc-1", "tc-2"]);
+    expect(
+      baseContainsToolCalls(base[1] as ModelMessage, new Set(["tc-1"])),
+    ).toBe(true);
+    expect(
+      baseContainsToolCalls(base[1] as ModelMessage, new Set(["tc-1", "tc-2"])),
+    ).toBe(true);
+    expect(
+      baseContainsToolCalls(base[1] as ModelMessage, new Set(["tc-1", "tc-3"])),
+    ).toBe(false);
+  });
+
+  it("false for non-array content and user messages", () => {
+    expect(baseContainsToolCalls(userBase[0], new Set(["tc-1"]))).toBe(false);
+    const textMsg: ModelMessage = {
+      role: "assistant",
+      content: "plain text",
+    };
+    expect(baseContainsToolCalls(textMsg, new Set(["tc-1"]))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInterruptedStepMessages
+// ---------------------------------------------------------------------------
+
+describe("buildInterruptedStepMessages", () => {
+  it("reconstructs assistant tool-calls + tool results when the base has no assistant turn", () => {
+    const synthetic = buildSyntheticToolResults({
+      inFlightTools: inFlight,
+      reason: "aborted",
+      responseToolName: "response",
+      responseSubmitted: false,
+    });
+    const done = completed(["tc-done-1"]);
+    const streamed = new Map<string, string>([
+      ["tc-open-1", '{"command":"nmap"}'],
+      ["tc-done-1", '{"a":1}'],
+    ]);
+
+    const { appended, needsStepReconstruction } = buildInterruptedStepMessages({
+      base: userBase,
+      inFlightTools: inFlight,
+      completedResults: done,
+      syntheticParts: synthetic,
+      streamedArgText: streamed,
+    });
+
+    expect(needsStepReconstruction).toBe(true);
+    expect(appended).toHaveLength(2);
+
+    const assistant = appended[0] as {
+      role: string;
+      content: Array<Record<string, unknown>>;
+    };
+    expect(assistant.role).toBe("assistant");
+    // Ordering: in-flight tools first, then completed results.
+    expect(assistant.content.map((p) => p.toolCallId)).toEqual([
+      "tc-open-1",
+      "tc-open-2",
+      "tc-done-1",
+    ]);
+    // Parsed streamed args preserved.
+    expect(assistant.content[0]).toMatchObject({
+      type: "tool-call",
+      input: { command: "nmap" },
+    });
+
+    const tool = appended[1] as { role: string; content: ToolResultPart[] };
+    expect(tool.role).toBe("tool");
+    // Completed results first, then synthetic closes.
+    expect(tool.content.map((p) => p.toolCallId)).toEqual([
+      "tc-done-1",
+      "tc-open-1",
+      "tc-open-2",
+    ]);
+  });
+
+  it("preserves malformed partial JSON as { _partial } and falls back to {}", () => {
+    const single = new Map<string, string>([["tc-1", "execute_command"]]);
+    const synthetic = buildSyntheticToolResults({
+      inFlightTools: single,
+      reason: "aborted",
+      responseToolName: "response",
+      responseSubmitted: false,
+    });
+
+    const { appended } = buildInterruptedStepMessages({
+      base: userBase,
+      inFlightTools: single,
+      completedResults: [],
+      syntheticParts: synthetic,
+      streamedArgText: new Map([["tc-1", '{"trunc']]),
+    });
+    const assistant = appended[0] as {
+      content: Array<Record<string, unknown>>;
+    };
+    expect(assistant.content[0]?.input).toEqual({ _partial: '{"trunc' });
+
+    const { appended: noText } = buildInterruptedStepMessages({
+      base: userBase,
+      inFlightTools: new Map([["tc-2", "t"]]),
+      completedResults: [],
+      syntheticParts: [],
+      streamedArgText: new Map(),
+    });
+    const noTextAssistant = noText[0] as {
+      content: Array<Record<string, unknown>>;
+    };
+    expect(noTextAssistant.content[0]?.input).toEqual({});
+  });
+
+  it("skips reconstruction when the base's last assistant turn already carries every call", () => {
+    const done = completed(["tc-1"]);
+    const base = assistantBaseWith(["tc-1"]);
+    const synthetic = buildSyntheticToolResults({
+      inFlightTools: new Map(),
+      reason: "aborted",
+      responseToolName: "response",
+      responseSubmitted: false,
+    });
+
+    const { appended, needsStepReconstruction } = buildInterruptedStepMessages({
+      base,
+      inFlightTools: new Map(),
+      completedResults: done,
+      syntheticParts: synthetic,
+    });
+
+    expect(needsStepReconstruction).toBe(false);
+    // Only the tool message appends — pairing lives in the existing base.
+    expect(appended).toHaveLength(1);
+    expect(appended[0]?.role).toBe("tool");
+  });
+
+  it("reconstructs when the base's assistant turn is missing some ids", () => {
+    const base = assistantBaseWith(["tc-1"]);
+    const done = completed(["tc-1", "tc-2"]);
+
+    const { needsStepReconstruction } = buildInterruptedStepMessages({
+      base,
+      inFlightTools: new Map(),
+      completedResults: done,
+      syntheticParts: [],
+    });
+
+    expect(needsStepReconstruction).toBe(true);
+  });
+
+  it("every reconstructed tool-call has a paired result in the tool message", () => {
+    const synthetic = buildSyntheticToolResults({
+      inFlightTools: inFlight,
+      reason: "aborted",
+      responseToolName: "response",
+      responseSubmitted: false,
+    });
+    const done = completed(["tc-done-1"]);
+
+    const { appended } = buildInterruptedStepMessages({
+      base: userBase,
+      inFlightTools: inFlight,
+      completedResults: done,
+      syntheticParts: synthetic,
+    });
+
+    const assistant = appended[0] as {
+      content: Array<Record<string, unknown>>;
+    };
+    const tool = appended[1] as { content: Array<Record<string, unknown>> };
+    const callIds = assistant.content.map((p) => p.toolCallId);
+    const resultIds = tool.content.map((p) => p.toolCallId);
+    expect(new Set(callIds)).toEqual(new Set(resultIds));
+    for (const id of callIds) {
+      expect(resultIds).toContain(id);
+    }
+  });
+
+  it("does not mutate the base", () => {
+    const base = userBase;
+    const original = structuredClone(base);
+    buildInterruptedStepMessages({
+      base,
+      inFlightTools: inFlight,
+      completedResults: completed(["tc-x"]),
+      syntheticParts: [],
+    });
+    expect(base).toEqual(original);
+  });
+});

--- a/src/core/agents/offSecAgent/interruptedStepMessages.ts
+++ b/src/core/agents/offSecAgent/interruptedStepMessages.ts
@@ -1,0 +1,137 @@
+import type { ModelMessage, ToolResultPart } from "ai";
+
+// ---------------------------------------------------------------------------
+// Interrupted-step messages — pure construction of the transcript messages
+// that make an interrupted step resumable: synthetic tool-results for open
+// calls, plus (when the persisted base doesn't already carry them) an
+// assistant tool-call turn reconstructed from streamed arguments.
+// ---------------------------------------------------------------------------
+
+export interface SyntheticToolResultsInput {
+  inFlightTools: ReadonlyMap<string, string>;
+  reason: string;
+  /** Tool name treated as the structured-response tool. */
+  responseToolName: string;
+  /** Whether the response tool fired successfully before the interruption. */
+  responseSubmitted: boolean;
+}
+
+/**
+ * Synthetic tool-results for every open call. A `response` tool that already
+ * fired before the interruption didn't fail — it reads "Response submitted."
+ * instead of the aborted error.
+ */
+export function buildSyntheticToolResults(
+  input: SyntheticToolResultsInput,
+): ToolResultPart[] {
+  const output = {
+    type: "error-text" as const,
+    value: `Tool execution aborted: ${input.reason}`,
+  };
+  const parts: ToolResultPart[] = [];
+  for (const [toolCallId, toolName] of input.inFlightTools) {
+    const result =
+      toolName === input.responseToolName && input.responseSubmitted
+        ? { type: "text" as const, value: "Response submitted." }
+        : output;
+    parts.push({
+      type: "tool-result",
+      toolCallId,
+      toolName,
+      output: result,
+    });
+  }
+  return parts;
+}
+
+/** Whether an assistant message's content already carries every tool-call id. */
+export function baseContainsToolCalls(
+  msg: ModelMessage,
+  toolCallIds: Set<string>,
+): boolean {
+  if (!Array.isArray(msg.content)) return false;
+  const contentToolIds = new Set(
+    (msg.content as Array<{ type: string; toolCallId?: string }>)
+      .filter((p) => p.type === "tool-call" && p.toolCallId)
+      .map((p) => p.toolCallId),
+  );
+  return [...toolCallIds].every((id) => contentToolIds.has(id));
+}
+
+export interface InterruptedStepMessagesInput {
+  /** Persisted conversation base the appended messages extend. */
+  base: readonly ModelMessage[];
+  inFlightTools: ReadonlyMap<string, string>;
+  completedResults: readonly ToolResultPart[];
+  /** Pre-built synthetic results for the open calls. */
+  syntheticParts: readonly ToolResultPart[];
+  /** Raw streamed arg text per tool-call id, for argument preservation. */
+  streamedArgText?: ReadonlyMap<string, string>;
+}
+
+export interface InterruptedStepMessages {
+  /** Messages to append to the base: optional assistant tool-calls, then the tool results. */
+  appended: ModelMessage[];
+  /** Whether an assistant tool-call turn was reconstructed. */
+  needsStepReconstruction: boolean;
+}
+
+/**
+ * Build the messages that close an interrupted step. When the base's last
+ * message doesn't already contain this step's tool-calls (onStepFinish never
+ * fired), an assistant turn is reconstructed from the streamed argument
+ * text — parsing it when possible, preserving it as `{ _partial }` when the
+ * JSON is malformed, `{}` when nothing streamed. The tool message pairs every
+ * call with a result: completed results first, then the synthetic closes.
+ */
+export function buildInterruptedStepMessages(
+  input: InterruptedStepMessagesInput,
+): InterruptedStepMessages {
+  const { base, inFlightTools, completedResults, syntheticParts } = input;
+
+  const allToolCallIds = new Set([
+    ...inFlightTools.keys(),
+    ...completedResults.map((r) => r.toolCallId),
+  ]);
+  const lastMsg = base[base.length - 1];
+  const needsStepReconstruction =
+    !lastMsg ||
+    lastMsg.role !== "assistant" ||
+    !baseContainsToolCalls(lastMsg, allToolCallIds);
+
+  const appended: ModelMessage[] = [];
+  if (needsStepReconstruction) {
+    const stepTools: Array<[string, string]> = [
+      ...inFlightTools,
+      ...completedResults.map((r): [string, string] => [
+        r.toolCallId,
+        r.toolName,
+      ]),
+    ];
+    // Preserve whatever args the model actually streamed instead of writing an empty `{}`.
+    const reconstructInput = (toolCallId: string): unknown => {
+      const raw = input.streamedArgText?.get(toolCallId);
+      if (!raw) return {};
+      try {
+        return JSON.parse(raw);
+      } catch {
+        return { _partial: raw };
+      }
+    };
+    appended.push({
+      role: "assistant",
+      content: stepTools.map(([toolCallId, toolName]) => ({
+        type: "tool-call" as const,
+        toolCallId,
+        toolName,
+        input: reconstructInput(toolCallId),
+      })),
+    });
+  }
+  appended.push({
+    role: "tool",
+    content: [...completedResults, ...syntheticParts],
+  });
+
+  return { appended, needsStepReconstruction };
+}

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -6,7 +6,6 @@ import type {
   StopCondition,
   StreamTextResult,
   TextStreamPart,
-  ToolCallPart,
   ToolResultPart,
   ToolSet,
 } from "ai";
@@ -25,6 +24,10 @@ import { ApprovalDeniedError } from "../../operator";
 import { create as createSession, type SessionInfo } from "../../session";
 import { scopedLogger } from "../../util/lazyLogger";
 import { detectOSAndEnhancePrompt } from "../specialized/utils";
+import {
+  buildInterruptedStepMessages,
+  buildSyntheticToolResults,
+} from "./interruptedStepMessages";
 import { buildBaseSystemPrompt, buildSessionWorkspaceSection } from "./prompt";
 import { responseArgBytes, StreamDiagnostics } from "./streamDiagnostics";
 import { ToolLifecycleTracker } from "./toolLifecycle";
@@ -1143,11 +1146,12 @@ export class OffensiveSecurityAgent<TResult = void> {
     streamedArgText?: ReadonlyMap<string, string>,
   ): Promise<void> {
     const sid = this.subagentId;
-    const output = {
-      type: "error-text" as const,
-      value: `Tool execution aborted: ${reason}`,
-    };
-    const syntheticParts: ToolResultPart[] = [];
+    const syntheticParts = buildSyntheticToolResults({
+      inFlightTools,
+      reason,
+      responseToolName: RESPONSE_TOOL_NAME,
+      responseSubmitted: this._responseToolFired,
+    });
     let emissionError: unknown;
     let hasEmissionError = false;
 
@@ -1164,27 +1168,16 @@ export class OffensiveSecurityAgent<TResult = void> {
       }
     }
 
-    for (const [toolCallId, toolName] of inFlightTools) {
-      // The `response` tool reaching here after a successful capture didn't fail — mark it completed, not aborted.
-      const result =
-        toolName === RESPONSE_TOOL_NAME && this._responseToolFired
-          ? { type: "text" as const, value: "Response submitted." }
-          : output;
-      syntheticParts.push({
-        type: "tool-result",
-        toolCallId,
-        toolName,
-        output: result,
-      });
+    for (const part of syntheticParts) {
       try {
         this.eventBus.emit("tool-result", {
-          toolCallId,
-          toolName,
-          result,
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          result: part.output,
           // Canonical session id, not just the legacy subagentId alias, so the translator routes to THIS subagent's session.
           sessionId: this.busSessionId,
           subagentId: sid,
-          partId: partIdFor?.(toolCallId),
+          partId: partIdFor?.(part.toolCallId),
           messageId,
         });
       } catch (error) {
@@ -1214,64 +1207,33 @@ export class OffensiveSecurityAgent<TResult = void> {
       }
     }
 
-    // When onStepFinish hasn't fired, this step's messages aren't in base yet; reconstruct so resumed sessions see valid pairs.
-    const allToolCallIds = new Set([
-      ...inFlightTools.keys(),
-      ...completedResults.map((r) => r.toolCallId),
-    ]);
-    const lastMsg = base[base.length - 1];
-    const needsStepReconstruction =
-      !lastMsg ||
-      lastMsg.role !== "assistant" ||
-      !this.baseContainsToolCalls(lastMsg, allToolCallIds);
-
-    const appended: ModelMessage[] = [];
-    if (needsStepReconstruction) {
-      const stepTools: Array<[string, string]> = [
-        ...inFlightTools,
-        ...completedResults.map((r): [string, string] => [
-          r.toolCallId,
-          r.toolName,
-        ]),
-      ];
-      // Preserve whatever args the model actually streamed instead of writing an empty `{}`.
-      const reconstructInput = (toolCallId: string): unknown => {
-        const raw = streamedArgText?.get(toolCallId);
-        if (!raw) return {};
-        try {
-          return JSON.parse(raw);
-        } catch {
-          return { _partial: raw };
-        }
-      };
-      if (RESPONSE_DEBUG) {
-        const responseReconstructed = stepTools
-          .filter(([, n]) => n === RESPONSE_TOOL_NAME)
-          .map(([id]) => id);
-        if (responseReconstructed.length > 0) {
-          rlog.warn(
-            `[response-debug] step-reconstruction for response call(s) ` +
-              `ids=${responseReconstructed.join(",")} ` +
-              `preservedArgChars=${responseReconstructed
-                .map((id) => streamedArgText?.get(id)?.length ?? 0)
-                .join(",")}`,
-          );
-        }
-      }
-      const toolCalls: ToolCallPart[] = stepTools.map(
-        ([toolCallId, toolName]) => ({
-          type: "tool-call" as const,
-          toolCallId,
-          toolName,
-          input: reconstructInput(toolCallId),
-        }),
-      );
-      appended.push({ role: "assistant", content: toolCalls });
-    }
-    appended.push({
-      role: "tool",
-      content: [...completedResults, ...syntheticParts],
+    // When onStepFinish hasn't fired, this step's messages aren't in base yet;
+    // reconstruct so resumed sessions see valid pairs (see
+    // ./interruptedStepMessages).
+    const { appended, needsStepReconstruction } = buildInterruptedStepMessages({
+      base,
+      inFlightTools,
+      completedResults,
+      syntheticParts,
+      streamedArgText,
     });
+    if (needsStepReconstruction && RESPONSE_DEBUG) {
+      const responseReconstructed = [
+        ...inFlightTools,
+        ...completedResults.map((r) => [r.toolCallId, r.toolName] as const),
+      ]
+        .filter(([, n]) => n === RESPONSE_TOOL_NAME)
+        .map(([id]) => id);
+      if (responseReconstructed.length > 0) {
+        rlog.warn(
+          `[response-debug] step-reconstruction for response call(s) ` +
+            `ids=${responseReconstructed.join(",")} ` +
+            `preservedArgChars=${responseReconstructed
+              .map((id) => streamedArgText?.get(id)?.length ?? 0)
+              .join(",")}`,
+        );
+      }
+    }
 
     const next: ModelMessage[] = [...base, ...appended];
     this.latestMessages = next;
@@ -1284,19 +1246,6 @@ export class OffensiveSecurityAgent<TResult = void> {
     }
 
     if (hasEmissionError) throw emissionError;
-  }
-
-  private baseContainsToolCalls(
-    msg: ModelMessage,
-    toolCallIds: Set<string>,
-  ): boolean {
-    if (!Array.isArray(msg.content)) return false;
-    const contentToolIds = new Set(
-      (msg.content as Array<{ type: string; toolCallId?: string }>)
-        .filter((p) => p.type === "tool-call" && p.toolCallId)
-        .map((p) => p.toolCallId),
-    );
-    return [...toolCallIds].every((id) => contentToolIds.has(id));
   }
 }
 


### PR DESCRIPTION
## Stack

> [!NOTE]
> **OffensiveSecurityAgent refactor · PR 3 of 7**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#986](https://github.com/pensarai/apex/pull/986) | Stream diagnostics |
| 2 | [#987](https://github.com/pensarai/apex/pull/987) | Tool lifecycle |
| **3** | **[#988](https://github.com/pensarai/apex/pull/988)** | **Interrupted-step messages** · `Current` |
| 4 | [#989](https://github.com/pensarai/apex/pull/989) | Message persistence |
| 5 | [#990](https://github.com/pensarai/apex/pull/990) | Interrupted-step finalization |
| 6 | [#991](https://github.com/pensarai/apex/pull/991) | Resource disposal |
| 7 | [#992](https://github.com/pensarai/apex/pull/992) | `consume()` simplification |

## Summary

- extract the interrupted-step transcript construction from `emitSyntheticToolResults` into pure functions in `interruptedStepMessages.ts`:
  - `buildSyntheticToolResults({inFlightTools, reason, responseToolName, responseSubmitted})` — one synthetic tool-result per open call, with the already-fired `response` tool reading "Response submitted." instead of the aborted error
  - `buildInterruptedStepMessages({base, inFlightTools, completedResults, syntheticParts, streamedArgText})` — the appended messages: an optional reconstructed assistant tool-call turn plus the tool message pairing completed results with synthetic closes
  - `baseContainsToolCalls` moved verbatim
- `emitSyntheticToolResults` now builds parts with the pure functions, keeps only emission + base-loading + write policy

## Motivation

A3 of Stack B. The reconstruction logic (partial-JSON preservation, `_partial` fallback, `{}` fallback, reconstruction gating, call/result pairing) was buried mid-way through an async private method — untestable except through full agent runs with stubbed filesystems. It is a pure conversion of (base, snapshot, reason) → messages, and it is the correctness core of abort recovery: a malformed pair here breaks session resume. Now directly tested.

## What changed

**New module: `src/core/agents/offSecAgent/interruptedStepMessages.ts`** — no filesystem, no EventBus, no class state.

- `buildSyntheticToolResults` — verbatim decision table from the emission loop
- `buildInterruptedStepMessages` — verbatim reconstruction: gate on the base's last message carrying every tool-call id; streamed args parsed when possible, `{ _partial: raw }` when malformed, `{}` when nothing streamed; ordering preserved (in-flight calls then completed results in the assistant turn; completed results then synthetic closes in the tool message); returns `{ appended, needsStepReconstruction }`
- `baseContainsToolCalls` — moved verbatim, now exported for reuse

**`offensiveSecurityAgent.ts`** — `emitSyntheticToolResults` keeps emission (with per-listener error capture), the debounce-cancel/drain, base resolution (`latestMessages` ?? on-disk), the write + `syntheticsPersisted` policy, and the two RESPONSE_DEBUG logs (the reconstruction log now keyed off `needsStepReconstruction`). The inline construction and the private `baseContainsToolCalls` are gone. Net −90 lines.

## Behavior preserved

- synthetic results identical, including the response-submitted special case
- reconstruction gate identical (last message missing/not assistant/missing ids)
- `{ _partial }` and `{}` argument fallbacks identical
- message ordering identical; every reconstructed call is paired with a result
- non-goals honored: no filesystem writes or EventBus calls in the pure module

## Test coverage

11 tests in `interruptedStepMessages.test.ts` (pure, zero mocks):

- synthetic results: aborted close for all open tools, response-submitted override, empty case
- `baseContainsToolCalls`: full/partial id matching, non-array content, user messages
- reconstruction: full appended shape over a user base (ordering, parsed args, completed-first tool message), skipped when the base already carries every call, forced when ids are missing
- malformed partial JSON → `{ _partial }`; no streamed text → `{}`
- call/result pairing asserted as sets for a mixed snapshot
- base immutability

## Validation

- `bun run test` (1,659 passed, 22 skipped — all 34 agent tests green)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the three touched files

## Notes

- A5 composes this builder with the tracker snapshot and the A4 writer behind one finalization operation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with direct unit coverage; runtime abort persistence still flows through the same `emitSyntheticToolResults` path.
> 
> **Overview**
> Pulls **interrupted-step transcript construction** out of `OffensiveSecurityAgent.emitSyntheticToolResults` into a new pure module `interruptedStepMessages.ts`, so abort/resume message shaping can be unit-tested without EventBus or disk I/O.
> 
> The module adds **`buildSyntheticToolResults`** (synthetic closes for in-flight tools, with the `response` tool marked submitted when it already fired), **`buildInterruptedStepMessages`** (optional reconstructed assistant tool-call turn from streamed args—JSON parse, `{ _partial }`, or `{}`—plus a tool message pairing completed results with synthetics), and exports **`baseContainsToolCalls`** for reconstruction gating. **`emitSyntheticToolResults`** now delegates to these helpers and only handles bus emission, base loading, persistence, and debug logging.
> 
> Adds **`interruptedStepMessages.test.ts`** with focused tests for synthetic results, reconstruction skip/force paths, ordering, pairing, and base immutability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c54f53ecdd9ad3cd4e86a750ac09f81d35e1ee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

