### PR TITLE
Fail closed when spawn_pentest_agent receives an invalid or out-of-scope target

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentFinding.test.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.test.ts
@@ -156,6 +156,23 @@ describe("documentVulnerability judge handling", () => {
     );
   });
 
+  it("rejects an out-of-scope endpoint before POC/judge run (keeps infra findings out of the registry)", async () => {
+    const ctx = makeToolContext(rootPath);
+    const tool = documentVulnerability(ctx);
+    const result = (await tool.execute?.(
+      { ...makeDocumentInput(), endpoint: "http://127.0.0.1:9000/metrics" },
+      { toolCallId: "test", messages: [] },
+    )) as DocumentToolResult & { error?: string };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Scope violation");
+    // Fail closed before any judge/POC work.
+    expect(mockedJudgeFinding).not.toHaveBeenCalled();
+    expect(existsSync(join(ctx.session.pocsPath, "poc_admin_data.sh"))).toBe(
+      false,
+    );
+  });
+
   it("preserves a PoC-backed finding when the judge returns degraded unverified status", async () => {
     mockedJudgeFinding.mockResolvedValue({
       valid: true,

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -27,6 +27,10 @@ import {
   judgeFinding,
 } from "../../specialized/findingJudge";
 import type { Finding } from "../types";
+import {
+  assertFindingEndpointInScope,
+  ScopeViolationError,
+} from "./scopeGuard";
 import type { ToolContext } from "./types";
 
 const log = scopedLogger(() => createLogger("document-finding"));
@@ -168,6 +172,22 @@ CRITICAL RULES — READ BEFORE CALLING:
 - If you could not exploit a vulnerability, do NOT call this tool — mention it in your final response summary instead`,
     inputSchema: documentVulnerabilityInputSchema,
     execute: async (input) => {
+      // Defense in depth: reject findings whose endpoint host is outside the
+      // immutable engagement scope so a routing error can't write
+      // infrastructure findings into the shared customer registry.
+      try {
+        assertFindingEndpointInScope(input.endpoint, ctx);
+      } catch (error) {
+        if (error instanceof ScopeViolationError) {
+          return {
+            success: false,
+            error: error.message,
+            message: `Finding endpoint rejected — out of scope: ${error.message}`,
+          };
+        }
+        throw error;
+      }
+
       try {
         // Early dedup check — avoid POC execution + LLM calls for known vulns
         const materializedEvidence = formatMateriality(input);

--- a/src/core/agents/offSecAgent/tools/scopeGuard.test.ts
+++ b/src/core/agents/offSecAgent/tools/scopeGuard.test.ts
@@ -3,6 +3,7 @@ import { applyHeadersToShellCommand } from "../../../http/targetHeaders";
 import type { SessionInfo } from "../../../session";
 import {
   assertCommandInScope,
+  assertFindingEndpointInScope,
   assertUrlInScope,
   extractHostname,
   extractHostsFromCommand,
@@ -321,6 +322,43 @@ describe("assertUrlInScope", () => {
     );
     expect(() =>
       assertUrlInScope("https://diracinc.com.evil.com", ctx),
+    ).toThrow(ScopeViolationError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertFindingEndpointInScope
+// ---------------------------------------------------------------------------
+
+describe("assertFindingEndpointInScope", () => {
+  it("is a no-op when no scope is configured", () => {
+    expect(() =>
+      assertFindingEndpointInScope("http://127.0.0.1/status", makeCtx()),
+    ).not.toThrow();
+  });
+
+  it("allows an in-scope absolute endpoint", () => {
+    const ctx = makeCtx({ target: "https://example.com" });
+    expect(() =>
+      assertFindingEndpointInScope("https://api.example.com/v1/users", ctx),
+    ).not.toThrow();
+  });
+
+  it("allows bare paths (implicitly the in-scope target host)", () => {
+    const ctx = makeCtx({ target: "https://example.com" });
+    expect(() =>
+      assertFindingEndpointInScope("/api/users/{id}", ctx),
+    ).not.toThrow();
+    expect(() => assertFindingEndpointInScope("", ctx)).not.toThrow();
+  });
+
+  it("blocks an out-of-scope absolute endpoint (infrastructure host)", () => {
+    const ctx = makeCtx({ target: "https://example.com" });
+    expect(() =>
+      assertFindingEndpointInScope("http://127.0.0.1:9000/metrics", ctx),
+    ).toThrow(ScopeViolationError);
+    expect(() =>
+      assertFindingEndpointInScope("https://evil.example.net/x", ctx),
     ).toThrow(ScopeViolationError);
   });
 });

--- a/src/core/agents/offSecAgent/tools/scopeGuard.ts
+++ b/src/core/agents/offSecAgent/tools/scopeGuard.ts
@@ -151,6 +151,37 @@ export function assertUrlInScope(url: string, ctx: ToolContext): void {
 }
 
 /**
+ * Assert that a finding's `endpoint` is within the engagement scope before it
+ * enters the shared findings registry. Defense in depth: a routing error must
+ * not be able to write infrastructure findings (e.g. against `127.0.0.1`) into
+ * the customer registry.
+ *
+ * Only enforced when the endpoint carries an explicit http(s) authority. Bare
+ * paths (e.g. `/api/users`) have no host — they are implicitly the in-scope
+ * target — so they are allowed. Throws `ScopeViolationError` for an
+ * out-of-scope host. No-op when no scope is configured.
+ */
+export function assertFindingEndpointInScope(
+  endpoint: string,
+  ctx: ToolContext,
+): void {
+  const allowedHosts = getAllowedHosts(ctx);
+  if (allowedHosts.length === 0) return;
+
+  // Only absolute http(s) URLs name their own host; anything else (a path,
+  // "host:port", a scheme-less token) is treated as relative to the in-scope
+  // target and left to the existing deterministic target boundary.
+  if (!/^https?:\/\//i.test(endpoint.trim())) return;
+
+  const hostname = extractHostname(endpoint);
+  if (!hostname) return;
+
+  if (!isHostAllowed(hostname, allowedHosts)) {
+    throw new ScopeViolationError(hostname, allowedHosts);
+  }
+}
+
+/**
  * Extract URLs and hostnames from a shell command string.
  *
  * Looks for:

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.test.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.test.ts
@@ -78,10 +78,10 @@ function makeParentSession(): {
 async function runSpawn(
   ctx: ToolContext,
   inputOverrides: Record<string, unknown> = {},
-): Promise<void> {
+): Promise<{ success?: boolean; message?: string }> {
   const tool = spawnPentestAgent(ctx);
   // biome-ignore lint/suspicious/noExplicitAny: ai-sdk tool execute receives an opaque ExecuteContext we don't need to narrow for this test.
-  await (tool as any).execute(
+  return await (tool as any).execute(
     {
       name: "worker",
       target: "https://example.com/api",
@@ -92,6 +92,14 @@ async function runSpawn(
     },
     { toolCallId: "tc1", messages: [], abortSignal: undefined },
   );
+}
+
+function makeEventBus(): {
+  bus: ToolContext["eventBus"];
+  emit: ReturnType<typeof vi.fn>;
+} {
+  const emit = vi.fn();
+  return { bus: { emit } as unknown as ToolContext["eventBus"], emit };
 }
 
 afterEach(() => {
@@ -162,5 +170,119 @@ describe("spawn_pentest_agent — shared browser session", () => {
       browserSession?: PlaywrightMcpSession;
     };
     expect(workerInput.browserSession).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Target validation & scope enforcement (fail-closed)
+// ---------------------------------------------------------------------------
+
+describe("spawn_pentest_agent — target validation", () => {
+  for (const [label, target] of [
+    ["missing", undefined],
+    ["empty", ""],
+    ["whitespace", "   "],
+    ["malformed", "http://"],
+  ] as const) {
+    it(`rejects a ${label} target with no worker and no subagent-spawn event`, async () => {
+      const { bus, emit } = makeEventBus();
+      const ctx = buildCtx({ target: "https://example.com", eventBus: bus });
+
+      const result = await runSpawn(ctx, { target });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("not a valid full URL");
+      // No child was minted or executed.
+      expect(constructorCalls).toHaveLength(0);
+      expect(emit).not.toHaveBeenCalled();
+    });
+  }
+});
+
+describe("spawn_pentest_agent — scope enforcement", () => {
+  it.each([
+    ["loopback IP", "http://127.0.0.1:8080/status"],
+    ["localhost", "http://localhost:3000/admin"],
+    ["link-local", "http://169.254.169.254/latest/meta-data/"],
+    ["private RFC1918 host", "http://10.0.0.5/internal"],
+    ["unrelated public domain", "https://evil.example.net/api"],
+  ])("an external engagement cannot spawn %s", async (_label, target) => {
+    const { bus, emit } = makeEventBus();
+    const ctx = buildCtx({ target: "https://example.com", eventBus: bus });
+
+    const result = await runSpawn(ctx, { target });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Scope violation");
+    expect(constructorCalls).toHaveLength(0);
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it("rejects a target that repair might have fabricated (127.0.0.1) at the execute boundary", async () => {
+    // Even if tool-call repair (or the model) substitutes a generic default,
+    // the deterministic scope check blocks it for an external engagement.
+    const ctx = buildCtx({ target: "https://example.com" });
+
+    const result = await runSpawn(ctx, { target: "127.0.0.1" });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Scope violation");
+    expect(constructorCalls).toHaveLength(0);
+  });
+
+  it("allows a same-host path under the engagement target", async () => {
+    const ctx = buildCtx({ target: "https://example.com/login" });
+
+    const result = await runSpawn(ctx, {
+      target: "https://example.com/api/users/{id}",
+    });
+
+    expect(result.success).toBe(true);
+    expect(constructorCalls).toHaveLength(1);
+    expect((constructorCalls[0] as { target: string }).target).toBe(
+      "https://example.com/api/users/{id}",
+    );
+  });
+
+  it("allows a subdomain of the engagement's registrable domain", async () => {
+    const ctx = buildCtx({ target: "https://web.example.com" });
+
+    const result = await runSpawn(ctx, {
+      target: "https://api.example.com/orders",
+    });
+
+    expect(result.success).toBe(true);
+    expect(constructorCalls).toHaveLength(1);
+  });
+
+  it("allows an explicitly authorized sibling host", async () => {
+    const ctx = buildCtx({
+      target: "https://example.com",
+      session: {
+        rootPath: "/tmp/apex-test",
+        findingsPath: "/tmp/apex-test/findings",
+        config: {
+          scopeConstraints: { allowedHosts: ["api.internal.test"] },
+        },
+      } as unknown as SessionInfo,
+    });
+
+    const result = await runSpawn(ctx, {
+      target: "https://api.internal.test/v1/keys",
+    });
+
+    expect(result.success).toBe(true);
+    expect(constructorCalls).toHaveLength(1);
+  });
+
+  it("lets a localhost-rooted engagement spawn an authorized localhost child", async () => {
+    const ctx = buildCtx({ target: "http://localhost:3000" });
+
+    const result = await runSpawn(ctx, {
+      target: "http://localhost:3000/admin",
+    });
+
+    expect(result.success).toBe(true);
+    expect(constructorCalls).toHaveLength(1);
   });
 });

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -1,11 +1,13 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { parseTargetUrl } from "../../../../util/url";
 import { AgentEventBus } from "../../../eventBus";
 import { FindingsRegistry } from "../../../findings/registry";
 import { newSessionId } from "../../../id/id";
 // Type-only (erased) — the value is lazy-imported below to break a circular dep.
 import type { GrpcPentestContext } from "../../specialized/attackSurface/grpcSchema";
 import type { TargetedPentestAgent } from "../../specialized/pentest/agent";
+import { assertUrlInScope, ScopeViolationError } from "./scopeGuard";
 import type { ToolContext } from "./types";
 
 // Cap the wait on a finished worker's background drain so it can't hang the slot.
@@ -89,6 +91,33 @@ Returns the worker's summary, objective results, and finding count — but NOT t
           success: false,
           message: "spawn_pentest_agent requires a model in the tool context.",
         };
+      }
+
+      // Fail closed on the child target BEFORE minting a child session id or
+      // emitting `subagent-spawn`. `target` is security-sensitive: it becomes
+      // the child's scope root, so an invalid or out-of-scope value must never
+      // spawn a worker. There is NO fallback/default — we never substitute
+      // localhost, a session target, or any other value for a bad target.
+      if (typeof target !== "string" || parseTargetUrl(target) === null) {
+        return {
+          success: false,
+          message:
+            `spawn_pentest_agent rejected: "target" is not a valid full URL (received ${JSON.stringify(target)}). ` +
+            `Pass the exact full URL the orchestrator received — do NOT invent, default, or substitute a target.`,
+        };
+      }
+
+      // Enforce the PARENT scope against the model-supplied child target. Using
+      // `ctx` (not a context rebased onto `target`) means the child can narrow
+      // to a same-host path or an already-authorized sibling host, but can
+      // never broaden the immutable root/session allowed-host set.
+      try {
+        assertUrlInScope(target, ctx);
+      } catch (error) {
+        if (error instanceof ScopeViolationError) {
+          return { success: false, message: error.message };
+        }
+        throw error;
       }
 
       // Lazy import to break circular dependency:

--- a/src/core/ai/ai.test.ts
+++ b/src/core/ai/ai.test.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   applySequentialToolCallPolicy,
   buildReasoningProviderOptions,
+  isRepairFailClosedTool,
   SEQUENTIAL_TOOL_CALL_INSTRUCTION,
   streamResponse,
 } from "./ai";
@@ -50,6 +51,18 @@ describe("applySequentialToolCallPolicy", () => {
     expect(
       applySequentialToolCallPolicy("Base.", tools, "claude-haiku-4-5"),
     ).toBe("Base.");
+  });
+});
+
+describe("isRepairFailClosedTool", () => {
+  it("fails closed for spawn_pentest_agent so repair cannot fabricate a target", () => {
+    expect(isRepairFailClosedTool("spawn_pentest_agent")).toBe(true);
+  });
+
+  it("leaves ordinary tools eligible for repair", () => {
+    expect(isRepairFailClosedTool("response")).toBe(false);
+    expect(isRepairFailClosedTool("document_vulnerability")).toBe(false);
+    expect(isRepairFailClosedTool("http_request")).toBe(false);
   });
 });
 

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -47,6 +47,26 @@ const RESPONSE_DEBUG =
   process.env.RESPONSE_DEBUG === "1" || process.env.RESPONSE_DEBUG === "true";
 const RESPONSE_TOOL_NAME = "response";
 
+/**
+ * Tools whose arguments carry a security-authorization boundary the model must
+ * never have re-synthesized by tool-call repair. Repair asks a model to invent
+ * schema-valid arguments from a failed call; for these tools a fabricated value
+ * (e.g. a default/localhost `target`) would silently bypass deterministic scope
+ * enforcement. Repair therefore FAILS CLOSED for them — it returns `null` and
+ * the original invalid call is never executed.
+ */
+const REPAIR_FAIL_CLOSED_TOOLS: ReadonlySet<string> = new Set([
+  "spawn_pentest_agent",
+]);
+
+/**
+ * Whether tool-call repair must fail closed (no argument synthesis) for a tool.
+ * Exported for regression tests covering the repaired-invalid-call path.
+ */
+export function isRepairFailClosedTool(toolName: string): boolean {
+  return REPAIR_FAIL_CLOSED_TOOLS.has(toolName);
+}
+
 export type AIModel = AnthropicMessagesModelId | OpenAIChatModelId | string; // For gateway and Bedrock model IDs
 
 export type OpenAIReasoningEffort =
@@ -1169,6 +1189,19 @@ export function streamResponse(
               `rawInputChars=${rawLen} error=${(error.message || String(error)).slice(0, 200)}`,
           );
         }
+
+        // Fail closed for security-sensitive tools: never let repair invent or
+        // replace arguments (e.g. a spawn `target`). Returning null drops the
+        // invalid call instead of executing a model-synthesized one.
+        if (isRepairFailClosedTool(toolCall.toolName)) {
+          if (!silent) {
+            log.warn(
+              `Tool-call repair disabled for security-sensitive tool "${toolCall.toolName}" — failing closed (no argument synthesis).`,
+            );
+          }
+          return null;
+        }
+
         try {
           if (!silent) {
             log.debug(`Repairing tool call: ${toolCall.toolName}`, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

A production targeted-pentest trace showed an orchestrator emit a generic `spawn_pentest_agent` call (`target: 127.0.0.1`, generic recon objectives) that spawned a child which scanned Apex sandbox infrastructure. Root cause: `spawnPentestAgent` relied on prompt/schema descriptions for target correctness — `target` was only `z.string()`, `assertUrlInScope` was never called before creating the child, and the model-supplied child target became the child's scope root (minting a new scope root instead of being checked against the parent scope).

This PR enforces the target as a deterministic safety boundary at the execution edge.

**`spawnPentestAgent.execute` (`src/core/agents/offSecAgent/tools/spawnPentestAgent.ts`)**
- Validates the child `target` deterministically with `parseTargetUrl` (the same parser scope enforcement uses). A missing, empty, whitespace, or malformed target is rejected — **no fallback/default** is ever substituted (no `localhost`, session target, or model-generated value).
- Calls `assertUrlInScope(target, ctx)` against the **parent** context (not a context rebased onto the child target) before minting a child session id or emitting `subagent-spawn`. An out-of-scope target returns a visible `ScopeViolationError` message with no worker execution. Because the check uses the immutable parent scope, a child can narrow to a same-host path or an already-authorized sibling host but can never broaden the root/session allowed-host set.

**Tool-call repair (`src/core/ai/ai.ts`)**
- Repair asks a model to synthesize schema-valid arguments from a failed call, which could fabricate a `target`. Added `REPAIR_FAIL_CLOSED_TOOLS` / `isRepairFailClosedTool`; `experimental_repairToolCall` now returns `null` for `spawn_pentest_agent`, so repair can never invent or replace its arguments — the invalid call is dropped instead of executed.

**Findings registry defense-in-depth (`scopeGuard.ts`, `documentFinding.ts`)**
- New `assertFindingEndpointInScope` rejects `document_vulnerability` endpoints that name an out-of-scope host (e.g. `http://127.0.0.1/...`) before any POC/judge work, so a future routing error can't write infrastructure findings into the shared customer registry. Bare paths (no host) stay allowed since they are implicitly the in-scope target.

### How did you verify your code works?

Added regression tests and ran the full suite (`bun run test`: 1656 passed, 15 skipped), plus `bun run tsc` and `bun run check` clean.

- `spawnPentestAgent.test.ts` — missing/empty/whitespace/malformed targets rejected with no worker and no `subagent-spawn` event; an external engagement cannot spawn loopback, `localhost`, link-local, RFC1918, or an unrelated public domain; a fabricated `127.0.0.1` (what repair would produce) is blocked at the execute boundary; same-host paths, registrable-domain subdomains, an explicitly authorized sibling host, and a localhost-rooted engagement's localhost child all remain supported.
- `ai.test.ts` — `isRepairFailClosedTool` fails closed for `spawn_pentest_agent` and leaves ordinary tools eligible for repair.
- `scopeGuard.test.ts` / `documentFinding.test.ts` — out-of-scope finding endpoints are rejected before POC/judge run; bare paths and in-scope absolute endpoints are allowed.

### Note on the additional observation

The parent emitting ten overlapping `spawn_pentest_agent` calls (concurrency vs. the "one worker at a time" comments) is out of scope here — deterministic target validation is the required safety boundary regardless of concurrency. Happy to open a follow-up issue to enforce or document the sequential-worker invariant separately.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0dd6d84f-0edb-4730-a0ef-ca6e47ddf45f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0dd6d84f-0edb-4730-a0ef-ca6e47ddf45f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

