### PR TITLE
docs(agents): add Apex PR workflow skill

### DIFF
--- a/.agent-instructions/skills/pr/babysit.md
+++ b/.agent-instructions/skills/pr/babysit.md
@@ -1,0 +1,52 @@
+# Babysit an Apex PR
+
+Stay with the PR until its technical state is settled. Opening it, pushing a fix, or seeing queued checks is not done.
+
+## Terminal state
+
+All of these must hold on the **latest PR head SHA**:
+
+| Gate                    | Pass when                                                                                                                                                                                                                  |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Branch identity         | The remote branch ref and PR `head.sha` match. Native-stack metadata has finished catching up.                                                                                                                             |
+| Core CI                 | Current expected checks — `lint / lint`, `dead-code / dead-code`, `typecheck / typecheck`, `test / test`, and `build / build` — succeed. Honor any additional required check GitHub reports.                               |
+| Integration/docs checks | `console-typecheck` and repository-owned documentation checks succeed when posted or required. A genuinely skipped non-applicable job is acceptable; a missing required status is pending.                                 |
+| Bugbot                  | `Cursor Bugbot` has a conclusion when posted. `success` and `neutral` are terminal; `neutral` may contain findings that still require review.                                                                              |
+| Mergeability            | GitHub reports `MERGEABLE`. `mergeStateStatus: BLOCKED` is terminal only after technical checks are green and the only remaining gate is human/CODEOWNERS approval. `DIRTY`, `BEHIND`, and `UNKNOWN` are not ready states. |
+| Review                  | No unresolved actionable human or Bugbot threads remain.                                                                                                                                                                   |
+
+Pending, queued, or in-progress work means keep waiting. Green checks from a previous SHA do not count.
+
+## Poll with backoff
+
+```
+gh api repos/OWNER/REPO/pulls/<N> --jq '{head:.head.sha,base:.base.sha,mergeable,mergeable_state,draft}'
+gh api repos/OWNER/REPO/commits/<SHA>/check-runs --paginate
+gh api repos/OWNER/REPO/commits/<SHA>/status
+```
+
+If mergeability is `null` or stack metadata still shows an older SHA, wait and retry using tens-of-seconds then minute-scale intervals. Do not busy-loop, mutate the PR to provoke recomputation, or call stale checks current.
+
+## Red CI
+
+1. Identify the failing check, run, job, and first substantive failure.
+2. Fetch enough logs to establish the cause:
+
+   ```
+   gh api repos/OWNER/REPO/actions/runs/<run_id>/jobs --paginate
+   gh api repos/OWNER/REPO/actions/jobs/<job_id>/logs
+   ```
+
+3. Reproduce locally when possible. Fix the smallest root cause and add or update a regression test for behavioral defects.
+4. Re-run focused checks plus the relevant project-level commands from `create-and-update.md`.
+5. Commit and push only when authorized by the user's requested workflow, then restart babysitting on the new SHA.
+
+Do not use `--no-verify`, retry a deterministic failure without a code/config change, or cancel another contributor's workflows.
+
+## CI outage or stuck run
+
+First distinguish queued capacity, an active run, a cancelled/failed outage run, and a missing workflow trigger. If the user asks to re-kick CI and the prior run is terminal, rerun the existing workflow through the Actions API. Do not create empty commits merely to retrigger checks, and do not duplicate a run that is still active.
+
+## Done
+
+Report the PR URL, latest head SHA, required-check conclusions, Bugbot/review state, mergeability, and any remaining human approval. Human approval alone may remain; unresolved technical state may not.

--- a/.agent-instructions/skills/pr/comments-and-bugbot.md
+++ b/.agent-instructions/skills/pr/comments-and-bugbot.md
@@ -1,0 +1,70 @@
+# Review comments and Cursor Bugbot
+
+Use after a PR exists and human reviews, inline comments, or Bugbot findings appear. Fix findings that are real; do not resolve a thread that has not been addressed.
+
+## Fetch everything
+
+Paginate issue comments, reviews, and inline comments:
+
+```
+gh api repos/OWNER/REPO/issues/<N>/comments --paginate
+gh api repos/OWNER/REPO/pulls/<N>/reviews --paginate
+gh api repos/OWNER/REPO/pulls/<N>/comments --paginate
+```
+
+Fetch review threads and resolved state through GraphQL, paging until `hasNextPage` is false:
+
+```
+gh api graphql -f query='
+query($o:String!,$r:String!,$n:Int!,$after:String) {
+  repository(owner:$o,name:$r) {
+    pullRequest(number:$n) {
+      headRefOid
+      reviewThreads(first:100,after:$after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id isResolved isOutdated path
+          comments(first:50) { nodes { databaseId author { login } body createdAt } }
+        }
+      }
+    }
+  }
+}' -f o=OWNER -f r=REPO -F n=<N>
+```
+
+Also inspect the `Cursor Bugbot` check output for the current SHA. A successful check does not replace reading unresolved review threads.
+
+## Classify against current HEAD
+
+For every unresolved item:
+
+1. Re-read the cited code at the current head; stale findings may already be fixed.
+2. **Valid** — reproduce or prove the violated invariant, fix the smallest cause, and add/adapt a test that would have caught behavioral defects.
+3. **Already fixed** — reply with the fixing SHA and current code path; do not make a duplicate change.
+4. **False positive** — reply with concrete evidence showing why the invariant holds. Do not distort code to silence a bot.
+5. **Out of scope or product disagreement** — explain the boundary and leave the thread open unless the user explicitly waives it.
+
+When two comments conflict, pick the interpretation supported by newer code, tests, or product direction. Explain the conflict; do not average incompatible requests.
+
+## Reply and resolve
+
+Reply to an inline comment with its database ID:
+
+```
+gh api --method POST repos/OWNER/REPO/pulls/<N>/comments \
+  -f body='<finding, evidence, change, and SHA>' \
+  -F in_reply_to=<comment_id>
+```
+
+Resolve a review thread only after the fix is pushed or the evidence-backed false-positive reply is posted:
+
+```
+gh api graphql -f query='
+mutation($id:ID!) {
+  resolveReviewThread(input:{threadId:$id}) { thread { isResolved } }
+}' -f id=<THREAD_NODE_ID>
+```
+
+Do not bulk-resolve, dismiss a human changes-requested review, or post a vague "fixed" reply. Preserve `CURSOR_SUMMARY` and `codesmith:footer` regions when updating the body.
+
+After pushing, apply `babysit.md` to the new SHA and re-fetch threads because Bugbot or reviewers may add findings during the run.

--- a/.agent-instructions/skills/pr/conflicts-and-merge.md
+++ b/.agent-instructions/skills/pr/conflicts-and-merge.md
@@ -1,0 +1,46 @@
+# Resolve conflicts and merge Apex PRs
+
+Conflict resolution and merging are separate intents. A request to resolve conflicts and push authorizes updating the PR branch; it does **not** authorize merging the PR.
+
+## Resolve conflicts
+
+1. GET the live PR and record its number, head/base refs and SHAs, stack metadata, mergeability, and current checks.
+2. Use a clean isolated checkout of the PR head. Verify the checked-out commit equals the recorded remote head before editing.
+3. Read `stacks.md` when the PR belongs to a dependent or parallel series. Preserve that topology.
+4. Fetch the current head and base. If the remote head advanced since step 1, stop and incorporate the new work before continuing.
+5. Prefer a regular merge of the current base into the PR branch; this refreshes reviewed history without requiring a force-push:
+
+   ```
+   git fetch origin <head-ref> <base-ref>
+   git merge --no-edit origin/<base-ref>
+   ```
+
+   Rebase only when the user explicitly asks or established stack tooling requires it. Never use an unguarded force-push.
+
+6. If conflicts occur, list every unmerged path and read both sides plus relevant callers/tests. Reconcile behavior deliberately; never blanket-select `ours` or `theirs`, and never remove one side's feature just to clear markers.
+7. Verify `git ls-files -u` is empty, `git diff --check` passes, the resulting diff still represents the PR's intended delta, and no conflict markers remain in changed source.
+8. Run focused regression tests and the project-level checks appropriate to the touched files. `bun run test` is mandatory when code changed.
+9. Fetch once more and confirm the remote PR head is still the SHA from which the resolution started. If it changed, integrate it rather than overwriting it.
+10. Push normally. Then wait until the PR `head.sha` matches the pushed branch ref and GitHub reports known mergeability. Native stacks may need a few minutes to recalculate; do not PATCH the base to hurry them.
+
+Report the merge commit SHA, validation, push result, and fresh CI state. Do not call `BLOCKED` a conflict when GitHub reports `MERGEABLE` and is only waiting on checks or approval.
+
+## Merge only when explicitly authorized
+
+Immediately before merging:
+
+1. Re-fetch the PR and confirm its latest head SHA, intended base, stack position, approvals, required checks, Bugbot conclusion, unresolved threads, and mergeability.
+2. Re-run `babysit.md` if any technical state is stale or pending.
+3. For a dependent stack, merge bottom-to-top and verify each merge before refreshing the next PR. For a parallel series, merge one requested PR at a time and refresh remaining branches from the new `canary` before their merges.
+4. Use the repository's current accepted merge method. If the method is ambiguous or materially changes history, ask rather than guessing.
+5. Supply the inspected head SHA as a concurrency guard:
+
+   ```
+   gh api --method PUT repos/OWNER/REPO/pulls/<N>/merge \
+     -f sha='<latest-head-sha>' \
+     -f merge_method='<approved-method>'
+   ```
+
+6. Verify the API reports `merged: true`, record the merge commit, and confirm the target branch contains it before moving to another stack member.
+
+Do not bypass branch protection, enable auto-merge, delete branches, merge additional stack members, or retry a rejected merge unless the user authorized those actions.

--- a/.agent-instructions/skills/pr/create-and-update.md
+++ b/.agent-instructions/skills/pr/create-and-update.md
@@ -1,0 +1,91 @@
+# Create or update an Apex PR
+
+Use for ordinary feature, fix, refactor, test, documentation, or chore work. Ordinary Apex PRs target `canary`.
+
+## Preflight
+
+1. Resolve `OWNER/REPO` from `origin`; do not assume a fork or repository name.
+2. Inspect `git status`, the branch upstream, and the full commit/diff range against the intended base. If the checkout contains unrelated work, use a separate worktree or clone rather than stashing or moving it.
+3. For a new PR, fetch current `canary` and branch from it. For an existing PR, fetch and trust the live `base.ref`, `base.sha`, `head.ref`, and `head.sha` from GitHub.
+4. Before changing an existing branch, confirm its remote head still equals the SHA you inspected. Surface concurrent updates instead of overwriting them.
+5. Read the complete PR delta, not only the newest commit:
+
+   ```
+   git log --oneline origin/<base>..HEAD
+   git diff --stat origin/<base>...HEAD
+   git diff origin/<base>...HEAD
+   ```
+
+6. The branch and PR must contain one coherent change. Keep refactors separate from feature behavior unless the feature cannot land cleanly without the refactor.
+7. Run checks proportional to the diff. For code changes, the floor is `bun run test`, `bun run tsc`, `bun run lint`, and `bun run format:check`; add focused tests while iterating, `bun run knip` for dependency/export changes, and `bun run build` for CLI/build-path changes. Record exact results and any named pre-existing warnings.
+8. Never put credentials, customer data, local configuration, or generated runtime artifacts in the branch or PR body.
+
+## Issue link
+
+Search before claiming there is no issue:
+
+```
+gh api -X GET search/issues -f q='repo:OWNER/REPO is:issue <terms>'
+```
+
+Use `Fixes #N`, `Closes #N`, or `Resolves #N` only when the PR actually completes that issue. Otherwise say `No linked issue`; never invent a number.
+
+## Title and body
+
+Titles follow recent Apex conventional-commit style: `fix(observability): flush traces on exit`, `feat(models): add family search`, or `docs(agents): add PR workflow`.
+
+The repository template is the floor. Prefer this compact human-authored structure:
+
+```
+## Summary
+
+<what changed, why it was needed, and the resulting behavior in 1–3 short paragraphs>
+
+No linked issue
+
+## Changes
+
+- <reviewable outcome, not a file inventory>
+
+## Validation
+
+- `bun run test` — <result>
+- `bun run tsc` — <result>
+- Manual: <behavior verified, when applicable>
+```
+
+Omit **Changes** when the summary is sufficient. Validation must describe commands and behavior actually verified; do not mark planned work as completed. Add screenshots or terminal captures only when they materially help review and contain no sensitive data.
+
+For stacked work, prepend the exact stack block from `stacks.md`.
+
+## Create
+
+Push the branch with a regular push, then create the PR through the API:
+
+```
+git push -u origin HEAD
+gh api --method POST repos/OWNER/REPO/pulls \
+  -f title='<type(scope): imperative summary>' \
+  -f head='<branch>' \
+  -f base='canary' \
+  -f body='<markdown>' \
+  -F draft=false
+```
+
+Use a draft only when the user asks or the work is knowingly incomplete. Return the URL, then apply `babysit.md`.
+
+## Update
+
+GET the current PR before every PATCH:
+
+```
+gh api repos/OWNER/REPO/pulls/<N>
+gh api --method PATCH repos/OWNER/REPO/pulls/<N> -f title='…' -f body='…'
+```
+
+Splice only the intended human-authored section. Preserve these regions and their contents exactly:
+
+- `<!-- CURSOR_SUMMARY -->` through `<!-- /CURSOR_SUMMARY -->`
+- `<!-- codesmith:footer -->` through `<!-- /codesmith:footer -->`
+
+After patching, GET the PR again and verify the title, base, stack block, bot-region marker counts, and current-row emphasis. Push code changes normally; force-push only with explicit authorization and only with `--force-with-lease`. Then babysit the new SHA.

--- a/.agent-instructions/skills/pr/stacks.md
+++ b/.agent-instructions/skills/pr/stacks.md
@@ -1,0 +1,77 @@
+# Apex PR stacks
+
+Use for any group called a stack, series, chain, or set of parallel PRs. Branch topology is an invariant; formatting follows it rather than defining it.
+
+## Discover the topology
+
+For every PR, record `number`, `state`, `base.ref`, `base.sha`, `head.ref`, `head.sha`, and URL from the API. Also query native stack metadata when present:
+
+```
+gh api repos/OWNER/REPO/pulls/<N>
+gh api graphql -f query='
+query($o:String!,$r:String!,$n:Int!) {
+  repository(owner:$o,name:$r) {
+    pullRequest(number:$n) {
+      number baseRefName baseRefOid headRefName headRefOid
+      stack {
+        number baseRefName size
+        entries(first:100) {
+          nodes { position pullRequest { number state baseRefName baseRefOid headRefName headRefOid } }
+        }
+      }
+    }
+  }
+}' -f o=OWNER -f r=REPO -F n=<N>
+```
+
+Classify before editing:
+
+- **Dependent stack** — each PR is based on the preceding branch, or GitHub reports a native stack. Review and merge bottom-to-top.
+- **Parallel series** — every PR independently targets `canary`. They can be reviewed in parallel, but each branch must be refreshed against current `canary` before merge.
+- **Mixed or inconsistent** — the advertised order and live bases disagree. Stop and surface the exact mismatch; do not silently retarget branches.
+
+Do not convert a parallel series into a dependent stack, flatten a dependent stack, or PATCH native-stack bases merely to make the UI look tidy.
+
+## Body format
+
+Every member gets the same table and a bold current row. Keep this block at the very top:
+
+```
+## Stack
+
+> [!NOTE]
+> **<Stack name> · PR N of M**<br>
+> <Accurate topology/review instruction.>
+
+| Step | Pull request | Focus |
+| :---: | --- | --- |
+| 1 | [#101](url) | Foundation |
+| **2** | **[#102](url)** | **Current focus** · `Current` |
+| 3 | [#103](url) | Follow-up |
+```
+
+Use one of these notes unless the live topology needs more specificity:
+
+- Dependent: `Review and merge in table order; each PR is based on the preceding step.`
+- Parallel: `All PRs target canary and are independently reviewable. The table order follows the implementation story; refresh each branch against canary before merge.`
+
+Use short outcome-oriented focus labels. Do not use arrow chains, repeat full titles, add decorative diagrams, or claim dependencies that do not exist.
+
+## Update every body safely
+
+1. GET every current body.
+2. Replace only the leading `## Stack` section, stopping at the next human section such as `## Summary`.
+3. Preserve Cursor and CodeSmith regions byte-for-byte.
+4. PATCH each PR through `gh api`.
+5. GET every body again. Verify the same PR order and labels, exactly one `Current` marker per body, the correct emphasized row, and unchanged bot-region marker counts.
+
+If any body has no unambiguous section boundary, stop rather than replacing it heuristically.
+
+## Refresh code without breaking the stack
+
+- Dependent stacks move bottom-to-top. Refresh the first PR from `canary`, then propagate the resulting parent through each child while preserving each PR's isolated delta.
+- Parallel series refresh each branch independently from `canary`.
+- Use `conflicts-and-merge.md` for conflict handling. Do not force-push unless explicitly authorized.
+- After each push, verify both the branch ref and PR `headRefOid`. GitHub native stacks can briefly show the old head/base and `UNKNOWN` mergeability after a successful push; wait for metadata to converge instead of trying to retarget the PR.
+
+Before declaring the stack aligned, report the verified order, topology type, base for each PR, and whether all displayed bodies match that topology.

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: pr
+description: Create, update, format, babysit, resolve conflicts and review findings on, and merge Apex pull requests and PR stacks. Use when the user asks to open or update a PR or merge request, align a stack, get CI green, address review or Bugbot findings, resolve merge conflicts, or merge.
+argument-hint: "[create | update | stack | babysit | comments | conflicts | merge | PR number]"
+allowed-tools: Bash(gh *) Bash(git *) Bash(bun *)
+---
+
+# PR
+
+Apex pull-request workflow. Read this file, then **read every applicable playbook** under [`.agent-instructions/skills/pr/`](../../../.agent-instructions/skills/pr/) before acting. Do not improvise past a playbook.
+
+This is repository-development guidance for coding agents working on Apex. Keep it in the repo's `.agents/skills` tree only; do not copy or link it into `.claude/skills`, `.skills`, `skills`, `~/.agents/skills`, or `~/.pensar/skills`, because Apex scans those locations as runtime skills.
+
+## Invariants
+
+- Resolve `OWNER/REPO`, the target PR's current head/base SHAs, and stack topology from live Git and GitHub state. A body saying "stack" is not proof of dependent branches.
+- Ordinary Apex work branches from and targets `canary`. Do not target `main`, retarget a PR, or rewrite stack topology unless the user explicitly asks for that exact change.
+- GitHub reads and writes go through `gh api` (REST or GraphQL). Do not use `gh pr create`, `gh pr comment`, or `gh pr merge`.
+- Preserve bot-managed body regions (`CURSOR_SUMMARY`, `codesmith:footer`) byte-for-byte when editing human-authored sections.
+- Never merge, squash, close, enable auto-merge, force-push, or delete a branch unless the user explicitly authorizes that exact action. A request to resolve conflicts and push does not authorize merging.
+- Work from a clean, isolated checkout when the user's current checkout has unrelated changes. Never stash, reset, or overwrite user work to make a PR task convenient.
+- Judge CI, reviews, and mergeability on the latest PR head SHA. Pending work or green checks on an older SHA are not done.
+
+## Route
+
+| Intent                                               | Playbook                                                                                  |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Create or update a feature/fix/docs PR               | [`create-and-update.md`](../../../.agent-instructions/skills/pr/create-and-update.md)     |
+| Create, inspect, format, or refresh a PR stack       | [`stacks.md`](../../../.agent-instructions/skills/pr/stacks.md)                           |
+| Stay until CI and mergeability settle                | [`babysit.md`](../../../.agent-instructions/skills/pr/babysit.md)                         |
+| Review comments, Cursor Bugbot, or thread resolution | [`comments-and-bugbot.md`](../../../.agent-instructions/skills/pr/comments-and-bugbot.md) |
+| Resolve conflicts or perform an authorized merge     | [`conflicts-and-merge.md`](../../../.agent-instructions/skills/pr/conflicts-and-merge.md) |
+
+After creating, updating, refreshing, or fixing a PR, babysit the new SHA. If it belongs to a stack, also apply `stacks.md`. If review findings exist, apply `comments-and-bugbot.md` before declaring the PR ready.
+
+**Babysit** means staying until required checks have conclusions on the latest SHA, mergeability is known, and no unresolved actionable review work remains. Waiting for human approval after every technical gate is green is terminal; pending CI is not.

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ sst-env.d.ts
 .agents/skills/*
 !.agents/skills/.gitkeep
 !.agents/skills/create-skill/
+!.agents/skills/pr/
 .claude/skills/*
 !.claude/skills/.gitkeep
 !.claude/skills/create-skill

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,9 @@ Enforced via the `import-x/no-internal-modules` ESLint rule in `eslint.config.js
 
 ### Skills
 
-Team-shared agent skills live at `.agents/skills/<name>/`. Use `/create-skill` to add a new one.
+Team-shared development-agent skills live at `.agents/skills/<name>/`. Use `/create-skill` to add a new one. The PR workflow below is developer-only and intentionally remains there: Apex scans `.claude/skills`, `.skills`, `skills`, `~/.agents/skills`, and `~/.pensar/skills` as runtime skill sources.
+
+Before pull-request or merge-request work, read and follow `.agents/skills/pr/SKILL.md` (`/pr` in coding agents that discover repo `.agents` skills). It covers creating or updating PRs, preserving stack topology and formatting, babysitting CI, handling review or Bugbot findings, resolving conflicts, and performing explicitly authorized merges. The skill is the source of truth for the workflow; verify live GitHub state and operate on the latest head SHA.
 
 ### Gotchas
 


### PR DESCRIPTION
## Summary

Adds a repository-development PR workflow for coding agents working on Apex, adapted from the Console router-and-playbook structure. It standardizes PR creation and updates, stack topology and formatting, latest-SHA CI babysitting, review and Cursor Bugbot handling, conflict resolution, and explicitly authorized merges.

The workflow intentionally lives only under `.agents/skills`. Apex scans `.claude/skills`, `.skills`, `skills`, `~/.agents/skills`, and `~/.pensar/skills` as runtime sources, so this PR does not add a compatibility link in any of those locations. `AGENTS.md` routes contributor agents directly to the skill, and the existing `CLAUDE.md` link to `AGENTS.md` preserves Claude-based engineering guidance without exposing the workflow inside Apex.

No linked issue

## Changes

- add a compact `pr` router with five focused Apex playbooks
- distinguish dependent stacks from parallel PR series before changing formatting or branches
- codify current `canary`, CI, Bugbot, conflict, native-stack, and merge-authorization rules
- document the development-agent versus Apex runtime-skill boundary in `AGENTS.md`

## Validation

- `bun run test -- --silent` — 2,607 passed, 22 skipped
- `bun run format:check` — passed; 192 pre-existing warnings and 10 infos
- `bun run lint` — passed; 192 pre-existing warnings and 10 infos
- `bun run tsc` — passed
- `bun run knip` — passed
- skill routing and relative playbook targets verified; committed paths contain no runtime-scanned skill source

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and gitignore whitelist only; no product runtime or CI behavior changes.
> 
> **Overview**
> Introduces a **development-only** PR workflow for coding agents: a `/pr` router at `.agents/skills/pr/SKILL.md` plus five playbooks under `.agent-instructions/skills/pr/` covering create/update, stacks, CI babysitting, review/Bugbot threads, and conflict resolution with explicitly authorized merges.
> 
> The playbooks codify Apex-specific rules: target **`canary`**, use **`gh api`** (not `gh pr *`), preserve bot body regions, distinguish dependent stacks from parallel series, and judge gates on the **latest head SHA**. The skill stays out of Apex runtime skill scan paths; **`.gitignore`** whitelists `!.agents/skills/pr/` so the skill can be committed, and **`AGENTS.md`** points contributors to `.agents/skills/pr/SKILL.md` and documents the dev-agent vs runtime-skill boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a74430e1220068385287f875808e64d6fc519124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->