### PR TITLE
feat(models): add GLM 5.3 via OpenRouter

### DIFF
--- a/src/core/ai/ai.test.ts
+++ b/src/core/ai/ai.test.ts
@@ -210,15 +210,17 @@ describe("buildReasoningProviderOptions", () => {
 });
 
 describe("buildOpenRouterProviderOptions", () => {
-  it("pins GLM 5.2 to Z.ai without provider fallbacks", () => {
-    expect(buildOpenRouterProviderOptions("z-ai/glm-5.2")).toEqual({
-      openrouter: {
-        provider: {
-          only: ["z-ai"],
-          allow_fallbacks: false,
+  it("pins GLM 5.2 and 5.3 to Z.ai without provider fallbacks", () => {
+    for (const model of ["z-ai/glm-5.2", "z-ai/glm-5.3"]) {
+      expect(buildOpenRouterProviderOptions(model)).toEqual({
+        openrouter: {
+          provider: {
+            only: ["z-ai"],
+            allow_fallbacks: false,
+          },
         },
-      },
-    });
+      });
+    }
   });
 
   it("leaves other OpenRouter models unchanged", () => {

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -977,7 +977,7 @@ export type OpenRouterProviderOptions = {
 export function buildOpenRouterProviderOptions(
   model: AIModel,
 ): OpenRouterProviderOptions | undefined {
-  if (model !== "z-ai/glm-5.2") return undefined;
+  if (model !== "z-ai/glm-5.2" && model !== "z-ai/glm-5.3") return undefined;
   return {
     openrouter: {
       provider: {

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -1436,6 +1436,7 @@ export function streamResponse(
             providerMetadata: repairProviderMetadata,
           } = await generateText({
             model: providerModel,
+            providerOptions: openRouterProviderOptions,
             output: Output.object({
               schema: tool.inputSchema, // Use the actual Zod schema from the tool
             }),

--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -188,13 +188,8 @@ function lookupOutputBudgetByPattern(modelId: string): number {
     return 131_072;
   }
 
-  // GLM 5.3 doubles the previous generation's max-output window.
-  if (modelId.includes("glm-5.3")) {
-    return 262_144;
-  }
-
-  // GLM 5 / 5.2 ship a ~131K (128Ki) max-output window. Matching both keeps the
-  // Bedrock `zai.glm-5` id and OpenRouter `z-ai/glm-5.2` on the same budget.
+  // GLM 5 models ship a ~131K (128Ki) max-output window. Matching the family
+  // keeps Bedrock and OpenRouter model IDs on the same budget.
   if (modelId.includes("glm-5")) {
     return 131_072;
   }

--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -188,6 +188,11 @@ function lookupOutputBudgetByPattern(modelId: string): number {
     return 131_072;
   }
 
+  // GLM 5.3 doubles the previous generation's max-output window.
+  if (modelId.includes("glm-5.3")) {
+    return 262_144;
+  }
+
   // GLM 5 / 5.2 ship a ~131K (128Ki) max-output window. Matching both keeps the
   // Bedrock `zai.glm-5` id and OpenRouter `z-ai/glm-5.2` on the same budget.
   if (modelId.includes("glm-5")) {

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -75,9 +75,9 @@ describe("getMaxOutputTokens", () => {
     expect(getModelInfo("z-ai/glm-5.3")).toMatchObject({
       name: "GLM 5.3",
       provider: "openrouter",
-      contextLength: 1_310_720,
+      contextLength: 1_048_576,
     });
-    expect(getMaxOutputTokens("z-ai/glm-5.3")).toBe(262_144);
+    expect(getMaxOutputTokens("z-ai/glm-5.3")).toBe(131_072);
   });
 
   it("recognizes GLM 5 / 5.2's 131.1K max-output window", () => {

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -71,6 +71,15 @@ describe("getMaxOutputTokens", () => {
     );
   });
 
+  it("registers GLM 5.3 with its OpenRouter limits", () => {
+    expect(getModelInfo("z-ai/glm-5.3")).toMatchObject({
+      name: "GLM 5.3",
+      provider: "openrouter",
+      contextLength: 1_310_720,
+    });
+    expect(getMaxOutputTokens("z-ai/glm-5.3")).toBe(262_144);
+  });
+
   it("recognizes GLM 5 / 5.2's 131.1K max-output window", () => {
     expect(getMaxOutputTokens("z-ai/glm-5.2")).toBe(131_072);
     expect(getMaxOutputTokens("zai.glm-5")).toBe(131_072);

--- a/src/core/ai/models/openrouter.ts
+++ b/src/core/ai/models/openrouter.ts
@@ -243,4 +243,10 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
     provider: "openrouter",
     contextLength: 1000000,
   },
+  {
+    id: "z-ai/glm-5.3",
+    name: "GLM 5.3",
+    provider: "openrouter",
+    contextLength: 1310720,
+  },
 ];

--- a/src/core/ai/models/openrouter.ts
+++ b/src/core/ai/models/openrouter.ts
@@ -247,6 +247,6 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
     id: "z-ai/glm-5.3",
     name: "GLM 5.3",
     provider: "openrouter",
-    contextLength: 1310720,
+    contextLength: 1048576,
   },
 ];

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -22,7 +22,12 @@ import { config } from "../config";
 import { createLogger } from "../logger/structured";
 import { createAiTelemetrySettings } from "../observability";
 import { scopedLogger } from "../util/lazyLogger";
-import { type AIModel, type StreamResponseOpts, streamResponse } from "./ai";
+import {
+  type AIModel,
+  buildOpenRouterProviderOptions,
+  type StreamResponseOpts,
+  streamResponse,
+} from "./ai";
 import {
   extractTaskSummaryFromMessages,
   truncateWithMarker,
@@ -442,6 +447,7 @@ async function summarizeConversation(
     providerMetadata: summaryProviderMetadata,
   } = await generateText({
     model,
+    providerOptions: buildOpenRouterProviderOptions(opts.model),
     system: `You are a helpful assistant that summarizes conversations to pass to another agent. Review the conversation and system prompt at the end provided by the user.`,
     messages: summarizedMessages,
     abortSignal: opts.abortSignal,

--- a/src/core/observability/telemetry.test.ts
+++ b/src/core/observability/telemetry.test.ts
@@ -340,6 +340,29 @@ describe("model-call helpers", () => {
     expect(span.attributes["ai.telemetry.metadata.sessionId"]).toBe("ses_sum");
   });
 
+  it("keeps GLM summarization pinned to Z.ai", async () => {
+    mockState.model = oneStepTextModel();
+    const stream = createSummarizationStream(
+      [{ role: "user", content: "history to summarize" }],
+      {
+        prompt: "resume",
+        model: "z-ai/glm-5.3",
+        silent: true,
+      },
+      mockState.model,
+    );
+    await drain(stream);
+
+    expect(mockState.model.doGenerateCalls[0]?.providerOptions).toEqual({
+      openrouter: {
+        provider: {
+          only: ["z-ai"],
+          allow_fallbacks: false,
+        },
+      },
+    });
+  });
+
   it("tool repair runs its model call with the repair id", async () => {
     mockState.model = invalidToolArgsModel();
     await drain(
@@ -365,6 +388,34 @@ describe("model-call helpers", () => {
     expect(generateSpans[0]?.attributes["ai.telemetry.functionId"]).toBe(
       "apex.tool.repair",
     );
+  });
+
+  it("keeps GLM tool repair pinned to Z.ai", async () => {
+    mockState.model = invalidToolArgsModel();
+    await drain(
+      streamResponse({
+        prompt: "hi",
+        model: "z-ai/glm-5.3",
+        silent: true,
+        tools: {
+          probe: {
+            description: "test tool",
+            inputSchema: z.object({ q: z.string() }),
+            execute: async (input: { q: string }) => `echo:${input.q}`,
+          },
+        },
+        stopWhen: stepCountIs(2),
+      }),
+    );
+
+    expect(mockState.model.doGenerateCalls[0]?.providerOptions).toEqual({
+      openrouter: {
+        provider: {
+          only: ["z-ai"],
+          allow_fallbacks: false,
+        },
+      },
+    });
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do?

Adds Z.ai GLM 5.3 to the curated OpenRouter model registry using `z-ai/glm-5.3`. Because requests are pinned to the official Z.AI endpoint with fallbacks disabled, the registry uses that endpoint's 1,048,576-token context window and 131,072-token completion limit.

The Z.AI-only route is applied consistently to primary streaming, structured generation, tool-call repair, and context summarization. The branch is rebased onto the latest `canary`; additive overlaps with the Laguna S 2.1 and Nemotron 3 Ultra additions preserve all three models and their regression tests.

No linked issue

### How did you verify your code works?

- `bun run test -- src/core/ai/ai.test.ts` — 23 passed, 1 skipped
- `bun run test -- src/core/ai/models/models.test.ts` — 26 passed
- `bun run test -- src/core/observability/telemetry.test.ts` — 17 passed
- `bun run test` — 2,706 passed, 22 skipped
- `bun run tsc` — passed
- `bun run lint` — passed with the existing warning-only baseline (192 warnings, 10 infos)
- `bun run format:check` — passed with the same existing warning-only baseline; Prettier confirmed all matched files use its code style
- `git ls-files -u` — no unmerged paths
- Conflict-marker search and `git diff --check` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c89f8c9-43a2-4684-8af8-2cd568317000?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c89f8c9-43a2-4684-8af8-2cd568317000&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>