### PR TITLE
feat(models): add Nemotron 3 Ultra via OpenRouter

### DIFF
--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -208,5 +208,9 @@ function lookupOutputBudgetByPattern(modelId: string): number {
     return 16_000;
   }
 
+  if (modelId.includes("nemotron-3-ultra")) {
+    return 16_384;
+  }
+
   return 4_096;
 }

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -60,6 +60,17 @@ describe("getMaxOutputTokens", () => {
     expect(getMaxOutputTokens("poolside/laguna-s-2.1")).toBe(131_072);
   });
 
+  it("registers Nemotron 3 Ultra with its OpenRouter limits", () => {
+    expect(getModelInfo("nvidia/nemotron-3-ultra-550b-a55b")).toMatchObject({
+      name: "Nemotron 3 Ultra 550B A55B",
+      provider: "openrouter",
+      contextLength: 262_144,
+    });
+    expect(getMaxOutputTokens("nvidia/nemotron-3-ultra-550b-a55b")).toBe(
+      16_384,
+    );
+  });
+
   it("recognizes GLM 5 / 5.2's 131.1K max-output window", () => {
     expect(getMaxOutputTokens("z-ai/glm-5.2")).toBe(131_072);
     expect(getMaxOutputTokens("zai.glm-5")).toBe(131_072);

--- a/src/core/ai/models/openrouter.ts
+++ b/src/core/ai/models/openrouter.ts
@@ -202,6 +202,12 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
     contextLength: 262144,
   },
   {
+    id: "nvidia/nemotron-3-ultra-550b-a55b",
+    name: "Nemotron 3 Ultra 550B A55B",
+    provider: "openrouter",
+    contextLength: 262144,
+  },
+  {
     id: "arcee-ai/trinity-mini:free",
     name: "Arcee Trinity Mini (Free)",
     provider: "openrouter",


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Apex model selection · PR 3 of 3**<br>
> Review and merge in table order; each PR is based on the preceding step.

| Step | Pull request | Focus |
| :---: | --- | --- |
| 1 | [#1047](https://github.com/pensarai/apex/pull/1047) | Model search focus |
| 2 | [#1048](https://github.com/pensarai/apex/pull/1048) | Laguna S 2.1 support |
| **3** | **[#1049](https://github.com/pensarai/apex/pull/1049)** | **Nemotron 3 Ultra support** · `Current` |

## Summary

Add NVIDIA Nemotron 3 Ultra 550B-A55B to Apex's curated OpenRouter models using `nvidia/nemotron-3-ultra-550b-a55b`. The registry uses the standard route's 262,144-token context window and a conservative 16,384-token output budget compatible with its advertised endpoints.

No linked issue

## Changes

- Expose Nemotron 3 Ultra when OpenRouter is configured.
- Apply route-compatible context and output limits.
- Add regression coverage for its identifier, provider, and budgets.

## Validation

- `bun run test` — 2,691 passed, 22 skipped.
- `bun run tsc` — passed.
- `bun run lint` — passed with 192 existing warnings outside this change.
- `bun run format:check` — passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry and token-budget metadata only; no auth, routing, or runtime behavior changes beyond correct max-output for the new model id.
> 
> **Overview**
> Adds **NVIDIA Nemotron 3 Ultra 550B A55B** (`nvidia/nemotron-3-ultra-550b-a55b`) to the curated OpenRouter model list with a **262,144** context window so it appears when OpenRouter is configured.
> 
> Extends `getMaxOutputTokens` with a `nemotron-3-ultra` pattern returning **16,384** tokens instead of the **4,096** catch-all, aligning streaming and context budgeting with the route’s advertised limits. Regression tests lock in registry metadata and the output budget for this id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb0d5ae088c9649d126173f8a0963e479b9878e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->