### PR TITLE
feat(observability): add root IO and consistent identity

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -1785,8 +1785,11 @@ describe("root agent-run spans", () => {
       expect(span).toBeDefined();
       const attrs = span?.attributes as Record<string, string>;
       expect(attrs["gen_ai.agent.name"]).toBe("recon-sub");
-      expect(attrs["gen_ai.conversation.id"]).toBe("ses_sub_1");
-      expect(attrs["pensar.session.id"]).toBe("ses_sub_1");
+      // PR4 identity contract: the shared session id is the conversation id;
+      // the subagent's own id is the separate execution id.
+      expect(attrs["gen_ai.conversation.id"]).toBe("ses_stub");
+      expect(attrs["pensar.session.id"]).toBe("ses_stub");
+      expect(attrs["pensar.agent.execution.id"]).toBe("ses_sub_1");
       expect(attrs["pensar.run.id"]).toBeUndefined();
       expect(attrs["pensar.agent.mode"]).toBeUndefined();
     } finally {
@@ -1909,6 +1912,140 @@ describe("error-part span completion", () => {
       contextManager.disable();
       api.trace.disable();
       api.context.disable();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR4: root IO + consistent trace identity
+// ---------------------------------------------------------------------------
+
+describe("trace identity and root IO", () => {
+  const textChunk = { type: "text-delta", id: "t1", delta: "hi" };
+  async function* oneStep(): AsyncGenerator<unknown, void, undefined> {
+    yield textChunk;
+  }
+
+  function setupOtel() {
+    const { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } =
+      require("@opentelemetry/sdk-trace-base") as typeof import("@opentelemetry/sdk-trace-base");
+    const { AsyncLocalStorageContextManager } =
+      require("@opentelemetry/context-async-hooks") as typeof import("@opentelemetry/context-async-hooks");
+    const api =
+      require("@opentelemetry/api") as typeof import("@opentelemetry/api");
+    const exporter = new InMemorySpanExporter();
+    const provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    const contextManager = new AsyncLocalStorageContextManager();
+    contextManager.enable();
+    api.trace.setGlobalTracerProvider(provider);
+    api.context.setGlobalContextManager(contextManager);
+    return {
+      spans: () => exporter.getFinishedSpans(),
+      async teardown() {
+        await provider.shutdown();
+        contextManager.disable();
+        api.trace.disable();
+        api.context.disable();
+      },
+    };
+  }
+
+  it("root spans mirror session.id and carry the run id", async () => {
+    const otel = setupOtel();
+    try {
+      const agent = buildStubAgent({ fullStream: oneStep() });
+      await agent.consume();
+
+      const span = otel.spans().find((s) => s.name === "invoke_agent default");
+      const attrs = span?.attributes as Record<string, string>;
+      expect(attrs["gen_ai.conversation.id"]).toBe("ses_stub");
+      expect(attrs["session.id"]).toBe("ses_stub");
+      expect(attrs["pensar.session.id"]).toBe("ses_stub");
+      expect(attrs["pensar.run.id"]).toMatch(/^run_/);
+      expect(attrs["pensar.agent.execution.id"]).toBeUndefined();
+    } finally {
+      await otel.teardown();
+    }
+  });
+
+  it("subagent spans carry their execution id, never as the conversation id", async () => {
+    const otel = setupOtel();
+    try {
+      const agent = buildStubAgent({
+        fullStream: oneStep(),
+        subagentId: "ses_exec_1",
+        subagentName: "recon-sub",
+      });
+      await agent.consume();
+
+      const span = otel
+        .spans()
+        .find((s) => s.name === "invoke_agent recon-sub");
+      const attrs = span?.attributes as Record<string, string>;
+      // Identity: the shared (root) session is the conversation/session id;
+      // the subagent's own id stays a separate execution attribute.
+      expect(attrs["gen_ai.conversation.id"]).toBe("ses_stub");
+      expect(attrs["session.id"]).toBe("ses_stub");
+      expect(attrs["pensar.agent.execution.id"]).toBe("ses_exec_1");
+      expect(attrs["pensar.run.id"]).toBeUndefined();
+    } finally {
+      await otel.teardown();
+    }
+  });
+
+  it("root span IO appears only under full payload capture", async () => {
+    process.env.AI_TRACE_RECORD_PAYLOADS = "true";
+    const otel = setupOtel();
+    try {
+      const agent = buildStubAgent({ fullStream: oneStep() });
+      Object.defineProperty(agent, "userPrompt", {
+        value: "pentest the acme api",
+      });
+      await agent.consume();
+
+      const span = otel.spans().find((s) => s.name === "invoke_agent default");
+      expect(span?.attributes["gen_ai.prompt"]).toBe("pentest the acme api");
+    } finally {
+      await otel.teardown();
+      process.env.AI_TRACE_RECORD_PAYLOADS = undefined;
+    }
+
+    // Default mode: metadata only — no prompt or result payload.
+    const otel2 = setupOtel();
+    try {
+      const agent = buildStubAgent({ fullStream: oneStep() });
+      Object.defineProperty(agent, "userPrompt", {
+        value: "pentest the acme api",
+      });
+      await agent.consume();
+      const span = otel2.spans().find((s) => s.name === "invoke_agent default");
+      expect(span?.attributes["gen_ai.prompt"]).toBeUndefined();
+      expect(span?.attributes["gen_ai.completion"]).toBeUndefined();
+    } finally {
+      await otel2.teardown();
+    }
+  });
+
+  it("failed runs record the failure as root output under full capture", async () => {
+    process.env.AI_TRACE_RECORD_PAYLOADS = "true";
+    const otel = setupOtel();
+    try {
+      async function* failing(): AsyncGenerator<unknown, void, undefined> {
+        yield textChunk;
+        throw new Error("final failure");
+      }
+      const agent = buildStubAgent({ fullStream: failing() });
+      await expect(agent.consume()).rejects.toThrow("final failure");
+
+      const span = otel.spans().find((s) => s.name === "invoke_agent default");
+      expect(String(span?.attributes["gen_ai.completion"])).toContain(
+        "Failure: final failure",
+      );
+    } finally {
+      await otel.teardown();
+      process.env.AI_TRACE_RECORD_PAYLOADS = undefined;
     }
   });
 });

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -2040,6 +2040,35 @@ describe("trace identity and root IO", () => {
     }
   });
 
+  it("records root IO for the primary Fast Strike run", async () => {
+    process.env.AI_TRACE_RECORD_PAYLOADS = "true";
+    const otel = setupOtel();
+    try {
+      const agent = buildStubAgent({
+        fullStream: oneStep(),
+        resolveResult: () => ({ summary: "strike complete" }),
+        subagentId: "fast-strike",
+        agentMode: "fast-strike",
+      });
+      Object.defineProperty(agent, "userPrompt", {
+        value: "strike the acme api",
+      });
+
+      await agent.consume();
+
+      const span = otel
+        .spans()
+        .find((candidate) => candidate.name === "invoke_agent fast-strike");
+      expect(span?.attributes["gen_ai.prompt"]).toBe("strike the acme api");
+      expect(String(span?.attributes["gen_ai.completion"])).toContain(
+        '"summary":"strike complete"',
+      );
+    } finally {
+      await otel.teardown();
+      process.env.AI_TRACE_RECORD_PAYLOADS = undefined;
+    }
+  });
+
   it("records the captured response tool result as root output", async () => {
     process.env.AI_TRACE_RECORD_PAYLOADS = "true";
     const otel = setupOtel();

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -240,6 +240,7 @@ function buildStubAgent(overrides: {
   latestMessages?: unknown[] | null;
   writeImpl?: (messagesPath: string, contents: string) => Promise<void>;
   responseCaptured?: Promise<unknown>;
+  responseToolResult?: unknown;
   subagentId?: string;
   subagentName?: string;
   agentMode?: "default" | "plan" | "fast-strike";
@@ -268,6 +269,9 @@ function buildStubAgent(overrides: {
   // Never resolves by default, so consume() settles via the drain path.
   Object.defineProperty(agent, "responseCaptured", {
     value: overrides.responseCaptured ?? new Promise(() => {}),
+  });
+  Object.defineProperty(agent, "_responseToolResult", {
+    value: overrides.responseToolResult,
   });
   // Stub bypasses the constructor, so provide a minimal session for busSessionId.
   Object.defineProperty(agent, "_session", {
@@ -2035,6 +2039,7 @@ describe("trace identity and root IO", () => {
       const agent = buildStubAgent({
         fullStream: oneStep(),
         responseCaptured: Promise.resolve({ summary: "scan complete" }),
+        responseToolResult: { summary: "scan complete" },
       });
       Object.defineProperty(agent, "_responseToolFired", { value: true });
 
@@ -2046,6 +2051,54 @@ describe("trace identity and root IO", () => {
         '"summary":"scan complete"',
       );
     } finally {
+      await otel.teardown();
+      process.env.AI_TRACE_RECORD_PAYLOADS = undefined;
+    }
+  });
+
+  it("does not wait on response resolution before ending a response-tool run", async () => {
+    process.env.AI_TRACE_RECORD_PAYLOADS = "true";
+    const otel = setupOtel();
+    let resolveCaptured!: (value: unknown) => void;
+    const responseCaptured = new Promise<unknown>((resolve) => {
+      resolveCaptured = resolve;
+    });
+    try {
+      const agent = buildStubAgent({
+        fullStream: oneStep(),
+        responseCaptured,
+        responseToolResult: { summary: "submitted" },
+      });
+      Object.defineProperty(agent, "_responseToolFired", { value: true });
+
+      const consume = agent.consume();
+      const drainRejection = Reflect.get(
+        agent,
+        "_drainRejection",
+      ) as Promise<never>;
+      void drainRejection.catch(() => {
+        resolveCaptured({ summary: "resolved" });
+      });
+
+      const result = await Promise.race([
+        consume,
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("response resolution stalled")),
+            1000,
+          ),
+        ),
+      ]);
+      await agent.drained;
+
+      expect(result).toEqual({ summary: "resolved" });
+      const span = otel.spans().find((s) => s.name === "invoke_agent default");
+      expect(span?.ended).toBe(true);
+      expect(String(span?.attributes["gen_ai.completion"])).toContain(
+        '"summary":"submitted"',
+      );
+    } finally {
+      resolveCaptured(undefined);
       await otel.teardown();
       process.env.AI_TRACE_RECORD_PAYLOADS = undefined;
     }

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -1646,7 +1646,7 @@ describe("root agent-run spans", () => {
     };
   }
 
-  it("one root span per top-level run, with full run attribution", async () => {
+  it("one root span per top-level run, with canonical identity", async () => {
     const otel = setupOtel();
     try {
       const agent = buildStubAgent({ fullStream: singleStepStream() });
@@ -1659,11 +1659,15 @@ describe("root agent-run spans", () => {
       expect(invokeSpans).toHaveLength(1);
       const attrs = invokeSpans[0]?.attributes as Record<string, string>;
       expect(attrs["gen_ai.operation.name"]).toBe("invoke_agent");
+      expect(attrs["gen_ai.agent.id"]).toBe("ses_stub");
       expect(attrs["gen_ai.agent.name"]).toBe("default");
       expect(attrs["gen_ai.conversation.id"]).toBe("ses_stub");
+      expect(attrs["session.id"]).toBe("ses_stub");
       expect(attrs["pensar.session.id"]).toBe("ses_stub");
+      expect(attrs["pensar.root_session.id"]).toBe("ses_stub");
       expect(attrs["pensar.agent.mode"]).toBe("default");
-      expect(attrs["pensar.run.id"]).toMatch(/^run_/);
+      expect(attrs["pensar.run.id"]).toBeUndefined();
+      expect(attrs["pensar.agent.execution.id"]).toBeUndefined();
     } finally {
       await otel.teardown();
     }
@@ -1773,7 +1777,7 @@ describe("root agent-run spans", () => {
     }
   });
 
-  it("subagent runs keep their span but carry no run id", async () => {
+  it("subagent runs keep current and root identity distinct", async () => {
     const otel = setupOtel();
     try {
       const agent = buildStubAgent({
@@ -1788,12 +1792,13 @@ describe("root agent-run spans", () => {
         .find((s) => s.name === "invoke_agent recon-sub");
       expect(span).toBeDefined();
       const attrs = span?.attributes as Record<string, string>;
+      expect(attrs["gen_ai.agent.id"]).toBe("ses_sub_1");
       expect(attrs["gen_ai.agent.name"]).toBe("recon-sub");
-      // PR4 identity contract: the shared session id is the conversation id;
-      // the subagent's own id is the separate execution id.
       expect(attrs["gen_ai.conversation.id"]).toBe("ses_stub");
-      expect(attrs["pensar.session.id"]).toBe("ses_stub");
-      expect(attrs["pensar.agent.execution.id"]).toBe("ses_sub_1");
+      expect(attrs["session.id"]).toBe("ses_stub");
+      expect(attrs["pensar.session.id"]).toBe("ses_sub_1");
+      expect(attrs["pensar.root_session.id"]).toBe("ses_stub");
+      expect(attrs["pensar.agent.execution.id"]).toBeUndefined();
       expect(attrs["pensar.run.id"]).toBeUndefined();
       expect(attrs["pensar.agent.mode"]).toBeUndefined();
     } finally {
@@ -1956,7 +1961,7 @@ describe("trace identity and root IO", () => {
     };
   }
 
-  it("root spans mirror session.id and carry the run id", async () => {
+  it("root spans carry canonical conversation and agent identity", async () => {
     const otel = setupOtel();
     try {
       const agent = buildStubAgent({ fullStream: oneStep() });
@@ -1964,17 +1969,19 @@ describe("trace identity and root IO", () => {
 
       const span = otel.spans().find((s) => s.name === "invoke_agent default");
       const attrs = span?.attributes as Record<string, string>;
+      expect(attrs["gen_ai.agent.id"]).toBe("ses_stub");
       expect(attrs["gen_ai.conversation.id"]).toBe("ses_stub");
       expect(attrs["session.id"]).toBe("ses_stub");
       expect(attrs["pensar.session.id"]).toBe("ses_stub");
-      expect(attrs["pensar.run.id"]).toMatch(/^run_/);
+      expect(attrs["pensar.root_session.id"]).toBe("ses_stub");
+      expect(attrs["pensar.run.id"]).toBeUndefined();
       expect(attrs["pensar.agent.execution.id"]).toBeUndefined();
     } finally {
       await otel.teardown();
     }
   });
 
-  it("subagent spans carry their execution id, never as the conversation id", async () => {
+  it("subagent spans separate agent identity from the root conversation", async () => {
     const otel = setupOtel();
     try {
       const agent = buildStubAgent({
@@ -1988,11 +1995,12 @@ describe("trace identity and root IO", () => {
         .spans()
         .find((s) => s.name === "invoke_agent recon-sub");
       const attrs = span?.attributes as Record<string, string>;
-      // Identity: the shared (root) session is the conversation/session id;
-      // the subagent's own id stays a separate execution attribute.
+      expect(attrs["gen_ai.agent.id"]).toBe("ses_exec_1");
       expect(attrs["gen_ai.conversation.id"]).toBe("ses_stub");
       expect(attrs["session.id"]).toBe("ses_stub");
-      expect(attrs["pensar.agent.execution.id"]).toBe("ses_exec_1");
+      expect(attrs["pensar.session.id"]).toBe("ses_exec_1");
+      expect(attrs["pensar.root_session.id"]).toBe("ses_stub");
+      expect(attrs["pensar.agent.execution.id"]).toBeUndefined();
       expect(attrs["pensar.run.id"]).toBeUndefined();
     } finally {
       await otel.teardown();

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -2028,6 +2028,29 @@ describe("trace identity and root IO", () => {
     }
   });
 
+  it("records the captured response tool result as root output", async () => {
+    process.env.AI_TRACE_RECORD_PAYLOADS = "true";
+    const otel = setupOtel();
+    try {
+      const agent = buildStubAgent({
+        fullStream: oneStep(),
+        responseCaptured: Promise.resolve({ summary: "scan complete" }),
+      });
+      Object.defineProperty(agent, "_responseToolFired", { value: true });
+
+      await agent.consume();
+      await agent.drained;
+
+      const span = otel.spans().find((s) => s.name === "invoke_agent default");
+      expect(String(span?.attributes["gen_ai.completion"])).toContain(
+        '"summary":"scan complete"',
+      );
+    } finally {
+      await otel.teardown();
+      process.env.AI_TRACE_RECORD_PAYLOADS = undefined;
+    }
+  });
+
   it("failed runs record the failure as root output under full capture", async () => {
     process.env.AI_TRACE_RECORD_PAYLOADS = "true";
     const otel = setupOtel();

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -2141,6 +2141,42 @@ describe("trace identity and root IO", () => {
     }
   });
 
+  it("preserves captured output when the background drain later fails", async () => {
+    process.env.AI_TRACE_RECORD_PAYLOADS = "true";
+    const otel = setupOtel();
+    const captured = { summary: "scan complete" };
+    try {
+      async function* failingAfterResponse(): AsyncGenerator<
+        unknown,
+        void,
+        undefined
+      > {
+        yield textChunk;
+        throw new Error("late drain failure");
+      }
+      const agent = buildStubAgent({
+        fullStream: failingAfterResponse(),
+        responseCaptured: Promise.resolve(captured),
+        responseToolResult: captured,
+      });
+      Object.defineProperty(agent, "_responseToolFired", { value: true });
+
+      await expect(agent.consume()).resolves.toEqual(captured);
+      await agent.drained;
+
+      const span = otel.spans().find((s) => s.name === "invoke_agent default");
+      expect(String(span?.attributes["gen_ai.completion"])).toContain(
+        '"summary":"scan complete"',
+      );
+      expect(String(span?.attributes["gen_ai.completion"])).not.toContain(
+        "Failure: late drain failure",
+      );
+    } finally {
+      await otel.teardown();
+      process.env.AI_TRACE_RECORD_PAYLOADS = undefined;
+    }
+  });
+
   it("failed runs record the failure as root output under full capture", async () => {
     process.env.AI_TRACE_RECORD_PAYLOADS = "true";
     const otel = setupOtel();

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -983,7 +983,11 @@ export class OffensiveSecurityAgent<TResult = void> {
           if (!isSubagent) registerActiveRootSpan(span);
           // Root-level input/output for trace previews — ONLY under full
           // payload capture (sensitive: objectives can name internal hosts).
-          const recordRootIO = !isSubagent && shouldRecordAiPayloads();
+          // Fast Strike uses a synthetic subagent id for UI routing but is the
+          // primary run in that workflow.
+          const recordRootIO =
+            (!isSubagent || this.agentMode === "fast-strike") &&
+            shouldRecordAiPayloads();
           if (recordRootIO && this.userPrompt) {
             span.setAttribute("gen_ai.prompt", this.userPrompt);
           }

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -20,6 +20,7 @@ import { createLogger } from "../../logger/structured";
 import {
   getApexTracer,
   registerActiveRootSpan,
+  shouldRecordAiPayloads,
   unregisterActiveRootSpan,
   withSubagentSessionBaggage,
 } from "../../observability";
@@ -269,6 +270,8 @@ export class OffensiveSecurityAgent<TResult = void> {
   private readonly subagentName?: string;
   /** Operating mode (tools surface); used for run-span attribution. */
   private readonly agentMode: AgentMode;
+  /** Run id minted by consume() for the in-flight execution (root runs). */
+  private currentRunId?: string;
 
   /** The current open assistant message id (`msg_…`); minted on `start-step` in {@link consume}, `null` between steps. */
   private currentMessageId: string | null = null;
@@ -727,6 +730,11 @@ export class OffensiveSecurityAgent<TResult = void> {
         // to the session root for the root/operator agent.
         sessionPath: messagesDir,
         sessionId: this.busSessionId,
+        // Run/execution attribution for AI-span metadata — the run id is
+        // minted in consume() before the stream starts (the getter deferral
+        // above guarantees ordering); subagents add their execution id.
+        ...(this.currentRunId ? { runId: this.currentRunId } : {}),
+        ...(this.subagentId ? { agentId: this.subagentId } : {}),
         onStepFinish: async (event) => {
           const auxiliaryModelEvent =
             event.response.id === "summarization" ||
@@ -958,15 +966,22 @@ export class OffensiveSecurityAgent<TResult = void> {
       ? (this.subagentName ?? sid ?? "subagent")
       : this.agentMode;
     const runId = isSubagent ? undefined : newRunId();
+    this.currentRunId = runId;
+    // One stable conversation/session id for the whole trace: every agent in
+    // the run shares the session object (`_session.id` = the root session),
+    // while a subagent's own id is its EXECUTION id — never the conversation
+    // id (busSessionId is the routing id, which for subagents IS their own).
+    const traceSessionId = this._session.id;
     const runSpanAttributes: Record<string, string> = {
       "gen_ai.operation.name": "invoke_agent",
       "gen_ai.agent.name": spanLabel,
-      "gen_ai.conversation.id": this.busSessionId,
-      "pensar.session.id": this.busSessionId,
+      "gen_ai.conversation.id": traceSessionId,
+      "session.id": traceSessionId,
+      "pensar.session.id": traceSessionId,
       ...(isSubagent
-        ? {}
+        ? { "pensar.agent.execution.id": sid as string }
         : {
-            "pensar.run.id": runId,
+            "pensar.run.id": runId as string,
             "pensar.agent.mode": this.agentMode,
           }),
     };
@@ -979,8 +994,18 @@ export class OffensiveSecurityAgent<TResult = void> {
           // Root runs register so process-exit shutdown can end an
           // in-flight run's span before the final flush.
           if (!isSubagent) registerActiveRootSpan(span);
+          // Root-level input/output for trace previews — ONLY under full
+          // payload capture (sensitive: objectives can name internal hosts).
+          const recordRootIO = !isSubagent && shouldRecordAiPayloads();
+          if (recordRootIO && this.userPrompt) {
+            span.setAttribute("gen_ai.prompt", this.userPrompt);
+          }
           try {
-            return await runConsume();
+            const result = await runConsume();
+            if (recordRootIO && result !== undefined && result !== null) {
+              span.setAttribute("gen_ai.completion", safePreview(result));
+            }
+            return result;
           } catch (err) {
             // Record once, keep the cardinality low, preserve the original.
             span.recordException(err as Error);
@@ -989,6 +1014,12 @@ export class OffensiveSecurityAgent<TResult = void> {
               "error.type",
               err instanceof Error ? err.name : "Error",
             );
+            if (recordRootIO) {
+              span.setAttribute(
+                "gen_ai.completion",
+                `Failure: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
             throw err;
           } finally {
             unregisterActiveRootSpan(span);
@@ -1330,4 +1361,14 @@ function wrapToolsWithApprovalGate(
   }
 
   return wrapped;
+}
+
+/** Bounded, crash-safe JSON preview of a run result for span output. */
+function safePreview(value: unknown): string {
+  try {
+    const text = JSON.stringify(value);
+    return text === undefined ? String(value) : text.slice(0, 2000);
+  } catch {
+    return "[unserializable result]";
+  }
 }

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -247,6 +247,9 @@ export class OffensiveSecurityAgent<TResult = void> {
   /** Set synchronously when `response` fires, ahead of any async `resolveResult`, to distinguish a clean finish from an abort. */
   private _responseToolFired = false;
 
+  /** Raw structured result submitted to the response tool, retained for root-span output. */
+  private _responseToolResult: unknown;
+
   /** Resolves the instant `response` captures the result, so {@link consume} can return early and drain in the background. */
   private _resolveResponseCaptured!: (result: TResult) => void;
   private _rejectResponseCaptured!: (err: unknown) => void;
@@ -548,6 +551,7 @@ export class OffensiveSecurityAgent<TResult = void> {
           input.responseSchema,
           (result) => {
             this._responseToolFired = true;
+            this._responseToolResult = result;
             if (RESPONSE_DEBUG) {
               rlog.warn(
                 `[response-debug] response tool EXECUTED (captured) session=${this.busSessionId} ` +
@@ -1004,7 +1008,7 @@ export class OffensiveSecurityAgent<TResult = void> {
             const result = await runConsume();
             const completedResult =
               result === undefined && this._responseToolFired
-                ? await this.responseCaptured
+                ? this._responseToolResult
                 : result;
             if (
               recordRootIO &&
@@ -1016,7 +1020,7 @@ export class OffensiveSecurityAgent<TResult = void> {
                 safePreview(completedResult),
               );
             }
-            return completedResult;
+            return result;
           } catch (err) {
             // Record once, keep the cardinality low, preserve the original.
             span.recordException(err as Error);

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -1002,10 +1002,21 @@ export class OffensiveSecurityAgent<TResult = void> {
           }
           try {
             const result = await runConsume();
-            if (recordRootIO && result !== undefined && result !== null) {
-              span.setAttribute("gen_ai.completion", safePreview(result));
+            const completedResult =
+              result === undefined && this._responseToolFired
+                ? await this.responseCaptured
+                : result;
+            if (
+              recordRootIO &&
+              completedResult !== undefined &&
+              completedResult !== null
+            ) {
+              span.setAttribute(
+                "gen_ai.completion",
+                safePreview(completedResult),
+              );
             }
-            return result;
+            return completedResult;
           } catch (err) {
             // Record once, keep the cardinality low, preserve the original.
             span.recordException(err as Error);

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -15,7 +15,7 @@ import {
   resolveEffectiveHeaders,
   stripBrowserManagedHeaders,
 } from "../../http/targetHeaders";
-import { newMessageId, newPartId, newRunId } from "../../id/id";
+import { newMessageId, newPartId } from "../../id/id";
 import { createLogger } from "../../logger/structured";
 import {
   getApexTracer,
@@ -273,9 +273,6 @@ export class OffensiveSecurityAgent<TResult = void> {
   private readonly subagentName?: string;
   /** Operating mode (tools surface); used for run-span attribution. */
   private readonly agentMode: AgentMode;
-  /** Run id minted by consume() for the in-flight execution (root runs). */
-  private currentRunId?: string;
-
   /** The current open assistant message id (`msg_…`); minted on `start-step` in {@link consume}, `null` between steps. */
   private currentMessageId: string | null = null;
 
@@ -734,11 +731,6 @@ export class OffensiveSecurityAgent<TResult = void> {
         // to the session root for the root/operator agent.
         sessionPath: messagesDir,
         sessionId: this.busSessionId,
-        // Run/execution attribution for AI-span metadata — the run id is
-        // minted in consume() before the stream starts (the getter deferral
-        // above guarantees ordering); subagents add their execution id.
-        ...(this.currentRunId ? { runId: this.currentRunId } : {}),
-        ...(this.subagentId ? { agentId: this.subagentId } : {}),
         onStepFinish: async (event) => {
           const auxiliaryModelEvent =
             event.response.id === "summarization" ||
@@ -962,32 +954,23 @@ export class OffensiveSecurityAgent<TResult = void> {
       return undefined as TResult;
     };
 
-    // One invoke_agent span per execution: root runs get the full run
-    // attribution (stable run id, mode); subagent runs nest beneath the root
-    // span via the async context and carry their own execution-session id.
+    // One invoke_agent span per execution. The conversation/root id stays
+    // stable across the tree while each span identifies its current agent.
     const isSubagent = Boolean(sid);
     const spanLabel = isSubagent
       ? (this.subagentName ?? sid ?? "subagent")
       : this.agentMode;
-    const runId = isSubagent ? undefined : newRunId();
-    this.currentRunId = runId;
-    // One stable conversation/session id for the whole trace: every agent in
-    // the run shares the session object (`_session.id` = the root session),
-    // while a subagent's own id is its EXECUTION id — never the conversation
-    // id (busSessionId is the routing id, which for subagents IS their own).
-    const traceSessionId = this._session.id;
+    const rootSessionId = this._session.id;
+    const agentSessionId = this.busSessionId;
     const runSpanAttributes: Record<string, string> = {
       "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.id": agentSessionId,
       "gen_ai.agent.name": spanLabel,
-      "gen_ai.conversation.id": traceSessionId,
-      "session.id": traceSessionId,
-      "pensar.session.id": traceSessionId,
-      ...(isSubagent
-        ? { "pensar.agent.execution.id": sid as string }
-        : {
-            "pensar.run.id": runId as string,
-            "pensar.agent.mode": this.agentMode,
-          }),
+      "gen_ai.conversation.id": rootSessionId,
+      "session.id": rootSessionId,
+      "pensar.session.id": agentSessionId,
+      "pensar.root_session.id": rootSessionId,
+      ...(!isSubagent ? { "pensar.agent.mode": this.agentMode } : {}),
     };
 
     const runInSpan = () =>

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -1019,7 +1019,9 @@ export class OffensiveSecurityAgent<TResult = void> {
             if (recordRootIO) {
               span.setAttribute(
                 "gen_ai.completion",
-                `Failure: ${err instanceof Error ? err.message : String(err)}`,
+                this._responseToolFired
+                  ? safePreview(this._responseToolResult)
+                  : `Failure: ${err instanceof Error ? err.message : String(err)}`,
               );
             }
             throw err;

--- a/src/core/agents/offSecAgent/tools/documentFinding.ts
+++ b/src/core/agents/offSecAgent/tools/documentFinding.ts
@@ -387,6 +387,7 @@ CRITICAL RULES — READ BEFORE CALLING:
                 ctx.model!,
                 ctx.authConfig,
                 ctx.abortSignal,
+                ctx.session.id,
               );
               break;
             } catch (err: unknown) {

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.test.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.test.ts
@@ -19,6 +19,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 // ---------------------------------------------------------------------------
 
 const constructorCalls: Array<Record<string, unknown>> = [];
+const registryCalls: Array<{
+  path: string;
+  options: Record<string, unknown>;
+}> = [];
 
 vi.mock("../../specialized/pentest/agent", () => ({
   TargetedPentestAgent: class {
@@ -33,8 +37,16 @@ vi.mock("../../specialized/pentest/agent", () => ({
 
 vi.mock("../../../findings/registry", () => ({
   FindingsRegistry: {
-    fromDirectory: () => ({}),
+    fromDirectory: (path: string, options: Record<string, unknown>) => {
+      registryCalls.push({ path, options });
+      return {};
+    },
   },
+}));
+
+vi.mock("../../../workflows/pentest", () => ({
+  DEFAULT_CONCURRENCY: 10,
+  runPentestSwarm: async () => [],
 }));
 
 import type { AIModel } from "../../../ai";
@@ -42,6 +54,7 @@ import type { SessionInfo } from "../../../session";
 import { inProcessSubagentSpawner } from "../subagentSpawner";
 import { PlaywrightMcpSession } from "./playwrightMcp";
 import { spawnPentestAgent } from "./spawnPentestAgent";
+import { spawnPentestSwarm } from "./spawnPentestSwarm";
 import type { ToolContext } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -52,6 +65,7 @@ function buildCtx(overrides: Partial<ToolContext> = {}): ToolContext {
   return {
     subagentSpawner: inProcessSubagentSpawner,
     session: {
+      id: "ses_root",
       rootPath: "/tmp/apex-test",
       findingsPath: "/tmp/apex-test/findings",
     } as unknown as SessionInfo,
@@ -106,6 +120,7 @@ function makeEventBus(): {
 
 afterEach(() => {
   constructorCalls.length = 0;
+  registryCalls.length = 0;
   vi.restoreAllMocks();
 });
 
@@ -123,6 +138,44 @@ describe("spawn_pentest_agent — usage callbacks", () => {
 
     expect(constructorCalls[0]?.onStepFinish).toBe(onStepFinish);
     expect(constructorCalls[0]?.onCacheMetrics).toBe(onCacheMetrics);
+  });
+});
+
+describe("spawn tools — findings session attribution", () => {
+  it("attributes the single-agent fallback registry to the root session", async () => {
+    await runSpawn(buildCtx());
+
+    expect(registryCalls).toEqual([
+      {
+        path: "/tmp/apex-test/findings",
+        options: expect.objectContaining({ sessionId: "ses_root" }),
+      },
+    ]);
+  });
+
+  it("attributes the swarm fallback registry to the root session", async () => {
+    const tool = spawnPentestSwarm(buildCtx());
+
+    // biome-ignore lint/suspicious/noExplicitAny: ai-sdk tool execute receives an opaque ExecuteContext we don't need to narrow for this test.
+    await (tool as any).execute(
+      {
+        targets: [
+          {
+            target: "https://example.com/api",
+            objectives: ["Test"],
+          },
+        ],
+        toolCallDescription: "spawn swarm",
+      },
+      { toolCallId: "tc1", messages: [], abortSignal: undefined },
+    );
+
+    expect(registryCalls).toEqual([
+      {
+        path: "/tmp/apex-test/findings",
+        options: expect.objectContaining({ sessionId: "ses_root" }),
+      },
+    ]);
   });
 });
 

--- a/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestAgent.ts
@@ -133,6 +133,7 @@ Returns the worker's summary, objective results, and finding count — but NOT t
           model: ctx.model,
           authConfig: ctx.authConfig,
           abortSignal: ctx.abortSignal,
+          sessionId: ctx.session.id,
         });
 
       // Share the orchestrator's browser session with the worker instead of

--- a/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
+++ b/src/core/agents/offSecAgent/tools/spawnPentestSwarm.ts
@@ -82,6 +82,7 @@ Pass every target you want tested — the swarm handles concurrency automaticall
           model: ctx.model!,
           authConfig: ctx.authConfig,
           abortSignal: ctx.abortSignal,
+          sessionId: ctx.session.id,
         });
 
       const total = targets.length;

--- a/src/core/agents/specialized/cvssScorer/index.ts
+++ b/src/core/agents/specialized/cvssScorer/index.ts
@@ -371,6 +371,7 @@ export async function scoreFindingWithCVSS(
   model: AIModel,
   authConfig?: AIAuthConfig,
   abortSignal?: AbortSignal,
+  sessionId?: string,
 ): Promise<CVSSScorerResult> {
   const prompt = buildScoringPrompt(input);
 
@@ -382,6 +383,8 @@ export async function scoreFindingWithCVSS(
     system: CVSS_SCORER_SYSTEM_PROMPT,
     authConfig,
     abortSignal,
+    sessionId,
+    operation: "apex.finding.cvss",
   });
 
   // Calculate final score using the CVSS calculator

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -21,6 +21,7 @@ import {
 import type { z } from "zod";
 import { createLogger } from "../logger/structured";
 import {
+  type AiTelemetryOperation,
   createAiTelemetrySettings,
   createGenerationSpanTracker,
   type GenerationSpanTracker,
@@ -1087,6 +1088,10 @@ export interface StreamResponseOpts {
   sessionPath?: string;
   /** Session id (`ses_…`) of the agent making this call; stamped onto AI-span telemetry so traces are filterable by session. */
   sessionId?: string;
+  /** Agent-run id (`run_…`) — attribution metadata on AI spans. */
+  runId?: string;
+  /** Agent execution id (subagent `ses_…`) — attribution metadata. */
+  agentId?: string;
   /**
    * Internal: recovery-recursion depth. Bumped at each summarize → resume
    * boundary; throws `ContextLengthExhaustedError` past `MAX_RESTART_DEPTH`.
@@ -1307,6 +1312,8 @@ export function streamResponse(
         ...createAiTelemetrySettings({
           operation: "apex.agent.stream",
           sessionId,
+          ...(opts.runId ? { runId: opts.runId } : {}),
+          ...(opts.agentId ? { agentId: opts.agentId } : {}),
         }),
         tracer: generationSpans.tracer,
       },
@@ -1589,6 +1596,12 @@ export interface GenerateObjectOpts<T extends z.ZodType> {
   onTokenUsage?: (inputTokens: number, outputTokens: number) => void;
   /** Session id (`ses_…`) of the caller — stamped onto AI-span telemetry. */
   sessionId?: string;
+  /** Stable operation id; defaults to `apex.structured.generate`. */
+  operation?: AiTelemetryOperation;
+  /** Agent-run id (`run_…`) — attribution metadata. */
+  runId?: string;
+  /** Agent execution id (subagent `ses_…`) — attribution metadata. */
+  agentId?: string;
 }
 
 const MAX_OBJECT_RATE_LIMIT_RETRIES = 8;
@@ -1646,8 +1659,10 @@ export async function generateObjectResponse<T extends z.ZodType>(
         maxRetries: 0,
         abortSignal,
         experimental_telemetry: createAiTelemetrySettings({
-          operation: "apex.structured.generate",
+          operation: opts.operation ?? "apex.structured.generate",
           sessionId,
+          ...(opts.runId ? { runId: opts.runId } : {}),
+          ...(opts.agentId ? { agentId: opts.agentId } : {}),
         }),
       });
 

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -1088,10 +1088,6 @@ export interface StreamResponseOpts {
   sessionPath?: string;
   /** Session id (`ses_…`) of the agent making this call; stamped onto AI-span telemetry so traces are filterable by session. */
   sessionId?: string;
-  /** Agent-run id (`run_…`) — attribution metadata on AI spans. */
-  runId?: string;
-  /** Agent execution id (subagent `ses_…`) — attribution metadata. */
-  agentId?: string;
   /**
    * Internal: recovery-recursion depth. Bumped at each summarize → resume
    * boundary; throws `ContextLengthExhaustedError` past `MAX_RESTART_DEPTH`.
@@ -1312,8 +1308,6 @@ export function streamResponse(
         ...createAiTelemetrySettings({
           operation: "apex.agent.stream",
           sessionId,
-          ...(opts.runId ? { runId: opts.runId } : {}),
-          ...(opts.agentId ? { agentId: opts.agentId } : {}),
         }),
         tracer: generationSpans.tracer,
       },
@@ -1598,10 +1592,6 @@ export interface GenerateObjectOpts<T extends z.ZodType> {
   sessionId?: string;
   /** Stable operation id; defaults to `apex.structured.generate`. */
   operation?: AiTelemetryOperation;
-  /** Agent-run id (`run_…`) — attribution metadata. */
-  runId?: string;
-  /** Agent execution id (subagent `ses_…`) — attribution metadata. */
-  agentId?: string;
 }
 
 const MAX_OBJECT_RATE_LIMIT_RETRIES = 8;
@@ -1661,8 +1651,6 @@ export async function generateObjectResponse<T extends z.ZodType>(
         experimental_telemetry: createAiTelemetrySettings({
           operation: opts.operation ?? "apex.structured.generate",
           sessionId,
-          ...(opts.runId ? { runId: opts.runId } : {}),
-          ...(opts.agentId ? { agentId: opts.agentId } : {}),
         }),
       });
 

--- a/src/core/findings/registry.ts
+++ b/src/core/findings/registry.ts
@@ -326,6 +326,8 @@ export interface FindingsRegistryOptions {
   authConfig?: AIAuthConfig;
   /** Signal to cancel in-flight LLM calls (Tier 3 semantic dedup). */
   abortSignal?: AbortSignal;
+  /** Session id — stamps the registry's LLM calls with session attribution. */
+  sessionId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -353,6 +355,7 @@ export class FindingsRegistry {
   private model?: AIModel;
   private authConfig?: AIAuthConfig;
   private abortSignal?: AbortSignal;
+  private sessionId?: string;
 
   // Simple async mutex: a chain of promises. Each register() call
   // appends to the chain so concurrent callers serialise naturally.
@@ -362,6 +365,7 @@ export class FindingsRegistry {
     this.model = opts?.model;
     this.authConfig = opts?.authConfig;
     this.abortSignal = opts?.abortSignal;
+    this.sessionId = opts?.sessionId;
   }
 
   /** How many findings are tracked. */
@@ -580,6 +584,8 @@ export class FindingsRegistry {
       system: SEMANTIC_DEDUP_SYSTEM,
       authConfig: this.authConfig,
       abortSignal: this.abortSignal,
+      sessionId: this.sessionId,
+      operation: "apex.finding.deduplicate",
     });
 
     if (result.isDuplicate && result.matchedIndex != null) {
@@ -649,6 +655,8 @@ export class FindingsRegistry {
         system: ROOT_CAUSE_GROUPING_SYSTEM,
         authConfig: this.authConfig,
         abortSignal: this.abortSignal,
+        sessionId: this.sessionId,
+        operation: "apex.finding.root-cause",
       });
     } catch {
       log.warn("groupByRootCause: LLM error — skipping root-cause grouping");

--- a/src/core/id/id.ts
+++ b/src/core/id/id.ts
@@ -7,7 +7,6 @@ const prefixes = {
   permission: "per",
   user: "usr",
   part: "prt",
-  run: "run",
 } as const;
 
 export type IdentifierPrefix = keyof typeof prefixes;
@@ -67,8 +66,6 @@ export type SessionID = string & { readonly __brand: "SessionID" };
 export type MessageID = string & { readonly __brand: "MessageID" };
 /** A part identifier: `prt_<time><random>`. */
 export type PartID = string & { readonly __brand: "PartID" };
-/** An agent-run identifier: `run_<time><random>`. */
-export type RunID = string & { readonly __brand: "RunID" };
 
 /** Mint a fresh, time-descending session id. */
 export const newSessionId = (): SessionID => descending("session") as SessionID;
@@ -76,8 +73,6 @@ export const newSessionId = (): SessionID => descending("session") as SessionID;
 export const newMessageId = (): MessageID => descending("message") as MessageID;
 /** Mint a fresh, time-descending part id. */
 export const newPartId = (): PartID => descending("part") as PartID;
-/** Mint a fresh, time-descending agent-run id. */
-export const newRunId = (): RunID => descending("run") as RunID;
 
 /** Runtime guard: is this string a session id? */
 export const isSessionId = (s: string): s is SessionID =>

--- a/src/core/observability/shutdown.test.ts
+++ b/src/core/observability/shutdown.test.ts
@@ -386,7 +386,10 @@ describe("final export", () => {
         {
           attributes: {
             "gen_ai.operation.name": "invoke_agent",
-            "pensar.run.id": "run_final",
+            "gen_ai.agent.id": "ses_root",
+            "gen_ai.conversation.id": "ses_root",
+            "pensar.session.id": "ses_root",
+            "pensar.root_session.id": "ses_root",
           },
         },
         async (root) => {

--- a/src/core/observability/telemetry.test.ts
+++ b/src/core/observability/telemetry.test.ts
@@ -778,9 +778,7 @@ describe("identity metadata propagation", () => {
     );
 
     const span = requireSpan(otel.getFinishedSpans(), "ai.streamText");
-    expect(span.attributes["ai.telemetry.metadata.sessionId"]).toBe(
-      "ses_root",
-    );
+    expect(span.attributes["ai.telemetry.metadata.sessionId"]).toBe("ses_root");
     expect(span.attributes["ai.telemetry.metadata.runId"]).toBe("run_meta1");
     expect(span.attributes["ai.telemetry.metadata.agentId"]).toBe("ses_exec9");
     expect(span.attributes["ai.telemetry.functionId"]).toBe(
@@ -807,9 +805,7 @@ describe("identity metadata propagation", () => {
     expect(span.attributes["ai.telemetry.functionId"]).toBe(
       "apex.finding.cvss",
     );
-    expect(span.attributes["ai.telemetry.metadata.sessionId"]).toBe(
-      "ses_root",
-    );
+    expect(span.attributes["ai.telemetry.metadata.sessionId"]).toBe("ses_root");
     expect(span.attributes["ai.telemetry.metadata.runId"]).toBe("run_meta2");
     expect(span.attributes["ai.telemetry.metadata.agentId"]).toBe("ses_exec8");
   });

--- a/src/core/observability/telemetry.test.ts
+++ b/src/core/observability/telemetry.test.ts
@@ -203,18 +203,12 @@ describe("createAiTelemetrySettings", () => {
     expect(settings.recordOutputs).toBe(true);
   });
 
-  it("propagates session, run, and agent metadata when present", () => {
+  it("propagates session metadata when present", () => {
     const settings = createAiTelemetrySettings({
       operation: "apex.agent.stream",
       sessionId: "ses_1",
-      runId: "run_1",
-      agentId: "sub_1",
     });
-    expect(settings.metadata).toEqual({
-      sessionId: "ses_1",
-      runId: "run_1",
-      agentId: "sub_1",
-    });
+    expect(settings.metadata).toEqual({ sessionId: "ses_1" });
   });
 
   it("operation identifiers are a fixed low-cardinality set", () => {
@@ -760,11 +754,11 @@ describe("auxiliary model lifecycle", () => {
 });
 
 // ---------------------------------------------------------------------------
-// PR4: runId/agentId metadata propagation + structured operation ids
+// PR4: stable session metadata + structured operation ids
 // ---------------------------------------------------------------------------
 
 describe("identity metadata propagation", () => {
-  it("streamResponse stamps runId/agentId onto AI-span telemetry", async () => {
+  it("streamResponse emits session metadata without redundant identity fields", async () => {
     mockState.model = oneStepTextModel();
     await drain(
       streamResponse({
@@ -772,15 +766,13 @@ describe("identity metadata propagation", () => {
         model: MODEL,
         silent: true,
         sessionId: "ses_root",
-        runId: "run_meta1",
-        agentId: "ses_exec9",
       }),
     );
 
     const span = requireSpan(otel.getFinishedSpans(), "ai.streamText");
     expect(span.attributes["ai.telemetry.metadata.sessionId"]).toBe("ses_root");
-    expect(span.attributes["ai.telemetry.metadata.runId"]).toBe("run_meta1");
-    expect(span.attributes["ai.telemetry.metadata.agentId"]).toBe("ses_exec9");
+    expect(span.attributes["ai.telemetry.metadata.runId"]).toBeUndefined();
+    expect(span.attributes["ai.telemetry.metadata.agentId"]).toBeUndefined();
     expect(span.attributes["ai.telemetry.functionId"]).toBe(
       "apex.agent.stream",
     );
@@ -794,8 +786,6 @@ describe("identity metadata propagation", () => {
       prompt: "hi",
       sessionId: "ses_root",
       operation: "apex.finding.cvss",
-      runId: "run_meta2",
-      agentId: "ses_exec8",
     });
 
     const span = requireSpan(
@@ -806,7 +796,7 @@ describe("identity metadata propagation", () => {
       "apex.finding.cvss",
     );
     expect(span.attributes["ai.telemetry.metadata.sessionId"]).toBe("ses_root");
-    expect(span.attributes["ai.telemetry.metadata.runId"]).toBe("run_meta2");
-    expect(span.attributes["ai.telemetry.metadata.agentId"]).toBe("ses_exec8");
+    expect(span.attributes["ai.telemetry.metadata.runId"]).toBeUndefined();
+    expect(span.attributes["ai.telemetry.metadata.agentId"]).toBeUndefined();
   });
 });

--- a/src/core/observability/telemetry.test.ts
+++ b/src/core/observability/telemetry.test.ts
@@ -758,3 +758,59 @@ describe("auxiliary model lifecycle", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// PR4: runId/agentId metadata propagation + structured operation ids
+// ---------------------------------------------------------------------------
+
+describe("identity metadata propagation", () => {
+  it("streamResponse stamps runId/agentId onto AI-span telemetry", async () => {
+    mockState.model = oneStepTextModel();
+    await drain(
+      streamResponse({
+        prompt: "hi",
+        model: MODEL,
+        silent: true,
+        sessionId: "ses_root",
+        runId: "run_meta1",
+        agentId: "ses_exec9",
+      }),
+    );
+
+    const span = requireSpan(otel.getFinishedSpans(), "ai.streamText");
+    expect(span.attributes["ai.telemetry.metadata.sessionId"]).toBe(
+      "ses_root",
+    );
+    expect(span.attributes["ai.telemetry.metadata.runId"]).toBe("run_meta1");
+    expect(span.attributes["ai.telemetry.metadata.agentId"]).toBe("ses_exec9");
+    expect(span.attributes["ai.telemetry.functionId"]).toBe(
+      "apex.agent.stream",
+    );
+  });
+
+  it("generateObjectResponse honors caller operation ids and identity", async () => {
+    mockState.model = generateModel();
+    await generateObjectResponse({
+      model: MODEL,
+      schema: z.object({ result: z.string() }),
+      prompt: "hi",
+      sessionId: "ses_root",
+      operation: "apex.finding.cvss",
+      runId: "run_meta2",
+      agentId: "ses_exec8",
+    });
+
+    const span = requireSpan(
+      otel.getFinishedSpans(),
+      "ai.generateText.doGenerate",
+    );
+    expect(span.attributes["ai.telemetry.functionId"]).toBe(
+      "apex.finding.cvss",
+    );
+    expect(span.attributes["ai.telemetry.metadata.sessionId"]).toBe(
+      "ses_root",
+    );
+    expect(span.attributes["ai.telemetry.metadata.runId"]).toBe("run_meta2");
+    expect(span.attributes["ai.telemetry.metadata.agentId"]).toBe("ses_exec8");
+  });
+});

--- a/src/core/observability/telemetry.ts
+++ b/src/core/observability/telemetry.ts
@@ -24,7 +24,11 @@ export type AiTelemetryOperation =
   | "apex.agent.stream"
   | "apex.structured.generate"
   | "apex.context.summarize"
-  | "apex.tool.repair";
+  | "apex.tool.repair"
+  | "apex.finding.cvss"
+  | "apex.finding.deduplicate"
+  | "apex.finding.root-cause"
+  | "apex.session.name";
 
 export interface CreateAiTelemetryInput {
   operation: AiTelemetryOperation;

--- a/src/core/observability/telemetry.ts
+++ b/src/core/observability/telemetry.ts
@@ -33,8 +33,6 @@ export type AiTelemetryOperation =
 export interface CreateAiTelemetryInput {
   operation: AiTelemetryOperation;
   sessionId?: string;
-  runId?: string;
-  agentId?: string;
 }
 
 /**
@@ -52,8 +50,6 @@ export function createAiTelemetrySettings(
   const recordPayloads = shouldRecordAiPayloads();
   const metadata: Record<string, string> = {};
   if (input.sessionId) metadata.sessionId = input.sessionId;
-  if (input.runId) metadata.runId = input.runId;
-  if (input.agentId) metadata.agentId = input.agentId;
   return {
     isEnabled: true,
     recordInputs: recordPayloads,

--- a/src/core/observability/trace-contract.test.ts
+++ b/src/core/observability/trace-contract.test.ts
@@ -44,6 +44,7 @@ const { parentOf, requireSpan, spansNamed, startOtelTestHarness } =
 // ---------------------------------------------------------------------------
 
 const MODEL = "claude-haiku-4-5";
+const ROOT_SESSION_ID = "ses_root";
 
 const NESTED_USAGE = {
   inputTokens: { total: 1000, noCache: 100, cacheRead: 900, cacheWrite: 0 },
@@ -160,7 +161,12 @@ async function subagentInvoke(
       {
         attributes: {
           "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.id": subagentId,
           "gen_ai.agent.name": label,
+          "gen_ai.conversation.id": ROOT_SESSION_ID,
+          "session.id": ROOT_SESSION_ID,
+          "pensar.session.id": subagentId,
+          "pensar.root_session.id": ROOT_SESSION_ID,
         },
       },
       async (span) => {
@@ -571,10 +577,12 @@ describe("root agent-run tree", () => {
     // Root span with the agent's production attribute shape.
     const rootAttributes = {
       "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.id": ROOT_SESSION_ID,
       "gen_ai.agent.name": "default",
-      "gen_ai.conversation.id": "ses_root",
-      "pensar.session.id": "ses_root",
-      "pensar.run.id": "run_test123",
+      "gen_ai.conversation.id": ROOT_SESSION_ID,
+      "session.id": ROOT_SESSION_ID,
+      "pensar.session.id": ROOT_SESSION_ID,
+      "pensar.root_session.id": ROOT_SESSION_ID,
       "pensar.agent.mode": "default",
     };
 
@@ -621,9 +629,21 @@ describe("root agent-run tree", () => {
     expect(parentOf(spans, subInvoke)?.spanContext().spanId).toBe(
       toolSpan.spanContext().spanId,
     );
-    // Root attributes survive.
-    expect(root.attributes["pensar.run.id"]).toBe("run_test123");
+    // Root and current-agent identity survive without redundant run ids.
+    expect(root.attributes["gen_ai.agent.id"]).toBe(ROOT_SESSION_ID);
+    expect(root.attributes["gen_ai.conversation.id"]).toBe(ROOT_SESSION_ID);
+    expect(root.attributes["pensar.session.id"]).toBe(ROOT_SESSION_ID);
+    expect(root.attributes["pensar.root_session.id"]).toBe(ROOT_SESSION_ID);
+    expect(root.attributes["pensar.run.id"]).toBeUndefined();
     expect(root.attributes["pensar.agent.mode"]).toBe("default");
+    expect(subInvoke.attributes["gen_ai.agent.id"]).toBe("ses_tree_sub");
+    expect(subInvoke.attributes["gen_ai.conversation.id"]).toBe(
+      ROOT_SESSION_ID,
+    );
+    expect(subInvoke.attributes["pensar.session.id"]).toBe("ses_tree_sub");
+    expect(subInvoke.attributes["pensar.root_session.id"]).toBe(
+      ROOT_SESSION_ID,
+    );
   });
 
   it("concurrent subagents under one root keep their own parents and trace", async () => {
@@ -634,10 +654,12 @@ describe("root agent-run tree", () => {
       {
         attributes: {
           "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.id": ROOT_SESSION_ID,
           "gen_ai.agent.name": "default",
-          "gen_ai.conversation.id": "ses_root",
-          "pensar.session.id": "ses_root",
-          "pensar.run.id": "run_conc",
+          "gen_ai.conversation.id": ROOT_SESSION_ID,
+          "session.id": ROOT_SESSION_ID,
+          "pensar.session.id": ROOT_SESSION_ID,
+          "pensar.root_session.id": ROOT_SESSION_ID,
           "pensar.agent.mode": "default",
         },
       },

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -608,6 +608,7 @@ export async function create(input: CreateInputProps) {
       userMessage: input.userMessage,
       model: input.model,
       authConfig: input.authConfig,
+      sessionId: result.id,
     }).then((aiName) => {
       if (aiName) {
         result.name = aiName;

--- a/src/core/workflows/fastStrike.ts
+++ b/src/core/workflows/fastStrike.ts
@@ -102,7 +102,7 @@ export async function runFastStrike(
 
   const findingsRegistry = FindingsRegistry.fromDirectory(
     session.findingsPath,
-    { model, authConfig, abortSignal },
+    { model, authConfig, abortSignal, sessionId: session.id },
   );
 
   const promptParts: string[] = [`Target: ${target}`];

--- a/src/core/workflows/pentest.ts
+++ b/src/core/workflows/pentest.ts
@@ -581,6 +581,7 @@ export async function runPentestWorkflow(
         model,
         authConfig,
         abortSignal,
+        sessionId: session.id,
       },
     );
 

--- a/src/core/workflows/usage-forwarding.test.ts
+++ b/src/core/workflows/usage-forwarding.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
     groupByRootCause: vi.fn(async () => {}),
     getFindings: vi.fn(() => []),
   },
+  registryOptions: [] as Array<Record<string, unknown>>,
 }));
 
 vi.mock("../agents/specialized/pentest/agent", () => ({
@@ -61,12 +62,30 @@ vi.mock("../agents/offSecAgent", () => ({
 
 vi.mock("../findings/registry", () => ({
   FindingsRegistry: {
-    fromDirectory: () => mocks.registry,
+    fromDirectory: (_path: string, options: Record<string, unknown>) => {
+      mocks.registryOptions.push(options);
+      return mocks.registry;
+    },
   },
 }));
 
+vi.mock("../session/loader", () => ({
+  loadAttackSurfaceResults: () => ({
+    targets: [
+      {
+        target: "https://example.com/api",
+        objective: "Test the target",
+      },
+    ],
+  }),
+}));
+
 import { runFastStrike } from "./fastStrike";
-import { type PentestWorkflowInput, runPentestSwarm } from "./pentest";
+import {
+  type PentestWorkflowInput,
+  runPentestSwarm,
+  runPentestWorkflow,
+} from "./pentest";
 
 let rootPath: string;
 let session: SessionInfo;
@@ -89,6 +108,7 @@ beforeEach(() => {
 afterEach(() => {
   mocks.targetedInputs.length = 0;
   mocks.fastStrikeInputs.length = 0;
+  mocks.registryOptions.length = 0;
   vi.clearAllMocks();
   rmSync(rootPath, { recursive: true, force: true });
 });
@@ -165,5 +185,19 @@ describe("pentest usage callback forwarding", () => {
       cacheReadInputTokens: 8,
       cacheCreationInputTokens: 2,
     });
+  });
+});
+
+describe("pentest findings session attribution", () => {
+  it("attributes the workflow registry to the root session", async () => {
+    await runPentestWorkflow({
+      target: "https://example.com",
+      model: {} as PentestWorkflowInput["model"],
+      session,
+    });
+
+    expect(mocks.registryOptions).toContainEqual(
+      expect.objectContaining({ sessionId: session.id }),
+    );
   });
 });

--- a/src/util/name.ts
+++ b/src/util/name.ts
@@ -98,6 +98,7 @@ export async function generateSessionName(opts: {
   model: AIModel;
   authConfig?: AIAuthConfig;
   abortSignal?: AbortSignal;
+  sessionId?: string;
 }): Promise<string | null> {
   const { targets, userMessage, model, authConfig, abortSignal } = opts;
 
@@ -127,6 +128,8 @@ export async function generateSessionName(opts: {
       temperature: 0.7,
       authConfig,
       abortSignal,
+      sessionId: opts.sessionId,
+      operation: "apex.session.name",
     });
 
     if (!result?.name) return null;


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Observability completeness · PR 4 of 5**  
> Start with #1029 and merge in table order. Each later PR is based on the step immediately above it.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#1029](https://github.com/pensarai/apex/pull/1029) | Auxiliary model telemetry |
| 2 | [#1030](https://github.com/pensarai/apex/pull/1030) | Exit-path trace flushing |
| 3 | [#1032](https://github.com/pensarai/apex/pull/1032) | Model span completion |
| **4** | **[#1033](https://github.com/pensarai/apex/pull/1033)** | **Root I/O and trace identity** · `Current` |
| 5 | [#1034](https://github.com/pensarai/apex/pull/1034) | OTel provider ownership |

## Summary

Traces now group correctly in Langfuse, distinguish the current agent from the root conversation, and show meaningful root input/output.

**Canonical trace identity:**

- `gen_ai.conversation.id`, `session.id`, and `pensar.root_session.id` use the shared root session (`this._session.id`) across the full agent tree.
- `gen_ai.agent.id` and `pensar.session.id` use the current agent session (`busSessionId`), so subagents remain individually attributable without splitting the Langfuse conversation.
- Root spans retain `pensar.agent.mode`. Redundant run and execution attributes and AI telemetry metadata were removed because the trace and canonical agent/session fields already carry that identity.

**Root I/O (payload-gated — absent by default):**

- Under `AI_TRACE_RECORD_PAYLOADS=true`, the root span records the user objective as `gen_ai.prompt` and the final structured result as `gen_ai.completion` (a bounded 2,000-character JSON preview), or the failure message on error.
- Default mode stays metadata-only, pinned by tests in both modes.

**Structured-call operation IDs and session attribution:**

| Call | Operation ID | Session metadata |
|---|---|---|
| CVSS scoring (`scoreFindingWithCVSS`) | `apex.finding.cvss` | `ctx.session.id` at the `documentFinding` call site |
| Semantic deduplication | `apex.finding.deduplicate` | `FindingsRegistryOptions.sessionId` |
| Root-cause grouping | `apex.finding.root-cause` | `FindingsRegistryOptions.sessionId` |
| Session naming (`generateSessionName`) | `apex.session.name` | The newly created session ID |

`GenerateObjectOpts` gains an optional `operation`; the default remains `apex.structured.generate`. The operation union in `telemetry.ts` remains the closed, low-cardinality set.

## Tests

- Root and subagent spans enforce the root-conversation/current-agent identity split and reject the removed redundant fields.
- Root I/O appears only when full payload capture is enabled, including failure output.
- Streaming and structured AI spans retain stable session metadata and operation IDs without duplicate run/agent metadata.

## Validation

- `bun run test` (2,623 passed, 22 skipped, 0 unhandled)
- `bun run tsc`
- `bun run knip`
- `bun run format:check`
- `bun run build`

## Non-goals honored

No user identity, Langfuse prompt management, dataset/evaluation APIs, or cost attributes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observability attribute contracts and optional payload capture on root spans (sensitive when enabled); behavior is test-gated but affects how traces are correlated in production backends.
> 
> **Overview**
> **Canonical trace identity** for `invoke_agent` spans: conversation/root fields (`gen_ai.conversation.id`, `session.id`, `pensar.root_session.id`) stay on the root session while per-agent fields (`gen_ai.agent.id`, `pensar.session.id`) reflect the executing agent—so subagents stay in one Langfuse conversation. **`pensar.run.id`**, **`pensar.agent.execution.id`**, and **`newRunId`** are removed; AI telemetry metadata drops redundant **`runId`** / **`agentId`**.
> 
> **Root span I/O** is opt-in via **`AI_TRACE_RECORD_PAYLOADS=true`**: user objective as **`gen_ai.prompt`**, success output from the response tool or **`resolveResult`** as a bounded **`gen_ai.completion`**, or a failure string on error. Default traces remain metadata-only.
> 
> **Auxiliary structured LLM calls** get stable **`operation`** ids (`apex.finding.cvss`, `apex.finding.deduplicate`, `apex.finding.root-cause`, `apex.session.name`) and **`sessionId`** wired from **`FindingsRegistry`**, spawn/workflow tools, CVSS scoring, and session naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dda1c653d5d7f4116f99ac9e6d5e4ba7ca302e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->