### PR TITLE
feat(usage): persist complete session usage

### DIFF
--- a/src/core/session/execution-metrics.test.ts
+++ b/src/core/session/execution-metrics.test.ts
@@ -1,0 +1,266 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  readExecutionMetrics,
+  writeExecutionMetrics,
+} from "./execution-metrics";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "exec-metrics-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function rootPath(): string {
+  return tmpDir;
+}
+
+function metricsPath(): string {
+  return join(tmpDir, "execution-metrics.json");
+}
+
+function writeRaw(value: unknown): void {
+  writeFileSync(metricsPath(), JSON.stringify(value, null, 2), "utf-8");
+}
+
+function readRaw(): Record<string, unknown> {
+  return JSON.parse(readFileSync(metricsPath(), "utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// writeExecutionMetrics / readExecutionMetrics — full shape
+// ---------------------------------------------------------------------------
+
+describe("execution-metrics round-trip", () => {
+  it("persists and hydrates the complete usage shape", () => {
+    writeExecutionMetrics({
+      sessionRootPath: rootPath(),
+      tokenUsage: {
+        inputTokens: 123_000,
+        outputTokens: 18_000,
+        cacheReadTokens: 90_000,
+        cacheWriteTokens: 4_000,
+        totalTokens: 141_000,
+      },
+      contextUsage: {
+        usedTokens: 84_000,
+        contextLimit: 200_000,
+        modelId: "claude-sonnet-4-5",
+      },
+    });
+
+    const metrics = readExecutionMetrics(rootPath());
+    expect(metrics?.tokenUsage).toEqual({
+      inputTokens: 123_000,
+      outputTokens: 18_000,
+      cacheReadTokens: 90_000,
+      cacheWriteTokens: 4_000,
+      totalTokens: 141_000,
+    });
+    expect(metrics?.contextUsage).toEqual({
+      usedTokens: 84_000,
+      contextLimit: 200_000,
+      modelId: "claude-sonnet-4-5",
+    });
+  });
+
+  it("writes the documented file shape (totalTokens present, cache inside input)", () => {
+    writeExecutionMetrics({
+      sessionRootPath: rootPath(),
+      tokenUsage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 90,
+        cacheWriteTokens: 5,
+      },
+      contextUsage: {
+        usedTokens: 10,
+        contextLimit: 200,
+        modelId: "m",
+      },
+    });
+
+    const raw = readRaw();
+    expect(raw.tokenUsage).toEqual({
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 90,
+      cacheWriteTokens: 5,
+      totalTokens: 120,
+    });
+    expect(raw.contextUsage).toEqual({
+      usedTokens: 10,
+      contextLimit: 200,
+      modelId: "m",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy compatibility
+// ---------------------------------------------------------------------------
+
+describe("execution-metrics legacy compatibility", () => {
+  it("hydrates legacy files lacking cache and context fields", () => {
+    writeRaw({
+      tokenUsage: { inputTokens: 7, outputTokens: 3, totalTokens: 10 },
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const metrics = readExecutionMetrics(rootPath());
+    expect(metrics?.tokenUsage).toEqual({
+      inputTokens: 7,
+      outputTokens: 3,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      totalTokens: 10,
+    });
+    expect(metrics?.contextUsage).toBeUndefined();
+    expect(metrics?.updatedAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("legacy callers writing without cache fields keep existing cache totals", () => {
+    writeExecutionMetrics({
+      sessionRootPath: rootPath(),
+      tokenUsage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 90,
+        cacheWriteTokens: 5,
+      },
+    });
+
+    // A caller that only knows input/output (e.g. the workflow path until T4).
+    writeExecutionMetrics({
+      sessionRootPath: rootPath(),
+      tokenUsage: { inputTokens: 150, outputTokens: 30 },
+    });
+
+    const metrics = readExecutionMetrics(rootPath());
+    expect(metrics?.tokenUsage.inputTokens).toBe(150);
+    expect(metrics?.tokenUsage.outputTokens).toBe(30);
+    expect(metrics?.tokenUsage.cacheReadTokens).toBe(0); // legacy write resets cache it doesn't know about
+  });
+
+  it("drops malformed context samples instead of failing the read", () => {
+    writeRaw({
+      tokenUsage: { inputTokens: 1 },
+      contextUsage: { usedTokens: 5, contextLimit: 10 }, // no modelId
+    });
+    expect(readExecutionMetrics(rootPath())?.contextUsage).toBeUndefined();
+  });
+
+  it("returns null for a missing or corrupt file", () => {
+    expect(readExecutionMetrics(rootPath())).toBeNull();
+    writeFileSync(metricsPath(), "{ not json", "utf-8");
+    expect(readExecutionMetrics(rootPath())).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// One writer — merge semantics
+// ---------------------------------------------------------------------------
+
+describe("execution-metrics single-writer merge", () => {
+  it("retains the context sample when a write omits it", () => {
+    writeExecutionMetrics({
+      sessionRootPath: rootPath(),
+      tokenUsage: { inputTokens: 1 },
+      contextUsage: { usedTokens: 42, contextLimit: 200, modelId: "m" },
+    });
+    writeExecutionMetrics({
+      sessionRootPath: rootPath(),
+      tokenUsage: { inputTokens: 2 },
+    });
+
+    expect(readExecutionMetrics(rootPath())?.contextUsage).toEqual({
+      usedTokens: 42,
+      contextLimit: 200,
+      modelId: "m",
+    });
+  });
+
+  it("replaces the context sample when a write provides one", () => {
+    writeExecutionMetrics({
+      sessionRootPath: rootPath(),
+      tokenUsage: { inputTokens: 1 },
+      contextUsage: { usedTokens: 42, contextLimit: 200, modelId: "old" },
+    });
+    writeExecutionMetrics({
+      sessionRootPath: rootPath(),
+      tokenUsage: { inputTokens: 2 },
+      contextUsage: { usedTokens: 84, contextLimit: 272_000, modelId: "new" },
+    });
+
+    expect(readExecutionMetrics(rootPath())?.contextUsage).toEqual({
+      usedTokens: 84,
+      contextLimit: 272_000,
+      modelId: "new",
+    });
+  });
+
+  it("retains runtime and elapsedSeconds across usage-only writes", () => {
+    writeExecutionMetrics({
+      sessionRootPath: rootPath(),
+      tokenUsage: { inputTokens: 1 },
+      runtime: "0h1m30s",
+      elapsedSeconds: 90,
+    });
+    writeExecutionMetrics({
+      sessionRootPath: rootPath(),
+      tokenUsage: { inputTokens: 2 },
+    });
+
+    const metrics = readExecutionMetrics(rootPath());
+    expect(metrics?.runtime).toBe("0h1m30s");
+    expect(metrics?.elapsedSeconds).toBe(90);
+  });
+
+  it("derives totalTokens from input + output (cache not double-counted)", () => {
+    writeExecutionMetrics({
+      sessionRootPath: rootPath(),
+      tokenUsage: {
+        inputTokens: 1000,
+        outputTokens: 100,
+        cacheReadTokens: 900,
+        cacheWriteTokens: 50,
+      },
+    });
+    expect(readExecutionMetrics(rootPath())?.tokenUsage.totalTokens).toBe(1100);
+  });
+
+  it("sanitize negative and non-numeric fields", () => {
+    writeExecutionMetrics({
+      sessionRootPath: rootPath(),
+      tokenUsage: {
+        inputTokens: -5,
+        outputTokens: Number.NaN,
+        cacheReadTokens: 2.9,
+      },
+      contextUsage: { usedTokens: -1, contextLimit: -2, modelId: "m" },
+    });
+    const metrics = readExecutionMetrics(rootPath());
+    expect(metrics?.tokenUsage).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 2,
+      cacheWriteTokens: 0,
+      totalTokens: 0,
+    });
+    expect(metrics?.contextUsage).toEqual({
+      usedTokens: 0,
+      contextLimit: 0,
+      modelId: "m",
+    });
+  });
+});

--- a/src/core/session/execution-metrics.ts
+++ b/src/core/session/execution-metrics.ts
@@ -6,11 +6,24 @@ const EXECUTION_METRICS_FILENAME = "execution-metrics.json";
 interface TokenUsageTotals {
   inputTokens: number;
   outputTokens: number;
+  /** Cache-read tokens. Already included in inputTokens. */
+  cacheReadTokens: number;
+  /** Cache-write tokens (Anthropic prompt caching). */
+  cacheWriteTokens: number;
   totalTokens: number;
+}
+
+interface ContextUsageMetrics {
+  usedTokens: number;
+  contextLimit: number;
+  /** The model the sampled root call ran on. */
+  modelId: string;
 }
 
 export interface ExecutionMetrics {
   tokenUsage: TokenUsageTotals;
+  /** Latest root-call context sample; absent in legacy files. */
+  contextUsage?: ContextUsageMetrics;
   runtime?: string;
   /** Accumulated wall-clock seconds the pentest has been actively running. */
   elapsedSeconds?: number;
@@ -19,7 +32,10 @@ export interface ExecutionMetrics {
 
 interface WriteExecutionMetricsInput {
   sessionRootPath: string;
+  /** Authoritative cumulative snapshot from the owning session. */
   tokenUsage?: Partial<TokenUsageTotals>;
+  /** Replaces the context sample when provided; retained otherwise. */
+  contextUsage?: ContextUsageMetrics;
   runtime?: string;
   elapsedSeconds?: number;
 }
@@ -40,7 +56,24 @@ function normalizeTokenUsage(
   return {
     inputTokens,
     outputTokens,
+    // Legacy files lack cache fields — they hydrate as zero.
+    cacheReadTokens: toNonNegativeInteger(value?.cacheReadTokens),
+    cacheWriteTokens: toNonNegativeInteger(value?.cacheWriteTokens),
+    // Cache reads are already inside inputTokens; total stays in + out.
     totalTokens: explicitTotal > 0 ? explicitTotal : derivedTotal,
+  };
+}
+
+function normalizeContextUsage(
+  value: unknown,
+): ContextUsageMetrics | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const v = value as Partial<ContextUsageMetrics>;
+  if (typeof v.modelId !== "string" || v.modelId.length === 0) return undefined;
+  return {
+    modelId: v.modelId,
+    usedTokens: toNonNegativeInteger(v.usedTokens),
+    contextLimit: toNonNegativeInteger(v.contextLimit),
   };
 }
 
@@ -61,6 +94,7 @@ export function readExecutionMetrics(
   try {
     const parsed = JSON.parse(readFileSync(path, "utf-8")) as Partial<{
       tokenUsage: Partial<TokenUsageTotals>;
+      contextUsage?: unknown;
       runtime: string;
       elapsedSeconds: number;
       updatedAt: string;
@@ -68,6 +102,7 @@ export function readExecutionMetrics(
 
     return {
       tokenUsage: normalizeTokenUsage(parsed.tokenUsage),
+      contextUsage: normalizeContextUsage(parsed.contextUsage),
       runtime: typeof parsed.runtime === "string" ? parsed.runtime : undefined,
       elapsedSeconds: toNonNegativeInteger(parsed.elapsedSeconds) || undefined,
       updatedAt:
@@ -109,11 +144,14 @@ export function writeExecutionMetrics(
     : (existing?.tokenUsage ?? {
         inputTokens: 0,
         outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
         totalTokens: 0,
       });
 
   const next: ExecutionMetrics = {
     tokenUsage: nextTokenUsage,
+    contextUsage: input.contextUsage ?? existing?.contextUsage,
     runtime: input.runtime ?? existing?.runtime,
     elapsedSeconds: input.elapsedSeconds ?? existing?.elapsedSeconds,
     updatedAt: new Date().toISOString(),

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -539,18 +539,9 @@ export default function OperatorDashboard({
     if (!session || !sessionId) return;
 
     const metrics = readExecutionMetrics(session.rootPath);
-    const persisted = metrics?.tokenUsage;
     usageStore.enterSession(session.id, {
-      ...(persisted
-        ? {
-            tokenUsage: {
-              inputTokens: persisted.inputTokens,
-              outputTokens: persisted.outputTokens,
-              cacheReadTokens: 0,
-              cacheWriteTokens: 0,
-            },
-          }
-        : {}),
+      ...(metrics?.tokenUsage ? { tokenUsage: metrics.tokenUsage } : {}),
+      ...(metrics?.contextUsage ? { contextUsage: metrics.contextUsage } : {}),
     });
   }, [session, sessionId, usageStore]);
 


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Usage + observability · PR 3 of 12**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#996](https://github.com/pensarai/apex/pull/996) | Session usage models |
| 2 | [#997](https://github.com/pensarai/apex/pull/997) | Session-scoped ownership |
| **3** | **[#998](https://github.com/pensarai/apex/pull/998)** | **Complete usage persistence** · `Current` |
| 4 | [#999](https://github.com/pensarai/apex/pull/999) | Consolidated usage ingestion |
| 5 | [#1000](https://github.com/pensarai/apex/pull/1000) | Token and context footer |
| 6 | [#1002](https://github.com/pensarai/apex/pull/1002) | Cache token breakdown |
| 7 | [#1004](https://github.com/pensarai/apex/pull/1004) | Agent trace contract |
| 8 | [#1005](https://github.com/pensarai/apex/pull/1005) | Optional OTLP runtime |
| 9 | [#1006](https://github.com/pensarai/apex/pull/1006) | Root agent run spans |
| 10 | [#1007](https://github.com/pensarai/apex/pull/1007) | Centralized telemetry settings |
| 11 | [#1008](https://github.com/pensarai/apex/pull/1008) | Telemetry correlation |
| 12 | [#1009](https://github.com/pensarai/apex/pull/1009) | OTLP shutdown hardening |
## Summary

- extend `execution-metrics.json` with the complete usage shape:
  ```json
  {
    "tokenUsage": {
      "inputTokens": …, "outputTokens": …,
      "cacheReadTokens": …, "cacheWriteTokens": …, "totalTokens": …
    },
    "contextUsage": { "usedTokens": …, "contextLimit": …, "modelId": … }
  }
  ```
- every field hydrates on resume; legacy files lacking cache or context fields hydrate with zero cache and no context sample
- `writeExecutionMetrics` remains the single writer with explicit merge semantics: `tokenUsage` is the authoritative cumulative snapshot from the caller, `contextUsage` replaces when provided and is retained otherwise (same for `runtime`/`elapsedSeconds`)
- the dashboard resume seed now hydrates cache totals and the context sample into the session usage store

## Motivation

T3 of the Narrow Token Stack. Durable session totals need the cache fields on disk (the footer's `cached` label must survive a restart), and the context percentage needs its sampled `modelId`/`contextLimit` persisted so a resumed session shows a meaningful number before its next root step. The file previously carried only input/output totals.

## What changed

**`src/core/session/execution-metrics.ts`**

- `TokenUsageTotals` gains `cacheReadTokens`/`cacheWriteTokens`; `totalTokens` stays derived (input + output — cache reads are already inside input, never double-counted)
- new `ContextUsageMetrics` `{ usedTokens, contextLimit, modelId }` on `ExecutionMetrics` — optional, absent in legacy files
- `readExecutionMetrics` hydrates every field, sanitizes values, and drops malformed context samples (missing/empty `modelId`) instead of failing the read
- `writeExecutionMetrics` merge semantics: provided `tokenUsage` normalizes and replaces; provided `contextUsage` replaces, omitted retains; legacy partial writes (callers that only know input/output) normalize unknown cache fields to zero
- `writeSessionJsonTokenTotals` (tokensIn/tokensOut on session.json) unchanged

**`operator-dashboard/index.tsx`** — the resume effect seeds the store with the full hydrated shape: `metrics.tokenUsage` (cache included) and `metrics.contextUsage` when present. `recordTokenUsage` already passed the store's full snapshot (T2), so cache totals now persist on every step write with no further change.

## Compatibility

- legacy metrics files read cleanly: cache fields hydrate as 0, `contextUsage` as absent
- the pentest workflow's write path (input/output only) keeps working — it goes through the same writer with defined merge semantics; its competing totals are removed in T4
- no format migration — the shape grows additively

## Test coverage

11 tests in `execution-metrics.test.ts` (new file): full round-trip; the documented raw file shape (totalTokens present, cache separate); legacy files without cache/context; legacy partial writes; malformed context dropped; missing/corrupt file → null; context retained across usage-only writes; context replaced when provided; runtime/elapsed retained; totalTokens derivation never double-counts cache; negative/NaN sanitization.

## Validation

- `bun run test` (1,739 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the touched files

## Notes

- nothing populates `contextUsage` yet — T4's root-step ingestion records the sample; T5's footer reads it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive on-disk schema and resume seeding; legacy metrics files remain readable with defined merge semantics.
> 
> **Overview**
> Extends **`execution-metrics.json`** so sessions can persist the full usage snapshot: token totals now include **`cacheReadTokens`** / **`cacheWriteTokens`** (with **`totalTokens`** still input + output, not double-counting cache reads), plus optional **`contextUsage`** (`usedTokens`, `contextLimit`, `modelId`).
> 
> **`readExecutionMetrics`** / **`writeExecutionMetrics`** hydrate and merge the new fields with legacy-safe defaults (missing cache → 0, malformed context without `modelId` dropped). Partial writes still replace the authoritative **`tokenUsage`** snapshot and retain **`contextUsage`**, **`runtime`**, and **`elapsedSeconds`** when omitted.
> 
> On **operator dashboard resume**, the usage store is seeded from the full persisted **`tokenUsage`** (cache included) and **`contextUsage`** when present, instead of forcing cache fields to zero.
> 
> Adds **`execution-metrics.test.ts`** covering round-trip, legacy files, merge behavior, and sanitization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4201378248b4f0d7983cdb4793e798a0168af4f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


