### PR TITLE
refactor(agent): extract interrupted-step finalization

### DIFF
--- a/src/core/agents/offSecAgent/interruptedStepFinalization.test.ts
+++ b/src/core/agents/offSecAgent/interruptedStepFinalization.test.ts
@@ -178,7 +178,10 @@ describe("createInterruptedStepFinalizer", () => {
   it("multiple interrupted tools: errors flushed, completed kept, all paired", async () => {
     const { finalize } = setup();
 
-    const snapshot = snapshotFrom([
+    // The interrupted path flushes deferred errors into completed results
+    // before finalization (consume() does this via the tracker).
+    const tracker = new ToolLifecycleTracker();
+    for (const part of [
       // One open call with streamed args.
       { type: "tool-input-start", id: "tc-open", toolName: "nmap_tool" },
       { type: "tool-input-delta", id: "tc-open", delta: '{"target":"x"}' },
@@ -191,24 +194,6 @@ describe("createInterruptedStepFinalizer", () => {
         output: { ok: true },
       },
       // One deferred tool error.
-      {
-        type: "tool-error",
-        toolCallId: "tc-err",
-        toolName: "browser_tool",
-        error: "crashed",
-      },
-    ]);
-    // The interrupted path flushes deferred errors into completed results
-    // before finalization (consume() does this via the tracker).
-    const tracker = new ToolLifecycleTracker();
-    for (const part of [
-      { type: "tool-call", toolCallId: "tc-open", toolName: "nmap_tool" },
-      {
-        type: "tool-result",
-        toolCallId: "tc-done",
-        toolName: "http_tool",
-        output: { ok: true },
-      },
       {
         type: "tool-error",
         toolCallId: "tc-err",
@@ -231,6 +216,9 @@ describe("createInterruptedStepFinalizer", () => {
     const resultIds = tool.content.map((p) => p.toolCallId);
     expect(callIds).toEqual(["tc-open", "tc-done", "tc-err"]);
     expect(new Set(resultIds)).toEqual(new Set(callIds));
+    expect(
+      assistant.content.find((p) => p.toolCallId === "tc-open")?.input,
+    ).toEqual({ target: "x" });
     // The flushed error result reads as error-text.
     expect(
       tool.content.find((p) => p.toolCallId === "tc-err")?.output,

--- a/src/core/agents/offSecAgent/interruptedStepFinalization.test.ts
+++ b/src/core/agents/offSecAgent/interruptedStepFinalization.test.ts
@@ -1,0 +1,307 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelMessage } from "ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AgentEventBus } from "../../eventBus";
+import { createInterruptedStepFinalizer } from "./interruptedStepFinalization";
+import { AgentMessageWriter } from "./messagePersistence";
+import { ToolLifecycleTracker } from "./toolLifecycle";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let writes: string[];
+let writeFailure: Error | null = null;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "interrupted-finalize-test-"));
+  writes = [];
+  writeFailure = null;
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function path(): string {
+  return join(tmpDir, "messages.json");
+}
+
+function userMsg(text: string): ModelMessage {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+/** Build a real snapshot by driving the tracker with stream parts. */
+function snapshotFrom(
+  parts: Parameters<ToolLifecycleTracker["observePart"]>[0][],
+): ReturnType<ToolLifecycleTracker["snapshot"]> {
+  const tracker = new ToolLifecycleTracker();
+  for (const part of parts) tracker.observePart(part);
+  return tracker.snapshot();
+}
+
+function setup(overrides?: {
+  bus?: AgentEventBus;
+  latest?: ModelMessage[] | null;
+}) {
+  const bus = overrides?.bus ?? new AgentEventBus();
+  const writer = new AgentMessageWriter({
+    messagesPath: path(),
+    writeImpl: async (p, contents) => {
+      if (writeFailure) throw writeFailure;
+      writes.push(contents);
+      writeFileSync(p, contents);
+    },
+  });
+  if (overrides?.latest) writer.setLatest(overrides.latest);
+  const finalize = createInterruptedStepFinalizer({
+    eventBus: bus,
+    sessionId: "ses_test",
+    subagentId: "sub_1",
+    writer,
+    responseToolName: "response",
+    responseToolFired: () => false,
+  });
+  return { bus, writer, finalize };
+}
+
+// ---------------------------------------------------------------------------
+// Interrupted-step finalizer
+// ---------------------------------------------------------------------------
+
+describe("createInterruptedStepFinalizer", () => {
+  it("provider error: closes open tools, persists a valid transcript, resolves", async () => {
+    const emitted: Array<Record<string, unknown>> = [];
+    const { bus, finalize, writer } = setup();
+    bus.on("tool-result", (e) => emitted.push(e as Record<string, unknown>));
+
+    const snapshot = snapshotFrom([
+      { type: "tool-input-start", id: "tc-1", toolName: "execute_command" },
+      { type: "tool-input-delta", id: "tc-1", delta: '{"command":"nmap"}' },
+      { type: "tool-call", toolCallId: "tc-1", toolName: "execute_command" },
+    ]);
+
+    await finalize({ snapshot, reason: "provider timeout" });
+
+    // Every open tool got a synthetic result on the bus.
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      toolCallId: "tc-1",
+      toolName: "execute_command",
+      sessionId: "ses_test",
+      subagentId: "sub_1",
+    });
+
+    // The persisted transcript carries valid pairs + the streamed args.
+    const written = JSON.parse(readFileSync(path(), "utf-8")) as ModelMessage[];
+    expect(written.at(-2)).toMatchObject({
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "tc-1",
+          input: { command: "nmap" },
+        },
+      ],
+    });
+    expect(written.at(-1)).toMatchObject({
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "tc-1",
+          output: {
+            type: "error-text",
+            value: "Tool execution aborted: provider timeout",
+          },
+        },
+      ],
+    });
+    expect(writer.syntheticsPersisted).toBe(true);
+  });
+
+  it("abort: same lifecycle with the abort reason", async () => {
+    const { finalize } = setup();
+    const snapshot = snapshotFrom([
+      { type: "tool-call", toolCallId: "tc-a", toolName: "t" },
+    ]);
+
+    await finalize({ snapshot, reason: "Agent aborted by user" });
+
+    const written = JSON.parse(readFileSync(path(), "utf-8")) as ModelMessage[];
+    const tool = written.at(-1) as { content: Array<Record<string, unknown>> };
+    expect(tool.content[0]?.output).toMatchObject({
+      value: "Tool execution aborted: Agent aborted by user",
+    });
+  });
+
+  it("listener error does not prevent persistence — and rethrows after the write", async () => {
+    const bus = new AgentEventBus();
+    bus.on("tool-result", () => {
+      throw new Error("listener explosion");
+    });
+    const { finalize, writer } = setup({ bus });
+
+    const snapshot = snapshotFrom([
+      { type: "tool-call", toolCallId: "tc-1", toolName: "t" },
+    ]);
+
+    // Rejects with the listener error…
+    await expect(finalize({ snapshot, reason: "stream died" })).rejects.toThrow(
+      "listener explosion",
+    );
+
+    // …but persistence completed first — the invariant that matters.
+    expect(writes).toHaveLength(1);
+    expect(writer.syntheticsPersisted).toBe(true);
+    const written = JSON.parse(readFileSync(path(), "utf-8")) as ModelMessage[];
+    expect(written.at(-1)).toMatchObject({ role: "tool" });
+  });
+
+  it("persistence failure resolves without marking synthetics persisted", async () => {
+    writeFailure = new Error("disk full");
+    const { finalize, writer } = setup();
+
+    const snapshot = snapshotFrom([
+      { type: "tool-call", toolCallId: "tc-1", toolName: "t" },
+    ]);
+
+    // Resolves — a failed snapshot write must not become the run's error
+    // (the original stream error stays primary; onFinish retries).
+    await expect(finalize({ snapshot, reason: "x" })).resolves.toBeUndefined();
+    expect(writer.syntheticsPersisted).toBe(false);
+  });
+
+  it("multiple interrupted tools: errors flushed, completed kept, all paired", async () => {
+    const { finalize } = setup();
+
+    const snapshot = snapshotFrom([
+      // One open call with streamed args.
+      { type: "tool-input-start", id: "tc-open", toolName: "nmap_tool" },
+      { type: "tool-input-delta", id: "tc-open", delta: '{"target":"x"}' },
+      { type: "tool-call", toolCallId: "tc-open", toolName: "nmap_tool" },
+      // One completed-but-unpersisted result.
+      {
+        type: "tool-result",
+        toolCallId: "tc-done",
+        toolName: "http_tool",
+        output: { ok: true },
+      },
+      // One deferred tool error.
+      {
+        type: "tool-error",
+        toolCallId: "tc-err",
+        toolName: "browser_tool",
+        error: "crashed",
+      },
+    ]);
+    // The interrupted path flushes deferred errors into completed results
+    // before finalization (consume() does this via the tracker).
+    const tracker = new ToolLifecycleTracker();
+    for (const part of [
+      { type: "tool-call", toolCallId: "tc-open", toolName: "nmap_tool" },
+      {
+        type: "tool-result",
+        toolCallId: "tc-done",
+        toolName: "http_tool",
+        output: { ok: true },
+      },
+      {
+        type: "tool-error",
+        toolCallId: "tc-err",
+        toolName: "browser_tool",
+        error: "crashed",
+      },
+    ])
+      tracker.observePart(part);
+    tracker.flushToolErrorsToResults();
+    const flushedSnapshot = tracker.snapshot();
+
+    await finalize({ snapshot: flushedSnapshot, reason: "aborted" });
+
+    const written = JSON.parse(readFileSync(path(), "utf-8")) as ModelMessage[];
+    const assistant = written.at(-2) as {
+      content: Array<Record<string, unknown>>;
+    };
+    const tool = written.at(-1) as { content: Array<Record<string, unknown>> };
+    const callIds = assistant.content.map((p) => p.toolCallId);
+    const resultIds = tool.content.map((p) => p.toolCallId);
+    expect(callIds).toEqual(["tc-open", "tc-done", "tc-err"]);
+    expect(new Set(resultIds)).toEqual(new Set(callIds));
+    // The flushed error result reads as error-text.
+    expect(
+      tool.content.find((p) => p.toolCallId === "tc-err")?.output,
+    ).toMatchObject({ type: "error-text", value: "Tool call failed: crashed" });
+    // The completed result's output is preserved.
+    expect(
+      tool.content.find((p) => p.toolCallId === "tc-done")?.output,
+    ).toEqual({ ok: true });
+  });
+
+  it("no writer path: emits but persists nothing; listener errors still throw", async () => {
+    const bus = new AgentEventBus();
+    const emitted: unknown[] = [];
+    bus.on("tool-result", (e) => emitted.push(e));
+    const writer = new AgentMessageWriter({ messagesPath: null });
+    const finalize = createInterruptedStepFinalizer({
+      eventBus: bus,
+      sessionId: "ses_test",
+      writer,
+      responseToolName: "response",
+      responseToolFired: () => false,
+    });
+
+    const snapshot = snapshotFrom([
+      { type: "tool-call", toolCallId: "tc-1", toolName: "t" },
+    ]);
+    await finalize({ snapshot, reason: "x" });
+
+    expect(emitted).toHaveLength(1);
+    expect(writes).toHaveLength(0);
+  });
+
+  it("drains the writer before reading the base (abort-write ordering)", async () => {
+    let releaseFirst!: () => void;
+    const gate = new Promise<void>((r) => (releaseFirst = r));
+    const writer = new AgentMessageWriter({
+      messagesPath: path(),
+      writeImpl: async (p, contents) => {
+        const isFirst = writes.length === 0;
+        writes.push(contents);
+        if (isFirst) await gate;
+        writeFileSync(p, contents);
+      },
+    });
+    const bus = new AgentEventBus();
+    const finalize = createInterruptedStepFinalizer({
+      eventBus: bus,
+      sessionId: "ses_test",
+      writer,
+      responseToolName: "response",
+      responseToolFired: () => false,
+    });
+
+    // An in-flight step write the snapshot must queue behind.
+    const inFlight = writer.enqueueWrite([userMsg("step")]).catch(() => {});
+    const snapshot = snapshotFrom([
+      { type: "tool-call", toolCallId: "tc-1", toolName: "t" },
+    ]);
+    const done = finalize({ snapshot, reason: "aborted" });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(writes).toHaveLength(1); // snapshot not yet written
+
+    releaseFirst();
+    await inFlight;
+    await done;
+    expect(writes).toHaveLength(2);
+    const final = JSON.parse(writes[1] ?? "") as ModelMessage[];
+    // Base from the drained write + reconstruction.
+    expect(final[0]).toEqual(userMsg("step"));
+    expect(final.at(-1)).toMatchObject({ role: "tool" });
+  });
+});

--- a/src/core/agents/offSecAgent/interruptedStepFinalization.ts
+++ b/src/core/agents/offSecAgent/interruptedStepFinalization.ts
@@ -1,0 +1,162 @@
+import { existsSync, readFileSync } from "node:fs";
+import type { ModelMessage } from "ai";
+import type { AgentEventBus } from "../../eventBus";
+import {
+  buildInterruptedStepMessages,
+  buildSyntheticToolResults,
+} from "./interruptedStepMessages";
+import type { AgentMessageWriter } from "./messagePersistence";
+import type { ToolRecoverySnapshot } from "./toolLifecycle";
+
+// ---------------------------------------------------------------------------
+// Interrupted-step finalization — one operation that closes an interrupted
+// step: synthetic results for every open call are emitted and persisted, the
+// transcript is reconstructed so resumed sessions see valid tool-call/result
+// pairs, and the write completes before the operation reports settled.
+//
+// Invariants:
+// - a throwing listener never prevents persistence (its error is rethrown
+//   only after the write has been attempted)
+// - every open tool receives a synthetic result
+// - a failed snapshot write leaves `syntheticsPersisted` false so onFinish
+//   still attempts a write
+// ---------------------------------------------------------------------------
+
+export interface InterruptedStepFinalizerDeps {
+  eventBus: AgentEventBus;
+  sessionId: string;
+  subagentId?: string;
+  writer: AgentMessageWriter;
+  responseToolName: string;
+  responseToolFired: () => boolean;
+  /** Read the persisted base from disk, or null when unavailable. */
+  readBaseFromDisk?: () => ModelMessage[] | null;
+  /** Opt-in debug sink for the response-tool tracer lines. */
+  debugLog?: (message: string) => void;
+}
+
+export interface FinalizeInterruptedStepInput {
+  snapshot: ToolRecoverySnapshot;
+  reason: string;
+  partIdFor?: (toolCallId: string) => string;
+  messageId?: string;
+}
+
+export function createInterruptedStepFinalizer(
+  deps: InterruptedStepFinalizerDeps,
+): (input: FinalizeInterruptedStepInput) => Promise<void> {
+  const debug = deps.debugLog;
+
+  const readBaseFromDisk =
+    deps.readBaseFromDisk ??
+    (() => {
+      const path = deps.writer.messagesPath;
+      if (!path || !existsSync(path)) return null;
+      try {
+        return JSON.parse(readFileSync(path, "utf-8")) as ModelMessage[];
+      } catch {
+        // Corrupt file → proceed with empty base.
+        return null;
+      }
+    });
+
+  return async (input) => {
+    const { snapshot, reason } = input;
+    const { inFlightTools, completedResults, streamedArgText } = snapshot;
+
+    const syntheticParts = buildSyntheticToolResults({
+      inFlightTools,
+      reason,
+      responseToolName: deps.responseToolName,
+      responseSubmitted: deps.responseToolFired(),
+    });
+    let emissionError: unknown;
+    let hasEmissionError = false;
+
+    if (debug) {
+      const responseInFlight = [...inFlightTools.entries()].filter(
+        ([, n]) => n === deps.responseToolName,
+      );
+      if (responseInFlight.length > 0) {
+        debug(
+          `[response-debug] emitSyntheticToolResults closing ${responseInFlight.length} response call(s) ` +
+            `ids=${responseInFlight.map(([id]) => id).join(",")} reason="${reason}" ` +
+            `responseToolFired=${deps.responseToolFired()}`,
+        );
+      }
+    }
+
+    for (const part of syntheticParts) {
+      try {
+        deps.eventBus.emit("tool-result", {
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          result: part.output,
+          // Canonical session id, not just the legacy subagentId alias, so the translator routes to THIS subagent's session.
+          sessionId: deps.sessionId,
+          subagentId: deps.subagentId,
+          partId: input.partIdFor?.(part.toolCallId),
+          messageId: input.messageId,
+        });
+      } catch (error) {
+        if (!hasEmissionError) {
+          emissionError = error;
+          hasEmissionError = true;
+        }
+      }
+    }
+
+    if (!deps.writer.messagesPath) {
+      if (hasEmissionError) throw emissionError;
+      return;
+    }
+
+    // Cancel an unfired debounce and drain writes that already started.
+    deps.writer.cancelTimer();
+    await deps.writer.waitForPendingWrites();
+
+    // Fall back to the on-disk snapshot once the debounced timer has flushed
+    // the latest snapshot, so we don't overwrite history.
+    let base: ModelMessage[] = deps.writer.latest ?? [];
+    if (base.length === 0) {
+      base = readBaseFromDisk() ?? [];
+    }
+
+    const { appended, needsStepReconstruction } = buildInterruptedStepMessages({
+      base,
+      inFlightTools,
+      completedResults,
+      syntheticParts,
+      streamedArgText,
+    });
+    if (needsStepReconstruction && debug) {
+      const responseReconstructed = [
+        ...inFlightTools,
+        ...completedResults.map((r) => [r.toolCallId, r.toolName] as const),
+      ]
+        .filter(([, n]) => n === deps.responseToolName)
+        .map(([id]) => id);
+      if (responseReconstructed.length > 0) {
+        debug(
+          `[response-debug] step-reconstruction for response call(s) ` +
+            `ids=${responseReconstructed.join(",")} ` +
+            `preservedArgChars=${responseReconstructed
+              .map((id) => streamedArgText?.get(id)?.length ?? 0)
+              .join(",")}`,
+        );
+      }
+    }
+
+    const next: ModelMessage[] = [...base, ...appended];
+    deps.writer.setLatest(next);
+    try {
+      await deps.writer.enqueueWrite(next);
+      // Only suppress onFinish's write once the snapshot is safely on disk.
+      deps.writer.markSyntheticsPersisted();
+    } catch {
+      // Write failed — leave the flag false so onFinish still attempts a write.
+    }
+
+    if (hasEmissionError) throw emissionError;
+  };
+}

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -78,6 +78,7 @@ vi.mock("../../operator", () => ({
 vi.mock("ai", () => ({ hasToolCall: () => () => false }));
 
 import { AgentEventBus } from "../../eventBus";
+import { createInterruptedStepFinalizer } from "./interruptedStepFinalization";
 import { AgentMessageWriter } from "./messagePersistence";
 import {
   filterWorkspaceToolsForRun,
@@ -156,6 +157,15 @@ function buildStubAgent(overrides: {
     writer.setLatest(overrides.latestMessages as never[]);
   }
   Object.defineProperty(agent, "writer", { value: writer });
+  Object.defineProperty(agent, "finalizeInterruptedStep", {
+    value: createInterruptedStepFinalizer({
+      eventBus: bus,
+      sessionId: "ses_stub",
+      writer,
+      responseToolName: "response",
+      responseToolFired: () => false,
+    }),
+  });
 
   return agent;
 }

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -1,11 +1,10 @@
-import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import type {
   ModelMessage,
   StopCondition,
   StreamTextResult,
   TextStreamPart,
-  ToolResultPart,
   ToolSet,
 } from "ai";
 import { hasToolCall } from "ai";
@@ -24,9 +23,9 @@ import { create as createSession, type SessionInfo } from "../../session";
 import { scopedLogger } from "../../util/lazyLogger";
 import { detectOSAndEnhancePrompt } from "../specialized/utils";
 import {
-  buildInterruptedStepMessages,
-  buildSyntheticToolResults,
-} from "./interruptedStepMessages";
+  createInterruptedStepFinalizer,
+  type FinalizeInterruptedStepInput,
+} from "./interruptedStepFinalization";
 import { AgentMessageWriter } from "./messagePersistence";
 import { buildBaseSystemPrompt, buildSessionWorkspaceSection } from "./prompt";
 import { responseArgBytes, StreamDiagnostics } from "./streamDiagnostics";
@@ -306,6 +305,11 @@ export class OffensiveSecurityAgent<TResult = void> {
 
   /** Agent-local message persistence (debounce + serialized writes). */
   private readonly writer!: AgentMessageWriter;
+
+  /** Closes an interrupted step: synthetic results, reconstruction, write. */
+  private readonly finalizeInterruptedStep!: (
+    input: FinalizeInterruptedStepInput,
+  ) => Promise<void>;
 
   private messagesPath: string | null = null;
 
@@ -616,6 +620,17 @@ export class OffensiveSecurityAgent<TResult = void> {
     // Agent-local persistence: debounce, latest snapshot, and the
     // serialized write queue live in the writer (see ./messagePersistence).
     this.writer = new AgentMessageWriter({ messagesPath: this.messagesPath });
+    this.finalizeInterruptedStep = createInterruptedStepFinalizer({
+      eventBus: this.eventBus,
+      sessionId: this.busSessionId,
+      subagentId: this.subagentId,
+      writer: this.writer,
+      responseToolName: RESPONSE_TOOL_NAME,
+      responseToolFired: () => this._responseToolFired,
+      ...(RESPONSE_DEBUG
+        ? { debugLog: (message: string) => rlog.warn(message) }
+        : {}),
+    });
     const schedulePersist = () => this.writer.schedulePersist();
 
     // -- Init record (trace.jsonl first line) ---------------------------------
@@ -697,7 +712,7 @@ export class OffensiveSecurityAgent<TResult = void> {
         onFinish: async (event) => {
           // Flush any pending persistence before finishing
           this.writer.cancelTimer();
-          // Skip if emitSyntheticToolResults already wrote the abort snapshot.
+          // Skip if the interrupted-step finalizer already wrote the abort snapshot.
           if (!this.writer.syntheticsPersisted) {
             const finalMessages = this.writer.latest ?? [
               ...initialMessagesRef.current,
@@ -951,14 +966,12 @@ export class OffensiveSecurityAgent<TResult = void> {
                 ? streamError.message
                 : "Stream terminated unexpectedly";
             try {
-              await this.emitSyntheticToolResults(
-                tracker.inFlightTools,
-                [...tracker.completedResults],
+              await this.finalizeInterruptedStep({
+                snapshot: tracker.snapshot(),
                 reason,
-                ids.toolPartId,
-                ids.messageId,
-                tracker.streamedArgText,
-              );
+                partIdFor: ids.toolPartId,
+                messageId: ids.messageId,
+              });
             } catch (error) {
               recordFinalizationError(error);
             }
@@ -1083,117 +1096,6 @@ export class OffensiveSecurityAgent<TResult = void> {
    */
   get response() {
     return this.streamResult.response;
-  }
-
-  private async emitSyntheticToolResults(
-    inFlightTools: ReadonlyMap<string, string>,
-    completedResults: readonly ToolResultPart[],
-    reason: string,
-    partIdFor?: (toolCallId: string) => string,
-    messageId?: string,
-    streamedArgText?: ReadonlyMap<string, string>,
-  ): Promise<void> {
-    const sid = this.subagentId;
-    const syntheticParts = buildSyntheticToolResults({
-      inFlightTools,
-      reason,
-      responseToolName: RESPONSE_TOOL_NAME,
-      responseSubmitted: this._responseToolFired,
-    });
-    let emissionError: unknown;
-    let hasEmissionError = false;
-
-    if (RESPONSE_DEBUG) {
-      const responseInFlight = [...inFlightTools.entries()].filter(
-        ([, n]) => n === RESPONSE_TOOL_NAME,
-      );
-      if (responseInFlight.length > 0) {
-        rlog.warn(
-          `[response-debug] emitSyntheticToolResults closing ${responseInFlight.length} response call(s) ` +
-            `ids=${responseInFlight.map(([id]) => id).join(",")} reason="${reason}" ` +
-            `aborted=${this.abortSignal?.aborted === true} responseToolFired=${this._responseToolFired}`,
-        );
-      }
-    }
-
-    for (const part of syntheticParts) {
-      try {
-        this.eventBus.emit("tool-result", {
-          toolCallId: part.toolCallId,
-          toolName: part.toolName,
-          result: part.output,
-          // Canonical session id, not just the legacy subagentId alias, so the translator routes to THIS subagent's session.
-          sessionId: this.busSessionId,
-          subagentId: sid,
-          partId: partIdFor?.(part.toolCallId),
-          messageId,
-        });
-      } catch (error) {
-        if (!hasEmissionError) {
-          emissionError = error;
-          hasEmissionError = true;
-        }
-      }
-    }
-
-    if (!this.messagesPath) {
-      if (hasEmissionError) throw emissionError;
-      return;
-    }
-
-    // Cancel an unfired debounce and drain writes that already started.
-    this.writer.cancelTimer();
-    await this.writer.waitForPendingWrites();
-
-    // Fall back to the on-disk snapshot once the debounced timer has flushed the latest snapshot, so we don't overwrite history.
-    let base: ModelMessage[] = this.writer.latest ?? [];
-    if (base.length === 0 && existsSync(this.messagesPath)) {
-      try {
-        base = JSON.parse(readFileSync(this.messagesPath, "utf-8"));
-      } catch {
-        // Corrupt file → proceed with empty base.
-      }
-    }
-
-    // When onStepFinish hasn't fired, this step's messages aren't in base yet;
-    // reconstruct so resumed sessions see valid pairs (see
-    // ./interruptedStepMessages).
-    const { appended, needsStepReconstruction } = buildInterruptedStepMessages({
-      base,
-      inFlightTools,
-      completedResults,
-      syntheticParts,
-      streamedArgText,
-    });
-    if (needsStepReconstruction && RESPONSE_DEBUG) {
-      const responseReconstructed = [
-        ...inFlightTools,
-        ...completedResults.map((r) => [r.toolCallId, r.toolName] as const),
-      ]
-        .filter(([, n]) => n === RESPONSE_TOOL_NAME)
-        .map(([id]) => id);
-      if (responseReconstructed.length > 0) {
-        rlog.warn(
-          `[response-debug] step-reconstruction for response call(s) ` +
-            `ids=${responseReconstructed.join(",")} ` +
-            `preservedArgChars=${responseReconstructed
-              .map((id) => streamedArgText?.get(id)?.length ?? 0)
-              .join(",")}`,
-        );
-      }
-    }
-
-    const next: ModelMessage[] = [...base, ...appended];
-    this.writer.setLatest(next);
-    try {
-      await this.writer.enqueueWrite(next);
-      // Only suppress onFinish's write once the snapshot is safely on disk.
-      this.writer.markSyntheticsPersisted();
-    } catch {
-      // Write failed — leave the flag false so onFinish still attempts a write.
-    }
-
-    if (hasEmissionError) throw emissionError;
   }
 }
 


### PR DESCRIPTION
## Stack

> [!NOTE]
> **OffensiveSecurityAgent refactor · PR 5 of 7**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#986](https://github.com/pensarai/apex/pull/986) | Stream diagnostics |
| 2 | [#987](https://github.com/pensarai/apex/pull/987) | Tool lifecycle |
| 3 | [#988](https://github.com/pensarai/apex/pull/988) | Interrupted-step messages |
| 4 | [#989](https://github.com/pensarai/apex/pull/989) | Message persistence |
| **5** | **[#990](https://github.com/pensarai/apex/pull/990)** | **Interrupted-step finalization** · `Current` |
| 6 | [#991](https://github.com/pensarai/apex/pull/991) | Resource disposal |
| 7 | [#992](https://github.com/pensarai/apex/pull/992) | `consume()` simplification |

## Summary

- compose the tracker snapshot (A2), the pure message builder (A3), event emission, and the writer (A4) behind one operation: `createInterruptedStepFinalizer(deps)` in `interruptedStepFinalization.ts`
- the agent's ~90-line `emitSyntheticToolResults` private method is deleted; `consume()`'s finally calls `finalizeInterruptedStep({ snapshot, reason, partIdFor, messageId })`
- the stub test harness now composes the real writer + real finalizer instead of relying on the agent's private method existing

## Motivation

A5 of Stack B. The interrupted-step path was the last tangled blob: emission, debounce cancellation, drain, base resolution, reconstruction, write policy, and error precedence all in one private method touching six fields. With A2–A4 extracted, composing them is mostly deletion — and the four stack invariants become testable at the operation level rather than only through full agent runs.

## What changed

**New module: `src/core/agents/offSecAgent/interruptedStepFinalization.ts`**

`createInterruptedStepFinalizer(deps)` returns `finalize(input)` which:

1. builds synthetic results via `buildSyntheticToolResults` (every open call gets one)
2. emits each on the bus with per-listener error capture (first error remembered, siblings unaffected)
3. with no `messagesPath`: emits only, then rethrows any listener error
4. cancels the debounce, drains in-flight writes, resolves the base (`writer.latest` ?? on-disk via injectable `readBaseFromDisk`)
5. builds the appended messages via `buildInterruptedStepMessages`
6. writes through the queue and marks `syntheticsPersisted` **only on success**
7. rethrows the listener error **after** persistence has been attempted

**Invariants preserved and now directly tested:**

- listener errors never prevent persistence (rejection arrives after the write)
- the original stream error remains primary — a failed snapshot write resolves rather than rejects (the caller's `recordFinalizationError` only replaces a null stream error)
- every open tool receives a synthetic result
- persistence completes before the operation reports settled (drain + awaited write before return/throw)

**`offensiveSecurityAgent.ts`** — constructor composes the finalizer (bus id, subagent id, writer, response-tool context, opt-in debug sink); the finally block computes the reason (abort vs stream error) and calls the finalizer with `tracker.snapshot()`. Net −124 lines.

## Deliberate debug-only change (flagged)

The `emitSyntheticToolResults closing…` debug line dropped its `aborted=` field (the finalizer doesn't know the signal; the `reason` string already distinguishes aborts). Opt-in RESPONSE_DEBUG output only.

## Test coverage

7 tests in `interruptedStepFinalization.test.ts`, composing real `AgentEventBus` + `AgentMessageWriter` + `ToolLifecycleTracker` snapshots:

- provider-error path: emission with session/subagent routing + persisted transcript with reconstructed args
- abort path: same shape with the abort reason
- **listener error**: rejects with the listener error *and* the file is written + flag marked before the rejection
- **persistence failure**: resolves, `syntheticsPersisted` stays false
- **multiple interrupted tools**: flushed error + completed result + open call all paired, outputs preserved
- no-path: emits, persists nothing
- **abort-write ordering**: the snapshot queues behind a gated in-flight write; base comes from the drained write

## Validation

- `bun run test` (1,678 passed, 22 skipped — all 34 agent tests green)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the touched files (clean)

## Notes

- the stub harness installing real collaborators is the stack exit condition materializing: manual private-state construction is down to the stream, shell, bus, and ids

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches abort/error persistence and event emission for in-flight tools; behavior is intended to be equivalent but mistakes could corrupt `messages.json` or mishandle synthetic closes on resume.
> 
> **Overview**
> Pulls **interrupted-step cleanup** out of `OffensiveSecurityAgent` into `createInterruptedStepFinalizer` in `interruptedStepFinalization.ts`. When a stream aborts or errors with unpersisted tool state, the agent now calls `finalizeInterruptedStep({ snapshot, reason, … })` instead of the removed ~90-line `emitSyntheticToolResults` helper.
> 
> The finalizer **composes** existing pieces: synthetic `tool-result` parts, `tool-result` bus events (with session/subagent routing), writer debounce cancel + drain, transcript reconstruction via `buildInterruptedStepMessages`, and queued persistence with `syntheticsPersisted` only set on a successful write. **Error ordering is unchanged**—persistence runs before rethrowing a listener failure; a failed snapshot write resolves so the original stream error stays primary and `onFinish` can retry.
> 
> Adds **seven focused unit tests** on the finalizer (abort vs provider error, listener vs write failures, multi-tool pairing, no `messagesPath`, write ordering). The `consume()` stub harness wires the real finalizer so agent tests still exercise the same path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2098e719b55e2da552c897c238ce2ee7b36fdfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

