### PR TITLE
feat(usage): honor usageRecorder in generateObjectResponse

### DIFF
--- a/src/core/ai/ai.durability-hooks.test.ts
+++ b/src/core/ai/ai.durability-hooks.test.ts
@@ -4,6 +4,7 @@ import type {
   ToolSet,
 } from "ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 
 const mocks = vi.hoisted(() => {
   const baseModel = {
@@ -19,6 +20,7 @@ const mocks = vi.hoisted(() => {
     baseModel,
     wrappedModel,
     streamText: vi.fn(),
+    generateText: vi.fn(),
     wrapLanguageModel: vi.fn(() => wrappedModel),
     getProviderModel: vi.fn(() => baseModel),
   };
@@ -29,6 +31,7 @@ vi.mock("ai", async () => {
   return {
     ...actual,
     streamText: mocks.streamText,
+    generateText: mocks.generateText,
     wrapLanguageModel: mocks.wrapLanguageModel,
   };
 });
@@ -38,7 +41,8 @@ vi.mock("./utils", async () => {
   return { ...actual, getProviderModel: mocks.getProviderModel };
 });
 
-const { onUsage, runWithStepContext, streamResponse } = await import("./ai");
+const { generateObjectResponse, onUsage, runWithStepContext, streamResponse } =
+  await import("./ai");
 
 function emptyStreamResult() {
   return {
@@ -76,6 +80,27 @@ function stepWithCache(
     providerMetadata: undefined,
   } as unknown as Parameters<StreamTextOnStepFinishCallback<ToolSet>>[0];
 }
+
+function objectResult(
+  inputTokens: number,
+  outputTokens: number,
+  cacheReadTokens = 0,
+  cacheWriteTokens = 0,
+) {
+  return {
+    output: { result: "ok" },
+    usage: {
+      inputTokens,
+      outputTokens,
+      ...(cacheReadTokens > 0 || cacheWriteTokens > 0
+        ? { inputTokenDetails: { cacheReadTokens, cacheWriteTokens } }
+        : {}),
+    },
+    providerMetadata: undefined,
+  };
+}
+
+const objectSchema = z.object({ result: z.string() });
 
 function streamCall(index: number) {
   const call = mocks.streamText.mock.calls[index];
@@ -211,6 +236,96 @@ describe("streamResponse durability hooks", () => {
         cacheReadTokens: 0,
         cacheWriteTokens: 0,
       });
+    });
+  });
+});
+
+describe("generateObjectResponse usageRecorder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getProviderModel.mockReturnValue(mocks.baseModel);
+    mocks.generateText.mockResolvedValue(objectResult(11, 7));
+  });
+
+  afterEach(() => {
+    onUsage(null);
+  });
+
+  it("falls back to the global usage callback when no recorder is set", async () => {
+    const globalUsage = vi.fn();
+    onUsage(globalUsage);
+    await generateObjectResponse({
+      model: "test-model",
+      schema: objectSchema,
+      prompt: "hi",
+    });
+    expect(globalUsage).toHaveBeenCalledOnce();
+    expect(globalUsage).toHaveBeenCalledWith("test-model", 11, 7, {
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+  });
+
+  it("routes usage to the per-run recorder and skips the global when set", async () => {
+    const globalUsage = vi.fn();
+    const usageRecorder = vi.fn();
+    onUsage(globalUsage);
+    await generateObjectResponse({
+      model: "test-model",
+      schema: objectSchema,
+      prompt: "hi",
+      usageRecorder,
+    });
+    expect(usageRecorder).toHaveBeenCalledOnce();
+    expect(usageRecorder).toHaveBeenCalledWith("test-model", 11, 7, {
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+    expect(globalUsage).not.toHaveBeenCalled();
+  });
+
+  it("attributes usage to the active run's step context", async () => {
+    const usageRecorder = vi.fn();
+    await runWithStepContext({ sessionId: "ses_durable", seedStepSeq: 4 }, () =>
+      generateObjectResponse({
+        model: "test-model",
+        schema: objectSchema,
+        prompt: "hi",
+        usageRecorder,
+      }),
+    );
+    expect(usageRecorder).toHaveBeenCalledWith("test-model", 11, 7, {
+      sessionId: "ses_durable",
+      stepSeq: 4,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+  });
+
+  it("does not fire usage for zero-token responses", async () => {
+    mocks.generateText.mockResolvedValue(objectResult(0, 0));
+    const usageRecorder = vi.fn();
+    await generateObjectResponse({
+      model: "test-model",
+      schema: objectSchema,
+      prompt: "hi",
+      usageRecorder,
+    });
+    expect(usageRecorder).not.toHaveBeenCalled();
+  });
+
+  it("passes the cached and uncached split to the recorder", async () => {
+    mocks.generateText.mockResolvedValue(objectResult(11, 7, 4, 2));
+    const usageRecorder = vi.fn();
+    await generateObjectResponse({
+      model: "test-model",
+      schema: objectSchema,
+      prompt: "hi",
+      usageRecorder,
+    });
+    expect(usageRecorder).toHaveBeenCalledWith("test-model", 11, 7, {
+      cacheReadTokens: 4,
+      cacheWriteTokens: 2,
     });
   });
 });

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -258,6 +258,26 @@ export function takeStepContext(): UsageStepContext | undefined {
   return { sessionId: store.sessionId, stepSeq };
 }
 
+/**
+ * Report one finished model call to a usage sink. Advances `stepSeq` whenever
+ * a sink is present (including zero-token steps) so the index stays aligned
+ * with the AI SDK. Skips the callback itself when both token counts are 0.
+ */
+async function emitUsage(
+  model: string,
+  stepUsage: NormalizedStepUsage,
+  sink: UsageRecorder | UsageCallback | null | undefined,
+): Promise<void> {
+  if (!sink) return;
+  const stepCtx = takeStepContext();
+  if (stepUsage.inputTokens <= 0 && stepUsage.outputTokens <= 0) return;
+  await sink(model, stepUsage.inputTokens, stepUsage.outputTokens, {
+    ...stepCtx,
+    cacheReadTokens: stepUsage.cacheReadTokens,
+    cacheWriteTokens: stepUsage.cacheWriteTokens,
+  });
+}
+
 export type AIModelProvider =
   | "anthropic"
   | "openai"
@@ -1156,35 +1176,7 @@ export function streamResponse(
       });
     }
     await userOnStepFinish?.(step);
-    if (usageRecorder || _usageCallback) {
-      // Advance stepSeq every finished step (even zero-usage) to stay aligned with the AI-SDK step index.
-      const stepCtx = takeStepContext();
-      if (stepUsage.inputTokens > 0 || stepUsage.outputTokens > 0) {
-        // Both sinks receive the same cache-aware context, so the cached and
-        // uncached split travels on the usage event itself. A per-run recorder,
-        // when set, replaces the process-global singleton for this stream.
-        const usageContext: UsageCallbackContext = {
-          ...stepCtx,
-          cacheReadTokens: stepUsage.cacheReadTokens,
-          cacheWriteTokens: stepUsage.cacheWriteTokens,
-        };
-        if (usageRecorder) {
-          await usageRecorder(
-            model,
-            stepUsage.inputTokens,
-            stepUsage.outputTokens,
-            usageContext,
-          );
-        } else {
-          await _usageCallback?.(
-            model,
-            stepUsage.inputTokens,
-            stepUsage.outputTokens,
-            usageContext,
-          );
-        }
-      }
-    }
+    await emitUsage(model, stepUsage, usageRecorder ?? _usageCallback);
   };
   const baseProviderModel = getProviderModel(model, authConfig);
   const providerModel = languageModelMiddleware
@@ -1598,6 +1590,8 @@ export interface GenerateObjectOpts<T extends z.ZodType> {
   authConfig?: AIAuthConfig;
   abortSignal?: AbortSignal;
   onTokenUsage?: (inputTokens: number, outputTokens: number) => void;
+  /** Per-run usage recorder; when set it replaces the global usage callback. */
+  usageRecorder?: UsageRecorder;
   /** Session id (`ses_…`) of the caller — stamped onto AI-span telemetry. */
   sessionId?: string;
   /** Stable operation id; defaults to `apex.structured.generate`. */
@@ -1620,6 +1614,7 @@ export async function generateObjectResponse<T extends z.ZodType>(
     authConfig,
     abortSignal,
     onTokenUsage,
+    usageRecorder,
     sessionId,
   } = opts;
 
@@ -1668,21 +1663,12 @@ export async function generateObjectResponse<T extends z.ZodType>(
         onTokenUsage(usage.inputTokens ?? 0, usage.outputTokens ?? 0);
       }
 
-      if (_usageCallback && usage) {
-        const stepUsage = normalizeStepUsage({ usage, providerMetadata });
-        const stepCtx = takeStepContext();
-        if (stepUsage.inputTokens > 0 || stepUsage.outputTokens > 0) {
-          await _usageCallback(
-            model,
-            stepUsage.inputTokens,
-            stepUsage.outputTokens,
-            {
-              ...stepCtx,
-              cacheReadTokens: stepUsage.cacheReadTokens,
-              cacheWriteTokens: stepUsage.cacheWriteTokens,
-            },
-          );
-        }
+      if (usage) {
+        await emitUsage(
+          model,
+          normalizeStepUsage({ usage, providerMetadata }),
+          usageRecorder ?? _usageCallback,
+        );
       }
 
       // zod v4: the AI SDK's `Output.object` no longer carries the schema's

--- a/src/core/ai/usage-callback.test.ts
+++ b/src/core/ai/usage-callback.test.ts
@@ -419,6 +419,36 @@ describe("usage callback cache breakdown (generateObjectResponse)", () => {
     expect(calls[0]?.context.cacheReadTokens).toBe(0);
     expect(calls[0]?.context.cacheWriteTokens).toBe(0);
   });
+
+  it("routes usage to usageRecorder and skips the global callback", async () => {
+    mockState.model = new MockLanguageModelV3({
+      doGenerate: async () => ({
+        content: [{ type: "text", text: '{"result":"ok"}' }],
+        finishReason: { unified: "stop", raw: "stop" },
+        warnings: [],
+        usage: {
+          inputTokens: { total: 50, noCache: 50, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 5, text: undefined, reasoning: undefined },
+        },
+      }),
+    });
+    const globalCalls = setupUsageCallback();
+    const usageRecorder = vi.fn();
+
+    await generateObjectResponse({
+      model: MODEL,
+      schema: z.object({ result: z.string() }),
+      prompt: "hi",
+      usageRecorder,
+    });
+
+    expect(usageRecorder).toHaveBeenCalledOnce();
+    expect(usageRecorder).toHaveBeenCalledWith(MODEL, 50, 5, {
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+    expect(globalCalls).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack

> [!NOTE]
> **Usage sink consolidation · PR 2 of 3**<br>
> Review and merge in table order; each PR is based on the preceding step.

| Step | Pull request | Focus |
| :---: | --- | --- |
| 1 | [#1053](https://github.com/pensarai/apex/pull/1053) | Fold Apex consumers off `onCacheMetrics` |
| **2** | **[#1054](https://github.com/pensarai/apex/pull/1054)** | **Honor the sink in `generateObjectResponse`** · `Current` |
| 3 | [#1055](https://github.com/pensarai/apex/pull/1055) | Resolve the sink from ALS; keep ambient `onUsage` |

## Summary

`generateObjectResponse` now accepts `usageRecorder` and reports usage through the same `emitUsage` helper as `streamResponse`. When a recorder is set it replaces the process-global `onUsage` callback, so structured-output tokens (CVSS, semantic dedup, session naming) are captured for durable runs.

`onTokenUsage` is unchanged. Callers are not yet plumbed; the next PR resolves the sink from run context so helpers pick it up without a fan-out.

Part of #1037 (step 3). Does not close the issue.

## Changes

- Shared `emitUsage` for streams and structured output (awaited, skip zero-token, attach step context + cache)
- Optional `usageRecorder` on `GenerateObjectOpts`
- Tests for recorder vs global, step attribution, skip-zero, and cache split

## Validation

- `bun run test` — 2717 passed, 15 skipped
- `bun run tsc` — passed
- `bun run format:check` — passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a979bf0-b923-4712-a02d-c215573a35a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a979bf0-b923-4712-a02d-c215573a35a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

