### PR TITLE
feat(cli): surface issueLabel and issue url on issues, fix subcommand --help

### DIFF
--- a/fern/docs/cli/fixes.mdx
+++ b/fern/docs/cli/fixes.mdx
@@ -14,6 +14,10 @@ pensar fixes <issueId>         # List fixes for an issue
 pensar fixes get <fixId>       # Get fix details (includes diff)
 ```
 
+<Note>
+`<issueId>` accepts either the issue UUID or its label — e.g. `VULN-000123`.
+</Note>
+
 ## Prerequisites
 
 You must be connected to Pensar Console via [`pensar login`](/apex/cli-commands/pensar-login) before using this command.
@@ -40,7 +44,7 @@ Returns detailed information about a specific fix, including the code diff.
 
 ```bash
 # List fixes for an issue
-pensar fixes issue_ghi789
+pensar fixes VULN-000123
 
 # Get details and diff for a specific fix
 pensar fixes get fix_jkl012

--- a/fern/docs/cli/issues.mdx
+++ b/fern/docs/cli/issues.mdx
@@ -42,13 +42,13 @@ Each entry carries both identifiers plus a direct link:
 
 ```json
 {
-  "id": "154e9b93-0590-4e9b-953b-eb13fd316675",
-  "issueLabel": "VULN-000157",
+  "id": "11111111-2222-3333-4444-555555555555",
+  "issueLabel": "VULN-000123",
   "title": "SQL Injection in login handler",
   "severity": "critical",
   "status": "open",
   "location": "src/auth/login.ts",
-  "url": "https://console.pensar.dev/acme/VULN-000157"
+  "url": "https://console.pensar.dev/acme/VULN-000123"
 }
 ```
 

--- a/fern/docs/cli/issues.mdx
+++ b/fern/docs/cli/issues.mdx
@@ -38,6 +38,24 @@ pensar issues [filters]
 
 Lists security issues in the selected workspace. Returns a JSON array. Use filters to narrow the results.
 
+Each entry carries both identifiers plus a direct link:
+
+```json
+{
+  "id": "154e9b93-0590-4e9b-953b-eb13fd316675",
+  "issueLabel": "VULN-000157",
+  "title": "SQL Injection in login handler",
+  "severity": "critical",
+  "status": "open",
+  "location": "src/auth/login.ts",
+  "url": "https://console.pensar.dev/acme/VULN-000157"
+}
+```
+
+`issueLabel` is the human-facing reference (`null` only for issues predating
+labels) and `url` opens the issue directly. Either identifier can be passed
+back to any command taking an `<issueId>`.
+
 | Filter              | Description                                                |
 | ------------------- | ---------------------------------------------------------- |
 | `--status <status>` | Filter by: `open`, `closed`, `false-positive`, `in-review` |
@@ -51,7 +69,9 @@ Lists security issues in the selected workspace. Returns a JSON array. Use filte
 pensar issues get <issueId>
 ```
 
-Returns detailed information about a specific issue, including vulnerability description, reproduction steps, and severity.
+Returns detailed information about a specific issue, including vulnerability description, reproduction steps, and severity. The response carries the same `issueLabel` and `url` as the list shape, plus description, line range, CWE, branch, and proof-of-concept.
+
+A reference that is neither a UUID nor a `VULN-…` label is rejected with a 400; a well-formed reference that matches no issue returns a 404.
 
 ### Update an Issue
 
@@ -104,16 +124,16 @@ Returns the pull requests linked to the issue as an array of `{ id, url, status,
 pensar issues --status open --severity critical
 
 # Get details for a specific issue
-pensar issues get issue_ghi789
+pensar issues get VULN-000123
 
 # Close an issue with a reason
-pensar issues update issue_ghi789 --status closed --closed-reason "Patched in v2.1"
+pensar issues update VULN-000123 --status closed --closed-reason "Patched in v2.1"
 
 # Flag as false positive
-pensar issues update issue_ghi789 --false-positive --fp-reason "Test environment only"
+pensar issues update VULN-000123 --false-positive --fp-reason "Test environment only"
 
 # Retest an issue after deploying a fix
-pensar issues retest issue_ghi789
+pensar issues retest VULN-000123
 
 # Reference an issue by its label instead of its UUID
 pensar issues get VULN-000123

--- a/fern/docs/cli/logs.mdx
+++ b/fern/docs/cli/logs.mdx
@@ -14,6 +14,10 @@ pensar logs <issueId> [filters]                 # List agent logs
 pensar logs search <issueId> <query> [options]  # Search agent logs
 ```
 
+<Note>
+`<issueId>` accepts either the issue UUID or its label — e.g. `VULN-000123`.
+</Note>
+
 ## Prerequisites
 
 You must be connected to Pensar Console via [`pensar login`](/apex/cli-commands/pensar-login) before using this command.
@@ -52,19 +56,19 @@ Searches log entries for a given query string.
 
 ```bash
 # List all logs for an issue
-pensar logs issue_ghi789
+pensar logs VULN-000123
 
 # List only error-level logs
-pensar logs issue_ghi789 --level error
+pensar logs VULN-000123 --level error
 
 # List tool call logs with a limit
-pensar logs issue_ghi789 --role tool-call --limit 50
+pensar logs VULN-000123 --role tool-call --limit 50
 
 # Search logs for a specific term
-pensar logs search issue_ghi789 "SQL injection"
+pensar logs search VULN-000123 "SQL injection"
 
 # Search with filters
-pensar logs search issue_ghi789 "timeout" --level warn --context 5
+pensar logs search VULN-000123 "timeout" --level warn --context 5
 ```
 
 ## Related Commands

--- a/src/cli/issues.test.ts
+++ b/src/cli/issues.test.ts
@@ -1,0 +1,53 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CLI = join(import.meta.dirname, "issues.ts");
+
+// Every case below prints help and exits before any API call, so these stay offline.
+function runIssues(args: string[]) {
+  const result = spawnSync("bun", [CLI, ...args], { encoding: "utf8" });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+describe("pensar issues CLI", () => {
+  it("documents issueLabel and the Console url on issue responses", () => {
+    const { status, stdout } = runIssues(["--help"]);
+
+    expect(status).toBe(0);
+    expect(stdout).toContain("issueLabel");
+    expect(stdout).toContain("deep link to the issue in the Console");
+  });
+
+  it.each([
+    "get",
+    "update",
+    "retest",
+    "link-pr",
+    "prs",
+  ])("prints help for `%s --help` instead of treating it as an issue id", (sub) => {
+    const { status, stdout, stderr } = runIssues([sub, "--help"]);
+
+    expect(status).toBe(0);
+    expect(stdout).toContain("pensar issues — Manage security issues");
+    expect(stderr).toBe("");
+  });
+
+  it("prints help for `-h` on a subcommand", () => {
+    const { status, stdout } = runIssues(["update", "-h"]);
+
+    expect(status).toBe(0);
+    expect(stdout).toContain("pensar issues — Manage security issues");
+  });
+
+  it("still requires an issue ID when help was not requested", () => {
+    const { status, stderr } = runIssues(["get"]);
+
+    expect(status).toBe(1);
+    expect(stderr).toContain("Usage: pensar issues get <issueId>");
+  });
+});

--- a/src/cli/issues.ts
+++ b/src/cli/issues.ts
@@ -43,6 +43,9 @@ Usage:
 
 <issueId> accepts the issue UUID or its label (e.g. VULN-000123).
 
+Issue responses include "issueLabel" (e.g. VULN-000123, null for issues created
+before labels existed) and "url", a deep link to the issue in the Console.
+
 List filters:
   --status <status>     Filter: open, closed, false-positive, in-review
   --severity <sev>      Filter: critical, high, medium, low
@@ -67,7 +70,9 @@ async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const sub = args[0];
 
-  if (sub === "--help" || sub === "-h" || sub === "help") {
+  // `--help` anywhere wins, so `pensar issues update --help` prints usage
+  // instead of forwarding "--help" through as an issue id.
+  if (sub === "help" || args.includes("--help") || args.includes("-h")) {
     showHelp();
     return;
   }

--- a/src/core/api/issues.test.ts
+++ b/src/core/api/issues.test.ts
@@ -11,12 +11,12 @@ const ISSUE_ID = "11111111-1111-1111-1111-111111111111";
 
 const ISSUE_SUMMARY: IssueSummary = {
   id: ISSUE_ID,
-  issueLabel: "VULN-000157",
+  issueLabel: "VULN-000123",
   title: "Reflected XSS",
   severity: "high",
   status: "open",
   location: "src/routes/search.ts",
-  url: "https://console.pensar.dev/nibbles/VULN-000157",
+  url: "https://console.pensar.dev/acme/VULN-000123",
 };
 
 describe("retestIssue", () => {
@@ -50,8 +50,8 @@ describe("issue label and url", () => {
 
     const [issue] = await listIssues();
 
-    expect(issue?.issueLabel).toBe("VULN-000157");
-    expect(issue?.url).toBe("https://console.pensar.dev/nibbles/VULN-000157");
+    expect(issue?.issueLabel).toBe("VULN-000123");
+    expect(issue?.url).toBe("https://console.pensar.dev/acme/VULN-000123");
   });
 
   it("allows a null issueLabel on an issue detail", async () => {
@@ -59,7 +59,7 @@ describe("issue label and url", () => {
       ...ISSUE_SUMMARY,
       issueLabel: null,
       workspaceId: "33333333-3333-3333-3333-333333333333",
-      workspaceName: "nibbles",
+      workspaceName: "acme",
       createdAt: "2026-08-27T00:00:00.000Z",
     };
     apiRequest.mockResolvedValue(detail);

--- a/src/core/api/issues.test.ts
+++ b/src/core/api/issues.test.ts
@@ -4,9 +4,20 @@ const apiRequest = vi.hoisted(() => vi.fn());
 
 vi.mock("./apiClient", () => ({ apiRequest }));
 
-import { retestIssue } from "./issues";
+import type { IssueDetail, IssueSummary } from "./issues";
+import { getIssue, listIssues, retestIssue } from "./issues";
 
 const ISSUE_ID = "11111111-1111-1111-1111-111111111111";
+
+const ISSUE_SUMMARY: IssueSummary = {
+  id: ISSUE_ID,
+  issueLabel: "VULN-000157",
+  title: "Reflected XSS",
+  severity: "high",
+  status: "open",
+  location: "src/routes/search.ts",
+  url: "https://console.pensar.dev/nibbles/VULN-000157",
+};
 
 describe("retestIssue", () => {
   beforeEach(() => {
@@ -26,5 +37,36 @@ describe("retestIssue", () => {
       "POST",
       `/issues/${ISSUE_ID}/retest`,
     );
+  });
+});
+
+describe("issue label and url", () => {
+  beforeEach(() => {
+    apiRequest.mockReset();
+  });
+
+  it("carries issueLabel and url through listIssues", async () => {
+    apiRequest.mockResolvedValue([ISSUE_SUMMARY]);
+
+    const [issue] = await listIssues();
+
+    expect(issue?.issueLabel).toBe("VULN-000157");
+    expect(issue?.url).toBe("https://console.pensar.dev/nibbles/VULN-000157");
+  });
+
+  it("allows a null issueLabel on an issue detail", async () => {
+    const detail: IssueDetail = {
+      ...ISSUE_SUMMARY,
+      issueLabel: null,
+      workspaceId: "33333333-3333-3333-3333-333333333333",
+      workspaceName: "nibbles",
+      createdAt: "2026-08-27T00:00:00.000Z",
+    };
+    apiRequest.mockResolvedValue(detail);
+
+    const result = await getIssue(ISSUE_ID);
+
+    expect(result.issueLabel).toBeNull();
+    expect(result.url).toBe(ISSUE_SUMMARY.url);
   });
 });

--- a/src/core/api/issues.ts
+++ b/src/core/api/issues.ts
@@ -30,7 +30,7 @@ export interface ScanDetail extends ScanSummary {
 
 export interface IssueSummary {
   id: string;
-  /** Human-facing label, e.g. `VULN-000157`. Null for issues created before labels existed. */
+  /** Human-facing label, e.g. `VULN-000123`. Null for issues created before labels existed. */
   issueLabel: string | null;
   title: string;
   severity: string;

--- a/src/core/api/issues.ts
+++ b/src/core/api/issues.ts
@@ -30,10 +30,14 @@ export interface ScanDetail extends ScanSummary {
 
 export interface IssueSummary {
   id: string;
+  /** Human-facing label, e.g. `VULN-000157`. Null for issues created before labels existed. */
+  issueLabel: string | null;
   title: string;
   severity: string;
   status: string;
   location: string;
+  /** Console deep link for the issue. */
+  url: string;
 }
 
 export interface IssueDetail extends IssueSummary {


### PR DESCRIPTION
The API now returns two additional fields on every issue payload: `issueLabel`, the friendly `VULN-000123` reference, and `url`, a deep link to the issue.

### What changed

`pensar issues` and `pensar issues get` print the API response verbatim, so they surface the new fields for free. What did **not** update itself is the hand-written TypeScript mirror of the API shape:

- `IssueSummary` gains `issueLabel: string | null` and `url: string`; `IssueDetail` inherits both.
- Help text documents that issue responses carry both.

Without this, anything importing those types — scripts, downstream agents — is typed as if the fields don't exist.

### Drive-by fix

`pensar issues update --help` (and `get`, `retest`, `link-pr`, `prs`) forwarded `--help` through as an issue id, which hit the API as an invalid identifier and came back a 500 rather than printing usage. The top-level help check now looks for a help flag anywhere in argv rather than only at `args[0]`, which covers all five subcommands in one line.

Sibling CLIs (`targets.ts`, `apps.ts`, `fixes.ts`) had no per-subcommand help pattern to copy, so this deliberately avoids inventing one.

### Tests

- `src/cli/issues.test.ts` (new) — mirrors `src/cli/apps.test.ts`: spawns the CLI offline and asserts exit 0 + usage for every subcommand's `--help`/`-h`, and that a missing issue id still errors with exit 1.
- `src/core/api/issues.test.ts` — typed fixtures so `tsc` fails if the new fields regress, plus runtime passthrough assertions.

`bun run tsc` clean, `bun run lint` clean on touched files, `bun run test` 1609 passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly type and documentation updates plus a localized CLI argv fix; no auth or API client behavior changes beyond reflecting new response fields.
> 
> **Overview**
> Aligns the CLI and docs with API issue payloads that now include **`issueLabel`** (e.g. `VULN-000123`, nullable for legacy issues) and a Console **`url`** deep link. `IssueSummary` / `IssueDetail` in `src/core/api/issues.ts` gain those fields so typed consumers match JSON output from `pensar issues` list/get.
> 
> **`pensar issues` help** documents the new response fields. **Help parsing** now treats `-h` / `--help` anywhere in argv (e.g. `pensar issues update --help`) so usage prints instead of sending `--help` to the API as an issue id.
> 
> **Fern docs** for `issues`, `fixes`, and `logs` add notes that `<issueId>` can be UUID or label, expand the list/get response shape and 400/404 behavior on `issues`, and refresh examples to `VULN-000123`.
> 
> **Tests:** new offline `src/cli/issues.test.ts` for help behavior; `src/core/api/issues.test.ts` asserts `issueLabel`/`url` passthrough and nullable labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 100a722e6d4606551cf3df5d2978ec69bed8211b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

