### PR TITLE
test(observability): establish agent trace contract

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.14",
+        "@opentelemetry/context-async-hooks": "^2.10.0",
+        "@opentelemetry/sdk-trace-base": "^2.10.0",
         "@types/bun": "^1.3.14",
         "@types/mailparser": "^3.4.6",
         "@types/mime-types": "^3.0.1",
@@ -369,6 +371,18 @@
     "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.9.1", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-okgq07Vdkro4CB5INbfhwa0e6VR1HS7sidNcfHN/MeXLJvX1JmQCff/vem6tcxwT9r1avyFrXSlfv9B28D/Pag=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.10.0", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.10.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA=="],
+
+    "@opentelemetry/sdk-trace": ["@opentelemetry/sdk-trace@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/sdk-trace": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
     "@opentui/core": ["@opentui/core@0.1.107", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.107", "@opentui/core-darwin-x64": "0.1.107", "@opentui/core-linux-arm64": "0.1.107", "@opentui/core-linux-x64": "0.1.107", "@opentui/core-win32-arm64": "0.1.107", "@opentui/core-win32-x64": "0.1.107", "bun-webgpu": "0.1.7", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-gadu9EtNR+sOGyHN0buZryllavkWHRkCcX4yW/1ldp/l7HGS52hvkjYmo+74cuzUcfds/5Rbw2cgiy0Z7RxXmQ=="],
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
   "description": "AI-powered penetration testing CLI tool with terminal UI",
   "devDependencies": {
     "@biomejs/biome": "2.4.14",
+    "@opentelemetry/context-async-hooks": "^2.10.0",
+    "@opentelemetry/sdk-trace-base": "^2.10.0",
     "@types/bun": "^1.3.14",
     "@types/mailparser": "^3.4.6",
     "@types/mime-types": "^3.0.1",

--- a/src/core/observability/testkit.test.ts
+++ b/src/core/observability/testkit.test.ts
@@ -1,0 +1,66 @@
+import {
+  type Context,
+  type ContextManager,
+  context,
+  createContextKey,
+  ROOT_CONTEXT,
+  trace,
+} from "@opentelemetry/api";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { startOtelTestHarness } from "./testkit";
+
+class StaleContextManager implements ContextManager {
+  active(): Context {
+    return ROOT_CONTEXT;
+  }
+
+  with<A extends unknown[], F extends (...args: A) => ReturnType<F>>(
+    _context: Context,
+    fn: F,
+    thisArg?: ThisParameterType<F>,
+    ...args: A
+  ): ReturnType<F> {
+    return fn.call(thisArg, ...args);
+  }
+
+  bind<T>(_context: Context, target: T): T {
+    return target;
+  }
+
+  enable(): this {
+    return this;
+  }
+
+  disable(): this {
+    return this;
+  }
+}
+
+beforeEach(() => {
+  trace.disable();
+  context.disable();
+});
+
+afterEach(() => {
+  trace.disable();
+  context.disable();
+});
+
+describe("startOtelTestHarness", () => {
+  it("replaces a previously registered context manager", async () => {
+    context.setGlobalContextManager(new StaleContextManager());
+
+    const harness = startOtelTestHarness();
+    try {
+      const key = createContextKey("testkit-context");
+      const expected = ROOT_CONTEXT.setValue(key, "active");
+
+      await context.with(expected, async () => {
+        await Promise.resolve();
+        expect(context.active().getValue(key)).toBe("active");
+      });
+    } finally {
+      await harness.shutdown();
+    }
+  });
+});

--- a/src/core/observability/testkit.ts
+++ b/src/core/observability/testkit.ts
@@ -22,6 +22,9 @@ export interface OtelTestHarness {
 }
 
 export function startOtelTestHarness(): OtelTestHarness {
+  trace.disable();
+  context.disable();
+
   const exporter = new InMemorySpanExporter();
   const provider = new BasicTracerProvider({
     spanProcessors: [new SimpleSpanProcessor(exporter)],
@@ -31,8 +34,17 @@ export function startOtelTestHarness(): OtelTestHarness {
 
   // BasicTracerProvider has no register() (that's NodeTracerProvider) —
   // wire the globals directly.
-  trace.setGlobalTracerProvider(provider);
-  context.setGlobalContextManager(contextManager);
+  if (!trace.setGlobalTracerProvider(provider)) {
+    contextManager.disable();
+    void provider.shutdown();
+    throw new Error("failed to register the OTel test tracer provider");
+  }
+  if (!context.setGlobalContextManager(contextManager)) {
+    trace.disable();
+    contextManager.disable();
+    void provider.shutdown();
+    throw new Error("failed to register the OTel test context manager");
+  }
 
   return {
     exporter,

--- a/src/core/observability/testkit.ts
+++ b/src/core/observability/testkit.ts
@@ -1,0 +1,85 @@
+import { context, trace } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  type ReadableSpan,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+
+/**
+ * In-memory OTel harness for observability tests. Registers a real
+ * tracer provider + async context manager globally so the AI SDK's built-in
+ * instrumentation emits spans, and collects them for assertion. Always call
+ * `shutdown()` in afterEach — it resets the global provider and context
+ * manager so other tests see the no-op SDK.
+ */
+export interface OtelTestHarness {
+  readonly exporter: InMemorySpanExporter;
+  readonly provider: BasicTracerProvider;
+  getFinishedSpans(): ReadableSpan[];
+  shutdown(): Promise<void>;
+}
+
+export function startOtelTestHarness(): OtelTestHarness {
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+  const contextManager = new AsyncLocalStorageContextManager();
+  contextManager.enable();
+
+  // BasicTracerProvider has no register() (that's NodeTracerProvider) —
+  // wire the globals directly.
+  trace.setGlobalTracerProvider(provider);
+  context.setGlobalContextManager(contextManager);
+
+  return {
+    exporter,
+    provider,
+    getFinishedSpans: () => exporter.getFinishedSpans(),
+    async shutdown() {
+      await provider.forceFlush();
+      await provider.shutdown();
+      contextManager.disable();
+      // Reset globals so later tests observe a no-op SDK.
+      trace.disable();
+      context.disable();
+    },
+  };
+}
+
+/** Find the first finished span by name, failing loudly when absent. */
+export function requireSpan(
+  spans: readonly ReadableSpan[],
+  name: string,
+): ReadableSpan {
+  const span = spans.find((s) => s.name === name);
+  if (!span) {
+    throw new Error(
+      `expected span ${JSON.stringify(name)}; got: ${spans.map((s) => s.name).join(", ")}`,
+    );
+  }
+  return span;
+}
+
+/** All finished spans by name. */
+export function spansNamed(
+  spans: readonly ReadableSpan[],
+  name: string,
+): ReadableSpan[] {
+  return spans.filter((s) => s.name === name);
+}
+
+/**
+ * The span a given span was a direct child of. SDK 2.x carries the parent as
+ * `parentSpanContext` (a SpanContext), not the legacy `parentSpanId` string.
+ */
+export function parentOf(
+  spans: readonly ReadableSpan[],
+  span: ReadableSpan,
+): ReadableSpan | undefined {
+  const parentId = span.parentSpanContext?.spanId;
+  if (!parentId) return undefined;
+  return spans.find((s) => s.spanContext().spanId === parentId);
+}

--- a/src/core/observability/trace-contract.test.ts
+++ b/src/core/observability/trace-contract.test.ts
@@ -211,7 +211,7 @@ describe("existing trace contract: model spans", () => {
       streamText.spanContext().spanId,
     );
     expect(doStream.attributes["gen_ai.request.model"]).toBe(MODEL);
-    expect(streamText.status.code).not.toBe("ERROR");
+    expect(streamText.status.code).not.toBe(SpanStatusCode.ERROR);
     expect(streamText.spanContext().traceId).toBe(
       doStream.spanContext().traceId,
     );

--- a/src/core/observability/trace-contract.test.ts
+++ b/src/core/observability/trace-contract.test.ts
@@ -1,0 +1,436 @@
+// O1 — the existing agent trace contract. These tests pin what Apex's OTel
+// API (`getApexTracer`, `withSubagentSessionBaggage`) and the AI SDK's
+// built-in instrumentation already emit, before Stack D changes any
+// production behavior. A real tracer provider + in-memory exporter is
+// registered per test; the provider model is a deterministic mock so no API
+// keys are needed and spans are reproducible.
+
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import { SpanStatusCode } from "@opentelemetry/api";
+import { simulateReadableStream, stepCountIs } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+// getProviderModel is patched so the mock model serves the provider call —
+// no provider keys, deterministic protocol parts.
+const mockState: { model: MockLanguageModelV3 | null } = { model: null };
+vi.mock("../ai/utils", async () => {
+  const actual =
+    await vi.importActual<typeof import("../ai/utils")>("../ai/utils");
+  return {
+    ...actual,
+    getProviderModel: () => {
+      if (!mockState.model) throw new Error("mock model not set");
+      return mockState.model;
+    },
+  };
+});
+
+import type { OtelTestHarness } from "./testkit";
+
+// Imported AFTER vi.mock so streamResponse's closure picks up the stub.
+const { streamResponse } = await import("../ai");
+const { getApexTracer, withSubagentSessionBaggage } = await import(
+  "../observability"
+);
+const { parentOf, requireSpan, spansNamed, startOtelTestHarness } =
+  await import("./testkit");
+
+// ---------------------------------------------------------------------------
+// Mock fixtures
+// ---------------------------------------------------------------------------
+
+const MODEL = "claude-haiku-4-5";
+
+const NESTED_USAGE = {
+  inputTokens: { total: 1000, noCache: 100, cacheRead: 900, cacheWrite: 0 },
+  outputTokens: { total: 20, text: 20, reasoning: undefined },
+};
+
+function textStepChunks(): Array<Record<string, unknown>> {
+  return [
+    { type: "stream-start", warnings: [] },
+    { type: "text-start", id: "txt-1" },
+    { type: "text-delta", id: "txt-1", delta: "hello" },
+    { type: "text-end", id: "txt-1" },
+    {
+      type: "finish",
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: NESTED_USAGE,
+    },
+  ];
+}
+
+function oneStepTextModel(): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    provider: "mock-anthropic",
+    modelId: MODEL,
+    doStream: async () => ({
+      stream: simulateReadableStream({
+        chunks: textStepChunks() as unknown as Array<LanguageModelV3StreamPart>,
+      }),
+    }),
+  });
+}
+
+/** A two-step stream: step 1 calls a tool, step 2 finishes with text. */
+function toolCallingModel(): MockLanguageModelV3 {
+  let call = 0;
+  return new MockLanguageModelV3({
+    provider: "mock-anthropic",
+    modelId: MODEL,
+    doStream: async () => {
+      call += 1;
+      if (call === 1) {
+        return {
+          stream: simulateReadableStream({
+            chunks: [
+              { type: "stream-start", warnings: [] },
+              { type: "tool-input-start", id: "call-1", toolName: "probe" },
+              { type: "tool-input-delta", id: "call-1", delta: '{"q":"hi"}' },
+              { type: "tool-input-end", id: "call-1" },
+              {
+                type: "tool-call",
+                toolCallId: "call-1",
+                toolName: "probe",
+                input: '{"q":"hi"}',
+              },
+              {
+                type: "finish",
+                finishReason: { unified: "tool-calls", raw: "tool_use" },
+                usage: {
+                  inputTokens: {
+                    total: 100,
+                    noCache: 100,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                  },
+                  outputTokens: { total: 10, text: 10, reasoning: undefined },
+                },
+              },
+            ] as unknown as Array<LanguageModelV3StreamPart>,
+          }),
+        };
+      }
+      return {
+        stream: simulateReadableStream({
+          chunks: [
+            { type: "stream-start", warnings: [] },
+            { type: "reasoning-start", id: "rsn-1" },
+            { type: "reasoning-delta", id: "rsn-1", delta: "thinking hard" },
+            { type: "reasoning-end", id: "rsn-1" },
+            ...textStepChunks(),
+          ] as unknown as Array<LanguageModelV3StreamPart>,
+        }),
+      };
+    },
+  });
+}
+
+function probeTool() {
+  return {
+    description: "test tool",
+    inputSchema: z.object({ q: z.string() }),
+    execute: async (input: { q: string }) => `echo:${input.q}`,
+  };
+}
+
+async function drain(stream: { fullStream: AsyncIterable<unknown> }) {
+  for await (const _part of stream.fullStream) {
+    // drain
+  }
+}
+
+/**
+ * Run a model call inside the exact span structure the agent's drain path
+ * uses for subagents (see offensiveSecurityAgent.ts): baggage-scoped
+ * active `invoke_agent` span wrapping the stream consumption.
+ */
+async function subagentInvoke(
+  subagentId: string,
+  label: string,
+  run: () => Promise<void>,
+): Promise<void> {
+  await withSubagentSessionBaggage(subagentId, () =>
+    getApexTracer().startActiveSpan(
+      `invoke_agent ${label}`,
+      {
+        attributes: {
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.name": label,
+        },
+      },
+      async (span) => {
+        try {
+          await run();
+        } catch (err) {
+          span.recordException(err as Error);
+          throw err;
+        } finally {
+          span.end();
+        }
+      },
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Harness lifecycle
+// ---------------------------------------------------------------------------
+
+let otel: OtelTestHarness;
+
+beforeEach(() => {
+  otel = startOtelTestHarness();
+});
+
+afterEach(async () => {
+  await otel.shutdown();
+  mockState.model = null;
+  process.env.AI_TRACE_RECORD_PAYLOADS = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// Model spans
+// ---------------------------------------------------------------------------
+
+describe("existing trace contract: model spans", () => {
+  it("AI SDK emits model spans when a tracer provider exists", async () => {
+    mockState.model = oneStepTextModel();
+
+    await drain(streamResponse({ prompt: "hi", model: MODEL, silent: true }));
+
+    const spans = otel.getFinishedSpans();
+    const streamText = requireSpan(spans, "ai.streamText");
+    const doStream = requireSpan(spans, "ai.streamText.doStream");
+    expect(streamText).toBeDefined();
+    expect(doStream).toBeDefined();
+    // The provider call is a child of the streamText operation span.
+    expect(parentOf(spans, doStream)?.spanContext().spanId).toBe(
+      streamText.spanContext().spanId,
+    );
+    expect(doStream.attributes["gen_ai.request.model"]).toBe(MODEL);
+    expect(streamText.status.code).not.toBe("ERROR");
+    expect(streamText.spanContext().traceId).toBe(
+      doStream.spanContext().traceId,
+    );
+  });
+
+  it("token and cache attributes are captured as emitted by the installed AI SDK", async () => {
+    mockState.model = oneStepTextModel();
+
+    await drain(streamResponse({ prompt: "hi", model: MODEL, silent: true }));
+
+    const spans = otel.getFinishedSpans();
+    const doStream = requireSpan(spans, "ai.streamText.doStream");
+    const streamText = requireSpan(spans, "ai.streamText");
+    // gen_ai.* usage lives on the provider-call span…
+    expect(doStream.attributes["gen_ai.usage.input_tokens"]).toBe(1000);
+    expect(doStream.attributes["gen_ai.usage.output_tokens"]).toBe(20);
+    expect(doStream.attributes["gen_ai.response.finish_reasons"]).toBeDefined();
+    // …while the operation span carries the ai.usage.* totals.
+    expect(streamText.attributes["ai.usage.inputTokens"]).toBe(1000);
+    expect(streamText.attributes["ai.usage.outputTokens"]).toBe(20);
+    // Cache-read tokens ride the SDK's ai.usage.* attributes — input stays
+    // inclusive (1000), cache reported separately (900).
+    expect(streamText.attributes["ai.usage.cachedInputTokens"]).toBe(900);
+  });
+
+  it("tool execution produces a child tool span", async () => {
+    mockState.model = toolCallingModel();
+
+    await drain(
+      streamResponse({
+        prompt: "hi",
+        model: MODEL,
+        silent: true,
+        tools: { probe: probeTool() },
+        stopWhen: stepCountIs(2),
+      }),
+    );
+
+    const spans = otel.getFinishedSpans();
+    const toolSpan = requireSpan(spans, "ai.toolCall");
+    const streamText = requireSpan(spans, "ai.streamText");
+    expect(toolSpan.attributes["ai.toolCall.name"]).toBe("probe");
+    // The tool span is a descendant of the streamText span (same trace).
+    expect(toolSpan.spanContext().traceId).toBe(
+      streamText.spanContext().traceId,
+    );
+    expect(toolSpan.parentSpanContext?.spanId).toBeDefined();
+  });
+
+  it("failed model calls record an exception", async () => {
+    // A provider failure (e.g. HTTP 500) surfaces as a thrown doStream —
+    // the SDK records the exception on both spans and ends them.
+    mockState.model = new MockLanguageModelV3({
+      provider: "mock-anthropic",
+      modelId: MODEL,
+      doStream: async () => {
+        throw new Error("provider 500");
+      },
+    });
+
+    await expect(
+      drain(streamResponse({ prompt: "hi", model: MODEL, silent: true })),
+    ).rejects.toThrow("provider 500");
+
+    const spans = otel.getFinishedSpans();
+    for (const name of ["ai.streamText", "ai.streamText.doStream"]) {
+      const span = requireSpan(spans, name);
+      expect(span.status.code, name).toBe(SpanStatusCode.ERROR);
+      expect(
+        span.events.some(
+          (e) =>
+            e.name === "exception" &&
+            (e.attributes?.["exception.message"] as string) === "provider 500",
+        ),
+        name,
+      ).toBe(true);
+    }
+  });
+
+  it("an in-stream error part currently leaks the root span (known limitation)", async () => {
+    // Contract finding: when the model emits an error PART (instead of
+    // throwing), the ai.streamText root span (endWhenDone: false) is never
+    // ended — no spans export. Pinned as-is; Stack D's O3 root-run spans
+    // own their end() on every path instead.
+    mockState.model = new MockLanguageModelV3({
+      provider: "mock-anthropic",
+      modelId: MODEL,
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: "stream-start", warnings: [] },
+            { type: "error", error: new Error("model exploded") },
+          ] as unknown as Array<LanguageModelV3StreamPart>,
+        }),
+      }),
+    });
+
+    await expect(
+      drain(streamResponse({ prompt: "hi", model: MODEL, silent: true })),
+    ).rejects.toThrow("model exploded");
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(otel.getFinishedSpans()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Payload policy
+// ---------------------------------------------------------------------------
+
+describe("existing trace contract: payload policy", () => {
+  it("AI_TRACE_RECORD_PAYLOADS=false excludes prompts and responses", async () => {
+    process.env.AI_TRACE_RECORD_PAYLOADS = "false";
+    mockState.model = oneStepTextModel();
+
+    await drain(
+      streamResponse({ prompt: "secret prompt", model: MODEL, silent: true }),
+    );
+
+    const streamText = requireSpan(otel.getFinishedSpans(), "ai.streamText");
+    expect(streamText.attributes["ai.prompt"]).toBeUndefined();
+    expect(streamText.attributes["ai.response.text"]).toBeUndefined();
+  });
+
+  it("AI_TRACE_RECORD_PAYLOADS=true includes prompts, responses, reasoning, tool arguments, and tool results", async () => {
+    process.env.AI_TRACE_RECORD_PAYLOADS = "true";
+    mockState.model = toolCallingModel();
+
+    await drain(
+      streamResponse({
+        prompt: "secret prompt",
+        system: "system prompt",
+        model: MODEL,
+        silent: true,
+        tools: { probe: probeTool() },
+        stopWhen: stepCountIs(2),
+      }),
+    );
+
+    const spans = otel.getFinishedSpans();
+    const streamText = requireSpan(spans, "ai.streamText");
+    const toolSpan = requireSpan(spans, "ai.toolCall");
+
+    const prompt = String(streamText.attributes["ai.prompt"] ?? "");
+    expect(prompt).toContain("secret prompt");
+    const responseText = spans
+      .map((s) => s.attributes["ai.response.text"])
+      .filter(Boolean)
+      .map(String)
+      .join(" ");
+    expect(responseText).toContain("hello");
+    const reasoning = spans
+      .map((s) => s.attributes["ai.response.reasoning"])
+      .filter(Boolean)
+      .map(String)
+      .join(" ");
+    expect(reasoning).toContain("thinking hard");
+    expect(toolSpan.attributes["ai.toolCall.args"]).toBeDefined();
+    expect(String(toolSpan.attributes["ai.toolCall.result"])).toContain(
+      "echo:hi",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subagent spans
+// ---------------------------------------------------------------------------
+
+describe("existing trace contract: subagent spans", () => {
+  it("existing subagent span parents model spans correctly", async () => {
+    mockState.model = oneStepTextModel();
+
+    await subagentInvoke("ses_subagent_1", "recon-sub", async () => {
+      await drain(streamResponse({ prompt: "hi", model: MODEL, silent: true }));
+    });
+
+    const spans = otel.getFinishedSpans();
+    const invoke = requireSpan(spans, "invoke_agent recon-sub");
+    const streamText = requireSpan(spans, "ai.streamText");
+    expect(invoke).toBeDefined();
+    expect(invoke.attributes["gen_ai.operation.name"]).toBe("invoke_agent");
+    expect(invoke.attributes["gen_ai.agent.name"]).toBe("recon-sub");
+    expect(streamText).toBeDefined();
+    // The model span nests under the subagent span — one trace, correct parent.
+    expect(parentOf(spans, streamText)?.spanContext().spanId).toBe(
+      invoke.spanContext().spanId,
+    );
+    expect(streamText.spanContext().traceId).toBe(invoke.spanContext().traceId);
+  });
+
+  it("concurrent subagents retain the active parent context", async () => {
+    mockState.model = oneStepTextModel();
+
+    const runA = subagentInvoke("ses_sub_a", "agent-a", async () => {
+      await drain(
+        streamResponse({ prompt: "for a", model: MODEL, silent: true }),
+      );
+    });
+    const runB = subagentInvoke("ses_sub_b", "agent-b", async () => {
+      await drain(
+        streamResponse({ prompt: "for b", model: MODEL, silent: true }),
+      );
+    });
+    await Promise.all([runA, runB]);
+
+    const spans = otel.getFinishedSpans();
+    const invokes = spans.filter((s) => s.name.startsWith("invoke_agent "));
+    const streamTexts = spansNamed(spans, "ai.streamText");
+    expect(invokes).toHaveLength(2);
+    expect(streamTexts).toHaveLength(2);
+
+    // Each model span's parent is its own subagent span — no cross-wiring.
+    for (const streamText of streamTexts) {
+      const parent = parentOf(spans, streamText);
+      expect(parent?.name.startsWith("invoke_agent ")).toBe(true);
+    }
+    const parentIds = new Set(
+      streamTexts.map((s) => s.parentSpanContext?.spanId),
+    );
+    expect(parentIds.size).toBe(2);
+  });
+});


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Usage + observability · PR 7 of 12**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#996](https://github.com/pensarai/apex/pull/996) | Session usage models |
| 2 | [#997](https://github.com/pensarai/apex/pull/997) | Session-scoped ownership |
| 3 | [#998](https://github.com/pensarai/apex/pull/998) | Complete usage persistence |
| 4 | [#999](https://github.com/pensarai/apex/pull/999) | Consolidated usage ingestion |
| 5 | [#1000](https://github.com/pensarai/apex/pull/1000) | Token and context footer |
| 6 | [#1002](https://github.com/pensarai/apex/pull/1002) | Cache token breakdown |
| **7** | **[#1004](https://github.com/pensarai/apex/pull/1004)** | **Agent trace contract** · `Current` |
| 8 | [#1005](https://github.com/pensarai/apex/pull/1005) | Optional OTLP runtime |
| 9 | [#1006](https://github.com/pensarai/apex/pull/1006) | Root agent run spans |
| 10 | [#1007](https://github.com/pensarai/apex/pull/1007) | Centralized telemetry settings |
| 11 | [#1008](https://github.com/pensarai/apex/pull/1008) | Telemetry correlation |
| 12 | [#1009](https://github.com/pensarai/apex/pull/1009) | OTLP shutdown hardening |
## Summary

- pin what Apex's existing OTel API and the AI SDK's built-in instrumentation **already emit**, before Stack D changes any production behavior
- new test-only harness (`src/core/observability/testkit.ts`): a real `BasicTracerProvider` + `AsyncLocalStorageContextManager` + `InMemorySpanExporter` registered globally per test, with full global-state reset in `shutdown()`
- 9 contract tests drive `streamResponse()` with deterministic `MockLanguageModelV3` provider models (no API keys) through the real provider path
- **zero production changes** — deps + tests only

## Contract findings (the point of this PR)

Probing empirically surfaced several facts worth having in writing before O2–O6 build on them:

1. **Span tree**: `ai.streamText` (root, `endWhenDone: false`) → `ai.streamText.doStream` (one per step) → `ai.toolCall` (parent = the step's `doStream`). The existing subagent `invoke_agent` span parents `ai.streamText` correctly via the async context manager.
2. **Attribute placement splits**: `gen_ai.usage.input_tokens`/`output_tokens` and `gen_ai.response.finish_reasons` live on **`ai.streamText.doStream`**; the `ai.usage.*` totals (incl. `ai.usage.cachedInputTokens`) live on **`ai.streamText`**. Tests pin both locations.
3. **Cache**: the SDK emits `ai.usage.cachedInputTokens` (900 in the fixture) alongside inclusive `ai.usage.inputTokens` (1000) — the T6 inclusive-input contract is visible in span attributes too.
4. **Thrown model errors** (the provider-500 shape): both `ai.streamText` and `ai.streamText.doStream` end with `SpanStatusCode.ERROR` and an `exception` event carrying `exception.message`. ✔
5. **Known limitation, pinned**: an in-stream **error part** (instead of a thrown `doStream`) currently **leaks the `ai.streamText` root span** — `end()` only runs in the normal flush path, so nothing exports. Pinned as-is with a dedicated test; O3's root-run spans own their `end()` on every path instead.
6. **SDK 2.x naming**: `ReadableSpan.parentSpanContext?.spanId` (an object), not the legacy `parentSpanId` string — the harness's `parentOf()` helper encodes this.

## Tests (9)

- model spans emitted when a provider exists; `doStream` parents `streamText`; same trace
- token + cache attributes as emitted by the installed SDK (both span locations)
- tool execution produces a child `ai.toolCall` span (name, args/result gating, same trace, has parent)
- thrown model calls record exceptions on both spans (status + `exception` event)
- in-stream error part leaks the root span (known limitation)
- `AI_TRACE_RECORD_PAYLOADS=false` excludes prompts and responses
- `AI_TRACE_RECORD_PAYLOADS=true` includes prompt, response text, reasoning, tool arguments, tool results
- existing subagent span parents model spans correctly (attributes + parent linkage + one trace)
- concurrent subagents retain their own active parent (two interleaved runs, no cross-wiring)

## What changed

- `package.json` — dev deps: `@opentelemetry/sdk-trace-base`, `@opentelemetry/context-async-hooks` (test-only; `@opentelemetry/api` was already a runtime dep)
- `src/core/observability/testkit.ts` — the harness (`startOtelTestHarness`, `requireSpan`, `spansNamed`, `parentOf`); reusable by O2–O6 tests
- `src/core/observability/trace-contract.test.ts` — the 9 contract tests; mocks `getProviderModel` so `streamResponse` runs its real code against a deterministic model

## Validation

- `bun run test` (1,777 passed, 22 skipped — no production behavior changed)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` clean

## Non-goals honored

No production exporter, no root agent spans, no Langfuse configuration, no logging changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests and dev dependencies only; no production tracing, exporter, or runtime behavior changes.
> 
> **Overview**
> Adds **test-only** OpenTelemetry infrastructure and contract tests that document what Apex’s existing tracing (`getApexTracer`, `withSubagentSessionBaggage`) and the AI SDK already emit—**before** later observability PRs change runtime behavior. There are **no production code changes**.
> 
> **New test harness** (`testkit.ts`): registers a real `BasicTracerProvider`, `AsyncLocalStorageContextManager`, and `InMemorySpanExporter` per test, with `shutdown()` resetting global OTel state. Helpers include `requireSpan`, `spansNamed`, and `parentOf` (SDK 2.x `parentSpanContext`).
> 
> **Contract suite** (`trace-contract.test.ts`): drives real `streamResponse()` with mocked `getProviderModel` / `MockLanguageModelV3` (no API keys). Tests lock in span trees (`ai.streamText` → `doStream` → `ai.toolCall`), usage attribute placement (`gen_ai.*` vs `ai.usage.*`, including cache), thrown vs in-stream errors (including the pinned leak when an error **part** never ends `ai.streamText`), `AI_TRACE_RECORD_PAYLOADS` gating, and subagent `invoke_agent` parenting (including concurrent runs).
> 
> **Dependencies**: dev-only `@opentelemetry/sdk-trace-base` and `@opentelemetry/context-async-hooks` plus lockfile updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f4aa13583ddc16d36907ef50df19f37b3b117c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

