### PR TITLE
refactor(agent): simplify consume finalization

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -833,163 +833,29 @@ export class OffensiveSecurityAgent<TResult = void> {
       diagnostics.start();
 
       try {
+        // 1–3. Iterate the stream: observe diagnostics, apply the part (id
+        // bookkeeping, tracker updates, step-close emissions), forward it.
         for await (const chunk of this.streamResult.fullStream) {
           diagnostics.observeChunk(chunk);
-          switch (chunk.type) {
-            case "start-step":
-              ids.messageId = newMessageId();
-              this.currentMessageId = ids.messageId;
-              ids.textPartId = undefined;
-              break;
-            case "text-start":
-              ids.textPartId = newPartId();
-              break;
-            case "text-end":
-              ids.textPartId = undefined;
-              break;
-            case "finish-step": {
-              tracker.onStepPersisted();
-              const finishReason = (chunk as { finishReason?: string })
-                .finishReason;
-              const truncated = finishReason === "length";
-
-              for (const [toolCallId, info] of tracker.toolErrors) {
-                diagnostics.logSurfacedToolError({
-                  toolCallId,
-                  toolName: info.toolName,
-                  message: info.message,
-                  streamedArgChars: (
-                    tracker.streamedArgText.get(toolCallId) ?? ""
-                  ).length,
-                  finishReason,
-                  truncated,
-                });
-                bus.emit("tool-result", {
-                  toolCallId,
-                  toolName: info.toolName,
-                  result: {
-                    type: "error-text",
-                    value: truncated
-                      ? `Tool call failed: the model's output was truncated at its max output tokens before the "${info.toolName}" arguments were complete. ${info.message}`
-                      : `Tool call failed: ${info.message}`,
-                  },
-                  sessionId: this.busSessionId,
-                  subagentId: sid,
-                  partId: ids.toolPartId?.(toolCallId),
-                  messageId: ids.messageId,
-                });
-              }
-              tracker.clearToolErrors();
-
-              // Close any call still in flight (args never finalized) so it doesn't render stuck "running".
-              for (const [toolCallId, toolName] of tracker.inFlightTools) {
-                diagnostics.logClosingInFlightTool({
-                  toolCallId,
-                  toolName,
-                  finishReason,
-                  truncated,
-                });
-                // Already-fired response: mark submitted, not "did not complete".
-                const result =
-                  toolName === RESPONSE_TOOL_NAME && this._responseToolFired
-                    ? { type: "text" as const, value: "Response submitted." }
-                    : {
-                        type: "error-text" as const,
-                        value: truncated
-                          ? "Tool call did not complete: the model's output was truncated at its max output tokens before the arguments were finalized."
-                          : "Tool call did not complete",
-                      };
-                bus.emit("tool-result", {
-                  toolCallId,
-                  toolName,
-                  result,
-                  sessionId: this.busSessionId,
-                  subagentId: sid,
-                  partId: ids.toolPartId?.(toolCallId),
-                  messageId: ids.messageId,
-                });
-              }
-              tracker.clearInFlight();
-              break;
-            }
-            default:
-              // Tool-input/delta, tool-call, tool-error, tool-result → tracker.
-              tracker.observePart(chunk);
-          }
+          this.applyStreamPart(chunk, { ids, tracker, diagnostics });
           bus.emitStreamPart(chunk, ids);
         }
-        // Keep completedResults: an abort with no trailing finish-step needs them for the finally snapshot.
+        // The tracker keeps completed results: an abort with no trailing
+        // finish-step needs them for the finalization snapshot.
       } catch (err) {
+        // 4. Capture the error; finalization below still runs.
         streamError = err;
       } finally {
-        // Stop the stall watchdog so it never leaks past stream end / throw.
-        diagnostics.stop();
-        let finalizationError: unknown;
-        let hasFinalizationError = false;
-        const recordFinalizationError = (error: unknown) => {
-          if (hasFinalizationError) return;
-          finalizationError = error;
-          hasFinalizationError = true;
-        };
-
-        try {
-          // Dispose first — don't block on persistence I/O.
-          try {
-            this.disposeOwnedShell();
-          } catch (error) {
-            recordFinalizationError(error);
-          }
-          // Flush tool-errors that never reached a finish-step into the snapshot.
-          for (const [toolCallId, info] of tracker.flushToolErrorsToResults()) {
-            const result = {
-              type: "error-text" as const,
-              value: `Tool call failed: ${info.message}`,
-            };
-            try {
-              bus.emit("tool-result", {
-                toolCallId,
-                toolName: info.toolName,
-                result,
-                sessionId: this.busSessionId,
-                subagentId: sid,
-                partId: ids.toolPartId?.(toolCallId),
-                messageId: ids.messageId,
-              });
-            } catch (error) {
-              recordFinalizationError(error);
-            }
-          }
-          // Snapshot unpersisted step state: open tools get synthetic closes, completed/errored results get written.
-          if (tracker.hasUnpersistedState()) {
-            const reason = this.abortSignal?.aborted
-              ? "Agent aborted by user"
-              : streamError instanceof Error && streamError.message
-                ? streamError.message
-                : "Stream terminated unexpectedly";
-            try {
-              await this.finalizeInterruptedStep({
-                snapshot: tracker.snapshot(),
-                reason,
-                partIdFor: ids.toolPartId,
-                messageId: ids.messageId,
-              });
-            } catch (error) {
-              recordFinalizationError(error);
-            }
-          }
-        } catch (error) {
-          recordFinalizationError(error);
-        } finally {
-          // Tear down the Chromium child process we own. Without this, a
-          // naturally-finishing agent leaks its Playwright MCP browser — over a
-          // long single-process scan (many endpoints) the leaked Chromium
-          // processes exhaust memory and OOM the run. disconnect() force-kills
-          // and never hangs, so awaiting here is safe.
-          await this.disconnectOwnedBrowser();
-        }
+        // 5–7. Close the interrupted step, dispose owned resources, settle.
+        const finalizeError = await this.finalizeRun({
+          tracker,
+          diagnostics,
+          ids,
+          streamError,
+        });
         // Teardown failures must not replace the provider/stream failure.
-        if (streamError === null && hasFinalizationError) {
-          streamError = finalizationError;
+        if (streamError === null && finalizeError !== null) {
+          streamError = finalizeError;
         }
       }
 
@@ -1070,6 +936,189 @@ export class OffensiveSecurityAgent<TResult = void> {
     // Free the browser on result capture; the drain can wedge and leak camoufox.
     await this.disconnectOwnedBrowser();
     return result;
+  }
+
+  /**
+   * Apply one stream part: part-id bookkeeping, lifecycle-tracker updates,
+   * and the finish-step close-out emissions. Pure projection of the part
+   * onto run state; forwarding to the bus is the caller's job.
+   */
+  private applyStreamPart(
+    chunk: TextStreamPart<ToolSet>,
+    ctx: {
+      ids: StreamIdContext;
+      tracker: ToolLifecycleTracker;
+      diagnostics: StreamDiagnostics;
+    },
+  ): void {
+    const { ids, tracker, diagnostics } = ctx;
+    const sid = this.subagentId;
+    const bus = this.eventBus;
+    switch (chunk.type) {
+      case "start-step":
+        ids.messageId = newMessageId();
+        this.currentMessageId = ids.messageId;
+        ids.textPartId = undefined;
+        break;
+      case "text-start":
+        ids.textPartId = newPartId();
+        break;
+      case "text-end":
+        ids.textPartId = undefined;
+        break;
+      case "finish-step": {
+        tracker.onStepPersisted();
+        const finishReason = (chunk as { finishReason?: string }).finishReason;
+        const truncated = finishReason === "length";
+
+        for (const [toolCallId, info] of tracker.toolErrors) {
+          diagnostics.logSurfacedToolError({
+            toolCallId,
+            toolName: info.toolName,
+            message: info.message,
+            streamedArgChars: (tracker.streamedArgText.get(toolCallId) ?? "")
+              .length,
+            finishReason,
+            truncated,
+          });
+          bus.emit("tool-result", {
+            toolCallId,
+            toolName: info.toolName,
+            result: {
+              type: "error-text",
+              value: truncated
+                ? `Tool call failed: the model's output was truncated at its max output tokens before the "${info.toolName}" arguments were complete. ${info.message}`
+                : `Tool call failed: ${info.message}`,
+            },
+            sessionId: this.busSessionId,
+            subagentId: sid,
+            partId: ids.toolPartId?.(toolCallId),
+            messageId: ids.messageId,
+          });
+        }
+        tracker.clearToolErrors();
+
+        // Close any call still in flight (args never finalized) so it doesn't render stuck "running".
+        for (const [toolCallId, toolName] of tracker.inFlightTools) {
+          diagnostics.logClosingInFlightTool({
+            toolCallId,
+            toolName,
+            finishReason,
+            truncated,
+          });
+          // Already-fired response: mark submitted, not "did not complete".
+          const result =
+            toolName === RESPONSE_TOOL_NAME && this._responseToolFired
+              ? { type: "text" as const, value: "Response submitted." }
+              : {
+                  type: "error-text" as const,
+                  value: truncated
+                    ? "Tool call did not complete: the model's output was truncated at its max output tokens before the arguments were finalized."
+                    : "Tool call did not complete",
+                };
+          bus.emit("tool-result", {
+            toolCallId,
+            toolName,
+            result,
+            sessionId: this.busSessionId,
+            subagentId: sid,
+            partId: ids.toolPartId?.(toolCallId),
+            messageId: ids.messageId,
+          });
+        }
+        tracker.clearInFlight();
+        break;
+      }
+      default:
+        // Tool-input/delta, tool-call, tool-error, tool-result → tracker.
+        tracker.observePart(chunk);
+    }
+  }
+
+  /**
+   * Finalize a finished (or failed) run: stop diagnostics, dispose the owned
+   * shell, surface deferred tool errors, close the interrupted step, and
+   * disconnect the owned browser on every path. Returns the first
+   * finalization error (or null) — the caller keeps the stream error
+   * primary.
+   */
+  private async finalizeRun(input: {
+    tracker: ToolLifecycleTracker;
+    diagnostics: StreamDiagnostics;
+    ids: StreamIdContext;
+    streamError: unknown;
+  }): Promise<unknown> {
+    const { tracker, diagnostics, ids, streamError } = input;
+    const sid = this.subagentId;
+    const bus = this.eventBus;
+
+    // Stop the stall watchdog so it never leaks past stream end / throw.
+    diagnostics.stop();
+    let finalizationError: unknown;
+    let hasFinalizationError = false;
+    const recordFinalizationError = (error: unknown) => {
+      if (hasFinalizationError) return;
+      finalizationError = error;
+      hasFinalizationError = true;
+    };
+
+    try {
+      // Dispose first — don't block on persistence I/O.
+      try {
+        this.disposeOwnedShell();
+      } catch (error) {
+        recordFinalizationError(error);
+      }
+      // Flush tool-errors that never reached a finish-step into the snapshot.
+      for (const [toolCallId, info] of tracker.flushToolErrorsToResults()) {
+        const result = {
+          type: "error-text" as const,
+          value: `Tool call failed: ${info.message}`,
+        };
+        try {
+          bus.emit("tool-result", {
+            toolCallId,
+            toolName: info.toolName,
+            result,
+            sessionId: this.busSessionId,
+            subagentId: sid,
+            partId: ids.toolPartId?.(toolCallId),
+            messageId: ids.messageId,
+          });
+        } catch (error) {
+          recordFinalizationError(error);
+        }
+      }
+      // Snapshot unpersisted step state: open tools get synthetic closes,
+      // completed/errored results get written.
+      if (tracker.hasUnpersistedState()) {
+        const reason = this.abortSignal?.aborted
+          ? "Agent aborted by user"
+          : streamError instanceof Error && streamError.message
+            ? streamError.message
+            : "Stream terminated unexpectedly";
+        try {
+          await this.finalizeInterruptedStep({
+            snapshot: tracker.snapshot(),
+            reason,
+            partIdFor: ids.toolPartId,
+            messageId: ids.messageId,
+          });
+        } catch (error) {
+          recordFinalizationError(error);
+        }
+      }
+    } catch (error) {
+      recordFinalizationError(error);
+    } finally {
+      // Tear down the Chromium child process we own. Without this, a
+      // naturally-finishing agent leaks its Playwright MCP browser — over a
+      // long single-process scan (many endpoints) the leaked Chromium
+      // processes exhaust memory and OOM the run. disconnect() force-kills
+      // and never hangs, so awaiting here is safe.
+      await this.disconnectOwnedBrowser();
+    }
+    return hasFinalizationError ? finalizationError : null;
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stack

> [!NOTE]
> **OffensiveSecurityAgent refactor · PR 7 of 7**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#986](https://github.com/pensarai/apex/pull/986) | Stream diagnostics |
| 2 | [#987](https://github.com/pensarai/apex/pull/987) | Tool lifecycle |
| 3 | [#988](https://github.com/pensarai/apex/pull/988) | Interrupted-step messages |
| 4 | [#989](https://github.com/pensarai/apex/pull/989) | Message persistence |
| 5 | [#990](https://github.com/pensarai/apex/pull/990) | Interrupted-step finalization |
| 6 | [#991](https://github.com/pensarai/apex/pull/991) | Resource disposal |
| **7** | **[#992](https://github.com/pensarai/apex/pull/992)** | **`consume()` simplification** · `Current` |

## Summary

- reduce `consume()` to the plain lifecycle sequence now that every concern is a named collaborator (A1–A5) or operation (A6):
  1. iterate the stream
  2. forward chunks (`emitStreamPart`)
  3. update the lifecycle tracker (`applyStreamPart`)
  4. capture result or error
  5. invoke interrupted-step finalization (`finalizeRun`)
  6. dispose owned resources
  7. settle tracing and drain state (unchanged, outside `runConsume`)
- the ~150-line inline switch and finally relocate verbatim into two private methods, `applyStreamPart` (steps 2–3 projection) and `finalizeRun` (steps 5–6, returning the finalization error so the stream error stays primary)
- no new abstractions — pure relocation plus deletion of the closure machinery

## Motivation

A7 closes Stack B per its exit condition. Before this stack, `consume()` interleaved diagnostics regimes, four tracker structures, persistence policy, message reconstruction, and disposal in one 300-line closure; the test harness had to hand-construct six private fields to run it. After A1–A6 the body could be reduced mechanically — this PR does exactly that and nothing more.

## What changed

**`runConsume`** (inside `consume()`): ids setup → tracker + diagnostics construction → `try { for await … observeChunk → applyStreamPart → emitStreamPart } catch { streamError } finally { finalizeRun; error precedence }` → result/abort/resolveResult. Each step is one line or one named call.

**`applyStreamPart(chunk, ctx)`** (new private, relocated): the stream-part switch — id bookkeeping (`start-step`/`text-start`/`text-end`), finish-step close-out emissions (deferred tool errors surfaced with truncation-aware messages, in-flight calls closed with the response-submitted special case), `default:` → `tracker.observePart`.

**`finalizeRun(input)`** (new private, relocated): diagnostics stop → shell disposal (error recorded, never blocks) → deferred tool-error flush + emission → `finalizeInterruptedStep` when the tracker has unpersisted state (abort-vs-stream reason) → browser disconnect in the nested `finally` → returns the first finalization error (or null).

**Deletions:** the `recordFinalizationError` closure machinery (now local to `finalizeRun`), the inline switch, the inline finally, stale comments referencing pre-extraction names.

## Behavior preserved — and how we know

Zero logic changes: every line in the two methods is a verbatim relocation (the only new code is the method signatures, the context object, and the error return). The proof is the test suite: all **40** agent tests (disposal ordering, abort races, persist-timer fallbacks, listener-error masking, multi-step abort dedup, drain decoupling, the six new disposal tests) pass unmodified — as does the full 1,684-test suite.

## Test coverage

No new tests by design — this PR is relocation, and the existing suite is the characterization. The stack exit condition is met: the harness constructs only the stream, shell, bus, writer, and finalizer collaborators; the tracker, diagnostics, persistence internals, and message builders are all real production objects now.

## Validation

- `bun run test` (1,684 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check`

## Notes

Stack B end state — `offensiveSecurityAgent.ts` is composition and lifecycle glue over six focused modules: `streamDiagnostics.ts`, `toolLifecycle.ts`, `interruptedStepMessages.ts`, `messagePersistence.ts`, `interruptedStepFinalization.ts`, and the disposal pair, each directly tested. Net across the stack: ~560 lines removed from the agent, 6 new test files (51 new tests), same behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical extraction only; stream, tool lifecycle, and disposal logic is unchanged and covered by existing agent tests.
> 
> **Overview**
> **Simplifies `consume()`’s `runConsume` loop** by moving ~150 lines of inline stream handling and teardown into two private helpers, so the main path reads as observe → apply → emit, then `finalizeRun` in `finally`.
> 
> **`applyStreamPart`** holds the former `switch` on stream part types: message/text part IDs, `finish-step` tool-error and in-flight close emissions (including truncation and response-tool special cases), and default routing to `tracker.observePart`. Bus forwarding stays in the caller.
> 
> **`finalizeRun`** holds the former `finally` body: stop diagnostics, dispose shell, flush deferred tool errors, `finalizeInterruptedStep` when needed, and always `disconnectOwnedBrowser`. It returns the first finalization error so **stream errors still win** over teardown failures.
> 
> No new behavior—verbatim relocation plus clearer step comments; closes the OffensiveSecurityAgent refactor stack (PR 7/7).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed4cee61ed81789fac7bd64f25464090d5881d4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

