### PR TITLE
feat(usage): add session usage models

### DIFF
--- a/src/core/session/usage.test.ts
+++ b/src/core/session/usage.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import {
+  accumulateSessionTokens,
+  contextPercentage,
+  EMPTY_SESSION_TOKEN_USAGE,
+  hydrateSessionUsage,
+  replaceRootContextUsage,
+  sessionTokenTotal,
+} from "./usage";
+
+// ---------------------------------------------------------------------------
+// accumulateSessionTokens
+// ---------------------------------------------------------------------------
+
+describe("accumulateSessionTokens", () => {
+  it("accumulates input, output, and cache counters across steps", () => {
+    let usage = EMPTY_SESSION_TOKEN_USAGE;
+    usage = accumulateSessionTokens(usage, {
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 80,
+      cacheWriteTokens: 10,
+    });
+    usage = accumulateSessionTokens(usage, {
+      inputTokens: 50,
+      outputTokens: 5,
+      cacheReadTokens: 40,
+    });
+
+    expect(usage).toEqual({
+      inputTokens: 150,
+      outputTokens: 25,
+      cacheReadTokens: 120,
+      cacheWriteTokens: 10,
+    });
+  });
+
+  it("does not double-count cache reads into input tokens", () => {
+    // Anthropic reports cache-read tokens as part of inputTokens; the model
+    // keeps them separate here so the footer can show both without summing
+    // them twice.
+    const usage = accumulateSessionTokens(EMPTY_SESSION_TOKEN_USAGE, {
+      inputTokens: 1000,
+      cacheReadTokens: 900,
+    });
+    expect(usage.inputTokens).toBe(1000);
+    expect(sessionTokenTotal(usage)).toBe(1000);
+  });
+
+  it("returns the identical reference for an all-zero step", () => {
+    const usage = {
+      inputTokens: 5,
+      outputTokens: 6,
+      cacheReadTokens: 7,
+      cacheWriteTokens: 8,
+    };
+    expect(accumulateSessionTokens(usage, {})).toBe(usage);
+    expect(
+      accumulateSessionTokens(usage, {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      }),
+    ).toBe(usage);
+  });
+
+  it("treats absent optional fields as zero", () => {
+    const usage = accumulateSessionTokens(EMPTY_SESSION_TOKEN_USAGE, {
+      inputTokens: 10,
+    });
+    expect(usage).toEqual({
+      inputTokens: 10,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replaceRootContextUsage
+// ---------------------------------------------------------------------------
+
+describe("replaceRootContextUsage", () => {
+  it("replaces rather than accumulates across root steps", () => {
+    const first = replaceRootContextUsage("claude-sonnet-4-5", 10_000, 200_000);
+    const second = replaceRootContextUsage(
+      "claude-sonnet-4-5",
+      42_000,
+      200_000,
+    );
+
+    // The newest sample is the context size — no summation.
+    expect(second.usedTokens).toBe(42_000);
+    expect(second).not.toEqual(first);
+  });
+
+  it("records the model the call ran on, even when it differs from selection", () => {
+    const sample = replaceRootContextUsage("gpt-5.2", 10_000, 272_000);
+    expect(sample.modelId).toBe("gpt-5.2");
+    expect(sample.contextLimit).toBe(272_000);
+  });
+
+  it("clamps negative values to zero", () => {
+    const sample = replaceRootContextUsage("m", -5, -10);
+    expect(sample.usedTokens).toBe(0);
+    expect(sample.contextLimit).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// contextPercentage
+// ---------------------------------------------------------------------------
+
+describe("contextPercentage", () => {
+  it("computes the percentage of the sampled context limit", () => {
+    const sample = replaceRootContextUsage("m", 84_000, 200_000);
+    expect(contextPercentage(sample)).toBe(42);
+  });
+
+  it("clamps above 100 and below 0", () => {
+    const over = replaceRootContextUsage("m", 300_000, 200_000);
+    expect(contextPercentage(over)).toBe(100);
+    const under = replaceRootContextUsage("m", -1, 200_000);
+    expect(contextPercentage(under)).toBe(0);
+  });
+
+  it("returns null for no sample and for zero limits", () => {
+    expect(contextPercentage(null)).toBeNull();
+    const zeroLimit = replaceRootContextUsage("m", 100, 0);
+    expect(contextPercentage(zeroLimit)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sessionTokenTotal
+// ---------------------------------------------------------------------------
+
+describe("sessionTokenTotal", () => {
+  it("sums input and output only — cache rides inside input", () => {
+    expect(
+      sessionTokenTotal({
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 90,
+        cacheWriteTokens: 5,
+      }),
+    ).toBe(120);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hydrateSessionUsage
+// ---------------------------------------------------------------------------
+
+describe("hydrateSessionUsage", () => {
+  it("hydrates a complete modern shape", () => {
+    const { tokenUsage, contextUsage } = hydrateSessionUsage({
+      tokenUsage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 90,
+        cacheWriteTokens: 5,
+      },
+      contextUsage: {
+        usedTokens: 42_000,
+        contextLimit: 200_000,
+        modelId: "claude-sonnet-4-5",
+      },
+    });
+
+    expect(tokenUsage).toEqual({
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 90,
+      cacheWriteTokens: 5,
+    });
+    expect(contextUsage).toEqual({
+      usedTokens: 42_000,
+      contextLimit: 200_000,
+      modelId: "claude-sonnet-4-5",
+    });
+  });
+
+  it("fills missing cache fields from legacy files", () => {
+    const { tokenUsage, contextUsage } = hydrateSessionUsage({
+      tokenUsage: { inputTokens: 7, outputTokens: 3 },
+    });
+    expect(tokenUsage).toEqual({
+      inputTokens: 7,
+      outputTokens: 3,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+    expect(contextUsage).toBeNull();
+  });
+
+  it("drops malformed context samples (no model id)", () => {
+    const { contextUsage } = hydrateSessionUsage({
+      contextUsage: { usedTokens: 10, contextLimit: 200 },
+    });
+    expect(contextUsage).toBeNull();
+  });
+
+  it("sanitizes negative and non-numeric values", () => {
+    const { tokenUsage } = hydrateSessionUsage({
+      tokenUsage: {
+        inputTokens: -5,
+        outputTokens: Number("abc"), // NaN - sanitized to 0
+        cacheReadTokens: 1.9,
+      },
+    });
+    expect(tokenUsage).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 1,
+      cacheWriteTokens: 0,
+    });
+  });
+});

--- a/src/core/session/usage.ts
+++ b/src/core/session/usage.ts
@@ -1,0 +1,133 @@
+// ---------------------------------------------------------------------------
+// Session usage models — pure accounting for a session's token usage:
+// cumulative session totals (input/output/cache), the latest root context
+// sample, and context-percentage math. No I/O, no React, no event sources.
+// ---------------------------------------------------------------------------
+
+/** Cumulative token usage for one session across all runs and agents. */
+export interface SessionTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  /** Cache-read tokens (Anthropic prompt caching). Already included in inputTokens. */
+  cacheReadTokens: number;
+  /** Cache-write tokens (Anthropic prompt caching). */
+  cacheWriteTokens: number;
+}
+
+export const EMPTY_SESSION_TOKEN_USAGE: SessionTokenUsage = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+};
+
+/**
+ * The latest root-call context sample. Subagent calls never replace this —
+ * they run in their own short-lived contexts that say nothing about the
+ * operator's conversation size.
+ */
+export interface ContextUsage {
+  usedTokens: number;
+  contextLimit: number;
+  /** The model the root call actually ran on (the denominator's source). */
+  modelId: string;
+}
+
+/**
+ * Add one step's usage to a session's cumulative totals. Cache-read tokens
+ * are already part of the provider's inputTokens, so they accumulate into
+ * their own counters and are never added into inputTokens.
+ */
+export function accumulateSessionTokens(
+  current: SessionTokenUsage,
+  step: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  },
+): SessionTokenUsage {
+  const inputTokens = step.inputTokens ?? 0;
+  const outputTokens = step.outputTokens ?? 0;
+  const cacheReadTokens = step.cacheReadTokens ?? 0;
+  const cacheWriteTokens = step.cacheWriteTokens ?? 0;
+  if (
+    inputTokens === 0 &&
+    outputTokens === 0 &&
+    cacheReadTokens === 0 &&
+    cacheWriteTokens === 0
+  ) {
+    return current;
+  }
+  return {
+    inputTokens: current.inputTokens + inputTokens,
+    outputTokens: current.outputTokens + outputTokens,
+    cacheReadTokens: current.cacheReadTokens + cacheReadTokens,
+    cacheWriteTokens: current.cacheWriteTokens + cacheWriteTokens,
+  };
+}
+
+/**
+ * Record the latest root-call context sample. Replacement, not accumulation:
+ * each root step's input reflects the whole conversation as the model saw
+ * it, so the newest sample *is* the current context size.
+ */
+export function replaceRootContextUsage(
+  modelId: string,
+  usedTokens: number,
+  contextLimit: number,
+): ContextUsage {
+  return {
+    modelId,
+    usedTokens: Math.max(0, usedTokens),
+    contextLimit: Math.max(0, contextLimit),
+  };
+}
+
+/**
+ * Percentage of the context window in use, clamped to [0, 100]. Returns null
+ * when there is no sample or no usable limit (zero limits never divide).
+ */
+export function contextPercentage(context: ContextUsage | null): number | null {
+  if (!context) return null;
+  if (context.contextLimit <= 0) return null;
+  const raw = (context.usedTokens / context.contextLimit) * 100;
+  return Math.min(100, Math.max(0, raw));
+}
+
+/** Total session tokens (input + output). Cache is already inside input. */
+export function sessionTokenTotal(usage: SessionTokenUsage): number {
+  return usage.inputTokens + usage.outputTokens;
+}
+
+/**
+ * Hydrate usage from a persisted shape, tolerating legacy files that lack
+ * cache or context fields.
+ */
+export function hydrateSessionUsage(parsed: {
+  tokenUsage?: Partial<SessionTokenUsage>;
+  contextUsage?: Partial<ContextUsage> | null;
+}): { tokenUsage: SessionTokenUsage; contextUsage: ContextUsage | null } {
+  const t = parsed.tokenUsage ?? {};
+  const tokenUsage: SessionTokenUsage = {
+    inputTokens: nonNeg(t.inputTokens),
+    outputTokens: nonNeg(t.outputTokens),
+    cacheReadTokens: nonNeg(t.cacheReadTokens),
+    cacheWriteTokens: nonNeg(t.cacheWriteTokens),
+  };
+  const c = parsed.contextUsage;
+  const contextUsage: ContextUsage | null =
+    c && typeof c.modelId === "string" && c.modelId.length > 0
+      ? {
+          modelId: c.modelId,
+          usedTokens: nonNeg(c.usedTokens),
+          contextLimit: nonNeg(c.contextLimit),
+        }
+      : null;
+  return { tokenUsage, contextUsage };
+}
+
+function nonNeg(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
+}


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Usage + observability · PR 1 of 12**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| **1** | **[#996](https://github.com/pensarai/apex/pull/996)** | **Session usage models** · `Current` |
| 2 | [#997](https://github.com/pensarai/apex/pull/997) | Session-scoped ownership |
| 3 | [#998](https://github.com/pensarai/apex/pull/998) | Complete usage persistence |
| 4 | [#999](https://github.com/pensarai/apex/pull/999) | Consolidated usage ingestion |
| 5 | [#1000](https://github.com/pensarai/apex/pull/1000) | Token and context footer |
| 6 | [#1002](https://github.com/pensarai/apex/pull/1002) | Cache token breakdown |
| 7 | [#1004](https://github.com/pensarai/apex/pull/1004) | Agent trace contract |
| 8 | [#1005](https://github.com/pensarai/apex/pull/1005) | Optional OTLP runtime |
| 9 | [#1006](https://github.com/pensarai/apex/pull/1006) | Root agent run spans |
| 10 | [#1007](https://github.com/pensarai/apex/pull/1007) | Centralized telemetry settings |
| 11 | [#1008](https://github.com/pensarai/apex/pull/1008) | Telemetry correlation |
| 12 | [#1009](https://github.com/pensarai/apex/pull/1009) | OTLP shutdown hardening |

_Scope: token usage only. Dollar tracking, cost estimation, pricing catalogs, provider billing metadata, per-agent breakdowns, per-step ledgers, retry accounting, and reports/W&B changes are intentionally excluded._
## Summary

- new pure module `src/core/session/usage.ts` defining the usage models the rest of the stack builds on:
  - `SessionTokenUsage` — cumulative session totals: `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheWriteTokens`
  - `ContextUsage` — the latest root-call sample: `usedTokens`, `contextLimit`, `modelId`
  - `accumulateSessionTokens(current, step)` — cumulative addition for a step; returns the identical reference for all-zero steps
  - `replaceRootContextUsage(modelId, usedTokens, limit)` — **replacement**, not accumulation: each root step's input already reflects the whole conversation
  - `contextPercentage(context)` — clamped to [0, 100]; `null` for no sample or zero limit
  - `sessionTokenTotal` — input + output only
  - `hydrateSessionUsage` — tolerant hydration for T3 (legacy files without cache/context fields)

## The two accounting rules this module encodes

1. **Cache-read tokens are already inside inputTokens.** Anthropic reports cached input as part of the step's input count, so the cache counters accumulate separately for display and are never added into the input total — `sessionTokenTotal` pins that no-double-counting rule.
2. **Root context is a sample, not a sum.** The newest root call's input is the current context size; older samples are replaced, and the denominator (`contextLimit`, `modelId`) comes from the model that call actually ran on.

## Test coverage

15 tests in `usage.test.ts`: accumulation across steps; the no-double-count rule (`inputTokens` unchanged when cache grows); identical-reference zero steps; absent-optional-field tolerance; replace-vs-accumulate; per-call `modelId`; negative clamping; percentage math incl. >100/<0 clamps and zero-limit null; input+output-only totals; hydration of complete, legacy (missing cache/context), malformed-context, and non-numeric shapes.

## Validation

- `bun run test` (1,720 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the two files

## Notes

- Pure module: no I/O, no React, no event sources — T2 wires it into a session-scoped store, T3 persists it, T5 displays it.
- The old `TokenUsage`/`accumulateTokenUsage` in the dashboard's `logic.ts` and the app-global state in `AgentProvider` still exist and are consumed unchanged; T2/T4 migrate them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated module with tests only; no production call sites or behavior changes until follow-up PRs land.
> 
> **Overview**
> Introduces **`src/core/session/usage.ts`**, a dependency-free foundation for session-scoped token and context accounting (first step in a 5-PR usage stack). It defines **`SessionTokenUsage`** (cumulative input/output/cache counters) and **`ContextUsage`** (latest root-call snapshot with `modelId`, `usedTokens`, `contextLimit`).
> 
> **`accumulateSessionTokens`** adds per-step totals and skips work on all-zero steps (same object reference). Cache read/write counters accumulate separately and are **not** folded into input again—**`sessionTokenTotal`** is input + output only. **`replaceRootContextUsage`** overwrites the root context sample (no summing across turns) and clamps negatives. **`contextPercentage`** returns a clamped 0–100 value or `null` when there is no sample or a zero limit. **`hydrateSessionUsage`** normalizes persisted/legacy shapes (missing cache fields, bad context without `modelId`, non-numeric values).
> 
> Adds **`usage.test.ts`** with Vitest coverage for those rules (15 cases). No wiring to stores, persistence, or UI in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efb458cbe7b3854b0932627abfb10ca4bf671908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



