### PR TITLE
feat(cli): read and post issue comments

### DIFF
--- a/fern/docs/cli/issues.mdx
+++ b/fern/docs/cli/issues.mdx
@@ -1,6 +1,6 @@
 ---
 title: "pensar issues"
-description: "List, view, update, retest, and link pull requests to security issues via the Pensar Console API"
+description: "List, view, update, retest, comment on, and link pull requests to security issues via the Pensar Console API"
 ---
 
 ## Overview
@@ -18,6 +18,8 @@ pensar issues update <issueId> [options]       # Update an issue
 pensar issues retest <issueId>                 # Queue an issue retest
 pensar issues link-pr <issueId> --url <url>    # Link a pull request to an issue
 pensar issues prs <issueId>                    # List pull requests linked to an issue
+pensar issues comments <issueId>               # List review comments on an issue
+pensar issues comment <issueId> --body "..."   # Post a comment on an issue
 ```
 
 <Note>
@@ -103,9 +105,9 @@ pensar issues link-pr <issueId> --url <prUrl>
 
 Links a pull request to the issue. `--url` is required.
 
-| Option        | Description                                          |
-| ------------- | ---------------------------------------------------- |
-| `--url <url>` | URL of the pull request to link (**required**)       |
+| Option        | Description                                    |
+| ------------- | ---------------------------------------------- |
+| `--url <url>` | URL of the pull request to link (**required**) |
 
 Returns `{ success, created, pullRequest, issue }`. `created` distinguishes a newly linked PR from one that was already attached, so re-running the command is safe.
 
@@ -116,6 +118,60 @@ pensar issues prs <issueId>
 ```
 
 Returns the pull requests linked to the issue as an array of `{ id, url, status, createMethod, createdAt }`. `createMethod` tells you whether the link came from an agent or from a person.
+
+### List Comments
+
+```bash
+pensar issues comments <issueId> [--page <n>] [--page-size <n>]
+```
+
+Returns the issue's review thread, **oldest first** — the running conversation
+between reviewers about a finding, which is where a corrected CVSS score or the
+argument for a dismissal usually lives.
+
+```json
+{
+  "comments": [
+    {
+      "id": "66666666-7777-8888-9999-000000000000",
+      "issueId": "11111111-2222-3333-4444-555555555555",
+      "body": "Rescored this to 7.1 — the endpoint needs an authenticated session.",
+      "author": {
+        "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "name": "Ada Lovelace",
+        "email": "ada@example.com",
+        "type": "user"
+      },
+      "createdAt": "2026-08-14T10:22:31.000Z",
+      "editedAt": null,
+      "url": "https://console.pensar.dev/acme/VULN-000123#comment-66666666-7777-8888-9999-000000000000"
+    }
+  ],
+  "pagination": { "page": 1, "pageSize": 50, "totalRows": 1, "totalPages": 1 }
+}
+```
+
+`author` is `null` when the person who wrote the comment no longer has an
+account. `editedAt` is `null` until the comment is edited. Mentions stay inline
+in `body` as `@first.last` — there is no separate mentions field.
+
+Default page size is 50; the maximum is 200.
+
+### Post a Comment
+
+```bash
+pensar issues comment <issueId> --body "<text>"
+```
+
+Adds a comment to the issue's thread and returns the created comment in the
+shape above. Mentions written as `@first.last` notify that person, exactly as
+they do from the Console.
+
+<Note>
+  Posting requires a **user login** (`pensar login`). A workspace API key is
+  accepted for reading comments but rejected for posting, because it has no
+  author to attribute the comment to.
+</Note>
 
 ## Examples
 
@@ -141,6 +197,10 @@ pensar issues get VULN-000123
 # Link the PR that fixes an issue, then confirm the link
 pensar issues link-pr VULN-000123 --url https://github.com/acme/api/pull/42
 pensar issues prs VULN-000123
+
+# Read the review thread on a finding, then reply to it
+pensar issues comments VULN-000123
+pensar issues comment VULN-000123 --body "Confirmed exploitable, rescored to 7.1"
 ```
 
 ## Related Commands

--- a/src/cli/issues.test.ts
+++ b/src/cli/issues.test.ts
@@ -29,6 +29,8 @@ describe("pensar issues CLI", () => {
     "retest",
     "link-pr",
     "prs",
+    "comments",
+    "comment",
   ])("prints help for `%s --help` instead of treating it as an issue id", (sub) => {
     const { status, stdout, stderr } = runIssues([sub, "--help"]);
 
@@ -49,5 +51,35 @@ describe("pensar issues CLI", () => {
 
     expect(status).toBe(1);
     expect(stderr).toContain("Usage: pensar issues get <issueId>");
+  });
+
+  it("requires an issue ID to read a thread", () => {
+    const { status, stderr } = runIssues(["comments"]);
+
+    expect(status).toBe(1);
+    expect(stderr).toContain("Usage: pensar issues comments <issueId>");
+  });
+
+  // Without this the flag is swallowed as the issue id and the request goes
+  // out with an empty comment.
+  it("requires --body to post a comment", () => {
+    const { status, stderr } = runIssues(["comment", "VULN-000123"]);
+
+    expect(status).toBe(1);
+    expect(stderr).toContain("issue ID and --body are required");
+  });
+
+  it("does not mistake a flag for the issue id when posting", () => {
+    const { status, stderr } = runIssues(["comment", "--body", "hi"]);
+
+    expect(status).toBe(1);
+    expect(stderr).toContain("issue ID and --body are required");
+  });
+
+  it("says posting needs a user login, not just an API key", () => {
+    const { status, stdout } = runIssues(["--help"]);
+
+    expect(status).toBe(0);
+    expect(stdout).toContain("Posting requires a user login");
   });
 });

--- a/src/cli/issues.ts
+++ b/src/cli/issues.ts
@@ -12,11 +12,15 @@
  *   pensar issues retest <issueId>                Retest an issue
  *   pensar issues link-pr <issueId> --url <url>   Link a pull request to an issue
  *   pensar issues prs <issueId>                   List pull requests linked to an issue
+ *   pensar issues comments <issueId>              List review comments on an issue
+ *   pensar issues comment <issueId> --body <text> Post a comment on an issue
  */
 
 import {
+  createIssueComment,
   getIssue,
   linkPullRequest,
+  listIssueComments,
   listIssuePullRequests,
   listIssues,
   retestIssue,
@@ -41,6 +45,8 @@ Usage:
   pensar issues retest <issueId>                 Retest an issue
   pensar issues link-pr <issueId> --url <url>    Link a pull request to an issue
   pensar issues prs <issueId>                    List pull requests linked to an issue
+  pensar issues comments <issueId>               List review comments on an issue
+  pensar issues comment <issueId> --body <text>  Post a comment on an issue
 
 <issueId> accepts the issue UUID or its label (e.g. VULN-000123).
 
@@ -62,6 +68,16 @@ Update options:
 
 Link-pr options:
   --url <url>               URL of the pull request to link (required)
+
+Comments options:
+  --page <n>                Page number (default 1)
+  --page-size <n>           Comments per page (default 50, max 200)
+
+Comment options:
+  --body <text>             Comment text (required)
+
+Comments are returned oldest first. Posting requires a user login; a workspace
+API key has no author to attribute a comment to.
 
 Options:
   -h, --help                Show this help message`);
@@ -136,6 +152,30 @@ async function main(): Promise<void> {
         return markCommandFailed();
       }
       const result = await linkPullRequest(issueId, url);
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub === "comments") {
+      const issueId = args[1];
+      if (!issueId || issueId.startsWith("--")) {
+        console.error("Error: issue ID is required");
+        console.error("Usage: pensar issues comments <issueId>");
+        return markCommandFailed();
+      }
+      const page = getFlag("--page", args);
+      const pageSize = getFlag("--page-size", args);
+      const result = await listIssueComments(issueId, {
+        page: page ? Number(page) : undefined,
+        pageSize: pageSize ? Number(pageSize) : undefined,
+      });
+      console.log(JSON.stringify(result, null, 2));
+    } else if (sub === "comment") {
+      const issueId = args[1];
+      const body = getFlag("--body", args);
+      if (!issueId || issueId.startsWith("--") || !body) {
+        console.error("Error: issue ID and --body are required");
+        console.error('Usage: pensar issues comment <issueId> --body "<text>"');
+        return markCommandFailed();
+      }
+      const result = await createIssueComment(issueId, body);
       console.log(JSON.stringify(result, null, 2));
     } else if (sub === "prs") {
       const issueId = args[1];

--- a/src/core/api/comments.test.ts
+++ b/src/core/api/comments.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiRequest = vi.hoisted(() => vi.fn());
+
+vi.mock("./apiClient", () => ({ apiRequest }));
+
+import { createIssueComment, listIssueComments } from "./issues";
+
+const ISSUE_ID = "11111111-1111-1111-1111-111111111111";
+
+describe("listIssueComments", () => {
+  beforeEach(() => {
+    apiRequest.mockReset();
+    apiRequest.mockResolvedValue({ comments: [], pagination: {} });
+  });
+
+  it("GETs the issue's comment sub-resource", async () => {
+    await listIssueComments(ISSUE_ID);
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      "GET",
+      `/issues/${ISSUE_ID}/comments`,
+    );
+  });
+
+  it("accepts a label in place of a uuid", async () => {
+    await listIssueComments("VULN-000123");
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      "GET",
+      "/issues/VULN-000123/comments",
+    );
+  });
+
+  it("passes pagination through as query params", async () => {
+    await listIssueComments(ISSUE_ID, { page: 2, pageSize: 10 });
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      "GET",
+      `/issues/${ISSUE_ID}/comments?page=2&pageSize=10`,
+    );
+  });
+
+  it("omits the query string entirely when no options are given", async () => {
+    await listIssueComments(ISSUE_ID, {});
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      "GET",
+      `/issues/${ISSUE_ID}/comments`,
+    );
+  });
+});
+
+describe("createIssueComment", () => {
+  beforeEach(() => {
+    apiRequest.mockReset();
+    apiRequest.mockResolvedValue({ id: "c1" });
+  });
+
+  it("POSTs the body to the issue's comment sub-resource", async () => {
+    await createIssueComment(ISSUE_ID, "Rescored to 7.1");
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      "POST",
+      `/issues/${ISSUE_ID}/comments`,
+      { body: "Rescored to 7.1" },
+    );
+  });
+});

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -69,9 +69,12 @@ export type { EnvironmentAgentInput, EnvironmentResult } from "./environment";
 export { runEnvironmentAgent } from "./environment";
 export type {
   AgentLogEntry,
+  CommentAuthor,
   DispatchPentestResult,
   FixDetail,
   FixSummary,
+  IssueCommentPage,
+  IssueCommentSummary,
   IssueDetail,
   IssueSummary,
   LinkPullRequestResult,
@@ -87,6 +90,7 @@ export type {
   UpdateIssueResult,
 } from "./issues";
 export {
+  createIssueComment,
   dispatchPentest,
   getFix,
   getIssue,
@@ -94,6 +98,7 @@ export {
   linkPullRequest,
   listAgentLogs,
   listFixes,
+  listIssueComments,
   listIssuePullRequests,
   listIssues,
   listPentestTargets,

--- a/src/core/api/issues.ts
+++ b/src/core/api/issues.ts
@@ -52,6 +52,37 @@ export interface IssueDetail extends IssueSummary {
   createdAt: string;
 }
 
+/** Who wrote a comment. Null when the author's user record is gone. */
+export interface CommentAuthor {
+  id: string;
+  name: string | null;
+  email: string;
+  type: "user";
+}
+
+export interface IssueCommentSummary {
+  id: string;
+  issueId: string;
+  /** Comment text as written; `@handle` mentions are left in place. */
+  body: string;
+  author: CommentAuthor | null;
+  createdAt: string;
+  /** Null if the comment has never been edited. */
+  editedAt: string | null;
+  /** Console deep link to the comment. */
+  url: string;
+}
+
+export interface IssueCommentPage {
+  comments: IssueCommentSummary[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    totalRows: number;
+    totalPages: number;
+  };
+}
+
 export interface UpdateIssueResult {
   success: boolean;
   issue: {
@@ -235,6 +266,36 @@ export async function updateIssue(
   },
 ): Promise<UpdateIssueResult> {
   return apiRequest<UpdateIssueResult>("PATCH", `/issues/${issueId}`, data);
+}
+
+/**
+ * The review thread on an issue, oldest first. Posting requires a user
+ * credential — a workspace API key has no author to attribute a comment to.
+ */
+export async function listIssueComments(
+  issueId: string,
+  options?: { page?: number; pageSize?: number },
+): Promise<IssueCommentPage> {
+  const params = new URLSearchParams();
+  if (options?.page) params.set("page", String(options.page));
+  if (options?.pageSize) params.set("pageSize", String(options.pageSize));
+
+  const qs = params.toString();
+  return apiRequest<IssueCommentPage>(
+    "GET",
+    `/issues/${issueId}/comments${qs ? `?${qs}` : ""}`,
+  );
+}
+
+export async function createIssueComment(
+  issueId: string,
+  body: string,
+): Promise<IssueCommentSummary> {
+  return apiRequest<IssueCommentSummary>(
+    "POST",
+    `/issues/${issueId}/comments`,
+    { body },
+  );
 }
 
 export async function retestIssue(issueId: string): Promise<RetestIssueResult> {


### PR DESCRIPTION
The review thread on a finding was only reachable from the Console web UI. Reviewers put their reasoning there — a corrected CVSS score, the argument for dismissing a finding — and there was no way to read it back from the CLI or to reply.

Adds two subcommands over the new comments sub-resource on the Console API:

```
pensar issues comments <issueId>               # read the thread, oldest first
pensar issues comment <issueId> --body "..."   # post to it
```

A comment comes back with an `author` object (null when the person's account is gone), `createdAt`, an `editedAt` that stays null until the comment is edited, and a deep link into the Console. Mentions stay inline in the body as written, so `@first.last` notifies the same person it would from the Console.

Reading a thread works with any workspace credential. Posting requires a user login: a workspace API key has no author to attribute a comment to, so the API rejects it rather than recording an anonymous one.

## Test Plan

**Unit — 19 tests, all passing.**

- `src/core/api/comments.test.ts` (5) — that `listIssueComments` GETs the issue's comment sub-resource, accepts a label in place of a uuid, forwards `page`/`pageSize` as query params, and omits the query string entirely when given no options; and that `createIssueComment` POSTs `{ body }` to the same path.
- `src/cli/issues.test.ts` (14, extended) — both subcommands print help for `--help` instead of treating it as an issue id; `comments` with no id errors with its usage line; `comment` errors when `--body` is missing **and** when a flag is passed where the issue id should be, which is the case that would otherwise send an empty comment; and the help text states that posting needs a user login.

The CLI tests spawn the real command and assert on exit code and stderr, so they stay offline — every case fails before any API call.

**Not covered.** The commands were not run against a live Console, because the routes do not exist until pensarai/console#2720 merges. The request shapes are asserted against the mocked client above; the server side of the same contract is tested in that PR.

Depends on the Console side landing first (pensarai/console#2720) — the routes do not exist until then.

No linked issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces user-authored content via a new API path; behavior depends on Console routes landing first, though auth rules are enforced server-side and CLI changes follow existing issue command patterns.
> 
> **Overview**
> Adds **`pensar issues comments`** and **`pensar issues comment`** so reviewers can read an issue’s review thread from the CLI and post replies, backed by new **`GET`/`POST `/issues/{id}/comments`**** client helpers with pagination and typed comment payloads (author, deep link, inline `@mentions`).
> 
> The CLI mirrors other issue subcommands: validates issue id vs flags (so `--body` is not mistaken for an id), supports **`--page` / `--page-size`** on list, and documents that **reading** works with workspace credentials while **posting** expects a **user `pensar login`** (API keys have no attributable author). Docs and tests cover usage, help text, and HTTP wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a91fefea7b70630fd04d0a040db58ffee7e22b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->