### PR TITLE
Make toolCallDescription optional and gate execution to activeTools

### DIFF
--- a/src/core/agents/offSecAgent/tools/addMemory.ts
+++ b/src/core/agents/offSecAgent/tools/addMemory.ts
@@ -26,6 +26,7 @@ const addMemoryInputSchema = z.object({
     .describe("Optional tags for categorisation and filtering"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Saving XSS payload pattern')",
     ),

--- a/src/core/agents/offSecAgent/tools/applyPatch.ts
+++ b/src/core/agents/offSecAgent/tools/applyPatch.ts
@@ -12,6 +12,7 @@ const applyPatchInputSchema = z.object({
     ),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Apply parameterized-query fix across auth handlers')",
     ),

--- a/src/core/agents/offSecAgent/tools/browserTools.ts
+++ b/src/core/agents/offSecAgent/tools/browserTools.ts
@@ -114,6 +114,7 @@ export function createBrowserToolset(ctx: ToolContext) {
       ),
     toolCallDescription: z
       .string()
+      .optional()
       .describe("Why you are filling this field with this value"),
   };
   if (injectionEnabled) {

--- a/src/core/agents/offSecAgent/tools/completeAuthentication.ts
+++ b/src/core/agents/offSecAgent/tools/completeAuthentication.ts
@@ -80,6 +80,7 @@ This tool marks the end of the authentication flow.`,
         .describe("Auth barrier if one was encountered"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("A concise description of what this tool call is doing"),
     }),
     execute: async (result) => {

--- a/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
+++ b/src/core/agents/offSecAgent/tools/crawlAuthenticated.ts
@@ -39,6 +39,7 @@ export function crawlAuthenticated(ctx: ToolContext) {
       maxPages: z.number().default(50).describe("Maximum pages to visit"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/createAttackSurfaceReport.ts
+++ b/src/core/agents/offSecAgent/tools/createAttackSurfaceReport.ts
@@ -53,6 +53,7 @@ Call this at the END of your analysis with:
       ),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/createFile.ts
+++ b/src/core/agents/offSecAgent/tools/createFile.ts
@@ -20,6 +20,7 @@ const createFileInputSchema = z.object({
     ),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Creating security middleware file')",
     ),

--- a/src/core/agents/offSecAgent/tools/delegateAuth.ts
+++ b/src/core/agents/offSecAgent/tools/delegateAuth.ts
@@ -181,6 +181,7 @@ IMPORTANT: Pass protectedEndpoints in authHints when you've discovered 401/403 e
       reason: z.string().describe("Why you are delegating to auth subagent"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("A concise description of what this tool call is doing"),
     }),
     execute: async ({

--- a/src/core/agents/offSecAgent/tools/deleteFile.ts
+++ b/src/core/agents/offSecAgent/tools/deleteFile.ts
@@ -8,6 +8,7 @@ const deleteFileInputSchema = z.object({
   path: z.string().describe("Absolute or relative path to the file to delete"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Remove obsolete insecure helper')",
     ),

--- a/src/core/agents/offSecAgent/tools/detectAuthScheme.ts
+++ b/src/core/agents/offSecAgent/tools/detectAuthScheme.ts
@@ -30,6 +30,7 @@ Returns detected scheme and required fields for authentication.`,
       endpoint: z.string().describe("URL to analyze for auth scheme"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("A concise description of what this tool call is doing"),
     }),
     execute: async ({ endpoint }) => {

--- a/src/core/agents/offSecAgent/tools/documentApp.ts
+++ b/src/core/agents/offSecAgent/tools/documentApp.ts
@@ -150,6 +150,7 @@ Each application creates a JSON file in the apps directory for tracking and anal
         ),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/documentEndpoint.ts
+++ b/src/core/agents/offSecAgent/tools/documentEndpoint.ts
@@ -103,6 +103,7 @@ const documentEndpointInputSchema = z.object({
     .describe("Additional notes or observations about the endpoint"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing",
     ),

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -71,6 +71,7 @@ export const documentVulnerabilityInputSchema = z.object({
     ),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Documenting SQL injection finding')",
     ),

--- a/src/core/agents/offSecAgent/tools/email/getAttachments.ts
+++ b/src/core/agents/offSecAgent/tools/email/getAttachments.ts
@@ -33,6 +33,7 @@ the attachment content as base64.`,
         ),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/email/getMessage.ts
+++ b/src/core/agents/offSecAgent/tools/email/getMessage.ts
@@ -26,6 +26,7 @@ first to find the message ID.`,
         ),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/email/listInboxes.ts
+++ b/src/core/agents/offSecAgent/tools/email/listInboxes.ts
@@ -18,6 +18,7 @@ inboxes are available, then reference them by ID in other email tools.`,
     inputSchema: z.object({
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/email/listMessages.ts
+++ b/src/core/agents/offSecAgent/tools/email/listMessages.ts
@@ -33,6 +33,7 @@ get the inbox ID, then pass it here.`,
         .describe("Pagination token from a previous call"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/email/markRead.ts
+++ b/src/core/agents/offSecAgent/tools/email/markRead.ts
@@ -24,6 +24,7 @@ Sets the read/seen flag on a message so it no longer appears as unread.`,
         ),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/email/searchMessages.ts
+++ b/src/core/agents/offSecAgent/tools/email/searchMessages.ts
@@ -41,6 +41,7 @@ Returns message summaries matching the query.`,
         .describe("Pagination token from a previous call"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/email/sendEmail.ts
+++ b/src/core/agents/offSecAgent/tools/email/sendEmail.ts
@@ -57,6 +57,7 @@ const sendEmailInputSchema = z.object({
     ),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing",
     ),

--- a/src/core/agents/offSecAgent/tools/executeCommand.ts
+++ b/src/core/agents/offSecAgent/tools/executeCommand.ts
@@ -60,6 +60,7 @@ const executeCommandInputSchema = z.object({
   // not actually sure if placing this above the other keys/zod values ensures that the model generates it first...
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Scanning for open ports on target')",
     ),

--- a/src/core/agents/offSecAgent/tools/extractJsEndpoints.ts
+++ b/src/core/agents/offSecAgent/tools/extractJsEndpoints.ts
@@ -32,6 +32,7 @@ Returns all discovered endpoint patterns.`,
         .describe("Whether to download and analyze external JS files"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/getMemory.ts
+++ b/src/core/agents/offSecAgent/tools/getMemory.ts
@@ -16,6 +16,7 @@ const getMemoryInputSchema = z.object({
   id: z.string().describe("The unique memory id (returned by list_memories)"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Retrieving SQL injection cheatsheet')",
     ),

--- a/src/core/agents/offSecAgent/tools/getPage.ts
+++ b/src/core/agents/offSecAgent/tools/getPage.ts
@@ -36,6 +36,7 @@ const getPageInputSchema = z.object({
     .describe("The URL of the page to fetch and extract content from."),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Fetching CVE details from NVD')",
     ),

--- a/src/core/agents/offSecAgent/tools/gitDiff.ts
+++ b/src/core/agents/offSecAgent/tools/gitDiff.ts
@@ -14,6 +14,7 @@ const gitDiffInputSchema = z.object({
     .describe("If true, show staged (--cached) diff. Default: unstaged."),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Review unstaged patch before finalize')",
     ),

--- a/src/core/agents/offSecAgent/tools/gitStatus.ts
+++ b/src/core/agents/offSecAgent/tools/gitStatus.ts
@@ -5,6 +5,7 @@ import type { ToolContext } from "./types";
 const gitStatusInputSchema = z.object({
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Check which files were modified')",
     ),

--- a/src/core/agents/offSecAgent/tools/glob.ts
+++ b/src/core/agents/offSecAgent/tools/glob.ts
@@ -32,6 +32,7 @@ const globInputSchema = z.object({
     ),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Find all TypeScript source files')",
     ),

--- a/src/core/agents/offSecAgent/tools/grep.ts
+++ b/src/core/agents/offSecAgent/tools/grep.ts
@@ -19,6 +19,7 @@ const grepInputSchema = z.object({
     ),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Searching for password hashes in config files')",
     ),

--- a/src/core/agents/offSecAgent/tools/httpRequest.test.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.test.ts
@@ -255,3 +255,42 @@ describe("httpRequest rate limiting", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 });
+
+describe("httpRequest input coercion", () => {
+  const schemaOf = () =>
+    httpRequest(makeCtx()).inputSchema as unknown as {
+      safeParse: (v: unknown) => {
+        success: boolean;
+        data?: { headers?: unknown; body?: unknown };
+      };
+    };
+
+  it("coerces an object body and headers to JSON strings", () => {
+    const parsed = schemaOf().safeParse({
+      url: "https://example.com/graphql",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: { query: "{ me { id } }" },
+      toolCallDescription: "graphql",
+    });
+    expect(parsed.success).toBe(true);
+    expect(parsed.data?.headers).toBe('{"Content-Type":"application/json"}');
+    expect(parsed.data?.body).toBe('{"query":"{ me { id } }"}');
+  });
+
+  it("still accepts string headers/body and a PromptInjectionRef body", () => {
+    expect(
+      schemaOf().safeParse({
+        url: "https://example.com",
+        headers: '{"a":"b"}',
+        body: "raw",
+      }).success,
+    ).toBe(true);
+    const ref = schemaOf().safeParse({
+      url: "https://example.com",
+      body: { kind: "prompt_injection_ref", id: "pi_1" },
+    });
+    expect(ref.success).toBe(true);
+    expect(ref.data?.body).toEqual({ kind: "prompt_injection_ref", id: "pi_1" });
+  });
+});

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -59,6 +59,7 @@ const httpRequestInputSchema = z.object({
   timeout: z.number().default(10000),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Testing SQL injection on login endpoint')",
     ),

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -33,19 +33,34 @@ const promptInjectionRefSchema = z.object({
     .describe("Stable prompt-injection id returned by list_prompt_injections"),
 });
 
+// The model routinely supplies headers/body as a JSON object rather than the
+// JSON-encoded string this tool expects, so a well-formed call gets rejected by
+// schema validation. Stringify a plain object here to accept both shapes. A
+// PromptInjectionRef object is passed through untouched so hidden-payload body
+// refs still resolve.
+const coerceObjectToJsonString = (value: unknown): unknown =>
+  value !== null &&
+  typeof value === "object" &&
+  (value as { kind?: unknown }).kind !== "prompt_injection_ref"
+    ? JSON.stringify(value)
+    : value;
+
 const httpRequestInputSchema = z.object({
   url: z.string().describe("The URL to request"),
   method: z
     .enum(["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"])
     .default("GET"),
   headers: z
-    .string()
+    .preprocess(coerceObjectToJsonString, z.string())
     .optional()
     .describe(
       'HTTP headers as a JSON-encoded object string, e.g. \'{"Content-Type": "application/json", "Authorization": "Bearer token"}\'',
     ),
   body: z
-    .union([z.string(), promptInjectionRefSchema])
+    .preprocess(
+      coerceObjectToJsonString,
+      z.union([z.string(), promptInjectionRefSchema]),
+    )
     .optional()
     .describe(
       "Request body (for POST, PUT, PATCH). To use a hidden prompt-injection payload, pass a PromptInjectionRef object instead of raw payload text.",

--- a/src/core/agents/offSecAgent/tools/listFiles.ts
+++ b/src/core/agents/offSecAgent/tools/listFiles.ts
@@ -17,6 +17,7 @@ const listFilesInputSchema = z.object({
     .describe("If true, list files recursively (default: false)"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Listing files in /etc/nginx')",
     ),

--- a/src/core/agents/offSecAgent/tools/listMemories.ts
+++ b/src/core/agents/offSecAgent/tools/listMemories.ts
@@ -21,6 +21,7 @@ const listMemoriesInputSchema = z.object({
     .describe("Optional tag to filter memories by (exact match)"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Listing stored recon notes')",
     ),

--- a/src/core/agents/offSecAgent/tools/listPromptInjections.ts
+++ b/src/core/agents/offSecAgent/tools/listPromptInjections.ts
@@ -34,6 +34,7 @@ export function listPromptInjections(ctx: ToolContext) {
         ),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description (one short sentence) of why " +
             "you are listing prompt-injection payloads right now, e.g. " +

--- a/src/core/agents/offSecAgent/tools/playwrightMcp.ts
+++ b/src/core/agents/offSecAgent/tools/playwrightMcp.ts
@@ -105,6 +105,7 @@ const BrowserNavigateInput = z.object({
   url: z.string().describe("Full URL to navigate to"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you are navigating to this URL"),
 });
 
@@ -114,6 +115,7 @@ const BrowserScreenshotInput = z.object({
     .describe("Descriptive filename for screenshot (without extension)"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("What evidence this screenshot captures"),
 });
 
@@ -129,7 +131,10 @@ const BrowserClickInput = z.object({
     .describe(
       "Element reference from browser_snapshot (e.g., 'e5'). If provided, uses exact element reference for precise clicking.",
     ),
-  toolCallDescription: z.string().describe("Why you are clicking this element"),
+  toolCallDescription: z
+    .string()
+    .optional()
+    .describe("Why you are clicking this element"),
 });
 
 const BrowserFillInput = z.object({
@@ -147,12 +152,14 @@ const BrowserFillInput = z.object({
   value: z.string().describe("Value to fill into the field"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you are filling this field with this value"),
 });
 
 const BrowserSnapshotInput = z.object({
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you need to get the page snapshot"),
 });
 
@@ -160,12 +167,14 @@ const BrowserEvaluateInput = z.object({
   script: z.string().describe("JavaScript code to execute in browser"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("What you are testing with this script"),
 });
 
 const BrowserConsoleInput = z.object({
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you need to check console messages"),
 });
 
@@ -178,6 +187,7 @@ const BrowserGetCookiesInput = z.object({
     ),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you need to extract cookies from the browser"),
 });
 

--- a/src/core/agents/offSecAgent/tools/probeAuthEndpoints.ts
+++ b/src/core/agents/offSecAgent/tools/probeAuthEndpoints.ts
@@ -92,6 +92,7 @@ Returns discovered endpoints and recommended login approach.`,
         .describe("Base URL to probe (e.g., https://example.com)"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("A concise description of what this tool call is doing"),
     }),
     execute: async ({ baseUrl }) => {

--- a/src/core/agents/offSecAgent/tools/profileCodebase.ts
+++ b/src/core/agents/offSecAgent/tools/profileCodebase.ts
@@ -27,6 +27,7 @@ Full structured output is written to the session artifact; inline data is a comp
         ),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("A concise description of the profiling task"),
     }),
     execute: async ({ path }) => {

--- a/src/core/agents/offSecAgent/tools/provideComparisonResults.ts
+++ b/src/core/agents/offSecAgent/tools/provideComparisonResults.ts
@@ -57,6 +57,7 @@ Results will be saved to: comparison-results.json in the session directory.`,
         .describe("Actual findings that don't match any expected findings"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("Concise description of this tool call")
         .optional(),
     }),

--- a/src/core/agents/offSecAgent/tools/queryWhiteboxCatalog.ts
+++ b/src/core/agents/offSecAgent/tools/queryWhiteboxCatalog.ts
@@ -87,6 +87,7 @@ Use this instead of asking for the whole playbook. Examples:
         .describe("Maximum records to return (default 12, max 50)"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("A concise description of the catalog lookup"),
     }),
     execute: async ({ query, kind, tags, limit }) => {

--- a/src/core/agents/offSecAgent/tools/readFile.ts
+++ b/src/core/agents/offSecAgent/tools/readFile.ts
@@ -20,6 +20,7 @@ const readFileInputSchema = z.object({
     .describe("1-based line number to stop reading at (inclusive)"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Reading nginx config file')",
     ),

--- a/src/core/agents/offSecAgent/tools/readSkill.ts
+++ b/src/core/agents/offSecAgent/tools/readSkill.ts
@@ -10,6 +10,7 @@ export function readSkill(ctx: ToolContext) {
       name: z.string().describe("Skill slug from the available skills catalog"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/runAttackSurface.ts
+++ b/src/core/agents/offSecAgent/tools/runAttackSurface.ts
@@ -47,6 +47,7 @@ should be passed directly to spawn_pentest_swarm for deep testing.`,
         ),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/runCodeQuery.ts
+++ b/src/core/agents/offSecAgent/tools/runCodeQuery.ts
@@ -109,6 +109,7 @@ instead of flooding context with every match. Output size and runtime are bounde
         .describe("Per-query timeout in seconds (default 30, max 900)."),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("A concise description of the code query"),
     }),
     execute: async ({ engine = "rg", queries, cwd, timeoutSeconds = 30 }) => {

--- a/src/core/agents/offSecAgent/tools/runPentestWorkflow.ts
+++ b/src/core/agents/offSecAgent/tools/runPentestWorkflow.ts
@@ -34,6 +34,7 @@ Omit \`cwd\` for blackbox mode (live target probing only).`,
         ),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/runWhiteboxScan.ts
+++ b/src/core/agents/offSecAgent/tools/runWhiteboxScan.ts
@@ -50,6 +50,7 @@ calling document_vulnerability.`,
         .describe("Per-scanner timeout in seconds. Defaults to 120, max 3600."),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("A concise description of the scan"),
     }),
     execute: async ({ path, kind, scannerIds, timeoutSeconds = 120 }) => {

--- a/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
+++ b/src/core/agents/offSecAgent/tools/sandboxPlaywright.ts
@@ -465,6 +465,7 @@ const BrowserNavigateInput = z.object({
   url: z.string().describe("Full URL to navigate to"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you are navigating to this URL"),
 });
 
@@ -474,12 +475,14 @@ const BrowserScreenshotInput = z.object({
     .describe("Descriptive filename for screenshot (without extension)"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("What evidence this screenshot captures"),
 });
 
 const BrowserSnapshotInput = z.object({
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you need to get the page snapshot"),
 });
 
@@ -495,7 +498,10 @@ const BrowserClickInput = z.object({
     .describe(
       "Element reference from browser_snapshot (e.g., 'e5'). If provided, uses exact element reference for precise clicking.",
     ),
-  toolCallDescription: z.string().describe("Why you are clicking this element"),
+  toolCallDescription: z
+    .string()
+    .optional()
+    .describe("Why you are clicking this element"),
 });
 
 const BrowserFillInput = z.object({
@@ -513,6 +519,7 @@ const BrowserFillInput = z.object({
   value: z.string().describe("Value to fill into the field"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you are filling this field with this value"),
 });
 
@@ -520,12 +527,14 @@ const BrowserEvaluateInput = z.object({
   script: z.string().describe("JavaScript code to execute in browser"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("What you are testing with this script"),
 });
 
 const BrowserConsoleInput = z.object({
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you need to check console messages"),
 });
 
@@ -538,6 +547,7 @@ const BrowserGetCookiesInput = z.object({
     ),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you need to extract cookies from the browser"),
 });
 

--- a/src/core/agents/offSecAgent/tools/smsListMessages.ts
+++ b/src/core/agents/offSecAgent/tools/smsListMessages.ts
@@ -101,6 +101,7 @@ Requires a Console sandbox (AGENT_API_URL).`,
           ),
         toolCallDescription: z
           .string()
+          .optional()
           .describe(
             "A concise, human-readable description of what this tool call is doing",
           ),

--- a/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnCodingAgent.ts
@@ -57,6 +57,7 @@ Returns an array of results with the text output from each agent.`,
         .describe("Array of tasks to fan out to coding sub-agents"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -88,6 +88,7 @@ Returns the worker's summary, objective results, and finding count — but NOT t
         ),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "Concise, human-readable description of what this spawn is doing (shown in the UI).",
         ),

--- a/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
@@ -58,6 +58,7 @@ Pass every target you want tested — the swarm handles concurrency automaticall
         .describe("Array of targets with their testing objectives"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/submitPlan.ts
+++ b/src/core/agents/offSecAgent/tools/submitPlan.ts
@@ -10,6 +10,7 @@ const log = scopedLogger(() => createLogger("submit_plan"));
 const submitPlanInputSchema = z.object({
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Submitting pentest plan for operator review')",
     ),

--- a/src/core/agents/offSecAgent/tools/testEndpointVariations.ts
+++ b/src/core/agents/offSecAgent/tools/testEndpointVariations.ts
@@ -30,6 +30,7 @@ Use this to:
         .describe("Session cookie if authentication required"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/updateFile.ts
+++ b/src/core/agents/offSecAgent/tools/updateFile.ts
@@ -22,6 +22,7 @@ const updateFileInputSchema = z.object({
     ),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Replacing vulnerable SQL query with parameterized version')",
     ),

--- a/src/core/agents/offSecAgent/tools/validateDiscovery.ts
+++ b/src/core/agents/offSecAgent/tools/validateDiscovery.ts
@@ -31,6 +31,7 @@ Returns a confidence score and identifies potential gaps based on:
         .describe("Whether any credentials were discovered"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe(
           "A concise, human-readable description of what this tool call is doing",
         ),

--- a/src/core/agents/offSecAgent/tools/webSearch.ts
+++ b/src/core/agents/offSecAgent/tools/webSearch.ts
@@ -16,6 +16,7 @@ const webSearchInputSchema = z.object({
     ),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Searching for CVE-2024-1234 details')",
     ),

--- a/src/core/agents/offSecAgent/tools/whiteboxCandidates.ts
+++ b/src/core/agents/offSecAgent/tools/whiteboxCandidates.ts
@@ -62,6 +62,7 @@ scanner artifacts, fuzzing logs, and verification status out of official finding
       artifacts: z.array(ArtifactSchema).optional(),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("A concise description of the candidate being created"),
     }),
     execute: async (input) => {
@@ -110,6 +111,7 @@ State machine: hypothesis -> investigating -> repro_attempted -> confirmed (requ
         .optional(),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("A concise description of the candidate update"),
     }),
     execute: async (input) => {
@@ -168,6 +170,7 @@ export function listWhiteboxCandidates(ctx: ToolContext) {
         .describe("Max candidates to return (default 50, max 200)"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("A concise description of the candidate listing"),
     }),
     execute: async ({ state, limit }) => {

--- a/src/core/agents/offSecAgent/tools/whiteboxJobs.ts
+++ b/src/core/agents/offSecAgent/tools/whiteboxJobs.ts
@@ -48,6 +48,7 @@ execution is not sandboxed.`,
       name: z.string().optional().describe("Short job label for the log file"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("A concise description of the whitebox job"),
     }),
     execute: async ({ command, cwd, timeoutSeconds = 300, name }) => {
@@ -116,7 +117,10 @@ export function pollWhiteboxJob(ctx: ToolContext) {
     description: "Poll a running or completed whitebox job by id.",
     inputSchema: z.object({
       jobId: z.string(),
-      toolCallDescription: z.string().describe("A concise polling description"),
+      toolCallDescription: z
+        .string()
+        .optional()
+        .describe("A concise polling description"),
     }),
     execute: async ({ jobId }) => {
       const record = pollJob(jobId, ctx.session.id);
@@ -151,7 +155,10 @@ export function stopWhiteboxJob(ctx: ToolContext) {
     description: "Stop a running whitebox job by id.",
     inputSchema: z.object({
       jobId: z.string(),
-      toolCallDescription: z.string().describe("A concise stop description"),
+      toolCallDescription: z
+        .string()
+        .optional()
+        .describe("A concise stop description"),
     }),
     execute: async ({ jobId }) => {
       const record = stopJob(jobId, ctx.session.id);
@@ -212,6 +219,7 @@ Prefer \`path\` from tool results (e.g. scan artifacts, code-query output, job l
         .describe("Legacy: read a job log by id when path is unknown"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("A concise description of what you are reading"),
     }),
     execute: async ({ path, jobId }) => {

--- a/src/core/agents/offSecAgent/tools/writePlan.ts
+++ b/src/core/agents/offSecAgent/tools/writePlan.ts
@@ -14,6 +14,7 @@ const writePlanInputSchema = z.object({
   content: z.string().describe("The full markdown content of the pentest plan"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe(
       "A concise, human-readable description of what this tool call is doing (e.g., 'Writing initial pentest plan with recon findings')",
     ),

--- a/src/core/agents/specialized/authenticationAgent/types.ts
+++ b/src/core/agents/specialized/authenticationAgent/types.ts
@@ -335,6 +335,7 @@ export const DetectAuthSchemeInputSchema = z.object({
     .describe("Target endpoint URL to analyze for auth requirements"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you are detecting auth scheme for this endpoint"),
 });
 
@@ -368,6 +369,7 @@ export const AuthenticateInputSchema = z.object({
   csrfToken: z.string().optional().describe("CSRF token if required"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you are authenticating with these credentials"),
 });
 
@@ -384,6 +386,7 @@ export const ValidateSessionInputSchema = z.object({
     .describe("Expected HTTP status code for valid session"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you are validating the session"),
   // Optional: provide tokens directly to test (instead of using stored auth state)
   providedTokens: z
@@ -416,6 +419,7 @@ export const RefreshSessionInputSchema = z.object({
     ),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you are refreshing the session"),
 });
 
@@ -427,6 +431,7 @@ export type RefreshSessionInput = z.infer<typeof RefreshSessionInputSchema>;
 export const GetAuthStateInputSchema = z.object({
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you need to check the current auth state"),
 });
 
@@ -442,6 +447,7 @@ export const ExportAuthForAgentInputSchema = z.object({
     .describe("Export format for auth information"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you are exporting auth for another agent"),
 });
 
@@ -456,6 +462,7 @@ export const LoadAuthFlowInputSchema = z.object({
   targetHost: z.string().describe("Target host to load auth flow for"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you are loading the documented auth flow"),
 });
 
@@ -552,6 +559,7 @@ export const DocumentAuthFlowInputSchema = z.object({
     .describe("Notes for future runs (rate limits, quirks, etc.)"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you are documenting this auth flow"),
 });
 
@@ -566,6 +574,7 @@ export const ProbeAuthEndpointsInputSchema = z.object({
     .describe("Base URL of the target (e.g., http://localhost:3002)"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you are probing for auth endpoints"),
 });
 
@@ -582,6 +591,7 @@ export const ProbeRegistrationInputSchema = z.object({
     .describe("Base URL of the target (e.g., http://localhost:3002)"),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you are probing for registration functionality"),
 });
 
@@ -603,6 +613,7 @@ export const AttemptRegistrationInputSchema = z.object({
     ),
   toolCallDescription: z
     .string()
+    .optional()
     .describe("Why you are attempting registration"),
 });
 

--- a/src/core/agents/specialized/benchmark/comparisonAgent.ts
+++ b/src/core/agents/specialized/benchmark/comparisonAgent.ts
@@ -185,6 +185,7 @@ Results will be saved to: comparison-results.json in the session directory.`,
         .describe("Actual findings that don't match any expected findings"),
       toolCallDescription: z
         .string()
+        .optional()
         .describe("Concise description of this tool call")
         .optional(),
     }),

--- a/src/core/ai/ai.test.ts
+++ b/src/core/ai/ai.test.ts
@@ -5,6 +5,7 @@ import {
   buildOpenRouterProviderOptions,
   buildReasoningProviderOptions,
   isRepairFailClosedTool,
+  restrictToolsToActive,
   SEQUENTIAL_TOOL_CALL_INSTRUCTION,
   streamResponse,
 } from "./ai";
@@ -52,6 +53,52 @@ describe("applySequentialToolCallPolicy", () => {
     expect(
       applySequentialToolCallPolicy("Base.", tools, "claude-haiku-4-5"),
     ).toBe("Base.");
+  });
+});
+
+describe("restrictToolsToActive", () => {
+  const tools = {
+    read_file: {
+      description: "read",
+      inputSchema: z.object({ p: z.string() }),
+    },
+    execute_command: {
+      description: "exec",
+      inputSchema: z.object({ c: z.string() }),
+    },
+    delete_file: {
+      description: "delete",
+      inputSchema: z.object({ p: z.string() }),
+    },
+  };
+
+  it("filters the tools map down to the activeTools allowlist", () => {
+    const result = restrictToolsToActive(tools, ["read_file", "delete_file"]);
+    expect(Object.keys(result ?? {}).sort()).toEqual([
+      "delete_file",
+      "read_file",
+    ]);
+    // execute_command must not be advertised, executable, or enumerable.
+    expect(result).not.toHaveProperty("execute_command");
+    // Retained tools keep their original definition (same reference).
+    expect(result?.read_file).toBe(tools.read_file);
+  });
+
+  it("is a no-op when activeTools is empty (means: all tools)", () => {
+    expect(restrictToolsToActive(tools, [])).toBe(tools);
+  });
+
+  it("is a no-op when activeTools is undefined", () => {
+    expect(restrictToolsToActive(tools, undefined)).toBe(tools);
+  });
+
+  it("returns tools unchanged when tools is undefined", () => {
+    expect(restrictToolsToActive(undefined, ["read_file"])).toBeUndefined();
+  });
+
+  it("ignores allowlist entries that are not present in the tools map", () => {
+    const result = restrictToolsToActive(tools, ["read_file", "no_such_tool"]);
+    expect(Object.keys(result ?? {})).toEqual(["read_file"]);
   });
 });
 

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -348,6 +348,32 @@ function applySequentialToolCallPolicy(
   return system;
 }
 
+// Restrict the SDK `tools` map to the `activeTools` allowlist so advertising,
+// execution, and NoSuchToolError enumeration all agree. The AI SDK treats
+// `activeTools` as advertise-only: it still executes any tool present in the
+// full `tools` map and enumerates every key in its NoSuchToolError, so a model
+// that names an un-advertised tool (e.g. learned from an error) still runs it,
+// and the full arsenal leaks into error messages. Passing only the allowlisted
+// tools makes `activeTools` authoritative for all three. No-op when
+// `activeTools` is empty/undefined (some callers pass `[]` meaning "all") or
+// when `tools` is undefined.
+export function restrictToolsToActive(
+  tools: ToolSet | undefined,
+  activeTools: string[] | undefined,
+): ToolSet | undefined {
+  if (!tools || !activeTools || activeTools.length === 0) {
+    return tools;
+  }
+  const allow = new Set(activeTools);
+  const restricted: ToolSet = {};
+  for (const [name, tool] of Object.entries(tools)) {
+    if (allow.has(name)) {
+      restricted[name] = tool;
+    }
+  }
+  return restricted;
+}
+
 const MAX_RATE_LIMIT_RETRIES = 20;
 const MAX_IDLE_RESUME_RETRIES = 3;
 const STREAM_IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
@@ -1250,6 +1276,10 @@ export function streamResponse(
 
   let rateLimitRetryCount = 0;
 
+  // Make `activeTools` authoritative: advertise, execute, and enumerate only
+  // the allowlisted tools. A no-op when `activeTools` is empty/undefined.
+  const effectiveTools = restrictToolsToActive(tools, activeTools);
+
   try {
     // Create the appropriate provider instance
     const response = streamText({
@@ -1258,7 +1288,7 @@ export function streamResponse(
       ...(effectiveMessages ? { messages: effectiveMessages } : { prompt }),
       stopWhen,
       toolChoice,
-      tools,
+      tools: effectiveTools,
       maxRetries: 3,
       providerOptions,
       experimental_telemetry: createAiTelemetrySettings({


### PR DESCRIPTION
## What was wrong

Two tool-layer problems surfaced while running the durable workspace chat agent.

`toolCallDescription` was a required input on every tool schema, but it only feeds a human-readable action label that already falls back when the field is absent. The model frequently omitted it, so tool calls failed validation before they could run.

Separately, the full tool registry was handed to the model loop while `activeTools` only filtered what was advertised. A tool outside `activeTools` could still be executed if the model named it, and the unavailable-tool error enumerated the whole registry back to the model.

## What changed

- `toolCallDescription` is now optional on every tool schema. Its describe text is unchanged.
- A new `restrictToolsToActive` helper filters the tools map down to `activeTools` before the model call, so `activeTools` is the single allowlist for advertising, execution, and error messages. It is a strict no-op when `activeTools` is empty or absent.

## Effect

Curated-toolset agents like the workspace chat can no longer be induced to call or discover tools outside their allowlist, and tool calls stop failing on a missing cosmetic field.

Stacked on `feat/durable-agent-workflows`.

No linked issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tool gating affects every agent using `activeTools` (including workspace chat); incorrect filtering could hide or block needed tools, but the change aligns execution with the intended allowlist.
> 
> **Overview**
> Makes **`toolCallDescription` optional** on every off-sec and authentication agent tool Zod schema so calls are not rejected when the model skips the UI-only label (behavior unchanged when it is provided).
> 
> Adds **`restrictToolsToActive`** in the streaming AI layer and passes the filtered tool map into `streamText`, so **`activeTools` is the real allowlist** for what is advertised, executed, and listed in unavailable-tool errors—not just a visibility filter on the full registry. Empty or missing `activeTools` still means all tools; unit tests cover the helper.
> 
> Also includes a trivial `import type` cleanup in `spawnCodingAgent.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43875282b1d0a910b7bf1beadb38d756cb208b9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->