### PR TITLE
fix(observability): flush traces on process exit

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -590,7 +590,9 @@ async function runUpgrade() {
   const result = await upgrade({ interactive: true });
   console.log(`\n${result.message}`);
 
-  process.exit(result.success ? 0 : 1);
+  // Set the code and unwind — the top-level finally flushes traces before
+  // the process exits; a direct exit would discard them.
+  process.exitCode = result.success ? 0 : 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -672,14 +674,19 @@ try {
         "TUI mode requires Bun. Install Bun (https://bun.sh) or use a standalone binary release for interactive mode.",
       );
       console.error("All other commands work with Node — run 'pensar --help'.");
-      process.exit(1);
+      // This branch owns the runtime lifecycle (the TUI never imported): the
+      // bounded shutdown flushes any queued spans before the process exits.
+      await observabilityRuntime.shutdown().catch(() => {});
+      process.exitCode = 1;
+    } else {
+      await import("./tui/index.tsx");
     }
-    await import("./tui/index.tsx");
   } else {
     console.error(`Error: Unknown command '${command}'`);
     console.error();
     console.error("Run 'pensar --help' for usage information");
-    process.exit(1);
+    // Unwind with the error code — the top-level finally flushes before exit.
+    process.exitCode = 1;
   }
 } catch (error) {
   if (exitAfterObservabilityShutdown !== null) {

--- a/src/tui/utils/command-flags.test.ts
+++ b/src/tui/utils/command-flags.test.ts
@@ -248,3 +248,22 @@ describe("parseWebFlags prompt/threatModel", () => {
     expect(flags.threatModel).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Exit routing: an invalid --header throws (surfacing through the TUI exit
+// handler: renderer teardown + bounded trace flush) instead of a direct
+// process.exit that would discard both.
+// ---------------------------------------------------------------------------
+
+describe("parseWebFlags exit routing", () => {
+  it("throws on an invalid --header instead of exiting the process", () => {
+    expect(() =>
+      parseWebFlags([
+        "--target",
+        "https://example.com",
+        "--header",
+        "bad header line",
+      ]),
+    ).toThrowError(/--header "bad header line" rejected/);
+  });
+});

--- a/src/tui/utils/command-flags.ts
+++ b/src/tui/utils/command-flags.ts
@@ -314,10 +314,12 @@ export function parseWebFlags(args: string[]): WebCommandFlags {
     for (const h of raw.header) {
       const parsed = parseHeaderLine(h);
       if (!parsed.ok) {
-        console.error(
+        // Throw instead of exiting: the TUI's exit handler still runs
+        // (renderer teardown + bounded trace flush) before the process
+        // exits — a direct exit would discard both.
+        throw new Error(
           `--header "${h}" rejected:\n${formatParseError(parsed.error)}`,
         );
-        process.exit(1);
       }
       flags.customHeaders[parsed.value.name] = parsed.value.value;
     }


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Observability completeness · PR 2 of 5**  
> Start with #1029 and merge in table order. Each later PR is based on the step immediately above it.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#1029](https://github.com/pensarai/apex/pull/1029) | Auxiliary model telemetry |
| **2** | **[#1030](https://github.com/pensarai/apex/pull/1030)** | **Exit-path trace flushing** · `Current` |
| 3 | [#1032](https://github.com/pensarai/apex/pull/1032) | Model span completion |
| 4 | [#1033](https://github.com/pensarai/apex/pull/1033) | Root I/O and trace identity |
| 5 | [#1034](https://github.com/pensarai/apex/pull/1034) | OTel provider ownership |

## Summary

the remaining direct `process.exit()` calls in traced paths now unwind through the observability shutdown instead of discarding queued spans:

| Exit site | Before | After |
|---|---|---|
| `runUpgrade` completion | `process.exit(0\|1)` — no flush | `process.exitCode = …` → top-level `finally` flushes, process exits naturally |
| `PENSAR_NO_TUI` error | direct exit — TUI branch has **no exit handler**, runtime never shut down | inline bounded `runtime.shutdown()` then exit code |
| Unknown command | direct exit | exit code → `finally` flushes |
| `parseWebFlags` bad `--header` | `process.exit(1)` from inside the TUI — killed the renderer with no teardown and no flush | **throws** — the TUI's exit handler runs (renderer teardown, error report, bounded flush), exit code 1 preserved |

Also verified: **.env is already loaded before the runtime starts** on current canary (`loadEnv()` at cli.ts:33, runtime at :603) — the requirement was satisfied; the redundant per-command dotenv loads were already gone. The double-Ctrl+C path already routes through the installed exit handler (`onExit → exitWith(0) → bounded shutdown`).

## Design notes

- "Prefer returning an exit code and letting the top-level entrypoint unwind": the upgrade / unknown-command paths set `process.exitCode` and fall through — the `finally` block's bounded shutdown runs, and the process exits with the right code naturally. No extra exit plumbing.
- The `PENSAR_NO_TUI` branch is special: `args.length === 0` means **no exit handler was installed** (the TUI would own the lifecycle) — but the TUI never imports on that path, so the branch owns the runtime: it shuts down inline before unwinding.
- The early-validation exits inside `runPentest`/`runTargetedPentest`/model resolution (missing `--target`, bad headers-file, no provider key) are **pre-span** — nothing has traced yet, so they stay direct (also per the non-goal: not refactoring every CLI command). Pentest/targeted-pentest **completion** already flushes via the `finally`'s explicit exit call for those commands.
- `parseWebFlags` throwing means the error surfaces through the TUI's `uncaughtException` reporting — the message is preserved (`--header "…" rejected:`), with the `Uncaught exception:` prefix.

## Test

- new regression test: `parseWebFlags` **throws** on an invalid `--header` (instead of exiting) — pinned in `command-flags.test.ts`

## Validation

- `bun run test` (2,611 passed, 22 skipped, 0 unhandled)
- `bun run tsc`
- biome clean (pre-existing warnings in untouched code)

## Acceptance check

- pentest / targeted-pentest completion flushes before exit ✓ (existing finally)
- double Ctrl+C flushes ✓ (existing exit-handler routing)
- fatal/signal paths preserve exit codes ✓ (existing handlers; unchanged)
- no process exit occurs while an owned runtime can still flush ✓ (this PR closes the remaining gaps)
- embedded mode untouched ✓

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Exit-behavior change only; observability flush is the goal and pre-validation `process.exit` paths in headless CLI are unchanged.
> 
> **Overview**
> Replaces **immediate `process.exit()`** on several CLI/TUI paths with **`process.exitCode` and normal unwind** so the top-level `finally` can run **bounded observability shutdown** and flush queued OTLP spans instead of dropping them.
> 
> **CLI (`cli.ts`):** `runUpgrade`, unknown-command, and similar paths now set `process.exitCode` only. The **`PENSAR_NO_TUI`** branch (no TUI, no exit handler) explicitly calls **`observabilityRuntime.shutdown()`** before setting exit code 1, since the TUI never loads to own the runtime.
> 
> **TUI flag parsing (`command-flags.ts`):** Invalid `--header` values **throw** instead of calling `process.exit(1)`, so the TUI exit path can tear down the renderer and flush traces. A regression test asserts the throw message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 642735d882401e63033921556ad2241e6b2c118e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->