### PR TITLE
Set and read the close disposition from the CLI

### DIFF
--- a/fern/docs/cli/issues.mdx
+++ b/fern/docs/cli/issues.mdx
@@ -81,13 +81,18 @@ A reference that is neither a UUID nor a `VULN-…` label is rejected with a 400
 pensar issues update <issueId> [options]
 ```
 
-| Option                     | Description                        |
-| -------------------------- | ---------------------------------- |
-| `--status <status>`        | New status                         |
-| `--closed-reason <reason>` | Reason for closing                 |
-| `--closed-comments <text>` | Additional comments when closing   |
-| `--false-positive`         | Flag the issue as a false positive |
-| `--fp-reason <reason>`     | Reason for the false positive flag |
+| Option                      | Description                                                             |
+| --------------------------- | ----------------------------------------------------------------------- |
+| `--status <status>`         | New status                                                              |
+| `--disposition <value>`     | Why the issue is closed: `resolved`, `wont-fix`, `out-of-scope`, `risk-accepted` |
+| `--closed-reason <reason>`  | Reason for closing                                                      |
+| `--closed-comments <text>`  | Additional comments when closing                                        |
+| `--false-positive`          | Flag the issue as a false positive                                      |
+| `--fp-reason <reason>`      | Reason for the false positive flag                                      |
+
+`--disposition` records *why* an issue is closed as a structured value, so it can
+be filtered and counted. Without it a close reads as a plain resolution whatever
+the reason was. The four values above are the full accepted set.
 
 ### Retest an Issue
 
@@ -183,7 +188,7 @@ pensar issues --status open --severity critical
 pensar issues get VULN-000123
 
 # Close an issue with a reason
-pensar issues update VULN-000123 --status closed --closed-reason "Patched in v2.1"
+pensar issues update VULN-000123 --status closed --disposition resolved --closed-reason "Patched in v2.1"
 
 # Flag as false positive
 pensar issues update VULN-000123 --false-positive --fp-reason "Test environment only"

--- a/src/cli/issues.test.ts
+++ b/src/cli/issues.test.ts
@@ -39,6 +39,27 @@ describe("pensar issues CLI", () => {
     expect(stderr).toBe("");
   });
 
+  it("documents the close disposition on update", () => {
+    const { status, stdout } = runIssues(["--help"]);
+
+    expect(status).toBe(0);
+    expect(stdout).toContain("--disposition <value>");
+    expect(stdout).toContain("resolved, wont-fix, out-of-scope");
+  });
+
+  it("rejects a disposition outside the accepted set, naming the set", () => {
+    const { status, stderr } = runIssues([
+      "update",
+      "VULN-000001",
+      "--disposition",
+      "other",
+    ]);
+
+    expect(status).toBe(1);
+    expect(stderr).toContain('invalid --disposition "other"');
+    expect(stderr).toContain("resolved, wont-fix, out-of-scope, risk-accepted");
+  });
+
   it("prints help for `-h` on a subcommand", () => {
     const { status, stdout } = runIssues(["update", "-h"]);
 

--- a/src/cli/issues.ts
+++ b/src/cli/issues.ts
@@ -16,7 +16,9 @@
  *   pensar issues comment <issueId> --body <text> Post a comment on an issue
  */
 
+import type { ClosedDisposition } from "../core/api";
 import {
+  CLOSED_DISPOSITIONS,
   createIssueComment,
   getIssue,
   linkPullRequest,
@@ -63,6 +65,8 @@ Update options:
   --status <status>         New status
   --closed-reason <reason>  Reason for closing
   --closed-comments <text>  Additional comments
+  --disposition <value>     Why it is closed: resolved, wont-fix, out-of-scope,
+                            risk-accepted
   --false-positive          Flag as false positive
   --fp-reason <reason>      Reason for false positive flag
 
@@ -121,6 +125,19 @@ async function main(): Promise<void> {
         | undefined;
       const closedReason = getFlag("--closed-reason", args);
       const closedComments = getFlag("--closed-comments", args);
+      const dispositionFlag = getFlag("--disposition", args);
+      if (
+        dispositionFlag !== undefined &&
+        !(CLOSED_DISPOSITIONS as readonly string[]).includes(dispositionFlag)
+      ) {
+        console.error(
+          `Error: invalid --disposition "${dispositionFlag}". Accepted: ${CLOSED_DISPOSITIONS.join(", ")}`,
+        );
+        return markCommandFailed();
+      }
+      const closedDisposition = dispositionFlag as
+        | ClosedDisposition
+        | undefined;
       const userFlaggedFalsePositive = args.includes("--false-positive")
         ? true
         : undefined;
@@ -130,6 +147,7 @@ async function main(): Promise<void> {
         status,
         closedReason,
         closedComments,
+        closedDisposition,
         userFlaggedFalsePositive,
         userFlaggedFalsePositiveReason,
       });

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -69,6 +69,7 @@ export type { EnvironmentAgentInput, EnvironmentResult } from "./environment";
 export { runEnvironmentAgent } from "./environment";
 export type {
   AgentLogEntry,
+  ClosedDisposition,
   CommentAuthor,
   DispatchPentestResult,
   FixDetail,
@@ -90,6 +91,7 @@ export type {
   UpdateIssueResult,
 } from "./issues";
 export {
+  CLOSED_DISPOSITIONS,
   createIssueComment,
   dispatchPentest,
   getFix,

--- a/src/core/api/issues.ts
+++ b/src/core/api/issues.ts
@@ -28,6 +28,19 @@ export interface ScanDetail extends ScanSummary {
   reportReady: boolean;
 }
 
+/**
+ * Close dispositions the API accepts. Mirrors the server's public vocabulary;
+ * `other` is deliberately absent — the server rejects it.
+ */
+export const CLOSED_DISPOSITIONS = [
+  "resolved",
+  "wont-fix",
+  "out-of-scope",
+  "risk-accepted",
+] as const;
+
+export type ClosedDisposition = (typeof CLOSED_DISPOSITIONS)[number];
+
 export interface IssueSummary {
   id: string;
   /** Human-facing label, e.g. `VULN-000123`. Null for issues created before labels existed. */
@@ -50,6 +63,12 @@ export interface IssueDetail extends IssueSummary {
   workspaceId: string;
   workspaceName: string;
   createdAt: string;
+  /** Close metadata. Absent when talking to a console that predates it. */
+  closedAt?: string | null;
+  closedMethod?: string | null;
+  closedReason?: string | null;
+  closedComments?: string | null;
+  closedDisposition?: ClosedDisposition | null;
 }
 
 /** Who wrote a comment. Null when the author's user record is gone. */
@@ -93,6 +112,9 @@ export interface UpdateIssueResult {
     userFlaggedFalsePositive: boolean;
     closedAt: string | null;
     closedReason: string | null;
+    closedMethod?: string | null;
+    closedComments?: string | null;
+    closedDisposition?: ClosedDisposition | null;
   };
 }
 
@@ -263,6 +285,7 @@ export async function updateIssue(
     userFlaggedFalsePositiveReason?: string;
     closedReason?: string;
     closedComments?: string;
+    closedDisposition?: ClosedDisposition;
   },
 ): Promise<UpdateIssueResult> {
   return apiRequest<UpdateIssueResult>("PATCH", `/issues/${issueId}`, data);


### PR DESCRIPTION
`pensar issues update` could record that an issue was closed but not why. Every close made through the CLI landed with no disposition, so it read back as a plain resolution whatever the actual reason was. `pensar issues get` did not return the close metadata either, so there was no way to check what a close had recorded.

Adds `--disposition` to `pensar issues update`, validated against the set the API accepts, and puts the close fields on the issue and update-result types so a caller can read back what it wrote.

```
pensar issues update VULN-000123 --status closed --disposition resolved \
  --closed-reason "Patched in v2.1"
```

`other` is deliberately not accepted. pensarai/console#2704 removes it from the vocabulary, and publishing a value on a brand-new flag only to withdraw it is worse than never offering it. An invalid value is rejected before any API call, naming the accepted set.

The close fields are optional on the read types because the CLI ships independently of the console it points at, so a newer CLI can be talking to a console that does not send them yet.

This is the CLI half of pensarai/console#2728. The server half — the write allowlist, the REST and MCP surfaces, and the REST docs — is a separate console PR. Neither blocks the other; the console submodule pointer gets bumped after this merges.

No linked issue in this repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a validated CLI flag and optional API types for issue close metadata; no auth or broad behavioral changes beyond issue updates.
> 
> **Overview**
> **`pensar issues update`** can now set a structured **close disposition** via **`--disposition`**, with values **`resolved`**, **`wont-fix`**, **`out-of-scope`**, and **`risk-accepted`**. Invalid values are rejected locally before the API call, with an error that lists the accepted set ( **`other`** is intentionally unsupported).
> 
> The issues API client gains **`CLOSED_DISPOSITIONS`** / **`ClosedDisposition`**, passes **`closedDisposition`** on PATCH, and exposes optional close metadata on **`IssueDetail`** and **`UpdateIssueResult`** so **`get`** and update responses can surface what was recorded. Fern CLI docs and an offline help/validation test cover the new flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d0014a26bcf53cf6fdc78763668908cfb409ec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->