### PR TITLE
fix(recon): preserve target domain in documented apps

### DIFF
--- a/src/core/agents/offSecAgent/tools/documentApp.test.ts
+++ b/src/core/agents/offSecAgent/tools/documentApp.test.ts
@@ -1,0 +1,81 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { documentApp } from "./documentApp";
+
+function makeContext(rootPath: string, target: string) {
+  return {
+    session: {
+      id: "test-session",
+      rootPath,
+      targets: [target],
+    },
+    agentCwd: rootPath,
+  } as Parameters<typeof documentApp>[0];
+}
+
+function makeInput(appType: "web_application" | "api" | "cloud_resource") {
+  return {
+    appName: "Primary App",
+    appType,
+    description: "Application discovered during reconnaissance",
+    toolCallDescription: "Document the discovered application",
+  };
+}
+
+describe("documentApp domain handling", () => {
+  let rootPath: string;
+
+  beforeEach(() => {
+    rootPath = mkdtempSync(join(tmpdir(), "apex-document-app-"));
+  });
+
+  afterEach(() => {
+    rmSync(rootPath, { recursive: true, force: true });
+  });
+
+  it("defaults a primary web app domain to the session target origin", async () => {
+    const tool = documentApp(
+      makeContext(rootPath, "https://example.com/recon/start?source=test"),
+    );
+    const result = (await tool.execute?.(makeInput("web_application"), {
+      toolCallId: "tool-1",
+      messages: [],
+    })) as { success: boolean; domain?: string; filepath: string };
+
+    expect(result.success).toBe(true);
+    expect(result.domain).toBe("https://example.com");
+    expect(JSON.parse(readFileSync(result.filepath, "utf8")).domain).toBe(
+      "https://example.com",
+    );
+  });
+
+  it("leaves the domain unset when the session target is not an HTTP URL", async () => {
+    const tool = documentApp(makeContext(rootPath, "/workspace/source"));
+    const result = (await tool.execute?.(makeInput("api"), {
+      toolCallId: "tool-2",
+      messages: [],
+    })) as { success: boolean; domain?: string; filepath: string };
+
+    expect(result.success).toBe(true);
+    expect(result.domain).toBeUndefined();
+    expect(
+      JSON.parse(readFileSync(result.filepath, "utf8")),
+    ).not.toHaveProperty("domain");
+  });
+
+  it("does not apply the session target to a cloud resource", async () => {
+    const tool = documentApp(makeContext(rootPath, "https://example.com"));
+    const result = (await tool.execute?.(makeInput("cloud_resource"), {
+      toolCallId: "tool-3",
+      messages: [],
+    })) as { success: boolean; domain?: string; filepath: string };
+
+    expect(result.success).toBe(true);
+    expect(result.domain).toBeUndefined();
+    expect(
+      JSON.parse(readFileSync(result.filepath, "utf8")),
+    ).not.toHaveProperty("domain");
+  });
+});

--- a/src/core/agents/offSecAgent/tools/documentApp.test.ts
+++ b/src/core/agents/offSecAgent/tools/documentApp.test.ts
@@ -4,18 +4,26 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { documentApp } from "./documentApp";
 
-function makeContext(rootPath: string, target: string) {
+function makeContext(rootPath: string, sessionTarget: string, target?: string) {
   return {
     session: {
       id: "test-session",
       rootPath,
-      targets: [target],
+      targets: [sessionTarget],
     },
     agentCwd: rootPath,
+    target,
   } as Parameters<typeof documentApp>[0];
 }
 
-function makeInput(appType: "web_application" | "api" | "cloud_resource") {
+function makeInput(
+  appType:
+    | "web_application"
+    | "api"
+    | "database"
+    | "cloud_resource"
+    | "storage",
+) {
   return {
     appName: "Primary App",
     appType,
@@ -35,9 +43,13 @@ describe("documentApp domain handling", () => {
     rmSync(rootPath, { recursive: true, force: true });
   });
 
-  it("defaults a primary web app domain to the session target origin", async () => {
+  it("defaults a primary web app domain to the blackbox target origin", async () => {
     const tool = documentApp(
-      makeContext(rootPath, "https://example.com/recon/start?source=test"),
+      makeContext(
+        rootPath,
+        "https://session.example.com",
+        "https://example.com/recon/start?source=test",
+      ),
     );
     const result = (await tool.execute?.(makeInput("web_application"), {
       toolCallId: "tool-1",
@@ -51,8 +63,8 @@ describe("documentApp domain handling", () => {
     );
   });
 
-  it("leaves the domain unset when the session target is not an HTTP URL", async () => {
-    const tool = documentApp(makeContext(rootPath, "/workspace/source"));
+  it("does not default a whitebox app from the session target", async () => {
+    const tool = documentApp(makeContext(rootPath, "https://example.com"));
     const result = (await tool.execute?.(makeInput("api"), {
       toolCallId: "tool-2",
       messages: [],
@@ -65,10 +77,51 @@ describe("documentApp domain handling", () => {
     ).not.toHaveProperty("domain");
   });
 
-  it("does not apply the session target to a cloud resource", async () => {
-    const tool = documentApp(makeContext(rootPath, "https://example.com"));
-    const result = (await tool.execute?.(makeInput("cloud_resource"), {
-      toolCallId: "tool-3",
+  it("preserves an explicit evidence-derived domain", async () => {
+    const tool = documentApp(
+      makeContext(rootPath, "https://example.com", "https://example.com"),
+    );
+    const result = (await tool.execute?.(
+      {
+        ...makeInput("api"),
+        domain: "https://api.example.com/v1",
+      },
+      { toolCallId: "tool-3", messages: [] },
+    )) as { success: boolean; domain?: string; filepath: string };
+
+    expect(result.success).toBe(true);
+    expect(result.domain).toBe("https://api.example.com");
+    expect(JSON.parse(readFileSync(result.filepath, "utf8")).domain).toBe(
+      "https://api.example.com",
+    );
+  });
+
+  it.each([
+    "database",
+    "cloud_resource",
+    "storage",
+  ] as const)("does not apply the blackbox target to a %s", async (appType) => {
+    const tool = documentApp(
+      makeContext(rootPath, "https://example.com", "https://example.com"),
+    );
+    const result = (await tool.execute?.(makeInput(appType), {
+      toolCallId: "tool-4",
+      messages: [],
+    })) as { success: boolean; domain?: string; filepath: string };
+
+    expect(result.success).toBe(true);
+    expect(result.domain).toBeUndefined();
+    expect(
+      JSON.parse(readFileSync(result.filepath, "utf8")),
+    ).not.toHaveProperty("domain");
+  });
+
+  it("leaves the domain unset when the blackbox target is not an HTTP URL", async () => {
+    const tool = documentApp(
+      makeContext(rootPath, "/workspace/source", "/workspace/source"),
+    );
+    const result = (await tool.execute?.(makeInput("web_application"), {
+      toolCallId: "tool-5",
       messages: [],
     })) as { success: boolean; domain?: string; filepath: string };
 

--- a/src/core/agents/offSecAgent/tools/documentApp.ts
+++ b/src/core/agents/offSecAgent/tools/documentApp.ts
@@ -159,9 +159,8 @@ Each application creates a JSON file in the apps directory for tracking and anal
         !input.domain &&
         ["web_application", "api", "full_stack"].includes(input.appType)
       ) {
-        const sessionTarget = ctx.session.targets[0];
-        if (sessionTarget) {
-          const targetCheck = validateDomainUrl(sessionTarget);
+        if (ctx.target) {
+          const targetCheck = validateDomainUrl(ctx.target);
           if (targetCheck.origin) {
             input = { ...input, domain: targetCheck.origin };
           }

--- a/src/core/agents/offSecAgent/tools/documentApp.ts
+++ b/src/core/agents/offSecAgent/tools/documentApp.ts
@@ -155,6 +155,19 @@ Each application creates a JSON file in the apps directory for tracking and anal
         ),
     }),
     execute: async (input) => {
+      if (
+        !input.domain &&
+        ["web_application", "api", "full_stack"].includes(input.appType)
+      ) {
+        const sessionTarget = ctx.session.targets[0];
+        if (sessionTarget) {
+          const targetCheck = validateDomainUrl(sessionTarget);
+          if (targetCheck.origin) {
+            input = { ...input, domain: targetCheck.origin };
+          }
+        }
+      }
+
       if (input.domain) {
         const domainCheck = validateDomainUrl(input.domain);
         if (!domainCheck.valid) {

--- a/src/core/agents/specialized/attackSurface/prompts.ts
+++ b/src/core/agents/specialized/attackSurface/prompts.ts
@@ -252,6 +252,7 @@ Use \`browser_get_cookies\` to document all cookies set by the application — n
 ## 5a. Document applications first, then endpoints
 
 **Step 1: Document each application** using \`document_app\`:
+- Set \`domain\` to the target URL for the primary web application or API, and to the evidence-derived URL for target-owned subdomains and resources.
 - \`web_application\` — the target web application (usually one per target domain)
 - \`api\` — API services hosted by the target (REST, GraphQL, WebSocket)
 - \`full_stack\` — applications serving both UI and API (e.g. Next.js, Django with templates)


### PR DESCRIPTION
## Summary
- default missing `document_app.domain` values for primary web, API, and full-stack apps from the session target's HTTP(S) origin
- preserve the existing behavior for non-URL whitebox targets and cloud resources
- clarify the blackbox recon prompt and add regression coverage for the persistence boundary

Fixes #971

## Testing
- `bun run tsc`
- `bun run test src/core/agents/offSecAgent/tools/documentApp.test.ts src/core/agents/offSecAgent/prompt.test.ts`
- `bunx biome check src/core/agents/offSecAgent/tools/documentApp.ts src/core/agents/offSecAgent/tools/documentApp.test.ts src/core/agents/specialized/attackSurface/prompts.ts`