### PR TITLE
refactor(usage): fold cache metrics into the step usage event

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.test.ts
@@ -74,6 +74,33 @@ vi.mock("../../ai", () => ({
     streamResponseCalls.push(opts);
     return { fullStream: (async function* () {})() };
   },
+  normalizeStepUsage: (step: {
+    usage?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      inputTokenDetails?: {
+        cacheReadTokens?: number;
+        cacheWriteTokens?: number;
+      };
+    };
+    providerMetadata?: {
+      anthropic?: {
+        cacheReadInputTokens?: number;
+        cacheCreationInputTokens?: number;
+      };
+    };
+  }) => {
+    const meta = step.providerMetadata?.anthropic;
+    const details = step.usage?.inputTokenDetails;
+    return {
+      inputTokens: step.usage?.inputTokens ?? 0,
+      outputTokens: step.usage?.outputTokens ?? 0,
+      cacheReadTokens:
+        meta?.cacheReadInputTokens ?? details?.cacheReadTokens ?? 0,
+      cacheWriteTokens:
+        meta?.cacheCreationInputTokens ?? details?.cacheWriteTokens ?? 0,
+    };
+  },
 }));
 vi.mock("../../session", () => ({ create: () => {} }));
 vi.mock("../specialized/utils", () => ({
@@ -191,6 +218,56 @@ describe("auxiliary model events", () => {
         cacheWriteTokens: 1,
       });
       expect(traceRecordStepCalls.at(-1)?.[2]).toEqual({ usageOnly: true });
+      writer.cancelTimer();
+    } finally {
+      rmSync(rootPath, { recursive: true, force: true });
+    }
+  });
+
+  it("records cache from the step event without onCacheMetrics", async () => {
+    streamResponseCalls.length = 0;
+    traceRecordStepCalls.length = 0;
+    const rootPath = join(
+      "/tmp",
+      `apex-step-cache-${Date.now()}-${Math.random()}`,
+    );
+
+    try {
+      const agent = new OffensiveSecurityAgent({
+        prompt: "test",
+        model: "test-model",
+        session: { id: "ses_step_cache", rootPath },
+        activeTools: [],
+        sandbox: {},
+      } as never);
+
+      void agent.streamResult;
+      const call = streamResponseCalls[0] as {
+        onStepFinish: (event: unknown) => Promise<void>;
+        onCacheMetrics?: unknown;
+      };
+      expect(call.onCacheMetrics).toBeUndefined();
+
+      await call.onStepFinish({
+        response: {
+          id: "step-1",
+          messages: [{ role: "assistant", content: "ok" }],
+        },
+        usage: {
+          inputTokens: 40,
+          outputTokens: 6,
+          inputTokenDetails: { cacheReadTokens: 30, cacheWriteTokens: 2 },
+        },
+      });
+
+      expect(traceRecordStepCalls.at(-1)?.[1]).toEqual({
+        inputTokens: 40,
+        outputTokens: 6,
+        cacheReadTokens: 30,
+        cacheWriteTokens: 2,
+      });
+      const writer = (agent as unknown as { writer: AgentMessageWriter })
+        .writer;
       writer.cancelTimer();
     } finally {
       rmSync(rootPath, { recursive: true, force: true });

--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -9,7 +9,7 @@ import type {
   ToolSet,
 } from "ai";
 import { hasToolCall } from "ai";
-import { streamResponse } from "../../ai";
+import { normalizeStepUsage, streamResponse } from "../../ai";
 import { AgentEventBus, type StreamIdContext } from "../../eventBus";
 import {
   resolveEffectiveHeaders,
@@ -703,13 +703,6 @@ export class OffensiveSecurityAgent<TResult = void> {
     });
 
     // -- Stream ---------------------------------------------------------------
-    // Mutable ref for cache metrics — onCacheMetrics fires synchronously
-    // before onStepFinish within the same step (see ai.ts:367-391).
-    let lastCacheMetrics: {
-      cacheReadTokens: number;
-      cacheWriteTokens: number;
-    } | null = null;
-
     // Deferred so the AI SDK telemetry binds to this agent's span (entered in
     // consume()) rather than the construction-time context. See `streamResult`.
     this.createStream = () =>
@@ -735,24 +728,10 @@ export class OffensiveSecurityAgent<TResult = void> {
           const auxiliaryModelEvent =
             event.response.id === "summarization" ||
             event.response.id === "tool-repair";
+          const stepUsage = normalizeStepUsage(event);
 
           if (auxiliaryModelEvent) {
-            const cacheDetails = event.usage.inputTokenDetails;
-            traceWriter.recordStep(
-              [],
-              {
-                inputTokens: event.usage.inputTokens ?? 0,
-                outputTokens: event.usage.outputTokens ?? 0,
-                cacheReadTokens:
-                  lastCacheMetrics?.cacheReadTokens ??
-                  cacheDetails?.cacheReadTokens,
-                cacheWriteTokens:
-                  lastCacheMetrics?.cacheWriteTokens ??
-                  cacheDetails?.cacheWriteTokens,
-              },
-              { usageOnly: true },
-            );
-            lastCacheMetrics = null;
+            traceWriter.recordStep([], stepUsage, { usageOnly: true });
             await input.onStepFinish?.(event);
             return;
           }
@@ -762,12 +741,10 @@ export class OffensiveSecurityAgent<TResult = void> {
             ...event.response.messages,
           ]);
           schedulePersist();
-          traceWriter.recordStep(event.response.messages as ModelMessage[], {
-            inputTokens: event.usage.inputTokens ?? 0,
-            outputTokens: event.usage.outputTokens ?? 0,
-            ...lastCacheMetrics,
-          });
-          lastCacheMetrics = null;
+          traceWriter.recordStep(
+            event.response.messages as ModelMessage[],
+            stepUsage,
+          );
           this.eventBus.emit("step-finish", {
             messages: event.response.messages,
             subagentId: this.subagentId,
@@ -799,13 +776,7 @@ export class OffensiveSecurityAgent<TResult = void> {
         },
         abortSignal: input.abortSignal,
         authConfig: input.authConfig,
-        onCacheMetrics: (metrics) => {
-          lastCacheMetrics = {
-            cacheReadTokens: metrics.cacheReadInputTokens,
-            cacheWriteTokens: metrics.cacheCreationInputTokens,
-          };
-          input.onCacheMetrics?.(metrics);
-        },
+        onCacheMetrics: input.onCacheMetrics,
         enableThinking: input.enableThinking,
         thinkingEffort: input.thinkingEffort,
         openAIReasoningEffort: input.openAIReasoningEffort,

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -1079,7 +1079,10 @@ export interface StreamResponseOpts {
    * new messages (not the full pre-summarization history).
    */
   onSummarized?: (summary: string) => void;
-  /** Called when Anthropic cache metrics are present in a step's providerMetadata */
+  /**
+   * Deprecated host shim: fires only when a cache counter is `> 0`.
+   * Apex internals read cache from {@link normalizeStepUsage} on the step.
+   */
   onCacheMetrics?: (metrics: CacheMetrics) => void;
   /** Enable extended thinking for supported models (Anthropic Claude 3.7+) */
   enableThinking?: boolean;

--- a/src/core/ai/index.ts
+++ b/src/core/ai/index.ts
@@ -4,6 +4,7 @@ export type {
   CacheMetrics,
   GenerateObjectOpts,
   ModelInfo,
+  NormalizedStepUsage,
   OpenAIReasoningEffort,
   StreamResponseOpts,
   ThinkingEffort,
@@ -19,6 +20,7 @@ export {
   modelSupportsOpenAIReasoning,
   modelSupportsThinking,
   normalizeOpenAIReasoningEffort,
+  normalizeStepUsage,
   runWithStepContext,
   streamResponse,
 } from "./ai";

--- a/src/core/api/blackboxPentest.test.ts
+++ b/src/core/api/blackboxPentest.test.ts
@@ -27,12 +27,12 @@ beforeEach(() => {
   mocks.runPentestWorkflow.mockImplementation(
     async (input: PentestWorkflowInput) => {
       await input.onStepFinish?.({
-        usage: { inputTokens: 100, outputTokens: 20 },
+        usage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          inputTokenDetails: { cacheReadTokens: 80, cacheWriteTokens: 10 },
+        },
       } as Parameters<NonNullable<PentestWorkflowInput["onStepFinish"]>>[0]);
-      input.onCacheMetrics?.({
-        cacheReadInputTokens: 80,
-        cacheCreationInputTokens: 10,
-      });
       return {
         findings: [],
         findingsPath: join(rootPath, "findings"),

--- a/src/core/api/blackboxPentest.ts
+++ b/src/core/api/blackboxPentest.ts
@@ -1,5 +1,6 @@
 //
 
+import { normalizeStepUsage } from "../ai";
 import {
   readExecutionMetrics,
   writeExecutionMetrics,
@@ -34,15 +35,8 @@ export async function runPentestAgent(
   let tokenUsage = persisted ?? EMPTY_SESSION_TOKEN_USAGE;
 
   const onStepFinish: PentestWorkflowInput["onStepFinish"] = async (event) => {
-    tokenUsage = accumulateSessionTokens(tokenUsage, event.usage ?? {});
+    tokenUsage = accumulateSessionTokens(tokenUsage, normalizeStepUsage(event));
     await input.onStepFinish?.(event);
-  };
-  const onCacheMetrics: PentestWorkflowInput["onCacheMetrics"] = (metrics) => {
-    tokenUsage = accumulateSessionTokens(tokenUsage, {
-      cacheReadTokens: metrics.cacheReadInputTokens,
-      cacheWriteTokens: metrics.cacheCreationInputTokens,
-    });
-    input.onCacheMetrics?.(metrics);
   };
 
   let result: PentestWorkflowResult;
@@ -50,7 +44,7 @@ export async function runPentestAgent(
     result = await runPentestWorkflow({
       ...input,
       onStepFinish,
-      onCacheMetrics,
+      onCacheMetrics: input.onCacheMetrics,
     });
   } finally {
     writeExecutionMetrics({

--- a/src/core/benchmark/runner.ts
+++ b/src/core/benchmark/runner.ts
@@ -13,7 +13,7 @@ import {
   BenchmarkComparisonAgent,
   type BenchmarkComparisonResult,
 } from "../agents/specialized/benchmarkComparisonAgent";
-import type { CacheMetrics } from "../ai";
+import { normalizeStepUsage } from "../ai";
 import { AgentEventBus } from "../eventBus";
 import * as sessions from "../session";
 import {
@@ -395,17 +395,14 @@ export async function runSingleBenchmark(
         abortSignal: controller.signal,
         eventBus: benchBus,
         onStepFinish: (event) => {
-          const u = event.usage;
-          if (u) {
-            tokenTotals.inputTokens += u.inputTokens ?? 0;
-            tokenTotals.outputTokens += u.outputTokens ?? 0;
-            tokenTotals.totalTokens +=
-              u.totalTokens ?? (u.inputTokens ?? 0) + (u.outputTokens ?? 0);
-          }
-        },
-        onCacheMetrics: (metrics: CacheMetrics) => {
-          cacheTotals.cacheReadTokens += metrics.cacheReadInputTokens;
-          cacheTotals.cacheWriteTokens += metrics.cacheCreationInputTokens;
+          const stepUsage = normalizeStepUsage(event);
+          tokenTotals.inputTokens += stepUsage.inputTokens;
+          tokenTotals.outputTokens += stepUsage.outputTokens;
+          tokenTotals.totalTokens +=
+            event.usage?.totalTokens ??
+            stepUsage.inputTokens + stepUsage.outputTokens;
+          cacheTotals.cacheReadTokens += stepUsage.cacheReadTokens;
+          cacheTotals.cacheWriteTokens += stepUsage.cacheWriteTokens;
         },
       });
     } finally {

--- a/src/tui/components/operator-dashboard/index.tsx
+++ b/src/tui/components/operator-dashboard/index.tsx
@@ -33,10 +33,10 @@ import {
 } from "../../../core/agents/offSecAgent";
 import {
   buildAuthConfig,
-  type CacheMetrics,
   getContextWindow,
   modelSupportsOpenAIReasoning,
   modelSupportsThinking,
+  normalizeStepUsage,
 } from "../../../core/ai";
 import {
   type RunAgentResult,
@@ -731,25 +731,37 @@ export default function OperatorDashboard({
       // whole conversation as the model saw it, and the denominator comes
       // from the model this run actually used.
       const runModelId = model.id;
-      const recordRootStepUsage = (usage: {
-        inputTokens?: number;
-        outputTokens?: number;
+      const recordRootStepUsage = (event: {
+        usage?: {
+          inputTokens?: number;
+          outputTokens?: number;
+          inputTokenDetails?: {
+            cacheReadTokens?: number;
+            cacheWriteTokens?: number;
+          };
+        };
+        providerMetadata?: unknown;
       }) => {
-        const inputTokens = usage.inputTokens ?? 0;
-        if (inputTokens > 0) {
+        const stepUsage = normalizeStepUsage(event);
+        if (stepUsage.inputTokens > 0) {
           usageStore.setRootContext(runSessionIdRef.current, {
-            usedTokens: inputTokens,
+            usedTokens: stepUsage.inputTokens,
             contextLimit: getContextWindow(runModelId),
             modelId: runModelId,
           });
         }
-        recordTokenUsage(inputTokens, usage.outputTokens ?? 0);
+        recordTokenUsage(
+          stepUsage.inputTokens,
+          stepUsage.outputTokens,
+          stepUsage.cacheReadTokens,
+          stepUsage.cacheWriteTokens,
+        );
       };
 
       const onStepFinish = (event: {
         usage?: { inputTokens?: number; outputTokens?: number };
       }) => {
-        recordRootStepUsage(event.usage ?? {});
+        recordRootStepUsage(event);
       };
 
       const eventBus = new AgentEventBus();
@@ -800,12 +812,6 @@ export default function OperatorDashboard({
             ? route.data.initialSkill?.args?.library
             : undefined),
         onStepFinish,
-        onCacheMetrics: (metrics: CacheMetrics) => {
-          usageStore.addSessionTokens(runSessionIdRef.current, {
-            cacheReadTokens: metrics.cacheReadInputTokens,
-            cacheWriteTokens: metrics.cacheCreationInputTokens,
-          });
-        },
         eventBus,
         onSessionReady: (s: SessionInfo) => {
           setSessionCwd(s.rootPath);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack

> [!NOTE]
> **Usage sink consolidation · PR 1 of 3**<br>
> Review and merge in table order; each PR is based on the preceding step.

| Step | Pull request | Focus |
| :---: | --- | --- |
| **1** | **[#1053](https://github.com/pensarai/apex/pull/1053)** | **Fold Apex consumers off `onCacheMetrics`** · `Current` |
| 2 | [#1054](https://github.com/pensarai/apex/pull/1054) | Honor the sink in `generateObjectResponse` |
| 3 | [#1055](https://github.com/pensarai/apex/pull/1055) | Resolve the sink from ALS; keep ambient `onUsage` |

## Summary

Apex traces, the TUI footer, headless pentest totals, and the benchmark runner now read cache from `normalizeStepUsage` on the finished step instead of joining a separate `onCacheMetrics` channel. That removes the `lastCacheMetrics` race in the agent trace writer.

`onCacheMetrics` stays on `StreamResponseOpts` and workflow plumbing as a deprecated host shim (still fires only when cache `> 0`) so Console can keep passing it. Apex internals no longer depend on it.

Part of #1037 (step 2). Does not close the issue.

## Changes

- Export `normalizeStepUsage` from the AI barrel
- Trace `recordStep` from normalized step usage; drop the cache-only join
- TUI root steps add input/output/cache in one `addSessionTokens` call
- Headless pentest and the benchmark runner accumulate cache from the step event
- Agent test covers cache on a normal step with `onCacheMetrics` unset

## Validation

- `bun run test` — 2711 passed, 15 skipped
- `bun run tsc` — passed
- `bun run lint` — no new errors (pre-existing warnings only)
- `bun run format:check` — passed
- `bun run knip` — passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a979bf0-b923-4712-a02d-c215573a35a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a979bf0-b923-4712-a02d-c215573a35a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

