### PR TITLE
fix(observability): enforce OTel provider ownership

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -20,6 +20,7 @@ Langfuse accepts OTLP/**HTTP** — not OTLP/gRPC. Configure:
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://cloud.langfuse.com/api/public/otel/v1/traces
 OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
 OTEL_EXPORTER_OTLP_TRACES_HEADERS=Authorization=Basic <base64 project-key:secret>,x-langfuse-ingestion-version=4
+OTEL_RESOURCE_ATTRIBUTES=langfuse.environment=production,langfuse.release=<git-sha>
 AI_TRACE_RECORD_PAYLOADS=true
 ```
 

--- a/src/core/observability/e2e-drain.ts
+++ b/src/core/observability/e2e-drain.ts
@@ -1,8 +1,0 @@
-/** Shared test helper: drain a stream result's fullStream. */
-export async function drain(stream: {
-  fullStream: AsyncIterable<unknown>;
-}): Promise<void> {
-  for await (const _part of stream.fullStream) {
-    // drain
-  }
-}

--- a/src/core/observability/e2e-drain.ts
+++ b/src/core/observability/e2e-drain.ts
@@ -1,0 +1,8 @@
+/** Shared test helper: drain a stream result's fullStream. */
+export async function drain(stream: {
+  fullStream: AsyncIterable<unknown>;
+}): Promise<void> {
+  for await (const _part of stream.fullStream) {
+    // drain
+  }
+}

--- a/src/core/observability/runtime.test.ts
+++ b/src/core/observability/runtime.test.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from "node:http";
-import { trace } from "@opentelemetry/api";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { context, trace } from "@opentelemetry/api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildResource,
   isOtelSdkDisabled,
@@ -339,6 +339,349 @@ describe("OTLP export", () => {
         [];
       expect(names).toContain("flush-on-shutdown");
     } finally {
+      await new Promise((resolve) => receiver.server.close(resolve));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR5: provider ownership — Apex registers its own SDK, never a host's
+// ---------------------------------------------------------------------------
+
+describe("provider ownership", () => {
+  it("a host-owned tracer keeps Apex embedded: no-op runtime, host untouched", async () => {
+    // The host (Console) registered its own SDK first.
+    const { startOtelTestHarness } = await import("./testkit");
+    const host = startOtelTestHarness();
+    try {
+      process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT =
+        "http://127.0.0.1:4318/v1/traces";
+      const runtime = startObservabilityRuntime();
+
+      // Apex did not take over — and its (no-op) shutdown leaves the host
+      // provider working: a host span still records and exports.
+      await runtime.shutdown();
+      const { getApexTracer } = await import("../observability");
+      const hostSpan = getApexTracer().startSpan("host-owned-work");
+      hostSpan.end();
+      expect(host.getFinishedSpans().map((s) => s.name)).toContain(
+        "host-owned-work",
+      );
+      // A later standalone-style start still sees the host's global.
+      expect(trace.getTracerProvider()).toBeDefined();
+    } finally {
+      await host.shutdown();
+    }
+  });
+
+  it("a host-owned context manager is reused but never disabled", async () => {
+    // Host owns ONLY the context manager; Apex's provider registration
+    // succeeds so the runtime goes active — but shutdown must not kill the
+    // host's context manager.
+    const { AsyncLocalStorageContextManager } = await import(
+      "@opentelemetry/context-async-hooks"
+    );
+    const hostContext = new AsyncLocalStorageContextManager();
+    hostContext.enable();
+    context.setGlobalContextManager(hostContext);
+    try {
+      process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT =
+        "http://127.0.0.1:4318/v1/traces";
+      const runtime = startObservabilityRuntime();
+      await runtime.forceFlush();
+      await runtime.shutdown();
+
+      // The host context manager survived Apex's shutdown: context still
+      // flows through it (a scoped run sees its own context back).
+      const marker = { probe: true };
+      const seen = await context.with(context.active(), async () => marker);
+      expect(seen).toBe(marker);
+    } finally {
+      hostContext.disable();
+      context.disable();
+      trace.disable();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR5: one real agent/model/tool/subagent flow through the local OTLP
+// receiver — the final export contract, not hand-built representative spans.
+// ---------------------------------------------------------------------------
+
+const mockState: { model: unknown } = { model: null };
+
+const STEP_ONE_CHUNKS = [
+  { type: "stream-start", warnings: [] },
+  { type: "tool-input-start", id: "c1", toolName: "probe" },
+  { type: "tool-input-delta", id: "c1", delta: '{"q":"hi"}' },
+  { type: "tool-input-end", id: "c1" },
+  {
+    type: "tool-call",
+    toolCallId: "c1",
+    toolName: "probe",
+    input: '{"q":"hi"}',
+  },
+  {
+    type: "finish",
+    finishReason: { unified: "tool-calls", raw: "tool_use" },
+    usage: {
+      inputTokens: { total: 1000, noCache: 100, cacheRead: 900, cacheWrite: 0 },
+      outputTokens: { total: 10, text: 10, reasoning: undefined },
+    },
+  },
+];
+
+const STEP_TWO_CHUNKS = [
+  { type: "stream-start", warnings: [] },
+  { type: "text-start", id: "t" },
+  { type: "text-delta", id: "t", delta: "final answer" },
+  { type: "text-end", id: "t" },
+  {
+    type: "finish",
+    finishReason: { unified: "stop", raw: "stop" },
+    usage: {
+      inputTokens: { total: 500, noCache: 50, cacheRead: 450, cacheWrite: 0 },
+      outputTokens: { total: 5, text: 5, reasoning: undefined },
+    },
+  },
+];
+
+describe("end-to-end export contract", () => {
+  vi.mock("../ai/utils", async () => {
+    const actual =
+      await vi.importActual<typeof import("../ai/utils")>("../ai/utils");
+    return {
+      ...actual,
+      getProviderModel: () => {
+        if (!mockState.model) throw new Error("mock model not set");
+        return mockState.model as ReturnType<
+          typeof import("../ai/utils").getProviderModel
+        >;
+      },
+    };
+  });
+
+  it("exports a complete, attributable run tree with payloads, tokens, and cache", async () => {
+    const { streamResponse } = await import("../ai");
+    const { MockLanguageModelV3 } = await import("ai/test");
+    const { simulateReadableStream, stepCountIs } = await import("ai");
+    const { getApexTracer } = await import("../observability");
+
+    const receiver = await startOtlpReceiver();
+    try {
+      process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = `http://127.0.0.1:${receiver.port}/v1/traces`;
+      process.env.AI_TRACE_RECORD_PAYLOADS = "true";
+      const runtime = startObservabilityRuntime();
+
+      // A deterministic two-step tool-calling model with cache + tokens.
+      let call = 0;
+      mockState.model = new MockLanguageModelV3({
+        provider: "mock-anthropic",
+        modelId: "claude-haiku-4-5",
+        doStream: async () => {
+          call += 1;
+          if (call === 1) {
+            return {
+              stream: simulateReadableStream({
+                chunks: STEP_ONE_CHUNKS as unknown as Array<
+                  import("@ai-sdk/provider").LanguageModelV3StreamPart
+                >,
+              }),
+            };
+          }
+          return {
+            stream: simulateReadableStream({
+              chunks: STEP_TWO_CHUNKS as unknown as Array<
+                import("@ai-sdk/provider").LanguageModelV3StreamPart
+              >,
+            }),
+          };
+        },
+      });
+
+      // Root run span (the agent's production shape) wrapping a real
+      // streamResponse with a tool whose execution nests a subagent run.
+      await getApexTracer().startActiveSpan(
+        "invoke_agent default",
+        {
+          attributes: {
+            "gen_ai.operation.name": "invoke_agent",
+            "gen_ai.agent.name": "default",
+            "gen_ai.conversation.id": "ses_e2e",
+            "session.id": "ses_e2e",
+            "pensar.session.id": "ses_e2e",
+            "pensar.run.id": "run_e2e",
+            "pensar.agent.mode": "default",
+            "gen_ai.prompt": "objective: test the target",
+          },
+        },
+        async (root) => {
+          try {
+            const probe = {
+              description: "spawns a subagent",
+              inputSchema: (await import("zod")).z.object({
+                q: (await import("zod")).z.string(),
+              }),
+              execute: async () => {
+                await getApexTracer().startActiveSpan(
+                  "invoke_agent recon-sub",
+                  {
+                    attributes: {
+                      "gen_ai.operation.name": "invoke_agent",
+                      "gen_ai.agent.name": "recon-sub",
+                      "gen_ai.conversation.id": "ses_e2e",
+                      "session.id": "ses_e2e",
+                      "pensar.session.id": "ses_e2e",
+                      "pensar.agent.execution.id": "ses_exec_e2e",
+                    },
+                  },
+                  async (sub) => {
+                    try {
+                      call += 1; // the subagent's own model call
+                      const { drain } = await import("./e2e-drain");
+                      await drain(
+                        streamResponse({
+                          prompt: "subagent task",
+                          model: "claude-haiku-4-5",
+                          silent: true,
+                          sessionId: "ses_e2e",
+                          agentId: "ses_exec_e2e",
+                        }),
+                      );
+                    } finally {
+                      sub.end();
+                    }
+                  },
+                );
+                return "subagent done";
+              },
+            };
+
+            const { drain } = await import("./e2e-drain");
+            await drain(
+              streamResponse({
+                prompt: "objective: test the target",
+                model: "claude-haiku-4-5",
+                silent: true,
+                sessionId: "ses_e2e",
+                runId: "run_e2e",
+                tools: { probe },
+                stopWhen: stepCountIs(2),
+              }),
+            );
+            root.setAttribute("gen_ai.completion", "final answer");
+          } finally {
+            root.end();
+          }
+        },
+      );
+
+      await runtime.shutdown();
+      const requests = await receiver.waitForRequests(1);
+      // The receiver stores full HTTP requests; the OTLP payload is the body.
+      const body = (requests[0] as { body: unknown }).body as {
+        resourceSpans?: Array<{
+          scopeSpans?: Array<{
+            spans?: Array<{
+              name?: string;
+              attributes?: Record<
+                string,
+                | { stringValue?: string }
+                | { intValue?: string }
+                | { doubleValue?: number }
+              >;
+              parentSpanId?: string;
+              spanId?: string;
+              traceId?: string;
+            }>;
+          }>;
+        }>;
+      };
+      const rawSpans =
+        body.resourceSpans?.flatMap((rs) =>
+          (rs.scopeSpans ?? []).flatMap((ss) => ss.spans ?? []),
+        ) ?? [];
+      // OTLP attributes arrive as [{key, value}] — index them per span.
+      const attrsOf = (
+        attributes?: Array<{ key?: string; value?: Record<string, unknown> }>,
+      ) =>
+        Object.fromEntries(
+          (attributes ?? []).map((a) => [a.key, a.value]),
+        ) as Record<string, Record<string, unknown>>;
+      const spans = rawSpans.map((sp) => ({
+        name: (sp as { name?: string }).name,
+        attributes: attrsOf(
+          (
+            sp as {
+              attributes?: Array<{
+                key?: string;
+                value?: Record<string, unknown>;
+              }>;
+            }
+          ).attributes,
+        ),
+        parentSpanId: (sp as { parentSpanId?: string }).parentSpanId,
+        spanId: (sp as { spanId?: string }).spanId,
+        traceId: (sp as { traceId?: string }).traceId,
+      }));
+      const byName = new Map(spans.map((sp) => [sp.name, sp]));
+      const attr = (
+        sp:
+          | { attributes?: Record<string, Record<string, unknown>> }
+          | undefined,
+        key: string,
+      ) => sp?.attributes?.[key]?.stringValue as string | undefined;
+      const numAttr = (
+        sp:
+          | { attributes?: Record<string, Record<string, unknown>> }
+          | undefined,
+        key: string,
+      ) => {
+        const a = sp?.attributes?.[key];
+        return (a?.intValue ?? a?.doubleValue) as string | number | undefined;
+      };
+
+      // Tree: root → model → provider → tool → subagent → its model.
+      const root = byName.get("invoke_agent default");
+      const model = byName.get("ai.streamText");
+      const tool = byName.get("ai.toolCall");
+      const sub = byName.get("invoke_agent recon-sub");
+      expect(root && model && tool && sub).toBeTruthy();
+      expect(model?.traceId).toBe(root?.traceId);
+      expect(tool?.traceId).toBe(root?.traceId);
+      expect(sub?.traceId).toBe(root?.traceId);
+      expect(sub?.parentSpanId).toBe(tool?.spanId);
+
+      // Identity: one session across every span, execution id separate.
+      for (const sp of spans) {
+        if (sp.name?.startsWith("invoke_agent")) {
+          expect(attr(sp, "gen_ai.conversation.id")).toBe("ses_e2e");
+        }
+      }
+      expect(attr(sub, "pensar.agent.execution.id")).toBe("ses_exec_e2e");
+
+      // Payload mode: prompts and tool payloads exported.
+      expect(String(attr(root, "gen_ai.prompt"))).toContain("objective");
+      expect(String(attr(root, "gen_ai.completion"))).toContain("final answer");
+      expect(String(attr(model, "ai.prompt") ?? "")).toContain("objective");
+
+      // Tokens + cache: inclusive input with cache reported separately —
+      // per-step gen_ai.usage.* on each provider-call span, cumulative
+      // ai.usage.* on the operation span. Both steps' spans exist.
+      const doStreamSpans = spans.filter(
+        (sp) => sp.name === "ai.streamText.doStream",
+      );
+      expect(doStreamSpans.length).toBeGreaterThanOrEqual(2);
+      // Export order is not creation order — identify step 1 by its usage.
+      expect(
+        doStreamSpans.some(
+          (sp) => numAttr(sp, "gen_ai.usage.input_tokens") === 1000,
+        ),
+      ).toBe(true);
+      expect(numAttr(model, "ai.usage.cachedInputTokens")).toBe(1350);
+    } finally {
+      delete process.env.AI_TRACE_RECORD_PAYLOADS;
       await new Promise((resolve) => receiver.server.close(resolve));
     }
   });

--- a/src/core/observability/runtime.test.ts
+++ b/src/core/observability/runtime.test.ts
@@ -534,11 +534,12 @@ describe("end-to-end export contract", () => {
         {
           attributes: {
             "gen_ai.operation.name": "invoke_agent",
+            "gen_ai.agent.id": "ses_e2e",
             "gen_ai.agent.name": "default",
             "gen_ai.conversation.id": "ses_e2e",
             "session.id": "ses_e2e",
             "pensar.session.id": "ses_e2e",
-            "pensar.run.id": "run_e2e",
+            "pensar.root_session.id": "ses_e2e",
             "pensar.agent.mode": "default",
             "gen_ai.prompt": "objective: test the target",
           },
@@ -556,11 +557,12 @@ describe("end-to-end export contract", () => {
                   {
                     attributes: {
                       "gen_ai.operation.name": "invoke_agent",
+                      "gen_ai.agent.id": "ses_exec_e2e",
                       "gen_ai.agent.name": "recon-sub",
                       "gen_ai.conversation.id": "ses_e2e",
                       "session.id": "ses_e2e",
-                      "pensar.session.id": "ses_e2e",
-                      "pensar.agent.execution.id": "ses_exec_e2e",
+                      "pensar.session.id": "ses_exec_e2e",
+                      "pensar.root_session.id": "ses_e2e",
                     },
                   },
                   async (sub) => {
@@ -573,7 +575,6 @@ describe("end-to-end export contract", () => {
                           model: "claude-haiku-4-5",
                           silent: true,
                           sessionId: "ses_e2e",
-                          agentId: "ses_exec_e2e",
                         }),
                       );
                     } finally {
@@ -592,7 +593,6 @@ describe("end-to-end export contract", () => {
                 model: "claude-haiku-4-5",
                 silent: true,
                 sessionId: "ses_e2e",
-                runId: "run_e2e",
                 tools: { probe },
                 stopWhen: stepCountIs(2),
               }),
@@ -680,13 +680,25 @@ describe("end-to-end export contract", () => {
       expect(sub?.traceId).toBe(root?.traceId);
       expect(sub?.parentSpanId).toBe(tool?.spanId);
 
-      // Identity: one session across every span, execution id separate.
+      // Identity: one root conversation across the tree, current agent kept
+      // separately on each invoke span.
       for (const sp of spans) {
         if (sp.name?.startsWith("invoke_agent")) {
           expect(attr(sp, "gen_ai.conversation.id")).toBe("ses_e2e");
+          expect(attr(sp, "session.id")).toBe("ses_e2e");
+          expect(attr(sp, "pensar.root_session.id")).toBe("ses_e2e");
+          expect(attr(sp, "pensar.run.id")).toBeUndefined();
+          expect(attr(sp, "pensar.agent.execution.id")).toBeUndefined();
         }
       }
-      expect(attr(sub, "pensar.agent.execution.id")).toBe("ses_exec_e2e");
+      expect(attr(root, "gen_ai.agent.id")).toBe("ses_e2e");
+      expect(attr(root, "pensar.session.id")).toBe("ses_e2e");
+      expect(attr(sub, "gen_ai.agent.id")).toBe("ses_exec_e2e");
+      expect(attr(sub, "pensar.session.id")).toBe("ses_exec_e2e");
+      for (const sp of spans.filter((span) => span.name === "ai.streamText")) {
+        expect(attr(sp, "ai.telemetry.metadata.runId")).toBeUndefined();
+        expect(attr(sp, "ai.telemetry.metadata.agentId")).toBeUndefined();
+      }
 
       // Payload mode: prompts and tool payloads exported.
       expect(String(attr(root, "gen_ai.prompt"))).toContain("objective");

--- a/src/core/observability/runtime.test.ts
+++ b/src/core/observability/runtime.test.ts
@@ -1,5 +1,5 @@
 import { createServer, type Server } from "node:http";
-import { context, trace } from "@opentelemetry/api";
+import { context, createContextKey, trace } from "@opentelemetry/api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildResource,
@@ -418,11 +418,14 @@ describe("provider ownership", () => {
       await runtime.forceFlush();
       await runtime.shutdown();
 
-      // The host context manager survived Apex's shutdown: context still
-      // flows through it (a scoped run sees its own context back).
-      const marker = { probe: true };
-      const seen = await context.with(context.active(), async () => marker);
-      expect(seen).toBe(marker);
+      // The host context manager survived Apex's shutdown: a value placed on
+      // a scoped context is visible through context.active() inside the run.
+      const probeKey = createContextKey("host-context-probe");
+      const probeContext = context.active().setValue(probeKey, "alive");
+      const seen = context.with(probeContext, () =>
+        context.active().getValue(probeKey),
+      );
+      expect(seen).toBe("alive");
     } finally {
       hostContext.disable();
       context.disable();

--- a/src/core/observability/runtime.test.ts
+++ b/src/core/observability/runtime.test.ts
@@ -409,6 +409,10 @@ describe("provider ownership", () => {
       "@opentelemetry/context-async-hooks"
     );
     const hostContext = new AsyncLocalStorageContextManager();
+    const disableSpy = vi.spyOn(
+      AsyncLocalStorageContextManager.prototype,
+      "disable",
+    );
     hostContext.enable();
     context.setGlobalContextManager(hostContext);
     try {
@@ -426,8 +430,11 @@ describe("provider ownership", () => {
         context.active().getValue(probeKey),
       );
       expect(seen).toBe("alive");
+      expect(disableSpy).toHaveBeenCalledOnce();
+      expect(disableSpy.mock.instances[0]).not.toBe(hostContext);
     } finally {
       hostContext.disable();
+      disableSpy.mockRestore();
       context.disable();
       trace.disable();
     }

--- a/src/core/observability/runtime.test.ts
+++ b/src/core/observability/runtime.test.ts
@@ -441,6 +441,14 @@ describe("provider ownership", () => {
 
 const mockState: { model: unknown } = { model: null };
 
+async function drain(stream: {
+  fullStream: AsyncIterable<unknown>;
+}): Promise<void> {
+  for await (const _part of stream.fullStream) {
+    // drain
+  }
+}
+
 const STEP_ONE_CHUNKS = [
   { type: "stream-start", warnings: [] },
   { type: "tool-input-start", id: "c1", toolName: "probe" },
@@ -571,7 +579,6 @@ describe("end-to-end export contract", () => {
                   async (sub) => {
                     try {
                       call += 1; // the subagent's own model call
-                      const { drain } = await import("./e2e-drain");
                       await drain(
                         streamResponse({
                           prompt: "subagent task",
@@ -589,7 +596,6 @@ describe("end-to-end export contract", () => {
               },
             };
 
-            const { drain } = await import("./e2e-drain");
             await drain(
               streamResponse({
                 prompt: "objective: test the target",

--- a/src/core/observability/runtime.test.ts
+++ b/src/core/observability/runtime.test.ts
@@ -349,6 +349,33 @@ describe("OTLP export", () => {
 // ---------------------------------------------------------------------------
 
 describe("provider ownership", () => {
+  it("does not register a context manager when the host owns the tracer", async () => {
+    const { AsyncLocalStorageContextManager } = await import(
+      "@opentelemetry/context-async-hooks"
+    );
+    const { BasicTracerProvider } = await import(
+      "@opentelemetry/sdk-trace-base"
+    );
+    const hostProvider = new BasicTracerProvider();
+    const hostContext = new AsyncLocalStorageContextManager();
+    expect(trace.setGlobalTracerProvider(hostProvider)).toBe(true);
+
+    try {
+      process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT =
+        "http://127.0.0.1:4318/v1/traces";
+      const runtime = startObservabilityRuntime();
+
+      hostContext.enable();
+      expect(context.setGlobalContextManager(hostContext)).toBe(true);
+      await runtime.shutdown();
+    } finally {
+      hostContext.disable();
+      context.disable();
+      trace.disable();
+      await hostProvider.shutdown();
+    }
+  });
+
   it("a host-owned tracer keeps Apex embedded: no-op runtime, host untouched", async () => {
     // The host (Console) registered its own SDK first.
     const { startOtelTestHarness } = await import("./testkit");

--- a/src/core/observability/runtime.ts
+++ b/src/core/observability/runtime.ts
@@ -191,12 +191,13 @@ export function startObservabilityRuntime(
   // owns the global. Apex must never disrupt host-owned state — only disable
   // globals it registered itself.
   const ownsTracerGlobal = trace.setGlobalTracerProvider(provider);
-  const ownsContextGlobal = context.setGlobalContextManager(contextManager);
 
   if (!ownsTracerGlobal) {
     // A host owns the tracer provider: our provider would never receive
     // spans. Clean up our own components, leave the host untouched, and do
-    // NOT mark an Apex runtime active (embedded mode).
+    // NOT mark an Apex runtime active (embedded mode). The context global
+    // was never touched — it is only registered after tracer ownership is
+    // confirmed.
     log.warn(
       "OTel tracer provider already registered by the host — Apex stays embedded and will not register its own",
     );
@@ -208,6 +209,7 @@ export function startObservabilityRuntime(
       );
     return NOOP_RUNTIME;
   }
+  const ownsContextGlobal = context.setGlobalContextManager(contextManager);
   if (!ownsContextGlobal) {
     log.warn(
       "OTel context manager already registered by the host — Apex reuses it and will not disable it",

--- a/src/core/observability/runtime.ts
+++ b/src/core/observability/runtime.ts
@@ -238,12 +238,12 @@ export function startObservabilityRuntime(
         };
         shutdownPromise = withTimeout(shutdownWork(), shutdownTimeoutMs)
           .then((result) => {
+            contextManager.disable();
             if (ownsContextGlobal) {
-              contextManager.disable();
               context.disable();
             }
-            // Only reset globals Apex owns (the tracer is ours by
-            // construction here — the context may belong to the host).
+            // Only reset globals Apex owns. The tracer is ours by
+            // construction here; the context global may belong to the host.
             trace.disable();
             return result;
           })

--- a/src/core/observability/runtime.ts
+++ b/src/core/observability/runtime.ts
@@ -19,6 +19,7 @@ import {
   type SpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import { version as apexVersion } from "../../../package.json";
+import { createLogger } from "../logger/structured";
 import { endAllActiveRootSpans } from "./active-root-spans";
 
 /**
@@ -66,6 +67,8 @@ function withTimeout(
     );
   });
 }
+
+const log = createLogger("observability");
 
 const NOOP_RUNTIME: ObservabilityRuntime = {
   async forceFlush() {},
@@ -184,8 +187,32 @@ export function startObservabilityRuntime(
   const contextManager = new AsyncLocalStorageContextManager();
   contextManager.enable();
 
-  trace.setGlobalTracerProvider(provider);
-  context.setGlobalContextManager(contextManager);
+  // Ownership check: registration fails (returns false) when a host already
+  // owns the global. Apex must never disrupt host-owned state — only disable
+  // globals it registered itself.
+  const ownsTracerGlobal = trace.setGlobalTracerProvider(provider);
+  const ownsContextGlobal = context.setGlobalContextManager(contextManager);
+
+  if (!ownsTracerGlobal) {
+    // A host owns the tracer provider: our provider would never receive
+    // spans. Clean up our own components, leave the host untouched, and do
+    // NOT mark an Apex runtime active (embedded mode).
+    log.warn(
+      "OTel tracer provider already registered by the host — Apex stays embedded and will not register its own",
+    );
+    contextManager.disable();
+    void provider
+      .shutdown()
+      .catch((error) =>
+        log.warn("Orphaned provider shutdown failed", { error: String(error) }),
+      );
+    return NOOP_RUNTIME;
+  }
+  if (!ownsContextGlobal) {
+    log.warn(
+      "OTel context manager already registered by the host — Apex reuses it and will not disable it",
+    );
+  }
 
   let shutdownPromise: Promise<ObservabilityShutdownResult> | null = null;
   const runtime: ObservabilityRuntime = {
@@ -195,22 +222,27 @@ export function startObservabilityRuntime(
     shutdown() {
       // Idempotent: every caller awaits the same bounded shutdown.
       if (!shutdownPromise) {
-        const shutdownWork = (async () => {
+        const shutdownWork = async () => {
           // End in-flight root runs first so their spans still export…
           endAllActiveRootSpans();
           // …then flush explicitly before processor/exporter teardown.
           try {
             await provider.forceFlush();
           } finally {
-            await provider.shutdown();
+            await provider.shutdown().catch((error) => {
+              log.warn("OTLP export/shutdown failed", { error: String(error) });
+            });
           }
-        })();
-        shutdownPromise = withTimeout(shutdownWork, shutdownTimeoutMs)
+        };
+        shutdownPromise = withTimeout(shutdownWork(), shutdownTimeoutMs)
           .then((result) => {
-            contextManager.disable();
-            // Reset globals so a later start (or the host's own SDK) begins clean.
+            if (ownsContextGlobal) {
+              contextManager.disable();
+              context.disable();
+            }
+            // Only reset globals Apex owns (the tracer is ours by
+            // construction here — the context may belong to the host).
             trace.disable();
-            context.disable();
             return result;
           })
           .finally(() => {


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Observability completeness · PR 5 of 5**  
> Start with #1029 and merge in table order. Each later PR is based on the step immediately above it.

| Step | Pull request | Focus |
|:---:|---|---|
| 1 | [#1029](https://github.com/pensarai/apex/pull/1029) | Auxiliary model telemetry |
| 2 | [#1030](https://github.com/pensarai/apex/pull/1030) | Exit-path trace flushing |
| 3 | [#1032](https://github.com/pensarai/apex/pull/1032) | Model span completion |
| 4 | [#1033](https://github.com/pensarai/apex/pull/1033) | Root I/O and trace identity |
| **5** | **[#1034](https://github.com/pensarai/apex/pull/1034)** | **OTel provider ownership** · `Current` |

## Summary

Apex can no longer disrupt a host-owned OTel SDK, and the final export contract is verified end to end.

**Ownership tracking.** `startObservabilityRuntime` checks the results of `trace.setGlobalTracerProvider` and `context.setGlobalContextManager`:

- **Host owns the tracer:** Apex shuts down its orphaned components, logs the fallback, returns the no-op runtime, and does not mark an Apex runtime active. It never touches the host's global registration.
- **Host owns only the context manager:** Apex remains active through its own provider, reuses the host context manager, and never calls `context.disable()` against host-owned state.
- **Apex owns both:** shutdown disables only the globals Apex registered.

**Failure surfacing.** Export, shutdown, and ownership-fallback failures use the structured `observability` logger. The bounded shutdown timeout is unchanged.

**Langfuse configuration** now documents environment and release resource attributes:

```text
OTEL_RESOURCE_ATTRIBUTES=langfuse.environment=production,langfuse.release=<git-sha>
```

**Final export contract.** A deterministic model/tool/subagent flow passes through the real `streamResponse` pipeline and OTLP HTTP exporter into a local receiver, then performs a real shutdown flush. The decoded OTLP JSON asserts:

- The tree: root → model → provider call(s) → tool → subagent → subagent model, all in one trace and with the subagent parented under the tool span.
- Identity: `gen_ai.conversation.id`, `session.id`, and `pensar.root_session.id` remain the root session across agent spans; `gen_ai.agent.id` and `pensar.session.id` identify the current root agent or subagent. Removed run/execution fields remain absent.
- Payload mode: root prompt/completion and model prompts export under `AI_TRACE_RECORD_PAYLOADS=true`.
- Tokens and cache: each provider-call span reports per-step `gen_ai.usage.input_tokens`, while the operation span reports cumulative `ai.usage.cachedInputTokens`.

## Tests

- Host-owned tracer → no-op Apex runtime while the host keeps recording.
- Host-owned context manager → reused and left enabled after Apex shutdown.
- End-to-end OTLP export contract for tree shape, canonical identity, payloads, tokens, and cache.

## Validation

- `bun run test` (2,627 passed, 22 skipped, 0 unhandled)
- `bun run tsc`
- `bun run knip`
- `bun run format:check`
- `bun run build`

## Stack exit criteria — all met

- Successful, failed, aborted, and early-result runs export complete traces ✅ (#1032)
- No directly traced exit bypasses flushing ✅ (#1030)
- Observability tests produce zero unhandled errors ✅ (#1029)
- Langfuse traces have root input/output and canonical root/current-agent identity ✅ (#1033)
- Auxiliary model calls are attributable ✅ (#1029)
- Standalone and embedded OTel ownership cannot conflict ✅ (this PR)
- No new telemetry framework or vendor coupling introduced ✅

## Non-goals honored

No real Langfuse credentials in CI, Langfuse SDK, cache-write presentation changes, or payload-size framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global OTel registration and shutdown behavior for embedded hosts; mistakes could break tracing in Console or standalone CLI, though behavior is covered by new ownership and e2e tests.
> 
> **Overview**
> **`startObservabilityRuntime`** now respects host-owned OpenTelemetry globals so embedded Apex (e.g. Console) cannot fight the host SDK. If **`trace.setGlobalTracerProvider`** fails because a host already registered a tracer, Apex tears down its own provider and context manager, logs a warning, and returns the **no-op** runtime without marking an active Apex runtime or touching the host’s globals. Context registration happens only after tracer ownership is confirmed. When the host already owns the context manager, Apex keeps its provider active but **reuses** the host context and skips **`context.disable()`** on shutdown; export/shutdown errors are logged via the structured **`observability`** logger.
> 
> **Langfuse** docs add **`OTEL_RESOURCE_ATTRIBUTES`** for **`langfuse.environment`** and **`langfuse.release`**.
> 
> Tests add **provider ownership** scenarios (host tracer → no-op Apex; host context survives Apex shutdown) and an **end-to-end OTLP** check through real **`streamResponse`** (tool + subagent) asserting trace tree, session/agent identity, payload mode, and token/cache attributes after shutdown flush.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 327c09c7813157ec141a03ad363c4771f1be4103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->