### PR TITLE
feat(models): add Laguna S 2.1 via OpenRouter

### DIFF
--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -184,6 +184,10 @@ function lookupOutputBudgetByPattern(modelId: string): number {
     return 128_000;
   }
 
+  if (modelId.includes("laguna-s-2.1")) {
+    return 131_072;
+  }
+
   // GLM 5 / 5.2 ship a ~131K (128Ki) max-output window. Matching both keeps the
   // Bedrock `zai.glm-5` id and OpenRouter `z-ai/glm-5.2` on the same budget.
   if (modelId.includes("glm-5")) {

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -51,6 +51,15 @@ describe("getMaxOutputTokens", () => {
     expect(getMaxOutputTokens("minimax/minimax-m3")).toBe(128_000);
   });
 
+  it("registers Laguna S 2.1 with its OpenRouter limits", () => {
+    expect(getModelInfo("poolside/laguna-s-2.1")).toMatchObject({
+      name: "Laguna S 2.1",
+      provider: "openrouter",
+      contextLength: 1_048_576,
+    });
+    expect(getMaxOutputTokens("poolside/laguna-s-2.1")).toBe(131_072);
+  });
+
   it("recognizes GLM 5 / 5.2's 131.1K max-output window", () => {
     expect(getMaxOutputTokens("z-ai/glm-5.2")).toBe(131_072);
     expect(getMaxOutputTokens("zai.glm-5")).toBe(131_072);

--- a/src/core/ai/models/openrouter.ts
+++ b/src/core/ai/models/openrouter.ts
@@ -160,6 +160,12 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
     contextLength: 524288,
   },
   {
+    id: "poolside/laguna-s-2.1",
+    name: "Laguna S 2.1",
+    provider: "openrouter",
+    contextLength: 1048576,
+  },
+  {
     id: "qwen/qwen3-8b",
     name: "Qwen 3 8B Thinking",
     provider: "openrouter",


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Apex model selection · PR 2 of 3**<br>
> Review and merge in table order; each PR is based on the preceding step.

| Step | Pull request | Focus |
| :---: | --- | --- |
| 1 | [#1047](https://github.com/pensarai/apex/pull/1047) | Model search focus |
| **2** | **[#1048](https://github.com/pensarai/apex/pull/1048)** | **Laguna S 2.1 support** · `Current` |
| 3 | [#1049](https://github.com/pensarai/apex/pull/1049) | Nemotron 3 Ultra support |

## Summary

Add Poolside Laguna S 2.1 to Apex's curated OpenRouter models using the standard `poolside/laguna-s-2.1` route. The registry and output-budget logic use OpenRouter's advertised 1,048,576-token context window and 131,072-token completion limit.

No linked issue

## Changes

- Expose Laguna S 2.1 when OpenRouter is configured.
- Apply the model's documented context and output limits.
- Add regression coverage for its identifier, provider, and budgets.

## Validation

- `bun run test` — 2,690 passed, 22 skipped.
- `bun run tsc` — passed.
- `bun run lint` — passed with 192 existing warnings outside this change.
- `bun run format:check` — passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry and token-budget metadata only; no changes to routing, auth, or request handling beyond selecting the new model.
> 
> **Overview**
> Adds **Poolside Laguna S 2.1** (`poolside/laguna-s-2.1`) to the curated OpenRouter model list so it appears when OpenRouter is configured.
> 
> Registers a **1,048,576** context window in the OpenRouter registry and a dedicated **`getMaxOutputTokens`** pattern for **`laguna-s-2.1`** at **131,072** completions (OpenRouter’s documented limit, aligned with GLM 5–style budgets). Regression tests pin the model’s name, provider, context length, and output cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca5239a6fe0c8eda15289b14e1a278f64941245. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->