### PR TITLE
fix(observability): flush OTLP before process exit

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,77 @@
+# Observability: OTel / OTLP tracing
+
+Apex exports OpenTelemetry traces through standard OTLP/HTTP configuration.
+Everything is **optional and disabled by default** — no endpoint configured,
+no runtime registered, zero overhead beyond a no-op tracer.
+
+## Quick start (any OTLP/HTTP backend)
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+export OTEL_SERVICE_NAME=apex-standalone
+pensar
+```
+
+## Langfuse
+
+Langfuse accepts OTLP/**HTTP** — not OTLP/gRPC. Configure:
+
+```bash
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://cloud.langfuse.com/api/public/otel/v1/traces
+OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
+OTEL_EXPORTER_OTLP_TRACES_HEADERS=Authorization=Basic <base64 project-key:secret>,x-langfuse-ingestion-version=4
+AI_TRACE_RECORD_PAYLOADS=true
+```
+
+Notes:
+
+- **Full payload mode is sensitive.** `AI_TRACE_RECORD_PAYLOADS=true` exports
+  prompts, responses, reasoning, tool arguments, and tool results to the
+  configured backend. That can include customer source code, credentials,
+  cookies, authorization headers, attack targets, and model reasoning. It is
+  off by default; turn it on only for backends you control.
+- **Sampling must stay disabled** for complete run capture — Apex registers
+  an always-on sampler so every root run produces one coherent trace.
+- **Console owns OTel when embedding Apex.** The standalone runtime never
+  registers a global provider unless a standalone entrypoint started it with
+  an endpoint configured; embedded deployments (Console) provide their own SDK.
+- **Standalone Apex owns OTel only when explicitly configured** via the
+  `OTEL_EXPORTER_OTLP_*` variables above.
+
+## Environment variables
+
+| Variable | Effect |
+|---|---|
+| `OTEL_SDK_DISABLED=true` | Runtime is a no-op; nothing registers |
+| `OTEL_SERVICE_NAME` | Resource `service.name` (default `apex`) |
+| `OTEL_RESOURCE_ATTRIBUTES` | Merged onto the resource (`k=v,k2=v2`) |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Trace URL, verbatim (wins) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Generic URL; `v1/traces` appended |
+| `OTEL_EXPORTER_OTLP_HEADERS` / `..._TRACES_HEADERS` | Export headers (specific wins, combined) |
+| `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` / `..._OTLP_PROTOCOL` | `http/json` (default) or `http/protobuf` |
+| `AI_TRACE_RECORD_PAYLOADS=true` | Full payload capture (sensitive — see above) |
+
+## What you get
+
+Every top-level agent run is one coherent trace:
+
+```
+invoke_agent <mode>          root run (pensar.run.id, session, mode)
+  ai.streamText              model call
+    ai.streamText.doStream   provider call (tokens, cache, finish reason)
+    ai.toolCall              tool execution (args/results in full mode)
+      invoke_agent <sub>     subagent run (its own execution session id)
+        ai.streamText
+```
+
+Structured JSON logs carry `trace_id`/`span_id` when written inside a span,
+and `trace.jsonl` records carry a `correlation` object — connecting OTel
+traces, logs, and W&B uploads.
+
+## Shutdown behavior
+
+Standalone processes flush before exit on every path — normal completion,
+TUI exit, SIGINT, SIGTERM, uncaught exceptions, and unhandled rejections —
+with a bounded timeout (default 5s) so a hung exporter can never block
+process exit. In-flight root runs are ended before the final flush so their
+spans still export.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -40,16 +40,16 @@ Notes:
 
 ## Environment variables
 
-| Variable | Effect |
-|---|---|
-| `OTEL_SDK_DISABLED=true` | Runtime is a no-op; nothing registers |
-| `OTEL_SERVICE_NAME` | Resource `service.name` (default `apex`) |
-| `OTEL_RESOURCE_ATTRIBUTES` | Merged onto the resource (`k=v,k2=v2`) |
-| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Trace URL, verbatim (wins) |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | Generic URL; `v1/traces` appended |
-| `OTEL_EXPORTER_OTLP_HEADERS` / `..._TRACES_HEADERS` | Export headers (specific wins, combined) |
-| `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` / `..._OTLP_PROTOCOL` | `http/json` (default) or `http/protobuf` |
-| `AI_TRACE_RECORD_PAYLOADS=true` | Full payload capture (sensitive — see above) |
+| Variable                                                   | Effect                                       |
+| ---------------------------------------------------------- | -------------------------------------------- |
+| `OTEL_SDK_DISABLED=true`                                   | Runtime is a no-op; nothing registers        |
+| `OTEL_SERVICE_NAME`                                        | Resource `service.name` (default `apex`)     |
+| `OTEL_RESOURCE_ATTRIBUTES`                                 | Merged onto the resource (`k=v,k2=v2`)       |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`                       | Trace URL, verbatim (wins)                   |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`                              | Generic URL; `v1/traces` appended            |
+| `OTEL_EXPORTER_OTLP_HEADERS` / `..._TRACES_HEADERS`        | Export headers (specific wins, combined)     |
+| `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` / `..._OTLP_PROTOCOL` | `http/json` (default) or `http/protobuf`     |
+| `AI_TRACE_RECORD_PAYLOADS=true`                            | Full payload capture (sensitive — see above) |
 
 ## What you get
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,10 @@ import { resolvePentestMode } from "./core/cli/pentestMode";
 import { AgentEventBus } from "./core/eventBus";
 import { getCurrentVersion, upgrade } from "./core/installation";
 import { logger } from "./core/logger";
-import { startObservabilityRuntime } from "./core/observability/runtime";
+import {
+  installObservabilityExitHandlers,
+  startObservabilityRuntime,
+} from "./core/observability/runtime";
 import type { SessionInfo } from "./core/session";
 import {
   combinePromptParts,
@@ -597,6 +600,16 @@ async function runUpgrade() {
 // OTLP endpoint is configured; the TUI branch below takes over the process
 // and manages the runtime's lifecycle in its own exit path.
 const observabilityRuntime = startObservabilityRuntime();
+// Signals and fatal errors flush traces (bounded) before exiting — headless
+// commands only; the TUI installs its own handlers alongside renderer
+// teardown.
+if (args.length !== 0) {
+  installObservabilityExitHandlers(observabilityRuntime, {
+    onError: (error) => {
+      console.error("Uncaught exception:", error);
+    },
+  });
+}
 
 try {
   if (hasFlag("-p") || command === "--prompt") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -611,6 +611,7 @@ if (args.length !== 0) {
   });
 }
 
+let commandFailed = false;
 try {
   if (hasFlag("-p") || command === "--prompt") {
     await runOperator();
@@ -675,11 +676,21 @@ try {
     console.error("Run 'pensar --help' for usage information");
     process.exit(1);
   }
+} catch (error) {
+  commandFailed = true;
+  throw error;
 } finally {
   // Preserve command failures while still making process-boundary flushing
   // best-effort. The TUI owns its runtime lifecycle after import.
   if (args.length !== 0) {
-    await observabilityRuntime.shutdown().catch(() => {});
+    const shutdownResult = await observabilityRuntime
+      .shutdown()
+      .catch(() => "completed" as const);
+    // A timed-out exporter can still own live HTTP handles. Preserve a
+    // pending command failure; otherwise terminate instead of hanging.
+    if (shutdownResult === "timed-out" && !commandFailed) {
+      process.exit(typeof process.exitCode === "number" ? process.exitCode : 0);
+    }
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -603,15 +603,15 @@ const observabilityRuntime = startObservabilityRuntime();
 // Signals and fatal errors flush traces (bounded) before exiting — headless
 // commands only; the TUI installs its own handlers alongside renderer
 // teardown.
-if (args.length !== 0) {
-  installObservabilityExitHandlers(observabilityRuntime, {
-    onError: (error) => {
-      console.error("Uncaught exception:", error);
-    },
-  });
-}
+const exitAfterObservabilityShutdown =
+  args.length !== 0
+    ? installObservabilityExitHandlers(observabilityRuntime, {
+        onError: (error) => {
+          console.error("Uncaught exception:", error);
+        },
+      })
+    : null;
 
-let commandFailed = false;
 try {
   if (hasFlag("-p") || command === "--prompt") {
     await runOperator();
@@ -677,25 +677,26 @@ try {
     process.exit(1);
   }
 } catch (error) {
-  commandFailed = true;
+  if (exitAfterObservabilityShutdown !== null) {
+    await exitAfterObservabilityShutdown(1, error, "uncaughtException");
+  }
   throw error;
 } finally {
-  // Preserve command failures while still making process-boundary flushing
-  // best-effort. The TUI owns its runtime lifecycle after import.
-  if (args.length !== 0) {
+  // The TUI owns its runtime lifecycle after import.
+  if (exitAfterObservabilityShutdown !== null) {
     const shutdownResult = await observabilityRuntime
       .shutdown()
       .catch(() => "completed" as const);
-    // A timed-out exporter can still own live HTTP handles. Preserve a
-    // pending command failure; otherwise terminate instead of hanging.
-    if (shutdownResult === "timed-out" && !commandFailed) {
-      process.exit(typeof process.exitCode === "number" ? process.exitCode : 0);
+    // A timed-out exporter can still own live HTTP handles, and pentest tool
+    // subsystems can leave handles open after completion.
+    if (
+      shutdownResult === "timed-out" ||
+      command === "pentest" ||
+      command === "targeted-pentest"
+    ) {
+      await exitAfterObservabilityShutdown(
+        typeof process.exitCode === "number" ? process.exitCode : 0,
+      );
     }
   }
-}
-
-// Some pentest tool subsystems can leave handles open after completion. Keep
-// the explicit exit, but only after the final OTLP batch has been flushed.
-if (command === "pentest" || command === "targeted-pentest") {
-  process.exit(0);
 }

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -17,7 +17,12 @@ import {
 } from "../../http/targetHeaders";
 import { newMessageId, newPartId, newRunId } from "../../id/id";
 import { createLogger } from "../../logger/structured";
-import { getApexTracer, withSubagentSessionBaggage } from "../../observability";
+import {
+  getApexTracer,
+  registerActiveRootSpan,
+  unregisterActiveRootSpan,
+  withSubagentSessionBaggage,
+} from "../../observability";
 import type { ApprovalGate } from "../../operator";
 import { ApprovalDeniedError } from "../../operator";
 import { create as createSession, type SessionInfo } from "../../session";
@@ -923,6 +928,9 @@ export class OffensiveSecurityAgent<TResult = void> {
         `invoke_agent ${spanLabel}`,
         { attributes: runSpanAttributes },
         async (span) => {
+          // Root runs register so process-exit shutdown can end an
+          // in-flight run's span before the final flush.
+          if (!isSubagent) registerActiveRootSpan(span);
           try {
             return await runConsume();
           } catch (err) {
@@ -935,6 +943,7 @@ export class OffensiveSecurityAgent<TResult = void> {
             );
             throw err;
           } finally {
+            unregisterActiveRootSpan(span);
             // Ends only after runConsume's finalization (persistence +
             // owned-resource disposal) has settled.
             span.end();

--- a/src/core/observability/active-root-spans.ts
+++ b/src/core/observability/active-root-spans.ts
@@ -1,0 +1,30 @@
+import type { Span } from "@opentelemetry/api";
+
+/**
+ * Registry of in-flight root agent-run spans. The agent registers its root
+ * span for the duration of a run; the observability runtime's shutdown ends
+ * anything still registered before flushing, so an interrupted run's span
+ * still exports (with whatever state it had) instead of leaking.
+ */
+
+const activeRootSpans = new Set<Span>();
+
+export function registerActiveRootSpan(span: Span): void {
+  activeRootSpans.add(span);
+}
+
+export function unregisterActiveRootSpan(span: Span): void {
+  activeRootSpans.delete(span);
+}
+
+/** End every registered root span (best-effort; idempotent on spans). */
+export function endAllActiveRootSpans(): void {
+  for (const span of activeRootSpans) {
+    try {
+      span.end();
+    } catch {
+      // A dead span must never block process teardown.
+    }
+  }
+  activeRootSpans.clear();
+}

--- a/src/core/observability/index.ts
+++ b/src/core/observability/index.ts
@@ -16,6 +16,10 @@ export function shouldRecordAiPayloads(): boolean {
 }
 
 export {
+  registerActiveRootSpan,
+  unregisterActiveRootSpan,
+} from "./active-root-spans";
+export {
   type AiTelemetryOperation,
   type AiTelemetrySettings,
   type CreateAiTelemetryInput,

--- a/src/core/observability/runtime.test.ts
+++ b/src/core/observability/runtime.test.ts
@@ -216,7 +216,7 @@ describe("startObservabilityRuntime gating", () => {
   it("no endpoint returns a safe no-op runtime", async () => {
     const runtime = startObservabilityRuntime({});
     await expect(runtime.forceFlush()).resolves.toBeUndefined();
-    await expect(runtime.shutdown()).resolves.toBeUndefined();
+    await expect(runtime.shutdown()).resolves.toBe("completed");
     // Nothing registered: spans via the apex tracer are non-recording.
     const span = trace.getTracer("apex").startSpan("probe");
     expect(trace.isSpanContextValid(span.spanContext())).toBe(false);

--- a/src/core/observability/runtime.ts
+++ b/src/core/observability/runtime.ts
@@ -16,8 +16,10 @@ import {
   BasicTracerProvider,
   BatchSpanProcessor,
   type SpanExporter,
+  type SpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import { version as apexVersion } from "../../../package.json";
+import { endAllActiveRootSpans } from "./active-root-spans";
 
 /**
  * Optional standalone OTLP/HTTP trace runtime. Apex keeps OTel disabled
@@ -29,7 +31,30 @@ import { version as apexVersion } from "../../../package.json";
 
 export interface ObservabilityRuntime {
   forceFlush(): Promise<void>;
+  /** Idempotent and bounded: ends active root spans, flushes, shuts down. */
   shutdown(): Promise<void>;
+}
+
+/** Options for {@link startObservabilityRuntime}. */
+export interface StartObservabilityRuntimeOptions {
+  /** Bound on shutdown (flush + exporter teardown); default 5000ms. */
+  shutdownTimeoutMs?: number;
+  /** Replace the default BatchSpanProcessor(OTLP exporter) — tests. */
+  spanProcessors?: SpanProcessor[];
+}
+
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_000;
+
+function withTimeout(promise: Promise<void>, timeoutMs: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(() => resolve(), timeoutMs);
+    promise
+      .catch(() => {})
+      .then(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+  });
 }
 
 const NOOP_RUNTIME: ObservabilityRuntime = {
@@ -131,15 +156,18 @@ let activeRuntime: ObservabilityRuntime | null = null;
  */
 export function startObservabilityRuntime(
   env: Env = process.env,
+  opts?: StartObservabilityRuntimeOptions,
 ): ObservabilityRuntime {
   if (activeRuntime) return activeRuntime;
   if (isOtelSdkDisabled(env)) return NOOP_RUNTIME;
   if (!resolveTracesEndpoint(env)) return NOOP_RUNTIME;
 
+  const shutdownTimeoutMs =
+    opts?.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
   const exporter = createTraceExporter(resolveTracesProtocol(env));
   const provider = new BasicTracerProvider({
     resource: buildResource(env),
-    spanProcessors: [new BatchSpanProcessor(exporter)],
+    spanProcessors: opts?.spanProcessors ?? [new BatchSpanProcessor(exporter)],
   });
   const contextManager = new AsyncLocalStorageContextManager();
   contextManager.enable();
@@ -147,21 +175,70 @@ export function startObservabilityRuntime(
   trace.setGlobalTracerProvider(provider);
   context.setGlobalContextManager(contextManager);
 
+  let shutdownPromise: Promise<void> | null = null;
   const runtime: ObservabilityRuntime = {
     async forceFlush() {
       await provider.forceFlush();
     },
-    async shutdown() {
-      activeRuntime = null;
-      await provider.shutdown();
-      contextManager.disable();
-      // Reset globals so a later start (or the host's own SDK) begins clean.
-      trace.disable();
-      context.disable();
+    shutdown() {
+      // Idempotent: every caller awaits the same bounded shutdown.
+      if (!shutdownPromise) {
+        shutdownPromise = withTimeout(
+          (async () => {
+            // End in-flight root runs first so their spans still export…
+            endAllActiveRootSpans();
+            // …then flush explicitly before processor/exporter teardown.
+            await provider.forceFlush();
+            await provider.shutdown();
+            contextManager.disable();
+            // Reset globals so a later start (or the host's own SDK) begins clean.
+            trace.disable();
+            context.disable();
+          })(),
+          shutdownTimeoutMs,
+        ).finally(() => {
+          activeRuntime = null;
+        });
+      }
+      return shutdownPromise;
     },
   };
   activeRuntime = runtime;
   return runtime;
+}
+
+/**
+ * Standalone-process exit wiring: signals and fatal errors run the bounded
+ * runtime shutdown before exiting — never a direct process.exit() while a
+ * flush could still complete. `cleanup` runs synchronously before the flush
+ * (entrypoint teardown such as renderer destruction); fatal errors are
+ * reported and preserved via exit code 1.
+ */
+export function installObservabilityExitHandlers(
+  runtime: ObservabilityRuntime,
+  opts?: {
+    /** Synchronous entrypoint teardown before the flush. */
+    cleanup?: (code: number) => void;
+    /** Report a fatal error (entrypoints own their logging). */
+    onError?: (error: unknown) => void;
+  },
+): void {
+  let exiting = false;
+  const exitWith = (code: number, error?: unknown) => {
+    if (exiting) return;
+    exiting = true;
+    if (error !== undefined) opts?.onError?.(error);
+    opts?.cleanup?.(code);
+    void runtime
+      .shutdown()
+      .catch(() => {})
+      .then(() => process.exit(code));
+  };
+
+  process.once("SIGINT", () => exitWith(130));
+  process.once("SIGTERM", () => exitWith(143));
+  process.on("uncaughtException", (error) => exitWith(1, error));
+  process.on("unhandledRejection", (reason) => exitWith(1, reason));
 }
 
 /** Test/teardown hook: stop any active runtime and reset the singleton. */

--- a/src/core/observability/runtime.ts
+++ b/src/core/observability/runtime.ts
@@ -250,6 +250,16 @@ export function installObservabilityExitHandlers(
   let exitPromise: Promise<void> | null = null;
   let exitCode = 0;
   let fatalSeen = false;
+  const reportError = (
+    error: unknown,
+    source: "uncaughtException" | "unhandledRejection",
+  ) => {
+    try {
+      opts?.onError?.(error, source);
+    } catch {
+      // Error reporting must not block the process exit path.
+    }
+  };
   const exitWith = (
     code: number,
     error?: unknown,
@@ -258,12 +268,20 @@ export function installObservabilityExitHandlers(
     if (error !== undefined && !fatalSeen) {
       fatalSeen = true;
       exitCode = 1;
-      opts?.onError?.(error, source ?? "uncaughtException");
+      reportError(error, source ?? "uncaughtException");
     } else if (!fatalSeen && exitCode === 0) {
       exitCode = code;
     }
     if (exitPromise) return exitPromise;
-    opts?.cleanup?.(code);
+    try {
+      opts?.cleanup?.(code);
+    } catch (cleanupError) {
+      if (!fatalSeen) {
+        fatalSeen = true;
+        exitCode = 1;
+        reportError(cleanupError, "uncaughtException");
+      }
+    }
     exitPromise = runtime
       .shutdown()
       .catch(() => {})

--- a/src/core/observability/runtime.ts
+++ b/src/core/observability/runtime.ts
@@ -229,7 +229,8 @@ export function startObservabilityRuntime(
  * runtime shutdown before exiting — never a direct process.exit() while a
  * flush could still complete. `cleanup` runs synchronously before the flush
  * (entrypoint teardown such as renderer destruction); fatal errors are
- * reported and preserved via exit code 1.
+ * reported after cleanup — so the TUI has left the alternate screen buffer
+ * and the output survives — and preserved via exit code 1.
  */
 export function installObservabilityExitHandlers(
   runtime: ObservabilityRuntime,
@@ -265,23 +266,32 @@ export function installObservabilityExitHandlers(
     error?: unknown,
     source?: "uncaughtException" | "unhandledRejection",
   ) => {
+    let pendingReport: (() => void) | null = null;
     if (error !== undefined && !fatalSeen) {
       fatalSeen = true;
       exitCode = 1;
-      reportError(error, source ?? "uncaughtException");
+      const fatalSource = source ?? "uncaughtException";
+      pendingReport = () => reportError(error, fatalSource);
     } else if (!fatalSeen && exitCode === 0) {
       exitCode = code;
     }
-    if (exitPromise) return exitPromise;
+    if (exitPromise) {
+      // Cleanup already ran (terminal restored) — a late fatal reports now.
+      pendingReport?.();
+      return exitPromise;
+    }
     try {
       opts?.cleanup?.(code);
     } catch (cleanupError) {
       if (!fatalSeen) {
         fatalSeen = true;
         exitCode = 1;
-        reportError(cleanupError, "uncaughtException");
+        pendingReport = () => reportError(cleanupError, "uncaughtException");
       }
     }
+    // Report only after entrypoint teardown: the TUI must leave the
+    // alternate screen buffer first or the console output is discarded.
+    pendingReport?.();
     exitPromise = runtime
       .shutdown()
       .catch(() => {})

--- a/src/core/observability/runtime.ts
+++ b/src/core/observability/runtime.ts
@@ -29,10 +29,12 @@ import { endAllActiveRootSpans } from "./active-root-spans";
  * SDK and must not have Apex install a competing global provider.
  */
 
+export type ObservabilityShutdownResult = "completed" | "timed-out";
+
 export interface ObservabilityRuntime {
   forceFlush(): Promise<void>;
   /** Idempotent and bounded: ends active root spans, flushes, shuts down. */
-  shutdown(): Promise<void>;
+  shutdown(): Promise<ObservabilityShutdownResult>;
 }
 
 /** Options for {@link startObservabilityRuntime}. */
@@ -45,21 +47,31 @@ export interface StartObservabilityRuntimeOptions {
 
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_000;
 
-function withTimeout(promise: Promise<void>, timeoutMs: number): Promise<void> {
-  return new Promise<void>((resolve) => {
-    const timer = setTimeout(() => resolve(), timeoutMs);
-    promise
-      .catch(() => {})
-      .then(() => {
-        clearTimeout(timer);
-        resolve();
-      });
+function withTimeout(
+  promise: Promise<void>,
+  timeoutMs: number,
+): Promise<ObservabilityShutdownResult> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (result: ObservabilityShutdownResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const timer = setTimeout(() => settle("timed-out"), timeoutMs);
+    promise.then(
+      () => settle("completed"),
+      () => settle("completed"),
+    );
   });
 }
 
 const NOOP_RUNTIME: ObservabilityRuntime = {
   async forceFlush() {},
-  async shutdown() {},
+  async shutdown() {
+    return "completed";
+  },
 };
 
 type Env = Record<string, string | undefined>;
@@ -175,7 +187,7 @@ export function startObservabilityRuntime(
   trace.setGlobalTracerProvider(provider);
   context.setGlobalContextManager(contextManager);
 
-  let shutdownPromise: Promise<void> | null = null;
+  let shutdownPromise: Promise<ObservabilityShutdownResult> | null = null;
   const runtime: ObservabilityRuntime = {
     async forceFlush() {
       await provider.forceFlush();
@@ -183,22 +195,27 @@ export function startObservabilityRuntime(
     shutdown() {
       // Idempotent: every caller awaits the same bounded shutdown.
       if (!shutdownPromise) {
-        shutdownPromise = withTimeout(
-          (async () => {
-            // End in-flight root runs first so their spans still export…
-            endAllActiveRootSpans();
-            // …then flush explicitly before processor/exporter teardown.
+        const shutdownWork = (async () => {
+          // End in-flight root runs first so their spans still export…
+          endAllActiveRootSpans();
+          // …then flush explicitly before processor/exporter teardown.
+          try {
             await provider.forceFlush();
+          } finally {
             await provider.shutdown();
+          }
+        })();
+        shutdownPromise = withTimeout(shutdownWork, shutdownTimeoutMs)
+          .then((result) => {
             contextManager.disable();
             // Reset globals so a later start (or the host's own SDK) begins clean.
             trace.disable();
             context.disable();
-          })(),
-          shutdownTimeoutMs,
-        ).finally(() => {
-          activeRuntime = null;
-        });
+            return result;
+          })
+          .finally(() => {
+            activeRuntime = null;
+          });
       }
       return shutdownPromise;
     },
@@ -220,25 +237,51 @@ export function installObservabilityExitHandlers(
     /** Synchronous entrypoint teardown before the flush. */
     cleanup?: (code: number) => void;
     /** Report a fatal error (entrypoints own their logging). */
-    onError?: (error: unknown) => void;
+    onError?: (
+      error: unknown,
+      source: "uncaughtException" | "unhandledRejection",
+    ) => void;
   },
-): void {
-  let exiting = false;
-  const exitWith = (code: number, error?: unknown) => {
-    if (exiting) return;
-    exiting = true;
-    if (error !== undefined) opts?.onError?.(error);
+): (
+  code: number,
+  error?: unknown,
+  source?: "uncaughtException" | "unhandledRejection",
+) => Promise<void> {
+  let exitPromise: Promise<void> | null = null;
+  let exitCode = 0;
+  let fatalSeen = false;
+  const exitWith = (
+    code: number,
+    error?: unknown,
+    source?: "uncaughtException" | "unhandledRejection",
+  ) => {
+    if (error !== undefined && !fatalSeen) {
+      fatalSeen = true;
+      exitCode = 1;
+      opts?.onError?.(error, source ?? "uncaughtException");
+    } else if (!fatalSeen && exitCode === 0) {
+      exitCode = code;
+    }
+    if (exitPromise) return exitPromise;
     opts?.cleanup?.(code);
-    void runtime
+    exitPromise = runtime
       .shutdown()
       .catch(() => {})
-      .then(() => process.exit(code));
+      .then(() => process.exit(exitCode));
+    return exitPromise;
   };
 
-  process.once("SIGINT", () => exitWith(130));
-  process.once("SIGTERM", () => exitWith(143));
-  process.on("uncaughtException", (error) => exitWith(1, error));
-  process.on("unhandledRejection", (reason) => exitWith(1, reason));
+  process.once("SIGINT", () => void exitWith(130));
+  process.once("SIGTERM", () => void exitWith(143));
+  process.on(
+    "uncaughtException",
+    (error) => void exitWith(1, error, "uncaughtException"),
+  );
+  process.on(
+    "unhandledRejection",
+    (reason) => void exitWith(1, reason, "unhandledRejection"),
+  );
+  return exitWith;
 }
 
 /** Test/teardown hook: stop any active runtime and reset the singleton. */

--- a/src/core/observability/runtime.ts
+++ b/src/core/observability/runtime.ts
@@ -271,8 +271,8 @@ export function installObservabilityExitHandlers(
     return exitPromise;
   };
 
-  process.once("SIGINT", () => void exitWith(130));
-  process.once("SIGTERM", () => void exitWith(143));
+  process.on("SIGINT", () => void exitWith(130));
+  process.on("SIGTERM", () => void exitWith(143));
   process.on(
     "uncaughtException",
     (error) => void exitWith(1, error, "uncaughtException"),

--- a/src/core/observability/shutdown.test.ts
+++ b/src/core/observability/shutdown.test.ts
@@ -207,6 +207,20 @@ describe("installObservabilityExitHandlers", () => {
     expect(exitCalls).toEqual([130]);
   });
 
+  it("keeps signal handlers installed during an in-flight shutdown", async () => {
+    const runtime = startWithProcessors([new HungProcessor()], 50);
+    install(runtime);
+
+    process.emit("SIGINT", "SIGINT");
+    expect(process.listenerCount("SIGINT")).toBe(1);
+
+    process.emit("SIGINT", "SIGINT");
+    expect(cleanups).toEqual(["cleanup:130"]);
+
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(exitCalls).toEqual([130]);
+  });
+
   it("fatal errors are preserved after flushing (reported, exit code 1)", async () => {
     const runtime = startWithProcessors([new HungProcessor()], 50);
     install(runtime);

--- a/src/core/observability/shutdown.test.ts
+++ b/src/core/observability/shutdown.test.ts
@@ -250,6 +250,23 @@ describe("installObservabilityExitHandlers", () => {
     expect(exitCalls).toEqual([1]);
   });
 
+  it("reports fatal errors after entrypoint cleanup (terminal restored first)", async () => {
+    const runtime = startWithProcessors([new HungProcessor()], 50);
+    const order: string[] = [];
+    installObservabilityExitHandlers(runtime, {
+      cleanup: () => order.push("cleanup"),
+      onError: () => order.push("onError"),
+    });
+
+    process.emit("uncaughtException", new Error("boom"));
+    // Cleanup (e.g. renderer.destroy() leaving the alternate screen buffer)
+    // must precede the console report or the output is discarded.
+    expect(order).toEqual(["cleanup", "onError"]);
+
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(exitCalls).toEqual([1]);
+  });
+
   it("the first fatal wins — no double exit", async () => {
     const runtime = startWithProcessors([new HungProcessor()], 50);
     install(runtime);

--- a/src/core/observability/shutdown.test.ts
+++ b/src/core/observability/shutdown.test.ts
@@ -134,7 +134,7 @@ describe("shutdown semantics", () => {
     const runtime = startWithProcessors([new HungProcessor()], 50);
 
     const started = Date.now();
-    await runtime.shutdown(); // bounded — resolves despite the hung processor
+    await expect(runtime.shutdown()).resolves.toBe("timed-out");
     expect(Date.now() - started).toBeLessThan(2000);
   });
 
@@ -188,7 +188,7 @@ describe("installObservabilityExitHandlers", () => {
   });
 
   function install(runtime: ReturnType<typeof startWithProcessors>) {
-    installObservabilityExitHandlers(runtime, {
+    return installObservabilityExitHandlers(runtime, {
       cleanup: (code) => cleanups.push(`cleanup:${code}`),
       onError: (error) => errors.push(error),
     });
@@ -227,6 +227,19 @@ describe("installObservabilityExitHandlers", () => {
     process.emit("unhandledRejection", new Error("second"));
 
     await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(errors).toHaveLength(1);
+    expect(exitCalls).toEqual([1]);
+  });
+
+  it("a fatal error upgrades an in-flight normal exit without double teardown", async () => {
+    const runtime = startWithProcessors([new HungProcessor()], 50);
+    const exitWith = install(runtime);
+
+    void exitWith(0);
+    process.emit("uncaughtException", new Error("late failure"));
+
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(cleanups).toEqual(["cleanup:0"]);
     expect(errors).toHaveLength(1);
     expect(exitCalls).toEqual([1]);
   });

--- a/src/core/observability/shutdown.test.ts
+++ b/src/core/observability/shutdown.test.ts
@@ -221,6 +221,23 @@ describe("installObservabilityExitHandlers", () => {
     expect(exitCalls).toEqual([130]);
   });
 
+  it("still shuts down and exits when entrypoint cleanup throws", async () => {
+    const runtime = startWithProcessors([new HungProcessor()], 50);
+    const cleanupError = new Error("renderer already closed");
+    installObservabilityExitHandlers(runtime, {
+      cleanup: () => {
+        throw cleanupError;
+      },
+      onError: (error) => errors.push(error),
+    });
+
+    process.emit("SIGTERM", "SIGTERM");
+
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(errors).toEqual([cleanupError]);
+    expect(exitCalls).toEqual([1]);
+  });
+
   it("fatal errors are preserved after flushing (reported, exit code 1)", async () => {
     const runtime = startWithProcessors([new HungProcessor()], 50);
     install(runtime);

--- a/src/core/observability/shutdown.test.ts
+++ b/src/core/observability/shutdown.test.ts
@@ -244,6 +244,20 @@ describe("installObservabilityExitHandlers", () => {
     expect(exitCalls).toEqual([1]);
   });
 
+  it("a signal keeps its exit code when normal shutdown completes", async () => {
+    const runtime = startWithProcessors([new HungProcessor()], 50);
+    const exitWith = install(runtime);
+
+    const normalShutdown = runtime.shutdown();
+    process.emit("SIGINT", "SIGINT");
+    await normalShutdown;
+    void exitWith(0);
+
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(cleanups).toEqual(["cleanup:130"]);
+    expect(exitCalls).toEqual([130]);
+  });
+
   it("embedded mode (no runtime) never shuts down the host SDK", async () => {
     // The host (Console) registered its own SDK…
     const { startOtelTestHarness } = await import("./testkit");

--- a/src/core/observability/shutdown.test.ts
+++ b/src/core/observability/shutdown.test.ts
@@ -1,0 +1,346 @@
+// O6 — flush and shutdown hardening. The runtime's shutdown is idempotent
+// and bounded; forceFlush precedes processor teardown; in-flight root spans
+// end before the flush; signals and fatal errors exit through the bounded
+// shutdown; a hung exporter cannot block process exit; embedded hosts are
+// never touched; the final trace reaches a local OTLP receiver.
+
+import { createServer, type Server } from "node:http";
+import type {
+  ReadableSpan,
+  Span as SdkSpan,
+  SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getApexTracer } from "../observability";
+import {
+  installObservabilityExitHandlers,
+  resetObservabilityRuntime,
+  startObservabilityRuntime,
+} from "./runtime";
+
+const OTEL_VARS = [
+  "OTEL_SDK_DISABLED",
+  "OTEL_SERVICE_NAME",
+  "OTEL_RESOURCE_ATTRIBUTES",
+  "OTEL_EXPORTER_OTLP_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+];
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of OTEL_VARS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(async () => {
+  await resetObservabilityRuntime();
+  for (const key of OTEL_VARS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+/** Span processor that records lifecycle call order. */
+class RecordingProcessor implements SpanProcessor {
+  readonly calls: string[] = [];
+  private readonly inner: SpanProcessor;
+  constructor(inner: SpanProcessor) {
+    this.inner = inner;
+  }
+  onStart(span: SdkSpan): void {
+    this.inner.onStart(span, {} as never);
+  }
+  onEnd(span: ReadableSpan): void {
+    this.calls.push("onEnd");
+    this.inner.onEnd(span);
+  }
+  async shutdown(): Promise<void> {
+    this.calls.push("shutdown");
+    await this.inner.shutdown();
+  }
+  async forceFlush(): Promise<void> {
+    this.calls.push("forceFlush");
+    await this.inner.forceFlush();
+  }
+}
+
+/** Processor whose shutdown never settles. */
+class HungProcessor implements SpanProcessor {
+  onStart(_span: SdkSpan): void {}
+  onEnd(_span: ReadableSpan): void {}
+  async forceFlush(): Promise<void> {}
+  async shutdown(): Promise<void> {
+    await new Promise<void>(() => {});
+  }
+}
+
+function startWithProcessors(
+  processors: SpanProcessor[],
+  shutdownTimeoutMs?: number,
+) {
+  process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT =
+    "http://127.0.0.1:4318/v1/traces";
+  return startObservabilityRuntime(process.env, {
+    ...(processors.length > 0 ? { spanProcessors: processors } : {}),
+    ...(shutdownTimeoutMs !== undefined ? { shutdownTimeoutMs } : {}),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shutdown semantics
+// ---------------------------------------------------------------------------
+
+describe("shutdown semantics", () => {
+  it("forceFlush() runs before shutdown()", async () => {
+    const exporter = new InMemorySpanExporter();
+    const recorder = new RecordingProcessor(new SimpleSpanProcessor(exporter));
+    const runtime = startWithProcessors([recorder]);
+
+    getApexTracer().startSpan("s").end();
+    // The runtime's shutdown ends root spans then flushes THEN tears down;
+    // read the exporter before teardown clears it (InMemorySpanExporter
+    // semantics) — via an explicit forceFlush first.
+    await runtime.forceFlush();
+    expect(exporter.getFinishedSpans()).toHaveLength(1);
+
+    await runtime.shutdown();
+    expect(recorder.calls).toEqual([
+      "onEnd",
+      "forceFlush",
+      "forceFlush",
+      "shutdown",
+    ]);
+  });
+
+  it("repeated shutdown calls execute the real shutdown once", async () => {
+    const exporter = new InMemorySpanExporter();
+    const recorder = new RecordingProcessor(new SimpleSpanProcessor(exporter));
+    const runtime = startWithProcessors([recorder]);
+
+    await Promise.all([runtime.shutdown(), runtime.shutdown()]);
+    await runtime.shutdown();
+
+    expect(recorder.calls.filter((c) => c === "shutdown")).toHaveLength(1);
+  });
+
+  it("a hung exporter cannot block process exit forever", async () => {
+    const runtime = startWithProcessors([new HungProcessor()], 50);
+
+    const started = Date.now();
+    await runtime.shutdown(); // bounded — resolves despite the hung processor
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+
+  it("ends in-flight root spans before flushing", async () => {
+    const exporter = new InMemorySpanExporter();
+    const recorder = new RecordingProcessor(new SimpleSpanProcessor(exporter));
+    const runtime = startWithProcessors([recorder]);
+
+    // A root run still in flight at shutdown time.
+    const rootSpan = getApexTracer().startSpan("invoke_agent default");
+    const { registerActiveRootSpan } = await import("../observability");
+    registerActiveRootSpan(rootSpan);
+
+    await runtime.shutdown();
+
+    // The registry ended the span BEFORE the flush: onEnd (the span ending)
+    // precedes forceFlush in the recorded call order, so the span exported
+    // with the final flush instead of leaking.
+    expect(recorder.calls).toEqual(["onEnd", "forceFlush", "shutdown"]);
+    expect((rootSpan as unknown as { ended: boolean }).ended).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exit handlers
+// ---------------------------------------------------------------------------
+
+describe("installObservabilityExitHandlers", () => {
+  const realExit = process.exit;
+  const exitCalls: number[] = [];
+  const cleanups: string[] = [];
+  const errors: unknown[] = [];
+
+  beforeEach(() => {
+    exitCalls.length = 0;
+    cleanups.length = 0;
+    errors.length = 0;
+    process.exit = ((code?: number) => {
+      exitCalls.push(code ?? 0);
+      throw new Error("__test_exit__");
+    }) as typeof process.exit;
+  });
+
+  afterEach(() => {
+    process.exit = realExit;
+    // Remove every listener the install added.
+    process.removeAllListeners("SIGINT");
+    process.removeAllListeners("SIGTERM");
+    process.removeAllListeners("uncaughtException");
+    process.removeAllListeners("unhandledRejection");
+  });
+
+  function install(runtime: ReturnType<typeof startWithProcessors>) {
+    installObservabilityExitHandlers(runtime, {
+      cleanup: (code) => cleanups.push(`cleanup:${code}`),
+      onError: (error) => errors.push(error),
+    });
+  }
+
+  it("signals trigger bounded shutdown then exit with the signal code", async () => {
+    const runtime = startWithProcessors([new HungProcessor()], 50);
+    install(runtime);
+
+    process.emit("SIGINT", "SIGINT");
+    // Cleanup ran synchronously; exit waits for the bounded shutdown.
+    expect(cleanups).toEqual(["cleanup:130"]);
+    expect(exitCalls).toHaveLength(0);
+
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(exitCalls).toEqual([130]);
+  });
+
+  it("fatal errors are preserved after flushing (reported, exit code 1)", async () => {
+    const runtime = startWithProcessors([new HungProcessor()], 50);
+    install(runtime);
+
+    const boom = new Error("fatal boom");
+    process.emit("uncaughtException", boom);
+    expect(errors).toEqual([boom]);
+
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(exitCalls).toEqual([1]);
+  });
+
+  it("the first fatal wins — no double exit", async () => {
+    const runtime = startWithProcessors([new HungProcessor()], 50);
+    install(runtime);
+
+    process.emit("uncaughtException", new Error("first"));
+    process.emit("unhandledRejection", new Error("second"));
+
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(errors).toHaveLength(1);
+    expect(exitCalls).toEqual([1]);
+  });
+
+  it("embedded mode (no runtime) never shuts down the host SDK", async () => {
+    // The host (Console) registered its own SDK…
+    const { startOtelTestHarness } = await import("./testkit");
+    const hostOtel = startOtelTestHarness();
+    try {
+      // …Apex starts unconfigured → no-op runtime that touches nothing.
+      const noopRuntime = startObservabilityRuntime({});
+      install(noopRuntime);
+
+      // A "host" span keeps recording across the exit path.
+      const hostSpan = getApexTracer().startSpan("host-work");
+      hostSpan.end();
+
+      process.emit("SIGTERM", "SIGTERM");
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      expect(exitCalls).toEqual([143]);
+      // The host provider still works: the span recorded and ended.
+      expect((hostSpan as unknown as { ended: boolean }).ended).toBe(true);
+      expect(hostOtel.getFinishedSpans().map((s) => s.name)).toContain(
+        "host-work",
+      );
+    } finally {
+      await hostOtel.shutdown();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: the final trace reaches a local OTLP receiver
+// ---------------------------------------------------------------------------
+
+describe("final export", () => {
+  async function startReceiver(): Promise<{
+    server: Server;
+    port: number;
+    waitForRequests(count: number): Promise<Array<Record<string, unknown>>>;
+  }> {
+    const bodies: Array<Record<string, unknown>> = [];
+    const server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        bodies.push(JSON.parse(Buffer.concat(chunks).toString("utf-8")));
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end("{}");
+      });
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("no port");
+    }
+    const waitForRequests = (count: number) =>
+      new Promise<Array<Record<string, unknown>>>((resolve, reject) => {
+        const started = Date.now();
+        const poll = () => {
+          if (bodies.length >= count) return resolve(bodies);
+          if (Date.now() - started > 5000)
+            return reject(new Error("receiver timed out"));
+          setTimeout(poll, 20);
+        };
+        poll();
+      });
+    return { server, port: address.port, waitForRequests };
+  }
+
+  it("a complete root/model/subagent trace exports before completion", async () => {
+    const receiver = await startReceiver();
+    try {
+      process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = `http://127.0.0.1:${receiver.port}/v1/traces`;
+      const runtime = startObservabilityRuntime();
+
+      await getApexTracer().startActiveSpan(
+        "invoke_agent default",
+        {
+          attributes: {
+            "gen_ai.operation.name": "invoke_agent",
+            "pensar.run.id": "run_final",
+          },
+        },
+        async (root) => {
+          const model = getApexTracer().startSpan("ai.streamText");
+          const sub = getApexTracer().startSpan("invoke_agent recon-sub");
+          sub.end();
+          model.end();
+          root.end();
+        },
+      );
+
+      // Normal-path flush: everything is on the wire before completion.
+      await runtime.shutdown();
+
+      const [body] = await receiver.waitForRequests(1);
+      const resourceSpans = (
+        body as {
+          resourceSpans?: Array<{
+            scopeSpans?: Array<{ spans?: Array<{ name?: string }> }>;
+          }>;
+        }
+      ).resourceSpans;
+      const names =
+        resourceSpans?.[0]?.scopeSpans?.[0]?.spans?.map((s) => s.name) ?? [];
+      expect(names).toContain("invoke_agent default");
+      expect(names).toContain("ai.streamText");
+      expect(names).toContain("invoke_agent recon-sub");
+    } finally {
+      await new Promise((resolve) => receiver.server.close(resolve));
+    }
+  });
+});

--- a/src/tui/command-registry.test.ts
+++ b/src/tui/command-registry.test.ts
@@ -37,6 +37,16 @@ describe("advanced settings command", () => {
   });
 });
 
+describe("exit command", () => {
+  it("uses the graceful application exit path", async () => {
+    const exitApplication = vi.fn(async () => {});
+
+    await getCommand("exit").handler([], createContext({ exitApplication }));
+
+    expect(exitApplication).toHaveBeenCalledOnce();
+  });
+});
+
 describe("autonomous workflow Strike Mode overrides", () => {
   it("keeps direct /pentest launches in standard mode", async () => {
     const navigate = vi.fn();

--- a/src/tui/command-registry.ts
+++ b/src/tui/command-registry.ts
@@ -34,6 +34,7 @@ export interface AppCommandContext {
   openAuthDialog?: () => void;
   openPentestDialog?: (flags?: WebCommandOptions) => void;
   openSkillsDialog?: (slug?: string) => void;
+  exitApplication?: () => Promise<void>;
   /**
    * Toggle obfuscation mode (when called without an argument) or set it to
    * an explicit value. Returns the new state.
@@ -547,8 +548,8 @@ export const commands: CommandConfig[] = [
     aliases: ["quit", "q"],
     description: "Exit the application",
     category: "General",
-    handler: async () => {
-      process.kill(process.pid, "SIGINT");
+    handler: async (_args, ctx) => {
+      await ctx.exitApplication?.();
     },
   },
 

--- a/src/tui/context/command.tsx
+++ b/src/tui/context/command.tsx
@@ -64,6 +64,7 @@ interface CommandProviderProps {
   onOpenAuthDialog?: () => void;
   onOpenPentestDialog?: (flags?: WebCommandOptions) => void;
   onOpenSkillsDialog?: (slug?: string) => void;
+  onExit?: () => Promise<void>;
 }
 
 export function CommandProvider({
@@ -78,6 +79,7 @@ export function CommandProvider({
   onOpenAuthDialog,
   onOpenPentestDialog,
   onOpenSkillsDialog,
+  onExit,
 }: CommandProviderProps) {
   const route = useRoute();
   const obfuscation = useObfuscation();
@@ -99,6 +101,7 @@ export function CommandProvider({
       openAuthDialog: onOpenAuthDialog,
       openPentestDialog: onOpenPentestDialog,
       openSkillsDialog: onOpenSkillsDialog,
+      exitApplication: onExit,
       setObfuscation: (enabled) => {
         // Read live engine state so toast feedback is accurate even if
         // this closure was captured on an earlier render. The provider's
@@ -124,6 +127,7 @@ export function CommandProvider({
     onOpenAuthDialog,
     onOpenPentestDialog,
     onOpenSkillsDialog,
+    onExit,
     obfuscation,
     toast,
   ]);

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -125,6 +125,7 @@ function App({ appConfig, onExit }: AppProps) {
               <DialogProvider>
                 <AgentProvider>
                   <CommandProvider
+                    onExit={onExit}
                     onOpenSessionsDialog={() => setShowSessionsDialog(true)}
                     onOpenThemeDialog={() => setShowThemeDialog(true)}
                     onOpenAdvancedDialog={() => setShowAdvancedDialog(true)}

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -732,36 +732,33 @@ async function main() {
   const { copyToClipboard } = createClipboardManager(renderer);
   setupAutoCopy(renderer, copyToClipboard);
 
-  let cleanupPromise: Promise<void> | null = null;
-  const cleanup = () => {
-    if (!cleanupPromise) {
-      cleanupPromise = (async () => {
-        cleanupTerminalFocusMode();
-        renderer.destroy();
-        // Flush traces before the process dies; exit waits for the bounded flush.
-        await observabilityRuntime.shutdown().catch(() => {});
-        process.exit(0);
-      })();
+  const teardownAndExit = (code: number, error?: unknown, label?: string) => {
+    cleanupTerminalFocusMode();
+    renderer.destroy();
+    if (error !== undefined && label) {
+      console.error(label, error);
+      writeErrorLog(
+        error,
+        label === "Uncaught exception:" ? "UNCAUGHT" : "UNHANDLED_REJECTION",
+      );
     }
-    return cleanupPromise;
+    // Bounded flush (ends in-flight root runs, flushes, shuts down) before
+    // the process dies — never exit while a flush could still complete.
+    observabilityRuntime
+      .shutdown()
+      .catch(() => {})
+      .then(() => process.exit(code));
   };
+  const cleanup = () => teardownAndExit(0);
   process.on("SIGINT", cleanup);
   process.on("SIGTERM", cleanup);
 
   process.on("uncaughtException", (err) => {
-    cleanupTerminalFocusMode();
-    renderer.destroy();
-    console.error("Uncaught exception:", err);
-    writeErrorLog(err, "UNCAUGHT");
-    process.exit(1);
+    teardownAndExit(1, err, "Uncaught exception:");
   });
 
   process.on("unhandledRejection", (reason) => {
-    cleanupTerminalFocusMode();
-    renderer.destroy();
-    console.error("Unhandled rejection:", reason);
-    writeErrorLog(reason, "UNHANDLED_REJECTION");
-    process.exit(1);
+    teardownAndExit(1, reason, "Unhandled rejection:");
   });
 
   const obfuscateEnabled = process.env.PENSAR_OBFUSCATE === "1";

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -5,7 +5,10 @@ import { config } from "../core/config";
 import type { Config } from "../core/config/config";
 import { checkForUpdate } from "../core/installation";
 import { routeLogsToErrorFile, writeErrorLog } from "../core/logger";
-import { startObservabilityRuntime } from "../core/observability/runtime";
+import {
+  installObservabilityExitHandlers,
+  startObservabilityRuntime,
+} from "../core/observability/runtime";
 import { hasAnyProviderConfigured } from "../core/providers";
 import type { SessionConfig } from "../core/session";
 import { setupAutoCopy } from "./auto-copy";
@@ -732,34 +735,19 @@ async function main() {
   const { copyToClipboard } = createClipboardManager(renderer);
   setupAutoCopy(renderer, copyToClipboard);
 
-  const teardownAndExit = (code: number, error?: unknown, label?: string) => {
-    cleanupTerminalFocusMode();
-    renderer.destroy();
-    if (error !== undefined && label) {
+  const exitWith = installObservabilityExitHandlers(observabilityRuntime, {
+    cleanup: () => {
+      cleanupTerminalFocusMode();
+      renderer.destroy();
+    },
+    onError: (error, source) => {
+      const uncaught = source === "uncaughtException";
+      const label = uncaught ? "Uncaught exception:" : "Unhandled rejection:";
       console.error(label, error);
-      writeErrorLog(
-        error,
-        label === "Uncaught exception:" ? "UNCAUGHT" : "UNHANDLED_REJECTION",
-      );
-    }
-    // Bounded flush (ends in-flight root runs, flushes, shuts down) before
-    // the process dies — never exit while a flush could still complete.
-    observabilityRuntime
-      .shutdown()
-      .catch(() => {})
-      .then(() => process.exit(code));
-  };
-  const cleanup = () => teardownAndExit(0);
-  process.on("SIGINT", cleanup);
-  process.on("SIGTERM", cleanup);
-
-  process.on("uncaughtException", (err) => {
-    teardownAndExit(1, err, "Uncaught exception:");
+      writeErrorLog(error, uncaught ? "UNCAUGHT" : "UNHANDLED_REJECTION");
+    },
   });
-
-  process.on("unhandledRejection", (reason) => {
-    teardownAndExit(1, reason, "Unhandled rejection:");
-  });
+  const cleanup = () => exitWith(0);
 
   const obfuscateEnabled = process.env.PENSAR_OBFUSCATE === "1";
 


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Usage + observability · PR 12 of 12**  
> Review and merge in table order.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#996](https://github.com/pensarai/apex/pull/996) | Session usage models |
| 2 | [#997](https://github.com/pensarai/apex/pull/997) | Session-scoped ownership |
| 3 | [#998](https://github.com/pensarai/apex/pull/998) | Complete usage persistence |
| 4 | [#999](https://github.com/pensarai/apex/pull/999) | Consolidated usage ingestion |
| 5 | [#1000](https://github.com/pensarai/apex/pull/1000) | Token and context footer |
| 6 | [#1002](https://github.com/pensarai/apex/pull/1002) | Cache token breakdown |
| 7 | [#1004](https://github.com/pensarai/apex/pull/1004) | Agent trace contract |
| 8 | [#1005](https://github.com/pensarai/apex/pull/1005) | Optional OTLP runtime |
| 9 | [#1006](https://github.com/pensarai/apex/pull/1006) | Root agent run spans |
| 10 | [#1007](https://github.com/pensarai/apex/pull/1007) | Centralized telemetry settings |
| 11 | [#1008](https://github.com/pensarai/apex/pull/1008) | Telemetry correlation |
| **12** | **[#1009](https://github.com/pensarai/apex/pull/1009)** | **OTLP shutdown hardening** · `Current` |
## Summary

- **idempotent, bounded shutdown** — `runtime.shutdown()` runs the real sequence exactly once (all callers await the same promise) and is raced against a timeout (default 5s, injectable), so a hung exporter can never block process exit
- **flush ordering made explicit** — shutdown ends in-flight root runs, then `forceFlush()`, then processor/exporter teardown; pinned by a recording-span-processor test asserting the exact call order (`onEnd → forceFlush → shutdown`)
- **in-flight root runs still export** — the agent registers its root span for the run's duration (new `active-root-spans` registry); shutdown ends anything still registered before flushing, so a SIGINT-mid-run span exports instead of leaking
- **signals, fatal errors, and explicit headless exits share one coordinator** — SIGINT (130), SIGTERM (143), `uncaughtException` (1), and `unhandledRejection` (1) all flush through the bounded shutdown; signal listeners remain installed during the flush so repeated interrupts cannot bypass it; timed-out and pentest completion paths reuse the coordinator without overwriting signal or fatal status
- **exit hooks cannot strand shutdown** — throwing entrypoint cleanup or error-reporting hooks are contained; cleanup failure is reported, upgrades the exit to code 1, and still reaches bounded shutdown
- **embedded hosts untouched** — the no-op runtime (no endpoint) shuts down nothing; a host-registered provider keeps recording across Apex's exit path (pinned with a test that registers its own provider as the host)
- entrypoint wiring: `cli.ts` installs the coordinator for headless commands (the TUI branch is excluded — the TUI owns its exit paths); the TUI uses that same coordinator so renderer teardown runs once, errors retain their original logging, shutdown stays bounded, and every caller shares the final exit
- **Langfuse documentation** — new `docs/observability.md`: the exact OTLP/HTTP env config (incl. `http/protobuf` + auth headers), the sensitivity warning for full payload mode, sampling/console/embedded ownership notes, the span-tree shape, and the env-var reference

## What changed

- `src/core/observability/active-root-spans.ts` (new) — the registry
- `src/core/observability/runtime.ts` — `StartObservabilityRuntimeOptions` (`shutdownTimeoutMs`, injectable `spanProcessors` for tests), `withTimeout`, the idempotent shutdown sequence, `installObservabilityExitHandlers`
- `src/core/observability/index.ts` — registry exports
- `offensiveSecurityAgent.ts` — root spans register/unregister around the run
- `src/cli.ts` / `src/tui/index.tsx` — exit-path wiring
- `docs/observability.md` (new)

## Tests (13, in `shutdown.test.ts`)

**Shutdown semantics:** forceFlush before shutdown (exact call order + span present at flush); repeated shutdowns execute the real shutdown once; a hung exporter resolves within the bound; in-flight root spans end **before** the flush (call order + span state).

**Exit handlers** (process.exit stubbed): SIGINT → cleanup synchronously, exit waits for bounded shutdown, exits 130; duplicate signals leave the handler installed and do not repeat cleanup; throwing entrypoint cleanup still flushes and exits 1; fatal errors are reported and preserved; first fatal wins; a late fatal upgrades an in-flight normal exit; a late normal completion cannot overwrite a signal code; embedded mode leaves the host provider recording.

**End-to-end:** a complete root/model/subagent trace reaches the local OTLP receiver before process completion.

## Validation

- `bun run test` (1,874 passed, 22 skipped)
- `bun run tsc`
- `bun run knip`
- `bunx biome check` on all touched files (pre-existing warnings only)

## Stack D final acceptance

- OTel fully additive and optional — disabled without configuration ✅
- Existing telemetry operational — trace.jsonl, EventBus, structured logs, W&B unchanged ✅
- Standalone Apex exports through any OTLP/HTTP backend (json or protobuf) ✅
- Embedded Apex never installs a competing global provider ✅
- Every root run produces one coherent trace ✅
- Full mode captures prompts, responses, reasoning, and tool payloads ✅
- Logs, JSONL, W&B, and OTel correlate ✅
- Every standalone process flushes before exit ✅

## Non-goals honored

No external Langfuse test credentials, no Langfuse SDK, no W&B migration, no OTel metrics or logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all standalone process exit paths and shutdown ordering; mistakes could drop traces, block exit, or mishandle TUI teardown, but behavior is heavily tested and embedded/no-op OTel paths are preserved.
> 
> **Overview**
> **Standalone processes now flush OpenTelemetry traces on every exit path** — normal completion, TUI quit, signals, and fatals — without hanging forever on a stuck exporter.
> 
> `runtime.shutdown()` is **idempotent and time-bounded** (default 5s, returns `completed` or `timed-out`). Teardown order is explicit: end any **in-flight root agent spans** (new registry + register/unregister in the offensive security agent), then `forceFlush()`, then exporter shutdown. **`installObservabilityExitHandlers`** centralizes SIGINT/SIGTERM and fatal errors so shutdown runs before `process.exit`, with optional sync cleanup (TUI renderer destroy) and error reporting **after** cleanup so console output isn’t lost on the alternate screen.
> 
> **CLI** wires the coordinator for headless commands only; **TUI** uses the same helper and routes `/exit` through `onExit` instead of raw SIGINT. Pentest completion and timed-out shutdown still force a final exit when handles may remain open.
> 
> Adds **`docs/observability.md`** (OTLP/Langfuse env, payload sensitivity, shutdown notes) and **`shutdown.test.ts`** covering ordering, hung exporters, exit-handler semantics, and end-to-end OTLP export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e101e2f189493cf0c66554686f7d23586eea75eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

