### PR TITLE
feat(pentest): add disableSubagents session config to run per-target …

### DIFF
--- a/src/core/agents/specialized/pentest/agent.test.ts
+++ b/src/core/agents/specialized/pentest/agent.test.ts
@@ -26,6 +26,34 @@ describe("TargetedPentestAgent prompt contracts", () => {
     );
   });
 
+  it("forces the solo-worker role when subagents are disabled", () => {
+    // disableSubagents opts a default-mode run out of orchestration: the
+    // per-target agent runs solo instead of spawning one worker per objective.
+    expect(resolvePentestAgentRole("default", "orchestrator", true)).toBe(
+      "worker",
+    );
+    // Off by default — orchestrated fan-out is preserved.
+    expect(resolvePentestAgentRole("default", "orchestrator", false)).toBe(
+      "orchestrator",
+    );
+    // A worker never gets promoted regardless of the flag.
+    expect(resolvePentestAgentRole("default", "worker", false)).toBe("worker");
+  });
+
+  it("drops the spawn tool and orchestrator prompt for a subagents-disabled run", () => {
+    // The solo worker resolved for a disabled run tests every objective itself:
+    // no spawn_pentest_agent tool, and the worker prompt (not the orchestrator
+    // fan-out prompt) drives it.
+    const role = resolvePentestAgentRole("default", "orchestrator", true);
+    const tools = buildPentestActiveTools(role, session);
+    const prompt = buildPentestSystemPrompt(session, role, "default");
+
+    expect(tools).not.toContain("spawn_pentest_agent");
+    expect(tools).toContain("document_vulnerability");
+    expect(prompt).not.toContain("Sub-Agent Delegation Rules");
+    expect(prompt).not.toContain("FAN OUT");
+  });
+
   it("uses the focused Strike loop without orchestrator fan-out", () => {
     const prompt = buildPentestSystemPrompt(
       session,

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -61,8 +61,15 @@ export type TargetedPentestMode = Extract<AgentMode, "default" | "fast-strike">;
 export function resolvePentestAgentRole(
   mode: TargetedPentestMode = "default",
   role: PentestAgentRole = "orchestrator",
+  disableSubagents = false,
 ): PentestAgentRole {
-  return mode === "fast-strike" ? "worker" : role;
+  // Fast Strike is always a single focused worker. `disableSubagents` opts a
+  // normal (default-mode) run out of orchestration too: the per-target agent
+  // runs solo as a worker, testing every objective itself with no
+  // `spawn_pentest_agent` fan-out.
+  if (mode === "fast-strike") return "worker";
+  if (disableSubagents) return "worker";
+  return role;
 }
 
 export type { GrpcPentestContext };
@@ -243,7 +250,11 @@ export class TargetedPentestAgent extends OffensiveSecurityAgent<PentestResult> 
       browserSession,
       display,
     } = opts;
-    const effectiveRole = resolvePentestAgentRole(mode, role);
+    const effectiveRole = resolvePentestAgentRole(
+      mode,
+      role,
+      session.config?.disableSubagents ?? false,
+    );
     const systemScope = opts.systemScope;
 
     // The base class creates the response tool from responseSchema and

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -258,6 +258,16 @@ const SessionConfigObject = z.object({
   taskDriven: z.boolean().optional(),
   /** When true, pentest agents run a plan phase before execution (default: false) */
   requirePlan: z.boolean().optional(),
+  /**
+   * Opt-out: disable sub-agent orchestration for targeted pentests. When true,
+   * the per-target pentest agent runs SOLO as a single worker — it tests every
+   * objective itself instead of acting as an orchestrator that spawns one
+   * `spawn_pentest_agent` worker per objective. Removes the `spawn_pentest_agent`
+   * tool and swaps the orchestrator system prompt for the worker prompt. Defaults
+   * to off (orchestrated fan-out). Trades depth for lower cost and duration — the
+   * orchestrated path is more thorough but spends a full agent run per objective.
+   */
+  disableSubagents: z.boolean().optional(),
   /** Local filesystem path for prompt-injection payload library */
   promptInjectionLibrarySource: z.string().optional(),
 });


### PR DESCRIPTION
…agent solo

When session.config.disableSubagents is true, the targeted pentest agent runs solo as a single worker instead of orchestrating one spawn_pentest_agent worker per objective. This removes the spawn_pentest_agent tool from its toolset and swaps the orchestrator system prompt for the worker prompt, so the agent tests every objective itself. Defaults to off (orchestrated fan-out preserved).

Trades depth for lower test cost and duration.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

### How did you verify your code works?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in behavior change to pentest execution model (solo vs multi-agent); default is unchanged, but misconfiguration could reduce coverage depth on engagements that expect per-objective workers.
> 
> **Overview**
> Adds an opt-in **`session.config.disableSubagents`** flag so targeted pentest runs can skip orchestrator fan-out and execute as a **single worker** that covers all objectives in one agent (lower cost/duration vs one spawn per objective).
> 
> **`resolvePentestAgentRole`** now accepts `disableSubagents` (after fast-strike → worker, same as today). When the flag is true in default mode, an orchestrator request is downgraded to **worker**, which reuses existing behavior: no **`spawn_pentest_agent`**, worker system prompt instead of orchestrator delegation/FAN OUT text. **`TargetedPentestAgent`** passes `session.config?.disableSubagents ?? false` into that resolver. Default remains orchestrated fan-out.
> 
> Contract tests assert role forcing, tool list, and prompt content when subagents are disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33f81a003114dc56d969d95f483cae4996004af2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->