### PR TITLE
fix(whitebox): stop on validated submit_results and fail loud instead of silent empty result

### DIFF
--- a/src/core/agents/specialized/whiteboxAttackSurface/agent.test.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/agent.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  finalizeWhiteboxResult,
+  WHITEBOX_FALLBACK_RESULT,
+  WhiteboxSubmitValidationError,
+} from "./agent";
+import type { WhiteboxAttackSurfaceResult } from "./types";
+
+describe("finalizeWhiteboxResult", () => {
+  const captured: WhiteboxAttackSurfaceResult = {
+    repoType: "monorepo",
+    packageManager: "pnpm",
+    apps: [],
+    summary: {
+      totalApps: 3,
+      totalPages: 7,
+      totalApiEndpoints: 22,
+      totalPentestObjectives: 68,
+    },
+  };
+
+  it("returns the captured result when submission validated", () => {
+    // submitAttempted is irrelevant once a validated result exists.
+    expect(finalizeWhiteboxResult(captured, true)).toBe(captured);
+    expect(finalizeWhiteboxResult(captured, false)).toBe(captured);
+  });
+
+  it("fails loud when submit_results was called but never validated", () => {
+    // The core defect: one bad field rejected the payload, capturedResult
+    // stayed null, and the run used to report success with an empty result.
+    expect(() => finalizeWhiteboxResult(null, true)).toThrow(
+      WhiteboxSubmitValidationError,
+    );
+  });
+
+  it("returns the empty fallback only when the model genuinely never submitted", () => {
+    expect(finalizeWhiteboxResult(null, false)).toBe(WHITEBOX_FALLBACK_RESULT);
+  });
+});

--- a/src/core/agents/specialized/whiteboxAttackSurface/agent.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/agent.ts
@@ -1,4 +1,4 @@
-import { hasToolCall, tool } from "ai";
+import { stepCountIs, tool } from "ai";
 import {
   OffensiveSecurityAgent,
   type SpecializedAgentInput,
@@ -9,7 +9,16 @@ import {
   WhiteboxAttackSurfaceResultSchema,
 } from "./types";
 
-const WHITEBOX_FALLBACK_RESULT: WhiteboxAttackSurfaceResult = {
+const SUBMIT_RESULTS_TOOL_NAME = "submit_results";
+
+/**
+ * Safety cap on the agent loop. The run normally stops the instant
+ * `submit_results` validates (see {@link WhiteboxAttackSurfaceAgent}); this only
+ * guards against a model that never produces a valid submission.
+ */
+const WHITEBOX_MAX_STEPS = 10_000;
+
+export const WHITEBOX_FALLBACK_RESULT: WhiteboxAttackSurfaceResult = {
   repoType: "unknown",
   packageManager: "unknown",
   apps: [],
@@ -20,6 +29,39 @@ const WHITEBOX_FALLBACK_RESULT: WhiteboxAttackSurfaceResult = {
     totalPentestObjectives: 0,
   },
 };
+
+/**
+ * Thrown when the model called `submit_results` but no attempt ever passed
+ * schema validation, so {@link WhiteboxAttackSurfaceAgent} has no captured
+ * result. Failing loud lets the caller retry or surface the error instead of
+ * silently proceeding on an empty attack surface.
+ */
+export class WhiteboxSubmitValidationError extends Error {
+  constructor() {
+    super(
+      "Whitebox attack surface recon called submit_results but no attempt passed " +
+        "schema validation — refusing to silently return an empty attack surface. " +
+        "The run should be retried.",
+    );
+    this.name = "WhiteboxSubmitValidationError";
+  }
+}
+
+/**
+ * Decide the final result once the run ends. Kept pure so the fail-loud vs.
+ * empty-fallback decision is unit-testable without a live stream:
+ * - a captured (validated) result is returned as-is;
+ * - a `submit_results` call that never validated fails loud;
+ * - a run where the model genuinely never submitted returns the empty fallback.
+ */
+export function finalizeWhiteboxResult(
+  capturedResult: WhiteboxAttackSurfaceResult | null,
+  submitAttempted: boolean,
+): WhiteboxAttackSurfaceResult {
+  if (capturedResult !== null) return capturedResult;
+  if (submitAttempted) throw new WhiteboxSubmitValidationError();
+  return WHITEBOX_FALLBACK_RESULT;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -86,10 +128,18 @@ export class WhiteboxAttackSurfaceAgent extends OffensiveSecurityAgent<WhiteboxA
         // Response tool (injected via extraTools)
         "submit_results",
       ],
-      stopWhen: hasToolCall("submit_results"),
+      // Stop on a *successful* submission, not merely on the tool call. A
+      // `submit_results` call whose arguments fail schema validation never sets
+      // `capturedResult`, so the loop continues and the model gets another turn
+      // to fix and resubmit (aided by tool-call repair). `stepCountIs` is only a
+      // safety cap for a model that never produces a valid submission.
+      stopWhen: [
+        () => capturedResult !== null,
+        stepCountIs(WHITEBOX_MAX_STEPS),
+      ],
       extraTools: {
         ...base.extraTools,
-        submit_results: tool({
+        [SUBMIT_RESULTS_TOOL_NAME]: tool({
           description: `Submit the final whitebox attack surface analysis results.
 
 Call this ONCE at the end with your complete structured findings.
@@ -101,7 +151,19 @@ This ends the agent run — make sure all data is included.`,
           },
         }),
       },
-      resolveResult: () => capturedResult ?? WHITEBOX_FALLBACK_RESULT,
+      resolveResult: async (streamResult) => {
+        // `capturedResult` is only set by a submission that passed validation.
+        // If it's null but the model *did* call `submit_results` (the call was
+        // rejected on a bad field), fail loud rather than masking the discarded
+        // recon with an empty fallback.
+        const steps = await streamResult.steps;
+        const submitAttempted = steps.some((step) =>
+          step.toolCalls.some(
+            (call) => call.toolName === SUBMIT_RESULTS_TOOL_NAME,
+          ),
+        );
+        return finalizeWhiteboxResult(capturedResult, submitAttempted);
+      },
       prompt: buildPrompt(codebasePath, domains, base.session.config?.prompt),
     });
   }

--- a/src/core/agents/specialized/whiteboxAttackSurface/types.test.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/types.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { EndpointSchema } from "./types";
+
+describe("EndpointSchema.method tolerance", () => {
+  it("accepts a plain HTTP method string", () => {
+    const parsed = EndpointSchema.parse({
+      method: "GET",
+      path: "/dashboard",
+      file: "src/app/page.tsx",
+    });
+    expect(parsed.method).toBe("GET");
+  });
+
+  it("accepts an array of methods and joins them into a single string", () => {
+    // The model routinely emits multi-method endpoints as an array
+    // (e.g. ["GET","POST"]). Before this tolerance, that rejected the whole
+    // submit_results payload and the entire recon was silently discarded.
+    const parsed = EndpointSchema.parse({
+      method: ["GET", "POST"],
+      path: "/api/users/:id",
+      file: "src/routes/users.ts",
+    });
+    expect(parsed.method).toBe("GET, POST");
+  });
+
+  it("still rejects a method that is neither string nor string array", () => {
+    const result = EndpointSchema.safeParse({
+      method: 42,
+      path: "/x",
+      file: "f.ts",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("EndpointSchema.pentestObjectives tolerance", () => {
+  it("defaults to an empty array when omitted", () => {
+    const parsed = EndpointSchema.parse({
+      method: "GET",
+      path: "/x",
+      file: "f.ts",
+    });
+    expect(parsed.pentestObjectives).toEqual([]);
+  });
+
+  it("wraps a lone string objective into a one-element array", () => {
+    const parsed = EndpointSchema.parse({
+      method: "GET",
+      path: "/x",
+      file: "f.ts",
+      pentestObjectives: "Test for IDOR by enumerating user IDs",
+    });
+    expect(parsed.pentestObjectives).toEqual([
+      "Test for IDOR by enumerating user IDs",
+    ]);
+  });
+
+  it("passes through an array of objectives unchanged", () => {
+    const parsed = EndpointSchema.parse({
+      method: "GET",
+      path: "/x",
+      file: "f.ts",
+      pentestObjectives: ["a", "b"],
+    });
+    expect(parsed.pentestObjectives).toEqual(["a", "b"]);
+  });
+});

--- a/src/core/agents/specialized/whiteboxAttackSurface/types.ts
+++ b/src/core/agents/specialized/whiteboxAttackSurface/types.ts
@@ -52,12 +52,24 @@ export type RiskScoreBreakdown = z.infer<typeof RiskScoreBreakdownSchema>;
 // Endpoint & App schemas
 // ---------------------------------------------------------------------------
 
+// The model routinely emits `method` as an array for multi-method endpoints
+// (e.g. ["GET","POST"]). Accept both shapes and normalize to a single string —
+// matching how `assetRecordToEndpoint` in the whitebox workflow already joins
+// array methods — so downstream consumers keep a plain string.
+const MethodSchema = z
+  .union([z.string(), z.array(z.string())])
+  .transform((m) => (Array.isArray(m) ? m.join(", ") : m));
+
+// Array-of-strings fields where the model sometimes emits a single bare string.
+// Wrap a lone string into a one-element array instead of rejecting the payload.
+const StringListSchema = z
+  .union([z.string(), z.array(z.string())])
+  .transform((v) => (Array.isArray(v) ? v : [v]));
+
 export const EndpointSchema = z.object({
-  method: z
-    .string()
-    .describe(
-      "HTTP method (GET, POST, PUT, DELETE, etc.) or 'PAGE' for web pages",
-    ),
+  method: MethodSchema.describe(
+    "HTTP method (GET, POST, PUT, DELETE, etc.) or 'PAGE' for web pages",
+  ),
   path: z.string().describe("Route path (e.g. /api/users/:id, /dashboard)"),
   handler: z
     .string()
@@ -73,13 +85,10 @@ export const EndpointSchema = z.object({
     .string()
     .optional()
     .describe("Brief description of what this endpoint does"),
-  pentestObjectives: z
-    .array(z.string())
-    .default([])
-    .describe(
-      "Pentest objectives for this endpoint, derived from the threat model when available " +
-        "(e.g. 'Test for IDOR by enumerating user IDs', 'Test for SQL injection in search parameter')",
-    ),
+  pentestObjectives: StringListSchema.default([]).describe(
+    "Pentest objectives for this endpoint, derived from the threat model when available " +
+      "(e.g. 'Test for IDOR by enumerating user IDs', 'Test for SQL injection in search parameter')",
+  ),
   riskScore: RiskScoreSchema.optional().describe(
     "AI-calculated risk score for prioritizing pentest efforts",
   ),

--- a/src/core/ai/ai.test.ts
+++ b/src/core/ai/ai.test.ts
@@ -62,8 +62,14 @@ describe("isRepairFailClosedTool", () => {
 
   it("leaves ordinary tools eligible for repair", () => {
     expect(isRepairFailClosedTool("response")).toBe(false);
-    expect(isRepairFailClosedTool("document_vulnerability")).toBe(false);
     expect(isRepairFailClosedTool("http_request")).toBe(false);
+  });
+
+  it("keeps result-submission tools eligible for repair so a bad field is fixed, not dropped", () => {
+    // These carry no authorization boundary; repair re-prompts the model to fix
+    // a mis-shaped field instead of discarding a completed recon or finding.
+    expect(isRepairFailClosedTool("submit_results")).toBe(false);
+    expect(isRepairFailClosedTool("document_vulnerability")).toBe(false);
   });
 });
 

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -61,6 +61,12 @@ const RESPONSE_TOOL_NAME = "response";
  * (e.g. a default/localhost `target`) would silently bypass deterministic scope
  * enforcement. Repair therefore FAILS CLOSED for them — it returns `null` and
  * the original invalid call is never executed.
+ *
+ * Result-submission tools (`submit_results`, `document_vulnerability`) are
+ * deliberately NOT listed: they carry no authorization boundary, so repair is
+ * safe and desirable — it re-prompts the model to fix a mis-shaped field (e.g.
+ * `method` sent as an array) instead of dropping a completed recon or a
+ * confirmed finding.
  */
 const REPAIR_FAIL_CLOSED_TOOLS: ReadonlySet<string> = new Set([
   "spawn_pentest_agent",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Fixes the defect where the whitebox attack-surface agent could complete a full recon (discover apps, endpoints, threat models, risk scores) and then discard all of it while reporting success, whenever the model's final `submit_results` call failed schema validation on a single field (observed: `method` sent as an array like `["GET","POST"]` where the schema expected a string).

**Root cause** (in `whiteboxAttackSurface/agent.ts`):

- `stopWhen: hasToolCall("submit_results")` ended the loop as soon as the tool was *called* — and an invalid tool call still counts as a call (the AI SDK represents it as a `tool-call` part with `invalid: true`, which `hasToolCall` matches).
- `submit_results.execute` — which is what assigns `capturedResult` — only runs when the arguments pass validation.
- `resolveResult` returned `WHITEBOX_FALLBACK_RESULT` (an empty result) whenever `capturedResult` was null.

So one bad field rejected the whole payload, the loop stopped anyway, and the run reported success with an empty attack surface — which the downstream pentest then proceeded on.

**Changes:**

1. **Never silently degrade to an empty result.** `resolveResult` now inspects the run's steps: if `submit_results` was called but never validated (`capturedResult` is still null), it throws `WhiteboxSubmitValidationError` so the caller (the subagent spawner) surfaces a failed run and can retry, instead of returning an empty result as success. The empty fallback is used only when the model genuinely never called `submit_results`. The decision is factored into a pure, unit-tested `finalizeWhiteboxResult(capturedResult, submitAttempted)`.
2. **Stop on a successful submission, not the call.** `stopWhen` is now `[() => capturedResult !== null, stepCountIs(10_000)]`. A rejected `submit_results` no longer ends the loop, so the model gets another turn to fix and resubmit (aided by tool-call repair). `stepCountIs` is only a safety cap, matching the convention used by the blackbox/benchmark agents.
3. **Keep result-submission tools eligible for tool-call repair.** `submit_results` and `document_vulnerability` carry no authorization boundary, so they are (and must remain) excluded from the `REPAIR_FAIL_CLOSED_TOOLS` set that correctly fails closed for target-facing tools like `spawn_pentest_agent`. Documented the intent in `ai.ts` and added regression tests asserting both stay repair-eligible.
4. **Loosen the schema where the model reasonably varies.** `EndpointSchema.method` now accepts `string | string[]` and normalizes an array to a joined string (`"GET, POST"`), matching how `assetRecordToEndpoint` in the whitebox workflow already joins array methods — so downstream consumers keep a plain string. `pentestObjectives` now also tolerates a lone string (wrapped into a one-element array). This reduces how often the fail-loud/repair paths have to fire.

**On `document_vulnerability` (item 5):** it does not share the `stopWhen`-on-call bug — it is a per-finding tool inside the pentest loop, not a stop condition, and its `execute` returns error objects (POC failure, judge rejection) rather than throwing, so the loop continues and the model can retry. With repair enabled (confirmed not fail-closed) a validation-failed call is re-prompted rather than dropped. No schema change was made there because there is no evidence of which field failed; the regression test locks in that it stays repair-eligible.

### How did you verify your code works?

- Added unit tests:
  - `types.test.ts` — `EndpointSchema.method` accepts a string, joins a string array, and still rejects a non-string/non-array; `pentestObjectives` defaults to `[]`, wraps a lone string, and passes arrays through.
  - `agent.test.ts` — `finalizeWhiteboxResult` returns a captured result, throws `WhiteboxSubmitValidationError` when a submission was attempted but never validated, and returns the empty fallback only when nothing was submitted.
  - `ai.test.ts` — added a case asserting `submit_results` and `document_vulnerability` are not repair-fail-closed.
- Verified the AI SDK behavior these changes rely on: an invalid tool call is surfaced as a `tool-call` content part (`invalid: true`) included in `step.toolCalls`, and the agent loop continues after an invalid call (an error tool result is fed back), so the model gets another turn.
- `bun run tsc` — clean.
- `bun run check` (Biome lint/format/organize) — clean for the changed files.
- `bun run test` — 2612 passed, 15 skipped (the skipped ones require live API keys).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c5ee81b-27b1-46f6-8b70-d21649d0df40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c5ee81b-27b1-46f6-8b70-d21649d0df40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

