### PR TITLE
fix(tui): keep model search focused

### DIFF
--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -183,7 +183,7 @@ export default function OperatorDashboard({
     replace: replaceDialog,
     clear: clearDialog,
   } = useDialog();
-  const { refocusPrompt } = useFocus();
+  const { refocusPromptIfNoActiveEditor } = useFocus();
   const initialStrikeModeRef = useRef(
     resolveOperatorStrikeMode({
       resuming: !!sessionId,
@@ -522,9 +522,9 @@ export default function OperatorDashboard({
   // Auto-focus the input when the operator dashboard finishes loading
   useEffect(() => {
     if (!loading) {
-      refocusPrompt();
+      refocusPromptIfNoActiveEditor();
     }
-  }, [loading, refocusPrompt]);
+  }, [loading, refocusPromptIfNoActiveEditor]);
 
   useEffect(() => {
     if (sessionId === undefined) usageStore.beginNewSession();
@@ -1899,11 +1899,12 @@ This three-phase flow is specific to the TUI \`/threat-model\` command. The same
                     ? "Type to redirect agent, or Y/A to approve..."
                     : "Enter directive or / for commands & skills..."
             }
-            focused={
-              status === "running"
-                ? selectedQueueIndex < 0
-                : resolveInputFocused(status, stack.length, externalDialogOpen)
-            }
+            focused={resolveInputFocused(
+              status,
+              stack.length,
+              externalDialogOpen,
+              selectedQueueIndex,
+            )}
             status={status === "waiting" ? "running" : status}
             mode="operator"
             operatorMode={operatorMode}

--- a/src/tui/components/operator-dashboard/logic.test.ts
+++ b/src/tui/components/operator-dashboard/logic.test.ts
@@ -725,23 +725,29 @@ describe("buildOperatorSystemPrompt", () => {
 
 describe("resolveInputFocused", () => {
   it("returns true when idle and no dialogs", () => {
-    expect(resolveInputFocused("idle", 0, false)).toBe(true);
+    expect(resolveInputFocused("idle", 0, false, -1)).toBe(true);
   });
 
-  it("returns false when running", () => {
-    expect(resolveInputFocused("running", 0, false)).toBe(false);
+  it("returns true while running when no queued message is selected", () => {
+    expect(resolveInputFocused("running", 0, false, -1)).toBe(true);
+  });
+
+  it("returns false while running when a queued message is selected", () => {
+    expect(resolveInputFocused("running", 0, false, 0)).toBe(false);
   });
 
   it("returns false when dialog stack is non-empty", () => {
-    expect(resolveInputFocused("idle", 1, false)).toBe(false);
+    expect(resolveInputFocused("idle", 1, false, -1)).toBe(false);
+    expect(resolveInputFocused("running", 1, false, -1)).toBe(false);
   });
 
   it("returns false when external dialog is open", () => {
-    expect(resolveInputFocused("idle", 0, true)).toBe(false);
+    expect(resolveInputFocused("idle", 0, true, -1)).toBe(false);
+    expect(resolveInputFocused("running", 0, true, -1)).toBe(false);
   });
 
   it("returns true when waiting (input is active for redirects)", () => {
-    expect(resolveInputFocused("waiting", 0, false)).toBe(true);
+    expect(resolveInputFocused("waiting", 0, false, -1)).toBe(true);
   });
 });
 

--- a/src/tui/components/operator-dashboard/logic.ts
+++ b/src/tui/components/operator-dashboard/logic.ts
@@ -447,12 +447,15 @@ ${refinementBlock}`;
 // Input focus resolution
 // ---------------------------------------------------------------------------
 
+/** Dialogs always win focus; queue selection only overrides the running input. */
 export function resolveInputFocused(
   status: DashboardStatus,
   dialogStackLength: number,
   externalDialogOpen: boolean,
+  selectedQueueIndex: number,
 ): boolean {
-  return status !== "running" && dialogStackLength === 0 && !externalDialogOpen;
+  if (dialogStackLength > 0 || externalDialogOpen) return false;
+  return status !== "running" || selectedQueueIndex < 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tui/components/terminal-focus-handler.tsx
+++ b/src/tui/components/terminal-focus-handler.tsx
@@ -15,19 +15,19 @@ import { setupTerminalFocusHandling } from "../terminal-focus";
  * Must be rendered inside FocusProvider to access refocusPrompt.
  */
 export function TerminalFocusHandler() {
-  const { refocusPrompt } = useFocus();
+  const { refocusPromptIfNoActiveEditor } = useFocus();
   const renderer = useRenderer();
 
   useEffect(() => {
     // Set up terminal focus handling with a callback to re-focus the prompt
     const cleanup = setupTerminalFocusHandling(renderer, {
-      onTerminalFocus: refocusPrompt,
+      onTerminalFocus: refocusPromptIfNoActiveEditor,
       debug: false, // Set to true for debugging
     });
 
     // Clean up on unmount
     return cleanup;
-  }, [renderer, refocusPrompt]);
+  }, [renderer, refocusPromptIfNoActiveEditor]);
 
   // This component doesn't render anything
   return null;

--- a/src/tui/context/focus-ownership.test.ts
+++ b/src/tui/context/focus-ownership.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { type FocusOwner, shouldRefocusPrompt } from "./focus-ownership";
+
+function focusOwner(isDestroyed = false): FocusOwner {
+  return { isDestroyed };
+}
+
+describe("shouldRefocusPrompt", () => {
+  it("allows focus when no editor owns it", () => {
+    expect(shouldRefocusPrompt(null, focusOwner())).toBe(true);
+  });
+
+  it("allows focus when the prompt already owns it", () => {
+    const prompt = focusOwner();
+    expect(shouldRefocusPrompt(prompt, prompt)).toBe(true);
+  });
+
+  it("allows focus when the previous editor was destroyed", () => {
+    expect(shouldRefocusPrompt(focusOwner(true), focusOwner())).toBe(true);
+  });
+
+  it("preserves focus on another live editor", () => {
+    expect(shouldRefocusPrompt(focusOwner(), focusOwner())).toBe(false);
+  });
+});

--- a/src/tui/context/focus-ownership.ts
+++ b/src/tui/context/focus-ownership.ts
@@ -1,0 +1,12 @@
+import type { Renderable } from "@opentui/core";
+
+export type FocusOwner = Pick<Renderable, "isDestroyed">;
+
+export function shouldRefocusPrompt(
+  currentFocus: FocusOwner | null,
+  prompt: FocusOwner | null,
+): boolean {
+  return (
+    currentFocus === null || currentFocus === prompt || currentFocus.isDestroyed
+  );
+}

--- a/src/tui/context/focus.tsx
+++ b/src/tui/context/focus.tsx
@@ -1,3 +1,4 @@
+import { useRenderer } from "@opentui/react";
 import {
   createContext,
   type ReactNode,
@@ -6,12 +7,12 @@ import {
   useRef,
 } from "react";
 import type { PromptInputRef } from "../components/shared";
+import { shouldRefocusPrompt } from "./focus-ownership";
 
 interface FocusContextType {
   promptRef: React.MutableRefObject<PromptInputRef | null>;
-  // Existing
   refocusPrompt: () => void;
-  // Ref control methods
+  refocusPromptIfNoActiveEditor: () => void;
   focusPrompt: () => void;
   blurPrompt: () => void;
   resetPrompt: () => void;
@@ -24,12 +25,23 @@ const FocusContext = createContext<FocusContextType | undefined>(undefined);
 
 export function FocusProvider({ children }: { children: ReactNode }) {
   const promptRef = useRef<PromptInputRef | null>(null);
+  const renderer = useRenderer();
 
   const refocusPrompt = useCallback(() => {
     setTimeout(() => {
       promptRef.current?.focus();
     }, 1);
   }, []);
+
+  const refocusPromptIfNoActiveEditor = useCallback(() => {
+    setTimeout(() => {
+      const prompt = promptRef.current?.getTextareaRef() ?? null;
+      if (!shouldRefocusPrompt(renderer.currentFocusedEditor, prompt)) {
+        return;
+      }
+      promptRef.current?.focus();
+    }, 1);
+  }, [renderer]);
 
   const focusPrompt = useCallback(() => promptRef.current?.focus(), []);
   const blurPrompt = useCallback(() => promptRef.current?.blur(), []);
@@ -51,6 +63,7 @@ export function FocusProvider({ children }: { children: ReactNode }) {
       value={{
         promptRef,
         refocusPrompt,
+        refocusPromptIfNoActiveEditor,
         focusPrompt,
         blurPrompt,
         resetPrompt,


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Apex model selection · PR 1 of 3**<br>
> Review and merge in table order; each PR is based on the preceding step.

| Step | Pull request | Focus |
| :---: | --- | --- |
| **1** | **[#1047](https://github.com/pensarai/apex/pull/1047)** | **Model search focus** · `Current` |
| 2 | [#1048](https://github.com/pensarai/apex/pull/1048) | Laguna S 2.1 support |
| 3 | [#1049](https://github.com/pensarai/apex/pull/1049) | Nemotron 3 Ultra support |

## Summary

Opening `/models` now keeps keyboard focus in the model search editor. Terminal focus restoration and operator running-state updates no longer steal input from the dialog, while closing the dialog still restores the prompt.

No linked issue

## Changes

- Preserve focus on an active model-search editor during terminal focus events.
- Make the operator prompt yield to dialogs in every run state.
- Cover prompt-focus ownership and operator focus resolution with regression tests.

## Validation

- `bun run test` — 2,689 passed, 22 skipped.
- `bun run tsc` — passed.
- `bun run lint` — passed with 192 existing warnings outside this change.
- `bun run format:check` — passed.
- Runtime probe — `/models` receives typed input on open, retains it across terminal/operator focus changes, and restores prompt focus on close.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI focus behavior only; logic is covered by new and updated unit tests with no auth or data-path changes.
> 
> **Overview**
> Fixes keyboard focus being stolen from the `/models` search field when the terminal regains focus or the operator dashboard finishes loading.
> 
> **Focus ownership:** Adds `shouldRefocusPrompt` and `refocusPromptIfNoActiveEditor`, which only focuses the main prompt when no other live OpenTUI editor holds focus (or focus already belongs to the prompt). `TerminalFocusHandler` and the operator dashboard post-load effect now use this guarded refocus instead of unconditional `refocusPrompt`.
> 
> **Operator input focus:** `resolveInputFocused` now accounts for `selectedQueueIndex`—the prompt stays focusable while the agent is **running** unless a queued message is selected or a dialog is open—replacing ad hoc logic on `InputArea`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3699a1dcf06b15d52a1233fa14d3beb5b1234e67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->