### PR TITLE
fix(observability): complete model spans before export

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -1859,3 +1859,56 @@ describe("OffensiveSecurityAgent.consume() streamIdFactory", () => {
     expect(deltaEmit?.messageId).not.toBe("msg-0");
   });
 });
+
+// ---------------------------------------------------------------------------
+// O3/PR3: in-stream error parts complete every span (agent + generation)
+// ---------------------------------------------------------------------------
+
+describe("error-part span completion", () => {
+  it("an error-part run exports the agent span with error status", async () => {
+    // Local in-memory harness (inlined per this file's rule).
+    const { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } =
+      require("@opentelemetry/sdk-trace-base") as typeof import("@opentelemetry/sdk-trace-base");
+    const { AsyncLocalStorageContextManager } =
+      require("@opentelemetry/context-async-hooks") as typeof import("@opentelemetry/context-async-hooks");
+    const api =
+      require("@opentelemetry/api") as typeof import("@opentelemetry/api");
+    const exporter = new InMemorySpanExporter();
+    const provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    const contextManager = new AsyncLocalStorageContextManager();
+    contextManager.enable();
+    api.trace.setGlobalTracerProvider(provider);
+    api.context.setGlobalContextManager(contextManager);
+
+    try {
+      // The stream yields a chunk then an error — the raw generator mimics
+      // the AI SDK's error part (consume() sees it as a thrown error after
+      // the drain in the real pipeline).
+      async function* errorPartStream(): AsyncGenerator<
+        unknown,
+        void,
+        undefined
+      > {
+        yield { type: "text-delta", id: "t1", delta: "partial" };
+        throw new Error("model exploded mid-stream");
+      }
+      const agent = buildStubAgent({ fullStream: errorPartStream() });
+      await expect(agent.consume()).rejects.toThrow("model exploded");
+
+      const span = exporter
+        .getFinishedSpans()
+        .find((s) => s.name === "invoke_agent default");
+      expect(span).toBeDefined();
+      expect(span?.status.code).toBe(api.SpanStatusCode.ERROR);
+      expect(span?.attributes["error.type"]).toBe("Error");
+      expect(span?.ended).toBe(true);
+    } finally {
+      await provider.shutdown();
+      contextManager.disable();
+      api.trace.disable();
+      api.context.disable();
+    }
+  });
+});

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -574,7 +574,11 @@ function wrapStreamWithErrorHandler(
                 await Promise.resolve(originalStream.response).catch(() => {});
                 throw streamError;
               }
-            } catch (error) {
+            } catch (caughtError) {
+              // A tail-drain failure must not replace the provider error that
+              // put the wrapper into drain mode.
+              const error =
+                streamError !== undefined ? streamError : caughtError;
               // Error-part runs complete normally inside the SDK, so nothing
               // sets the root generation span failed — mark it here (the
               // SDK's own thrown-error marking is guarded against below).

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -20,7 +20,11 @@ import {
 } from "ai";
 import type { z } from "zod";
 import { createLogger } from "../logger/structured";
-import { createAiTelemetrySettings } from "../observability";
+import {
+  createAiTelemetrySettings,
+  createGenerationSpanTracker,
+  type GenerationSpanTracker,
+} from "../observability";
 import { scopedLogger } from "../util/lazyLogger";
 import {
   cacheBreakpointFor,
@@ -487,6 +491,7 @@ function wrapStreamWithErrorHandler(
   silent?: boolean,
   rateLimitRetryCount: number = 0,
   idleResumeCount: number = 0,
+  generationSpans?: GenerationSpanTracker,
 ): StreamTextResult<ToolSet, never> {
   // Create a lazy getter for fullStream that wraps it with error handling
   let wrappedStream: AsyncIterable<TextStreamPart<ToolSet>> | null = null;
@@ -505,6 +510,7 @@ function wrapStreamWithErrorHandler(
           const toolGate = createToolExecutionGate();
 
           wrappedStream = (async function* () {
+            let streamError: unknown;
             try {
               for await (const chunk of withIdleTimeout(
                 originalStream.fullStream,
@@ -540,13 +546,40 @@ function wrapStreamWithErrorHandler(
 
                 // Only stream-level errors are fatal; tool-level errors
                 // flow through so the UI renders them as failed tool results.
+                // Instead of throwing mid-stream, capture the error and drain
+                // the tail (finish-step/finish): the AI SDK's terminal
+                // lifecycle — root-span end included — only runs when the
+                // stream completes, and aborting the iteration leaks it.
                 if (chunk.type === "error") {
-                  throw (chunk as unknown as { error: unknown }).error;
+                  streamError = (chunk as unknown as { error: unknown }).error;
+                  // Mark the root generation span failed NOW: the SDK's
+                  // flush ends it mid-drain, before the loop exits — a
+                  // later mark is a no-op on an ended span.
+                  generationSpans?.markFailed(streamError);
+                  continue;
+                }
+                // Drain the post-error tail silently: the terminal parts
+                // must be consumed for the SDK's finalization, but consumers
+                // must not observe step-close-out after a fatal error.
+                if (streamError !== undefined) {
+                  continue;
                 }
 
                 yield chunk;
               }
+              if (streamError !== undefined) {
+                // The tail is consumed but the SDK's finalization
+                // (root-span end) settles with the response promise —
+                // await it so the error never overtakes the span lifecycle.
+                await Promise.resolve(originalStream.response).catch(() => {});
+                throw streamError;
+              }
             } catch (error) {
+              // Error-part runs complete normally inside the SDK, so nothing
+              // sets the root generation span failed — mark it here (the
+              // SDK's own thrown-error marking is guarded against below).
+              generationSpans?.markFailed(error);
+
               const errorMessage =
                 error instanceof Error ? error.message : String(error);
 
@@ -1251,7 +1284,9 @@ export function streamResponse(
   let rateLimitRetryCount = 0;
 
   try {
-    // Create the appropriate provider instance
+    // Create the appropriate provider instance. The span tracker captures
+    // the SDK's root generation span for error marking (see below).
+    const generationSpans = createGenerationSpanTracker();
     const response = streamText({
       model: providerModel,
       system: effectiveSystem,
@@ -1261,10 +1296,16 @@ export function streamResponse(
       tools,
       maxRetries: 3,
       providerOptions,
-      experimental_telemetry: createAiTelemetrySettings({
-        operation: "apex.agent.stream",
-        sessionId,
-      }),
+      // The forwarding tracer keeps a handle on the SDK's root generation
+      // span: error-part runs complete normally in the SDK, so nothing
+      // marks the span failed — the wrapper's catch does.
+      experimental_telemetry: {
+        ...createAiTelemetrySettings({
+          operation: "apex.agent.stream",
+          sessionId,
+        }),
+        tracer: generationSpans.tracer,
+      },
       // Pin actual emission to the same value `fitMessagesToContext`
       // reserved for output. Without this, the SDK applies provider
       // defaults that can exceed our budget — e.g. GPT-4o defaults to
@@ -1283,6 +1324,12 @@ export function streamResponse(
         return undefined;
       },
       onError: async ({ error }: { error: unknown }) => {
+        // Never throw here: the SDK calls this inside its stream pipeline,
+        // and a thrown callback kills the pipeline's terminal lifecycle —
+        // the root generation span never ends and nothing exports. Return
+        // normally instead; the error part continues downstream and the
+        // consumption wrapper converts it to a thrown error (after the
+        // tail drains), where the retry machinery takes over.
         const errorMessage =
           error instanceof Error ? error.message : String(error);
         if (
@@ -1293,11 +1340,7 @@ export function streamResponse(
           await new Promise((resolve) =>
             setTimeout(resolve, 1000 * rateLimitRetryCount),
           );
-          if (rateLimitRetryCount < 20) {
-            return;
-          }
         }
-        throw error;
       },
       onStepFinish,
       abortSignal,
@@ -1479,6 +1522,9 @@ export function streamResponse(
       opts,
       providerModel,
       silent,
+      0,
+      0,
+      generationSpans,
     );
   } catch (error) {
     // Check if the error is related to context length

--- a/src/core/api/targetedPentest.ts
+++ b/src/core/api/targetedPentest.ts
@@ -17,6 +17,8 @@ export type TargetedPentestHandle = {
   result: Promise<TargetedPentestResult>;
   /** Force-disconnect owned browser + await drain. Idempotent; never throws. */
   abortAndDrain: () => Promise<void>;
+  /** Resolves when the background drain finalizes (span teardown included). */
+  drained: Promise<void>;
 };
 
 /** Guard against malformed consume() shapes (don't crash on findings.length). */
@@ -63,6 +65,9 @@ export function startTargetedPentestAgent(
   return {
     result: agent.consume().then(normalizeResult),
     abortAndDrain: () => agent.abortAndDrain(),
+    // Settles when the background drain (stream teardown, span finalization)
+    // completes — read AFTER consume() started so it is the real promise.
+    drained: agent.drained,
   };
 }
 
@@ -70,5 +75,12 @@ export function startTargetedPentestAgent(
 export async function runTargetedPentestAgent(
   input: PentestAgentInput,
 ): Promise<TargetedPentestResult> {
-  return startTargetedPentestAgent(input).result;
+  const { result, drained } = startTargetedPentestAgent(input);
+  const findings = await result;
+  // Standalone completion boundary: the early structured-result return
+  // settles while the drain is still finalizing (span teardown, browser
+  // disconnect). Await it here so the process's trace flush happens after
+  // every span ended — the CLI's bounded shutdown follows this return.
+  await drained;
+  return findings;
 }

--- a/src/core/observability/index.ts
+++ b/src/core/observability/index.ts
@@ -44,9 +44,9 @@ export {
   type AiTelemetryOperation,
   type AiTelemetrySettings,
   type CreateAiTelemetryInput,
-  type GenerationSpanTracker,
   createAiTelemetrySettings,
   createGenerationSpanTracker,
+  type GenerationSpanTracker,
 } from "./telemetry";
 
 /**

--- a/src/core/observability/index.ts
+++ b/src/core/observability/index.ts
@@ -44,7 +44,9 @@ export {
   type AiTelemetryOperation,
   type AiTelemetrySettings,
   type CreateAiTelemetryInput,
+  type GenerationSpanTracker,
   createAiTelemetrySettings,
+  createGenerationSpanTracker,
 } from "./telemetry";
 
 /**

--- a/src/core/observability/telemetry.ts
+++ b/src/core/observability/telemetry.ts
@@ -76,6 +76,16 @@ export interface GenerationSpanTracker {
   markFailed(error: unknown): void;
 }
 
+function describeFailure(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error) || String(error);
+  } catch {
+    return String(error);
+  }
+}
+
 export function createGenerationSpanTracker(): GenerationSpanTracker {
   const inner = trace.getTracer("ai");
   let rootSpan: Span | null = null;
@@ -119,12 +129,9 @@ export function createGenerationSpanTracker(): GenerationSpanTracker {
       const span = rootSpan;
       if (!span || marked) return;
       marked = true;
-      if (error instanceof Error) {
-        span.recordException(error);
-        span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
-      } else {
-        span.setStatus({ code: SpanStatusCode.ERROR });
-      }
+      const message = describeFailure(error);
+      span.recordException(error instanceof Error ? error : message);
+      span.setStatus({ code: SpanStatusCode.ERROR, message });
     },
   };
 }

--- a/src/core/observability/telemetry.ts
+++ b/src/core/observability/telemetry.ts
@@ -1,3 +1,9 @@
+import {
+  type Span,
+  SpanStatusCode,
+  type Tracer,
+  trace,
+} from "@opentelemetry/api";
 import { shouldRecordAiPayloads } from "./index";
 
 /**
@@ -52,5 +58,73 @@ export function createAiTelemetrySettings(
     // operation name — a per-model functionId is unbounded cardinality.
     functionId: input.operation,
     ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Generation span tracker — the AI SDK completes error-part runs normally,
+// so its root generation span exports without error status. A forwarding
+// tracer captures that span's handle so the stream wrapper can mark it
+// failed. Not a span processor; the spans are the SDK's own.
+// ---------------------------------------------------------------------------
+
+export interface GenerationSpanTracker {
+  /** Forwarding tracer — pass as `experimental_telemetry.tracer`. */
+  readonly tracer: Tracer;
+  /** Record the failure on the captured root generation span (no-op if none
+   *  or already marked by the SDK's thrown-error handling). */
+  markFailed(error: unknown): void;
+}
+
+export function createGenerationSpanTracker(): GenerationSpanTracker {
+  const inner = trace.getTracer("ai");
+  let rootSpan: Span | null = null;
+  // The SDK creates its spans via startActiveSpan (recordSpan); capture the
+  // root generation span by wrapping the caller's callback.
+  const tracer = {
+    startSpan: (
+      name: string,
+      options?: Parameters<Tracer["startSpan"]>[1],
+      context?: Parameters<Tracer["startSpan"]>[2],
+    ) => {
+      const span = inner.startSpan(name, options, context);
+      if (name === "ai.streamText") rootSpan = span;
+      return span;
+    },
+    // The API resolves overloads by arguments.length — forward with the
+    // caller's exact arity and wrap the callback to capture the span.
+    startActiveSpan: (name: string, ...rest: unknown[]) => {
+      const callback = rest[rest.length - 1] as (
+        span: Span,
+        ...r: unknown[]
+      ) => unknown;
+      const capture = (span: Span, ...restArgs: unknown[]) => {
+        if (name === "ai.streamText") rootSpan = span;
+        return callback(span, ...restArgs);
+      };
+      const forwardArgs = [...rest.slice(0, -1), capture];
+      return (
+        inner.startActiveSpan as unknown as (
+          this: unknown,
+          n: string,
+          ...a: unknown[]
+        ) => unknown
+      ).call(inner, name, ...forwardArgs);
+    },
+  } as unknown as Tracer;
+  let marked = false;
+  return {
+    tracer,
+    markFailed(error: unknown) {
+      const span = rootSpan;
+      if (!span || marked) return;
+      marked = true;
+      if (error instanceof Error) {
+        span.recordException(error);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+      } else {
+        span.setStatus({ code: SpanStatusCode.ERROR });
+      }
+    },
   };
 }

--- a/src/core/observability/trace-contract.test.ts
+++ b/src/core/observability/trace-contract.test.ts
@@ -334,6 +334,67 @@ describe("existing trace contract: model spans", () => {
     );
   });
 
+  it("preserves an in-stream error when its tail drain times out", async () => {
+    vi.useFakeTimers();
+    const providerError = new Error("model exploded before stalled tail");
+    let calls = 0;
+    let tailWaitStartedResolve!: () => void;
+    const tailWaitStarted = new Promise<void>((resolve) => {
+      tailWaitStartedResolve = resolve;
+    });
+
+    try {
+      mockState.model = new MockLanguageModelV3({
+        provider: "mock-anthropic",
+        modelId: MODEL,
+        doStream: async () => {
+          calls += 1;
+          if (calls > 1) {
+            return {
+              stream: simulateReadableStream({
+                chunks:
+                  textStepChunks() as unknown as Array<LanguageModelV3StreamPart>,
+              }),
+            };
+          }
+
+          let emittedError = false;
+          return {
+            stream: new ReadableStream<LanguageModelV3StreamPart>({
+              pull(controller) {
+                if (!emittedError) {
+                  emittedError = true;
+                  controller.enqueue({ type: "stream-start", warnings: [] });
+                  controller.enqueue({ type: "error", error: providerError });
+                  return;
+                }
+                tailWaitStartedResolve();
+                return new Promise<void>(() => {});
+              },
+            }),
+          };
+        },
+      });
+
+      const consumption = drain(
+        streamResponse({
+          prompt: "hi",
+          messages: [{ role: "user", content: "hi" }],
+          model: MODEL,
+          silent: true,
+        }),
+      );
+      const rejection = expect(consumption).rejects.toBe(providerError);
+
+      await tailWaitStarted;
+      await vi.advanceTimersByTimeAsync(300_000);
+      await rejection;
+      expect(calls).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("records details for non-Error provider failures", () => {
     const tracker = createGenerationSpanTracker();
     tracker.tracer.startActiveSpan("ai.streamText", (span) => {

--- a/src/core/observability/trace-contract.test.ts
+++ b/src/core/observability/trace-contract.test.ts
@@ -291,11 +291,10 @@ describe("existing trace contract: model spans", () => {
     }
   });
 
-  it("an in-stream error part currently leaks the root span (known limitation)", async () => {
-    // Contract finding: when the model emits an error PART (instead of
-    // throwing), the ai.streamText root span (endWhenDone: false) is never
-    // ended — no spans export. Pinned as-is; Stack D's O3 root-run spans
-    // own their end() on every path instead.
+  it("an in-stream error part exports a complete tree with error status", async () => {
+    // The wrapper drains the post-error tail (the SDK's terminal lifecycle
+    // only runs when the stream completes), awaits the terminal response,
+    // and marks the root generation span failed before propagating.
     mockState.model = new MockLanguageModelV3({
       provider: "mock-anthropic",
       modelId: MODEL,
@@ -309,12 +308,28 @@ describe("existing trace contract: model spans", () => {
       }),
     });
 
+    // The original provider error is preserved.
     await expect(
       drain(streamResponse({ prompt: "hi", model: MODEL, silent: true })),
     ).rejects.toThrow("model exploded");
 
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(otel.getFinishedSpans()).toHaveLength(0);
+    // Both generation spans export — deterministic, no sleeps — with the
+    // root marked error (the provider-call span completes normally in the
+    // SDK and stays unset).
+    const spans = otel.getFinishedSpans();
+    const streamText = requireSpan(spans, "ai.streamText");
+    const doStream = requireSpan(spans, "ai.streamText.doStream");
+    expect(streamText.status.code).toBe(SpanStatusCode.ERROR);
+    expect(
+      streamText.events.some(
+        (e) =>
+          e.name === "exception" &&
+          (e.attributes?.["exception.message"] as string) === "model exploded",
+      ),
+    ).toBe(true);
+    expect(doStream.spanContext().traceId).toBe(
+      streamText.spanContext().traceId,
+    );
   });
 });
 

--- a/src/core/observability/trace-contract.test.ts
+++ b/src/core/observability/trace-contract.test.ts
@@ -31,9 +31,11 @@ import type { OtelTestHarness } from "./testkit";
 
 // Imported AFTER vi.mock so streamResponse's closure picks up the stub.
 const { streamResponse } = await import("../ai");
-const { getApexTracer, withSubagentSessionBaggage } = await import(
-  "../observability"
-);
+const {
+  createGenerationSpanTracker,
+  getApexTracer,
+  withSubagentSessionBaggage,
+} = await import("../observability");
 const { parentOf, requireSpan, spansNamed, startOtelTestHarness } =
   await import("./testkit");
 
@@ -330,6 +332,31 @@ describe("existing trace contract: model spans", () => {
     expect(doStream.spanContext().traceId).toBe(
       streamText.spanContext().traceId,
     );
+  });
+
+  it("records details for non-Error provider failures", () => {
+    const tracker = createGenerationSpanTracker();
+    tracker.tracer.startActiveSpan("ai.streamText", (span) => {
+      tracker.markFailed({
+        name: "BedrockServiceError",
+        message: "throttled",
+      });
+      span.end();
+    });
+
+    const span = requireSpan(otel.getFinishedSpans(), "ai.streamText");
+    expect(span.status).toEqual({
+      code: SpanStatusCode.ERROR,
+      message: '{"name":"BedrockServiceError","message":"throttled"}',
+    });
+    expect(
+      span.events.some(
+        (event) =>
+          event.name === "exception" &&
+          event.attributes?.["exception.message"] ===
+            '{"name":"BedrockServiceError","message":"throttled"}',
+      ),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Observability completeness · PR 3 of 5**  
> Start with #1029 and merge in table order. Each later PR is based on the step immediately above it.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#1029](https://github.com/pensarai/apex/pull/1029) | Auxiliary model telemetry |
| 2 | [#1030](https://github.com/pensarai/apex/pull/1030) | Exit-path trace flushing |
| **3** | **[#1032](https://github.com/pensarai/apex/pull/1032)** | **Model span completion** · `Current` |
| 4 | [#1033](https://github.com/pensarai/apex/pull/1033) | Root I/O and trace identity |
| 5 | [#1034](https://github.com/pensarai/apex/pull/1034) | OTel provider ownership |

## Summary

failed, error-part, and early-result runs now export complete span trees. Three stacked root causes, found by bisecting the error-part path layer by layer:

1. **`onError` killed the SDK pipeline** (the deepest cause). `streamResponse`'s `onError` callback rethrew non-rate-limit errors — and the SDK invokes that callback *inside its stream pipeline*, so the throw aborted the pipeline mid-flight: the terminal flush never ran, the root generation span (`endWhenDone: false`) never ended, **nothing exported**. The callback now returns normally (keeping the rate-limit backoff); the error part continues downstream and the consumption wrapper converts it to a thrown error — where the existing retry machinery fires unchanged.
2. **The wrapper threw mid-stream instead of draining.** On an error part it threw immediately, aborting the iteration before the SDK's terminal lifecycle. Now it captures the error, **drains the post-error tail silently** (finish-step/finish consumed — consumers observe nothing after the fatal error, preserving the old contract), awaits the terminal `response` promise (which settles with the root span's end — pinned deterministic, no sleeps), and only then propagates the **original provider error**.
3. **Error status needed a span handle.** Error-part runs complete *normally* inside the SDK, so nothing marks the root generation span failed. A forwarding tracer (`createGenerationSpanTracker`, passed as `experimental_telemetry.tracer` — the SDK's own extension point, not a span processor) captures the SDK's root span and marks it at **error-part observation time** — the flush ends the span mid-drain, so any later mark is a no-op. Guarded against double-marking (the SDK already marks thrown-`doStream` failures).

Plus the early-result boundary:

- `startTargetedPentestAgent`'s handle now exposes `drained` (the agent's public drain promise — retained, not recreated), and `runTargetedPentestAgent` — the standalone CLI wrapper — **awaits the drain after the structured result resolves**. The early return behavior is unchanged (callers get the result promptly); the drain finalization (span teardown, browser disconnect) now completes before the CLI's bounded trace flush. Wedge protection is unchanged: signal handlers still bound the exit.

## The replaced contract test

The old test pinned the zero-spans behavior as a "known limitation" (from the O1 trace contract). It now asserts the **fixed** contract: both generation spans export deterministically, the root carries `SpanStatusCode.ERROR` + the exception event with the original message, same trace.

## Tests

- contract: error-part → complete tree, root span ERROR + exception, provider-call span same-trace (replaces the zero-spans pin)
- agent: an error-part run ends the `invoke_agent` span with ERROR status + `error.type` + ended — through the real `consume()` path
- existing 49 agent tests + full AI suite unchanged (retry/summarize/recovery machinery behavior preserved)

## Validation

- `bun run test` (2,612 passed, 22 skipped, 0 unhandled)
- `bun run tsc`
- biome clean

## Non-goals honored

Public result shape unchanged; early response capture retained; retry policy unchanged; no manual span recreation; no new indefinite waits (the drain await is a plain promise settle on the normal path; wedges remain covered by the existing bounded signal exits).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core AI streaming error handling and telemetry on every `streamResponse` call; behavior is heavily tested but mistakes could affect retries, error propagation, or trace accuracy.
> 
> **Overview**
> Failed model streams that emit an **error part** (instead of throwing immediately) now export **complete OpenTelemetry span trees** with the root generation span marked **ERROR**, instead of leaking unfinished spans or exporting nothing.
> 
> **`streamResponse`** stops rethrowing from the AI SDK **`onError`** callback (which aborted terminal stream finalization), **captures** in-stream errors, **silently drains** the post-error tail so the SDK can end spans, **awaits** the terminal `response` promise, then propagates the original provider error. A new **`createGenerationSpanTracker`** forwarding tracer marks the SDK’s **`ai.streamText`** root span failed when error-part runs complete “successfully” in the SDK.
> 
> **`startTargetedPentestAgent`** exposes **`drained`** on the handle; **`runTargetedPentestAgent`** awaits it after the structured result so CLI trace flush runs after span teardown. Contract and agent tests replace the old “zero spans” limitation with assertions for ERROR status and ended spans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2312a53bd74b61c09a11bce2d0c5b2ff4a95e3fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->