### PR TITLE
refactor(usage): consolidate usage ingestion

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -11,6 +11,8 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
+const toolContexts = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+
 // ---------------------------------------------------------------------------
 // Module stubs — prevent the full tool/AI/zod import chain from loading.
 //
@@ -32,7 +34,10 @@ vi.mock("zod", () => {
 });
 
 vi.mock("./tools", () => ({
-  createAllTools: () => ({}),
+  createAllTools: (ctx: Record<string, unknown>) => {
+    toolContexts.push(ctx);
+    return {};
+  },
   EMAIL_TOOL_NAMES_ACTIVE: [],
   SEND_EMAIL_TOOL_NAME: "send_email",
   PLAN_MODE_TOOL_NAMES: [],
@@ -69,6 +74,7 @@ vi.mock("./prompt", () => ({
 }));
 vi.mock("./trace", () => ({
   StepTraceWriter: class {
+    writeInit() {}
     onStepFinish() {}
   },
 }));
@@ -84,6 +90,34 @@ import {
   filterWorkspaceToolsForRun,
   OffensiveSecurityAgent,
 } from "./offensiveSecurityAgent";
+
+describe("spawned-agent usage callbacks", () => {
+  it("requires explicit forwarding when trace events own subagent accounting", () => {
+    toolContexts.length = 0;
+    const onStepFinish = vi.fn();
+    const onCacheMetrics = vi.fn();
+    const input = {
+      prompt: "test",
+      model: "test-model",
+      session: { id: "ses_test", rootPath: "/tmp/apex-usage-test" },
+      activeTools: [],
+      sandbox: {},
+      onStepFinish,
+      onCacheMetrics,
+    };
+
+    new OffensiveSecurityAgent(input as never);
+    new OffensiveSecurityAgent({
+      ...input,
+      forwardUsageCallbacksToSpawnedAgents: true,
+    } as never);
+
+    expect(toolContexts[0]?.onStepFinish).toBeUndefined();
+    expect(toolContexts[0]?.onCacheMetrics).toBeUndefined();
+    expect(toolContexts[1]?.onStepFinish).toBe(onStepFinish);
+    expect(toolContexts[1]?.onCacheMetrics).toBe(onCacheMetrics);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -458,8 +458,12 @@ export class OffensiveSecurityAgent<TResult = void> {
       model: input.model,
       authConfig: input.authConfig,
       eventBus: this.eventBus,
-      onStepFinish: input.onStepFinish,
-      onCacheMetrics: input.onCacheMetrics,
+      onStepFinish: input.forwardUsageCallbacksToSpawnedAgents
+        ? input.onStepFinish
+        : undefined,
+      onCacheMetrics: input.forwardUsageCallbacksToSpawnedAgents
+        ? input.onCacheMetrics
+        : undefined,
       sandbox: input.sandbox,
       findingsRegistry: input.findingsRegistry,
       attackSurfaceRegistry: input.attackSurfaceRegistry,

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -458,6 +458,8 @@ export class OffensiveSecurityAgent<TResult = void> {
       model: input.model,
       authConfig: input.authConfig,
       eventBus: this.eventBus,
+      onStepFinish: input.onStepFinish,
+      onCacheMetrics: input.onCacheMetrics,
       sandbox: input.sandbox,
       findingsRegistry: input.findingsRegistry,
       attackSurfaceRegistry: input.attackSurfaceRegistry,

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.test.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.test.ts
@@ -111,6 +111,19 @@ afterEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
+describe("spawn_pentest_agent — usage callbacks", () => {
+  it("forwards usage callbacks to the worker", async () => {
+    const onStepFinish = vi.fn();
+    const onCacheMetrics = vi.fn();
+    const ctx = buildCtx({ onStepFinish, onCacheMetrics });
+
+    await runSpawn(ctx);
+
+    expect(constructorCalls[0]?.onStepFinish).toBe(onStepFinish);
+    expect(constructorCalls[0]?.onCacheMetrics).toBe(onCacheMetrics);
+  });
+});
+
 describe("spawn_pentest_agent — shared browser session", () => {
   it("hands the worker the orchestrator's session directly (no clone) in native mode", async () => {
     const parent = makeParentSession();

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -202,6 +202,8 @@ Returns the worker's summary, objective results, and finding count — but NOT t
           session: ctx.session,
           authConfig: ctx.authConfig,
           abortSignal: ctx.abortSignal,
+          onStepFinish: ctx.onStepFinish,
+          onCacheMetrics: ctx.onCacheMetrics,
           findingsRegistry,
           eventBus: childBus,
           subagentId,

--- a/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
@@ -98,6 +98,8 @@ Pass every target you want tested — the swarm handles concurrency automaticall
         abortSignal: ctx.abortSignal,
         findingsRegistry,
         eventBus: ctx.eventBus,
+        onStepFinish: ctx.onStepFinish,
+        onCacheMetrics: ctx.onCacheMetrics,
         concurrency: DEFAULT_CONCURRENCY,
         enableThinking: ctx.enableThinking,
         thinkingEffort: ctx.thinkingEffort,

--- a/src/core/agents/offSecAgent/tools/types.ts
+++ b/src/core/agents/offSecAgent/tools/types.ts
@@ -1,6 +1,8 @@
+import type { StreamTextOnStepFinishCallback, ToolSet } from "ai";
 import type {
   AIAuthConfig,
   AIModel,
+  CacheMetrics,
   OpenAIReasoningEffort,
   ThinkingEffort,
 } from "../../../ai";
@@ -52,6 +54,10 @@ export type ToolContext = {
 
   /** Event bus for streaming agent output and subagent lifecycle events */
   eventBus?: AgentEventBus;
+
+  /** Usage callbacks forwarded to sub-agents spawned by tools. */
+  onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
+  onCacheMetrics?: (metrics: CacheMetrics) => void;
 
   /**
    * When set, tools like execute_command / http_request / document_vulnerability

--- a/src/core/agents/offSecAgent/types.ts
+++ b/src/core/agents/offSecAgent/types.ts
@@ -153,6 +153,12 @@ export type OffensiveSecurityAgentInput<TResult = void> = {
   /** Called when Anthropic cache metrics are present in a step's providerMetadata */
   onCacheMetrics?: (metrics: CacheMetrics) => void;
 
+  /**
+   * Forward usage callbacks through tools that spawn agents. Enable only when
+   * the caller does not already account for subagents from trace events.
+   */
+  forwardUsageCallbacksToSpawnedAgents?: boolean;
+
   /** AbortSignal to cancel the agent mid-run */
   abortSignal?: AbortSignal;
 

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -101,6 +101,9 @@ export interface PentestAgentInput extends SpecializedAgentInput {
    * unset to get the default orchestrator behavior.
    */
   role?: PentestAgentRole;
+
+  /** Forward direct usage callbacks to workers when no event-based sink exists. */
+  forwardUsageCallbacksToSpawnedAgents?: boolean;
 }
 
 /** The typed result returned by `PentestAgent.consume()`. */
@@ -214,6 +217,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       authConfig,
       onStepFinish,
       onCacheMetrics,
+      forwardUsageCallbacksToSpawnedAgents,
       abortSignal,
       eventBus,
       subagentId,
@@ -285,6 +289,7 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       authConfig,
       onStepFinish,
       onCacheMetrics,
+      forwardUsageCallbacksToSpawnedAgents,
       abortSignal,
       eventBus,
       subagentId,

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -174,7 +174,7 @@ export type AIModelProvider =
   | "local";
 
 /** Conservative default when `getModelInfo` doesn't have a `contextLength`. */
-function getContextWindow(modelId: string): number {
+export function getContextWindow(modelId: string): number {
   return getModelInfo(modelId).contextLength ?? 200_000;
 }
 

--- a/src/core/ai/index.ts
+++ b/src/core/ai/index.ts
@@ -12,6 +12,7 @@ export {
   buildReasoningProviderOptions,
   DEFAULT_OPENAI_REASONING_EFFORT,
   generateObjectResponse,
+  getContextWindow,
   getOpenAIReasoningEfforts,
   modelSupportsAdaptiveThinking,
   modelSupportsOpenAIReasoning,

--- a/src/core/api/blackboxPentest.test.ts
+++ b/src/core/api/blackboxPentest.test.ts
@@ -1,0 +1,89 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionInfo } from "../session";
+import {
+  readExecutionMetrics,
+  writeExecutionMetrics,
+} from "../session/execution-metrics";
+import type { PentestWorkflowInput } from "../workflows/pentest";
+
+const mocks = vi.hoisted(() => ({
+  runPentestWorkflow: vi.fn(),
+}));
+
+vi.mock("../workflows/pentest", () => ({
+  runPentestWorkflow: mocks.runPentestWorkflow,
+}));
+
+import { runPentestAgent } from "./blackboxPentest";
+
+let rootPath: string;
+
+beforeEach(() => {
+  rootPath = mkdtempSync(join(tmpdir(), "headless-pentest-usage-"));
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  mocks.runPentestWorkflow.mockImplementation(
+    async (input: PentestWorkflowInput) => {
+      await input.onStepFinish?.({
+        usage: { inputTokens: 100, outputTokens: 20 },
+      } as Parameters<NonNullable<PentestWorkflowInput["onStepFinish"]>>[0]);
+      input.onCacheMetrics?.({
+        cacheReadInputTokens: 80,
+        cacheCreationInputTokens: 10,
+      });
+      return {
+        findings: [],
+        findingsPath: join(rootPath, "findings"),
+        pocsPath: join(rootPath, "pocs"),
+        reportPath: null,
+      };
+    },
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  mocks.runPentestWorkflow.mockReset();
+  rmSync(rootPath, { recursive: true, force: true });
+});
+
+describe("runPentestAgent usage persistence", () => {
+  it("persists headless step and cache usage without clobbering prior totals", async () => {
+    writeExecutionMetrics({
+      sessionRootPath: rootPath,
+      tokenUsage: {
+        inputTokens: 10,
+        outputTokens: 2,
+        cacheReadTokens: 5,
+      },
+    });
+
+    const session = {
+      id: "ses_headless",
+      version: "test",
+      targets: ["https://example.com"],
+      time: { created: 0, updated: 0 },
+      rootPath,
+      logsPath: join(rootPath, "logs"),
+      findingsPath: join(rootPath, "findings"),
+      scratchpadPath: join(rootPath, "scratchpad"),
+      pocsPath: join(rootPath, "pocs"),
+    } as SessionInfo;
+
+    await runPentestAgent({
+      target: "https://example.com",
+      model: {} as PentestWorkflowInput["model"],
+      session,
+    });
+
+    expect(readExecutionMetrics(rootPath)?.tokenUsage).toEqual({
+      inputTokens: 110,
+      outputTokens: 22,
+      cacheReadTokens: 85,
+      cacheWriteTokens: 10,
+      totalTokens: 132,
+    });
+  });
+});

--- a/src/core/api/blackboxPentest.ts
+++ b/src/core/api/blackboxPentest.ts
@@ -1,4 +1,13 @@
 //
+
+import {
+  readExecutionMetrics,
+  writeExecutionMetrics,
+} from "../session/execution-metrics";
+import {
+  accumulateSessionTokens,
+  EMPTY_SESSION_TOKEN_USAGE,
+} from "../session/usage";
 import {
   type PentestWorkflowInput,
   type PentestWorkflowResult,
@@ -21,8 +30,36 @@ import {
 export async function runPentestAgent(
   input: PentestWorkflowInput,
 ): Promise<PentestWorkflowResult> {
-  const { findings, findingsPath, pocsPath, reportPath } =
-    await runPentestWorkflow(input);
+  const persisted = readExecutionMetrics(input.session.rootPath)?.tokenUsage;
+  let tokenUsage = persisted ?? EMPTY_SESSION_TOKEN_USAGE;
+
+  const onStepFinish: PentestWorkflowInput["onStepFinish"] = async (event) => {
+    tokenUsage = accumulateSessionTokens(tokenUsage, event.usage ?? {});
+    await input.onStepFinish?.(event);
+  };
+  const onCacheMetrics: PentestWorkflowInput["onCacheMetrics"] = (metrics) => {
+    tokenUsage = accumulateSessionTokens(tokenUsage, {
+      cacheReadTokens: metrics.cacheReadInputTokens,
+      cacheWriteTokens: metrics.cacheCreationInputTokens,
+    });
+    input.onCacheMetrics?.(metrics);
+  };
+
+  let result: PentestWorkflowResult;
+  try {
+    result = await runPentestWorkflow({
+      ...input,
+      onStepFinish,
+      onCacheMetrics,
+    });
+  } finally {
+    writeExecutionMetrics({
+      sessionRootPath: input.session.rootPath,
+      tokenUsage,
+    });
+  }
+
+  const { findings, findingsPath, pocsPath, reportPath } = result;
 
   console.log(`\nFound ${findings.length} vulnerabilities`);
   console.log(`Findings: ${findingsPath}`);

--- a/src/core/session/execution-metrics.test.ts
+++ b/src/core/session/execution-metrics.test.ts
@@ -264,3 +264,34 @@ describe("execution-metrics single-writer merge", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// T4: runtime-only writes never clobber usage
+// ---------------------------------------------------------------------------
+
+describe("execution-metrics runtime-only writes", () => {
+  it("a write with no tokenUsage retains the persisted totals (workflow path)", () => {
+    writeExecutionMetrics({
+      sessionRootPath: rootPath(),
+      tokenUsage: {
+        inputTokens: 500,
+        outputTokens: 60,
+        cacheReadTokens: 400,
+        cacheWriteTokens: 10,
+      },
+      contextUsage: { usedTokens: 500, contextLimit: 200_000, modelId: "m" },
+    });
+
+    // The pentest workflow's finally block writes only runtime now.
+    writeExecutionMetrics({
+      sessionRootPath: rootPath(),
+      runtime: "0h10m0s",
+    });
+
+    const metrics = readExecutionMetrics(rootPath());
+    expect(metrics?.tokenUsage.inputTokens).toBe(500);
+    expect(metrics?.tokenUsage.cacheReadTokens).toBe(400);
+    expect(metrics?.contextUsage?.usedTokens).toBe(500);
+    expect(metrics?.runtime).toBe("0h10m0s");
+  });
+});

--- a/src/core/workflows/fastStrike.ts
+++ b/src/core/workflows/fastStrike.ts
@@ -59,6 +59,7 @@ export async function runFastStrike(
     abortSignal,
     eventBus,
     onStepFinish,
+    onCacheMetrics,
     enableThinking,
     openAIReasoningEffort,
     prompt,
@@ -125,6 +126,7 @@ export async function runFastStrike(
     abortSignal,
     eventBus,
     onStepFinish,
+    onCacheMetrics,
     enableThinking,
     openAIReasoningEffort,
   });

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -163,29 +163,6 @@ export interface PentestSwarmInput {
   display?: string;
 }
 
-interface TokenUsageTotals {
-  inputTokens: number;
-  outputTokens: number;
-  totalTokens: number;
-}
-
-function addUsageTotals(
-  totals: TokenUsageTotals,
-  usage?: {
-    inputTokens?: number;
-    outputTokens?: number;
-    totalTokens?: number;
-  },
-): void {
-  if (!usage) return;
-  const inputTokens = usage.inputTokens ?? 0;
-  const outputTokens = usage.outputTokens ?? 0;
-  const totalTokens = usage.totalTokens ?? inputTokens + outputTokens;
-  totals.inputTokens += inputTokens;
-  totals.outputTokens += outputTokens;
-  totals.totalTokens += totalTokens;
-}
-
 // ---------------------------------------------------------------------------
 // Pentest swarm orchestration
 // ---------------------------------------------------------------------------
@@ -460,26 +437,6 @@ export async function runPentestWorkflow(
   }
 
   const startedAt = Date.now();
-  const tokenUsageTotals: TokenUsageTotals = {
-    inputTokens: 0,
-    outputTokens: 0,
-    totalTokens: 0,
-  };
-
-  const wrappedOnStepFinish = (event: {
-    usage?: {
-      inputTokens?: number;
-      outputTokens?: number;
-      totalTokens?: number;
-    };
-  }) => {
-    addUsageTotals(tokenUsageTotals, event.usage);
-    // Call the original onStepFinish if it exists - we need to cast event to the full type
-    // because onStepFinish expects StreamTextOnStepFinishCallback, but we're working with a simpler type here
-    if (onStepFinish) {
-      onStepFinish(event as Parameters<typeof onStepFinish>[0]);
-    }
-  };
 
   try {
     const mode: "blackbox" | "whitebox" = cwd ? "whitebox" : "blackbox";
@@ -525,7 +482,7 @@ export async function runPentestWorkflow(
           authConfig,
           abortSignal,
           eventBus,
-          onStepFinish: wrappedOnStepFinish,
+          onStepFinish,
           onCacheMetrics,
           openAIReasoningEffort,
           surfaceIntegrationEnabled,
@@ -538,7 +495,7 @@ export async function runPentestWorkflow(
           authConfig,
           abortSignal,
           eventBus,
-          onStepFinish: wrappedOnStepFinish,
+          onStepFinish,
           onCacheMetrics,
           openAIReasoningEffort,
         });
@@ -606,7 +563,11 @@ export async function runPentestWorkflow(
         abortSignal,
         findingsRegistry,
         eventBus,
-        onStepFinish: wrappedOnStepFinish,
+        // The swarm's narrow step-finish signature is structurally satisfied
+        // by the caller's full callback (the event carries more than it reads).
+        onStepFinish: onStepFinish as Parameters<
+          typeof runPentestSwarm
+        >[0]["onStepFinish"],
         enableThinking,
         thinkingEffort,
         openAIReasoningEffort,
@@ -666,10 +627,12 @@ export async function runPentestWorkflow(
       reportPath: mdPath,
     };
   } finally {
+    // Runtime only — token usage has exactly one accounting path (the
+    // dashboard's session store), which already persists each step. Writing
+    // workflow-local totals here would compete with and clobber it.
     const runtime = formatDurationHmsFromMs(Date.now() - startedAt);
     writeExecutionMetrics({
       sessionRootPath: session.rootPath,
-      tokenUsage: tokenUsageTotals,
       runtime,
     });
   }

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -315,6 +315,7 @@ export async function runPentestSwarm(
           findingsRegistry,
           onStepFinish: handleStepFinish,
           onCacheMetrics,
+          forwardUsageCallbacksToSpawnedAgents: true,
           messages: previousMessages.length > 0 ? previousMessages : undefined,
           eventBus,
           subagentId,

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -145,13 +145,8 @@ export interface PentestSwarmInput {
   eventBus?: AgentEventBus;
   onError?: (e: unknown) => void;
   concurrency?: number;
-  onStepFinish?: (event: {
-    usage?: {
-      inputTokens?: number;
-      outputTokens?: number;
-      totalTokens?: number;
-    };
-  }) => void;
+  onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
+  onCacheMetrics?: (metrics: CacheMetrics) => void;
   enableThinking?: boolean;
   thinkingEffort?: ThinkingEffort | null;
   openAIReasoningEffort?: OpenAIReasoningEffort | null;
@@ -190,6 +185,7 @@ export async function runPentestSwarm(
     onError,
     concurrency = DEFAULT_CONCURRENCY,
     onStepFinish,
+    onCacheMetrics,
     enableThinking,
     thinkingEffort,
     openAIReasoningEffort,
@@ -221,14 +217,7 @@ export async function runPentestSwarm(
       const previousMessages = loadSubagentMessages(session, subagentId);
       let lastMessages: ModelMessage[] = [];
 
-      const handleStepFinish = (e: {
-        response: { messages?: ModelMessage[] };
-        usage?: {
-          inputTokens?: number;
-          outputTokens?: number;
-          totalTokens?: number;
-        };
-      }) => {
+      const handleStepFinish: StreamTextOnStepFinishCallback<ToolSet> = (e) => {
         if (e.response.messages) {
           lastMessages = e.response.messages;
         }
@@ -285,6 +274,8 @@ export async function runPentestSwarm(
             tasksDir: executionTasksDir,
             planSubagentId: subagentId,
             eventBus,
+            onStepFinish,
+            onCacheMetrics,
             enableThinking,
             thinkingEffort,
             openAIReasoningEffort,
@@ -323,6 +314,7 @@ export async function runPentestSwarm(
           abortSignal,
           findingsRegistry,
           onStepFinish: handleStepFinish,
+          onCacheMetrics,
           messages: previousMessages.length > 0 ? previousMessages : undefined,
           eventBus,
           subagentId,
@@ -563,11 +555,8 @@ export async function runPentestWorkflow(
         abortSignal,
         findingsRegistry,
         eventBus,
-        // The swarm's narrow step-finish signature is structurally satisfied
-        // by the caller's full callback (the event carries more than it reads).
-        onStepFinish: onStepFinish as Parameters<
-          typeof runPentestSwarm
-        >[0]["onStepFinish"],
+        onStepFinish,
+        onCacheMetrics,
         enableThinking,
         thinkingEffort,
         openAIReasoningEffort,

--- a/src/core/workflows/usage-forwarding.test.ts
+++ b/src/core/workflows/usage-forwarding.test.ts
@@ -1,0 +1,135 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionInfo } from "../session";
+
+const mocks = vi.hoisted(() => ({
+  targetedInputs: [] as Array<Record<string, unknown>>,
+  fastStrikeInputs: [] as Array<Record<string, unknown>>,
+  registry: {
+    groupByRootCause: vi.fn(async () => {}),
+    getFindings: vi.fn(() => []),
+  },
+}));
+
+vi.mock("../agents/specialized/pentest/agent", () => ({
+  buildPentestSystemPrompt: () => "test system prompt",
+  TargetedPentestAgent: class {
+    readonly userPrompt = "test user prompt";
+
+    constructor(private readonly input: Record<string, unknown>) {
+      mocks.targetedInputs.push(input);
+    }
+
+    async consume() {
+      await (
+        this.input.onStepFinish as
+          | ((event: unknown) => Promise<void> | void)
+          | undefined
+      )?.({ usage: { inputTokens: 10 }, response: { messages: [] } });
+      (this.input.onCacheMetrics as ((metrics: unknown) => void) | undefined)?.(
+        { cacheReadInputTokens: 8, cacheCreationInputTokens: 2 },
+      );
+      return { findings: [], findingsPath: "", pocsPath: "" };
+    }
+  },
+}));
+
+vi.mock("../agents/offSecAgent", () => ({
+  PLAN_MODE_TOOL_NAMES: [],
+  OffensiveSecurityAgent: class {
+    constructor(private readonly input: Record<string, unknown>) {
+      mocks.fastStrikeInputs.push(input);
+    }
+
+    async consume() {
+      await (
+        this.input.onStepFinish as
+          | ((event: unknown) => Promise<void> | void)
+          | undefined
+      )?.({ usage: { inputTokens: 10 }, response: { messages: [] } });
+      (this.input.onCacheMetrics as ((metrics: unknown) => void) | undefined)?.(
+        { cacheReadInputTokens: 8, cacheCreationInputTokens: 2 },
+      );
+      return { solved: true, summary: "done" };
+    }
+  },
+}));
+
+vi.mock("../findings/registry", () => ({
+  FindingsRegistry: {
+    fromDirectory: () => mocks.registry,
+  },
+}));
+
+import { runFastStrike } from "./fastStrike";
+import { type PentestWorkflowInput, runPentestSwarm } from "./pentest";
+
+let rootPath: string;
+let session: SessionInfo;
+
+beforeEach(() => {
+  rootPath = mkdtempSync(join(tmpdir(), "usage-forwarding-"));
+  session = {
+    id: "ses_usage_forwarding",
+    version: "test",
+    targets: ["https://example.com"],
+    time: { created: 0, updated: 0 },
+    rootPath,
+    logsPath: join(rootPath, "logs"),
+    findingsPath: join(rootPath, "findings"),
+    scratchpadPath: join(rootPath, "scratchpad"),
+    pocsPath: join(rootPath, "pocs"),
+  } as SessionInfo;
+});
+
+afterEach(() => {
+  mocks.targetedInputs.length = 0;
+  mocks.fastStrikeInputs.length = 0;
+  vi.clearAllMocks();
+  rmSync(rootPath, { recursive: true, force: true });
+});
+
+describe("pentest usage callback forwarding", () => {
+  it("forwards step and cache usage through the pentest swarm", async () => {
+    const onStepFinish = vi.fn();
+    const onCacheMetrics = vi.fn();
+
+    await runPentestSwarm({
+      targets: [
+        { target: "https://example.com", objectives: ["Test the target"] },
+      ],
+      model: {} as PentestWorkflowInput["model"],
+      session,
+      findingsRegistry: mocks.registry as never,
+      onStepFinish,
+      onCacheMetrics,
+    });
+
+    expect(onStepFinish).toHaveBeenCalledOnce();
+    expect(onCacheMetrics).toHaveBeenCalledWith({
+      cacheReadInputTokens: 8,
+      cacheCreationInputTokens: 2,
+    });
+  });
+
+  it("forwards step and cache usage through fast strike", async () => {
+    const onStepFinish = vi.fn();
+    const onCacheMetrics = vi.fn();
+
+    await runFastStrike({
+      target: "https://example.com",
+      model: {} as PentestWorkflowInput["model"],
+      session,
+      onStepFinish,
+      onCacheMetrics,
+    });
+
+    expect(onStepFinish).toHaveBeenCalledOnce();
+    expect(onCacheMetrics).toHaveBeenCalledWith({
+      cacheReadInputTokens: 8,
+      cacheCreationInputTokens: 2,
+    });
+  });
+});

--- a/src/core/workflows/usage-forwarding.test.ts
+++ b/src/core/workflows/usage-forwarding.test.ts
@@ -112,6 +112,9 @@ describe("pentest usage callback forwarding", () => {
       cacheReadInputTokens: 8,
       cacheCreationInputTokens: 2,
     });
+    expect(mocks.targetedInputs[0]?.forwardUsageCallbacksToSpawnedAgents).toBe(
+      true,
+    );
   });
 
   it("forwards step and cache usage through fast strike", async () => {

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -34,6 +34,7 @@ import {
 import {
   buildAuthConfig,
   type CacheMetrics,
+  getContextWindow,
   modelSupportsOpenAIReasoning,
   modelSupportsThinking,
 } from "../../../core/ai";
@@ -551,6 +552,11 @@ export default function OperatorDashboard({
   // setters stay behind the narrow sink.
   // ---------------------------------------------------------------------------
 
+  // The session id the CURRENT run belongs to. Usage events route here (not
+  // to whichever session is active) so late stragglers from a finishing run
+  // never leak into a different session's totals.
+  const runSessionIdRef = useRef<string | null>(null);
+
   const displayEvents = useMemo(
     () =>
       createDisplayEventHandlers({
@@ -650,6 +656,7 @@ export default function OperatorDashboard({
       }
 
       const gen = ++generationRef.current;
+      runSessionIdRef.current = sessionRef.current?.id ?? session?.id ?? null;
 
       setStatus("running");
       setThinking(true);
@@ -687,8 +694,9 @@ export default function OperatorDashboard({
         nextMessages = conversationRef.current;
       }
 
-      // Shared sink for orchestrator + subagent token usage. Routes into the
-      // session-scoped store; metrics write the owning session's snapshot.
+      // THE accounting path: every step (root via onStepFinish, subagents via
+      // trace records) funnels through here exactly once. Routes into the
+      // run's owning session; metrics write that session's snapshot.
       const recordTokenUsage = (
         inputTokens: number,
         outputTokens: number,
@@ -696,7 +704,8 @@ export default function OperatorDashboard({
         cacheWriteTokens = 0,
       ) => {
         if (inputTokens > 0 || outputTokens > 0) markExecuted();
-        usageStore.addSessionTokens(usageStore.activeSessionId, {
+        const runSessionId = runSessionIdRef.current;
+        usageStore.addSessionTokens(runSessionId, {
           inputTokens,
           outputTokens,
           cacheReadTokens,
@@ -715,13 +724,29 @@ export default function OperatorDashboard({
         }
       };
 
+      // Root steps also replace the context sample: the step's input is the
+      // whole conversation as the model saw it, and the denominator comes
+      // from the model this run actually used.
+      const runModelId = model.id;
+      const recordRootStepUsage = (usage: {
+        inputTokens?: number;
+        outputTokens?: number;
+      }) => {
+        recordTokenUsage(usage.inputTokens ?? 0, usage.outputTokens ?? 0);
+        const inputTokens = usage.inputTokens ?? 0;
+        if (inputTokens > 0) {
+          usageStore.setRootContext(runSessionIdRef.current, {
+            usedTokens: inputTokens,
+            contextLimit: getContextWindow(runModelId),
+            modelId: runModelId,
+          });
+        }
+      };
+
       const onStepFinish = (event: {
         usage?: { inputTokens?: number; outputTokens?: number };
       }) => {
-        recordTokenUsage(
-          event.usage?.inputTokens ?? 0,
-          event.usage?.outputTokens ?? 0,
-        );
+        recordRootStepUsage(event.usage ?? {});
       };
 
       const eventBus = new AgentEventBus();
@@ -773,7 +798,7 @@ export default function OperatorDashboard({
             : undefined),
         onStepFinish,
         onCacheMetrics: (metrics: CacheMetrics) => {
-          usageStore.addSessionTokens(usageStore.activeSessionId, {
+          usageStore.addSessionTokens(runSessionIdRef.current, {
             cacheReadTokens: metrics.cacheReadInputTokens,
             cacheWriteTokens: metrics.cacheCreationInputTokens,
           });
@@ -783,6 +808,7 @@ export default function OperatorDashboard({
           setSessionCwd(s.rootPath);
           sessionRef.current = s;
           setSession((prev) => prev ?? s);
+          runSessionIdRef.current = s.id;
           usageStore.enterSession(s.id);
           runTrace.tryAttach(s);
         },

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -714,9 +714,13 @@ export default function OperatorDashboard({
         const activeSession = sessionRef.current;
         if (activeSession) {
           try {
+            const usage = usageStore.getSnapshot(activeSession.id);
             writeExecutionMetrics({
               sessionRootPath: activeSession.rootPath,
-              tokenUsage: usageStore.getSnapshot(activeSession.id).tokenUsage,
+              tokenUsage: usage.tokenUsage,
+              ...(usage.contextUsage
+                ? { contextUsage: usage.contextUsage }
+                : {}),
             });
           } catch {
             // Best effort: token metrics should not interrupt operator runs.
@@ -732,7 +736,6 @@ export default function OperatorDashboard({
         inputTokens?: number;
         outputTokens?: number;
       }) => {
-        recordTokenUsage(usage.inputTokens ?? 0, usage.outputTokens ?? 0);
         const inputTokens = usage.inputTokens ?? 0;
         if (inputTokens > 0) {
           usageStore.setRootContext(runSessionIdRef.current, {
@@ -741,6 +744,7 @@ export default function OperatorDashboard({
             modelId: runModelId,
           });
         }
+        recordTokenUsage(inputTokens, usage.outputTokens ?? 0);
       };
 
       const onStepFinish = (event: {

--- a/src/tui/context/session-usage.test.ts
+++ b/src/tui/context/session-usage.test.ts
@@ -260,3 +260,36 @@ describe("SessionUsageStore provisional + active view", () => {
     expect(store.getActiveSnapshot().tokenUsage.inputTokens).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// T4: single ingestion path
+// ---------------------------------------------------------------------------
+
+describe("SessionUsageStore context-sample routing", () => {
+  it("drops a context sample with no owning session (pre-mint root step)", () => {
+    const store = new SessionUsageStore();
+    // A root step fires before onSessionReady mints the id.
+    store.setRootContext(null, {
+      modelId: "m",
+      usedTokens: 10,
+      contextLimit: 100,
+    });
+    // The provisional bucket carries tokens only — no context sample leaked
+    // into the first entered session.
+    store.enterSession("ses_new");
+    expect(store.getSnapshot("ses_new").contextUsage).toBeNull();
+  });
+
+  it("late subagent tokens route to the run's session, not the active one", () => {
+    const store = new SessionUsageStore();
+    store.enterSession("ses_run");
+    store.addSessionTokens("ses_run", { inputTokens: 100 });
+
+    // Operator switches sessions while the run's straggler event arrives.
+    store.enterSession("ses_other");
+    store.addSessionTokens("ses_run", { inputTokens: 50 });
+
+    expect(store.getSnapshot("ses_run").tokenUsage.inputTokens).toBe(150);
+    expect(store.getSnapshot("ses_other").tokenUsage.inputTokens).toBe(0);
+  });
+});

--- a/src/tui/context/session-usage.ts
+++ b/src/tui/context/session-usage.ts
@@ -134,8 +134,14 @@ export class SessionUsageStore {
     }));
   }
 
-  /** Replace the latest root context sample. Subagent calls never touch it. */
-  setRootContext(sessionId: string, sample: ContextUsage): void {
+  /**
+   * Replace the latest root context sample. Subagent calls never touch it.
+   * A null session id (session not yet minted) is dropped — there is no
+   * owner to attach the sample to yet, and the first root step of the
+   * entered session will supply a fresh one.
+   */
+  setRootContext(sessionId: string | null, sample: ContextUsage): void {
+    if (sessionId === null) return;
     this.update(sessionId, (state) => ({
       ...state,
       contextUsage: sample,


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Usage + observability · PR 4 of 12**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#996](https://github.com/pensarai/apex/pull/996) | Session usage models |
| 2 | [#997](https://github.com/pensarai/apex/pull/997) | Session-scoped ownership |
| 3 | [#998](https://github.com/pensarai/apex/pull/998) | Complete usage persistence |
| **4** | **[#999](https://github.com/pensarai/apex/pull/999)** | **Consolidated usage ingestion** · `Current` |
| 5 | [#1000](https://github.com/pensarai/apex/pull/1000) | Token and context footer |
| 6 | [#1002](https://github.com/pensarai/apex/pull/1002) | Cache token breakdown |
| 7 | [#1004](https://github.com/pensarai/apex/pull/1004) | Agent trace contract |
| 8 | [#1005](https://github.com/pensarai/apex/pull/1005) | Optional OTLP runtime |
| 9 | [#1006](https://github.com/pensarai/apex/pull/1006) | Root agent run spans |
| 10 | [#1007](https://github.com/pensarai/apex/pull/1007) | Centralized telemetry settings |
| 11 | [#1008](https://github.com/pensarai/apex/pull/1008) | Telemetry correlation |
| 12 | [#1009](https://github.com/pensarai/apex/pull/1009) | OTLP shutdown hardening |
## Summary

- one accounting path for token usage, in the dashboard's session store:
  - **root steps** (`onStepFinish`) add session tokens **and** replace the root context sample — `usedTokens` = the step's input, denominator from `getContextWindow(runModelId)` where `runModelId` is the model the run actually used
  - **subagent steps** (trace records via `RunTraceSession`) add session tokens only
  - **cache values persist**: root cache flows through `onCacheMetrics`, subagent cache through the trace records — each step's cache counted exactly once
- usage events route to the **run's owning session** (`runSessionIdRef`, set at run start and by `onSessionReady`), never to whichever session happens to be active — late stragglers from a finishing run can no longer land in a different session's totals
- the pentest workflow's local `TokenUsageTotals` accumulator, `addUsageTotals`, and `wrappedOnStepFinish` are removed; its `finally` block writes **runtime only**, so it can no longer clobber the store-persisted usage

## Motivation

T4 of the Narrow Token Stack. Before this PR there were two competing totals: the dashboard's session store (root + subagent steps) and the workflow's own accumulator written to `execution-metrics.json` at workflow end — whichever wrote last won, silently losing the other's counts. Root context usage wasn't sampled at all, so the footer's percentage (T5) had nothing meaningful to read. And the ingestion sink used `activeSessionId`, making late events session-sensitive.

## What changed

**`operator-dashboard/index.tsx`**

- `runSessionIdRef` — the current run's owning session id; set at `runAgent` start (`sessionRef.current?.id ?? session?.id ?? null`) and by `onSessionReady`. All usage recording routes through it.
- `recordTokenUsage` — unchanged signature, now the documented single sink; routes to the run's session.
- `recordRootStepUsage(usage)` — new: records tokens then replaces the root context sample (`usedTokens` = step input, `contextLimit` = `getContextWindow(runModelId)`, `modelId` = the run's model). `onStepFinish` delegates to it.
- `onCacheMetrics` routes cache to the run's session.

**`src/core/ai/ai.ts` / `index.ts`** — `getContextWindow` (the conservative `contextLength ?? 200_000` helper) exported through the barrel.

**`src/core/workflows/pentest.ts`** — the local accumulator trio is deleted; the three phase agents take `onStepFinish` directly (one structural cast where the swarm's narrow signature meets the caller's full callback — the cast the old wrapper performed); the `finally` writes `runtime` only, and the T3 merge semantics retain the store-written usage.

**`session-usage.ts`** — `setRootContext` accepts a null session id and drops the sample (a pre-mint root step has no owner; the session's first post-mint root step supplies a fresh sample).

## Behavior notes

- per-step cache no longer depends on ordering: root steps count input/output at `onStepFinish` with cache arriving via `onCacheMetrics` (which fires synchronously earlier in the same step), subagent steps carry cache in their trace records — both accumulate into the same totals
- the workflow's runtime persistence is preserved exactly; only its competing usage write is gone

## Test coverage

3 new tests:

- **store**: a context sample with no owning session is dropped (no leak into the first entered session); late subagent tokens route to the run's session while another session is active
- **metrics**: a runtime-only write (the workflow's new `finally` path) retains prior usage totals and the context sample

The root/subagent split itself is exercised through the existing store + metrics suites (`accumulateSessionTokens` accumulation, `replaceRootContextUsage` replacement, `hydrateSessionUsage`).

## Validation

- `bun run test` (1,742 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the seven touched files (two pre-existing `noNonNullAssertion` warnings in untouched workflow code)

## Notes

- T5 reads `contextUsage` (now recorded and persisted) for the footer percentage; everything it needs is in place

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how tokens, cache, and context samples are attributed across operator runs, workflows, and subagents; incorrect routing or double-counting would skew session metrics and persisted execution-metrics.
> 
> **Overview**
> **Unifies token and cache accounting** so the operator dashboard’s session store is the primary sink, while headless `runPentestAgent` still accumulates into `execution-metrics.json` without fighting the workflow.
> 
> The operator run path now pins usage to the **run’s session** via `runSessionIdRef` (not the active tab). Root steps use `recordRootStepUsage` to add tokens and refresh **context usage** (`usedTokens` from step input, limit from exported `getContextWindow`). Cache metrics follow the same session routing.
> 
> **Removes the pentest workflow’s parallel token totals** (`TokenUsageTotals` / `wrappedOnStepFinish`); discovery, swarm, and plan agents receive `onStepFinish` / `onCacheMetrics` directly, and the workflow `finally` block persists **runtime only** so it no longer overwrites store-written usage.
> 
> **Adds opt-in callback forwarding for spawned agents**: `forwardUsageCallbacksToSpawnedAgents` gates whether `onStepFinish` / `onCacheMetrics` reach `createAllTools` and worker constructors (default off for operator/trace accounting; enabled for swarm workers and propagated through `spawn_pentest_agent` / `spawn_pentest_swarm`). `ToolContext` and `PentestAgentInput` carry the new callbacks and flag.
> 
> `SessionUsageStore.setRootContext` ignores a null session id (pre-mint steps). New tests cover forwarding, headless persistence, runtime-only metrics writes, and session routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 305a16a200f0ff218432b1380e49d22dcc9a7455. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


