### PR TITLE
refactor(usage): make usage session-scoped

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -96,7 +96,6 @@ import {
 } from "./conversation";
 import { markInFlightToolsErrored } from "./display-state";
 import {
-  accumulateTokenUsage,
   buildOperatorSystemPrompt,
   type DashboardStatus,
   filterOperatorAutocomplete,
@@ -163,9 +162,8 @@ export default function OperatorDashboard({
     setThinking,
     setIsExecuting,
     tokenUsage,
-    addTokenUsage,
-    addCacheUsage,
-    resetTokenUsage,
+    usageStore,
+    markExecuted,
     setSessionCwd,
     reasoningEnabled,
     openAIReasoningEffort,
@@ -364,11 +362,6 @@ export default function OperatorDashboard({
   useEffect(() => {
     approvedPlanRef.current = approvedPlanContent;
   }, [approvedPlanContent]);
-  const tokenUsageRef = useRef(tokenUsage);
-
-  useEffect(() => {
-    tokenUsageRef.current = tokenUsage;
-  }, [tokenUsage]);
 
   // Subscribe to approval gate events
   useEffect(() => {
@@ -534,44 +527,28 @@ export default function OperatorDashboard({
   }, [loading, refocusPrompt]);
 
   useEffect(() => {
-    // Only run the reset / hydrate cycle for *resumed* sessions (those
-    // with a `sessionId` prop). Brand-new sessions reach this effect after
-    // their first agent step has already accumulated tokens via
-    // `addTokenUsage`, and a reset here would wipe that initial usage.
+    // Enter the resumed session in the usage store: seeds its totals from
+    // persisted metrics when first tracked, and never resets live totals on
+    // re-entry (another run in the same session accumulates). Brand-new
+    // sessions enter via onSessionReady once the session is minted, carrying
+    // the provisional bucket with them.
     if (!session || !sessionId) return;
-
-    resetTokenUsage();
-    tokenUsageRef.current = {
-      inputTokens: 0,
-      outputTokens: 0,
-      totalTokens: 0,
-      cachedTokens: 0,
-      cacheWriteTokens: 0,
-    };
 
     const metrics = readExecutionMetrics(session.rootPath);
     const persisted = metrics?.tokenUsage;
-    if (
-      persisted &&
-      (persisted.inputTokens > 0 || persisted.outputTokens > 0)
-    ) {
-      addTokenUsage(persisted.inputTokens, persisted.outputTokens);
-      tokenUsageRef.current = {
-        ...persisted,
-        cachedTokens: 0,
-        cacheWriteTokens: 0,
-      };
-    }
-
-    try {
-      writeExecutionMetrics({
-        sessionRootPath: session.rootPath,
-        tokenUsage: tokenUsageRef.current,
-      });
-    } catch {
-      // Best effort hydration write.
-    }
-  }, [session, sessionId, addTokenUsage, resetTokenUsage]);
+    usageStore.enterSession(session.id, {
+      ...(persisted
+        ? {
+            tokenUsage: {
+              inputTokens: persisted.inputTokens,
+              outputTokens: persisted.outputTokens,
+              cacheReadTokens: 0,
+              cacheWriteTokens: 0,
+            },
+          }
+        : {}),
+    });
+  }, [session, sessionId, usageStore]);
 
   // ---------------------------------------------------------------------------
   // Display event adapter — root display projections (partial text, tool-arg
@@ -715,34 +692,31 @@ export default function OperatorDashboard({
         nextMessages = conversationRef.current;
       }
 
-      // Shared sink for orchestrator + subagent token usage.
+      // Shared sink for orchestrator + subagent token usage. Routes into the
+      // session-scoped store; metrics write the owning session's snapshot.
       const recordTokenUsage = (
         inputTokens: number,
         outputTokens: number,
         cacheReadTokens = 0,
         cacheWriteTokens = 0,
       ) => {
-        const nextUsage = accumulateTokenUsage(
-          tokenUsageRef.current,
+        if (inputTokens > 0 || outputTokens > 0) markExecuted();
+        usageStore.addSessionTokens(usageStore.activeSessionId, {
           inputTokens,
           outputTokens,
-        );
-        if (nextUsage) {
-          tokenUsageRef.current = nextUsage;
-          addTokenUsage(inputTokens, outputTokens);
-          if (session) {
-            try {
-              writeExecutionMetrics({
-                sessionRootPath: session.rootPath,
-                tokenUsage: nextUsage,
-              });
-            } catch {
-              // Best effort: token metrics should not interrupt operator runs.
-            }
+          cacheReadTokens,
+          cacheWriteTokens,
+        });
+        const activeSession = sessionRef.current;
+        if (activeSession) {
+          try {
+            writeExecutionMetrics({
+              sessionRootPath: activeSession.rootPath,
+              tokenUsage: usageStore.getSnapshot(activeSession.id).tokenUsage,
+            });
+          } catch {
+            // Best effort: token metrics should not interrupt operator runs.
           }
-        }
-        if (cacheReadTokens > 0 || cacheWriteTokens > 0) {
-          addCacheUsage(cacheReadTokens, cacheWriteTokens);
         }
       };
 
@@ -804,16 +778,17 @@ export default function OperatorDashboard({
             : undefined),
         onStepFinish,
         onCacheMetrics: (metrics: CacheMetrics) => {
-          addCacheUsage(
-            metrics.cacheReadInputTokens,
-            metrics.cacheCreationInputTokens,
-          );
+          usageStore.addSessionTokens(usageStore.activeSessionId, {
+            cacheReadTokens: metrics.cacheReadInputTokens,
+            cacheWriteTokens: metrics.cacheCreationInputTokens,
+          });
         },
         eventBus,
         onSessionReady: (s: SessionInfo) => {
           setSessionCwd(s.rootPath);
           sessionRef.current = s;
           setSession((prev) => prev ?? s);
+          usageStore.enterSession(s.id);
           runTrace.tryAttach(s);
         },
       };
@@ -990,12 +965,10 @@ export default function OperatorDashboard({
       operatorState,
       operatorMode,
       agentMode,
-      addTokenUsage,
       displayEvents,
       runEventProjections,
       setThinking,
       setIsExecuting,
-      addCacheUsage,
       initialConfig?.sandbox,
       initialConfig?.taskDriven,
       initialConfig?.target,
@@ -1009,6 +982,8 @@ export default function OperatorDashboard({
       skillsRegistry,
       reasoningEnabled,
       openAIReasoningEffort,
+      usageStore,
+      markExecuted,
     ],
   );
 

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -527,12 +527,17 @@ export default function OperatorDashboard({
   }, [loading, refocusPrompt]);
 
   useEffect(() => {
+    if (!sessionId) {
+      usageStore.beginNewSession();
+      return;
+    }
+
     // Enter the resumed session in the usage store: seeds its totals from
     // persisted metrics when first tracked, and never resets live totals on
     // re-entry (another run in the same session accumulates). Brand-new
     // sessions enter via onSessionReady once the session is minted, carrying
     // the provisional bucket with them.
-    if (!session || !sessionId) return;
+    if (!session) return;
 
     const metrics = readExecutionMetrics(session.rootPath);
     const persisted = metrics?.tokenUsage;

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -527,17 +527,16 @@ export default function OperatorDashboard({
   }, [loading, refocusPrompt]);
 
   useEffect(() => {
-    if (!sessionId) {
-      usageStore.beginNewSession();
-      return;
-    }
+    if (sessionId === undefined) usageStore.beginNewSession();
+  }, [sessionId, usageStore]);
 
+  useEffect(() => {
     // Enter the resumed session in the usage store: seeds its totals from
     // persisted metrics when first tracked, and never resets live totals on
     // re-entry (another run in the same session accumulates). Brand-new
     // sessions enter via onSessionReady once the session is minted, carrying
     // the provisional bucket with them.
-    if (!session) return;
+    if (!session || !sessionId) return;
 
     const metrics = readExecutionMetrics(session.rootPath);
     const persisted = metrics?.tokenUsage;

--- a/src/tui/components/operator-dashboard/logic.test.ts
+++ b/src/tui/components/operator-dashboard/logic.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { OperatorSessionState } from "../../../core/operator";
 import type { AutocompleteOption } from "../shared";
 import {
-  accumulateTokenUsage,
   buildOperatorSystemPrompt,
   type DashboardStatus,
   filterOperatorAutocomplete,
@@ -747,66 +746,3 @@ describe("resolveInputFocused", () => {
 });
 
 // ---------------------------------------------------------------------------
-// accumulateTokenUsage
-// ---------------------------------------------------------------------------
-
-describe("accumulateTokenUsage", () => {
-  const base = {
-    inputTokens: 100,
-    outputTokens: 50,
-    totalTokens: 150,
-    cachedTokens: 10,
-    cacheWriteTokens: 5,
-  };
-
-  it("accumulates input and output tokens", () => {
-    const result = accumulateTokenUsage(base, 20, 10);
-    expect(result).toEqual({
-      inputTokens: 120,
-      outputTokens: 60,
-      totalTokens: 180,
-      cachedTokens: 10,
-      cacheWriteTokens: 5,
-    });
-  });
-
-  it("returns null when both step values are zero", () => {
-    expect(accumulateTokenUsage(base, 0, 0)).toBeNull();
-  });
-
-  it("returns null when both step values are negative", () => {
-    expect(accumulateTokenUsage(base, -1, -1)).toBeNull();
-  });
-
-  it("accumulates when only input tokens are provided", () => {
-    const result = accumulateTokenUsage(base, 10, 0);
-    expect(result).not.toBeNull();
-    expect(result?.inputTokens).toBe(110);
-    expect(result?.outputTokens).toBe(50);
-  });
-
-  it("accumulates when only output tokens are provided", () => {
-    const result = accumulateTokenUsage(base, 0, 5);
-    expect(result).not.toBeNull();
-    expect(result?.outputTokens).toBe(55);
-    expect(result?.inputTokens).toBe(100);
-  });
-
-  it("handles zero base", () => {
-    const zero = {
-      inputTokens: 0,
-      outputTokens: 0,
-      totalTokens: 0,
-      cachedTokens: 0,
-      cacheWriteTokens: 0,
-    };
-    const result = accumulateTokenUsage(zero, 10, 5);
-    expect(result).toEqual({
-      inputTokens: 10,
-      outputTokens: 5,
-      totalTokens: 15,
-      cachedTokens: 0,
-      cacheWriteTokens: 0,
-    });
-  });
-});

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -458,26 +458,3 @@ export function resolveInputFocused(
 // ---------------------------------------------------------------------------
 // Token usage accumulation
 // ---------------------------------------------------------------------------
-
-export interface TokenUsage {
-  inputTokens: number;
-  outputTokens: number;
-  totalTokens: number;
-  cachedTokens: number;
-  cacheWriteTokens: number;
-}
-
-export function accumulateTokenUsage(
-  current: TokenUsage,
-  stepInputTokens: number,
-  stepOutputTokens: number,
-): TokenUsage | null {
-  if (stepInputTokens <= 0 && stepOutputTokens <= 0) return null;
-  return {
-    inputTokens: current.inputTokens + stepInputTokens,
-    outputTokens: current.outputTokens + stepOutputTokens,
-    totalTokens: current.totalTokens + stepInputTokens + stepOutputTokens,
-    cachedTokens: current.cachedTokens,
-    cacheWriteTokens: current.cacheWriteTokens,
-  };
-}

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -23,6 +23,7 @@ import {
   getDefaultModelForConfig,
 } from "../../core/providers/utils";
 import { useConfig } from "./config";
+import { SessionUsageStore, useActiveSessionUsage } from "./session-usage";
 
 interface TokenUsage {
   inputTokens: number;
@@ -42,9 +43,10 @@ interface AgentContextValue {
   setModel: (model: ModelInfo, persist?: boolean) => void;
   isModelUserSelected: boolean;
   tokenUsage: TokenUsage;
-  addTokenUsage: (input: number, output: number) => void;
-  addCacheUsage: (cacheRead: number, cacheWrite: number) => void;
-  resetTokenUsage: () => void;
+  /** Session-scoped usage ownership (T2): per-session totals + context sample. */
+  usageStore: SessionUsageStore;
+  /** Marks that an agent step has executed (drives the footer status). */
+  markExecuted: () => void;
   hasExecuted: boolean;
   thinking: boolean;
   setThinking: (thinking: boolean) => void;
@@ -82,13 +84,20 @@ export function AgentProvider({ children }: AgentProviderProps) {
   });
   const [isModelUserSelected, setIsModelUserSelected] =
     useState<boolean>(false);
-  const [tokenUsage, setTokenUsage] = useState<TokenUsage>({
-    inputTokens: 0,
-    outputTokens: 0,
-    totalTokens: 0,
-    cachedTokens: 0,
-    cacheWriteTokens: 0,
-  });
+  const usageStore = useMemo(() => new SessionUsageStore(), []);
+  const activeUsage = useActiveSessionUsage(usageStore);
+  const tokenUsage: TokenUsage = useMemo(
+    () => ({
+      inputTokens: activeUsage.tokenUsage.inputTokens,
+      outputTokens: activeUsage.tokenUsage.outputTokens,
+      totalTokens:
+        activeUsage.tokenUsage.inputTokens +
+        activeUsage.tokenUsage.outputTokens,
+      cachedTokens: activeUsage.tokenUsage.cacheReadTokens,
+      cacheWriteTokens: activeUsage.tokenUsage.cacheWriteTokens,
+    }),
+    [activeUsage],
+  );
   const [hasExecuted, setHasExecuted] = useState<boolean>(false);
   const [thinking, setThinking] = useState<boolean>(false);
   const [reasoningEnabled, setReasoningEnabledInternal] = useState<boolean>(
@@ -219,34 +228,7 @@ export function AgentProvider({ children }: AgentProviderProps) {
     }
   }, [appConfig.data, isModelUserSelected]);
 
-  const addTokenUsage = useCallback((input: number, output: number) => {
-    setHasExecuted(true);
-    setTokenUsage((prev) => ({
-      ...prev,
-      inputTokens: prev.inputTokens + input,
-      outputTokens: prev.outputTokens + output,
-      totalTokens: prev.totalTokens + input + output,
-    }));
-  }, []);
-
-  const addCacheUsage = useCallback((cacheRead: number, cacheWrite: number) => {
-    setTokenUsage((prev) => ({
-      ...prev,
-      cachedTokens: prev.cachedTokens + cacheRead,
-      cacheWriteTokens: prev.cacheWriteTokens + cacheWrite,
-    }));
-  }, []);
-
-  const resetTokenUsage = useCallback(() => {
-    setHasExecuted(false);
-    setTokenUsage({
-      inputTokens: 0,
-      outputTokens: 0,
-      totalTokens: 0,
-      cachedTokens: 0,
-      cacheWriteTokens: 0,
-    });
-  }, []);
+  const markExecuted = useCallback(() => setHasExecuted(true), []);
 
   const contextValue = useMemo(
     () => ({
@@ -254,9 +236,8 @@ export function AgentProvider({ children }: AgentProviderProps) {
       setModel,
       isModelUserSelected,
       tokenUsage,
-      addTokenUsage,
-      addCacheUsage,
-      resetTokenUsage,
+      usageStore,
+      markExecuted,
       hasExecuted,
       thinking,
       setThinking,
@@ -281,9 +262,8 @@ export function AgentProvider({ children }: AgentProviderProps) {
       openAIReasoningEffort,
       isExecuting,
       sessionCwd,
-      addTokenUsage,
-      addCacheUsage,
-      resetTokenUsage,
+      usageStore,
+      markExecuted,
       setOpenAIReasoningEffort,
     ],
   );

--- a/src/tui/context/session-usage.test.ts
+++ b/src/tui/context/session-usage.test.ts
@@ -177,6 +177,23 @@ describe("SessionUsageStore", () => {
 // ---------------------------------------------------------------------------
 
 describe("SessionUsageStore provisional + active view", () => {
+  it("detaches a new session from the prior active session", () => {
+    const store = new SessionUsageStore();
+    store.enterSession("ses_old");
+    store.addSessionTokens("ses_old", { inputTokens: 100 });
+
+    store.beginNewSession();
+    expect(store.activeSessionId).toBeNull();
+    expect(store.getActiveSnapshot().tokenUsage.inputTokens).toBe(0);
+
+    store.addSessionTokens(store.activeSessionId, { inputTokens: 5 });
+    expect(store.getSnapshot("ses_old").tokenUsage.inputTokens).toBe(100);
+    expect(store.getActiveSnapshot().tokenUsage.inputTokens).toBe(5);
+
+    store.enterSession("ses_new");
+    expect(store.getSnapshot("ses_new").tokenUsage.inputTokens).toBe(5);
+  });
+
   it("tokens recorded before a session exists seed the first entered session", () => {
     const store = new SessionUsageStore();
     // Brand-new session: first steps fire before onSessionReady mints the id.
@@ -234,8 +251,12 @@ describe("SessionUsageStore provisional + active view", () => {
     store.addSessionTokens("ses_a", { inputTokens: 1 });
     expect(listener).toHaveBeenCalledTimes(2); // switch fired once
 
-    // Provisional updates fire the active view (it displays the bucket).
-    store.addSessionTokens(null, { inputTokens: 1 });
+    store.beginNewSession();
     expect(listener).toHaveBeenCalledTimes(3);
+
+    // Provisional updates fire the active view while it displays the bucket.
+    store.addSessionTokens(null, { inputTokens: 1 });
+    expect(listener).toHaveBeenCalledTimes(4);
+    expect(store.getActiveSnapshot().tokenUsage.inputTokens).toBe(1);
   });
 });

--- a/src/tui/context/session-usage.test.ts
+++ b/src/tui/context/session-usage.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, vi } from "vitest";
+import { SessionUsageStore } from "./session-usage";
+
+// ---------------------------------------------------------------------------
+// SessionUsageStore
+// ---------------------------------------------------------------------------
+
+describe("SessionUsageStore", () => {
+  it("new session: starts empty, accumulates tokens and context", () => {
+    const store = new SessionUsageStore();
+    store.enterSession("ses_a");
+
+    expect(store.getSnapshot("ses_a").tokenUsage.inputTokens).toBe(0);
+    expect(store.getSnapshot("ses_a").contextUsage).toBeNull();
+
+    store.addSessionTokens("ses_a", {
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 80,
+    });
+    store.setRootContext("ses_a", {
+      modelId: "claude-sonnet-4-5",
+      usedTokens: 10_000,
+      contextLimit: 200_000,
+    });
+
+    const snap = store.getSnapshot("ses_a");
+    expect(snap.tokenUsage.inputTokens).toBe(100);
+    expect(snap.contextUsage).toMatchObject({ usedTokens: 10_000 });
+  });
+
+  it("switching sessions resets the view, not the other session's totals", () => {
+    const store = new SessionUsageStore();
+    store.enterSession("ses_a");
+    store.addSessionTokens("ses_a", { inputTokens: 100, outputTokens: 10 });
+
+    store.enterSession("ses_b");
+    expect(store.activeSessionId).toBe("ses_b");
+    expect(store.getSnapshot("ses_b").tokenUsage.inputTokens).toBe(0);
+
+    // Session A keeps its totals — switching did not reset it.
+    expect(store.getSnapshot("ses_a").tokenUsage.inputTokens).toBe(100);
+
+    // Late events still account into their originating session.
+    store.addSessionTokens("ses_a", { inputTokens: 50 });
+    expect(store.getSnapshot("ses_a").tokenUsage.inputTokens).toBe(150);
+    expect(store.getSnapshot("ses_b").tokenUsage.inputTokens).toBe(0);
+  });
+
+  it("multiple runs in the same session accumulate — never reset", () => {
+    const store = new SessionUsageStore();
+    store.enterSession("ses_a");
+
+    // Run 1
+    store.addSessionTokens("ses_a", { inputTokens: 100, outputTokens: 10 });
+    // Run 2 re-enters the same session (remount, new runAgent call)
+    store.enterSession("ses_a");
+    store.addSessionTokens("ses_a", { inputTokens: 40, outputTokens: 5 });
+
+    const usage = store.getSnapshot("ses_a").tokenUsage;
+    expect(usage.inputTokens).toBe(140);
+    expect(usage.outputTokens).toBe(15);
+  });
+
+  it("resume: enterSession seeds a tracked session exactly once", () => {
+    const store = new SessionUsageStore();
+    const seed = {
+      tokenUsage: {
+        inputTokens: 1000,
+        outputTokens: 200,
+        cacheReadTokens: 900,
+        cacheWriteTokens: 50,
+      },
+      contextUsage: {
+        modelId: "claude-sonnet-4-5",
+        usedTokens: 42_000,
+        contextLimit: 200_000,
+      },
+    };
+    store.enterSession("ses_a", seed);
+    expect(store.getSnapshot("ses_a").tokenUsage.inputTokens).toBe(1000);
+    expect(store.getSnapshot("ses_a").contextUsage?.usedTokens).toBe(42_000);
+
+    // A later re-entry with a different seed must NOT clobber live totals.
+    store.addSessionTokens("ses_a", { inputTokens: 10 });
+    store.enterSession("ses_a", {
+      tokenUsage: {
+        inputTokens: 99_999,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      },
+      contextUsage: null,
+    });
+    expect(store.getSnapshot("ses_a").tokenUsage.inputTokens).toBe(1010);
+  });
+
+  it("untracked session reads are empty and writes are dropped", () => {
+    const store = new SessionUsageStore();
+    expect(store.getSnapshot("nope").tokenUsage.inputTokens).toBe(0);
+    expect(() =>
+      store.addSessionTokens("nope", { inputTokens: 5 }),
+    ).not.toThrow();
+    expect(store.getSnapshot("nope").tokenUsage.inputTokens).toBe(0);
+  });
+
+  it("subscribers fire on changes to their session only", () => {
+    const store = new SessionUsageStore();
+    store.enterSession("ses_a");
+    store.enterSession("ses_b");
+
+    const aListener = vi.fn();
+    const bListener = vi.fn();
+    store.subscribe("ses_a", aListener);
+    store.subscribe("ses_b", bListener);
+
+    store.addSessionTokens("ses_a", { inputTokens: 1 });
+    expect(aListener).toHaveBeenCalledTimes(1);
+    expect(bListener).not.toHaveBeenCalled();
+
+    store.setRootContext("ses_b", {
+      modelId: "m",
+      usedTokens: 1,
+      contextLimit: 10,
+    });
+    expect(aListener).toHaveBeenCalledTimes(1);
+    expect(bListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("zero-value steps do not fire subscribers (identical state)", () => {
+    const store = new SessionUsageStore();
+    store.enterSession("ses_a");
+    const listener = vi.fn();
+    store.subscribe("ses_a", listener);
+
+    store.addSessionTokens("ses_a", {});
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("snapshot references are stable across unrelated updates", () => {
+    const store = new SessionUsageStore();
+    store.enterSession("ses_a");
+    store.enterSession("ses_b");
+
+    const before = store.getSnapshot("ses_a");
+    store.addSessionTokens("ses_b", { inputTokens: 1 });
+    expect(store.getSnapshot("ses_a")).toBe(before);
+  });
+
+  it("forgetSession drops state and deactivates it", () => {
+    const store = new SessionUsageStore();
+    store.enterSession("ses_a");
+    store.addSessionTokens("ses_a", { inputTokens: 5 });
+
+    store.forgetSession("ses_a");
+    expect(store.activeSessionId).toBeNull();
+    expect(store.getSnapshot("ses_a").tokenUsage.inputTokens).toBe(0);
+
+    // Re-entering after forgetting starts fresh.
+    store.enterSession("ses_a");
+    expect(store.getSnapshot("ses_a").tokenUsage.inputTokens).toBe(0);
+  });
+
+  it("entering the already-active session does not re-emit", () => {
+    const store = new SessionUsageStore();
+    store.enterSession("ses_a");
+    const listener = vi.fn();
+    store.subscribe("ses_a", listener);
+
+    store.enterSession("ses_a");
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provisional bucket + active view
+// ---------------------------------------------------------------------------
+
+describe("SessionUsageStore provisional + active view", () => {
+  it("tokens recorded before a session exists seed the first entered session", () => {
+    const store = new SessionUsageStore();
+    // Brand-new session: first steps fire before onSessionReady mints the id.
+    store.addSessionTokens(null, { inputTokens: 100, outputTokens: 10 });
+    store.addSessionTokens(null, { cacheReadTokens: 90 });
+
+    store.enterSession("ses_new");
+    const usage = store.getSnapshot("ses_new").tokenUsage;
+    expect(usage.inputTokens).toBe(100);
+    expect(usage.outputTokens).toBe(10);
+    expect(usage.cacheReadTokens).toBe(90);
+
+    // Provisional bucket is drained — a second new session starts empty.
+    store.enterSession("ses_next");
+    expect(store.getSnapshot("ses_next").tokenUsage.inputTokens).toBe(0);
+  });
+
+  it("an explicit seed wins over the (empty) provisional bucket on resume", () => {
+    const store = new SessionUsageStore();
+    store.enterSession("ses_resumed", {
+      tokenUsage: {
+        inputTokens: 1000,
+        outputTokens: 200,
+        cacheReadTokens: 900,
+        cacheWriteTokens: 50,
+      },
+    });
+    expect(store.getSnapshot("ses_resumed").tokenUsage.inputTokens).toBe(1000);
+  });
+
+  it("active snapshot follows session switches", () => {
+    const store = new SessionUsageStore();
+    store.enterSession("ses_a");
+    store.addSessionTokens("ses_a", { inputTokens: 5 });
+    expect(store.getActiveSnapshot().tokenUsage.inputTokens).toBe(5);
+
+    store.enterSession("ses_b");
+    expect(store.getActiveSnapshot().tokenUsage.inputTokens).toBe(0);
+
+    store.enterSession("ses_a");
+    expect(store.getActiveSnapshot().tokenUsage.inputTokens).toBe(5);
+  });
+
+  it("active subscribers fire on active-session changes and switches", () => {
+    const store = new SessionUsageStore();
+    store.enterSession("ses_a");
+    const listener = vi.fn();
+    store.subscribeActive(listener);
+
+    store.addSessionTokens("ses_a", { inputTokens: 1 });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // Non-active session changes do not fire the active view.
+    store.enterSession("ses_b");
+    store.addSessionTokens("ses_a", { inputTokens: 1 });
+    expect(listener).toHaveBeenCalledTimes(2); // switch fired once
+
+    // Provisional updates fire the active view (it displays the bucket).
+    store.addSessionTokens(null, { inputTokens: 1 });
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/tui/context/session-usage.ts
+++ b/src/tui/context/session-usage.ts
@@ -35,11 +35,20 @@ export class SessionUsageStore {
    * steps can fire before `onSessionReady` mints the session). Merged into
    * the first session entered, mirroring the old app-global accumulator.
    */
-  private provisionalUsage: SessionTokenUsage = EMPTY_SESSION_TOKEN_USAGE;
+  private provisionalState: SessionUsageState = EMPTY_STATE;
 
   /** The session usage is currently displayed for. */
   get activeSessionId(): string | null {
     return this.activeId;
+  }
+
+  /** Start a brand-new session before it has an id. */
+  beginNewSession(): void {
+    const changed =
+      this.activeId !== null || this.provisionalState !== EMPTY_STATE;
+    this.activeId = null;
+    this.provisionalState = EMPTY_STATE;
+    if (changed) this.emitActive();
   }
 
   /**
@@ -56,10 +65,10 @@ export class SessionUsageStore {
   ): void {
     if (!this.sessions.has(sessionId)) {
       this.sessions.set(sessionId, {
-        tokenUsage: seed?.tokenUsage ?? this.provisionalUsage,
+        tokenUsage: seed?.tokenUsage ?? this.provisionalState.tokenUsage,
         contextUsage: seed?.contextUsage ?? null,
       });
-      this.provisionalUsage = EMPTY_SESSION_TOKEN_USAGE;
+      this.provisionalState = EMPTY_STATE;
     }
     if (this.activeId !== sessionId) {
       this.activeId = sessionId;
@@ -109,10 +118,13 @@ export class SessionUsageStore {
     },
   ): void {
     if (sessionId === null) {
-      const next = accumulateSessionTokens(this.provisionalUsage, step);
-      if (next !== this.provisionalUsage) {
-        this.provisionalUsage = next;
-        this.emitActive();
+      const next = accumulateSessionTokens(
+        this.provisionalState.tokenUsage,
+        step,
+      );
+      if (next !== this.provisionalState.tokenUsage) {
+        this.provisionalState = { tokenUsage: next, contextUsage: null };
+        if (this.activeId === null) this.emitActive();
       }
       return;
     }
@@ -148,9 +160,11 @@ export class SessionUsageStore {
     this.emit(sessionId);
   }
 
-  /** Stable snapshot of whatever session is active (empty when none). */
+  /** Stable snapshot of the active session or the not-yet-minted one. */
   getActiveSnapshot(): SessionUsageState {
-    return this.getSnapshot(this.activeId);
+    return this.activeId === null
+      ? this.provisionalState
+      : this.getSnapshot(this.activeId);
   }
 
   /** Subscribe to changes affecting the active-session view. */

--- a/src/tui/context/session-usage.ts
+++ b/src/tui/context/session-usage.ts
@@ -1,0 +1,184 @@
+import { useCallback, useSyncExternalStore } from "react";
+import {
+  accumulateSessionTokens,
+  type ContextUsage,
+  EMPTY_SESSION_TOKEN_USAGE,
+  type SessionTokenUsage,
+} from "../../core/session/usage";
+
+// ---------------------------------------------------------------------------
+// Session usage store — owns token usage per session instead of app-global
+// AgentProvider state. Each session owns its cumulative totals and its latest
+// root context sample; the TUI subscribes per session for live updates.
+// Entering a different session switches the active view; starting another
+// run in the same session never resets anything.
+// ---------------------------------------------------------------------------
+
+export interface SessionUsageState {
+  tokenUsage: SessionTokenUsage;
+  contextUsage: ContextUsage | null;
+}
+
+const EMPTY_STATE: SessionUsageState = {
+  tokenUsage: EMPTY_SESSION_TOKEN_USAGE,
+  contextUsage: null,
+};
+
+export class SessionUsageStore {
+  private readonly sessions = new Map<string, SessionUsageState>();
+  private readonly listeners = new Map<string, Set<() => void>>();
+  private readonly activeListeners = new Set<() => void>();
+  private activeId: string | null = null;
+
+  /**
+   * Tokens recorded before any session exists (a brand-new session's first
+   * steps can fire before `onSessionReady` mints the session). Merged into
+   * the first session entered, mirroring the old app-global accumulator.
+   */
+  private provisionalUsage: SessionTokenUsage = EMPTY_SESSION_TOKEN_USAGE;
+
+  /** The session usage is currently displayed for. */
+  get activeSessionId(): string | null {
+    return this.activeId;
+  }
+
+  /**
+   * Enter a session: makes it active and seeds it when not yet tracked.
+   * Re-entering a tracked session (another run, a remount) keeps its
+   * totals — only switching to a *different* session changes the view.
+   */
+  enterSession(
+    sessionId: string,
+    seed?: {
+      tokenUsage?: SessionTokenUsage;
+      contextUsage?: ContextUsage | null;
+    },
+  ): void {
+    if (!this.sessions.has(sessionId)) {
+      this.sessions.set(sessionId, {
+        tokenUsage: seed?.tokenUsage ?? this.provisionalUsage,
+        contextUsage: seed?.contextUsage ?? null,
+      });
+      this.provisionalUsage = EMPTY_SESSION_TOKEN_USAGE;
+    }
+    if (this.activeId !== sessionId) {
+      this.activeId = sessionId;
+      // emit() reaches this session's listeners and — because it is now the
+      // active one — the active-view listeners too.
+      this.emit(sessionId);
+    }
+  }
+
+  /** Drop a session's state (session deleted / left). */
+  forgetSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
+    this.listeners.delete(sessionId);
+    if (this.activeId === sessionId) this.activeId = null;
+  }
+
+  /** Stable snapshot for `useSyncExternalStore`; empty until tracked. */
+  getSnapshot(sessionId: string | null): SessionUsageState {
+    if (sessionId === null) return EMPTY_STATE;
+    return this.sessions.get(sessionId) ?? EMPTY_STATE;
+  }
+
+  subscribe(sessionId: string, listener: () => void): () => void {
+    let set = this.listeners.get(sessionId);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(sessionId, set);
+    }
+    set.add(listener);
+    return () => {
+      set.delete(listener);
+    };
+  }
+
+  /**
+   * Accumulate one step's tokens into the owning session. A null session id
+   * (session not yet created) accumulates into the provisional bucket that
+   * the first entered session inherits.
+   */
+  addSessionTokens(
+    sessionId: string | null,
+    step: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheReadTokens?: number;
+      cacheWriteTokens?: number;
+    },
+  ): void {
+    if (sessionId === null) {
+      const next = accumulateSessionTokens(this.provisionalUsage, step);
+      if (next !== this.provisionalUsage) {
+        this.provisionalUsage = next;
+        this.emitActive();
+      }
+      return;
+    }
+    this.update(sessionId, (state) => ({
+      ...state,
+      tokenUsage: accumulateSessionTokens(state.tokenUsage, step),
+    }));
+  }
+
+  /** Replace the latest root context sample. Subagent calls never touch it. */
+  setRootContext(sessionId: string, sample: ContextUsage): void {
+    this.update(sessionId, (state) => ({
+      ...state,
+      contextUsage: sample,
+    }));
+  }
+
+  private update(
+    sessionId: string,
+    updater: (state: SessionUsageState) => SessionUsageState,
+  ): void {
+    const current = this.sessions.get(sessionId);
+    if (!current) return; // unknown session — nothing to account into
+    const next = updater(current);
+    if (
+      next === current ||
+      (next.tokenUsage === current.tokenUsage &&
+        next.contextUsage === current.contextUsage)
+    ) {
+      return;
+    }
+    this.sessions.set(sessionId, next);
+    this.emit(sessionId);
+  }
+
+  /** Stable snapshot of whatever session is active (empty when none). */
+  getActiveSnapshot(): SessionUsageState {
+    return this.getSnapshot(this.activeId);
+  }
+
+  /** Subscribe to changes affecting the active-session view. */
+  subscribeActive(listener: () => void): () => void {
+    this.activeListeners.add(listener);
+    return () => {
+      this.activeListeners.delete(listener);
+    };
+  }
+
+  private emit(sessionId: string): void {
+    for (const listener of this.listeners.get(sessionId) ?? []) listener();
+    if (sessionId === this.activeId) this.emitActive();
+  }
+
+  private emitActive(): void {
+    for (const listener of this.activeListeners) listener();
+  }
+}
+
+/** Subscribe to the active session's usage view (switches with the store). */
+export function useActiveSessionUsage(
+  store: SessionUsageStore,
+): SessionUsageState {
+  const subscribe = useCallback(
+    (listener: () => void) => store.subscribeActive(listener),
+    [store],
+  );
+  const getSnapshot = useCallback(() => store.getActiveSnapshot(), [store]);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Usage + observability · PR 2 of 12**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#996](https://github.com/pensarai/apex/pull/996) | Session usage models |
| **2** | **[#997](https://github.com/pensarai/apex/pull/997)** | **Session-scoped ownership** · `Current` |
| 3 | [#998](https://github.com/pensarai/apex/pull/998) | Complete usage persistence |
| 4 | [#999](https://github.com/pensarai/apex/pull/999) | Consolidated usage ingestion |
| 5 | [#1000](https://github.com/pensarai/apex/pull/1000) | Token and context footer |
| 6 | [#1002](https://github.com/pensarai/apex/pull/1002) | Cache token breakdown |
| 7 | [#1004](https://github.com/pensarai/apex/pull/1004) | Agent trace contract |
| 8 | [#1005](https://github.com/pensarai/apex/pull/1005) | Optional OTLP runtime |
| 9 | [#1006](https://github.com/pensarai/apex/pull/1006) | Root agent run spans |
| 10 | [#1007](https://github.com/pensarai/apex/pull/1007) | Centralized telemetry settings |
| 11 | [#1008](https://github.com/pensarai/apex/pull/1008) | Telemetry correlation |
| 12 | [#1009](https://github.com/pensarai/apex/pull/1009) | OTLP shutdown hardening |
## Summary

- move token-usage ownership out of app-global `AgentProvider` state into a per-session `SessionUsageStore` (`src/tui/context/session-usage.ts`)
- each session owns its cumulative `SessionTokenUsage`, its latest root `ContextUsage`, and a subscription API for live TUI updates (`useSyncExternalStore`-compatible snapshots)
- entering a different session switches the active view; **another run in the same session never resets anything** — re-entry keeps live totals, seeding happens exactly once
- a provisional bucket preserves the brand-new-session flow (first steps can fire before `onSessionReady` mints the session id)

## Motivation

T2 of the Narrow Token Stack. The old model was one app-global `useState` in `AgentProvider` plus a `tokenUsageRef` mirror in the dashboard plus a manual reset-and-rehydrate effect — which carried the exact bug its own comment described ("a reset here would wipe that initial usage"). Ownership per session makes reset semantics structural: switching sessions changes the view, runs within a session accumulate, and late events can target their owning session (T4 relies on this).

## What changed

**New: `src/tui/context/session-usage.ts`**

- `SessionUsageStore` — `Map<sessionId, {tokenUsage, contextUsage}>` with per-session listeners plus active-view listeners
  - `enterSession(id, seed?)` — makes the session active; seeds it (from the seed, or the provisional bucket) only when not yet tracked; re-entry is a no-op that keeps totals
  - `addSessionTokens(sessionId | null, step)` — accumulates via T1's pure function; a null id (session not yet minted) accumulates into the provisional bucket the first entered session inherits; zero steps are no-ops that don't emit
  - `setRootContext(sessionId, sample)` — replacement semantics for the root context sample
  - `getSnapshot`/`subscribe` (per-session) and `getActiveSnapshot`/`subscribeActive` (view-level)
  - `forgetSession` for cleanup
- `useActiveSessionUsage(store)` hook — subscribes to the active view

**`AgentProvider`** — the `tokenUsage` useState and the `addTokenUsage`/`addCacheUsage`/`resetTokenUsage` trio are replaced by the store (plus `markExecuted` for the has-executed flag). The context keeps a derived legacy `tokenUsage` shape (`totalTokens` = in+out, `cachedTokens` = cache reads) so the footer renders unchanged until T5.

**Dashboard** — the resume effect becomes one `enterSession(session.id, seedFromMetrics)` call (no manual reset, no mirror reset, no hydration re-write); `recordTokenUsage` routes through the store and reads the owning session's snapshot for metrics writes; `onCacheMetrics` and `onSessionReady` route through the store. The `tokenUsageRef` mirror is deleted. The now-dead `accumulateTokenUsage`/`TokenUsage` in `logic.ts` (and its tests) are removed — the T1 pure functions own that.

## Behavior notes

- the dashboard's old "reset then rehydrate then rewrite" cycle is replaced by seed-once semantics: a resumed session hydrates from disk when first tracked, and subsequent effect re-fires keep live totals — this is the spec's "reset only when entering a different session"
- brand-new sessions: first-step tokens land in the provisional bucket and merge at `onSessionReady`, preserving today's global-accumulator behavior
- one intentional semantic change: `resetTokenUsage` no longer exists — it was only ever used by the reset-and-rehydrate dance this PR replaces

## Test coverage

14 tests in `session-usage.test.ts`: new-session accumulation; switching sessions (view resets, other session's totals survive, late events hit their owning session); multiple runs in one session accumulate; resume seeds exactly once (a later re-entry with a different seed doesn't clobber live totals); untracked-session reads/writes are safe no-ops; per-session subscriber isolation; zero-step no-emit; snapshot stability; forgetSession; same-session re-entry doesn't re-emit; provisional bucket seeds the first entered session and drains; explicit seed wins on resume; active snapshot follows switches; active subscribers fire on active changes/switches/provisional updates.

## Validation

- `bun run test` (1,728 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the six touched files

## Notes

- T3 persists the full per-session shape (cache + context fields) through execution-metrics; T4 consolidates ingestion (root vs subagent distinction, late-event routing by session id — the store API already accepts explicit ids for exactly that); T5 rewires the footer onto the store.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how token totals are accumulated and persisted across new vs resumed sessions and multiple runs; incorrect session routing could misreport usage or wipe early-step tokens without the old reset bug.
> 
> **Overview**
> Token and cache usage moves from app-global `AgentProvider` state into a new **`SessionUsageStore`**, so each operator session keeps its own cumulative totals and the UI follows the active session instead of resetting on resume.
> 
> **`AgentProvider`** drops `addTokenUsage` / `addCacheUsage` / `resetTokenUsage` in favor of `usageStore` and `markExecuted`, while still exposing a derived `tokenUsage` shape for existing footer consumers. **`SessionUsageStore`** tracks per-session token + context snapshots, supports `enterSession` (seed once from persisted metrics), `beginNewSession` + a provisional bucket for tokens recorded before `onSessionReady`, and active-view subscriptions via `useActiveSessionUsage`.
> 
> The **operator dashboard** wires `recordTokenUsage`, cache metrics, resume hydration, and `onSessionReady` through the store and drops the `tokenUsageRef` mirror and reset-then-rehydrate effect. Local **`accumulateTokenUsage`** in `logic.ts` and its tests are removed in favor of core `accumulateSessionTokens`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e223fd7858fa0a85e8b96d81f37142c3b2ff519. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


