### PR TITLE
fix(observability): settle auxiliary model telemetry

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -15,6 +15,7 @@ const toolContexts = vi.hoisted(() => [] as Array<Record<string, unknown>>);
 const streamResponseCalls = vi.hoisted(
   () => [] as Array<Record<string, unknown>>,
 );
+const traceRecordStepCalls = vi.hoisted(() => [] as unknown[][]);
 
 // ---------------------------------------------------------------------------
 // Module stubs — prevent the full tool/AI/zod import chain from loading.
@@ -85,7 +86,9 @@ vi.mock("./prompt", () => ({
 vi.mock("./trace", () => ({
   StepTraceWriter: class {
     writeInit() {}
-    recordStep() {}
+    recordStep(...args: unknown[]) {
+      traceRecordStepCalls.push(args);
+    }
     markSummarized() {}
   },
 }));
@@ -133,6 +136,7 @@ describe("spawned-agent usage callbacks", () => {
 describe("auxiliary model events", () => {
   it("keeps the last complete message snapshot while forwarding usage", async () => {
     streamResponseCalls.length = 0;
+    traceRecordStepCalls.length = 0;
     const rootPath = join(
       "/tmp",
       `apex-auxiliary-model-event-${Date.now()}-${Math.random()}`,
@@ -171,11 +175,22 @@ describe("auxiliary model events", () => {
 
       await call.onStepFinish({
         response: { id: "summarization", messages: [] },
-        usage: { inputTokens: 5, outputTokens: 1 },
+        usage: {
+          inputTokens: 5,
+          outputTokens: 1,
+          inputTokenDetails: { cacheReadTokens: 4, cacheWriteTokens: 1 },
+        },
       });
 
       expect(writer.latest).toEqual([...initialMessages, ...completedMessages]);
       expect(onStepFinish).toHaveBeenCalledTimes(2);
+      expect(traceRecordStepCalls.at(-1)?.[1]).toEqual({
+        inputTokens: 5,
+        outputTokens: 1,
+        cacheReadTokens: 4,
+        cacheWriteTokens: 1,
+      });
+      expect(traceRecordStepCalls.at(-1)?.[2]).toEqual({ usageOnly: true });
       writer.cancelTimer();
     } finally {
       rmSync(rootPath, { recursive: true, force: true });

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -12,6 +12,9 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 const toolContexts = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+const streamResponseCalls = vi.hoisted(
+  () => [] as Array<Record<string, unknown>>,
+);
 
 // ---------------------------------------------------------------------------
 // Module stubs — prevent the full tool/AI/zod import chain from loading.
@@ -65,7 +68,12 @@ vi.mock("./tools", () => ({
   ],
   PersistentShell: class {},
 }));
-vi.mock("../../ai", () => ({ streamResponse: () => {} }));
+vi.mock("../../ai", () => ({
+  streamResponse: (opts: Record<string, unknown>) => {
+    streamResponseCalls.push(opts);
+    return { fullStream: (async function* () {})() };
+  },
+}));
 vi.mock("../../session", () => ({ create: () => {} }));
 vi.mock("../specialized/utils", () => ({
   detectOSAndEnhancePrompt: (p: string) => p,
@@ -77,7 +85,8 @@ vi.mock("./prompt", () => ({
 vi.mock("./trace", () => ({
   StepTraceWriter: class {
     writeInit() {}
-    onStepFinish() {}
+    recordStep() {}
+    markSummarized() {}
   },
 }));
 vi.mock("../../operator", () => ({
@@ -118,6 +127,59 @@ describe("spawned-agent usage callbacks", () => {
     expect(toolContexts[0]?.onCacheMetrics).toBeUndefined();
     expect(toolContexts[1]?.onStepFinish).toBe(onStepFinish);
     expect(toolContexts[1]?.onCacheMetrics).toBe(onCacheMetrics);
+  });
+});
+
+describe("auxiliary model events", () => {
+  it("keeps the last complete message snapshot while forwarding usage", async () => {
+    streamResponseCalls.length = 0;
+    const rootPath = join(
+      "/tmp",
+      `apex-auxiliary-model-event-${Date.now()}-${Math.random()}`,
+    );
+    const initialMessages = [
+      { role: "user" as const, content: "original request" },
+    ];
+    const completedMessages = [
+      { role: "assistant" as const, content: "completed step" },
+    ];
+    const onStepFinish = vi.fn();
+
+    try {
+      const agent = new OffensiveSecurityAgent({
+        prompt: "test",
+        model: "test-model",
+        messages: initialMessages,
+        session: { id: "ses_auxiliary", rootPath },
+        activeTools: [],
+        sandbox: {},
+        onStepFinish,
+      } as never);
+
+      void agent.streamResult;
+      const call = streamResponseCalls[0] as {
+        onStepFinish: (event: unknown) => Promise<void>;
+      };
+      await call.onStepFinish({
+        response: { id: "step-1", messages: completedMessages },
+        usage: { inputTokens: 10, outputTokens: 2 },
+      });
+
+      const writer = (agent as unknown as { writer: AgentMessageWriter })
+        .writer;
+      expect(writer.latest).toEqual([...initialMessages, ...completedMessages]);
+
+      await call.onStepFinish({
+        response: { id: "summarization", messages: [] },
+        usage: { inputTokens: 5, outputTokens: 1 },
+      });
+
+      expect(writer.latest).toEqual([...initialMessages, ...completedMessages]);
+      expect(onStepFinish).toHaveBeenCalledTimes(2);
+      writer.cancelTimer();
+    } finally {
+      rmSync(rootPath, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -733,11 +733,21 @@ export class OffensiveSecurityAgent<TResult = void> {
             event.response.id === "tool-repair";
 
           if (auxiliaryModelEvent) {
-            traceWriter.recordStep([], {
-              inputTokens: event.usage.inputTokens ?? 0,
-              outputTokens: event.usage.outputTokens ?? 0,
-              ...lastCacheMetrics,
-            });
+            const cacheDetails = event.usage.inputTokenDetails;
+            traceWriter.recordStep(
+              [],
+              {
+                inputTokens: event.usage.inputTokens ?? 0,
+                outputTokens: event.usage.outputTokens ?? 0,
+                cacheReadTokens:
+                  lastCacheMetrics?.cacheReadTokens ??
+                  cacheDetails?.cacheReadTokens,
+                cacheWriteTokens:
+                  lastCacheMetrics?.cacheWriteTokens ??
+                  cacheDetails?.cacheWriteTokens,
+              },
+              { usageOnly: true },
+            );
             lastCacheMetrics = null;
             await input.onStepFinish?.(event);
             return;

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -728,6 +728,21 @@ export class OffensiveSecurityAgent<TResult = void> {
         sessionPath: messagesDir,
         sessionId: this.busSessionId,
         onStepFinish: async (event) => {
+          const auxiliaryModelEvent =
+            event.response.id === "summarization" ||
+            event.response.id === "tool-repair";
+
+          if (auxiliaryModelEvent) {
+            traceWriter.recordStep([], {
+              inputTokens: event.usage.inputTokens ?? 0,
+              outputTokens: event.usage.outputTokens ?? 0,
+              ...lastCacheMetrics,
+            });
+            lastCacheMetrics = null;
+            await input.onStepFinish?.(event);
+            return;
+          }
+
           this.writer.setLatest([
             ...initialMessagesRef.current,
             ...event.response.messages,

--- a/src/core/agents/offSecAgent/trace.test.ts
+++ b/src/core/agents/offSecAgent/trace.test.ts
@@ -172,6 +172,31 @@ describe("StepTraceWriter", () => {
     expect(records.map((r) => r.stepIndex)).toEqual([0, 1, 2]);
   });
 
+  it("usage-only records do not reset the cumulative message cursor", () => {
+    const tracePath = join(tmpDir, "trace.jsonl");
+    const writer = new StepTraceWriter({ tracePath, agentId: null });
+    const msgs = buildMessages();
+
+    writer.recordStep(msgs.afterStep0, { inputTokens: 100, outputTokens: 50 });
+    writer.recordStep(
+      [],
+      { inputTokens: 25, outputTokens: 5, cacheReadTokens: 20 },
+      { usageOnly: true },
+    );
+    writer.recordStep(msgs.afterStep1, { inputTokens: 200, outputTokens: 80 });
+
+    const records = readStepRecords(tracePath);
+    expect(records[1]?.actions).toEqual([]);
+    expect(records[1]?.usage.cacheReadTokens).toBe(20);
+    expect(records[2]?.text).toBeNull();
+    expect(records[2]?.observations?.map((item) => item.toolCallId)).toEqual([
+      "tc_001",
+    ]);
+    expect(records[2]?.actions.map((item) => item.toolCallId)).toEqual([
+      "tc_002",
+    ]);
+  });
+
   it("sets observations to null on step 0", () => {
     const tracePath = join(tmpDir, "trace.jsonl");
     const writer = new StepTraceWriter({ tracePath, agentId: null });

--- a/src/core/agents/offSecAgent/trace.ts
+++ b/src/core/agents/offSecAgent/trace.ts
@@ -434,6 +434,8 @@ export class StepTraceWriter {
    * @param responseMessages - `event.response.messages` from the AI SDK
    *   (cumulative response messages, NOT including initial prompt messages)
    * @param usage - `event.usage` from the AI SDK (this step's token counts)
+   * @param options.usageOnly - record token usage without advancing the
+   *   cumulative response-message cursor
    */
   recordStep(
     responseMessages: ModelMessage[],
@@ -443,10 +445,16 @@ export class StepTraceWriter {
       cacheReadTokens?: number;
       cacheWriteTokens?: number;
     },
+    options?: { usageOnly?: boolean },
   ): void {
     const now = Date.now();
-    const newMessages = responseMessages.slice(this.previousMessageCount);
-    this.previousMessageCount = responseMessages.length;
+    const usageOnly = options?.usageOnly ?? false;
+    const newMessages = usageOnly
+      ? []
+      : responseMessages.slice(this.previousMessageCount);
+    if (!usageOnly) {
+      this.previousMessageCount = responseMessages.length;
+    }
 
     const observations: NonNullable<StepRecord["observations"]> = [];
     const reasoningParts: string[] = [];
@@ -538,13 +546,13 @@ export class StepTraceWriter {
 
       stepDurationMs: now - this.lastStepTime,
       elapsedMs: now - this.agentStartTime,
-      summarized: this.summarized,
+      summarized: usageOnly ? false : this.summarized,
     };
 
     this.appendRecord(record);
     this.stepIndex++;
     this.lastStepTime = now;
-    this.summarized = false;
+    if (!usageOnly) this.summarized = false;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -1410,37 +1410,45 @@ export function streamResponse(
           // into the tool loop. Provider metadata and cache details flow
           // through so repair usage stays attributable.
           if (onStepFinish && repairUsage) {
-            await onStepFinish({
-              text: "",
-              reasoning: undefined,
-              reasoningDetails: [],
-              files: [],
-              sources: [],
-              toolCalls: [],
-              toolResults: [],
-              finishReason: "stop",
-              usage: {
-                inputTokens: repairUsage.inputTokens ?? 0,
-                outputTokens: repairUsage.outputTokens ?? 0,
-                totalTokens: repairUsage.totalTokens ?? 0,
-                ...(repairUsage.inputTokenDetails
-                  ? { inputTokenDetails: repairUsage.inputTokenDetails }
-                  : {}),
-              },
-              warnings: [],
-              request: {},
-              response: {
-                id: "tool-repair",
-                timestamp: new Date(),
-                modelId: "",
-                messages: [],
-              },
-              providerMetadata: repairProviderMetadata,
-              stepType: "initial",
-              isContinued: false,
-            } as unknown as Parameters<
-              StreamTextOnStepFinishCallback<ToolSet>
-            >[0]);
+            try {
+              await onStepFinish({
+                text: "",
+                reasoning: undefined,
+                reasoningDetails: [],
+                files: [],
+                sources: [],
+                toolCalls: [],
+                toolResults: [],
+                finishReason: "stop",
+                usage: {
+                  inputTokens: repairUsage.inputTokens ?? 0,
+                  outputTokens: repairUsage.outputTokens ?? 0,
+                  totalTokens: repairUsage.totalTokens ?? 0,
+                  ...(repairUsage.inputTokenDetails
+                    ? { inputTokenDetails: repairUsage.inputTokenDetails }
+                    : {}),
+                },
+                warnings: [],
+                request: {},
+                response: {
+                  id: "tool-repair",
+                  timestamp: new Date(),
+                  modelId: "",
+                  messages: messagesContainer.current,
+                },
+                providerMetadata: repairProviderMetadata,
+                stepType: "initial",
+                isContinued: false,
+              } as unknown as Parameters<
+                StreamTextOnStepFinishCallback<ToolSet>
+              >[0]);
+            } catch (callbackError) {
+              if (!silent) {
+                log.warn("Error reporting tool repair usage", {
+                  error: String(callbackError),
+                });
+              }
+            }
           }
 
           if (repairedArgs === undefined || repairedArgs === null) {

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -1376,34 +1376,41 @@ export function streamResponse(
             "schema",
           );
 
-          const { output: repairedArgs, usage: repairUsage } =
-            await generateText({
-              model: providerModel,
-              output: Output.object({
-                schema: tool.inputSchema, // Use the actual Zod schema from the tool
-              }),
-              prompt: [
-                `The model tried to call the tool "${toolCall.toolName}"` +
-                  ` with the following inputs:`,
-                boundedInput,
-                `The tool accepts the following schema:`,
-                boundedSchema,
-                `Error encountered: ${error}`,
-                "Please fix the inputs to match the schema.",
-                "",
-                "IMPORTANT: For enum fields like 'severity' or 'riskLevel', use ONLY the exact values from the enum (e.g., 'HIGH', 'CRITICAL', 'MEDIUM', 'LOW').",
-                "Do not add prefixes, suffixes, or formatting characters like '>', '-', '!', etc.",
-              ].join("\n"),
-              abortSignal,
-              experimental_telemetry: createAiTelemetrySettings({
-                operation: "apex.tool.repair",
-                sessionId,
-              }),
-            });
+          const {
+            output: repairedArgs,
+            usage: repairUsage,
+            providerMetadata: repairProviderMetadata,
+          } = await generateText({
+            model: providerModel,
+            output: Output.object({
+              schema: tool.inputSchema, // Use the actual Zod schema from the tool
+            }),
+            prompt: [
+              `The model tried to call the tool "${toolCall.toolName}"` +
+                ` with the following inputs:`,
+              boundedInput,
+              `The tool accepts the following schema:`,
+              boundedSchema,
+              `Error encountered: ${error}`,
+              "Please fix the inputs to match the schema.",
+              "",
+              "IMPORTANT: For enum fields like 'severity' or 'riskLevel', use ONLY the exact values from the enum (e.g., 'HIGH', 'CRITICAL', 'MEDIUM', 'LOW').",
+              "Do not add prefixes, suffixes, or formatting characters like '>', '-', '!', etc.",
+            ].join("\n"),
+            abortSignal,
+            experimental_telemetry: createAiTelemetrySettings({
+              operation: "apex.tool.repair",
+              sessionId,
+            }),
+          });
 
-          // Report tool repair token usage if onStepFinish callback is provided
+          // Report tool repair token usage if onStepFinish callback is
+          // provided. Awaited: the callback persists messages and records
+          // usage — a detached invocation would leak unhandled rejections
+          // into the tool loop. Provider metadata and cache details flow
+          // through so repair usage stays attributable.
           if (onStepFinish && repairUsage) {
-            onStepFinish({
+            await onStepFinish({
               text: "",
               reasoning: undefined,
               reasoningDetails: [],
@@ -1416,6 +1423,9 @@ export function streamResponse(
                 inputTokens: repairUsage.inputTokens ?? 0,
                 outputTokens: repairUsage.outputTokens ?? 0,
                 totalTokens: repairUsage.totalTokens ?? 0,
+                ...(repairUsage.inputTokenDetails
+                  ? { inputTokenDetails: repairUsage.inputTokenDetails }
+                  : {}),
               },
               warnings: [],
               request: {},
@@ -1425,7 +1435,7 @@ export function streamResponse(
                 modelId: "",
                 messages: [],
               },
-              providerMetadata: undefined,
+              providerMetadata: repairProviderMetadata,
               stepType: "initial",
               isContinued: false,
             } as unknown as Parameters<

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -436,7 +436,11 @@ async function summarizeConversation(
     },
   ];
 
-  const { text: summary, usage: summaryUsage } = await generateText({
+  const {
+    text: summary,
+    usage: summaryUsage,
+    providerMetadata: summaryProviderMetadata,
+  } = await generateText({
     model,
     system: `You are a helpful assistant that summarizes conversations to pass to another agent. Review the conversation and system prompt at the end provided by the user.`,
     messages: summarizedMessages,
@@ -448,10 +452,14 @@ async function summarizeConversation(
   });
 
   // Report summarization token usage if onStepFinish callback is provided
-  // This ensures summarization tokens are tracked even though it's not a "step"
+  // This ensures summarization tokens are tracked even though it's not a "step".
+  // Awaited: the callback persists messages and records usage — a detached
+  // invocation would leak unhandled rejections into the resumed stream.
   if (opts.onStepFinish && summaryUsage) {
-    // Create a minimal step finish event for the summarization
-    opts.onStepFinish({
+    // Create a minimal step finish event for the summarization. `messages`
+    // must be a valid array (handlers spread it); cache details and provider
+    // metadata flow through so cache usage stays attributable.
+    await opts.onStepFinish({
       text: "",
       reasoning: undefined,
       reasoningDetails: [],
@@ -464,6 +472,9 @@ async function summarizeConversation(
         inputTokens: summaryUsage.inputTokens ?? 0,
         outputTokens: summaryUsage.outputTokens ?? 0,
         totalTokens: summaryUsage.totalTokens ?? 0,
+        ...(summaryUsage.inputTokenDetails
+          ? { inputTokenDetails: summaryUsage.inputTokenDetails }
+          : {}),
       },
       warnings: [],
       request: {},
@@ -471,8 +482,9 @@ async function summarizeConversation(
         id: "summarization",
         timestamp: new Date(),
         modelId: "",
+        messages: [],
       },
-      providerMetadata: undefined,
+      providerMetadata: summaryProviderMetadata,
       stepType: "initial",
       isContinued: false,
     } as unknown as Parameters<NonNullable<typeof opts.onStepFinish>>[0]);
@@ -588,24 +600,27 @@ export function createSummarizationStream(
     }
   })();
 
-  // Return a minimal StreamTextResult-like object with the wrapped stream
-  // We delegate most properties to the resumed stream once it's available
+  // Convenience fields delegate to the resumed stream once available. A
+  // summarization failure surfaces through `fullStream` (the primary
+  // consumption path); these derived promises must not each reject unhandled —
+  // derive them from a caught base so a failure resolves undefined here.
+  const resumedForFields = resumedStreamPromise.catch(() => undefined);
   return {
     fullStream: wrappedFullStream,
-    text: resumedStreamPromise.then((s) => s.text),
-    content: resumedStreamPromise.then((s) => s.content),
-    reasoning: resumedStreamPromise.then((s) => s.reasoning),
-    reasoningText: resumedStreamPromise.then((s) => s.reasoningText),
-    toolCalls: resumedStreamPromise.then((s) => s.toolCalls),
-    toolResults: resumedStreamPromise.then((s) => s.toolResults),
-    usage: resumedStreamPromise.then((s) => s.usage),
-    finishReason: resumedStreamPromise.then((s) => s.finishReason),
-    warnings: resumedStreamPromise.then((s) => s.warnings),
-    response: resumedStreamPromise.then((s) => s.response),
-    files: resumedStreamPromise.then((s) => s.files),
-    sources: resumedStreamPromise.then((s) => s.sources),
-    staticToolCalls: resumedStreamPromise.then((s) => s.staticToolCalls),
-    dynamicToolCalls: resumedStreamPromise.then((s) => s.dynamicToolCalls),
+    text: resumedForFields.then((s) => s?.text),
+    content: resumedForFields.then((s) => s?.content),
+    reasoning: resumedForFields.then((s) => s?.reasoning),
+    reasoningText: resumedForFields.then((s) => s?.reasoningText),
+    toolCalls: resumedForFields.then((s) => s?.toolCalls),
+    toolResults: resumedForFields.then((s) => s?.toolResults),
+    usage: resumedForFields.then((s) => s?.usage),
+    finishReason: resumedForFields.then((s) => s?.finishReason),
+    warnings: resumedForFields.then((s) => s?.warnings),
+    response: resumedForFields.then((s) => s?.response),
+    files: resumedForFields.then((s) => s?.files),
+    sources: resumedForFields.then((s) => s?.sources),
+    staticToolCalls: resumedForFields.then((s) => s?.staticToolCalls),
+    dynamicToolCalls: resumedForFields.then((s) => s?.dynamicToolCalls),
     pipeTextStreamToResponse: async (response: unknown, init?: unknown) => {
       const stream = await resumedStreamPromise;
       return stream.pipeTextStreamToResponse(

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -482,7 +482,7 @@ async function summarizeConversation(
         id: "summarization",
         timestamp: new Date(),
         modelId: "",
-        messages: [],
+        messages,
       },
       providerMetadata: summaryProviderMetadata,
       stepType: "initial",

--- a/src/core/observability/telemetry.test.ts
+++ b/src/core/observability/telemetry.test.ts
@@ -498,3 +498,248 @@ describe("full payload capture (stream path)", () => {
     expect(reasoning).toContain("pondering");
   });
 });
+
+// ---------------------------------------------------------------------------
+// PR1: auxiliary model lifecycle — summarization and tool-repair callbacks
+// are awaited, their synthetic events are handler-safe, and cache usage
+// flows through.
+// ---------------------------------------------------------------------------
+
+/** A model that streams one text step AND generates with cache + metadata. */
+function generateAndStreamModel(): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    provider: "mock-anthropic",
+    modelId: MODEL,
+    doStream: async () => ({
+      stream: simulateReadableStream({
+        chunks: [
+          { type: "stream-start", warnings: [] },
+          { type: "text-start", id: "t" },
+          { type: "text-delta", id: "t", delta: "resumed" },
+          { type: "text-end", id: "t" },
+          {
+            type: "finish",
+            finishReason: { unified: "stop", raw: "stop" },
+            usage: {
+              inputTokens: {
+                total: 100,
+                noCache: 100,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+              outputTokens: { total: 5, text: 5, reasoning: undefined },
+            },
+          },
+        ] as unknown as Array<LanguageModelV3StreamPart>,
+      }),
+    }),
+    doGenerate: async () => ({
+      content: [{ type: "text", text: "summary text" }],
+      finishReason: { unified: "stop", raw: "stop" },
+      warnings: [],
+      usage: {
+        inputTokens: {
+          total: 500,
+          noCache: 100,
+          cacheRead: 400,
+          cacheWrite: 7,
+        },
+        outputTokens: { total: 40, text: 40, reasoning: undefined },
+      },
+      providerMetadata: { anthropic: { cacheReadInputTokens: 400 } },
+    }),
+  });
+}
+
+describe("auxiliary model lifecycle", () => {
+  it("summarization awaits the wrapped onStepFinish and its synthetic event is handler-safe", async () => {
+    mockState.model = generateAndStreamModel();
+
+    const events: Array<{
+      response: { id?: string; messages?: unknown[] };
+      providerMetadata?: Record<string, unknown>;
+      usage: {
+        inputTokens: number;
+        inputTokenDetails?: {
+          cacheReadTokens?: number;
+          cacheWriteTokens?: number;
+        };
+      };
+    }> = [];
+    let syntheticCompleted = false;
+
+    const stream = createSummarizationStream(
+      [{ role: "user", content: "history to summarize" }],
+      {
+        prompt: "resume",
+        model: MODEL,
+        silent: true,
+        onStepFinish: async (event) => {
+          const isSynthetic =
+            (event as { response: { id?: string } }).response.id ===
+            "summarization";
+          events.push(event as never);
+          // Deferred work (persistence) — the summarization must await it.
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          if (isSynthetic) syntheticCompleted = true;
+        },
+      },
+      mockState.model,
+    );
+
+    await drain(stream);
+
+    // The synthetic event's callback finished — it was awaited, not detached.
+    expect(syntheticCompleted).toBe(true);
+
+    const synthetic = events.find((e) => e.response.id === "summarization");
+    expect(synthetic).toBeDefined();
+    // Handler-safe: handlers spread response.messages; cache and provider
+    // metadata survive the synthetic event.
+    expect(Array.isArray(synthetic?.response.messages)).toBe(true);
+    expect(synthetic?.usage.inputTokenDetails?.cacheReadTokens).toBe(400);
+    expect(synthetic?.usage.inputTokenDetails?.cacheWriteTokens).toBe(7);
+    expect(synthetic?.providerMetadata).toEqual({
+      anthropic: { cacheReadInputTokens: 400 },
+    });
+  });
+
+  it("a rejecting summarization callback surfaces through the resumed stream, not as an unhandled rejection", async () => {
+    mockState.model = generateAndStreamModel();
+
+    const stream = createSummarizationStream(
+      [{ role: "user", content: "history" }],
+      {
+        prompt: "resume",
+        model: MODEL,
+        silent: true,
+        onStepFinish: async (event) => {
+          if (
+            (event as { response: { id?: string } }).response.id ===
+            "summarization"
+          ) {
+            throw new Error("persistence boom");
+          }
+        },
+      },
+      mockState.model,
+    );
+
+    // Awaited: the failure propagates through the resumed stream. Detached,
+    // this would be an unhandled rejection with the stream continuing.
+    await expect(drain(stream)).rejects.toThrow("persistence boom");
+  });
+
+  it("tool repair awaits the wrapped onStepFinish and preserves provider metadata", async () => {
+    let call = 0;
+    mockState.model = new MockLanguageModelV3({
+      provider: "mock-anthropic",
+      modelId: MODEL,
+      doStream: async () => {
+        call += 1;
+        if (call === 1) {
+          return {
+            stream: simulateReadableStream({
+              chunks: [
+                { type: "stream-start", warnings: [] },
+                {
+                  type: "tool-call",
+                  toolCallId: "call-bad",
+                  toolName: "probe",
+                  input: '{"q":42}',
+                },
+                {
+                  type: "finish",
+                  finishReason: { unified: "tool-calls", raw: "tool_use" },
+                  usage: {
+                    inputTokens: {
+                      total: 50,
+                      noCache: 50,
+                      cacheRead: 0,
+                      cacheWrite: 0,
+                    },
+                    outputTokens: { total: 5, text: 5, reasoning: undefined },
+                  },
+                },
+              ] as unknown as Array<LanguageModelV3StreamPart>,
+            }),
+          };
+        }
+        return {
+          stream: simulateReadableStream({
+            chunks: [
+              { type: "stream-start", warnings: [] },
+              { type: "text-start", id: "t" },
+              { type: "text-delta", id: "t", delta: "done" },
+              { type: "text-end", id: "t" },
+              {
+                type: "finish",
+                finishReason: { unified: "stop", raw: "stop" },
+                usage: {
+                  inputTokens: {
+                    total: 60,
+                    noCache: 60,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                  },
+                  outputTokens: { total: 6, text: 6, reasoning: undefined },
+                },
+              },
+            ] as unknown as Array<LanguageModelV3StreamPart>,
+          }),
+        };
+      },
+      doGenerate: async () => ({
+        content: [{ type: "text", text: '{"q":"fixed"}' }],
+        finishReason: { unified: "stop", raw: "stop" },
+        warnings: [],
+        usage: {
+          inputTokens: { total: 80, noCache: 30, cacheRead: 50, cacheWrite: 0 },
+          outputTokens: { total: 8, text: 8, reasoning: undefined },
+        },
+        providerMetadata: { anthropic: { cacheReadInputTokens: 50 } },
+      }),
+    });
+
+    const events: Array<{
+      response: { id?: string };
+      providerMetadata?: Record<string, unknown>;
+      usage: {
+        inputTokens: number;
+        inputTokenDetails?: { cacheReadTokens?: number };
+      };
+    }> = [];
+    let callbackCompleted = false;
+
+    await drain(
+      streamResponse({
+        prompt: "hi",
+        model: MODEL,
+        silent: true,
+        onStepFinish: async (event) => {
+          events.push(event as never);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          callbackCompleted = true;
+        },
+        tools: {
+          probe: {
+            description: "test tool",
+            inputSchema: z.object({ q: z.string() }),
+            execute: async (input: { q: string }) => `echo:${input.q}`,
+          },
+        },
+        stopWhen: stepCountIs(2),
+      }),
+    );
+
+    expect(callbackCompleted).toBe(true);
+
+    const repairEvent = events.find((e) => e.response.id === "tool-repair");
+    expect(repairEvent).toBeDefined();
+    expect(repairEvent?.usage.inputTokens).toBe(80);
+    expect(repairEvent?.usage.inputTokenDetails?.cacheReadTokens).toBe(50);
+    expect(repairEvent?.providerMetadata).toEqual({
+      anthropic: { cacheReadInputTokens: 50 },
+    });
+  });
+});

--- a/src/core/observability/telemetry.test.ts
+++ b/src/core/observability/telemetry.test.ts
@@ -554,6 +554,9 @@ function generateAndStreamModel(): MockLanguageModelV3 {
 describe("auxiliary model lifecycle", () => {
   it("summarization awaits the wrapped onStepFinish and its synthetic event is handler-safe", async () => {
     mockState.model = generateAndStreamModel();
+    const history = [
+      { role: "user" as const, content: "history to summarize" },
+    ];
 
     const events: Array<{
       response: { id?: string; messages?: unknown[] };
@@ -569,7 +572,7 @@ describe("auxiliary model lifecycle", () => {
     let syntheticCompleted = false;
 
     const stream = createSummarizationStream(
-      [{ role: "user", content: "history to summarize" }],
+      history,
       {
         prompt: "resume",
         model: MODEL,
@@ -597,6 +600,7 @@ describe("auxiliary model lifecycle", () => {
     // Handler-safe: handlers spread response.messages; cache and provider
     // metadata survive the synthetic event.
     expect(Array.isArray(synthetic?.response.messages)).toBe(true);
+    expect(synthetic?.response.messages).toEqual(history);
     expect(synthetic?.usage.inputTokenDetails?.cacheReadTokens).toBe(400);
     expect(synthetic?.usage.inputTokenDetails?.cacheWriteTokens).toBe(7);
     expect(synthetic?.providerMetadata).toEqual({
@@ -630,7 +634,7 @@ describe("auxiliary model lifecycle", () => {
     await expect(drain(stream)).rejects.toThrow("persistence boom");
   });
 
-  it("tool repair awaits the wrapped onStepFinish and preserves provider metadata", async () => {
+  it("preserves a successful tool repair when its usage callback rejects", async () => {
     let call = 0;
     mockState.model = new MockLanguageModelV3({
       provider: "mock-anthropic",
@@ -710,6 +714,7 @@ describe("auxiliary model lifecycle", () => {
       };
     }> = [];
     let callbackCompleted = false;
+    const executeProbe = vi.fn();
 
     await drain(
       streamResponse({
@@ -720,12 +725,21 @@ describe("auxiliary model lifecycle", () => {
           events.push(event as never);
           await new Promise((resolve) => setTimeout(resolve, 5));
           callbackCompleted = true;
+          if (
+            (event as { response: { id?: string } }).response.id ===
+            "tool-repair"
+          ) {
+            throw new Error("repair persistence boom");
+          }
         },
         tools: {
           probe: {
             description: "test tool",
             inputSchema: z.object({ q: z.string() }),
-            execute: async (input: { q: string }) => `echo:${input.q}`,
+            execute: async (input: { q: string }) => {
+              executeProbe(input);
+              return `echo:${input.q}`;
+            },
           },
         },
         stopWhen: stepCountIs(2),
@@ -733,6 +747,7 @@ describe("auxiliary model lifecycle", () => {
     );
 
     expect(callbackCompleted).toBe(true);
+    expect(executeProbe).toHaveBeenCalledWith({ q: "fixed" });
 
     const repairEvent = events.find((e) => e.response.id === "tool-repair");
     expect(repairEvent).toBeDefined();


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Observability completeness · PR 1 of 5**  
> Start with #1029 and merge in table order. Each later PR is based on the step immediately above it.

| Step | Pull request | Focus |
|:---:|---|---|
| **1** | **[#1029](https://github.com/pensarai/apex/pull/1029)** | **Auxiliary model telemetry** · `Current` |
| 2 | [#1030](https://github.com/pensarai/apex/pull/1030) | Exit-path trace flushing |
| 3 | [#1032](https://github.com/pensarai/apex/pull/1032) | Model span completion |
| 4 | [#1033](https://github.com/pensarai/apex/pull/1033) | Root I/O and trace identity |
| 5 | [#1034](https://github.com/pensarai/apex/pull/1034) | OTel provider ownership |

## Summary

the auxiliary model calls (context summarization, tool repair) had three lifecycle defects that made their telemetry unreliable — and two of them are **production crash paths**:

1. **un-awaited callbacks** — both sites fired the wrapped `onStepFinish` (the agent's async persistence/usage handler) without awaiting it: any failure became an unhandled rejection, and the run continued with usage accounting silently lost. Both now `await` the callback, so failures surface through the stream instead of leaking.
2. **synthetic events missing `response.messages`** — the summarization event had **no `messages` field**, and handlers spread it (`[...initial, ...event.response.messages]`): every real summarization threw a TypeError inside the detached callback — usage accounting never worked. The event now carries `messages: []` (handler-safe, matching the tool-repair precedent).
3. **dropped cache + provider metadata** — both sites forced `providerMetadata: undefined` and discarded the result's `providerMetadata`/`inputTokenDetails`. Cache-read/write now flows through the synthetic events (`inputTokenDetails` + real provider metadata), keeping repair/summarization token usage attributable.

Plus a rejection swarm fix the new tests uncovered: `createSummarizationStream` derives **14 convenience promise fields** (`text`, `usage`, `response`, …) directly from `resumedStreamPromise` — on any summarization failure every one rejected unhandled. They now derive from a caught base: failures surface once through `fullStream` (the primary path), and the fields resolve `undefined`.

## Tests (3 new in `telemetry.test.ts`, fully deterministic — no fixed sleeps)

- summarization: the synthetic callback completes before the stream (awaited, not detached); the event is handler-safe (`messages` array), preserves `inputTokenDetails.cacheReadTokens=400`/`cacheWriteTokens=7` and the real provider metadata
- **a rejecting summarization callback surfaces through the resumed stream** — `drain` rejects with the error; previously this was an unhandled rejection with the stream continuing
- tool repair: awaited callback; the repair event preserves `inputTokens`, cache details, and provider metadata from the repair generation

## Verification

- `bun run test src/core/observability` → 64 passed, exit 0
- full suite: **2,610 passed, 0 unhandled rejections** (previously 14 unhandled rejections in this suite alone — every summarization failure path leaked)
- `bun run tsc`, biome clean (one pre-existing warning in untouched code)

## Behavior preserved

- existing JSONL, W&B, billing, agent behavior unchanged — the only semantic change is fail-loud instead of fail-silent in the auxiliary callbacks, which today never worked anyway (they threw on the missing `messages` field)
- non-goals honored: no session naming, no root spans, no retry redesign

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async persistence/usage callbacks on summarization and tool-repair paths; behavior shifts from fail-silent to fail-loud, but fixes prior broken accounting and rejection leaks.
> 
> **Overview**
> Fixes **context summarization** and **tool-input repair** so their token usage is recorded reliably without corrupting agent state or leaking unhandled rejections.
> 
> **Synthetic `onStepFinish` events** (`response.id` of `summarization` or `tool-repair`) are now **awaited** (failures propagate through the stream instead of detached rejections). They carry **`inputTokenDetails`**, **provider metadata**, and **handler-safe `response.messages`** (summarization uses the live message list; repair uses the in-flight container).
> 
> **OffensiveSecurityAgent** treats those events separately: it **does not** refresh `messages.json` from empty auxiliary payloads, but still **forwards usage** and writes **`usageOnly`** trace steps via `StepTraceWriter.recordStep`, which records tokens **without advancing** the cumulative message cursor.
> 
> **Summarization stream** convenience promises (`text`, `usage`, etc.) derive from a **caught** resumed-stream promise so a summarization failure surfaces once on `fullStream` instead of many parallel rejections. Tool-repair usage reporting is wrapped in **try/catch** so callback errors are logged without aborting repair.
> 
> Tests cover agent message snapshots, trace cursor behavior, and end-to-end auxiliary lifecycle in telemetry tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed6b42b6ac7738ea0563e4f23370a4b524e1b5d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->