### PR TITLE
2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,5 +119,5 @@
     "tsc": "tsc --noEmit"
   },
   "type": "module",
-  "version": "2.4.0"
+  "version": "2.5.0"
 }


### PR DESCRIPTION
Bump the version to 2.5.0 for release.

## Features

- **Usage and observability.** Session usage is now modelled and scoped per session, persisted in full, and ingested through a single path. The footer was rewritten with explicit token and context labels, and now shows the prompt-cache token breakdown. An optional OTLP runtime traces root agent runs and correlates agent telemetry. (#996, #997, #998, #999, #1000, #1002, #1004, #1005, #1006, #1007, #1008)
- **Pentest.** Findings carry structured system scope and attack paths. A new `disableSubagents` session config runs the per-target agent on its own. (#1010, #1015)
- **CLI.** Read and post issue comments. Issues now surface their label and URL, and subcommand `--help` works. `pensar apps` exposes endpoint transport and workspace domains. (#1025, #1003, #960)
- **API.** Every request now identifies the client to Console. (#1022)
- **TUI.** Better model search and recents, deprecated models hidden from the picker, and SMS message listing. (#982, #983, #985)

## Fixes

- CVSS 4.0 calculator now matches the reference implementation. (#1018)
- Shell reads stderr from disk instead of racing the pipe. (#1014)
- `spawn_pentest_agent` fails closed when given an invalid or out-of-scope target. (#995)
- Agent abort state survives teardown. (#964)
- The Camoufox screen constraint is floored rather than pinned exactly. (#972)

## Internal

Operator and agent execution were broken into smaller collaborators across #965 through #992. Typecheck and test resource usage is bounded (#973), and the Fern CLI reference is level with 2.4.0 (#961).

45 commits since v2.4.0, across 149 files.

No linked issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata change with no runtime or logic impact.
> 
> **Overview**
> **Bumps `@pensar/apex` from `2.4.0` to `2.5.0`** in `package.json` as the release version tag for publish (`prepublishOnly` still runs `build`).
> 
> This PR’s diff is only that version field; the broader 2.5.0 changelog lives in the release description rather than in code changes here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17cd3f11b8b925f2e9b51f5408cbe1dc8074fd05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->