### PR TITLE
fix(ai): pin GLM 5.2 to Z.ai

### DIFF
--- a/src/core/ai/ai.test.ts
+++ b/src/core/ai/ai.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import {
   applySequentialToolCallPolicy,
+  buildOpenRouterProviderOptions,
   buildReasoningProviderOptions,
   isRepairFailClosedTool,
   SEQUENTIAL_TOOL_CALL_INSTRUCTION,
@@ -199,6 +200,25 @@ describe("buildReasoningProviderOptions", () => {
         thinkingEffort: "high",
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("buildOpenRouterProviderOptions", () => {
+  it("pins GLM 5.2 to Z.ai without provider fallbacks", () => {
+    expect(buildOpenRouterProviderOptions("z-ai/glm-5.2")).toEqual({
+      openrouter: {
+        provider: {
+          only: ["z-ai"],
+          allow_fallbacks: false,
+        },
+      },
+    });
+  });
+
+  it("leaves other OpenRouter models unchanged", () => {
+    expect(buildOpenRouterProviderOptions("anthropic/claude-opus-4-6")).toBe(
+      undefined,
+    );
   });
 });
 

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -903,6 +903,29 @@ export type ReasoningProviderOptions = {
   openai?: OpenAIResponsesProviderOptions;
 };
 
+export type OpenRouterProviderOptions = {
+  openrouter?: {
+    provider: {
+      only: ["z-ai"];
+      allow_fallbacks: false;
+    };
+  };
+};
+
+export function buildOpenRouterProviderOptions(
+  model: AIModel,
+): OpenRouterProviderOptions | undefined {
+  if (model !== "z-ai/glm-5.2") return undefined;
+  return {
+    openrouter: {
+      provider: {
+        only: ["z-ai"],
+        allow_fallbacks: false,
+      },
+    },
+  };
+}
+
 /**
  * Build the `providerOptions` for a request based on the model and reasoning
  * settings. Returns `undefined` when no reasoning/thinking is requested.
@@ -1171,11 +1194,16 @@ export function streamResponse(
   // not top-level providerOptions, so there is no collision.
   // Note: when thinking is enabled, temperature must not be set (Anthropic rejects it);
   // this path never sets temperature, so there is nothing to clear.
-  const providerOptions = buildReasoningProviderOptions(model, {
+  const reasoningProviderOptions = buildReasoningProviderOptions(model, {
     enableThinking,
     thinkingEffort,
     openAIReasoningEffort,
   });
+  const openRouterProviderOptions = buildOpenRouterProviderOptions(model);
+  const providerOptions =
+    reasoningProviderOptions || openRouterProviderOptions
+      ? { ...reasoningProviderOptions, ...openRouterProviderOptions }
+      : undefined;
 
   let rateLimitRetryCount = 0;
 
@@ -1476,6 +1504,7 @@ export async function generateObjectResponse<T extends z.ZodType>(
     model,
     openAIReasoningEffort,
   );
+  const openRouterProviderOptions = buildOpenRouterProviderOptions(model);
 
   let lastError: unknown;
 
@@ -1490,13 +1519,19 @@ export async function generateObjectResponse<T extends z.ZodType>(
         system,
         maxOutputTokens: maxTokens,
         temperature,
-        providerOptions: normalizedOpenAIEffort
-          ? {
-              openai: {
-                reasoningEffort: normalizedOpenAIEffort,
-              },
-            }
-          : undefined,
+        providerOptions:
+          normalizedOpenAIEffort || openRouterProviderOptions
+            ? {
+                ...(normalizedOpenAIEffort
+                  ? {
+                      openai: {
+                        reasoningEffort: normalizedOpenAIEffort,
+                      },
+                    }
+                  : {}),
+                ...openRouterProviderOptions,
+              }
+            : undefined,
         maxRetries: 0,
         abortSignal,
         experimental_telemetry: createAiTelemetrySettings({


### PR DESCRIPTION
## Summary
- pin OpenRouter GLM 5.2 requests to Z.ai with provider fallback disabled
- apply the routing policy to streamed and structured generation paths
- preserve a stable upstream identity for Console's cache-aware rate card

## Test plan
- [x] `bun run tsc`
- [x] `bunx biome check src/core/ai/ai.ts src/core/ai/ai.test.ts`
- [x] `bun run test` (2,570 passed, 22 skipped)

Companion to pensarai/console#2675.

Made with [Cursor](https://cursor.com)