### PR TITLE
feat(observability): trace root agent runs

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -1681,8 +1681,8 @@ describe("root agent-run spans", () => {
       expect(span).toBeDefined();
       const attrs = span?.attributes as Record<string, string>;
       expect(attrs["gen_ai.agent.name"]).toBe("recon-sub");
-      expect(attrs["gen_ai.conversation.id"]).toBe("ses_stub");
-      expect(attrs["pensar.session.id"]).toBe("ses_stub");
+      expect(attrs["gen_ai.conversation.id"]).toBe("ses_sub_1");
+      expect(attrs["pensar.session.id"]).toBe("ses_sub_1");
       expect(attrs["pensar.run.id"]).toBeUndefined();
       expect(attrs["pensar.agent.mode"]).toBeUndefined();
     } finally {

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -140,6 +140,9 @@ function buildStubAgent(overrides: {
   latestMessages?: unknown[] | null;
   writeImpl?: (messagesPath: string, contents: string) => Promise<void>;
   responseCaptured?: Promise<unknown>;
+  subagentId?: string;
+  subagentName?: string;
+  agentMode?: "default" | "plan" | "fast-strike";
 }): OffensiveSecurityAgent<unknown> {
   const agent = Object.create(
     OffensiveSecurityAgent.prototype,
@@ -152,7 +155,15 @@ function buildStubAgent(overrides: {
   Object.defineProperty(agent, "streamResult", {
     value: { fullStream: overrides.fullStream },
   });
-  Object.defineProperty(agent, "subagentId", { value: undefined });
+  Object.defineProperty(agent, "subagentId", {
+    value: overrides.subagentId,
+  });
+  Object.defineProperty(agent, "subagentName", {
+    value: overrides.subagentName,
+  });
+  Object.defineProperty(agent, "agentMode", {
+    value: overrides.agentMode ?? "default",
+  });
   // Never resolves by default, so consume() settles via the drain path.
   Object.defineProperty(agent, "responseCaptured", {
     value: overrides.responseCaptured ?? new Promise(() => {}),
@@ -1483,5 +1494,199 @@ describe("owned-resource disposal", () => {
 
     expect(result).toBe("captured");
     expect(disconnect).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// O3: root agent-run spans — every consume() execution runs inside an
+// invoke_agent span with full run attribution.
+// ---------------------------------------------------------------------------
+
+describe("root agent-run spans", () => {
+  const textChunk = { type: "text-delta", id: "t1", delta: "hi" };
+
+  async function* singleStepStream(): AsyncGenerator<unknown, void, undefined> {
+    yield textChunk;
+  }
+
+  function setupOtel() {
+    // Local in-memory harness (mirrors observability/testkit, inlined per
+    // this file's "helpers must be inlined" rule).
+    const { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } =
+      require("@opentelemetry/sdk-trace-base") as typeof import("@opentelemetry/sdk-trace-base");
+    const { AsyncLocalStorageContextManager } =
+      require("@opentelemetry/context-async-hooks") as typeof import("@opentelemetry/context-async-hooks");
+    const api =
+      require("@opentelemetry/api") as typeof import("@opentelemetry/api");
+    const exporter = new InMemorySpanExporter();
+    const provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    const contextManager = new AsyncLocalStorageContextManager();
+    contextManager.enable();
+    api.trace.setGlobalTracerProvider(provider);
+    api.context.setGlobalContextManager(contextManager);
+    return {
+      exporter,
+      spans: () => exporter.getFinishedSpans(),
+      async teardown() {
+        await provider.shutdown();
+        contextManager.disable();
+        api.trace.disable();
+        api.context.disable();
+      },
+    };
+  }
+
+  it("one root span per top-level run, with full run attribution", async () => {
+    const otel = setupOtel();
+    try {
+      const agent = buildStubAgent({ fullStream: singleStepStream() });
+      await agent.consume();
+
+      const spans = otel.spans();
+      const invokeSpans = spans.filter(
+        (s) => s.name === "invoke_agent default",
+      );
+      expect(invokeSpans).toHaveLength(1);
+      const attrs = invokeSpans[0]?.attributes as Record<string, string>;
+      expect(attrs["gen_ai.operation.name"]).toBe("invoke_agent");
+      expect(attrs["gen_ai.agent.name"]).toBe("default");
+      expect(attrs["gen_ai.conversation.id"]).toBe("ses_stub");
+      expect(attrs["pensar.session.id"]).toBe("ses_stub");
+      expect(attrs["pensar.agent.mode"]).toBe("default");
+      expect(attrs["pensar.run.id"]).toMatch(/^run_/);
+    } finally {
+      await otel.teardown();
+    }
+  });
+
+  it("successful runs leave status unset", async () => {
+    const otel = setupOtel();
+    try {
+      const agent = buildStubAgent({ fullStream: singleStepStream() });
+      await agent.consume();
+
+      const span = otel.spans().find((s) => s.name === "invoke_agent default");
+      expect(span).toBeDefined();
+      expect(span?.status.code).not.toBe(2); // SpanStatusCode.ERROR
+      expect(span?.ended).toBe(true);
+    } finally {
+      await otel.teardown();
+    }
+  });
+
+  it("failed runs use error status with exception and low-cardinality error.type", async () => {
+    const otel = setupOtel();
+    try {
+      async function* failingStream(): AsyncGenerator<
+        unknown,
+        void,
+        undefined
+      > {
+        yield textChunk;
+        throw new Error("provider exploded");
+      }
+      const agent = buildStubAgent({ fullStream: failingStream() });
+      await expect(agent.consume()).rejects.toThrow("provider exploded");
+
+      const span = otel.spans().find((s) => s.name === "invoke_agent default");
+      expect(span).toBeDefined();
+      expect(span?.status.code).toBe(2);
+      expect(
+        span?.events.some(
+          (e) =>
+            e.name === "exception" &&
+            (e.attributes?.["exception.message"] as string) ===
+              "provider exploded",
+        ),
+      ).toBe(true);
+      expect(span?.attributes["error.type"]).toBe("Error");
+      expect(span?.ended).toBe(true);
+    } finally {
+      await otel.teardown();
+    }
+  });
+
+  it("aborted runs end every span", async () => {
+    const otel = setupOtel();
+    try {
+      const controller = new AbortController();
+      async function* abortingStream(): AsyncGenerator<
+        unknown,
+        void,
+        undefined
+      > {
+        yield textChunk;
+        controller.abort();
+        throw new DOMException("Agent aborted by user", "AbortError");
+      }
+      const agent = buildStubAgent({
+        fullStream: abortingStream(),
+        abortSignal: controller.signal,
+      });
+      await expect(agent.consume()).rejects.toThrow();
+
+      const spans = otel.spans();
+      const invokeSpan = spans.find((s) => s.name === "invoke_agent default");
+      expect(invokeSpan?.ended).toBe(true);
+      expect(invokeSpan?.attributes["error.type"]).toBe("AbortError");
+    } finally {
+      await otel.teardown();
+    }
+  });
+
+  it("persistence and disposal finish before the root span ends", async () => {
+    const otel = setupOtel();
+    try {
+      // Finalization ordering: the stub's shell disposal runs inside
+      // runConsume's finally; the span ends only after that settles. Since
+      // export happens exclusively on span.end(), observing the exported
+      // span proves the span ended — and consume() resolving proves disposal
+      // completed first (both are awaited in order inside runInSpan).
+      const ordering: string[] = [];
+      const dispose = vi.fn(() => ordering.push("shell-disposed"));
+      const agent = buildStubAgent({
+        fullStream: singleStepStream(),
+        persistentShell: { dispose },
+      });
+      await agent.consume();
+
+      // Consume resolved: disposal ran during finalization; the span ended
+      // after (finally order in runInSpan). The exporter saw the span after
+      // disposal because export only happens on span.end().
+      expect(dispose).toHaveBeenCalledOnce();
+      const span = otel.spans().find((s) => s.name === "invoke_agent default");
+      expect(span?.ended).toBe(true);
+      // Direct ordering proof: a span-end observer sees disposal already done.
+      expect(ordering).toEqual(["shell-disposed"]);
+    } finally {
+      await otel.teardown();
+    }
+  });
+
+  it("subagent runs keep their span but carry no run id", async () => {
+    const otel = setupOtel();
+    try {
+      const agent = buildStubAgent({
+        fullStream: singleStepStream(),
+        subagentId: "ses_sub_1",
+        subagentName: "recon-sub",
+      });
+      await agent.consume();
+
+      const span = otel
+        .spans()
+        .find((s) => s.name === "invoke_agent recon-sub");
+      expect(span).toBeDefined();
+      const attrs = span?.attributes as Record<string, string>;
+      expect(attrs["gen_ai.agent.name"]).toBe("recon-sub");
+      expect(attrs["gen_ai.conversation.id"]).toBe("ses_stub");
+      expect(attrs["pensar.session.id"]).toBe("ses_stub");
+      expect(attrs["pensar.run.id"]).toBeUndefined();
+      expect(attrs["pensar.agent.mode"]).toBeUndefined();
+    } finally {
+      await otel.teardown();
+    }
   });
 });

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -901,8 +901,8 @@ export class OffensiveSecurityAgent<TResult = void> {
     const runSpanAttributes: Record<string, string> = {
       "gen_ai.operation.name": "invoke_agent",
       "gen_ai.agent.name": spanLabel,
-      "gen_ai.conversation.id": this._session.id,
-      "pensar.session.id": this._session.id,
+      "gen_ai.conversation.id": this.busSessionId,
+      "pensar.session.id": this.busSessionId,
       ...(isSubagent
         ? {}
         : {

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
+import { SpanStatusCode } from "@opentelemetry/api";
 import type {
   ModelMessage,
   StopCondition,
@@ -14,7 +15,7 @@ import {
   resolveEffectiveHeaders,
   stripBrowserManagedHeaders,
 } from "../../http/targetHeaders";
-import { newMessageId, newPartId } from "../../id/id";
+import { newMessageId, newPartId, newRunId } from "../../id/id";
 import { createLogger } from "../../logger/structured";
 import { getApexTracer, withSubagentSessionBaggage } from "../../observability";
 import type { ApprovalGate } from "../../operator";
@@ -45,7 +46,11 @@ import {
   WORKSPACE_WRITE_TOOL_NAMES,
 } from "./tools";
 import { StepTraceWriter } from "./trace";
-import type { CreateAgentInput, OffensiveSecurityAgentInput } from "./types";
+import type {
+  AgentMode,
+  CreateAgentInput,
+  OffensiveSecurityAgentInput,
+} from "./types";
 
 const log = scopedLogger(() => createLogger("approval-gate"));
 
@@ -253,6 +258,8 @@ export class OffensiveSecurityAgent<TResult = void> {
 
   /** Display label for span name / `gen_ai.agent.name`; the id stays the join key. */
   private readonly subagentName?: string;
+  /** Operating mode (tools surface); used for run-span attribution. */
+  private readonly agentMode: AgentMode;
 
   /** The current open assistant message id (`msg_…`); minted on `start-step` in {@link consume}, `null` between steps. */
   private currentMessageId: string | null = null;
@@ -354,6 +361,7 @@ export class OffensiveSecurityAgent<TResult = void> {
     this._session = input.session;
     this.subagentId = input.subagentId;
     this.subagentName = input.subagentName;
+    this.agentMode = input.mode ?? "default";
     this.abortSignal = input.abortSignal;
     this.userPrompt = input.prompt;
     this.eventBus = input.eventBus ?? new AgentEventBus();
@@ -882,31 +890,54 @@ export class OffensiveSecurityAgent<TResult = void> {
       return undefined as TResult;
     };
 
-    // Only subagents get a span here; top-level runs are wrapped by the host.
-    const spanLabel = this.subagentName ?? sid;
-    const drain = !sid
-      ? runConsume()
-      : withSubagentSessionBaggage(sid, () =>
-          getApexTracer().startActiveSpan(
-            `invoke_agent ${spanLabel}`,
-            {
-              attributes: {
-                "gen_ai.operation.name": "invoke_agent",
-                "gen_ai.agent.name": spanLabel,
-              },
-            },
-            async (span) => {
-              try {
-                return await runConsume();
-              } catch (err) {
-                span.recordException(err as Error);
-                throw err;
-              } finally {
-                span.end();
-              }
-            },
-          ),
-        );
+    // One invoke_agent span per execution: root runs get the full run
+    // attribution (stable run id, mode); subagent runs nest beneath the root
+    // span via the async context and carry their own execution-session id.
+    const isSubagent = Boolean(sid);
+    const spanLabel = isSubagent
+      ? (this.subagentName ?? sid ?? "subagent")
+      : this.agentMode;
+    const runId = isSubagent ? undefined : newRunId();
+    const runSpanAttributes: Record<string, string> = {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.name": spanLabel,
+      "gen_ai.conversation.id": this._session.id,
+      "pensar.session.id": this._session.id,
+      ...(isSubagent
+        ? {}
+        : {
+            "pensar.run.id": runId,
+            "pensar.agent.mode": this.agentMode,
+          }),
+    };
+
+    const runInSpan = () =>
+      getApexTracer().startActiveSpan(
+        `invoke_agent ${spanLabel}`,
+        { attributes: runSpanAttributes },
+        async (span) => {
+          try {
+            return await runConsume();
+          } catch (err) {
+            // Record once, keep the cardinality low, preserve the original.
+            span.recordException(err as Error);
+            span.setStatus({ code: SpanStatusCode.ERROR });
+            span.setAttribute(
+              "error.type",
+              err instanceof Error ? err.name : "Error",
+            );
+            throw err;
+          } finally {
+            // Ends only after runConsume's finalization (persistence +
+            // owned-resource disposal) has settled.
+            span.end();
+          }
+        },
+      );
+
+    const drain = !isSubagent
+      ? runInSpan()
+      : withSubagentSessionBaggage(sid, runInSpan);
 
     // Decouple the result from stream teardown: with a `response` schema, return as soon as it's captured rather than waiting for the stream to close (which can wedge).
     let rejectDrain: ((err: unknown) => void) | undefined;

--- a/src/core/id/id.ts
+++ b/src/core/id/id.ts
@@ -7,6 +7,7 @@ const prefixes = {
   permission: "per",
   user: "usr",
   part: "prt",
+  run: "run",
 } as const;
 
 export type IdentifierPrefix = keyof typeof prefixes;
@@ -66,6 +67,8 @@ export type SessionID = string & { readonly __brand: "SessionID" };
 export type MessageID = string & { readonly __brand: "MessageID" };
 /** A part identifier: `prt_<time><random>`. */
 export type PartID = string & { readonly __brand: "PartID" };
+/** An agent-run identifier: `run_<time><random>`. */
+export type RunID = string & { readonly __brand: "RunID" };
 
 /** Mint a fresh, time-descending session id. */
 export const newSessionId = (): SessionID => descending("session") as SessionID;
@@ -73,6 +76,8 @@ export const newSessionId = (): SessionID => descending("session") as SessionID;
 export const newMessageId = (): MessageID => descending("message") as MessageID;
 /** Mint a fresh, time-descending part id. */
 export const newPartId = (): PartID => descending("part") as PartID;
+/** Mint a fresh, time-descending agent-run id. */
+export const newRunId = (): RunID => descending("run") as RunID;
 
 /** Runtime guard: is this string a session id? */
 export const isSessionId = (s: string): s is SessionID =>

--- a/src/core/observability/trace-contract.test.ts
+++ b/src/core/observability/trace-contract.test.ts
@@ -434,3 +434,146 @@ describe("existing trace contract: subagent spans", () => {
     expect(parentIds.size).toBe(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// O3: root agent-run tree — one coherent trace per top-level execution
+// ---------------------------------------------------------------------------
+
+describe("root agent-run tree", () => {
+  it("model and tool spans belong to the root trace; nested subagents too", async () => {
+    mockState.model = toolCallingModel();
+
+    // Subagent invocation nested inside the orchestrator's tool execution —
+    // exactly where a spawned agent runs in production.
+    const probeTool = () => ({
+      description: "spawns a subagent",
+      inputSchema: z.object({ q: z.string() }),
+      execute: async (input: { q: string }) => {
+        const subModel = oneStepTextModel();
+        const saved = mockState.model;
+        mockState.model = subModel;
+        try {
+          await subagentInvoke("ses_tree_sub", "recon-sub", async () => {
+            await drain(
+              streamResponse({ prompt: input.q, model: MODEL, silent: true }),
+            );
+          });
+        } finally {
+          mockState.model = saved;
+        }
+        return "subagent done";
+      },
+    });
+
+    // Root span with the agent's production attribute shape.
+    const rootAttributes = {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.name": "default",
+      "gen_ai.conversation.id": "ses_root",
+      "pensar.session.id": "ses_root",
+      "pensar.run.id": "run_test123",
+      "pensar.agent.mode": "default",
+    };
+
+    await getApexTracer().startActiveSpan(
+      "invoke_agent default",
+      { attributes: rootAttributes },
+      async (rootSpan) => {
+        try {
+          await drain(
+            streamResponse({
+              prompt: "hi",
+              model: MODEL,
+              silent: true,
+              tools: { probe: probeTool() },
+              stopWhen: stepCountIs(2),
+            }),
+          );
+        } finally {
+          rootSpan.end();
+        }
+      },
+    );
+
+    const spans = otel.getFinishedSpans();
+    const root = requireSpan(spans, "invoke_agent default");
+    const rootStreamText = requireSpan(spans, "ai.streamText");
+    const doStream = requireSpan(spans, "ai.streamText.doStream");
+    const toolSpan = requireSpan(spans, "ai.toolCall");
+    const subInvoke = requireSpan(spans, "invoke_agent recon-sub");
+    const subStreamTexts = spans.filter(
+      (s) => s.name === "ai.streamText" && s !== rootStreamText,
+    );
+
+    // The expected tree, one trace:
+    //   invoke_agent root → ai.streamText → doStream → ai.toolCall
+    //     → invoke_agent subagent → ai.streamText → doStream
+    const rootTraceId = root.spanContext().traceId;
+    for (const span of [rootStreamText, doStream, toolSpan, subInvoke]) {
+      expect(span.spanContext().traceId, span.name).toBe(rootTraceId);
+    }
+    expect(subStreamTexts).toHaveLength(1);
+    expect(subStreamTexts[0]?.spanContext().traceId).toBe(rootTraceId);
+    // The subagent span nests under the tool span.
+    expect(parentOf(spans, subInvoke)?.spanContext().spanId).toBe(
+      toolSpan.spanContext().spanId,
+    );
+    // Root attributes survive.
+    expect(root.attributes["pensar.run.id"]).toBe("run_test123");
+    expect(root.attributes["pensar.agent.mode"]).toBe("default");
+  });
+
+  it("concurrent subagents under one root keep their own parents and trace", async () => {
+    mockState.model = oneStepTextModel();
+
+    await getApexTracer().startActiveSpan(
+      "invoke_agent default",
+      {
+        attributes: {
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.name": "default",
+          "gen_ai.conversation.id": "ses_root",
+          "pensar.session.id": "ses_root",
+          "pensar.run.id": "run_conc",
+          "pensar.agent.mode": "default",
+        },
+      },
+      async (rootSpan) => {
+        try {
+          await Promise.all([
+            subagentInvoke("ses_c1", "agent-a", async () => {
+              await drain(
+                streamResponse({ prompt: "a", model: MODEL, silent: true }),
+              );
+            }),
+            subagentInvoke("ses_c2", "agent-b", async () => {
+              await drain(
+                streamResponse({ prompt: "b", model: MODEL, silent: true }),
+              );
+            }),
+          ]);
+        } finally {
+          rootSpan.end();
+        }
+      },
+    );
+
+    const spans = otel.getFinishedSpans();
+    const root = requireSpan(spans, "invoke_agent default");
+    const subInvokes = spans.filter((s) => s.name.startsWith("invoke_agent "));
+    const streamTexts = spans.filter((s) => s.name === "ai.streamText");
+
+    expect(subInvokes).toHaveLength(3); // root + two subagents
+    expect(streamTexts).toHaveLength(2);
+    // Everything shares the root trace…
+    for (const span of [...subInvokes, ...streamTexts]) {
+      expect(span.spanContext().traceId).toBe(root.spanContext().traceId);
+    }
+    // …and each model span parents its own subagent span.
+    for (const streamText of streamTexts) {
+      const parent = parentOf(spans, streamText);
+      expect(parent?.name.startsWith("invoke_agent ")).toBe(true);
+      expect(parent).not.toBe(root);
+    }
+  });
+});


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Usage + observability · PR 9 of 12**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#996](https://github.com/pensarai/apex/pull/996) | Session usage models |
| 2 | [#997](https://github.com/pensarai/apex/pull/997) | Session-scoped ownership |
| 3 | [#998](https://github.com/pensarai/apex/pull/998) | Complete usage persistence |
| 4 | [#999](https://github.com/pensarai/apex/pull/999) | Consolidated usage ingestion |
| 5 | [#1000](https://github.com/pensarai/apex/pull/1000) | Token and context footer |
| 6 | [#1002](https://github.com/pensarai/apex/pull/1002) | Cache token breakdown |
| 7 | [#1004](https://github.com/pensarai/apex/pull/1004) | Agent trace contract |
| 8 | [#1005](https://github.com/pensarai/apex/pull/1005) | Optional OTLP runtime |
| **9** | **[#1006](https://github.com/pensarai/apex/pull/1006)** | **Root agent run spans** · `Current` |
| 10 | [#1007](https://github.com/pensarai/apex/pull/1007) | Centralized telemetry settings |
| 11 | [#1008](https://github.com/pensarai/apex/pull/1008) | Telemetry correlation |
| 12 | [#1009](https://github.com/pensarai/apex/pull/1009) | OTLP shutdown hardening |
## Summary

- every `OffensiveSecurityAgent.consume()` execution now runs inside an active `invoke_agent` span — root runs previously relied on "the host" (Console) to wrap them; standalone runs had no root span at all
- the root span carries full run attribution:
  - `gen_ai.operation.name = invoke_agent`
  - `gen_ai.agent.name` — the agent mode (`default` / `plan` / `fast-strike`), low-cardinality by construction
  - `gen_ai.conversation.id` / `pensar.session.id` — the session id
  - `pensar.run.id` — a stable `run_<ulid>` minted once per top-level execution (`newRunId()` in the id module, following the existing prefix registry)
  - `pensar.agent.mode`
- subagent spans keep their existing shape (name + execution-session baggage) and nest beneath the root span via the async context — **no run id on subagent spans** (the trace id correlates them)
- failure handling (both root and subagent paths, unified): exception recorded once, `SpanStatusCode.ERROR`, low-cardinality `error.type` attribute (`err.name`, e.g. `AbortError` / `Error`), the original error rethrown, span always ended

## Span lifetime

The span ends only after `runConsume()` settles — its `finally` covers interrupted-step finalization (persistence) and owned-resource disposal (shell + browser). The early-capture path (result race won by `responseCaptured`) returns while the drain continues in the background; the span ends when the drain's cleanup completes.

## Expected tree (pinned by tests)

```
invoke_agent default                (root — run id, mode)
  ai.streamText
    ai.streamText.doStream
    ai.toolCall
      invoke_agent recon-sub        (subagent — session baggage)
        ai.streamText
          ai.streamText.doStream
```

## What changed

- `src/core/id/id.ts` — `run` prefix, `RunID` brand, `newRunId()` (same pattern as `newSessionId`)
- `offensiveSecurityAgent.ts` — constructor stores `agentMode` (was read-only at tool-build time); the drain block becomes one unified `runInSpan()` used by both root and subagent paths (subagent keeps the `withSubagentSessionBaggage` wrapper); error handling upgraded from record-only to record + status + `error.type`
- `offensiveSecurityAgent.test.ts` — stub harness gains `subagentId` / `subagentName` / `agentMode` overrides; 6 new agent-level tests
- `trace-contract.test.ts` — 2 new tree-composition tests (real `streamResponse` inside the span structure)

## Tests (8 new)

**Agent-level (real `consume()` via the stub harness):**
- one root span per top-level run with the full attribute set (`run_` id format included)
- successful runs leave status unset
- failed runs: ERROR status, `exception` event with the message, `error.type` = class name
- aborted runs: every span ended, `error.type` = `AbortError`
- persistence and disposal finish before the root span ends (disposal runs inside the finalization the span wraps; export happens only at end)
- subagent runs: span with conversation/session ids, **no** run id / mode attributes

**Tree-composition (real `streamResponse` through the mock model):**
- the full expected tree in one trace: root → model → provider → tool → nested subagent → its model span; subagent parents under the tool span; root attributes survive
- concurrent subagents under one root: all spans share the root trace, each model span parents its own subagent span (not the root, not each other)

## Validation

- `bun run test` (1,801 passed, 22 skipped — all 46 agent tests green)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the four touched files

## Non-goals honored

No workflow-phase spans, no EventBus→span conversion, no payload-policy changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only wrapping around existing consume/finalization paths; no auth, billing, or tool behavior changes.
> 
> **Overview**
> **Every top-level `OffensiveSecurityAgent.consume()` now opens its own `invoke_agent` span**, so standalone runs get a trace root without relying on the Console host. Subagents still use the same span wrapper plus session baggage; model/tool spans nest under the active context as before.
> 
> **Root spans carry run attribution:** `gen_ai.conversation.id` / `pensar.session.id`, agent mode as `gen_ai.agent.name` (e.g. `default`), `pensar.agent.mode`, and a minted **`pensar.run.id`** (`newRunId()` / `run_…` in `id.ts`). Subagent spans keep name and session ids but **omit** run id and mode.
> 
> **Unified span lifecycle:** one `runInSpan()` path for root and subagent; failures set ERROR status, record the exception, and set low-cardinality `error.type`. The span ends only after `runConsume()` finalization (persistence and owned shell/browser disposal).
> 
> **Tests:** six agent-level OTel tests on `consume()` and two trace-contract tests for the expected root → model → tool → nested subagent tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab061863ed98b62587c46e42606c412008abf7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

