### PR TITLE
refactor(agent): encapsulate message persistence

### DIFF
--- a/src/core/agents/offSecAgent/messagePersistence.test.ts
+++ b/src/core/agents/offSecAgent/messagePersistence.test.ts
@@ -1,0 +1,281 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelMessage } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentMessageWriter } from "./messagePersistence";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "agent-writer-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function path(): string {
+  return join(tmpDir, "messages.json");
+}
+
+function msgs(...texts: string[]): ModelMessage[] {
+  return texts.map((text) => ({
+    role: "user" as const,
+    content: [{ type: "text" as const, text }],
+  }));
+}
+
+function read(): ModelMessage[] {
+  return JSON.parse(readFileSync(path(), "utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// AgentMessageWriter
+// ---------------------------------------------------------------------------
+
+describe("AgentMessageWriter", () => {
+  it("enqueueWrite writes the exact JSON, file format unchanged", async () => {
+    const writer = new AgentMessageWriter({ messagesPath: path() });
+    const messages = msgs("hello");
+    await writer.enqueueWrite(messages);
+
+    expect(read()).toEqual(messages);
+    expect(readFileSync(path(), "utf-8")).toBe(JSON.stringify(messages));
+  });
+
+  it("serializes writes: a queued write never starts before the previous settles", async () => {
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((r) => (releaseFirst = r));
+
+    const writer = new AgentMessageWriter({
+      messagesPath: path(),
+      writeImpl: async (_p, contents) => {
+        if (contents === JSON.stringify(msgs("first"))) {
+          order.push("first:start");
+          await firstGate;
+          order.push("first:end");
+          return;
+        }
+        order.push(`second:start:${contents.includes("second")}`);
+      },
+    });
+
+    const first = writer.enqueueWrite(msgs("first"));
+    const second = writer.enqueueWrite(msgs("first", "second"));
+
+    // Give the microtask queue a chance — the second write must not start.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual(["first:start"]);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["first:start", "first:end", "second:start:true"]);
+  });
+
+  it("a failed write rejects its caller but does not poison the queue", async () => {
+    let failNext = true;
+    const writer = new AgentMessageWriter({
+      messagesPath: path(),
+      writeImpl: async (_p, _contents) => {
+        if (failNext) {
+          failNext = false;
+          throw new Error("disk full");
+        }
+        return Promise.resolve();
+      },
+    });
+
+    await expect(writer.enqueueWrite(msgs("doomed"))).rejects.toThrow(
+      "disk full",
+    );
+    // The queue still works, and the tail was not left rejected.
+    await writer.enqueueWrite(msgs("after"));
+    expect(writer.waitForPendingWrites()).resolves.toBeUndefined();
+  });
+
+  it("schedulePersist debounces; cancelTimer prevents the write and retains latest", () => {
+    vi.useFakeTimers();
+    try {
+      const writer = new AgentMessageWriter({ messagesPath: path() });
+      writer.setLatest(msgs("pending"));
+      writer.schedulePersist();
+      // Re-schedule is a no-op while one timer is pending.
+      writer.schedulePersist();
+
+      vi.advanceTimersByTime(14_999);
+      expect(() => read()).toThrow(); // nothing written yet
+
+      writer.cancelTimer();
+      vi.advanceTimersByTime(60_000);
+      expect(() => read()).toThrow(); // cancelled — never written
+      expect(writer.latest).toEqual(msgs("pending")); // retained
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("the debounce flush writes latest and clears it only on success", async () => {
+    vi.useFakeTimers();
+    try {
+      const written: string[] = [];
+      const writer = new AgentMessageWriter({
+        messagesPath: path(),
+        writeImpl: async (_p, contents) => {
+          written.push(contents);
+        },
+      });
+      writer.setLatest(msgs("flush-me"));
+      writer.schedulePersist();
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(written).toEqual([JSON.stringify(msgs("flush-me"))]);
+      expect(writer.latest).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a guarded clear keeps a newer snapshot recorded during the debounced write", async () => {
+    vi.useFakeTimers();
+    try {
+      let releaseWrite!: () => void;
+      const gate = new Promise<void>((r) => (releaseWrite = r));
+      const writer = new AgentMessageWriter({
+        messagesPath: path(),
+        writeImpl: async (_p, contents) => {
+          if (contents.includes("old")) {
+            await gate;
+          }
+        },
+      });
+
+      writer.setLatest(msgs("old"));
+      writer.schedulePersist();
+      await vi.advanceTimersByTimeAsync(15_000); // write now gated in flight
+
+      writer.setLatest(msgs("old", "new")); // newer snapshot arrives
+      releaseWrite();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // The guarded clear must NOT drop the newer snapshot.
+      expect(writer.latest).toEqual(msgs("old", "new"));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("failed debounced write retains latest for the next flush", async () => {
+    vi.useFakeTimers();
+    try {
+      let failures = 1;
+      const writer = new AgentMessageWriter({
+        messagesPath: path(),
+        writeImpl: async () => {
+          if (failures > 0) {
+            failures--;
+            throw new Error("transient");
+          }
+        },
+      });
+
+      writer.setLatest(msgs("keep-me"));
+      writer.schedulePersist();
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(writer.latest).toEqual(msgs("keep-me")); // retained on failure
+
+      writer.schedulePersist();
+      await vi.advanceTimersByTimeAsync(15_000);
+      // Retained snapshot gets retried by the next debounce.
+      expect(failures).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("final flush composes cancelTimer + enqueueWrite (the onFinish path)", async () => {
+    vi.useFakeTimers();
+    try {
+      const writer = new AgentMessageWriter({ messagesPath: path() });
+      writer.setLatest(msgs("step-1"));
+      writer.schedulePersist();
+      writer.cancelTimer();
+
+      const final = msgs("step-1", "final");
+      writer.setLatest(final);
+      await writer.enqueueWrite(final);
+
+      expect(read()).toEqual(final);
+      vi.advanceTimersByTime(60_000); // cancelled timer never fires
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("abort-write ordering: the snapshot queues behind an in-flight write", async () => {
+    let releaseFirst!: () => void;
+    const gate = new Promise<void>((r) => (releaseFirst = r));
+    const writes: string[] = [];
+    const writer = new AgentMessageWriter({
+      messagesPath: path(),
+      writeImpl: async (_p, contents) => {
+        writes.push(contents);
+        if (writes.length === 1) await gate;
+        return;
+      },
+    });
+
+    const inFlight = writer.enqueueWrite(msgs("base")).catch(() => {});
+    const snapshot = writer.enqueueWrite(msgs("base", "abort-snapshot"));
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(writes).toHaveLength(1); // snapshot waits
+
+    releaseFirst();
+    await Promise.all([inFlight, snapshot]);
+    expect(writes).toHaveLength(2);
+    // Ordering preserved: base first, snapshot second.
+    expect(JSON.parse(writes[1] ?? "")).toEqual(msgs("base", "abort-snapshot"));
+  });
+
+  it("waitForPendingWrites drains the queue completely", async () => {
+    const writer = new AgentMessageWriter({
+      messagesPath: path(),
+      writeImpl: async (_p, _contents) => {
+        await new Promise((r) => setTimeout(r, 5));
+        return;
+      },
+    });
+
+    const w1 = writer.enqueueWrite(msgs("a")).catch(() => {});
+    const w2 = writer.enqueueWrite(msgs("a", "b")).catch(() => {});
+    const w3 = writer.enqueueWrite(msgs("a", "b", "c")).catch(() => {});
+    await writer.waitForPendingWrites();
+    await Promise.all([w1, w2, w3]);
+    // After the drain, the tail is settled and stable.
+    const tail = (writer as unknown as { tail: Promise<void> }).tail;
+    await expect(tail).resolves.toBeUndefined();
+  });
+
+  it("syntheticsPersisted starts false and only marks on demand", () => {
+    const writer = new AgentMessageWriter({ messagesPath: path() });
+    expect(writer.syntheticsPersisted).toBe(false);
+    writer.markSyntheticsPersisted();
+    expect(writer.syntheticsPersisted).toBe(true);
+  });
+
+  it("no path configured: enqueueWrite and latest are safe no-ops", async () => {
+    const writer = new AgentMessageWriter({ messagesPath: null });
+    await expect(writer.enqueueWrite(msgs("x"))).resolves.toBeUndefined();
+    writer.setLatest(msgs("x"));
+    expect(writer.latest).toEqual(msgs("x"));
+    expect(writer.messagesPath).toBeNull();
+  });
+});

--- a/src/core/agents/offSecAgent/messagePersistence.ts
+++ b/src/core/agents/offSecAgent/messagePersistence.ts
@@ -1,0 +1,111 @@
+import { writeFile } from "node:fs/promises";
+import type { ModelMessage } from "ai";
+
+// ---------------------------------------------------------------------------
+// Agent message persistence — the agent-local writer for messages.json.
+// Owns the debounce timer, the latest pending snapshot, the serialized write
+// queue, and the synthetics-persisted flag. File format and path are
+// unchanged; there is no shared session store here.
+// ---------------------------------------------------------------------------
+
+const PERSIST_INTERVAL_MS = 15_000;
+
+export interface AgentMessageWriterOptions {
+  messagesPath: string | null;
+  /** Debounce window for scheduled persists (tests shrink this). */
+  intervalMs?: number;
+  /** Write sink; defaults to fs/promises writeFile. */
+  writeImpl?: (messagesPath: string, contents: string) => Promise<void>;
+}
+
+export class AgentMessageWriter {
+  private readonly intervalMs: number;
+  private readonly writeImpl: (
+    messagesPath: string,
+    contents: string,
+  ) => Promise<void>;
+  private readonly path: string | null;
+
+  private pending: ModelMessage[] | null = null;
+  private tail: Promise<void> = Promise.resolve();
+  private persistTimer: ReturnType<typeof setTimeout> | null = null;
+  private syntheticsWritten = false;
+
+  constructor(options: AgentMessageWriterOptions) {
+    this.path = options.messagesPath;
+    this.intervalMs = options.intervalMs ?? PERSIST_INTERVAL_MS;
+    this.writeImpl =
+      options.writeImpl ?? ((p, contents) => writeFile(p, contents));
+  }
+
+  get messagesPath(): string | null {
+    return this.path;
+  }
+
+  /** Latest unpersisted snapshot, or null once a debounced write flushed it. */
+  get latest(): ModelMessage[] | null {
+    return this.pending;
+  }
+
+  setLatest(messages: ModelMessage[]): void {
+    this.pending = messages;
+  }
+
+  /** True once the interrupted-step snapshot is safely on disk. */
+  get syntheticsPersisted(): boolean {
+    return this.syntheticsWritten;
+  }
+
+  markSyntheticsPersisted(): void {
+    this.syntheticsWritten = true;
+  }
+
+  /**
+   * Debounced persistence: avoid blocking the event loop with
+   * JSON.stringify on every step when many agents run concurrently.
+   */
+  schedulePersist(): void {
+    if (this.persistTimer) return;
+    this.persistTimer = setTimeout(() => {
+      this.persistTimer = null;
+      const toWrite = this.pending;
+      if (!toWrite) return;
+      void this.enqueueWrite(toWrite)
+        .then(() => {
+          if (this.pending === toWrite) this.pending = null;
+        })
+        .catch(() => {});
+    }, this.intervalMs);
+  }
+
+  /** Cancels a pending debounce; already-started writes remain in the queue. */
+  cancelTimer(): void {
+    if (this.persistTimer) {
+      clearTimeout(this.persistTimer);
+      this.persistTimer = null;
+    }
+  }
+
+  /**
+   * Serialized write: enqueued writes execute in order and never interleave.
+   * A failed write rejects to its caller but does not poison the queue.
+   */
+  async enqueueWrite(messages: ModelMessage[]): Promise<void> {
+    const path = this.path;
+    if (!path) return;
+
+    const contents = JSON.stringify(messages);
+    const write = this.tail.then(() => this.writeImpl(path, contents));
+    this.tail = write.catch(() => {});
+    await write;
+  }
+
+  /** Resolves once every already-enqueued write has settled. */
+  async waitForPendingWrites(): Promise<void> {
+    let pending: Promise<void>;
+    do {
+      pending = this.tail;
+      await pending;
+    } while (pending !== this.tail);
+  }
+}

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -78,6 +78,7 @@ vi.mock("../../operator", () => ({
 vi.mock("ai", () => ({ hasToolCall: () => () => false }));
 
 import { AgentEventBus } from "../../eventBus";
+import { AgentMessageWriter } from "./messagePersistence";
 import {
   filterWorkspaceToolsForRun,
   OffensiveSecurityAgent,
@@ -102,7 +103,7 @@ function buildStubAgent(overrides: {
   ownsBrowserSession?: boolean;
   messagesPath?: string | null;
   latestMessages?: unknown[] | null;
-  persistenceTail?: Promise<void>;
+  writeImpl?: (messagesPath: string, contents: string) => Promise<void>;
   responseCaptured?: Promise<unknown>;
 }): OffensiveSecurityAgent<unknown> {
   const agent = Object.create(
@@ -144,20 +145,17 @@ function buildStubAgent(overrides: {
   Object.defineProperty(agent, "ownsBrowserSession", {
     value: overrides.ownsBrowserSession ?? false,
   });
-  Object.defineProperty(agent, "latestMessages", {
-    value: overrides.latestMessages ?? null,
-    writable: true,
-  });
   Object.defineProperty(agent, "messagesPath", {
     value: overrides.messagesPath ?? null,
   });
-  Object.defineProperty(agent, "cancelPersistTimer", {
-    value: () => {},
+  const writer = new AgentMessageWriter({
+    messagesPath: overrides.messagesPath ?? null,
+    ...(overrides.writeImpl ? { writeImpl: overrides.writeImpl } : {}),
   });
-  Object.defineProperty(agent, "persistenceTail", {
-    value: overrides.persistenceTail ?? Promise.resolve(),
-    writable: true,
-  });
+  if (overrides.latestMessages) {
+    writer.setLatest(overrides.latestMessages as never[]);
+  }
+  Object.defineProperty(agent, "writer", { value: writer });
 
   return agent;
 }
@@ -963,24 +961,37 @@ describe("OffensiveSecurityAgent.consume()", () => {
       ];
       writeFileSync(messagesPath, JSON.stringify(staleMessages));
 
-      let finishPersist!: () => void;
-      const persistenceTail = new Promise<void>((resolve) => {
-        finishPersist = () => {
-          writeFileSync(messagesPath, JSON.stringify(persistedMessages));
-          resolve();
-        };
+      // Gate the writer's write sink so an in-flight persist can be held
+      // while the stream throws and the abort snapshot waits its turn.
+      let releasePersist!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releasePersist = resolve;
       });
+      const writeImpl = async (path: string, contents: string) => {
+        await gate;
+        writeFileSync(path, contents);
+      };
 
       const agent = buildStubAgent({
         fullStream: yieldThenThrow([toolCallChunk], new Error("timeout")),
         messagesPath,
         latestMessages: null,
-        persistenceTail,
+        writeImpl,
       });
+
+      // Start the in-flight persist against the gated sink.
+      const writer = (agent as unknown as { writer: AgentMessageWriter })
+        .writer;
+      const inFlight = writer
+        .enqueueWrite(persistedMessages as never[])
+        .catch(() => {});
 
       const consume = agent.consume().catch(() => {});
       await new Promise((resolve) => setTimeout(resolve, 50));
-      finishPersist();
+      // The gated persist is still in flight — the abort snapshot must be
+      // queued behind it, not interleaved.
+      releasePersist();
+      await inFlight;
       await consume;
 
       const written = JSON.parse(readFileSync(messagesPath, "utf-8"));
@@ -1223,8 +1234,11 @@ describe("OffensiveSecurityAgent.consume()", () => {
       await new Promise((r) => setTimeout(r, 50));
 
       expect(
-        (agent as unknown as { syntheticsPersisted?: boolean })
-          .syntheticsPersisted,
+        (
+          agent as unknown as {
+            writer: { syntheticsPersisted: boolean };
+          }
+        ).writer.syntheticsPersisted,
       ).toBeFalsy();
     });
   });

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -1,5 +1,4 @@
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
-import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type {
   ModelMessage,
@@ -28,6 +27,7 @@ import {
   buildInterruptedStepMessages,
   buildSyntheticToolResults,
 } from "./interruptedStepMessages";
+import { AgentMessageWriter } from "./messagePersistence";
 import { buildBaseSystemPrompt, buildSessionWorkspaceSection } from "./prompt";
 import { responseArgBytes, StreamDiagnostics } from "./streamDiagnostics";
 import { ToolLifecycleTracker } from "./toolLifecycle";
@@ -304,19 +304,12 @@ export class OffensiveSecurityAgent<TResult = void> {
   /** The session this agent is operating within. */
   private readonly _session: SessionInfo;
 
-  /** Latest accumulated messages, shared with `consume()` for abort persistence. */
-  private latestMessages: ModelMessage[] | null = null;
+  /** Agent-local message persistence (debounce + serialized writes). */
+  private readonly writer!: AgentMessageWriter;
 
   private messagesPath: string | null = null;
 
   /** Serializes agent-owned messages.json writes in enqueue order. */
-  private persistenceTail: Promise<void> = Promise.resolve();
-
-  /** Cancels a pending debounce; already-started writes remain in persistenceTail. */
-  private cancelPersistTimer: (() => void) | null = null;
-
-  private syntheticsPersisted = false;
-
   /**
    * Async factory that creates a session when one is not provided,
    * then constructs the agent. Use this instead of `new` when you
@@ -620,32 +613,10 @@ export class OffensiveSecurityAgent<TResult = void> {
           ],
     };
 
-    // Debounced persistence: avoid blocking the event loop with
-    // JSON.stringify on every step when many agents run concurrently.
-    const PERSIST_INTERVAL_MS = 15_000;
-    let persistTimer: ReturnType<typeof setTimeout> | null = null;
-
-    const schedulePersist = () => {
-      if (persistTimer) return;
-      persistTimer = setTimeout(() => {
-        persistTimer = null;
-        if (this.latestMessages) {
-          const toWrite = this.latestMessages;
-          void this.enqueueMessagesWrite(toWrite)
-            .then(() => {
-              if (this.latestMessages === toWrite) this.latestMessages = null;
-            })
-            .catch(() => {});
-        }
-      }, PERSIST_INTERVAL_MS);
-    };
-
-    this.cancelPersistTimer = () => {
-      if (persistTimer) {
-        clearTimeout(persistTimer);
-        persistTimer = null;
-      }
-    };
+    // Agent-local persistence: debounce, latest snapshot, and the
+    // serialized write queue live in the writer (see ./messagePersistence).
+    this.writer = new AgentMessageWriter({ messagesPath: this.messagesPath });
+    const schedulePersist = () => this.writer.schedulePersist();
 
     // -- Init record (trace.jsonl first line) ---------------------------------
     // Hash only the base system prompt (excluding session workspace paths)
@@ -697,10 +668,10 @@ export class OffensiveSecurityAgent<TResult = void> {
         sessionPath: messagesDir,
         sessionId: this.busSessionId,
         onStepFinish: async (event) => {
-          this.latestMessages = [
+          this.writer.setLatest([
             ...initialMessagesRef.current,
             ...event.response.messages,
-          ];
+          ]);
           schedulePersist();
           traceWriter.recordStep(event.response.messages as ModelMessage[], {
             inputTokens: event.usage.inputTokens ?? 0,
@@ -725,18 +696,15 @@ export class OffensiveSecurityAgent<TResult = void> {
         },
         onFinish: async (event) => {
           // Flush any pending persistence before finishing
-          if (persistTimer) {
-            clearTimeout(persistTimer);
-            persistTimer = null;
-          }
+          this.writer.cancelTimer();
           // Skip if emitSyntheticToolResults already wrote the abort snapshot.
-          if (!this.syntheticsPersisted) {
-            const finalMessages = this.latestMessages ?? [
+          if (!this.writer.syntheticsPersisted) {
+            const finalMessages = this.writer.latest ?? [
               ...initialMessagesRef.current,
               ...event.response.messages,
             ];
-            this.latestMessages = finalMessages;
-            await this.enqueueMessagesWrite(finalMessages).catch(() => {});
+            this.writer.setLatest(finalMessages);
+            await this.writer.enqueueWrite(finalMessages).catch(() => {});
           }
           await input.onFinish?.(event);
         },
@@ -1098,26 +1066,6 @@ export class OffensiveSecurityAgent<TResult = void> {
     await this.browserSession.disconnect().catch(() => {});
   }
 
-  private async enqueueMessagesWrite(messages: ModelMessage[]): Promise<void> {
-    const messagesPath = this.messagesPath;
-    if (!messagesPath) return;
-
-    const contents = JSON.stringify(messages);
-    const write = this.persistenceTail.then(() =>
-      writeFile(messagesPath, contents),
-    );
-    this.persistenceTail = write.catch(() => {});
-    await write;
-  }
-
-  private async waitForPendingMessagesWrites(): Promise<void> {
-    let pending: Promise<void>;
-    do {
-      pending = this.persistenceTail;
-      await pending;
-    } while (pending !== this.persistenceTail);
-  }
-
   /**
    * Idempotent teardown for hosts that abort before `consume()` settles
    * (Console `settleOnAbort` on timeout/pause). Force-disconnects the owned
@@ -1194,11 +1142,11 @@ export class OffensiveSecurityAgent<TResult = void> {
     }
 
     // Cancel an unfired debounce and drain writes that already started.
-    this.cancelPersistTimer?.();
-    await this.waitForPendingMessagesWrites();
+    this.writer.cancelTimer();
+    await this.writer.waitForPendingWrites();
 
-    // Fall back to the on-disk snapshot once the debounced timer has flushed latestMessages, so we don't overwrite history.
-    let base: ModelMessage[] = this.latestMessages ?? [];
+    // Fall back to the on-disk snapshot once the debounced timer has flushed the latest snapshot, so we don't overwrite history.
+    let base: ModelMessage[] = this.writer.latest ?? [];
     if (base.length === 0 && existsSync(this.messagesPath)) {
       try {
         base = JSON.parse(readFileSync(this.messagesPath, "utf-8"));
@@ -1236,11 +1184,11 @@ export class OffensiveSecurityAgent<TResult = void> {
     }
 
     const next: ModelMessage[] = [...base, ...appended];
-    this.latestMessages = next;
+    this.writer.setLatest(next);
     try {
-      await this.enqueueMessagesWrite(next);
+      await this.writer.enqueueWrite(next);
       // Only suppress onFinish's write once the snapshot is safely on disk.
-      this.syntheticsPersisted = true;
+      this.writer.markSyntheticsPersisted();
     } catch {
       // Write failed — leave the flag false so onFinish still attempts a write.
     }


### PR DESCRIPTION
## Stack

> [!NOTE]
> **OffensiveSecurityAgent refactor · PR 4 of 7**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#986](https://github.com/pensarai/apex/pull/986) | Stream diagnostics |
| 2 | [#987](https://github.com/pensarai/apex/pull/987) | Tool lifecycle |
| 3 | [#988](https://github.com/pensarai/apex/pull/988) | Interrupted-step messages |
| **4** | **[#989](https://github.com/pensarai/apex/pull/989)** | **Message persistence** · `Current` |
| 5 | [#990](https://github.com/pensarai/apex/pull/990) | Interrupted-step finalization |
| 6 | [#991](https://github.com/pensarai/apex/pull/991) | Resource disposal |
| 7 | [#992](https://github.com/pensarai/apex/pull/992) | `consume()` simplification |

## Summary

- encapsulate the agent-local `messages.json` persistence into an `AgentMessageWriter` (`messagePersistence.ts`) owning the debounce timer, the latest pending snapshot, the serialized write queue, the drain, and the synthetics-persisted flag
- the agent's four private fields (`latestMessages`, `persistenceTail`, `cancelPersistTimer`, `syntheticsPersisted`) and two private methods (`enqueueMessagesWrite`, `waitForPendingMessagesWrites`) collapse into the writer
- file format and path unchanged; no shared session store

## Motivation

A4 of Stack B. The persistence machinery (landed as the race fixes in #964) was spread across the constructor closure, two private methods, and four fields — every piece individually untestable without a full agent. The writer is a cohesive queue-with-debounce; extracting it makes write serialization, guarded-snapshot clears, and abort ordering directly testable, and shrinks the test harness (the stub agent now installs a real writer instead of hand-building four private fields — the stack's exit condition in action).

## What changed

**New module: `src/core/agents/offSecAgent/messagePersistence.ts`**

- `enqueueWrite(messages)` — serialize-once, chain on the tail, `tail = write.catch(() => {})`; a failed write rejects its caller without poisoning the queue
- `schedulePersist()` / `cancelTimer()` — the 15s debounce (injectable interval); the flush writes the pending snapshot and clears it **only when the snapshot is unchanged** (a newer `setLatest` during the write survives) and **only on success** (failures retain the snapshot for the next flush)
- `waitForPendingWrites()` — the drain loop (settles only when the tail stops moving)
- `latest` / `setLatest()` — the pending snapshot
- `syntheticsPersisted` / `markSyntheticsPersisted()` — the abort-snapshot flag policy
- injectable `writeImpl` for deterministic tests; defaults to `fs/promises writeFile`

**`offensiveSecurityAgent.ts`** — constructor creates the writer after `messagesPath` is known; `onStepFinish` → `writer.setLatest` + `schedulePersist`; `onFinish` → `cancelTimer` + the final flush guarded by `syntheticsPersisted`; `emitSyntheticToolResults` → `writer.cancelTimer()` / `waitForPendingWrites()` / `latest` / `enqueueWrite` / `markSyntheticsPersisted()`. Net −94 lines.

**`offensiveSecurityAgent.test.ts`** — `buildStubAgent` installs a real `AgentMessageWriter` (with optional `writeImpl`), dropping three hand-stubbed private fields. The in-flight-persist race test now drives the writer's public API with a gated sink instead of injecting a fake `persistenceTail` promise; the flag poke reads `agent.writer.syntheticsPersisted`.

## Behavior preserved

- debounced writes serialize identically; the guarded clear reference-equality semantics are identical
- a failed write leaves `syntheticsPersisted` false so `onFinish` still attempts a write (pinned by the existing bugbot regression test)
- abort ordering: `cancelTimer` + drain before the snapshot write (pinned by the rewritten race test)
- `JSON.stringify(messages)` exactly — no format change

## Test coverage

12 tests in `messagePersistence.test.ts`: exact file format; strict serialization (gated first write blocks the second); failed write doesn't poison the queue; debounce window + cancellation retains the snapshot; flush writes and clears on success; guarded clear keeps a newer snapshot recorded mid-write; failed debounce retains for retry; the `onFinish` compose (cancel + final flush); abort-snapshot ordering behind an in-flight write; drain completeness; flag lifecycle; no-path no-ops.

## Validation

- `bun run test` (1,671 passed, 22 skipped — all 34 agent tests green after harness update)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the four touched files (clean)

## Notes

- A5 composes this writer with the tracker snapshot and the A3 builder behind one finalization operation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior-preserving delegation; persistence edge cases are covered by new and existing regression tests.
> 
> **Overview**
> Extracts agent-local `messages.json` persistence from **OffensiveSecurityAgent** into a dedicated **`AgentMessageWriter`** (`messagePersistence.ts`). The writer owns the 15s debounced flush, the pending snapshot, the serialized write queue (with drain), and the **synthetics-persisted** flag; **`messages.json` format and path are unchanged**.
> 
> **OffensiveSecurityAgent** now holds a `writer` and routes `onStepFinish`, `onFinish`, and abort/synthetic snapshot logic through it instead of four private fields plus `enqueueMessagesWrite` / `waitForPendingMessagesWrites`. Inline debounce/timer code in the constructor is removed.
> 
> Adds **12 unit tests** for the writer (serialization, debounce/cancel, guarded snapshot clear, failure recovery, abort ordering). **`offensiveSecurityAgent.test.ts`** stubs install a real `AgentMessageWriter` (optional gated `writeImpl`) instead of faking `persistenceTail` / `latestMessages`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8181f30c30bc745ae5d6ff4bdd18edcdca8d831e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

