### PR TITLE
feat(usage): rewrite footer with explicit token and context labels

### DIFF
--- a/src/tui/components/footer.tsx
+++ b/src/tui/components/footer.tsx
@@ -1,31 +1,16 @@
 import os from "node:os";
-import type { RGBA } from "@opentui/core";
 import { useAgent } from "../context/agent";
 import { useDimensions } from "../context/dimensions";
 import { useInput } from "../context/input";
 import { useObfuscation } from "../context/obfuscation";
 import { useSession } from "../context/session";
+import { useActiveSessionUsage } from "../context/session-usage";
 import { useTheme } from "../theme";
-import { withAlpha } from "./loaders";
+import { buildUsageFooterLabels } from "./usage-labels";
 
 interface FooterProps {
   cwd?: string;
   showExitWarning?: boolean;
-}
-
-function formatTokenCount(count: number): string {
-  // Drop the trailing `.0` for whole-number K/M values so round counts
-  // render as `200K` / `1M` instead of `200.0K` / `1.0M`. Fractional
-  // values keep one decimal (`1.2K`, `1.5M`).
-  if (count >= 1_000_000) {
-    const v = count / 1_000_000;
-    return `${Number.isInteger(v) ? v.toFixed(0) : v.toFixed(1)}M`;
-  }
-  if (count >= 1000) {
-    const v = count / 1000;
-    return `${Number.isInteger(v) ? v.toFixed(0) : v.toFixed(1)}K`;
-  }
-  return count.toString();
 }
 
 export default function Footer({
@@ -90,99 +75,27 @@ export default function Footer({
 
 function AgentStatus() {
   const { colors } = useTheme();
-  const { tokenUsage } = useAgent();
+  const { usageStore } = useAgent();
   const { width: termWidth } = useDimensions();
-  const showTokenCount = termWidth > 85;
+  const usage = useActiveSessionUsage(usageStore);
 
-  const tokenLabel = `↓${formatTokenCount(tokenUsage.inputTokens)} ↑${formatTokenCount(tokenUsage.outputTokens)}${tokenUsage.cachedTokens > 0 ? ` ⚡${formatTokenCount(tokenUsage.cachedTokens)}` : ""} Σ${formatTokenCount(tokenUsage.totalTokens)}`;
+  const { tokensLabel, contextLabel } = buildUsageFooterLabels({
+    tokenUsage: usage.tokenUsage,
+    contextUsage: usage.contextUsage,
+    width: termWidth,
+  });
+
+  if (!tokensLabel) return null;
 
   return (
     <box flexDirection="row" gap={1}>
-      {showTokenCount && (
+      <text fg={colors.text}>{tokensLabel}</text>
+      {contextLabel && (
         <>
-          <box border={["right"]} borderColor={colors.primary} />
-          <text fg={colors.text}>{tokenLabel}</text>
-          <box border={["right"]} borderColor={colors.primary} />
+          <text fg={colors.textMuted}>|</text>
+          <text fg={colors.text}>{contextLabel}</text>
         </>
       )}
-      <ContextProgress width={16} showPercent={true} />
-    </box>
-  );
-}
-
-const FILL_CHAR = "▬";
-const DASH_CHAR = "─";
-
-/**
- * `[ ███████  42% ─────]` style progress bar showing how much of the
- * model's context window has been consumed. The label is centered
- * inside the bracketed track and switches foreground color depending
- * on whether it sits over the filled or unfilled portion so it stays
- * legible at any progress level.
- *
- * @param width        Total cells including brackets.
- * @param showPercent  When true, prefix the label with `NN% ` so the
- *                     usage percentage is rendered alongside the
- *                     context window size.
- */
-function ContextProgress({
-  width = 20,
-  showPercent = false,
-}: {
-  width?: number;
-  showPercent?: boolean;
-}) {
-  const { colors } = useTheme();
-  const { model, tokenUsage } = useAgent();
-
-  const contextLength = model.contextLength ?? 200_000;
-  const fraction = Math.max(
-    0,
-    Math.min(1, tokenUsage.totalTokens / contextLength),
-  );
-
-  const inner = Math.max(1, width - 2);
-  const filledCells = Math.round(fraction * inner);
-
-  const fillColor = colors.success;
-
-  const sizeText = formatTokenCount(contextLength);
-  const labelText = showPercent
-    ? `${Math.floor(fraction * 100)}% ${sizeText}`
-    : sizeText;
-  const labelLen = labelText.length;
-  // Right-aligned with a 1-cell breathing space from the closing bracket.
-  const labelStart = Math.max(0, inner - labelLen - 1);
-  const labelEnd = labelStart + labelLen;
-
-  const dashColor = withAlpha(colors.textMuted, 0.35);
-  const bracketColor = withAlpha(colors.textMuted, 0.7);
-
-  type Cell = { ch: string; fg: RGBA };
-  const cells: Cell[] = [];
-  cells.push({ ch: "[", fg: bracketColor });
-  for (let col = 0; col < inner; col++) {
-    const inLabel = col >= labelStart && col < labelEnd;
-    const isFilled = col < filledCells;
-    if (inLabel) {
-      cells.push({
-        ch: labelText[col - labelStart]!,
-        fg: colors.text,
-      });
-    } else if (isFilled) {
-      cells.push({ ch: FILL_CHAR, fg: fillColor });
-    } else {
-      cells.push({ ch: DASH_CHAR, fg: dashColor });
-    }
-  }
-  cells.push({ ch: "]", fg: bracketColor });
-
-  return (
-    <box flexDirection="row">
-      {cells.map((cell, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: positional progress-bar cells, never reorder
-        <text key={i} fg={cell.fg} content={cell.ch} />
-      ))}
     </box>
   );
 }

--- a/src/tui/components/loaders.tsx
+++ b/src/tui/components/loaders.tsx
@@ -51,7 +51,7 @@ function useTick(): number {
   return tick;
 }
 
-export function withAlpha(base: RGBA, alpha: number): RGBA {
+function withAlpha(base: RGBA, alpha: number): RGBA {
   return RGBA.fromInts(
     Math.round(base.r * 255),
     Math.round(base.g * 255),

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -162,7 +162,6 @@ export default function OperatorDashboard({
     isModelUserSelected,
     setThinking,
     setIsExecuting,
-    tokenUsage,
     usageStore,
     markExecuted,
     setSessionCwd,

--- a/src/tui/components/usage-labels.test.ts
+++ b/src/tui/components/usage-labels.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import type { ContextUsage, SessionTokenUsage } from "../../core/session/usage";
+import { buildUsageFooterLabels, formatTokenCount } from "./usage-labels";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const usage: SessionTokenUsage = {
+  inputTokens: 123_000,
+  outputTokens: 18_000,
+  cacheReadTokens: 90_000,
+  cacheWriteTokens: 4_000,
+};
+
+const context: ContextUsage = {
+  usedTokens: 84_000,
+  contextLimit: 200_000,
+  modelId: "claude-sonnet-4-5",
+};
+
+// ---------------------------------------------------------------------------
+// formatTokenCount
+// ---------------------------------------------------------------------------
+
+describe("formatTokenCount", () => {
+  it("uses lowercase k/m units with trailing .0 dropped", () => {
+    expect(formatTokenCount(0)).toBe("0");
+    expect(formatTokenCount(999)).toBe("999");
+    expect(formatTokenCount(1000)).toBe("1k");
+    expect(formatTokenCount(123_000)).toBe("123k");
+    expect(formatTokenCount(141_500)).toBe("141.5k");
+    expect(formatTokenCount(1_000_000)).toBe("1m");
+    expect(formatTokenCount(1_200_000)).toBe("1.2m");
+    expect(formatTokenCount(200_000)).toBe("200k");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildUsageFooterLabels — wide mode
+// ---------------------------------------------------------------------------
+
+describe("buildUsageFooterLabels wide", () => {
+  it("renders the explicit labeled form", () => {
+    const labels = buildUsageFooterLabels({
+      tokenUsage: usage,
+      contextUsage: context,
+      width: 120,
+    });
+    expect(labels.tokensLabel).toBe("in 123k  out 18k  cached 90k");
+    expect(labels.contextLabel).toBe("context 42% / 200k");
+  });
+
+  it("omits the cached segment when cache reads are zero", () => {
+    const labels = buildUsageFooterLabels({
+      tokenUsage: { ...usage, cacheReadTokens: 0 },
+      contextUsage: context,
+      width: 120,
+    });
+    expect(labels.tokensLabel).toBe("in 123k  out 18k");
+  });
+
+  it("never adds cache tokens into the totals (cache rides inside input)", () => {
+    // input 123k includes the 90k cached — the label shows both, no sum.
+    const labels = buildUsageFooterLabels({
+      tokenUsage: usage,
+      contextUsage: context,
+      width: 120,
+    });
+    expect(labels.tokensLabel).toContain("in 123k");
+    expect(labels.tokensLabel).toContain("cached 90k");
+  });
+
+  it("hides the context segment until a root step has completed", () => {
+    const labels = buildUsageFooterLabels({
+      tokenUsage: usage,
+      contextUsage: null,
+      width: 120,
+    });
+    expect(labels.contextLabel).toBeNull();
+    expect(labels.tokensLabel).toBe("in 123k  out 18k  cached 90k");
+  });
+
+  it("hides the context segment for a zero-limit sample", () => {
+    const labels = buildUsageFooterLabels({
+      tokenUsage: usage,
+      contextUsage: { usedTokens: 10, contextLimit: 0, modelId: "m" },
+      width: 120,
+    });
+    expect(labels.contextLabel).toBeNull();
+  });
+
+  it("floors the percentage and formats the sampled limit", () => {
+    const labels = buildUsageFooterLabels({
+      tokenUsage: usage,
+      contextUsage: {
+        usedTokens: 199_999,
+        contextLimit: 200_000,
+        modelId: "m",
+      },
+      width: 120,
+    });
+    expect(labels.contextLabel).toBe("context 99% / 200k");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildUsageFooterLabels — narrow mode
+// ---------------------------------------------------------------------------
+
+describe("buildUsageFooterLabels narrow", () => {
+  it("renders the compact total form", () => {
+    const labels = buildUsageFooterLabels({
+      tokenUsage: usage,
+      contextUsage: context,
+      width: 70,
+    });
+    // 123k in + 18k out; cache is inside input and not added again.
+    expect(labels.tokensLabel).toBe("141k tokens");
+    expect(labels.contextLabel).toBe("42% / 200k");
+  });
+
+  it("hides context with no sample", () => {
+    const labels = buildUsageFooterLabels({
+      tokenUsage: usage,
+      contextUsage: null,
+      width: 70,
+    });
+    expect(labels.tokensLabel).toBe("141k tokens");
+    expect(labels.contextLabel).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Width gating
+// ---------------------------------------------------------------------------
+
+describe("buildUsageFooterLabels width gating", () => {
+  it("hides everything below the narrow threshold", () => {
+    const labels = buildUsageFooterLabels({
+      tokenUsage: usage,
+      contextUsage: context,
+      width: 55,
+    });
+    expect(labels.tokensLabel).toBeNull();
+    expect(labels.contextLabel).toBeNull();
+  });
+
+  it("narrow at the boundary, wide at the wide boundary", () => {
+    const narrow = buildUsageFooterLabels({
+      tokenUsage: usage,
+      contextUsage: context,
+      width: 85,
+    });
+    expect(narrow.tokensLabel).toBe("141k tokens");
+    const wide = buildUsageFooterLabels({
+      tokenUsage: usage,
+      contextUsage: context,
+      width: 86,
+    });
+    expect(wide.tokensLabel).toBe("in 123k  out 18k  cached 90k");
+  });
+
+  it("zero usage still renders token labels (durable totals, honest zeros)", () => {
+    const labels = buildUsageFooterLabels({
+      tokenUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      },
+      contextUsage: null,
+      width: 120,
+    });
+    expect(labels.tokensLabel).toBe("in 0  out 0");
+    expect(labels.contextLabel).toBeNull();
+  });
+});

--- a/src/tui/components/usage-labels.test.ts
+++ b/src/tui/components/usage-labels.test.ts
@@ -102,6 +102,19 @@ describe("buildUsageFooterLabels wide", () => {
     });
     expect(labels.contextLabel).toBe("context 99% / 200k");
   });
+
+  it("caps the context percentage at one hundred", () => {
+    const labels = buildUsageFooterLabels({
+      tokenUsage: usage,
+      contextUsage: {
+        usedTokens: 300_000,
+        contextLimit: 200_000,
+        modelId: "m",
+      },
+      width: 120,
+    });
+    expect(labels.contextLabel).toBe("context 100% / 200k");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tui/components/usage-labels.ts
+++ b/src/tui/components/usage-labels.ts
@@ -1,0 +1,73 @@
+import type { ContextUsage, SessionTokenUsage } from "../../core/session/usage";
+
+// ---------------------------------------------------------------------------
+// Usage footer labels — pure formatting for the token/context display:
+//   wide:    in 123k  out 18k  cached 90k  |  context 42% / 200k
+//   narrow:  141k tokens  |  42% / 200k
+// Cache-read tokens are already part of input and are never added again;
+// cache-write tokens stay persisted but are not displayed. The context
+// percentage uses the latest root call's sample — its limit comes from the
+// model that call ran on, not the currently selected model — and stays
+// hidden until a root step has completed.
+// ---------------------------------------------------------------------------
+
+const WIDE_MIN_WIDTH = 86;
+const NARROW_MIN_WIDTH = 56;
+
+export function formatTokenCount(count: number): string {
+  if (count >= 1_000_000) {
+    const v = count / 1_000_000;
+    return `${Number.isInteger(v) ? v.toFixed(0) : v.toFixed(1)}m`;
+  }
+  if (count >= 1000) {
+    const v = count / 1000;
+    return `${Number.isInteger(v) ? v.toFixed(0) : v.toFixed(1)}k`;
+  }
+  return count.toString();
+}
+
+export interface UsageFooterLabels {
+  /** Null when the terminal is too narrow to show anything. */
+  tokensLabel: string | null;
+  /** Null until a root step has completed (no sample) or too narrow. */
+  contextLabel: string | null;
+}
+
+export function buildUsageFooterLabels(input: {
+  tokenUsage: SessionTokenUsage;
+  contextUsage: ContextUsage | null;
+  width: number;
+}): UsageFooterLabels {
+  const { tokenUsage, contextUsage, width } = input;
+  if (width < NARROW_MIN_WIDTH) {
+    return { tokensLabel: null, contextLabel: null };
+  }
+
+  if (width >= WIDE_MIN_WIDTH) {
+    let tokensLabel = `in ${formatTokenCount(tokenUsage.inputTokens)}  out ${formatTokenCount(tokenUsage.outputTokens)}`;
+    if (tokenUsage.cacheReadTokens > 0) {
+      tokensLabel += `  cached ${formatTokenCount(tokenUsage.cacheReadTokens)}`;
+    }
+    // Cache is already inside input; the total is in + out.
+    return {
+      tokensLabel,
+      contextLabel: contextLabel(contextUsage, true),
+    };
+  }
+
+  const total = tokenUsage.inputTokens + tokenUsage.outputTokens;
+  return {
+    tokensLabel: `${formatTokenCount(total)} tokens`,
+    contextLabel: contextLabel(contextUsage, false),
+  };
+}
+
+function contextLabel(
+  context: ContextUsage | null,
+  wide: boolean,
+): string | null {
+  if (!context || context.contextLimit <= 0) return null;
+  const pct = Math.floor((context.usedTokens / context.contextLimit) * 100);
+  const limit = formatTokenCount(context.contextLimit);
+  return wide ? `context ${pct}% / ${limit}` : `${pct}% / ${limit}`;
+}

--- a/src/tui/components/usage-labels.ts
+++ b/src/tui/components/usage-labels.ts
@@ -1,4 +1,8 @@
-import type { ContextUsage, SessionTokenUsage } from "../../core/session/usage";
+import {
+  type ContextUsage,
+  contextPercentage,
+  type SessionTokenUsage,
+} from "../../core/session/usage";
 
 // ---------------------------------------------------------------------------
 // Usage footer labels — pure formatting for the token/context display:
@@ -66,8 +70,9 @@ function contextLabel(
   context: ContextUsage | null,
   wide: boolean,
 ): string | null {
-  if (!context || context.contextLimit <= 0) return null;
-  const pct = Math.floor((context.usedTokens / context.contextLimit) * 100);
+  const percentage = contextPercentage(context);
+  if (percentage === null || !context) return null;
+  const pct = Math.floor(percentage);
   const limit = formatTokenCount(context.contextLimit);
   return wide ? `context ${pct}% / ${limit}` : `${pct}% / ${limit}`;
 }

--- a/src/tui/context/agent.tsx
+++ b/src/tui/context/agent.tsx
@@ -23,15 +23,7 @@ import {
   getDefaultModelForConfig,
 } from "../../core/providers/utils";
 import { useConfig } from "./config";
-import { SessionUsageStore, useActiveSessionUsage } from "./session-usage";
-
-interface TokenUsage {
-  inputTokens: number;
-  outputTokens: number;
-  totalTokens: number;
-  cachedTokens: number;
-  cacheWriteTokens: number;
-}
+import { SessionUsageStore } from "./session-usage";
 
 interface AgentContextValue {
   model: ModelInfo;
@@ -42,8 +34,7 @@ interface AgentContextValue {
    */
   setModel: (model: ModelInfo, persist?: boolean) => void;
   isModelUserSelected: boolean;
-  tokenUsage: TokenUsage;
-  /** Session-scoped usage ownership (T2): per-session totals + context sample. */
+  /** Session-scoped usage ownership: per-session totals + context sample. */
   usageStore: SessionUsageStore;
   /** Marks that an agent step has executed (drives the footer status). */
   markExecuted: () => void;
@@ -85,19 +76,6 @@ export function AgentProvider({ children }: AgentProviderProps) {
   const [isModelUserSelected, setIsModelUserSelected] =
     useState<boolean>(false);
   const usageStore = useMemo(() => new SessionUsageStore(), []);
-  const activeUsage = useActiveSessionUsage(usageStore);
-  const tokenUsage: TokenUsage = useMemo(
-    () => ({
-      inputTokens: activeUsage.tokenUsage.inputTokens,
-      outputTokens: activeUsage.tokenUsage.outputTokens,
-      totalTokens:
-        activeUsage.tokenUsage.inputTokens +
-        activeUsage.tokenUsage.outputTokens,
-      cachedTokens: activeUsage.tokenUsage.cacheReadTokens,
-      cacheWriteTokens: activeUsage.tokenUsage.cacheWriteTokens,
-    }),
-    [activeUsage],
-  );
   const [hasExecuted, setHasExecuted] = useState<boolean>(false);
   const [thinking, setThinking] = useState<boolean>(false);
   const [reasoningEnabled, setReasoningEnabledInternal] = useState<boolean>(
@@ -235,7 +213,6 @@ export function AgentProvider({ children }: AgentProviderProps) {
       model,
       setModel,
       isModelUserSelected,
-      tokenUsage,
       usageStore,
       markExecuted,
       hasExecuted,
@@ -254,7 +231,6 @@ export function AgentProvider({ children }: AgentProviderProps) {
       model,
       setModel,
       isModelUserSelected,
-      tokenUsage,
       hasExecuted,
       thinking,
       reasoningEnabled,


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Usage + observability · PR 5 of 12**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#996](https://github.com/pensarai/apex/pull/996) | Session usage models |
| 2 | [#997](https://github.com/pensarai/apex/pull/997) | Session-scoped ownership |
| 3 | [#998](https://github.com/pensarai/apex/pull/998) | Complete usage persistence |
| 4 | [#999](https://github.com/pensarai/apex/pull/999) | Consolidated usage ingestion |
| **5** | **[#1000](https://github.com/pensarai/apex/pull/1000)** | **Token and context footer** · `Current` |
| 6 | [#1002](https://github.com/pensarai/apex/pull/1002) | Cache token breakdown |
| 7 | [#1004](https://github.com/pensarai/apex/pull/1004) | Agent trace contract |
| 8 | [#1005](https://github.com/pensarai/apex/pull/1005) | Optional OTLP runtime |
| 9 | [#1006](https://github.com/pensarai/apex/pull/1006) | Root agent run spans |
| 10 | [#1007](https://github.com/pensarai/apex/pull/1007) | Centralized telemetry settings |
| 11 | [#1008](https://github.com/pensarai/apex/pull/1008) | Telemetry correlation |
| 12 | [#1009](https://github.com/pensarai/apex/pull/1009) | OTLP shutdown hardening |
## Summary

- replace the footer's arrow/sigma notation and progress bar with explicit labels:
  - wide terminals (≥86 cols): `in 123k  out 18k  cached 90k  |  context 42% / 200k`
  - narrower terminals (56–85 cols): `141k tokens  |  42% / 200k`
  - below 56 cols: hidden
- the display reads the session usage store (T2): durable session totals, cache reads, and the latest root context sample with its own denominator
- `cached` = cache-read tokens (already inside input, never added again); cache-write tokens stay persisted but are not displayed
- the context percentage comes from the sampled root call — the limit is the model that call ran on, not the currently selected model — and stays hidden until a root step has completed
- `AgentProvider`'s derived `tokenUsage` (the app-global display shape) is deleted; the footer subscribes via `useActiveSessionUsage`

## Motivation

T5 closes the Narrow Token Stack. The old footer showed `↓123K ↑18K ⚡90K Σ141K` with a context bar computed from the *currently selected* model's limit against a *total-tokens* numerator — both wrong for the question users actually ask ("how full is my context right now?"). The new display is the Codex/Claude Code-style information: durable session totals, visible cache usage, and a meaningful current-context percentage.

## What changed

**New: `src/tui/components/usage-labels.ts`** — pure formatting, directly tested:

- `formatTokenCount` — lowercase `k`/`m` units, trailing `.0` dropped
- `buildUsageFooterLabels({tokenUsage, contextUsage, width})` — the two-mode label builder with all the display rules encoded:
  - wide form with per-counter labels; the `cached` segment omitted when cache reads are zero
  - narrow form shows the in+out total (`141k tokens`); cache never added into it
  - context label wide `context 42% / 200k`, narrow `42% / 200k`
  - context hidden with no sample (before the first root step) or a zero limit
  - percentage floored; limit formatted from the sample's own `contextLimit`
  - width gating at 56/86 columns

**`footer.tsx`** — `AgentStatus` renders the labels from `useActiveSessionUsage(usageStore)`; the `ContextProgress` bar, the old `formatTokenCount`, and the `withAlpha` import are deleted. The divider bars around the token label are replaced by the `|` separator in the label itself.

**`agent.tsx`** — the derived `tokenUsage` shape and the `TokenUsage` interface are removed from the provider and context; `usageStore` is the single usage surface.

**`loaders.tsx`** — `withAlpha` un-exported (the bar was its only external consumer; it stays as an internal helper).

## Explicitly removed (per the stack charter)

No dollar tracking, cost estimation, pricing catalogs, provider billing metadata, per-agent breakdown UI, per-step ledgers, retry accounting, or reports/W&B changes — this PR (and the stack) adds none of them.

## Test coverage

12 tests in `usage-labels.test.ts`: unit formatting; the wide form (labels, cached omission, cache-not-added rule); context hiding before the first root step and for zero-limit samples; floored percentage with the sampled limit; the narrow total form; width gating at both boundaries; honest zeros on a fresh session.

## Validation

- `bun run test` (1,754 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the five touched files (one pre-existing warning in untouched code)

## Notes

Stack end state: usage flows one path — steps (root with context sample, subagents without) → `SessionUsageStore` (per-session ownership, run-session routing) → `execution-metrics.json` (full shape, single writer, legacy-compatible) → the footer. Nothing displays money; nothing estimates cost.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only TUI refactor with tested label logic; no auth, billing, or persistence contract changes beyond removing a redundant context field.
> 
> **Overview**
> Replaces the footer’s **↓/↑/⚡/Σ** token line and bracketed **context progress bar** with text labels driven by the session usage store (`useActiveSessionUsage`).
> 
> **Wide terminals (≥86 cols)** show `in … out … cached …` and `context NN% / limit`; **narrow (56–85)** show `…k tokens` and `NN% / limit`; **below 56** the usage strip is hidden. Context % uses the latest root-step sample (that step’s model limit), not the currently selected model, and stays off until a root step completes. Cache-read is shown separately but not double-counted in totals; cache-write stays in persistence only.
> 
> Adds **`usage-labels.ts`** (`formatTokenCount`, `buildUsageFooterLabels`) with unit tests. **`AgentProvider`** drops the derived `tokenUsage` field—callers use `usageStore` directly. **`withAlpha`** is no longer exported from `loaders.tsx` after the bar removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14eca820f1f4a67f0354b3a5971a002e3426dbd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



