### PR TITLE
feat(usage): emit cache token breakdown

### DIFF
--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -114,18 +114,86 @@ export interface UsageStepContext {
   stepSeq?: number;
 }
 
-/** Callback for reporting token usage from AI operations */
-type UsageCallback = (
-  model: string,
+/**
+ * Context attached to every usage report. The cache counters are always
+ * present — zero when the provider supplies none — and are already included
+ * in `inputTokens`:
+ * `uncachedInputTokens = inputTokens - cacheReadTokens - cacheWriteTokens`.
+ */
+export interface UsageCallbackContext extends UsageStepContext {
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}
+
+/** Callback for reporting token usage from AI operations. */
+export type UsageCallback = (
+  modelId: string,
   inputTokens: number,
   outputTokens: number,
-  ctx?: UsageStepContext,
-) => void;
+  context: UsageCallbackContext,
+) => void | Promise<void>;
 let _usageCallback: UsageCallback | null = null;
 
-/** Register a callback to receive token usage reports from all AI operations */
+/** Register a callback to receive token usage reports from all AI operations. */
 export function onUsage(cb: UsageCallback | null): void {
   _usageCallback = cb;
+}
+
+/** Normalized per-step usage: input/output plus cache buckets, provider-agnostic. */
+export interface NormalizedStepUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}
+
+/**
+ * Extract normalized usage from one completed model step. A single function
+ * feeds both `onCacheMetrics` and the usage callback so provider metadata is
+ * never parsed twice. Anthropic's `providerMetadata.anthropic` wins; the
+ * SDK's normalized `usage.inputTokenDetails` is the fallback (Pensar
+ * provider). Input stays inclusive of cached tokens.
+ */
+export function normalizeStepUsage(step: {
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    inputTokenDetails?: {
+      cacheReadTokens?: number;
+      cacheWriteTokens?: number;
+    };
+  };
+  providerMetadata?: unknown;
+}): NormalizedStepUsage {
+  const inputTokens = step.usage?.inputTokens ?? 0;
+  const outputTokens = step.usage?.outputTokens ?? 0;
+
+  // Extract Anthropic cache metrics from providerMetadata (direct Anthropic / Bedrock SDK)
+  const meta = (
+    step.providerMetadata as
+      | { anthropic?: Record<string, unknown> }
+      | null
+      | undefined
+  )?.anthropic;
+  let cacheRead = (meta?.cacheReadInputTokens as number) ?? 0;
+  let cacheWrite = (meta?.cacheCreationInputTokens as number) ?? 0;
+
+  // Pensar provider doesn't populate providerMetadata.anthropic;
+  // fall back to the SDK's normalized usage.inputTokenDetails.
+  const details = step.usage?.inputTokenDetails;
+  if (cacheRead === 0) {
+    cacheRead = details?.cacheReadTokens ?? 0;
+  }
+  if (cacheWrite === 0) {
+    cacheWrite = details?.cacheWriteTokens ?? 0;
+  }
+
+  return {
+    inputTokens,
+    outputTokens,
+    cacheReadTokens: cacheRead,
+    cacheWriteTokens: cacheWrite,
+  };
 }
 
 // Per-run step counter for billing attribution, scoped via AsyncLocalStorage so
@@ -977,17 +1045,38 @@ export function streamResponse(
     sessionId,
   } = opts;
 
-  // Wrap onStepFinish to fire usage callback for every step.
-  // Must be async so that callers returning a Promise (e.g. persistence /
-  // issue queuing) are fully awaited before the AI SDK starts the next step.
+  // Wrap onStepFinish to fire cache metrics and the usage callback for every
+  // step. Must be async so that callers returning a Promise (persistence,
+  // issue queuing, or the usage callback itself) are fully awaited before
+  // the AI SDK starts the next step. One normalization feeds both sinks —
+  // provider metadata is never parsed twice.
   const onStepFinish: typeof userOnStepFinish = async (step) => {
+    const stepUsage = normalizeStepUsage(step);
+    if (
+      onCacheMetrics &&
+      (stepUsage.cacheReadTokens > 0 || stepUsage.cacheWriteTokens > 0)
+    ) {
+      await onCacheMetrics({
+        cacheReadInputTokens: stepUsage.cacheReadTokens,
+        cacheCreationInputTokens: stepUsage.cacheWriteTokens,
+      });
+    }
     await userOnStepFinish?.(step);
     if (_usageCallback) {
-      const inp = step.usage?.inputTokens ?? 0;
-      const out = step.usage?.outputTokens ?? 0;
       // Advance stepSeq every finished step (even zero-usage) to stay aligned with the AI-SDK step index.
       const stepCtx = takeStepContext();
-      if (inp > 0 || out > 0) _usageCallback(model, inp, out, stepCtx);
+      if (stepUsage.inputTokens > 0 || stepUsage.outputTokens > 0) {
+        await _usageCallback(
+          model,
+          stepUsage.inputTokens,
+          stepUsage.outputTokens,
+          {
+            ...stepCtx,
+            cacheReadTokens: stepUsage.cacheReadTokens,
+            cacheWriteTokens: stepUsage.cacheWriteTokens,
+          },
+        );
+      }
     }
   };
   const providerModel = getProviderModel(model, authConfig);
@@ -1143,34 +1232,7 @@ export function streamResponse(
         }
         throw error;
       },
-      onStepFinish: onCacheMetrics
-        ? (stepResult) => {
-            // Extract Anthropic cache metrics from providerMetadata (direct Anthropic / Bedrock SDK)
-            const meta = stepResult.providerMetadata?.anthropic as
-              | Record<string, unknown>
-              | undefined;
-            let cacheRead = (meta?.cacheReadInputTokens as number) ?? 0;
-            let cacheCreation = (meta?.cacheCreationInputTokens as number) ?? 0;
-
-            // Pensar provider doesn't populate providerMetadata.anthropic;
-            // fall back to the SDK's normalized usage.inputTokenDetails.
-            const { inputTokenDetails } = stepResult.usage;
-            if (cacheRead === 0) {
-              cacheRead = inputTokenDetails?.cacheReadTokens ?? 0;
-            }
-            if (cacheCreation === 0) {
-              cacheCreation = inputTokenDetails?.cacheWriteTokens ?? 0;
-            }
-
-            if (cacheRead > 0 || cacheCreation > 0) {
-              onCacheMetrics({
-                cacheReadInputTokens: cacheRead,
-                cacheCreationInputTokens: cacheCreation,
-              });
-            }
-            onStepFinish?.(stepResult);
-          }
-        : onStepFinish,
+      onStepFinish,
       abortSignal,
       activeTools,
       experimental_repairToolCall: async ({
@@ -1427,7 +1489,7 @@ export async function generateObjectResponse<T extends z.ZodType>(
   for (let attempt = 0; attempt <= MAX_OBJECT_RATE_LIMIT_RETRIES; attempt++) {
     try {
       const recordPayloads = shouldRecordAiPayloads();
-      const { output, usage } = await generateText({
+      const { output, usage, providerMetadata } = await generateText({
         model: providerModel,
         output: Output.object({
           schema,
@@ -1459,10 +1521,20 @@ export async function generateObjectResponse<T extends z.ZodType>(
       }
 
       if (_usageCallback && usage) {
-        const inp = usage.inputTokens ?? 0;
-        const out = usage.outputTokens ?? 0;
+        const stepUsage = normalizeStepUsage({ usage, providerMetadata });
         const stepCtx = takeStepContext();
-        if (inp > 0 || out > 0) _usageCallback(model, inp, out, stepCtx);
+        if (stepUsage.inputTokens > 0 || stepUsage.outputTokens > 0) {
+          await _usageCallback(
+            model,
+            stepUsage.inputTokens,
+            stepUsage.outputTokens,
+            {
+              ...stepCtx,
+              cacheReadTokens: stepUsage.cacheReadTokens,
+              cacheWriteTokens: stepUsage.cacheWriteTokens,
+            },
+          );
+        }
       }
 
       // zod v4: the AI SDK's `Output.object` no longer carries the schema's

--- a/src/core/ai/usage-callback.test.ts
+++ b/src/core/ai/usage-callback.test.ts
@@ -1,0 +1,481 @@
+// Tests for the cache-aware usage callback (T6): every usage report carries
+// cache-read and cache-write counters (zero when the provider supplies
+// none), inputTokens stays inclusive of cached tokens, one normalization
+// feeds both onCacheMetrics and the usage callback, and async callbacks are
+// awaited before the step settles.
+
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import { simulateReadableStream, stepCountIs } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { generateObjectResponse, normalizeStepUsage, onUsage } from "./ai";
+
+// getProviderModel is patched so no provider keys are needed — the mock
+// model serves protocol parts directly.
+const mockState: { model: MockLanguageModelV3 | null } = { model: null };
+vi.mock("./utils", async () => {
+  const actual = await vi.importActual<typeof import("./utils")>("./utils");
+  return {
+    ...actual,
+    getProviderModel: () => {
+      if (!mockState.model) throw new Error("mock model not set");
+      return mockState.model;
+    },
+  };
+});
+
+// Imported AFTER vi.mock so streamResponse/generateObjectResponse closures
+// pick up the stubbed getProviderModel.
+const { streamResponse } = await import("./ai");
+
+// ---------------------------------------------------------------------------
+// Mock fixtures
+// ---------------------------------------------------------------------------
+
+interface StepUsageSpec {
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    inputTokenDetails?: {
+      cacheReadTokens?: number;
+      cacheWriteTokens?: number;
+    };
+  };
+  providerMetadata?: Record<string, unknown>;
+}
+
+function textStepChunks(spec: StepUsageSpec): Array<Record<string, unknown>> {
+  // The v3 protocol carries nested usage; the SDK normalizes it into the
+  // inclusive inputTokens + inputTokenDetails the normalizer reads.
+  const cacheRead = spec.usage.inputTokenDetails?.cacheReadTokens ?? 0;
+  const cacheWrite = spec.usage.inputTokenDetails?.cacheWriteTokens ?? 0;
+  return [
+    { type: "stream-start", warnings: [] },
+    { type: "text-start", id: "txt-1" },
+    { type: "text-delta", id: "txt-1", delta: "hi" },
+    { type: "text-end", id: "txt-1" },
+    {
+      type: "finish",
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: {
+        inputTokens: {
+          total: spec.usage.inputTokens,
+          noCache: spec.usage.inputTokens - cacheRead - cacheWrite,
+          cacheRead,
+          cacheWrite,
+        },
+        outputTokens: { total: spec.usage.outputTokens },
+      },
+      ...(spec.providerMetadata
+        ? { providerMetadata: spec.providerMetadata }
+        : {}),
+    },
+  ];
+}
+
+function oneStepModel(spec: StepUsageSpec): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doStream: async () => ({
+      stream: simulateReadableStream({
+        chunks: textStepChunks(
+          spec,
+        ) as unknown as Array<LanguageModelV3StreamPart>,
+      }),
+    }),
+  });
+}
+
+type UsageCall = {
+  modelId: string;
+  inputTokens: number;
+  outputTokens: number;
+  context: {
+    sessionId?: string;
+    stepSeq?: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+  };
+};
+
+function setupUsageCallback(): UsageCall[] {
+  const calls: UsageCall[] = [];
+  onUsage((modelId, inputTokens, outputTokens, context) => {
+    calls.push({ modelId, inputTokens, outputTokens, context });
+  });
+  return calls;
+}
+
+async function drain(stream: { fullStream: AsyncIterable<unknown> }) {
+  for await (const _part of stream.fullStream) {
+    // drain
+  }
+}
+
+const MODEL = "claude-haiku-4-5";
+
+afterEach(() => {
+  onUsage(null);
+  mockState.model = null;
+});
+
+// ---------------------------------------------------------------------------
+// streamResponse — cache counters on the usage callback
+// ---------------------------------------------------------------------------
+
+describe("usage callback cache breakdown (streamResponse)", () => {
+  it("no-cache usage emits both cache fields as zero", async () => {
+    mockState.model = oneStepModel({
+      usage: { inputTokens: 100, outputTokens: 20 },
+    });
+    const calls = setupUsageCallback();
+
+    await drain(streamResponse({ prompt: "hi", model: MODEL, silent: true }));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.modelId).toBe(MODEL);
+    expect(calls[0]?.inputTokens).toBe(100);
+    expect(calls[0]?.outputTokens).toBe(20);
+    expect(calls[0]?.context.cacheReadTokens).toBe(0);
+    expect(calls[0]?.context.cacheWriteTokens).toBe(0);
+  });
+
+  it("cache-read usage preserves inclusive input totals", async () => {
+    mockState.model = oneStepModel({
+      usage: { inputTokens: 1000, outputTokens: 50 },
+      providerMetadata: { anthropic: { cacheReadInputTokens: 900 } },
+    });
+    const calls = setupUsageCallback();
+
+    await drain(streamResponse({ prompt: "hi", model: MODEL, silent: true }));
+
+    // 900 of the 1000 input tokens were cache reads — input stays inclusive.
+    expect(calls[0]?.inputTokens).toBe(1000);
+    expect(calls[0]?.context.cacheReadTokens).toBe(900);
+    expect(calls[0]?.context.cacheWriteTokens).toBe(0);
+  });
+
+  it("cache-write usage preserves inclusive input totals", async () => {
+    mockState.model = oneStepModel({
+      usage: { inputTokens: 1000, outputTokens: 50 },
+      providerMetadata: { anthropic: { cacheCreationInputTokens: 400 } },
+    });
+    const calls = setupUsageCallback();
+
+    await drain(streamResponse({ prompt: "hi", model: MODEL, silent: true }));
+
+    expect(calls[0]?.inputTokens).toBe(1000);
+    expect(calls[0]?.context.cacheReadTokens).toBe(0);
+    expect(calls[0]?.context.cacheWriteTokens).toBe(400);
+  });
+
+  it("mixed read/write usage emits both buckets", async () => {
+    mockState.model = oneStepModel({
+      usage: { inputTokens: 1000, outputTokens: 30 },
+      providerMetadata: {
+        anthropic: {
+          cacheReadInputTokens: 900,
+          cacheCreationInputTokens: 100,
+        },
+      },
+    });
+    const calls = setupUsageCallback();
+
+    await drain(streamResponse({ prompt: "hi", model: MODEL, silent: true }));
+
+    expect(calls[0]?.context.cacheReadTokens).toBe(900);
+    expect(calls[0]?.context.cacheWriteTokens).toBe(100);
+    expect(calls[0]?.inputTokens).toBe(1000);
+  });
+
+  it("responses cached input is not added to input twice", async () => {
+    // OpenAI-Responses-style: cached tokens arrive via the SDK's normalized
+    // inputTokenDetails (no anthropic providerMetadata). The cached tokens
+    // are part of the 1000 input tokens — the callback must not report 1800.
+    mockState.model = oneStepModel({
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 20,
+        inputTokenDetails: { cacheReadTokens: 800 },
+      },
+    });
+    const calls = setupUsageCallback();
+
+    await drain(streamResponse({ prompt: "hi", model: MODEL, silent: true }));
+
+    expect(calls[0]?.inputTokens).toBe(1000);
+    expect(calls[0]?.context.cacheReadTokens).toBe(800);
+  });
+
+  it("usage callback fires exactly once per completed model step", async () => {
+    let streamCall = 0;
+    mockState.model = new MockLanguageModelV3({
+      doStream: async () => {
+        streamCall += 1;
+        if (streamCall === 1) {
+          // Step 1: a tool call (usage arrives with the finish part).
+          return {
+            stream: simulateReadableStream({
+              chunks: [
+                { type: "stream-start", warnings: [] },
+                { type: "tool-input-start", id: "call-1", toolName: "probe" },
+                { type: "tool-input-delta", id: "call-1", delta: "{}" },
+                { type: "tool-input-end", id: "call-1" },
+                {
+                  type: "tool-call",
+                  toolCallId: "call-1",
+                  toolName: "probe",
+                  input: "{}",
+                },
+                {
+                  type: "finish",
+                  finishReason: { unified: "tool-calls", raw: "tool_use" },
+                  usage: {
+                    inputTokens: {
+                      total: 100,
+                      noCache: 100,
+                      cacheRead: 0,
+                      cacheWrite: 0,
+                    },
+                    outputTokens: { total: 10 },
+                  },
+                },
+              ] as unknown as Array<LanguageModelV3StreamPart>,
+            }),
+          };
+        }
+        // Step 2: plain text finish.
+        return {
+          stream: simulateReadableStream({
+            chunks: [
+              { type: "stream-start", warnings: [] },
+              { type: "text-start", id: "txt-2" },
+              { type: "text-delta", id: "txt-2", delta: "done" },
+              { type: "text-end", id: "txt-2" },
+              {
+                type: "finish",
+                finishReason: { unified: "stop", raw: "stop" },
+                usage: {
+                  inputTokens: {
+                    total: 200,
+                    noCache: 200,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                  },
+                  outputTokens: { total: 5 },
+                },
+              },
+            ] as unknown as Array<LanguageModelV3StreamPart>,
+          }),
+        };
+      },
+    });
+    const calls = setupUsageCallback();
+
+    await drain(
+      streamResponse({
+        prompt: "hi",
+        model: MODEL,
+        silent: true,
+        tools: {
+          probe: {
+            description: "test tool",
+            inputSchema: z.object({}),
+            execute: async () => "ok",
+          },
+        },
+        stopWhen: stepCountIs(2),
+      }),
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(calls.map((c) => c.inputTokens)).toEqual([100, 200]);
+  });
+
+  it("a deferred async usage callback is awaited before the step settles", async () => {
+    mockState.model = oneStepModel({
+      usage: { inputTokens: 100, outputTokens: 10 },
+    });
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const seen: number[] = [];
+    onUsage(async (_modelId, inputTokens) => {
+      await gate;
+      seen.push(inputTokens);
+    });
+
+    const result = streamResponse({ prompt: "hi", model: MODEL, silent: true });
+    let drained = false;
+    const consumed = (async () => {
+      await drain(result);
+      drained = true;
+    })();
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    // The step cannot settle while the usage callback is pending.
+    expect(drained).toBe(false);
+    expect(seen).toHaveLength(0);
+
+    release();
+    await consumed;
+    expect(drained).toBe(true);
+    expect(seen).toEqual([100]);
+  });
+
+  it("onCacheMetrics still receives the normalized cache metrics (session-usage path unchanged)", async () => {
+    mockState.model = oneStepModel({
+      usage: { inputTokens: 1000, outputTokens: 30 },
+      providerMetadata: {
+        anthropic: {
+          cacheReadInputTokens: 900,
+          cacheCreationInputTokens: 100,
+        },
+      },
+    });
+    const cacheEvents: Array<{
+      cacheReadInputTokens: number;
+      cacheCreationInputTokens: number;
+    }> = [];
+
+    await drain(
+      streamResponse({
+        prompt: "hi",
+        model: MODEL,
+        silent: true,
+        onCacheMetrics: (m) => {
+          cacheEvents.push(m);
+        },
+      }),
+    );
+
+    expect(cacheEvents).toEqual([
+      { cacheReadInputTokens: 900, cacheCreationInputTokens: 100 },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateObjectResponse — same structure
+// ---------------------------------------------------------------------------
+
+describe("usage callback cache breakdown (generateObjectResponse)", () => {
+  it("emits the same structure with cache from providerMetadata", async () => {
+    mockState.model = new MockLanguageModelV3({
+      doGenerate: async () => ({
+        content: [{ type: "text", text: '{"result":"ok"}' }],
+        finishReason: { unified: "stop", raw: "stop" },
+        warnings: [],
+        usage: {
+          inputTokens: {
+            total: 500,
+            noCache: 100,
+            cacheRead: 400,
+            cacheWrite: 0,
+          },
+          outputTokens: { total: 40, text: undefined, reasoning: undefined },
+        },
+        providerMetadata: { anthropic: { cacheReadInputTokens: 400 } },
+      }),
+    });
+    const calls = setupUsageCallback();
+
+    const output = await generateObjectResponse({
+      model: MODEL,
+      schema: z.object({ result: z.string() }),
+      prompt: "hi",
+    });
+
+    expect(output).toEqual({ result: "ok" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.inputTokens).toBe(500);
+    expect(calls[0]?.outputTokens).toBe(40);
+    expect(calls[0]?.context.cacheReadTokens).toBe(400);
+    expect(calls[0]?.context.cacheWriteTokens).toBe(0);
+  });
+
+  it("emits zero cache counters when the provider supplies none", async () => {
+    mockState.model = new MockLanguageModelV3({
+      doGenerate: async () => ({
+        content: [{ type: "text", text: '{"result":"ok"}' }],
+        finishReason: { unified: "stop", raw: "stop" },
+        warnings: [],
+        usage: {
+          inputTokens: { total: 50, noCache: 50, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 5, text: undefined, reasoning: undefined },
+        },
+      }),
+    });
+    const calls = setupUsageCallback();
+
+    await generateObjectResponse({
+      model: MODEL,
+      schema: z.object({ result: z.string() }),
+      prompt: "hi",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.context.cacheReadTokens).toBe(0);
+    expect(calls[0]?.context.cacheWriteTokens).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeStepUsage — Anthropic normalization and precedence
+// ---------------------------------------------------------------------------
+
+describe("normalizeStepUsage", () => {
+  it("anthropic cache creation and reads normalize correctly", () => {
+    const normalized = normalizeStepUsage({
+      usage: { inputTokens: 1000, outputTokens: 25 },
+      providerMetadata: {
+        anthropic: {
+          cacheReadInputTokens: 700,
+          cacheCreationInputTokens: 300,
+        },
+      },
+    });
+    expect(normalized).toEqual({
+      inputTokens: 1000,
+      outputTokens: 25,
+      cacheReadTokens: 700,
+      cacheWriteTokens: 300,
+    });
+  });
+
+  it("anthropic providerMetadata wins over inputTokenDetails", () => {
+    const normalized = normalizeStepUsage({
+      usage: {
+        inputTokens: 100,
+        outputTokens: 1,
+        inputTokenDetails: { cacheReadTokens: 999, cacheWriteTokens: 999 },
+      },
+      providerMetadata: { anthropic: { cacheReadInputTokens: 10 } },
+    });
+    expect(normalized.cacheReadTokens).toBe(10);
+    // anthropic metadata only supplied the read; the write falls back.
+    expect(normalized.cacheWriteTokens).toBe(999);
+  });
+
+  it("falls back to inputTokenDetails when anthropic metadata is absent", () => {
+    const normalized = normalizeStepUsage({
+      usage: {
+        inputTokens: 100,
+        outputTokens: 1,
+        inputTokenDetails: { cacheReadTokens: 80, cacheWriteTokens: 20 },
+      },
+      providerMetadata: { openai: {} },
+    });
+    expect(normalized.cacheReadTokens).toBe(80);
+    expect(normalized.cacheWriteTokens).toBe(20);
+  });
+
+  it("zeros when the provider supplies nothing", () => {
+    const normalized = normalizeStepUsage({
+      usage: { inputTokens: 10, outputTokens: 2 },
+    });
+    expect(normalized.cacheReadTokens).toBe(0);
+    expect(normalized.cacheWriteTokens).toBe(0);
+  });
+});


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Usage + observability · PR 6 of 12**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#996](https://github.com/pensarai/apex/pull/996) | Session usage models |
| 2 | [#997](https://github.com/pensarai/apex/pull/997) | Session-scoped ownership |
| 3 | [#998](https://github.com/pensarai/apex/pull/998) | Complete usage persistence |
| 4 | [#999](https://github.com/pensarai/apex/pull/999) | Consolidated usage ingestion |
| 5 | [#1000](https://github.com/pensarai/apex/pull/1000) | Token and context footer |
| **6** | **[#1002](https://github.com/pensarai/apex/pull/1002)** | **Cache token breakdown** · `Current` |
| 7 | [#1004](https://github.com/pensarai/apex/pull/1004) | Agent trace contract |
| 8 | [#1005](https://github.com/pensarai/apex/pull/1005) | Optional OTLP runtime |
| 9 | [#1006](https://github.com/pensarai/apex/pull/1006) | Root agent run spans |
| 10 | [#1007](https://github.com/pensarai/apex/pull/1007) | Centralized telemetry settings |
| 11 | [#1008](https://github.com/pensarai/apex/pull/1008) | Telemetry correlation |
| 12 | [#1009](https://github.com/pensarai/apex/pull/1009) | OTLP shutdown hardening |
## Summary

- extend the usage callback so Console receives accurate cache-read and cache-write counts on every report:
  - `UsageCallbackContext` (additive: `sessionId`, `stepSeq`, `cacheReadTokens`, `cacheWriteTokens` — the cache counters always present, zero when the provider supplies none)
  - `UsageCallback` now takes the context as a required parameter and may return a promise — both emission sites `await` it
- one `normalizeStepUsage()` extraction feeds both `onCacheMetrics` and the usage callback — provider metadata is never parsed twice
- both usage paths updated: `streamResponse()` step completion and `generateObjectResponse()` completion
- fixed the cache-enabled `onStepFinish` wrapper so it awaits: `await onCacheMetrics(...)` then `await wrappedOnStepFinish?.(step)` — an async usage callback now finishes before the step settles
- `inputTokens` stays inclusive of cached tokens: `uncachedInputTokens = inputTokens - cacheReadTokens - cacheWriteTokens`

## Motivation

T6 of the Narrow Token Stack. The usage callback is the Console-facing telemetry hook, but it carried only input/output — cache counts were only reachable through `onCacheMetrics`, which the dashboard consumes but Console cannot. Meanwhile the cache extraction lived inline in a conditional `onStepFinish` wrapper that (a) only existed when `onCacheMetrics` was supplied, and (b) never awaited its callbacks — an async usage callback could still be in flight when the step settled. One normalization function + awaited emissions fixes both.

## What changed

**`src/core/ai/ai.ts`**

- `UsageCallbackContext extends UsageStepContext` adding the two cache counters; the contract is documented on the type — cache tokens are already included in `inputTokens`
- `normalizeStepUsage(step)` — exported; extracts input/output plus cache from Anthropic `providerMetadata.anthropic` (direct Anthropic / Bedrock) with the SDK's normalized `usage.inputTokenDetails` as fallback (Pensar provider), exactly the precedence the old inline wrapper used
- `streamResponse`'s step wrapper now normalizes once, `await`s `onCacheMetrics` (when cache > 0), `await`s the user callback, then `await`s `_usageCallback` with the full context — the conditional cache wrapper in the `streamText` options is deleted
- `generateObjectResponse` destructures `providerMetadata` from the `generateText` result and emits the same structure, awaited

**Behavior notes:**

- the usage callback now carries cache counts even when `onCacheMetrics` is not supplied (previously those ran through different code paths)
- `stepSeq` advancement semantics unchanged — advances per finished step when a callback is registered, aligned with the AI-SDK step index
- `onCacheMetrics` still fires only when cache counters are non-zero (unchanged gating)

## Test coverage

14 tests in `usage-callback.test.ts`, driving a real `MockLanguageModelV3` through `streamResponse`/`generateObjectResponse` (with `getProviderModel` patched — no API keys):

- no-cache usage emits both cache fields as zero
- cache-read usage preserves inclusive input totals (anthropic metadata path)
- cache-write usage preserves inclusive input totals
- mixed read/write usage emits both buckets
- Responses-style cached input (`inputTokenDetails` path) is not added to input twice
- `generateObjectResponse()` emits the same structure (with cache, and zeros without)
- usage callback fires exactly once per completed model step — a two-step tool-calling stream yields exactly two reports, one per step
- a deferred async usage callback is awaited — the stream does not drain while the callback's promise is pending
- `onCacheMetrics` still receives the normalized metrics (the session-usage path from T4 is unchanged)
- `normalizeStepUsage` unit tests: anthropic creation/read normalization, anthropic-metadata precedence over `inputTokenDetails`, fallback, zeros

Protocol notes for reviewers: the v3 model protocol carries **nested** usage (`inputTokens: { total, noCache, cacheRead, cacheWrite }`) and object finish reasons (`{ unified, raw }`); the SDK normalizes these into the inclusive `inputTokens` + `inputTokenDetails` the normalizer reads. The fixtures emit the protocol shape, so the tests exercise the real mapping end to end.

## Validation

- `bun run test` (1,768 passed, 22 skipped — all existing session usage, metrics, and footer tests unchanged)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the two touched files

## Non-goals honored

No cost calculation, pricing, Console event changes, request/retry identity, new persistence files, footer changes, or per-agent usage display.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the usage/billing callback contract and step-finish ordering; any `onUsage` registrant must adopt the new required context shape, though miscounting risk is mitigated by tests and unchanged inclusive input semantics.
> 
> **Overview**
> Extends the global **`onUsage`** hook so every billing report includes **cache-read and cache-write token counts** (always present, zero when unknown), while **`inputTokens` stays inclusive** of cached input (`uncached = input - cacheRead - cacheWrite`).
> 
> Introduces **`normalizeStepUsage()`** as the single provider-agnostic extractor (Anthropic `providerMetadata` first, SDK `inputTokenDetails` fallback) and wires it through **`streamResponse`** step completion and **`generateObjectResponse`**, so **`onCacheMetrics`** and the usage callback share one parse. The old conditional `onStepFinish` wrapper for cache metrics is removed; step finish now **`await`s** `onCacheMetrics`, the user callback, and async usage handlers before the next SDK step.
> 
> The **`UsageCallback`** signature changes: required **`UsageCallbackContext`** (session/step attribution plus cache buckets) and optional **`Promise`** return. Adds **`usage-callback.test.ts`** covering streaming, object generation, normalization precedence, per-step firing, and async await semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac327a95599ee33cdaf9f30e652c937508f93ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

