### PR TITLE
refactor(observability): centralize AI telemetry settings

### DIFF
--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -18,7 +18,7 @@ import {
 } from "ai";
 import type { z } from "zod";
 import { createLogger } from "../logger/structured";
-import { shouldRecordAiPayloads } from "../observability";
+import { createAiTelemetrySettings } from "../observability";
 import { scopedLogger } from "../util/lazyLogger";
 import {
   cacheBreakpointFor,
@@ -1181,7 +1181,6 @@ export function streamResponse(
 
   try {
     // Create the appropriate provider instance
-    const recordPayloads = shouldRecordAiPayloads();
     const response = streamText({
       model: providerModel,
       system: effectiveSystem,
@@ -1191,13 +1190,10 @@ export function streamResponse(
       tools,
       maxRetries: 3,
       providerOptions,
-      experimental_telemetry: {
-        isEnabled: true,
-        recordInputs: recordPayloads,
-        recordOutputs: recordPayloads,
-        functionId: `apex.stream.${model}`,
-        ...(sessionId ? { metadata: { sessionId } } : {}),
-      },
+      experimental_telemetry: createAiTelemetrySettings({
+        operation: "apex.agent.stream",
+        sessionId,
+      }),
       // Pin actual emission to the same value `fitMessagesToContext`
       // reserved for output. Without this, the SDK applies provider
       // defaults that can exceed our budget — e.g. GPT-4o defaults to
@@ -1328,13 +1324,10 @@ export function streamResponse(
                 "Do not add prefixes, suffixes, or formatting characters like '>', '-', '!', etc.",
               ].join("\n"),
               abortSignal,
-              experimental_telemetry: {
-                isEnabled: true,
-                recordInputs: recordPayloads,
-                recordOutputs: recordPayloads,
-                functionId: "apex.tool_repair",
-                ...(sessionId ? { metadata: { sessionId } } : {}),
-              },
+              experimental_telemetry: createAiTelemetrySettings({
+                operation: "apex.tool.repair",
+                sessionId,
+              }),
             });
 
           // Report tool repair token usage if onStepFinish callback is provided
@@ -1488,7 +1481,6 @@ export async function generateObjectResponse<T extends z.ZodType>(
 
   for (let attempt = 0; attempt <= MAX_OBJECT_RATE_LIMIT_RETRIES; attempt++) {
     try {
-      const recordPayloads = shouldRecordAiPayloads();
       const { output, usage, providerMetadata } = await generateText({
         model: providerModel,
         output: Output.object({
@@ -1507,13 +1499,10 @@ export async function generateObjectResponse<T extends z.ZodType>(
           : undefined,
         maxRetries: 0,
         abortSignal,
-        experimental_telemetry: {
-          isEnabled: true,
-          recordInputs: recordPayloads,
-          recordOutputs: recordPayloads,
-          functionId: "apex.generate_object",
-          ...(sessionId ? { metadata: { sessionId } } : {}),
-        },
+        experimental_telemetry: createAiTelemetrySettings({
+          operation: "apex.structured.generate",
+          sessionId,
+        }),
       });
 
       if (onTokenUsage && usage) {

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -19,6 +19,7 @@ import { getPensarGatewayUrl } from "../api/constants";
 import { ensureValidToken } from "../auth";
 import { config } from "../config";
 import { createLogger } from "../logger/structured";
+import { createAiTelemetrySettings } from "../observability";
 import { scopedLogger } from "../util/lazyLogger";
 import { type AIModel, type StreamResponseOpts, streamResponse } from "./ai";
 import {
@@ -439,6 +440,10 @@ async function summarizeConversation(
     system: `You are a helpful assistant that summarizes conversations to pass to another agent. Review the conversation and system prompt at the end provided by the user.`,
     messages: summarizedMessages,
     abortSignal: opts.abortSignal,
+    experimental_telemetry: createAiTelemetrySettings({
+      operation: "apex.context.summarize",
+      sessionId: opts.sessionId,
+    }),
   });
 
   // Report summarization token usage if onStepFinish callback is provided

--- a/src/core/observability/index.ts
+++ b/src/core/observability/index.ts
@@ -15,6 +15,13 @@ export function shouldRecordAiPayloads(): boolean {
   return process.env.AI_TRACE_RECORD_PAYLOADS === "true";
 }
 
+export {
+  type AiTelemetryOperation,
+  type AiTelemetrySettings,
+  type CreateAiTelemetryInput,
+  createAiTelemetrySettings,
+} from "./telemetry";
+
 /**
  * OTel baggage key for the execution-session id. Console's SpanProcessor copies
  * `pensar.*` baggage onto every span — must stay in sync with it.

--- a/src/core/observability/telemetry.test.ts
+++ b/src/core/observability/telemetry.test.ts
@@ -1,0 +1,489 @@
+// O4 — centralized AI telemetry. One builder feeds every model call; the
+// operation identifiers are a fixed low-cardinality set; payload capture
+// stays opt-in; metadata propagates to span attributes.
+
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import { simulateReadableStream, stepCountIs } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+const mockState: { model: MockLanguageModelV3 | null } = { model: null };
+vi.mock("../ai/utils", async () => {
+  const actual =
+    await vi.importActual<typeof import("../ai/utils")>("../ai/utils");
+  return {
+    ...actual,
+    getProviderModel: () => {
+      if (!mockState.model) throw new Error("mock model not set");
+      return mockState.model;
+    },
+  };
+});
+
+const { streamResponse, generateObjectResponse } = await import("../ai");
+const { createSummarizationStream } = await import("../ai/utils");
+const { createAiTelemetrySettings } = await import("../observability");
+
+import type { OtelTestHarness } from "./testkit";
+
+const { requireSpan, startOtelTestHarness } = await import("./testkit");
+
+const MODEL = "claude-haiku-4-5";
+
+function oneStepTextModel(): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    provider: "mock-anthropic",
+    modelId: MODEL,
+    doStream: async () => ({
+      stream: simulateReadableStream({
+        chunks: [
+          { type: "stream-start", warnings: [] },
+          { type: "text-start", id: "t" },
+          { type: "text-delta", id: "t", delta: "hello" },
+          { type: "text-end", id: "t" },
+          {
+            type: "finish",
+            finishReason: { unified: "stop", raw: "stop" },
+            usage: {
+              inputTokens: {
+                total: 1000,
+                noCache: 100,
+                cacheRead: 900,
+                cacheWrite: 0,
+              },
+              outputTokens: { total: 20, text: 20, reasoning: undefined },
+            },
+          },
+        ] as unknown as Array<LanguageModelV3StreamPart>,
+      }),
+    }),
+  });
+}
+
+/** A model whose step-1 tool args fail zod validation, triggering repair. */
+function invalidToolArgsModel(): MockLanguageModelV3 {
+  let call = 0;
+  return new MockLanguageModelV3({
+    provider: "mock-anthropic",
+    modelId: MODEL,
+    doStream: async () => {
+      call += 1;
+      if (call === 1) {
+        return {
+          stream: simulateReadableStream({
+            chunks: [
+              { type: "stream-start", warnings: [] },
+              {
+                type: "tool-call",
+                toolCallId: "call-bad",
+                toolName: "probe",
+                // invalid: q must be a string
+                input: '{"q":42}',
+              },
+              {
+                type: "finish",
+                finishReason: { unified: "tool-calls", raw: "tool_use" },
+                usage: {
+                  inputTokens: {
+                    total: 50,
+                    noCache: 50,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                  },
+                  outputTokens: { total: 5, text: 5, reasoning: undefined },
+                },
+              },
+            ] as unknown as Array<LanguageModelV3StreamPart>,
+          }),
+        };
+      }
+      return {
+        stream: simulateReadableStream({
+          chunks: [
+            { type: "stream-start", warnings: [] },
+            { type: "text-start", id: "t" },
+            { type: "text-delta", id: "t", delta: "repaired" },
+            { type: "text-end", id: "t" },
+            {
+              type: "finish",
+              finishReason: { unified: "stop", raw: "stop" },
+              usage: {
+                inputTokens: {
+                  total: 60,
+                  noCache: 60,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                },
+                outputTokens: { total: 6, text: 6, reasoning: undefined },
+              },
+            },
+          ] as unknown as Array<LanguageModelV3StreamPart>,
+        }),
+      };
+    },
+  });
+}
+
+function generateModel(): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    provider: "mock-anthropic",
+    modelId: MODEL,
+    doGenerate: async () => ({
+      content: [{ type: "text", text: '{"result":"ok"}' }],
+      finishReason: { unified: "stop", raw: "stop" },
+      warnings: [],
+      usage: {
+        inputTokens: {
+          total: 500,
+          noCache: 100,
+          cacheRead: 400,
+          cacheWrite: 0,
+        },
+        outputTokens: { total: 40, text: 40, reasoning: undefined },
+      },
+    }),
+  });
+}
+
+async function drain(stream: { fullStream: AsyncIterable<unknown> }) {
+  for await (const _part of stream.fullStream) {
+    // drain
+  }
+}
+
+let otel: OtelTestHarness;
+
+beforeEach(() => {
+  otel = startOtelTestHarness();
+});
+
+afterEach(async () => {
+  await otel.shutdown();
+  mockState.model = null;
+  process.env.AI_TRACE_RECORD_PAYLOADS = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// Builder units
+// ---------------------------------------------------------------------------
+
+describe("createAiTelemetrySettings", () => {
+  it("enables telemetry with payload capture off by default", () => {
+    const settings = createAiTelemetrySettings({
+      operation: "apex.agent.stream",
+    });
+    expect(settings.isEnabled).toBe(true);
+    expect(settings.recordInputs).toBe(false);
+    expect(settings.recordOutputs).toBe(false);
+    expect(settings.functionId).toBe("apex.agent.stream");
+    expect(settings.metadata).toBeUndefined();
+  });
+
+  it("follows AI_TRACE_RECORD_PAYLOADS for full capture", () => {
+    process.env.AI_TRACE_RECORD_PAYLOADS = "true";
+    const settings = createAiTelemetrySettings({
+      operation: "apex.structured.generate",
+    });
+    expect(settings.recordInputs).toBe(true);
+    expect(settings.recordOutputs).toBe(true);
+  });
+
+  it("propagates session, run, and agent metadata when present", () => {
+    const settings = createAiTelemetrySettings({
+      operation: "apex.agent.stream",
+      sessionId: "ses_1",
+      runId: "run_1",
+      agentId: "sub_1",
+    });
+    expect(settings.metadata).toEqual({
+      sessionId: "ses_1",
+      runId: "run_1",
+      agentId: "sub_1",
+    });
+  });
+
+  it("operation identifiers are a fixed low-cardinality set", () => {
+    const ids = [
+      "apex.agent.stream",
+      "apex.structured.generate",
+      "apex.context.summarize",
+      "apex.tool.repair",
+    ] as const;
+    for (const operation of ids) {
+      expect(createAiTelemetrySettings({ operation }).functionId).toBe(
+        operation,
+      );
+    }
+    // The builder cannot mint a high-cardinality id (model ids, session ids…)
+    // — the operation is a closed union at compile time.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Every model-call helper: telemetry enabled, stable functionId, payloads
+// ---------------------------------------------------------------------------
+
+describe("model-call helpers", () => {
+  it("streamResponse enables telemetry with the stable operation id (no model in the name)", async () => {
+    mockState.model = oneStepTextModel();
+    await drain(
+      streamResponse({
+        prompt: "hi",
+        model: MODEL,
+        silent: true,
+        sessionId: "ses_stream",
+      }),
+    );
+
+    const span = requireSpan(otel.getFinishedSpans(), "ai.streamText");
+    // Model id lives in an attribute, not the operation name.
+    expect(span.attributes["ai.telemetry.functionId"]).toBe(
+      "apex.agent.stream",
+    );
+    expect(span.attributes["resource.name"]).toBe("apex.agent.stream");
+    expect(span.attributes["ai.model.id"]).toBe(MODEL);
+    // Session metadata propagates.
+    expect(span.attributes["ai.telemetry.metadata.sessionId"]).toBe(
+      "ses_stream",
+    );
+  });
+
+  it("generateObjectResponse creates a model span with structured-generation id", async () => {
+    mockState.model = generateModel();
+    const output = await generateObjectResponse({
+      model: MODEL,
+      schema: z.object({ result: z.string() }),
+      prompt: "hi",
+      sessionId: "ses_obj",
+    });
+
+    expect(output).toEqual({ result: "ok" });
+    const span = requireSpan(
+      otel.getFinishedSpans(),
+      "ai.generateText.doGenerate",
+    );
+    expect(span.attributes["ai.telemetry.functionId"]).toBe(
+      "apex.structured.generate",
+    );
+    expect(span.attributes["ai.telemetry.metadata.sessionId"]).toBe("ses_obj");
+    // Usage not double-counted: inclusive input, cache reported separately.
+    expect(span.attributes["gen_ai.usage.input_tokens"]).toBe(500);
+    expect(span.attributes["ai.usage.cachedInputTokens"]).toBe(400);
+    expect(span.attributes["ai.usage.inputTokens"]).toBe(500);
+  });
+
+  it("generateObjectResponse default mode carries no prompt payload; full mode does", async () => {
+    mockState.model = generateModel();
+    await generateObjectResponse({
+      model: MODEL,
+      schema: z.object({ result: z.string() }),
+      prompt: "secret objective",
+    });
+    const opSpan = requireSpan(
+      otel.getFinishedSpans(),
+      "ai.generateText.doGenerate",
+    );
+    expect(opSpan.attributes["ai.prompt.messages"]).toBeUndefined();
+    expect(opSpan.attributes["ai.response.text"]).toBeUndefined();
+
+    // Reset so the full-mode assertions read the second call's spans.
+    otel.exporter.reset();
+    mockState.model = generateModel();
+    process.env.AI_TRACE_RECORD_PAYLOADS = "true";
+    await generateObjectResponse({
+      model: MODEL,
+      schema: z.object({ result: z.string() }),
+      prompt: "secret objective",
+    });
+    // On the generateText path payloads live on the provider-call span
+    // (opposite of streamText, where they sit on the operation span).
+    const fullSpan = requireSpan(
+      otel.getFinishedSpans(),
+      "ai.generateText.doGenerate",
+    );
+    expect(String(fullSpan.attributes["ai.prompt.messages"])).toContain(
+      "secret objective",
+    );
+    expect(String(fullSpan.attributes["ai.response.text"])).toContain("result");
+  });
+
+  it("direct summarization creates a model span with the summarize id", async () => {
+    mockState.model = oneStepTextModel();
+    const stream = createSummarizationStream(
+      [{ role: "user", content: "history to summarize" }],
+      {
+        prompt: "resume",
+        model: MODEL,
+        silent: true,
+        sessionId: "ses_sum",
+      },
+      mockState.model,
+    );
+    // Drain only the summarization's generateText — the resumed stream would
+    // call back into the mock; we only need the summary span to exist.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const span = requireSpan(
+      otel.getFinishedSpans(),
+      "ai.generateText.doGenerate",
+    );
+    expect(span.attributes["ai.telemetry.functionId"]).toBe(
+      "apex.context.summarize",
+    );
+    expect(span.attributes["ai.telemetry.metadata.sessionId"]).toBe("ses_sum");
+    void stream;
+  });
+
+  it("tool repair runs its model call with the repair id", async () => {
+    mockState.model = invalidToolArgsModel();
+    await drain(
+      streamResponse({
+        prompt: "hi",
+        model: MODEL,
+        silent: true,
+        tools: {
+          probe: {
+            description: "test tool",
+            inputSchema: z.object({ q: z.string() }),
+            execute: async (input: { q: string }) => `echo:${input.q}`,
+          },
+        },
+        stopWhen: stepCountIs(2),
+      }),
+    );
+
+    const generateSpans = otel
+      .getFinishedSpans()
+      .filter((s) => s.name === "ai.generateText.doGenerate");
+    expect(generateSpans.length).toBeGreaterThan(0);
+    expect(generateSpans[0]?.attributes["ai.telemetry.functionId"]).toBe(
+      "apex.tool.repair",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full mode across the stream path: prompts, responses, reasoning, tools
+// ---------------------------------------------------------------------------
+
+describe("full payload capture (stream path)", () => {
+  it("includes prompt, response, reasoning, and tool payloads", async () => {
+    process.env.AI_TRACE_RECORD_PAYLOADS = "true";
+    let call = 0;
+    mockState.model = new MockLanguageModelV3({
+      provider: "mock-anthropic",
+      modelId: MODEL,
+      doStream: async () => {
+        call += 1;
+        if (call === 1) {
+          return {
+            stream: simulateReadableStream({
+              chunks: [
+                { type: "stream-start", warnings: [] },
+                { type: "reasoning-start", id: "r1" },
+                { type: "reasoning-delta", id: "r1", delta: "pondering" },
+                { type: "reasoning-end", id: "r1" },
+                { type: "tool-input-start", id: "c1", toolName: "probe" },
+                { type: "tool-input-delta", id: "c1", delta: '{"q":"hi"}' },
+                { type: "tool-input-end", id: "c1" },
+                {
+                  type: "tool-call",
+                  toolCallId: "c1",
+                  toolName: "probe",
+                  input: '{"q":"hi"}',
+                },
+                {
+                  type: "finish",
+                  finishReason: { unified: "tool-calls", raw: "tool_use" },
+                  usage: {
+                    inputTokens: {
+                      total: 100,
+                      noCache: 100,
+                      cacheRead: 0,
+                      cacheWrite: 0,
+                    },
+                    outputTokens: { total: 10, text: 10, reasoning: undefined },
+                  },
+                },
+              ] as unknown as Array<LanguageModelV3StreamPart>,
+            }),
+          };
+        }
+        return {
+          stream: simulateReadableStream({
+            chunks: [
+              { type: "stream-start", warnings: [] },
+              { type: "text-start", id: "t" },
+              { type: "text-delta", id: "t", delta: "final answer" },
+              { type: "text-end", id: "t" },
+              {
+                type: "finish",
+                finishReason: { unified: "stop", raw: "stop" },
+                usage: {
+                  inputTokens: {
+                    total: 90,
+                    noCache: 90,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                  },
+                  outputTokens: { total: 9, text: 9, reasoning: undefined },
+                },
+              },
+            ] as unknown as Array<LanguageModelV3StreamPart>,
+          }),
+        };
+      },
+    });
+
+    await drain(
+      streamResponse({
+        prompt: "secret objective",
+        system: "system directive",
+        model: MODEL,
+        silent: true,
+        tools: {
+          probe: {
+            description: "test tool",
+            inputSchema: z.object({ q: z.string() }),
+            execute: async (input: { q: string }) => `echo:${input.q}`,
+          },
+        },
+        stopWhen: stepCountIs(2),
+      }),
+    );
+
+    const spans = otel.getFinishedSpans();
+    const streamText = requireSpan(spans, "ai.streamText");
+    // System + prompt inside the serialized prompt payload.
+    const prompt = String(streamText.attributes["ai.prompt"] ?? "");
+    expect(prompt).toContain("secret objective");
+    expect(prompt).toContain("system directive");
+    // Tool definitions recorded on the provider-call span.
+    const doStream = requireSpan(spans, "ai.streamText.doStream");
+    expect(String(doStream.attributes["ai.prompt.tools"] ?? "")).toContain(
+      "probe",
+    );
+
+    const toolSpan = requireSpan(spans, "ai.toolCall");
+    expect(String(toolSpan.attributes["ai.toolCall.args"])).toContain(
+      '"q":"hi"',
+    );
+    expect(String(toolSpan.attributes["ai.toolCall.result"])).toContain(
+      "echo:hi",
+    );
+
+    const responseText = spans
+      .map((s) => s.attributes["ai.response.text"])
+      .filter(Boolean)
+      .map(String)
+      .join(" ");
+    expect(responseText).toContain("final answer");
+    const reasoning = spans
+      .map((s) => s.attributes["ai.response.reasoning"])
+      .filter(Boolean)
+      .map(String)
+      .join(" ");
+    expect(reasoning).toContain("pondering");
+  });
+});

--- a/src/core/observability/telemetry.test.ts
+++ b/src/core/observability/telemetry.test.ts
@@ -35,6 +35,20 @@ function oneStepTextModel(): MockLanguageModelV3 {
   return new MockLanguageModelV3({
     provider: "mock-anthropic",
     modelId: MODEL,
+    doGenerate: async () => ({
+      content: [{ type: "text", text: "summary" }],
+      finishReason: { unified: "stop", raw: "stop" },
+      warnings: [],
+      usage: {
+        inputTokens: {
+          total: 500,
+          noCache: 500,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+        outputTokens: { total: 20, text: 20, reasoning: undefined },
+      },
+    }),
     doStream: async () => ({
       stream: simulateReadableStream({
         chunks: [
@@ -320,9 +334,7 @@ describe("model-call helpers", () => {
       },
       mockState.model,
     );
-    // Drain only the summarization's generateText — the resumed stream would
-    // call back into the mock; we only need the summary span to exist.
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await drain(stream);
 
     const span = requireSpan(
       otel.getFinishedSpans(),
@@ -332,7 +344,6 @@ describe("model-call helpers", () => {
       "apex.context.summarize",
     );
     expect(span.attributes["ai.telemetry.metadata.sessionId"]).toBe("ses_sum");
-    void stream;
   });
 
   it("tool repair runs its model call with the repair id", async () => {

--- a/src/core/observability/telemetry.ts
+++ b/src/core/observability/telemetry.ts
@@ -1,0 +1,56 @@
+import { shouldRecordAiPayloads } from "./index";
+
+/**
+ * Structurally the AI SDK's `TelemetrySettings` (the package does not
+ * re-export the type). Passed as `experimental_telemetry` on model calls.
+ */
+export interface AiTelemetrySettings {
+  isEnabled: boolean;
+  recordInputs: boolean;
+  recordOutputs: boolean;
+  /** Stable, low-cardinality operation identifier (`apex.<area>.<verb>`). */
+  functionId: string;
+  metadata?: Record<string, string>;
+}
+
+/** Stable operation identifiers for every model-call helper. */
+export type AiTelemetryOperation =
+  | "apex.agent.stream"
+  | "apex.structured.generate"
+  | "apex.context.summarize"
+  | "apex.tool.repair";
+
+export interface CreateAiTelemetryInput {
+  operation: AiTelemetryOperation;
+  sessionId?: string;
+  runId?: string;
+  agentId?: string;
+}
+
+/**
+ * One builder for every model call's telemetry — identical payload policy
+ * everywhere. Full payload capture (`recordInputs`/`recordOutputs`) is
+ * opt-in via `AI_TRACE_RECORD_PAYLOADS=true` and never defaults on.
+ *
+ * ⚠️ Full mode exports sensitive data to the configured OTLP backend,
+ * including customer source code, credentials, cookies, authorization
+ * headers, attack targets, and model reasoning. Off by default.
+ */
+export function createAiTelemetrySettings(
+  input: CreateAiTelemetryInput,
+): AiTelemetrySettings {
+  const recordPayloads = shouldRecordAiPayloads();
+  const metadata: Record<string, string> = {};
+  if (input.sessionId) metadata.sessionId = input.sessionId;
+  if (input.runId) metadata.runId = input.runId;
+  if (input.agentId) metadata.agentId = input.agentId;
+  return {
+    isEnabled: true,
+    recordInputs: recordPayloads,
+    recordOutputs: recordPayloads,
+    // Model ids belong in span attributes (ai.model.id), never in the
+    // operation name — a per-model functionId is unbounded cardinality.
+    functionId: input.operation,
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+  };
+}


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Usage + observability · PR 10 of 12**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#996](https://github.com/pensarai/apex/pull/996) | Session usage models |
| 2 | [#997](https://github.com/pensarai/apex/pull/997) | Session-scoped ownership |
| 3 | [#998](https://github.com/pensarai/apex/pull/998) | Complete usage persistence |
| 4 | [#999](https://github.com/pensarai/apex/pull/999) | Consolidated usage ingestion |
| 5 | [#1000](https://github.com/pensarai/apex/pull/1000) | Token and context footer |
| 6 | [#1002](https://github.com/pensarai/apex/pull/1002) | Cache token breakdown |
| 7 | [#1004](https://github.com/pensarai/apex/pull/1004) | Agent trace contract |
| 8 | [#1005](https://github.com/pensarai/apex/pull/1005) | Optional OTLP runtime |
| 9 | [#1006](https://github.com/pensarai/apex/pull/1006) | Root agent run spans |
| **10** | **[#1007](https://github.com/pensarai/apex/pull/1007)** | **Centralized telemetry settings** · `Current` |
| 11 | [#1008](https://github.com/pensarai/apex/pull/1008) | Telemetry correlation |
| 12 | [#1009](https://github.com/pensarai/apex/pull/1009) | OTLP shutdown hardening |
## Summary

- one `createAiTelemetrySettings({ operation, sessionId?, runId?, agentId? })` builder (`src/core/observability/telemetry.ts`) replaces every hand-rolled `experimental_telemetry` object, giving all model calls an identical payload policy
- stable, low-cardinality operation identifiers:
  | Site | Before | After |
  |---|---|---|
  | `streamResponse()` | `apex.stream.${model}` ⚠️ | `apex.agent.stream` |
  | `generateObjectResponse()` | `apex.generate_object` | `apex.structured.generate` |
  | tool repair | `apex.tool_repair` | `apex.tool.repair` |
  | context summarization | *(none — no telemetry at all)* | `apex.context.summarize` |
- **cardinality fix**: the stream operation id embedded the model id (`apex.stream.claude-haiku-4-5` → one `resource.name` value per model per backend). Model ids already live in the `ai.model.id` span attribute; the operation name is now a closed 4-value union
- **gap fix**: `summarizeConversation`'s direct `generateText` ran with telemetry entirely absent — it now emits a model span
- payload capture reuses `AI_TRACE_RECORD_PAYLOADS` via the builder — **never defaults on**
- session metadata (`sessionId`) propagates to `ai.telemetry.metadata.sessionId` on spans, as before; `runId`/`agentId` are supported by the builder for callers that have them

## Payload sensitivity (documented on the builder)

> ⚠️ Full mode exports sensitive data to the configured OTLP backend, including customer source code, credentials, cookies, authorization headers, attack targets, and model reasoning. Off by default.

## Attribute-placement findings (pinned by tests, worth knowing)

- **streamText**: `ai.prompt` (serialized request) and `ai.usage.*` totals on the operation span; `ai.prompt.messages` / `ai.prompt.tools` / `ai.prompt.toolChoice` and `gen_ai.usage.*` on the **`doStream`** span
- **generateText** (object responses): the opposite — payload attributes (`ai.prompt.messages`, `ai.response.text`) on the **`doGenerate`** span

## Tests (10, in `telemetry.test.ts`)

Builder units: telemetry enabled with payloads off by default; follows `AI_TRACE_RECORD_PAYLOADS`; session/run/agent metadata propagation (omitted when absent); the closed operation-id set.

Helper integration (real `streamResponse`/`generateObjectResponse`/summarization/repair through the mock model):
- every helper enables telemetry with its stable id — including `resource.name` now free of the model id, model id present as `ai.model.id`, session metadata propagating
- structured generation: model span, metadata, **usage not double-counted** (inclusive input 500, `ai.usage.cachedInputTokens` 400)
- default mode carries no prompt/response payload; full mode carries both (on the correct span)
- direct summarization creates a model span with `apex.context.summarize`
- tool repair (triggered by schema-invalid tool args) runs its model call with `apex.tool.repair`
- full stream mode includes prompt + system, tool definitions, tool args/results, response text, and reasoning

## What changed

- `src/core/observability/telemetry.ts` (new) — the builder + `AiTelemetrySettings` (structural — the SDK doesn't export `TelemetrySettings`) + the operation union + the sensitivity doc
- `src/core/observability/index.ts` — barrel re-export
- `src/core/ai/ai.ts` — three inline objects replaced; two now-unused `recordPayloads` locals and the `shouldRecordAiPayloads` import removed
- `src/core/ai/utils.ts` — summarization `generateText` gains telemetry

## Validation

- `bun run test` (1,811 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the five touched files (one pre-existing warning in untouched code)

## Non-goals honored

No payload redaction, no Langfuse-specific attributes, no trace.jsonl changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only refactor that standardizes trace identifiers and adds missing summarization spans; runtime AI behavior and opt-in payload capture policy are unchanged.
> 
> **Overview**
> Introduces **`createAiTelemetrySettings`** so every AI SDK model call shares one **`experimental_telemetry`** policy instead of hand-built objects scattered in **`ai.ts`** and **`utils.ts`**.
> 
> **Stable, low-cardinality operation names** replace ad hoc `functionId` values: agent streaming is **`apex.agent.stream`** (no longer **`apex.stream.${model}`**), structured output is **`apex.structured.generate`**, tool repair is **`apex.tool.repair`**, and context summarization **`generateText`** now emits **`apex.context.summarize`** (previously had no telemetry). Payload recording still follows **`AI_TRACE_RECORD_PAYLOADS`** via the builder and stays off by default; optional **`sessionId` / `runId` / `agentId`** metadata is attached when provided.
> 
> Adds **`telemetry.test.ts`** to lock builder behavior and end-to-end span attributes across stream, object generation, summarization, repair, and full payload capture modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3523f2e99df9a1554589f0f3367c8988ff876e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

