### PR TITLE
fix(pentest): describe http_request body as a verbatim string

### DIFF
--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -48,7 +48,7 @@ const httpRequestInputSchema = z.object({
     .union([z.string(), promptInjectionRefSchema])
     .optional()
     .describe(
-      "Request body (for POST, PUT, PATCH). To use a hidden prompt-injection payload, pass a PromptInjectionRef object instead of raw payload text.",
+      'Request body (for POST, PUT, PATCH), sent verbatim to the target. Pass it as a raw string, not a JSON object — e.g. \'{"user":"admin"}\' as the string `{"user":"admin"}`. Any payload that must reach the target byte-for-byte MUST be a JSON-encoded string, never an object: this includes prototype-pollution payloads (send `{"__proto__":{"isAdmin":true}}` as a string, NOT as an object with a `__proto__` key, which the tool-call transport rejects), injection strings, and intentionally malformed JSON. To use a hidden prompt-injection payload, pass a PromptInjectionRef object instead of raw payload text.',
     ),
   followRedirects: z
     .boolean()

--- a/src/core/agents/offSecAgent/tools/httpRequest.ts
+++ b/src/core/agents/offSecAgent/tools/httpRequest.ts
@@ -48,7 +48,7 @@ const httpRequestInputSchema = z.object({
     .union([z.string(), promptInjectionRefSchema])
     .optional()
     .describe(
-      'Request body (for POST, PUT, PATCH), sent verbatim to the target. Pass it as a raw string, not a JSON object — e.g. \'{"user":"admin"}\' as the string `{"user":"admin"}`. Any payload that must reach the target byte-for-byte MUST be a JSON-encoded string, never an object: this includes prototype-pollution payloads (send `{"__proto__":{"isAdmin":true}}` as a string, NOT as an object with a `__proto__` key, which the tool-call transport rejects), injection strings, and intentionally malformed JSON. To use a hidden prompt-injection payload, pass a PromptInjectionRef object instead of raw payload text.',
+      'Request body (for POST, PUT, PATCH), sent to the target verbatim. Pass it as a string — for a JSON body, JSON-encode it into that string (e.g. `{"user":"admin"}`) rather than a nested object. To send a hidden prompt-injection payload instead, pass a PromptInjectionRef object.',
     ),
   followRedirects: z
     .boolean()


### PR DESCRIPTION
### What this changes

The `http_request` tool's `body` parameter is a string: the request body sent to the target verbatim. The description now says that plainly. Pass the body as a string, and for a JSON body JSON-encode it into that string instead of passing a nested object. The prompt-injection ref guidance is unchanged.

### Why

The model often writes a JSON body as a nested object. The field only accepts a string, so those calls fail input validation and the body never reaches the target. A clearer description steers the model to send a string.

### Scope

This is a description-only nudge. It does not change the schema, add coercion, or guarantee the model complies:

- Benign object bodies (for example GraphQL) still fail validation until a separate object-to-string coercion lands.
- A prototype-pollution payload passed as an object is rejected by the SDK secure JSON parse ("Object contains forbidden prototype property") before the tool runs. Sending it as a string avoids that, but only if the model follows the description.

The deterministic fixes (accept object bodies via coercion, and re-prompt on the secure-parse failure) are described in #1042.
