### PR TITLE
feat(api): identify this client to Console on every API request

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@
 import { config as loadEnv } from "dotenv";
 import packageJson from "../package.json";
 import { type AIModel, buildAuthConfig } from "./core/ai";
+import { setCurrentCommand } from "./core/api/clientIdentity";
 import { resolveCliLogLevel } from "./core/cli/logLevelArgs";
 import { resolvePentestMode } from "./core/cli/pentestMode";
 import { AgentEventBus } from "./core/eventBus";
@@ -597,6 +598,10 @@ async function runUpgrade() {
 // OTLP endpoint is configured; the TUI branch below takes over the process
 // and manages the runtime's lifecycle in its own exit path.
 const observabilityRuntime = startObservabilityRuntime();
+
+// Tell Console which command is talking to it; one place, so a command added
+// below is covered without another edit.
+setCurrentCommand(command);
 
 try {
   if (hasFlag("-p") || command === "--prompt") {

--- a/src/core/api/apiClient.test.ts
+++ b/src/core/api/apiClient.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../auth", () => ({
+  ensureValidToken: vi.fn(async () => ({ token: "tok" })),
+}));
+vi.mock("../config", () => ({
+  config: { get: vi.fn(async () => ({ workspaceId: "ws-1" })) },
+}));
+vi.mock("./constants", () => ({
+  getPensarApiUrl: () => "https://api.example.com",
+}));
+vi.mock("../installation", () => ({ getCurrentVersion: () => "1.4.2" }));
+
+import { apiRequest } from "./apiClient";
+import { CLIENT_HEADERS, setCurrentCommand } from "./clientIdentity";
+
+function sentHeaders(): Record<string, string> {
+  const call = vi.mocked(globalThis.fetch).mock.calls.at(-1);
+  return (call?.[1] as { headers: Record<string, string> }).headers;
+}
+
+beforeEach(() => {
+  setCurrentCommand(undefined);
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, text: async () => "{}" })),
+  );
+});
+
+describe("apiRequest client identity", () => {
+  // Console attributes a launch to whoever calls; without these headers every
+  // caller of the public API looks the same and defaults to a generic client.
+  it("identifies this client on every request", async () => {
+    await apiRequest("GET", "/issues");
+
+    expect(sentHeaders()).toMatchObject({
+      [CLIENT_HEADERS.client]: "cli",
+      [CLIENT_HEADERS.version]: "1.4.2",
+    });
+  });
+
+  it("carries the command the router recorded", async () => {
+    setCurrentCommand("pentests");
+    await apiRequest("POST", "/pentests", {});
+
+    expect(sentHeaders()[CLIENT_HEADERS.command]).toBe("pentests");
+  });
+
+  it("still sends auth and workspace headers", async () => {
+    await apiRequest("GET", "/issues");
+
+    expect(sentHeaders()).toMatchObject({
+      Authorization: "Bearer tok",
+      "X-Workspace-Id": "ws-1",
+      "Content-Type": "application/json",
+    });
+  });
+});

--- a/src/core/api/apiClient.ts
+++ b/src/core/api/apiClient.ts
@@ -7,6 +7,7 @@
 
 import { ensureValidToken } from "../auth";
 import { config } from "../config";
+import { clientIdentityHeaders } from "./clientIdentity";
 import { getPensarApiUrl } from "./constants";
 
 async function getAuthHeaders(): Promise<Record<string, string>> {
@@ -27,6 +28,7 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     Authorization: `Bearer ${validToken.token}`,
+    ...clientIdentityHeaders(),
   };
 
   if (cfg.workspaceId) {

--- a/src/core/api/clientIdentity.test.ts
+++ b/src/core/api/clientIdentity.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../installation", () => ({ getCurrentVersion: () => "1.4.2" }));
+
+import {
+  CLIENT_HEADERS,
+  clientIdentityHeaders,
+  getCurrentCommand,
+  setCurrentCommand,
+} from "./clientIdentity";
+
+beforeEach(() => {
+  setCurrentCommand(undefined);
+});
+
+describe("clientIdentityHeaders", () => {
+  it("names the client and its version on every request", () => {
+    expect(clientIdentityHeaders()).toEqual({
+      [CLIENT_HEADERS.client]: "cli",
+      [CLIENT_HEADERS.version]: "1.4.2",
+    });
+  });
+
+  it("includes the command once the router has set one", () => {
+    setCurrentCommand("pentests");
+    expect(clientIdentityHeaders()[CLIENT_HEADERS.command]).toBe("pentests");
+  });
+
+  it("omits the command header entirely when there is none", () => {
+    expect(clientIdentityHeaders()).not.toHaveProperty(CLIENT_HEADERS.command);
+  });
+});
+
+describe("setCurrentCommand", () => {
+  it("normalizes case and surrounding whitespace", () => {
+    setCurrentCommand("  Issues  ");
+    expect(getCurrentCommand()).toBe("issues");
+  });
+
+  // Console drops anything that is not a short lowercase identifier, so sending
+  // it would be noise. The router passes raw argv, which can be anything.
+  it("drops a command Console would reject rather than sending it", () => {
+    for (const raw of [
+      "a".repeat(64),
+      "--prompt",
+      "issues list",
+      "../traversal",
+      "https://example.com",
+      "",
+    ]) {
+      setCurrentCommand(raw);
+      expect(getCurrentCommand()).toBeUndefined();
+    }
+  });
+
+  it("clears a previously set command when given nothing", () => {
+    setCurrentCommand("issues");
+    setCurrentCommand(undefined);
+    expect(getCurrentCommand()).toBeUndefined();
+  });
+});

--- a/src/core/api/clientIdentity.ts
+++ b/src/core/api/clientIdentity.ts
@@ -1,0 +1,57 @@
+/**
+ * How this client identifies itself to the Pensar Console API.
+ *
+ * The API is reachable by the CLI, CI jobs, curl and customer automation with
+ * the same credentials, and the credential says nothing about the client. So we
+ * say who we are on every request; a caller that says nothing is recorded as a
+ * generic API caller rather than being assumed to be the CLI.
+ *
+ * Console parses these in `packages/functions/src/callerClient.ts` and only
+ * honours a known client name and a bounded command, so keep the names in step
+ * and keep the command a short identifier, never free text.
+ */
+import { getCurrentVersion } from "../installation";
+
+export const CLIENT_HEADERS = {
+  client: "X-Pensar-Client",
+  version: "X-Pensar-Client-Version",
+  command: "X-Pensar-Command",
+} as const;
+
+/** What this binary is, from Console's point of view. */
+const CLIENT_NAME = "cli";
+
+// The top-level command, set once by the CLI router. Deliberately not the
+// subcommand: Console already records the endpoint each request hits, so
+// `pentests` here plus `POST /pentests` there gives the same resolution
+// without threading a name through every API function.
+let currentCommand: string | undefined;
+
+/** Record the command being run. Called once, by the CLI entrypoint. */
+export function setCurrentCommand(command: string | undefined): void {
+  currentCommand = normalizeCommand(command);
+}
+
+export function getCurrentCommand(): string | undefined {
+  return currentCommand;
+}
+
+// Console drops anything that is not a short lowercase identifier, so send
+// nothing rather than something it will discard.
+const COMMAND_SHAPE = /^[a-z][a-z0-9-]{0,31}$/;
+
+function normalizeCommand(command: string | undefined): string | undefined {
+  if (!command) return undefined;
+  const trimmed = command.trim().toLowerCase();
+  return COMMAND_SHAPE.test(trimmed) ? trimmed : undefined;
+}
+
+/** Client identification headers for a Console API request. */
+export function clientIdentityHeaders(): Record<string, string> {
+  const command = getCurrentCommand();
+  return {
+    [CLIENT_HEADERS.client]: CLIENT_NAME,
+    [CLIENT_HEADERS.version]: getCurrentVersion(),
+    ...(command ? { [CLIENT_HEADERS.command]: command } : {}),
+  };
+}


### PR DESCRIPTION
## Summary

Console's REST API is reachable by the CLI, CI jobs, curl and customer automation using the same credentials, and the credential says nothing about which one is calling — a CI job and the CLI both authenticate with an API key. Console had no way to tell them apart, so it recorded every caller of `POST /pentests` as a CLI launch and its "pentests launched by source" breakdown was wrong.

Every request now carries the client name and version, plus the top-level command when one is running.

Pairs with the Console side, which parses these and falls back to a generic `api` caller when they are absent. Neither blocks the other: Console works with old clients that send nothing, and this works before Console ships.

Fixes pensarai/console#2711.

## Changes

- **`src/core/api/clientIdentity.ts`** (new) — owns the header contract and the current command. One module, so nothing else needs to know the header names.
- **`src/core/api/apiClient.ts`** — one spread in `getAuthHeaders`, so every API call is covered. There is no second HTTP path to Console.
- **`src/cli.ts`** — `setCurrentCommand(command)` once, before the dispatch chain, so a command added later is covered without another edit.

## Notes for the reviewer

**The command is the top-level one, not the subcommand.** `pensar pentests dispatch` sends `pentests`. Console already records which endpoint each request hits, so `pentests` here plus `POST /pentests` there resolves the subcommand anyway. Threading a subcommand through every function in `core/api/` would be roughly thirty call sites for something already recoverable.

**We only send what Console will accept.** It drops a command that is not a short lowercase identifier, so `normalizeCommand` applies the same shape and sends nothing rather than something that will be discarded. That is why `pensar --version` sends no command header: the router passes raw argv, and a flag is not a command.

Nothing sensitive is added. The client name is a constant, the version comes from `package.json`, and the command is a fixed identifier from our own router — no user input reaches these headers.

## Test Plan

- [x] `bun run tsc` — clean
- [x] `bunx biome lint` on the changed files — no new warnings (the two reported are pre-existing, at `cli.ts:92` in code this PR does not touch)
- [x] `src/core/api/clientIdentity.test.ts` — the headers, and that a command Console would reject is dropped rather than sent (`--prompt`, `issues list`, a 64-character string, a path, a URL)
- [x] `src/core/api/apiClient.test.ts` — stubs `fetch` and asserts the headers actually reach the wire alongside the existing auth and workspace headers, since a helper that is never composed in would pass its own tests
- [x] `bunx vitest run` — full suite, 2,582 pass, 0 fail

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive HTTP headers only; auth and request bodies are unchanged, and command values are sanitized before sending.
> 
> **Overview**
> **Console can now distinguish the CLI from other API callers** (CI, curl, automation) that share the same credentials. Every Pensar Console REST call from the shared HTTP client sends **`X-Pensar-Client`**, **`X-Pensar-Client-Version`**, and optionally **`X-Pensar-Command`** when the router recorded a valid top-level subcommand.
> 
> A new **`clientIdentity`** module owns the header contract and normalizes commands (lowercase, bounded identifier shape) so invalid argv values like flags or URLs are **not** sent. The CLI entrypoint calls **`setCurrentCommand(command)`** once before dispatch so new commands are covered automatically. **`getAuthHeaders`** in **`apiClient`** merges identity headers into every request alongside existing auth and workspace headers.
> 
> Tests cover header composition, command sanitization, and that **`apiRequest`** actually attaches the headers on the wire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90024e885fc4c6e9a196de99d66f96e511d4f856. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->