### PR TITLE
feat(auth): distinguish Mobile OTP MFA prompts

### DIFF
--- a/src/core/agents/offSecAgent/tools/smsListMessages.test.ts
+++ b/src/core/agents/offSecAgent/tools/smsListMessages.test.ts
@@ -96,6 +96,23 @@ describe("sessionHasSmsPasswordless", () => {
     ).toBe(true);
   });
 
+  it("enables the SMS tool for sms-mfa credentials", () => {
+    expect(
+      sessionHasSmsPasswordless({
+        config: {
+          authCredentials: {
+            username: "tester",
+            password: "secret",
+            additionalFields: {
+              authMethod: "sms-mfa",
+              phoneNumber: "stage-managed-number",
+            },
+          },
+        },
+      } as unknown as SessionInfo),
+    ).toBe(true);
+  });
+
   it("requires a phoneNumber for sms-passwordless credentials", () => {
     expect(
       sessionHasSmsPasswordless({

--- a/src/core/agents/offSecAgent/tools/smsListMessages.ts
+++ b/src/core/agents/offSecAgent/tools/smsListMessages.ts
@@ -72,9 +72,9 @@ async function agentFetch(
 
 export function smsListMessages(ctx: ToolContext) {
   return tool({
-    description: `Reserve or list inbound SMS on the stage-managed Mobile OTP (sms-passwordless) receiving number.
+    description: `Reserve or list inbound SMS on the stage-managed Mobile OTP receiving number for sms-passwordless or sms-mfa authentication.
 
-Reserve immediately before filling the target phone field and clicking send-code: call with reserve=true. The Console chooses and leases the receiving number from the signed session; never supply or request a phone number here.
+For sms-passwordless, reserve immediately before filling the target phone field and requesting a code. For sms-mfa, fill username and password first, then reserve immediately before the action that sends the code. The Console chooses and leases the receiving number from the signed session; never supply or request a phone number here.
 
 After the target sends a code, sleep with execute_command (e.g. sleep 5), then call with sinceMs from the send-code click. Set claim=true to consume the newest unconsumed message (exclusive; other runs cannot reuse that OTP). This is a single request — it does not wait. A 429 means the shared number is busy; retry the reservation later rather than waiting in this tool.
 

--- a/src/core/agents/specialized/attackSurface/blackboxAgent.test.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxAgent.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { CredentialManager } from "../../../credentials";
+import type { SessionInfo } from "../../../session";
+import { buildBlackboxPrompt } from "./blackboxAgent";
+
+describe("buildBlackboxPrompt", () => {
+  it("guides SMS MFA without exposing the shared number", () => {
+    const credentialManager = new CredentialManager();
+    credentialManager.add({
+      username: "tester",
+      password: "secret",
+      loginUrl: "https://example.com/login",
+      additionalFields: {
+        authMethod: "sms-mfa",
+        phoneNumber: "stage-managed-number",
+      },
+    });
+
+    const prompt = buildBlackboxPrompt("https://example.com", {
+      id: "session-1",
+      rootPath: "/tmp/apex-blackbox-prompt",
+      config: {},
+      credentialManager,
+    } as SessionInfo);
+
+    expect(prompt).toContain("Authentication method: sms-mfa");
+    expect(prompt).toContain("`sms-mfa`: fill username and password first");
+    expect(prompt).toContain("Make at most two separate reservation attempts");
+    expect(prompt).not.toContain("stage-managed-number");
+  });
+});

--- a/src/core/agents/specialized/attackSurface/blackboxAgent.ts
+++ b/src/core/agents/specialized/attackSurface/blackboxAgent.ts
@@ -6,6 +6,7 @@ import {
   OffensiveSecurityAgent,
   type SpecializedAgentInput,
 } from "../../offSecAgent";
+import { MOBILE_OTP_PROMPT_GUIDANCE } from "../mobileOtpPrompt";
 import { detectOSAndEnhancePrompt } from "../utils";
 import { SYSTEM as ATTACK_SURFACE_SYSTEM_PROMPT } from "./prompts";
 import type { AttackSurfaceAnalysisResults, PentestTarget } from "./types";
@@ -124,7 +125,7 @@ export class BlackboxAttackSurfaceAgent extends OffensiveSecurityAgent<AttackSur
         "email_get_message",
         // Send email (filtered out by base class when no SMTP configured)
         "send_email",
-        // Mobile OTP list (filtered out by base class when no sms-passwordless cred)
+        // Mobile OTP list (filtered out by base class when no Mobile OTP cred)
         "sms_list_messages",
         // Web search tools — research target technologies, find known vulnerabilities
         "web_search",
@@ -154,7 +155,7 @@ export class BlackboxAttackSurfaceAgent extends OffensiveSecurityAgent<AttackSur
 
         return { results, targets, resultsPath, assetsPath };
       },
-      prompt: buildPrompt(target, session),
+      prompt: buildBlackboxPrompt(target, session),
       onStepFinish: (e) => {
         onStepFinish?.(e);
         const messages = e.response.messages;
@@ -173,7 +174,10 @@ export class BlackboxAttackSurfaceAgent extends OffensiveSecurityAgent<AttackSur
 // Prompt builder
 // ---------------------------------------------------------------------------
 
-function buildPrompt(target: string, session: SessionInfo): string {
+export function buildBlackboxPrompt(
+  target: string,
+  session: SessionInfo,
+): string {
   const scopeConstraints = session.config?.scopeConstraints;
   const authenticationInstructions = session.config?.authenticationInstructions;
   const enumerateSubdomains = session.config?.enumerateSubdomains ?? false;
@@ -201,7 +205,7 @@ function buildPrompt(target: string, session: SessionInfo): string {
 Your FIRST tool call must be: browser_navigate to ${loginTarget}
 Then use browser tools to authenticate. Pass the credentialId to delegate_to_auth_subagent — secrets are resolved automatically.
 For browser_fill on password/secret fields, use credentialId + credentialField instead of raw values.
-When a credential has a phoneNumber additional field (Mobile OTP / sms-passwordless), phone is the login identifier — not MFA-after-password. Immediately before filling it, call sms_list_messages with reserve=true; never pass that tool a phone number. If it returns 429, retry the reservation later as a separate attempt without waiting in the tool. Then fill credentialField="phoneNumber", click send-code, sleep with execute_command, and call sms_list_messages with sinceMs from that click and claim=true. If the list is empty, make one delayed list retry; if it stays empty, stop and report. Do not report phone_verification as a barrier. TOTP-via-env for authenticator MFA is unchanged.
+${MOBILE_OTP_PROMPT_GUIDANCE}
 
 Do NOT run curl, nmap, dig, or any other command before completing login.
 Include authentication information with EVERY target that requires it in your final report.

--- a/src/core/agents/specialized/authenticationAgent/agent.ts
+++ b/src/core/agents/specialized/authenticationAgent/agent.ts
@@ -19,8 +19,8 @@ import type { SessionInfo } from "../../../session";
 import { scopedLogger } from "../../../util/lazyLogger";
 import { OffensiveSecurityAgent } from "../../offSecAgent";
 import type { StreamIdFactory } from "../../offSecAgent/types";
-import { detectOSAndEnhancePrompt } from "../utils";
 import { MOBILE_OTP_PROMPT_GUIDANCE } from "../mobileOtpPrompt";
+import { detectOSAndEnhancePrompt } from "../utils";
 import { AUTH_SUBAGENT_SYSTEM_PROMPT } from "./prompts";
 import type { AuthBarrier } from "./types";
 

--- a/src/core/agents/specialized/authenticationAgent/agent.ts
+++ b/src/core/agents/specialized/authenticationAgent/agent.ts
@@ -20,6 +20,7 @@ import { scopedLogger } from "../../../util/lazyLogger";
 import { OffensiveSecurityAgent } from "../../offSecAgent";
 import type { StreamIdFactory } from "../../offSecAgent/types";
 import { detectOSAndEnhancePrompt } from "../utils";
+import { MOBILE_OTP_PROMPT_GUIDANCE } from "../mobileOtpPrompt";
 import { AUTH_SUBAGENT_SYSTEM_PROMPT } from "./prompts";
 import type { AuthBarrier } from "./types";
 
@@ -188,7 +189,7 @@ export class AuthenticationAgent extends OffensiveSecurityAgent<AuthenticationRe
         "email_get_message",
         // Send email (filtered out by base class when no SMTP configured)
         "send_email",
-        // Mobile OTP list (filtered out by base class when no sms-passwordless cred)
+        // Mobile OTP list (filtered out by base class when no Mobile OTP cred)
         "sms_list_messages",
         // Web search tools — look up auth bypass techniques, default credentials
         "web_search",
@@ -308,19 +309,11 @@ function buildAuthPrompt(
   }
 
   if (credBlock) {
-    const hasSmsPasswordless = credentialManager
+    const hasMobileOtp = credentialManager
       ?.listReferences()
       .some((ref) => ref.additionalFieldKeys?.includes("phoneNumber"));
-    const smsInstructions = hasSmsPasswordless
-      ? `
-If a credential has a phoneNumber additional field (Mobile OTP / sms-passwordless), phone is the login
-identifier — not MFA-after-password. Immediately before filling the phone field, call sms_list_messages
-with reserve=true; never pass that tool a phone number. If it returns 429, retry the reservation later as
-a separate attempt without waiting in the tool. Then browser_fill credentialField="phoneNumber", click
-send-code, and call sms_list_messages with sinceMs = Date.now() at that click and claim=true after a brief
-execute_command sleep. If the list is empty, make one delayed list retry; if it stays empty, fail with what
-you observed. Then browser_fill the OTP. Do NOT report phone_verification as a barrier for this flow.
-TOTP-via-env for authenticator MFA is unchanged.`
+    const smsInstructions = hasMobileOtp
+      ? `\n${MOBILE_OTP_PROMPT_GUIDANCE}\n`
       : "";
     parts.push(`INSTRUCTIONS:
 You have credentials available via credential IDs — authenticate immediately.

--- a/src/core/agents/specialized/authenticationAgent/prompts.test.ts
+++ b/src/core/agents/specialized/authenticationAgent/prompts.test.ts
@@ -2,15 +2,24 @@ import { describe, expect, it } from "vitest";
 import { AUTH_SUBAGENT_SYSTEM_PROMPT } from "./prompts";
 
 describe("AUTH_SUBAGENT_SYSTEM_PROMPT", () => {
-  it("reserves a shared Mobile OTP number before requesting a code", () => {
+  it("distinguishes passwordless phone login from SMS MFA", () => {
     expect(AUTH_SUBAGENT_SYSTEM_PROMPT).toContain(
-      "sms_list_messages` with `reserve=true",
+      "`sms-passwordless`: `phoneNumber` is the login identifier",
     );
     expect(AUTH_SUBAGENT_SYSTEM_PROMPT).toContain(
-      "Never pass\n   a phone number to this tool",
+      "`sms-mfa`: fill username and password first",
     );
     expect(AUTH_SUBAGENT_SYSTEM_PROMPT).toContain(
-      "If it returns 429, retry this reservation later",
+      "If submitting the password triggers the SMS code, reserve immediately before submitting",
+    );
+  });
+
+  it("bounds busy-number retries without exposing a phone number", () => {
+    expect(AUTH_SUBAGENT_SYSTEM_PROMPT).toContain(
+      "Never ask for, write, log, or pass a public phone number",
+    );
+    expect(AUTH_SUBAGENT_SYSTEM_PROMPT).toContain(
+      "Make at most two separate reservation attempts",
     );
     expect(AUTH_SUBAGENT_SYSTEM_PROMPT).toContain(
       "sms_list_messages` with `sinceMs` and `claim=true",

--- a/src/core/agents/specialized/authenticationAgent/prompts.ts
+++ b/src/core/agents/specialized/authenticationAgent/prompts.ts
@@ -1,3 +1,5 @@
+import { MOBILE_OTP_PROMPT_GUIDANCE } from "../mobileOtpPrompt";
+
 /**
  * Authentication Subagent Prompts
  *
@@ -128,21 +130,7 @@ every 30 seconds, so run this immediately before filling the field. If the code 
 retry once (you may have crossed a period boundary). Only report an MFA barrier if no seed is available
 or two fresh codes are both rejected.
 
-# SMS passwordless (phone as login)
-
-If a credential has a \`phoneNumber\` additional field, the phone number IS the login identifier — not MFA
-after a password. Do **not** report \`phone_verification\` as a barrier for this flow.
-
-1. Call \`sms_list_messages\` with \`reserve=true\` immediately before filling the phone field. Never pass
-   a phone number to this tool. If it returns 429, retry this reservation later as a separate attempt; do
-   not wait or poll inside the tool.
-2. \`browser_fill\` with \`credentialId\` and \`credentialField="phoneNumber"\` (never type the number).
-3. Click the target's send-code / text-me control. Note \`Date.now()\` at that click as \`sinceMs\`.
-4. \`execute_command\` \`sleep 5\`, then call \`sms_list_messages\` with \`sinceMs\` and \`claim=true\`.
-   If the list is empty, make one delayed list retry; if it stays empty or returns an error, stop and report
-   what you observed — do not hang in a wait loop.
-5. \`browser_fill\` the OTP from the claimed/listed result (\`code\`, or parse \`body\` if \`code\` is null).
-6. Continue the login and call \`complete_authentication\`.
+${MOBILE_OTP_PROMPT_GUIDANCE}
 
 TOTP-via-environment-variable above is unchanged and still applies when the login asks for an authenticator
 app code.

--- a/src/core/agents/specialized/mobileOtpPrompt.ts
+++ b/src/core/agents/specialized/mobileOtpPrompt.ts
@@ -1,0 +1,9 @@
+export const MOBILE_OTP_PROMPT_GUIDANCE = `## Mobile OTP credentials
+
+Read each credential's \`Authentication method\` before starting:
+- \`sms-passwordless\`: \`phoneNumber\` is the login identifier, not MFA after a password. Reserve immediately before filling that field, then request the code.
+- \`sms-mfa\`: fill username and password first. If submitting the password triggers the SMS code, reserve immediately before submitting. If it reveals a separate send-code action, reserve immediately before that action. Fill a destination phone field only if the target asks, using \`credentialId\` + \`credentialField="phoneNumber"\`.
+
+Never ask for, write, log, or pass a public phone number. Reserve with \`sms_list_messages\` and \`reserve=true\`; the Console chooses the shared number. A 429 means that number is busy: do not wait or poll inside the tool. Make at most two separate reservation attempts (with an \`execute_command\` sleep between them), then report the authentication block.
+
+At the action that sends the code, record \`Date.now()\` as \`sinceMs\`. Run \`execute_command\` \`sleep 5\`, then call \`sms_list_messages\` with \`sinceMs\` and \`claim=true\`. If no message arrives, make one delayed list retry; otherwise report the result rather than waiting indefinitely. Fill the claimed OTP and continue. Do not report \`phone_verification\` as a barrier for either Mobile OTP flow. TOTP via an environment variable is unchanged.`;

--- a/src/core/agents/specialized/pentest/agent.test.ts
+++ b/src/core/agents/specialized/pentest/agent.test.ts
@@ -554,6 +554,8 @@ The following credentials are available. To use a credential, pass its ID to the
   Type: username-password
   Username: dev@pensarai.com
   Login URL: https://example.com/#/login
+  Additional secret fields: phoneNumber
+  Authentication method: sms-mfa
   Context: Standard user account for the customer portal
 </available_credentials>`;
 
@@ -577,10 +579,14 @@ The following credentials are available. To use a credential, pass its ID to the
     expect(prompt).toContain("Standard user account for the customer portal");
     // And it's told to report_error rather than silently skip if auth fails.
     expect(prompt).toContain("authentication_failed");
-    expect(prompt).toContain("sms_list_messages");
-    expect(prompt).toContain("sms_list_messages with reserve=true");
-    expect(prompt).toContain("never pass that tool a phone number");
-    expect(prompt).toContain("If it returns 429");
+    expect(prompt).toContain("`sms-mfa`: fill username and password first");
+    expect(prompt).toContain(
+      "If submitting the password triggers the SMS code, reserve immediately before submitting",
+    );
+    expect(prompt).toContain(
+      "Never ask for, write, log, or pass a public phone number",
+    );
+    expect(prompt).toContain("Make at most two separate reservation attempts");
   });
 
   it("points the agent at the credential Context instructions instead of defaulting to a browser login", () => {

--- a/src/core/agents/specialized/pentest/agent.ts
+++ b/src/core/agents/specialized/pentest/agent.ts
@@ -19,6 +19,7 @@ import {
   type SystemPentestScope,
 } from "../../offSecAgent";
 import type { GrpcPentestContext } from "../attackSurface/grpcSchema";
+import { MOBILE_OTP_PROMPT_GUIDANCE } from "../mobileOtpPrompt";
 
 const log = scopedLogger(() => createLogger("pentest-agent"));
 
@@ -1110,8 +1111,11 @@ Do NOT discover or enumerate other endpoints or services. Focus exclusively on t
   // Always included (independent of `authSection`) so the orchestrator AND every
   // spawned worker receive the operator's auth instructions; when a live session
   // is also present, these double as re-auth guidance if it expires.
+  const mobileOtpGuidance = credentialContext?.includes("phoneNumber")
+    ? `\n${MOBILE_OTP_PROMPT_GUIDANCE}\n`
+    : "";
   const credentialSection = credentialContext
-    ? `\n## Available Credentials\nThe operator provided the following credentials and authentication instructions for this engagement. Authenticate by following the instructions in each credential's Context exactly — use the method it describes (for example, a token/API exchange via execute_command or http_request) rather than defaulting to a browser login. Treat the Context as the source of truth for how to authenticate, and how to re-authenticate if a provided session expires. When a tool needs a secret value and supports it (e.g. browser_fill), reference it by credentialId + credentialField so the secret resolves securely at execution time instead of hardcoding it. If required authentication cannot be established and blocks the assigned objective or all further testing, call report_error with reason "authentication_failed" and a specific message; otherwise continue reachable testing and report the limitation in your final response.\nWhen a credential has additional field phoneNumber, phone is the login identifier (not MFA-after-password). Immediately before filling it, call sms_list_messages with reserve=true; never pass that tool a phone number. If it returns 429, retry the reservation later as a separate attempt without waiting in the tool. Then fill credentialField="phoneNumber", click send-code, sleep with execute_command, and call sms_list_messages with sinceMs from that click and claim=true. If the list is empty, make one delayed list retry; if it stays empty, stop and report. Do not report phone_verification as a barrier. TOTP-via-environment-variable for authenticator MFA is unchanged.\n\n${credentialContext}\n`
+    ? `\n## Available Credentials\nThe operator provided the following credentials and authentication instructions for this engagement. Authenticate by following the instructions in each credential's Context exactly — use the method it describes (for example, a token/API exchange via execute_command or http_request) rather than defaulting to a browser login. Treat the Context as the source of truth for how to authenticate, and how to re-authenticate if a provided session expires. When a tool needs a secret value and supports it (e.g. browser_fill), reference it by credentialId + credentialField so the secret resolves securely at execution time instead of hardcoding it. If required authentication cannot be established and blocks the assigned objective or all further testing, call report_error with reason "authentication_failed" and a specific message; otherwise continue reachable testing and report the limitation in your final response.${mobileOtpGuidance}\n${credentialContext}\n`
     : "";
 
   const contextSection = context
@@ -1216,7 +1220,7 @@ const SHARED_PENTEST_TOOLS = [
   "email_get_message",
   // Send email (filtered out by base class when no SMTP configured)
   "send_email",
-  // Mobile OTP list (filtered out by base class when no sms-passwordless cred)
+  // Mobile OTP list (filtered out by base class when no Mobile OTP cred)
   "sms_list_messages",
   // Memory tools — for on-demand retrieval of project knowledge
   "list_memories",

--- a/src/core/credentials/manager.ts
+++ b/src/core/credentials/manager.ts
@@ -64,10 +64,11 @@ function toReference(stored: StoredCredential): CredentialReference {
   }
   if (stored.additionalFields) {
     const authMethod = stored.additionalFields.authMethod;
-    if (isMobileOtpAuthMethod(authMethod)) ref.authMethod = authMethod;
+    const recognized = isMobileOtpAuthMethod(authMethod);
+    if (recognized) ref.authMethod = authMethod;
 
     const keys = Object.keys(stored.additionalFields).filter(
-      (key) => key !== "authMethod",
+      (key) => !(key === "authMethod" && recognized),
     );
     if (keys.length > 0) ref.additionalFieldKeys = keys;
   }

--- a/src/core/credentials/manager.ts
+++ b/src/core/credentials/manager.ts
@@ -11,6 +11,7 @@ import type { AuthCredentials } from "../session";
 import type {
   CredentialReference,
   CredentialType,
+  MobileOtpAuthMethod,
   StoredCredential,
 } from "./types";
 
@@ -62,12 +63,23 @@ function toReference(stored: StoredCredential): CredentialReference {
     ref.customHeaderKeys = Object.keys(stored.tokens.customHeaders);
   }
   if (stored.additionalFields) {
-    const keys = Object.keys(stored.additionalFields);
+    const authMethod = stored.additionalFields.authMethod;
+    if (isMobileOtpAuthMethod(authMethod)) ref.authMethod = authMethod;
+
+    const keys = Object.keys(stored.additionalFields).filter(
+      (key) => key !== "authMethod",
+    );
     if (keys.length > 0) ref.additionalFieldKeys = keys;
   }
   const ctx = stored.metadata?.context;
   if (typeof ctx === "string" && ctx) ref.context = ctx;
   return ref;
+}
+
+function isMobileOtpAuthMethod(
+  value: string | undefined,
+): value is MobileOtpAuthMethod {
+  return value === "sms-passwordless" || value === "sms-mfa";
 }
 
 // ---------------------------------------------------------------------------
@@ -258,6 +270,9 @@ export class CredentialManager {
         parts.push(
           `  Additional secret fields: ${ref.additionalFieldKeys.join(", ")}`,
         );
+      }
+      if (ref.authMethod) {
+        parts.push(`  Authentication method: ${ref.authMethod}`);
       }
       if (ref.context) parts.push(`  Context: ${ref.context}`);
       return parts.join("\n");

--- a/src/core/credentials/types.ts
+++ b/src/core/credentials/types.ts
@@ -19,6 +19,9 @@ export type CredentialType =
   | "cookies"
   | "composite";
 
+/** Safe Mobile OTP flow metadata surfaced to prompts. */
+export type MobileOtpAuthMethod = "sms-passwordless" | "sms-mfa";
+
 /**
  * Full credential record stored in the manager.
  * Contains the actual secrets — never exposed to the agent.
@@ -94,6 +97,9 @@ export interface CredentialReference {
 
   /** Names of operator-defined extra secret fields (values redacted) */
   additionalFieldKeys?: string[];
+
+  /** Mobile OTP flow metadata (safe to expose to prompts) */
+  authMethod?: MobileOtpAuthMethod;
 
   /** Usage context / notes about when and how to use this credential */
   context?: string;

--- a/src/tests/credentialManager.test.ts
+++ b/src/tests/credentialManager.test.ts
@@ -374,6 +374,23 @@ describe("CredentialManager", () => {
       expect(prompt).toContain("TOTP_SEED");
       expect(prompt).not.toContain("JBSWY3DPEHPK3PXP");
     });
+
+    it("surfaces the Mobile OTP method without exposing its number", () => {
+      cm.add({
+        id: "cred-sms-mfa",
+        username: "tester",
+        password: "secret",
+        additionalFields: {
+          authMethod: "sms-mfa",
+          phoneNumber: "stage-managed-number",
+        },
+      });
+
+      const prompt = cm.formatForPrompt();
+      expect(prompt).toContain("Authentication method: sms-mfa");
+      expect(prompt).toContain("Additional secret fields: phoneNumber");
+      expect(prompt).not.toContain("stage-managed-number");
+    });
   });
 
   describe("additional secret fields", () => {
@@ -395,6 +412,22 @@ describe("CredentialManager", () => {
     it("omits the key list when there are no extra fields", () => {
       const id = cm.add({ username: "admin", password: "pw" });
       expect(cm.getReference(id)!.additionalFieldKeys).toBeUndefined();
+    });
+
+    it("surfaces a recognized Mobile OTP method separately from secrets", () => {
+      const id = cm.add({
+        username: "admin",
+        password: "pw",
+        additionalFields: {
+          authMethod: "sms-passwordless",
+          phoneNumber: "stage-managed-number",
+        },
+      });
+
+      const ref = cm.getReference(id)!;
+      expect(ref.authMethod).toBe("sms-passwordless");
+      expect(ref.additionalFieldKeys).toEqual(["phoneNumber"]);
+      expect(JSON.stringify(ref)).not.toContain("stage-managed-number");
     });
 
     it("keeps credentials that differ only by additional fields distinct", () => {

--- a/src/tests/credentialManager.test.ts
+++ b/src/tests/credentialManager.test.ts
@@ -391,6 +391,26 @@ describe("CredentialManager", () => {
       expect(prompt).toContain("Additional secret fields: phoneNumber");
       expect(prompt).not.toContain("stage-managed-number");
     });
+
+    it("lists unrecognized authMethod as a secret field instead of dropping it", () => {
+      cm.add({
+        id: "cred-unknown-auth",
+        username: "tester",
+        password: "secret",
+        additionalFields: {
+          authMethod: "email-otp",
+          recoveryCode: "hidden-recovery",
+        },
+      });
+
+      const prompt = cm.formatForPrompt();
+      expect(prompt).not.toContain("Authentication method:");
+      expect(prompt).toContain(
+        "Additional secret fields: authMethod, recoveryCode",
+      );
+      expect(prompt).not.toContain("email-otp");
+      expect(prompt).not.toContain("hidden-recovery");
+    });
   });
 
   describe("additional secret fields", () => {
@@ -427,6 +447,23 @@ describe("CredentialManager", () => {
       const ref = cm.getReference(id)!;
       expect(ref.authMethod).toBe("sms-passwordless");
       expect(ref.additionalFieldKeys).toEqual(["phoneNumber"]);
+      expect(JSON.stringify(ref)).not.toContain("stage-managed-number");
+    });
+
+    it("keeps unrecognized authMethod on the secret-field list", () => {
+      const id = cm.add({
+        username: "admin",
+        password: "pw",
+        additionalFields: {
+          authMethod: "email-otp",
+          phoneNumber: "stage-managed-number",
+        },
+      });
+
+      const ref = cm.getReference(id)!;
+      expect(ref.authMethod).toBeUndefined();
+      expect(ref.additionalFieldKeys).toEqual(["authMethod", "phoneNumber"]);
+      expect(JSON.stringify(ref)).not.toContain("email-otp");
       expect(JSON.stringify(ref)).not.toContain("stage-managed-number");
     });
 


### PR DESCRIPTION
## Summary
- distinguish phone-as-login passwordless flow from username/password SMS MFA in authentication, pentest, and blackbox prompts
- surface only the safe Mobile OTP auth-method metadata; phone numbers remain redacted
- bound busy-number reservations and tell agents to report the block

## Testing
- `bun run test`
- `bun run lint`
- `bun run tsc`
- `bun run build`

No matching open issue found.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator-facing auth instructions and credential metadata that drive automated login/MFA behavior; secrets handling is tightened but wrong guidance could still mis-route SMS MFA runs.
> 
> **Overview**
> Agents now get **shared Mobile OTP guidance** that treats **`sms-passwordless`** (phone as login) and **`sms-mfa`** (username/password first, then reserve before the send-code step) as separate flows, with caps on busy-number retries and explicit rules not to log or pass phone numbers.
> 
> **Credential references** expose a safe **`Authentication method`** (`sms-passwordless` | `sms-mfa`) from `additionalFields.authMethod`, while **`phoneNumber` stays a redacted secret** in prompts. Authentication, pentest, and blackbox agents import `MOBILE_OTP_PROMPT_GUIDANCE` instead of the old passwordless-only inline text; **`sms_list_messages`**’ tool description is aligned with both flows. Blackbox prompt building is exported as **`buildBlackboxPrompt`** for testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceafbd5544c28a3e86479b8188612006e2c7d4b8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->