### PR TITLE
feat(observability): correlate agent telemetry

### DIFF
--- a/src/core/agents/offSecAgent/trace.ts
+++ b/src/core/agents/offSecAgent/trace.ts
@@ -14,6 +14,7 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import type { ModelMessage } from "ai";
 import type { AgentEventBus } from "../../eventBus";
+import { getActiveTraceCorrelation } from "../../observability";
 
 // ---------------------------------------------------------------------------
 // Shared type aliases
@@ -129,6 +130,9 @@ export interface StateCheckpoint {
   /** Discriminator — distinguishes from StepRecord in trace.jsonl */
   type: "checkpoint";
 
+  /** OTel correlation (active span at write time). */
+  correlation?: TraceCorrelation;
+
   /** Step index at which the checkpoint was emitted */
   stepIndex: number;
 
@@ -177,6 +181,9 @@ export interface InitRecord {
 
   timestamp: string;
 
+  /** OTel correlation (active span at write time). */
+  correlation?: TraceCorrelation;
+
   agentId: string | null;
 
   /** AI model identifier used for this agent */
@@ -213,6 +220,9 @@ export interface TaskRecord {
   /** Discriminator — distinguishes from other record types in trace.jsonl */
   type: "task";
 
+  /** OTel correlation (active span at write time). */
+  correlation?: TraceCorrelation;
+
   /** ISO 8601 timestamp when the task event occurred */
   timestamp: string;
 
@@ -245,12 +255,24 @@ export type TaskRecordInput = Omit<
   "type" | "timestamp" | "agentId" | "stepIndex"
 >;
 
+/**
+ * OTel correlation for a trace record, populated when the writer runs
+ * inside an active span. Absent on legacy records.
+ */
+export interface TraceCorrelation {
+  traceId?: string;
+  spanId?: string;
+}
+
 /** Discriminated union of all trace record types. */
 export type TraceRecord =
   | InitRecord
   | StepRecord
   | StateCheckpoint
   | TaskRecord;
+
+/** Every record may carry OTel correlation (absent on legacy records). */
+export type CorrelatedRecord = TraceRecord & { correlation?: TraceCorrelation };
 
 // ---------------------------------------------------------------------------
 // Extraction helpers
@@ -577,14 +599,20 @@ export class StepTraceWriter {
 
   /** Sync append — ~1-3KB per line, sub-ms. Sync ensures crash safety. */
   private appendRecord(record: TraceRecord): void {
+    // Correlate with the active OTel span when valid — W&B and JSONL
+    // consumers receive it through this same record, no extra wiring.
+    const correlation = getActiveTraceCorrelation();
+    const enriched: CorrelatedRecord = correlation
+      ? { ...record, correlation }
+      : record;
     try {
-      appendFileSync(this.tracePath, `${JSON.stringify(record)}\n`);
+      appendFileSync(this.tracePath, `${JSON.stringify(enriched)}\n`);
     } catch {
       // Trace is non-critical observability — never crash the agent for it.
     }
     try {
       this.eventBus?.emit("trace-record", {
-        record,
+        record: enriched,
         subagentId: this.agentId ?? undefined,
       });
     } catch {

--- a/src/core/agents/offSecAgent/trace.ts
+++ b/src/core/agents/offSecAgent/trace.ts
@@ -37,6 +37,9 @@ export interface StepRecord {
   /** Discriminator — distinguishes from StateCheckpoint in trace.jsonl */
   type: "step";
 
+  /** OTel correlation (active span at write time). */
+  correlation?: TraceCorrelation;
+
   /** Monotonically increasing within this agent, starting at 0 */
   stepIndex: number;
 

--- a/src/core/logger/structured.ts
+++ b/src/core/logger/structured.ts
@@ -1,3 +1,4 @@
+import { getActiveTraceCorrelation } from "../observability";
 import { writeErrorLog } from "./index";
 
 // SCREAMING_SNAKE to match the Console logLevel flag value (PENSAR_LOG_LEVEL),
@@ -161,6 +162,13 @@ class Logger {
           record[k] = v;
         }
       }
+    }
+    // OTel correlation when a valid span is active; absent otherwise.
+    // Pretty output stays clean — ids belong in machine-readable JSON only.
+    const correlation = getActiveTraceCorrelation();
+    if (correlation) {
+      record.trace_id = correlation.traceId;
+      record.span_id = correlation.spanId;
     }
     return safeStringify(record);
   }

--- a/src/core/observability/index.ts
+++ b/src/core/observability/index.ts
@@ -48,3 +48,16 @@ export function withSubagentSessionBaggage<T>(
   ).setEntry(SESSION_BAGGAGE_KEY, { value: sessionId });
   return context.with(propagation.setBaggage(context.active(), baggage), fn);
 }
+
+/**
+ * The active span's correlation ids, when a valid recording span is active.
+ * Null outside spans (or under a no-op SDK) — callers skip the fields.
+ */
+export function getActiveTraceCorrelation(): {
+  traceId: string;
+  spanId: string;
+} | null {
+  const spanContext = trace.getSpan(context.active())?.spanContext();
+  if (!spanContext || !trace.isSpanContextValid(spanContext)) return null;
+  return { traceId: spanContext.traceId, spanId: spanContext.spanId };
+}

--- a/src/core/observability/log-correlation.test.ts
+++ b/src/core/observability/log-correlation.test.ts
@@ -1,0 +1,279 @@
+// O5 — correlation between OTel spans, structured logs, and trace.jsonl
+// records. The active span's ids land in JSON logs (trace_id/span_id) and
+// on every StepTraceWriter record (correlation), flowing to W&B verbatim
+// through the existing trace-record event. Legacy records without
+// correlation stay readable.
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { StepTraceWriter } from "../agents/offSecAgent/trace";
+import { AgentEventBus } from "../eventBus";
+import { createLogger, setLogSink } from "../logger/structured";
+import { getApexTracer } from "../observability";
+import {
+  type OtelTestHarness,
+  requireSpan,
+  startOtelTestHarness,
+} from "./testkit";
+
+let otel: OtelTestHarness;
+let tmpDir: string;
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = ["PENSAR_LOG_FORMAT", "PENSAR_LOG_LEVEL"];
+
+beforeEach(() => {
+  otel = startOtelTestHarness();
+  tmpDir = mkdtempSync(join(tmpdir(), "correlation-test-"));
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+  }
+  process.env.PENSAR_LOG_FORMAT = "json";
+  process.env.PENSAR_LOG_LEVEL = "INFO";
+});
+
+afterEach(async () => {
+  await otel.shutdown();
+  rmSync(tmpDir, { recursive: true, force: true });
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  setLogSink(null);
+});
+
+function captureLogLines(): string[] {
+  const lines: string[] = [];
+  setLogSink((line) => lines.push(line));
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Structured logger
+// ---------------------------------------------------------------------------
+
+describe("logger correlation", () => {
+  it("active spans add valid trace and span IDs to JSON logs", async () => {
+    const lines = captureLogLines();
+    const logger = createLogger("correlated");
+
+    await getApexTracer().startActiveSpan("log-span", {}, async (span) => {
+      logger.info("inside span", { extra: 1 });
+      span.end();
+    });
+
+    expect(lines).toHaveLength(1);
+    const record = JSON.parse(lines[0] ?? "") as Record<string, string>;
+    // 32-hex trace id, 16-hex span id — valid OTel formats.
+    expect(record.trace_id).toMatch(/^[0-9a-f]{32}$/);
+    expect(record.span_id).toMatch(/^[0-9a-f]{16}$/);
+    expect(record.msg).toBe("inside span");
+    expect(record.extra).toBe(1);
+  });
+
+  it("logs outside spans remain unchanged", () => {
+    const lines = captureLogLines();
+    createLogger("plain").info("outside span");
+
+    expect(lines).toHaveLength(1);
+    const record = JSON.parse(lines[0] ?? "") as Record<string, unknown>;
+    expect(record.trace_id).toBeUndefined();
+    expect(record.span_id).toBeUndefined();
+  });
+
+  it("child logs carry the child span id and the shared trace id", async () => {
+    const lines = captureLogLines();
+    const logger = createLogger("nested");
+
+    await getApexTracer().startActiveSpan("root", {}, async (root) => {
+      await getApexTracer().startActiveSpan("child", {}, async (child) => {
+        logger.info("in child");
+        child.end();
+      });
+      root.end();
+    });
+
+    const record = JSON.parse(lines[0] ?? "") as Record<string, string>;
+    const childSpan = requireSpan(otel.getFinishedSpans(), "child");
+    const rootSpan = requireSpan(otel.getFinishedSpans(), "root");
+    expect(record.span_id).toBe(childSpan.spanContext().spanId);
+    expect(record.trace_id).toBe(rootSpan.spanContext().traceId);
+  });
+
+  it("JSON logs remain valid one-line records", async () => {
+    const lines = captureLogLines();
+    const logger = createLogger("oneline");
+
+    await getApexTracer().startActiveSpan("s", {}, async (span) => {
+      logger.info("multi", { nested: { deep: "value" } });
+      span.end();
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]?.includes("\n")).toBe(false);
+    expect(() => JSON.parse(lines[0] ?? "")).not.toThrow();
+  });
+
+  it("pretty terminal logs remain readable (no trace ids)", () => {
+    process.env.PENSAR_LOG_FORMAT = "pretty";
+    const lines = captureLogLines();
+    const logger = createLogger("pretty");
+
+    return getApexTracer()
+      .startActiveSpan("pretty-span", {}, async (span) => {
+        logger.info("pretty message");
+        span.end();
+      })
+      .then(() => {
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toContain("pretty message");
+        expect(lines[0]).not.toContain("trace_id");
+        expect(lines[0]).not.toMatch(/[0-9a-f]{32}/);
+      });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StepTraceWriter / trace.jsonl records
+// ---------------------------------------------------------------------------
+
+function makeWriter(eventBus?: AgentEventBus): {
+  writer: StepTraceWriter;
+  tracePath: string;
+} {
+  const tracePath = join(tmpDir, "trace.jsonl");
+  return {
+    writer: new StepTraceWriter({
+      tracePath,
+      agentId: "ses_agent_1",
+      ...(eventBus ? { eventBus } : {}),
+    }),
+    tracePath,
+  };
+}
+
+describe("trace record correlation", () => {
+  it("root and child records share the same trace ID; child carries its own span ID", async () => {
+    const { writer, tracePath } = makeWriter();
+
+    await getApexTracer().startActiveSpan("root", {}, async (root) => {
+      writer.recordStep(
+        [{ role: "assistant", content: [{ type: "text", text: "root step" }] }],
+        { inputTokens: 10, outputTokens: 2 },
+      );
+      await getApexTracer().startActiveSpan("child", {}, async (child) => {
+        writer.recordStep(
+          [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "child step" }],
+            },
+          ],
+          { inputTokens: 5, outputTokens: 1 },
+        );
+        child.end();
+      });
+      root.end();
+    });
+
+    const lines = readFileSync(tracePath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    const [rootRecord, childRecord] = lines.map(
+      (l) =>
+        JSON.parse(l) as {
+          correlation?: { traceId?: string; spanId?: string };
+        },
+    );
+
+    const rootSpan = requireSpan(otel.getFinishedSpans(), "root");
+    const childSpan = requireSpan(otel.getFinishedSpans(), "child");
+    // Same trace…
+    expect(rootRecord.correlation?.traceId).toBe(
+      rootSpan.spanContext().traceId,
+    );
+    expect(childRecord.correlation?.traceId).toBe(
+      rootSpan.spanContext().traceId,
+    );
+    // …but each record names the span it was written under.
+    expect(rootRecord.correlation?.spanId).toBe(rootSpan.spanContext().spanId);
+    expect(childRecord.correlation?.spanId).toBe(
+      childSpan.spanContext().spanId,
+    );
+  });
+
+  it("records written outside spans carry no correlation", () => {
+    const { writer, tracePath } = makeWriter();
+    writer.recordStep(
+      [{ role: "assistant", content: [{ type: "text", text: "bare" }] }],
+      { inputTokens: 1, outputTokens: 1 },
+    );
+
+    const record = JSON.parse(
+      readFileSync(tracePath, "utf-8").trim(),
+    ) as Record<string, unknown>;
+    expect(record.correlation).toBeUndefined();
+  });
+
+  it("JSONL readers accept old and new records", () => {
+    const { writer, tracePath } = makeWriter();
+    // A legacy record line, exactly as older Apex wrote it (no correlation).
+    const legacy = JSON.stringify({
+      type: "step",
+      timestamp: new Date().toISOString(),
+      agentId: null,
+      stepIndex: 0,
+      text: "legacy",
+    });
+    writeFileSync(tracePath, `${legacy}\n`);
+
+    return getApexTracer()
+      .startActiveSpan("modern", {}, async (span) => {
+        writer.recordStep(
+          [{ role: "assistant", content: [{ type: "text", text: "modern" }] }],
+          { inputTokens: 1, outputTokens: 1 },
+        );
+        span.end();
+      })
+      .then(() => {
+        const records = readFileSync(tracePath, "utf-8")
+          .trim()
+          .split("\n")
+          .map((l) => JSON.parse(l) as Record<string, unknown>);
+        expect(records).toHaveLength(2);
+        expect(records[0]?.correlation).toBeUndefined(); // legacy untouched
+        expect(records[1]?.correlation).toBeDefined(); // new correlated
+      });
+  });
+
+  it("W&B receives correlation through its existing trace-record input", async () => {
+    const bus = new AgentEventBus();
+    const received: Array<{
+      record: { correlation?: { traceId?: string; spanId?: string } };
+      subagentId?: string;
+    }> = [];
+    bus.on("trace-record", (e) => {
+      received.push(
+        e as {
+          record: { correlation?: { traceId?: string; spanId?: string } };
+          subagentId?: string;
+        },
+      );
+    });
+
+    const { writer } = makeWriter(bus);
+    await getApexTracer().startActiveSpan("wandb-span", {}, async (span) => {
+      writer.recordStep(
+        [{ role: "assistant", content: [{ type: "text", text: "uploaded" }] }],
+        { inputTokens: 3, outputTokens: 1 },
+      );
+      span.end();
+    });
+
+    // The event payload IS what attachWandbToEventBus hands the uploader —
+    // no additional upload logic needed for correlation to reach W&B.
+    expect(received).toHaveLength(1);
+    expect(received[0]?.record.correlation?.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(received[0]?.subagentId).toBe("ses_agent_1");
+  });
+});

--- a/src/core/observability/log-correlation.test.ts
+++ b/src/core/observability/log-correlation.test.ts
@@ -8,7 +8,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { StepTraceWriter } from "../agents/offSecAgent/trace";
+import { type StepRecord, StepTraceWriter } from "../agents/offSecAgent/trace";
 import { AgentEventBus } from "../eventBus";
 import { createLogger, setLogSink } from "../logger/structured";
 import { getApexTracer } from "../observability";
@@ -180,10 +180,7 @@ describe("trace record correlation", () => {
     const lines = readFileSync(tracePath, "utf-8").trim().split("\n");
     expect(lines).toHaveLength(2);
     const [rootRecord, childRecord] = lines.map(
-      (l) =>
-        JSON.parse(l) as {
-          correlation?: { traceId?: string; spanId?: string };
-        },
+      (line) => JSON.parse(line) as StepRecord,
     );
 
     const rootSpan = requireSpan(otel.getFinishedSpans(), "root");


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Usage + observability · PR 11 of 12**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#996](https://github.com/pensarai/apex/pull/996) | Session usage models |
| 2 | [#997](https://github.com/pensarai/apex/pull/997) | Session-scoped ownership |
| 3 | [#998](https://github.com/pensarai/apex/pull/998) | Complete usage persistence |
| 4 | [#999](https://github.com/pensarai/apex/pull/999) | Consolidated usage ingestion |
| 5 | [#1000](https://github.com/pensarai/apex/pull/1000) | Token and context footer |
| 6 | [#1002](https://github.com/pensarai/apex/pull/1002) | Cache token breakdown |
| 7 | [#1004](https://github.com/pensarai/apex/pull/1004) | Agent trace contract |
| 8 | [#1005](https://github.com/pensarai/apex/pull/1005) | Optional OTLP runtime |
| 9 | [#1006](https://github.com/pensarai/apex/pull/1006) | Root agent run spans |
| 10 | [#1007](https://github.com/pensarai/apex/pull/1007) | Centralized telemetry settings |
| **11** | **[#1008](https://github.com/pensarai/apex/pull/1008)** | **Telemetry correlation** · `Current` |
| 12 | [#1009](https://github.com/pensarai/apex/pull/1009) | OTLP shutdown hardening |
## Summary

connect the three existing telemetry surfaces to OTel traces:

- **structured logs** — `formatJson` reads the active span and adds `trace_id`/`span_id` when a valid recording span is active; absent otherwise; **pretty output stays clean** (ids belong in machine-readable JSON only)
- **trace.jsonl records** — `TraceRecord` grows an optional `correlation?: { traceId?, spanId? }` (all four record types), populated by `StepTraceWriter.appendRecord` from the active span — the single choke point through which every record flows
- **W&B** — zero changes: the uploader consumes the `trace-record` event's record verbatim, so correlation reaches W&B through the existing input
- one new helper: `getActiveTraceCorrelation()` in the observability module (null outside spans or under a no-op SDK — the no-op global returns invalid span contexts, so nothing leaks)

## Compatibility

- legacy JSONL records (no `correlation`) parse unchanged — pinned by a test mixing an old-format line with a new correlated one in the same file
- logs outside spans are byte-identical to before (no new fields)
- nothing breaks when no OTel SDK is registered: the helper returns null, fields/records stay absent

## Tests (9, in `log-correlation.test.ts`)

**Logger:** active spans add valid `trace_id` (32-hex) / `span_id` (16-hex); outside spans unchanged; nested spans — child log carries the child's span id and the shared trace id; JSON stays a valid single line; pretty output has no ids.

**Trace records:** root + child records share the trace id while each names the span it was written under; records outside spans carry no correlation; JSONL readers accept old and new records mixed; **W&B receives correlation through the existing trace-record event** (the payload `attachWandbToEventBus` hands the uploader, asserted directly).

## What changed

- `src/core/observability/index.ts` — `getActiveTraceCorrelation()`
- `src/core/logger/structured.ts` — `trace_id`/`span_id` in `formatJson` (after the fields loop, so correlation wins on collision)
- `src/core/agents/offSecAgent/trace.ts` — `TraceCorrelation` + `CorrelatedRecord` types, `correlation?` on the four record interfaces, `appendRecord` enriches the record once (disk + event bus see the same object)

## Validation

- `bun run test` (1,820 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on the four touched files

## Non-goals honored

No OTel log exporter, no JSONL→span conversion, W&B stays as-is, EventBus behavior unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only enrichment on non-critical paths; fields stay absent without OTel or outside spans, preserving backward compatibility.
> 
> **Overview**
> **Links structured logs, agent `trace.jsonl`, and W&B to the active OpenTelemetry span** via a shared `getActiveTraceCorrelation()` helper that returns `traceId`/`spanId` when a valid recording span is active, or `null` otherwise.
> 
> JSON logs gain optional `trace_id` and `span_id` in `formatJson` only; pretty terminal output is unchanged. Every trace record written through `StepTraceWriter.appendRecord` may include an optional `correlation` object on all four record types, with the same enriched payload going to disk and the `trace-record` event (so W&B needs no upload changes). Legacy JSONL lines without `correlation` remain valid.
> 
> Adds **`log-correlation.test.ts`** covering nested spans, no-span behavior, mixed legacy/modern JSONL, and event-bus correlation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c3a272adccb35a819fe8cdad45d91091008df96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

