### PR TITLE
feat(usage): resolve the usage sink from run context

### DIFF
--- a/src/core/ai/ai.durability-hooks.test.ts
+++ b/src/core/ai/ai.durability-hooks.test.ts
@@ -329,3 +329,115 @@ describe("generateObjectResponse usageRecorder", () => {
     });
   });
 });
+
+describe("usage sink resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getProviderModel.mockReturnValue(mocks.baseModel);
+    mocks.wrapLanguageModel.mockReturnValue(mocks.wrappedModel);
+    mocks.streamText.mockImplementation(emptyStreamResult);
+    mocks.generateText.mockResolvedValue(objectResult(11, 7));
+  });
+
+  afterEach(() => {
+    onUsage(null);
+  });
+
+  it("uses the ALS run sink when no recorder is set", async () => {
+    const usageSink = vi.fn();
+    streamResponse({ model: "test-model", prompt: "hi" });
+    await runWithStepContext({ sessionId: "ses_als", usageSink }, () =>
+      Promise.resolve(streamCall(0).onStepFinish(step(11, 7))),
+    );
+    expect(usageSink).toHaveBeenCalledWith("test-model", 11, 7, {
+      sessionId: "ses_als",
+      stepSeq: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+  });
+
+  it("lets an explicit recorder win over the ALS sink and ambient callback", async () => {
+    const ambient = vi.fn();
+    const usageSink = vi.fn();
+    const usageRecorder = vi.fn();
+    onUsage(ambient);
+    streamResponse({ model: "test-model", prompt: "hi", usageRecorder });
+    await runWithStepContext({ sessionId: "ses_als", usageSink }, () =>
+      Promise.resolve(streamCall(0).onStepFinish(step(11, 7))),
+    );
+    expect(usageRecorder).toHaveBeenCalledOnce();
+    expect(usageSink).not.toHaveBeenCalled();
+    expect(ambient).not.toHaveBeenCalled();
+  });
+
+  it("falls back to onUsage outside any run context", async () => {
+    const ambient = vi.fn();
+    onUsage(ambient);
+    streamResponse({ model: "test-model", prompt: "hi" });
+    await streamCall(0).onStepFinish(step(11, 7));
+    expect(ambient).toHaveBeenCalledOnce();
+  });
+
+  it("keeps concurrent ALS sinks isolated", async () => {
+    const sinkA = vi.fn();
+    const sinkB = vi.fn();
+    streamResponse({ model: "model-a", prompt: "a" });
+    streamResponse({ model: "model-b", prompt: "b" });
+    await Promise.all([
+      runWithStepContext({ sessionId: "ses_a", usageSink: sinkA }, () =>
+        Promise.resolve(streamCall(0).onStepFinish(step(3, 5))),
+      ),
+      runWithStepContext({ sessionId: "ses_b", usageSink: sinkB }, () =>
+        Promise.resolve(streamCall(1).onStepFinish(step(13, 17))),
+      ),
+    ]);
+    expect(sinkA).toHaveBeenCalledWith("model-a", 3, 5, {
+      sessionId: "ses_a",
+      stepSeq: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+    expect(sinkB).toHaveBeenCalledWith("model-b", 13, 17, {
+      sessionId: "ses_b",
+      stepSeq: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+  });
+
+  it("generateObjectResponse records via ALS without opts.usageRecorder", async () => {
+    const usageSink = vi.fn();
+    await runWithStepContext(
+      { sessionId: "ses_als", seedStepSeq: 2, usageSink },
+      () =>
+        generateObjectResponse({
+          model: "test-model",
+          schema: objectSchema,
+          prompt: "hi",
+        }),
+    );
+    expect(usageSink).toHaveBeenCalledWith("test-model", 11, 7, {
+      sessionId: "ses_als",
+      stepSeq: 2,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+  });
+
+  it("inherits the ALS sink across nested runWithStepContext calls", async () => {
+    const usageSink = vi.fn();
+    streamResponse({ model: "test-model", prompt: "hi" });
+    await runWithStepContext({ sessionId: "ses_outer", usageSink }, () =>
+      runWithStepContext({ sessionId: "ses_inner", seedStepSeq: 9 }, () =>
+        Promise.resolve(streamCall(0).onStepFinish(step(11, 7))),
+      ),
+    );
+    expect(usageSink).toHaveBeenCalledWith("test-model", 11, 7, {
+      sessionId: "ses_inner",
+      stepSeq: 9,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+  });
+});

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -148,10 +148,9 @@ export type UsageCallback = (
 
 /**
  * Per-run usage recorder threaded through {@link StreamResponseOpts}. When set
- * it replaces the process-global {@link onUsage} callback for that stream's
- * steps, so a durable runtime can attribute usage per run instead of relying on
- * a shared singleton. Async work is awaited before the next model step. Receives
- * the same cache-aware {@link UsageCallbackContext} as the global callback, so
+ * it replaces the ALS run sink and the ambient {@link onUsage} callback for
+ * that call. Async work is awaited before the next model step. Receives the
+ * same cache-aware {@link UsageCallbackContext} as the global callback, so
  * the cached/uncached split travels on the usage event itself.
  */
 export type UsageRecorder = (
@@ -163,7 +162,7 @@ export type UsageRecorder = (
 
 let _usageCallback: UsageCallback | null = null;
 
-/** Register a callback to receive token usage reports from all AI operations. */
+/** Ambient default usage sink when no run-context sink is set. */
 export function onUsage(cb: UsageCallback | null): void {
   _usageCallback = cb;
 }
@@ -234,17 +233,28 @@ interface StepContext {
   sessionId?: string;
   /** Next step index to hand out; mutated in place as steps finish. */
   next: number;
+  /** Per-run usage sink; wins over the ambient {@link onUsage} callback. */
+  usageSink?: UsageCallback;
 }
 
 const stepContextStore = new AsyncLocalStorage<StepContext>();
 
 /** Runs `fn` in a per-run step-counting context; `streamResponse` steps inside it report usage tagged with `sessionId` and an increasing `stepSeq` starting at `seedStepSeq`. */
 export function runWithStepContext<T>(
-  opts: { sessionId?: string; seedStepSeq?: number },
+  opts: {
+    sessionId?: string;
+    seedStepSeq?: number;
+    usageSink?: UsageCallback;
+  },
   fn: () => T,
 ): T {
+  const parent = stepContextStore.getStore();
   return stepContextStore.run(
-    { sessionId: opts.sessionId, next: opts.seedStepSeq ?? 0 },
+    {
+      sessionId: opts.sessionId,
+      next: opts.seedStepSeq ?? 0,
+      usageSink: opts.usageSink ?? parent?.usageSink,
+    },
     fn,
   );
 }
@@ -276,6 +286,13 @@ async function emitUsage(
     cacheReadTokens: stepUsage.cacheReadTokens,
     cacheWriteTokens: stepUsage.cacheWriteTokens,
   });
+}
+
+/** explicit recorder > ALS run sink > ambient {@link onUsage}. */
+function resolveUsageSink(
+  explicit?: UsageRecorder,
+): UsageRecorder | UsageCallback | null {
+  return explicit ?? stepContextStore.getStore()?.usageSink ?? _usageCallback;
 }
 
 export type AIModelProvider =
@@ -1176,7 +1193,7 @@ export function streamResponse(
       });
     }
     await userOnStepFinish?.(step);
-    await emitUsage(model, stepUsage, usageRecorder ?? _usageCallback);
+    await emitUsage(model, stepUsage, resolveUsageSink(usageRecorder));
   };
   const baseProviderModel = getProviderModel(model, authConfig);
   const providerModel = languageModelMiddleware
@@ -1667,7 +1684,7 @@ export async function generateObjectResponse<T extends z.ZodType>(
         await emitUsage(
           model,
           normalizeStepUsage({ usage, providerMetadata }),
-          usageRecorder ?? _usageCallback,
+          resolveUsageSink(usageRecorder),
         );
       }
 

--- a/src/core/ai/index.ts
+++ b/src/core/ai/index.ts
@@ -8,7 +8,10 @@ export type {
   OpenAIReasoningEffort,
   StreamResponseOpts,
   ThinkingEffort,
+  UsageCallback,
+  UsageCallbackContext,
   UsageRecorder,
+  UsageStepContext,
 } from "./ai";
 export {
   buildReasoningProviderOptions,
@@ -21,6 +24,7 @@ export {
   modelSupportsThinking,
   normalizeOpenAIReasoningEffort,
   normalizeStepUsage,
+  onUsage,
   runWithStepContext,
   streamResponse,
 } from "./ai";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack

> [!NOTE]
> **Usage sink consolidation · PR 3 of 3**<br>
> Review and merge in table order; each PR is based on the preceding step.

| Step | Pull request | Focus |
| :---: | --- | --- |
| 1 | [#1053](https://github.com/pensarai/apex/pull/1053) | Fold Apex consumers off `onCacheMetrics` |
| 2 | [#1054](https://github.com/pensarai/apex/pull/1054) | Honor the sink in `generateObjectResponse` |
| **3** | **[#1055](https://github.com/pensarai/apex/pull/1055)** | **Resolve the sink from ALS; keep ambient `onUsage`** · `Current` |

## Summary

Usage now resolves **explicit `usageRecorder` > ALS run sink > ambient `onUsage()`**. `runWithStepContext` accepts `usageSink` and inherits it across nested contexts. `generateObjectResponse` inside a wrapped run records usage without being passed a recorder.

`onUsage` remains the thin ambient default. `usageRecorder` on agent/workflow inputs is unchanged so Console's #941 injection still works. Console should wrap durable/classic runs in `runWithStepContext({ usageSink })` as a follow-up; cache-aware pricing remains Console step 5 of #1037.

Part of #1037 (step 4). Does not close the issue.

## Changes

- `resolveUsageSink` on both stream and structured-output emit paths
- Export `onUsage`, `UsageCallback`, and `UsageCallbackContext` from the AI barrel
- Tests for ALS isolation, explicit-wins, ambient fallback, nested inherit, and object-response without `opts.usageRecorder`

## Validation

- `bun run test` — 2723 passed, 15 skipped
- `bun run tsc` — passed
- `bun run format:check` — passed (pre-existing lint warnings only)
- `bun run knip` — passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a979bf0-b923-4712-a02d-c215573a35a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a979bf0-b923-4712-a02d-c215573a35a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

