### PR TITLE
fix(shell): read stderr from disk instead of racing the pipe

### DIFF
--- a/src/core/agents/offSecAgent/tools/persistentShell.stderrRace.test.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.stderrRace.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, describe, expect, it } from "vitest";
+
+import { PersistentShell } from "./persistentShell";
+
+/**
+ * Isolated from persistentShell.test.ts: this case blocks the event loop on
+ * purpose, and that file has concurrent tests with upper-bound timing
+ * assertions. Vitest runs each file in its own worker, so the block stays here.
+ *
+ * The bug: stdout and stderr are separate pipes with no delivery ordering
+ * between them. The wrapper writes the command's stderr on fd2 and the exit
+ * marker on fd1; when libuv serviced the stdout handle first, `onStdoutData`
+ * resolved the call with an empty stderr and the fd2 bytes were dropped on the
+ * floor (`this.current` was already null). Under CI load this flaked ~1 run in
+ * 20. Blocking the loop while both pipes hold queued bytes makes it fire every
+ * time — 10/10 before the disk-read fix, 0/10 after.
+ */
+describe("PersistentShell — stderr/stdout pipe ordering", () => {
+  const shells: PersistentShell[] = [];
+  afterAll(() => {
+    for (const shell of shells) shell.dispose();
+  });
+
+  it("keeps stderr when the exit marker wins the race to the event loop", async () => {
+    const shell = new PersistentShell();
+    shells.push(shell);
+
+    for (let i = 0; i < 3; i++) {
+      const a = shell.execute(">&2 echo apex-call-a-stderr", 5);
+      const b = shell.execute("echo apex-call-b-stdout", 5);
+
+      // Let both commands reach the shell, then stall libuv so the wrapper
+      // finishes and both pipes hold readable bytes at the same moment.
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      const until = Date.now() + 120;
+      while (Date.now() < until) {
+        /* block */
+      }
+
+      const [ra, rb] = await Promise.all([a, b]);
+      expect(ra.exitCode).toBe(0);
+      expect(rb.exitCode).toBe(0);
+      expect(ra.stderr).toContain("apex-call-a-stderr");
+      expect(rb.stderr).not.toContain("apex-call-a-stderr");
+      expect(rb.stdout).toContain("apex-call-b-stdout");
+    }
+  }, 30_000);
+});

--- a/src/core/agents/offSecAgent/tools/persistentShell.ts
+++ b/src/core/agents/offSecAgent/tools/persistentShell.ts
@@ -344,13 +344,19 @@ export class PersistentShell {
           : Number.isNaN(naturalExitCode)
             ? 1
             : naturalExitCode;
-      const effectiveStderr = cmd.forcedStderrSuffix
-        ? (cmd.stderr || "") + cmd.forcedStderrSuffix
-        : cmd.stderr || "";
+      // stdout and stderr are separate pipes with no delivery ordering between
+      // them, so the exit marker on fd1 can arrive before the command's stderr
+      // on fd2 and resolve the call with an empty stderr. The tempfile is
+      // closed before the exit code is captured, so read it instead of racing
+      // the pipe — every other resolve path already prefers the disk read.
+      const diskStderr = readTempfileCapped(cmd.errPath);
 
       // Cleanup is owned by Node now that the wrapper no longer rm's.
       unlinkSafe(cmd.outPath);
       unlinkSafe(cmd.errPath);
+
+      const effectiveStderr =
+        (diskStderr || cmd.stderr || "") + (cmd.forcedStderrSuffix ?? "");
 
       const resolve = cmd.resolve;
       this.current = null;


### PR DESCRIPTION
`PersistentShell` resolved a command the instant the exit marker appeared on **stdout**, taking whatever had arrived on the **stderr** pipe by that moment. Those are two separate pipes with no delivery ordering between them, so when libuv serviced the stdout handle first the call resolved with an empty `stderr` and the fd2 bytes were dropped on the floor — `this.current` was already `null` by the time `onStderrData` saw them.

This is the flake behind `does not cross-contaminate stderr across parallel execute() calls` (`AssertionError: expected '' to contain 'apex-call-a-stderr'`), which fails roughly one run in twenty under CI load. It has been failing intermittently in Console CI for at least two days — most recently on Console's `staging` HEAD, where it is currently blocking the production promotion.

### Fix

Every other resolve path — the `close` handler and the timeout salvage — already prefers `readTempfileCapped(errPath)` over the piped buffer. The normal-exit path was the only one that didn't. The wrapper closes `2>"$__APEX_ERR"` when the brace group ends, before `__APEX_EC=$?`, so by the time the exit marker is echoed the tempfile is complete: the disk read is ordering-independent. It also excludes bash's own diagnostics entirely, which is exactly what the fd2 cutover fence exists to strip.

### Test

The regression test is in its own file because it blocks the event loop on purpose, and `persistentShell.test.ts` has concurrent cases with upper-bound timing assertions (`toBeLessThan(1_500)` / `toBeLessThan(3_000)`) that a shared-loop stall could destabilize. Vitest gives each file its own worker, so the block stays contained.

Stalling libuv while both pipes hold queued bytes makes the race fire every time:

| | empty stderr |
|---|---|
| before | 10/10 |
| after | 0/10 |

Verified from the Console monorepo: `packages/apex/src/core/agents/offSecAgent/tools/` — 22 files, 355 passed. `biome check src/` exits 0 (the two warnings on `persistentShell.ts` are pre-existing and untouched). Console-level `bun run lint` (0 errors) and `bun run tsc` (clean).

No linked issue — found while investigating a red `test / test` on Console `staging`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes command result assembly on every successful shell exit; behavior should be more correct but affects a core agent execution path used in production sandboxes.
> 
> **Overview**
> Fixes an intermittent CI flake where `PersistentShell.execute()` could return **empty stderr** when the stdout exit marker was processed before stderr bytes arrived on the separate fd2 pipe—late stderr was dropped because `this.current` was already cleared.
> 
> On the normal-exit path in `onStdoutData`, stderr is now built from **`readTempfileCapped(errPath)`** (with piped `cmd.stderr` as fallback), aligned with the `close` and timeout/salvage handlers. The wrapper closes the stderr tempfile before echoing the exit marker, so the disk read avoids the pipe ordering race.
> 
> Adds **`persistentShell.stderrRace.test.ts`** in its own Vitest worker: it stalls the event loop while parallel commands have queued stdout/stderr so the race reproduces deterministically and asserts stderr is preserved without cross-contamination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71bcdf4e080a0a1303f93b85ad52a8570f94cb57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->