### PR TITLE
feat(ai): add Concentrate GLM 5.3 responses provider

### DIFF
--- a/src/core/ai/ai.test.ts
+++ b/src/core/ai/ai.test.ts
@@ -4,7 +4,10 @@ import {
   applySequentialToolCallPolicy,
   buildOpenRouterProviderOptions,
   buildReasoningProviderOptions,
+  getOpenAIReasoningEfforts,
   isRepairFailClosedTool,
+  modelSupportsOpenAIReasoning,
+  normalizeOpenAIReasoningEffort,
   SEQUENTIAL_TOOL_CALL_INSTRUCTION,
   streamResponse,
 } from "./ai";
@@ -153,6 +156,22 @@ describe("buildReasoningProviderOptions", () => {
         openAIReasoningEffort: "ultra",
       }),
     ).toEqual({ openai: { reasoningEffort: "max" } });
+  });
+
+  it("maps GLM 5.3 onto its always-on Concentrate effort levels", () => {
+    const model = "concentrate:glm-5.3";
+
+    expect(modelSupportsOpenAIReasoning(model)).toBe(true);
+    expect(getOpenAIReasoningEfforts(model)).toEqual(["low", "high", "max"]);
+    expect(normalizeOpenAIReasoningEffort(model, "none")).toBe("low");
+    expect(normalizeOpenAIReasoningEffort(model, "medium")).toBe("high");
+    expect(normalizeOpenAIReasoningEffort(model, "xhigh")).toBe("max");
+    expect(normalizeOpenAIReasoningEffort(model)).toBe("high");
+    expect(
+      buildReasoningProviderOptions(model, {
+        openAIReasoningEffort: "medium",
+      }),
+    ).toEqual({ openai: { reasoningEffort: "high" } });
   });
 
   it("carries the adaptive-thinking effort hint on both anthropic and bedrock for a 4.6 model", () => {

--- a/src/core/ai/ai.ts
+++ b/src/core/ai/ai.ts
@@ -38,6 +38,7 @@ import {
   getModelInfo,
   prefersSequentialToolCalls,
 } from "./models";
+import { CONCENTRATE_GLM_5_3_MODEL_ID } from "./providers/concentrate";
 import { STREAM_DEBUG } from "./streamTelemetry";
 import {
   type AIAuthConfig,
@@ -902,6 +903,7 @@ export function modelSupportsAdaptiveThinking(modelId: string): boolean {
 }
 
 export function modelSupportsOpenAIReasoning(modelId: string): boolean {
+  if (modelId === CONCENTRATE_GLM_5_3_MODEL_ID) return true;
   const { provider } = getModelInfo(modelId);
   if (provider !== "openai") return false;
   return (
@@ -909,10 +911,17 @@ export function modelSupportsOpenAIReasoning(modelId: string): boolean {
   );
 }
 
+export function modelRequiresReasoning(modelId: string): boolean {
+  return modelId === CONCENTRATE_GLM_5_3_MODEL_ID;
+}
+
 export function getOpenAIReasoningEfforts(
   modelId: string,
 ): OpenAIReasoningEffort[] {
   if (!modelSupportsOpenAIReasoning(modelId)) return [];
+  if (modelId === CONCENTRATE_GLM_5_3_MODEL_ID) {
+    return ["low", "high", "max"];
+  }
   if (/^gpt-5\.6(?:\b|-)/.test(modelId)) {
     return ["low", "medium", "high", "xhigh", "max", "ultra"];
   }
@@ -926,6 +935,22 @@ export function normalizeOpenAIReasoningEffort(
   modelId: string,
   effort?: OpenAIReasoningEffort | null,
 ): OpenAIReasoningEffort | undefined {
+  if (modelId === CONCENTRATE_GLM_5_3_MODEL_ID) {
+    switch (effort) {
+      case "none":
+      case "low":
+        return "low";
+      case "medium":
+      case "high":
+        return "high";
+      case "xhigh":
+      case "max":
+      case "ultra":
+        return "max";
+      default:
+        return "high";
+    }
+  }
   const efforts = getOpenAIReasoningEfforts(modelId);
   if (efforts.length === 0) return undefined;
   if (effort && efforts.includes(effort)) {

--- a/src/core/ai/concentrate.test.ts
+++ b/src/core/ai/concentrate.test.ts
@@ -1,22 +1,23 @@
 import { describe, expect, it } from "vitest";
-import { getModelInfo } from "./models";
+import { getMaxOutputTokens, getModelInfo } from "./models";
 import { buildAuthConfig, getProviderModel } from "./utils";
 
 describe("Concentrate provider", () => {
-  it("registers namespaced model IDs", () => {
-    const info = getModelInfo("concentrate:claude-opus-4-6");
+  it("registers GLM 5.3 with its live context and output limits", () => {
+    const info = getModelInfo("concentrate:glm-5.3");
 
     expect(info.provider).toBe("concentrate");
-    expect(info.contextLength).toBe(200000);
+    expect(info.contextLength).toBe(1_048_576);
+    expect(getMaxOutputTokens(info.id)).toBe(131_072);
   });
 
-  it("passes the unprefixed model ID to the compatible provider", () => {
-    const model = getProviderModel("concentrate:gpt-5.4", {
+  it("passes the unprefixed model ID to the Responses provider", () => {
+    const model = getProviderModel("concentrate:glm-5.3", {
       concentrateAPIKey: "sk-cn-test",
     }) as unknown as { modelId: string; provider: string };
 
-    expect(model.modelId).toBe("gpt-5.4");
-    expect(model.provider).toBe("concentrate.chat");
+    expect(model.modelId).toBe("glm-5.3");
+    expect(model.provider).toBe("concentrate.responses");
   });
 
   it("includes the persisted key in auth config", () => {

--- a/src/core/ai/index.ts
+++ b/src/core/ai/index.ts
@@ -15,6 +15,7 @@ export {
   generateObjectResponse,
   getContextWindow,
   getOpenAIReasoningEfforts,
+  modelRequiresReasoning,
   modelSupportsAdaptiveThinking,
   modelSupportsOpenAIReasoning,
   modelSupportsThinking,

--- a/src/core/ai/models/concentrate.ts
+++ b/src/core/ai/models/concentrate.ts
@@ -106,6 +106,12 @@ export const CONCENTRATE_MODELS: ModelInfo[] = [
     contextLength: 204800,
   },
   {
+    id: "concentrate:glm-5.3",
+    name: "GLM-5.3",
+    provider: "concentrate",
+    contextLength: 1048576,
+  },
+  {
     id: "concentrate:glm-5",
     name: "GLM-5",
     provider: "concentrate",

--- a/src/core/ai/providers/concentrate.live.test.ts
+++ b/src/core/ai/providers/concentrate.live.test.ts
@@ -9,67 +9,63 @@ const liveEnabled =
 const describeLive = liveEnabled ? describe : describe.skip;
 
 describeLive("Concentrate GLM 5.3 live contract", () => {
-  it(
-    "streams reasoning through a two-turn tool call on the ZDR route",
-    async () => {
-      const apiKey = process.env.CONCENTRATE_API_KEY;
-      if (!apiKey) throw new Error("CONCENTRATE_API_KEY is required");
+  it("streams reasoning through a two-turn tool call on the ZDR route", async () => {
+    const apiKey = process.env.CONCENTRATE_API_KEY;
+    if (!apiKey) throw new Error("CONCENTRATE_API_KEY is required");
 
-      const resolvedModels: string[] = [];
-      const usages: Array<{ input: number; output: number; cached: number }> = [];
-      let reasoningParts = 0;
-      let toolCalls = 0;
-      let toolResults = 0;
+    const resolvedModels: string[] = [];
+    const usages: Array<{ input: number; output: number; cached: number }> = [];
+    let reasoningParts = 0;
+    let toolCalls = 0;
+    let toolResults = 0;
 
-      const response = streamResponse({
-        model: "concentrate:glm-5.3",
-        authConfig: { concentrateAPIKey: apiKey },
-        system:
-          "You are validating an inference transport. Follow the requested tool workflow exactly.",
-        prompt:
-          'Call the echo_probe tool exactly once with {"value":"probe"}, read its result, then answer with exactly DONE.',
-        openAIReasoningEffort: "low",
-        tools: {
-          echo_probe: {
-            description: "Return the supplied probe value.",
-            inputSchema: z.object({ value: z.literal("probe") }),
-            execute: async ({ value }: { value: "probe" }) => ({
-              echoed: value,
-            }),
-          },
+    const response = streamResponse({
+      model: "concentrate:glm-5.3",
+      authConfig: { concentrateAPIKey: apiKey },
+      system:
+        "You are validating an inference transport. Follow the requested tool workflow exactly.",
+      prompt:
+        'Call the echo_probe tool exactly once with {"value":"probe"}, read its result, then answer with exactly DONE.',
+      openAIReasoningEffort: "low",
+      tools: {
+        echo_probe: {
+          description: "Return the supplied probe value.",
+          inputSchema: z.object({ value: z.literal("probe") }),
+          execute: async ({ value }: { value: "probe" }) => ({
+            echoed: value,
+          }),
         },
-        stopWhen: stepCountIs(3),
-        onStepFinish: (step) => {
-          if (step.response.modelId) {
-            resolvedModels.push(step.response.modelId);
-          }
-          usages.push({
-            input: step.usage.inputTokens ?? 0,
-            output: step.usage.outputTokens ?? 0,
-            cached: step.usage.inputTokenDetails.cacheReadTokens ?? 0,
-          });
-        },
-      });
+      },
+      stopWhen: stepCountIs(3),
+      onStepFinish: (step) => {
+        if (step.response.modelId) {
+          resolvedModels.push(step.response.modelId);
+        }
+        usages.push({
+          input: step.usage.inputTokens ?? 0,
+          output: step.usage.outputTokens ?? 0,
+          cached: step.usage.inputTokenDetails.cacheReadTokens ?? 0,
+        });
+      },
+    });
 
-      for await (const part of response.fullStream) {
-        if (part.type === "reasoning-delta") reasoningParts++;
-        if (part.type === "tool-call") toolCalls++;
-        if (part.type === "tool-result") toolResults++;
-      }
+    for await (const part of response.fullStream) {
+      if (part.type === "reasoning-delta") reasoningParts++;
+      if (part.type === "tool-call") toolCalls++;
+      if (part.type === "tool-result") toolResults++;
+    }
 
-      expect(await response.text).toBe("DONE");
-      expect(reasoningParts).toBeGreaterThan(0);
-      expect(toolCalls).toBe(1);
-      expect(toolResults).toBe(1);
-      expect(resolvedModels.length).toBeGreaterThan(0);
-      expect(
-        resolvedModels.every((model) => model === "fireworks/glm-5.3"),
-      ).toBe(true);
-      expect(
-        usages.some(({ input, output }) => input > 0 && output > 0),
-      ).toBe(true);
-      expect(usages.every(({ cached }) => cached >= 0)).toBe(true);
-    },
-    180_000,
-  );
+    expect(await response.text).toBe("DONE");
+    expect(reasoningParts).toBeGreaterThan(0);
+    expect(toolCalls).toBe(1);
+    expect(toolResults).toBe(1);
+    expect(resolvedModels.length).toBeGreaterThan(0);
+    expect(resolvedModels.every((model) => model === "fireworks/glm-5.3")).toBe(
+      true,
+    );
+    expect(usages.some(({ input, output }) => input > 0 && output > 0)).toBe(
+      true,
+    );
+    expect(usages.every(({ cached }) => cached >= 0)).toBe(true);
+  }, 180_000);
 });

--- a/src/core/ai/providers/concentrate.live.test.ts
+++ b/src/core/ai/providers/concentrate.live.test.ts
@@ -1,0 +1,75 @@
+import { stepCountIs } from "ai";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { streamResponse } from "../ai";
+
+const liveEnabled =
+  process.env.RUN_CONCENTRATE_INTEGRATION === "1" &&
+  Boolean(process.env.CONCENTRATE_API_KEY);
+const describeLive = liveEnabled ? describe : describe.skip;
+
+describeLive("Concentrate GLM 5.3 live contract", () => {
+  it(
+    "streams reasoning through a two-turn tool call on the ZDR route",
+    async () => {
+      const apiKey = process.env.CONCENTRATE_API_KEY;
+      if (!apiKey) throw new Error("CONCENTRATE_API_KEY is required");
+
+      const resolvedModels: string[] = [];
+      const usages: Array<{ input: number; output: number; cached: number }> = [];
+      let reasoningParts = 0;
+      let toolCalls = 0;
+      let toolResults = 0;
+
+      const response = streamResponse({
+        model: "concentrate:glm-5.3",
+        authConfig: { concentrateAPIKey: apiKey },
+        system:
+          "You are validating an inference transport. Follow the requested tool workflow exactly.",
+        prompt:
+          'Call the echo_probe tool exactly once with {"value":"probe"}, read its result, then answer with exactly DONE.',
+        openAIReasoningEffort: "low",
+        tools: {
+          echo_probe: {
+            description: "Return the supplied probe value.",
+            inputSchema: z.object({ value: z.literal("probe") }),
+            execute: async ({ value }: { value: "probe" }) => ({
+              echoed: value,
+            }),
+          },
+        },
+        stopWhen: stepCountIs(3),
+        onStepFinish: (step) => {
+          if (step.response.modelId) {
+            resolvedModels.push(step.response.modelId);
+          }
+          usages.push({
+            input: step.usage.inputTokens ?? 0,
+            output: step.usage.outputTokens ?? 0,
+            cached: step.usage.inputTokenDetails.cacheReadTokens ?? 0,
+          });
+        },
+      });
+
+      for await (const part of response.fullStream) {
+        if (part.type === "reasoning-delta") reasoningParts++;
+        if (part.type === "tool-call") toolCalls++;
+        if (part.type === "tool-result") toolResults++;
+      }
+
+      expect(await response.text).toBe("DONE");
+      expect(reasoningParts).toBeGreaterThan(0);
+      expect(toolCalls).toBe(1);
+      expect(toolResults).toBe(1);
+      expect(resolvedModels.length).toBeGreaterThan(0);
+      expect(
+        resolvedModels.every((model) => model === "fireworks/glm-5.3"),
+      ).toBe(true);
+      expect(
+        usages.some(({ input, output }) => input > 0 && output > 0),
+      ).toBe(true);
+      expect(usages.every(({ cached }) => cached >= 0)).toBe(true);
+    },
+    180_000,
+  );
+});

--- a/src/core/ai/providers/concentrate.test.ts
+++ b/src/core/ai/providers/concentrate.test.ts
@@ -1,0 +1,146 @@
+import {
+  APICallError,
+  type LanguageModelV3CallOptions,
+} from "@ai-sdk/provider";
+import { describe, expect, it, vi } from "vitest";
+import {
+  CONCENTRATE_BASE_URL,
+  createConcentrateFetch,
+  createConcentrateModel,
+} from "./concentrate";
+
+function completedResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      id: "resp_1",
+      created_at: 1_786_665_600,
+      model: "fireworks/glm-5.3",
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          id: "msg_1",
+          content: [{ type: "output_text", text: "ok", annotations: [] }],
+        },
+      ],
+      usage: {
+        input_tokens: 12,
+        input_tokens_details: { cached_tokens: 4 },
+        output_tokens: 8,
+        output_tokens_details: { reasoning_tokens: 3 },
+      },
+    }),
+    {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": "req_123",
+      },
+    },
+  );
+}
+
+describe("createConcentrateModel", () => {
+  it("uses the Responses API with the bare model slug and safe defaults", async () => {
+    const fetchMock = vi.fn(async () => completedResponse());
+    const model = createConcentrateModel("concentrate:glm-5.3", {
+      apiKey: "sk-cn-test",
+      fetch: fetchMock as typeof fetch,
+    });
+
+    await model.doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Say ok" }] }],
+      providerOptions: { openai: { reasoningEffort: "high", store: true } },
+    } satisfies LanguageModelV3CallOptions);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe(`${CONCENTRATE_BASE_URL}/responses`);
+    expect(new Headers(init?.headers).get("authorization")).toBe(
+      "Bearer sk-cn-test",
+    );
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      model: "glm-5.3",
+      store: false,
+      reasoning: { effort: "high" },
+      input: [{ role: "user", content: "Say ok" }],
+    });
+  });
+
+  it("fails before constructing a request when the key is missing", () => {
+    expect(() =>
+      createConcentrateModel("concentrate:glm-5.3", { apiKey: " " }),
+    ).toThrow(/CONCENTRATE_API_KEY/);
+  });
+
+  it("rejects non-namespaced and empty model IDs", () => {
+    expect(() =>
+      createConcentrateModel("glm-5.3", { apiKey: "sk-cn-test" }),
+    ).toThrow(/must start/);
+    expect(() =>
+      createConcentrateModel("concentrate:", { apiKey: "sk-cn-test" }),
+    ).toThrow(/cannot be empty/);
+  });
+});
+
+describe("createConcentrateFetch", () => {
+  it.each([
+    [400, false],
+    [401, false],
+    [402, false],
+    [422, false],
+    [424, true],
+    [429, true],
+    [500, true],
+    [503, true],
+    [504, true],
+  ])("classifies HTTP %i retryable=%s", async (status, retryable) => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          error: "Upstream request failed",
+          message: "Provider unavailable",
+          model: "fireworks/glm-5.3",
+        }),
+        {
+          status,
+          headers: {
+            "retry-after": "2",
+            "x-request-id": "req_error",
+          },
+        },
+      );
+    });
+    const fetchConcentrate = createConcentrateFetch(
+      fetchMock as typeof fetch,
+    );
+
+    try {
+      await fetchConcentrate(`${CONCENTRATE_BASE_URL}/responses`, {
+        method: "POST",
+        body: '{"sensitive":"not retained on the error"}',
+      });
+      throw new Error("Expected Concentrate request to fail");
+    } catch (error) {
+      expect(APICallError.isInstance(error)).toBe(true);
+      if (!APICallError.isInstance(error)) return;
+      expect(error.message).toBe("Provider unavailable");
+      expect(error.statusCode).toBe(status);
+      expect(error.isRetryable).toBe(retryable);
+      expect(error.responseHeaders?.["retry-after"]).toBe("2");
+      expect(error.responseHeaders?.["x-request-id"]).toBe("req_error");
+      expect(error.requestBodyValues).toBeUndefined();
+    }
+  });
+
+  it("passes successful streaming responses through unchanged", async () => {
+    const response = completedResponse();
+    const fetchConcentrate = createConcentrateFetch(
+      vi.fn(async () => response) as typeof fetch,
+    );
+
+    await expect(
+      fetchConcentrate(`${CONCENTRATE_BASE_URL}/responses`),
+    ).resolves.toBe(response);
+  });
+});

--- a/src/core/ai/providers/concentrate.test.ts
+++ b/src/core/ai/providers/concentrate.test.ts
@@ -5,6 +5,7 @@ import {
 import { describe, expect, it, vi } from "vitest";
 import {
   CONCENTRATE_BASE_URL,
+  type ConcentrateFetch,
   createConcentrateFetch,
   createConcentrateModel,
 } from "./concentrate";
@@ -42,10 +43,13 @@ function completedResponse(): Response {
 
 describe("createConcentrateModel", () => {
   it("uses the Responses API with the bare model slug and safe defaults", async () => {
-    const fetchMock = vi.fn(async () => completedResponse());
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        completedResponse(),
+    );
     const model = createConcentrateModel("concentrate:glm-5.3", {
       apiKey: "sk-cn-test",
-      fetch: fetchMock as typeof fetch,
+      fetch: fetchMock,
     });
 
     await model.doGenerate({
@@ -54,7 +58,10 @@ describe("createConcentrateModel", () => {
     } satisfies LanguageModelV3CallOptions);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0]!;
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    if (!call) throw new Error("Expected Concentrate fetch call");
+    const [url, init] = call;
     expect(String(url)).toBe(`${CONCENTRATE_BASE_URL}/responses`);
     expect(new Headers(init?.headers).get("authorization")).toBe(
       "Bearer sk-cn-test",
@@ -63,7 +70,12 @@ describe("createConcentrateModel", () => {
       model: "glm-5.3",
       store: false,
       reasoning: { effort: "high" },
-      input: [{ role: "user", content: "Say ok" }],
+      input: [
+        {
+          role: "user",
+          content: [{ type: "input_text", text: "Say ok" }],
+        },
+      ],
     });
   });
 
@@ -95,25 +107,25 @@ describe("createConcentrateFetch", () => {
     [503, true],
     [504, true],
   ])("classifies HTTP %i retryable=%s", async (status, retryable) => {
-    const fetchMock = vi.fn(async () => {
-      return new Response(
-        JSON.stringify({
-          error: "Upstream request failed",
-          message: "Provider unavailable",
-          model: "fireworks/glm-5.3",
-        }),
-        {
-          status,
-          headers: {
-            "retry-after": "2",
-            "x-request-id": "req_error",
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        return new Response(
+          JSON.stringify({
+            error: "Upstream request failed",
+            message: "Provider unavailable",
+            model: "fireworks/glm-5.3",
+          }),
+          {
+            status,
+            headers: {
+              "retry-after": "2",
+              "x-request-id": "req_error",
+            },
           },
-        },
-      );
-    });
-    const fetchConcentrate = createConcentrateFetch(
-      fetchMock as typeof fetch,
+        );
+      },
     );
+    const fetchConcentrate = createConcentrateFetch(fetchMock);
 
     try {
       await fetchConcentrate(`${CONCENTRATE_BASE_URL}/responses`, {
@@ -136,7 +148,9 @@ describe("createConcentrateFetch", () => {
   it("passes successful streaming responses through unchanged", async () => {
     const response = completedResponse();
     const fetchConcentrate = createConcentrateFetch(
-      vi.fn(async () => response) as typeof fetch,
+      vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) => response,
+      ) satisfies ConcentrateFetch,
     );
 
     await expect(

--- a/src/core/ai/providers/concentrate.test.ts
+++ b/src/core/ai/providers/concentrate.test.ts
@@ -69,7 +69,7 @@ describe("createConcentrateModel", () => {
     expect(JSON.parse(String(init?.body))).toMatchObject({
       model: "glm-5.3",
       store: false,
-      reasoning: { effort: "high" },
+      reasoning: { effort: "high", summary: "auto" },
       input: [
         {
           role: "user",

--- a/src/core/ai/providers/concentrate.ts
+++ b/src/core/ai/providers/concentrate.ts
@@ -90,7 +90,9 @@ function withConcentrateDefaults(
       openai: {
         ...options.providerOptions?.openai,
         store: false,
-        ...(forceReasoning ? { forceReasoning: true } : {}),
+        ...(forceReasoning
+          ? { forceReasoning: true, reasoningSummary: "auto" }
+          : {}),
       },
     },
   });

--- a/src/core/ai/providers/concentrate.ts
+++ b/src/core/ai/providers/concentrate.ts
@@ -1,0 +1,130 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import {
+  APICallError,
+  type LanguageModelV3,
+  type LanguageModelV3CallOptions,
+} from "@ai-sdk/provider";
+
+export const CONCENTRATE_BASE_URL = "https://api.concentrate.ai/v1";
+export const CONCENTRATE_GLM_5_3_MODEL_ID = "concentrate:glm-5.3";
+
+const RETRYABLE_STATUSES = new Set([424, 429, 500, 503, 504]);
+
+type ConcentrateErrorBody = {
+  error?: string | { message?: string };
+  message?: string;
+  model?: string;
+};
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+function responseHeaders(headers: Headers): Record<string, string> {
+  return Object.fromEntries(headers.entries());
+}
+
+function parseErrorBody(body: string): {
+  data?: ConcentrateErrorBody;
+  message?: string;
+} {
+  try {
+    const data = JSON.parse(body) as ConcentrateErrorBody;
+    const nested =
+      typeof data.error === "object" ? data.error.message : undefined;
+    const direct = typeof data.error === "string" ? data.error : undefined;
+    return { data, message: data.message ?? nested ?? direct };
+  } catch {
+    return {};
+  }
+}
+
+export function createConcentrateFetch(
+  fetchFn: typeof fetch = globalThis.fetch,
+): typeof fetch {
+  return async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const response = await fetchFn(input, init);
+    if (response.ok) return response;
+
+    const body = await response.text();
+    const parsed = parseErrorBody(body);
+    throw new APICallError({
+      message:
+        parsed.message ??
+        `Concentrate request failed with HTTP ${response.status}`,
+      url: requestUrl(input),
+      requestBodyValues: undefined,
+      statusCode: response.status,
+      responseHeaders: responseHeaders(response.headers),
+      responseBody: body,
+      data: parsed.data,
+      isRetryable: RETRYABLE_STATUSES.has(response.status),
+    });
+  };
+}
+
+function withConcentrateDefaults(
+  model: LanguageModelV3,
+  forceReasoning: boolean,
+): LanguageModelV3 {
+  const withDefaults = (
+    options: LanguageModelV3CallOptions,
+  ): LanguageModelV3CallOptions => ({
+    ...options,
+    providerOptions: {
+      ...options.providerOptions,
+      openai: {
+        ...options.providerOptions?.openai,
+        store: false,
+        ...(forceReasoning ? { forceReasoning: true } : {}),
+      },
+    },
+  });
+
+  return {
+    specificationVersion: model.specificationVersion,
+    provider: model.provider,
+    modelId: model.modelId,
+    supportedUrls: model.supportedUrls,
+    doGenerate: (options) => model.doGenerate(withDefaults(options)),
+    doStream: (options) => model.doStream(withDefaults(options)),
+  };
+}
+
+export function createConcentrateModel(
+  modelId: string,
+  options: { apiKey?: string; fetch?: typeof fetch },
+): LanguageModelV3 {
+  const apiKey = options.apiKey?.trim();
+  if (!apiKey) {
+    throw new Error(
+      "Concentrate is not configured. Set CONCENTRATE_API_KEY first.",
+    );
+  }
+  if (!modelId.startsWith("concentrate:")) {
+    throw new Error(
+      `Concentrate model IDs must start with "concentrate:": ${modelId}`,
+    );
+  }
+
+  const upstreamModelId = modelId.slice("concentrate:".length);
+  if (!upstreamModelId) {
+    throw new Error("Concentrate model ID cannot be empty.");
+  }
+
+  const concentrate = createOpenAI({
+    name: "concentrate",
+    apiKey,
+    baseURL: CONCENTRATE_BASE_URL,
+    fetch: createConcentrateFetch(options.fetch),
+  });
+  return withConcentrateDefaults(
+    concentrate.responses(upstreamModelId),
+    modelId === CONCENTRATE_GLM_5_3_MODEL_ID,
+  );
+}

--- a/src/core/ai/providers/concentrate.ts
+++ b/src/core/ai/providers/concentrate.ts
@@ -10,6 +10,11 @@ export const CONCENTRATE_GLM_5_3_MODEL_ID = "concentrate:glm-5.3";
 
 const RETRYABLE_STATUSES = new Set([424, 429, 500, 503, 504]);
 
+export type ConcentrateFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
 type ConcentrateErrorBody = {
   error?: string | { message?: string };
   message?: string;
@@ -23,7 +28,11 @@ function requestUrl(input: RequestInfo | URL): string {
 }
 
 function responseHeaders(headers: Headers): Record<string, string> {
-  return Object.fromEntries(headers.entries());
+  const result: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
 }
 
 function parseErrorBody(body: string): {
@@ -42,8 +51,8 @@ function parseErrorBody(body: string): {
 }
 
 export function createConcentrateFetch(
-  fetchFn: typeof fetch = globalThis.fetch,
-): typeof fetch {
+  fetchFn: ConcentrateFetch = (input, init) => globalThis.fetch(input, init),
+): ConcentrateFetch {
   return async (
     input: RequestInfo | URL,
     init?: RequestInit,
@@ -98,7 +107,7 @@ function withConcentrateDefaults(
 
 export function createConcentrateModel(
   modelId: string,
-  options: { apiKey?: string; fetch?: typeof fetch },
+  options: { apiKey?: string; fetch?: ConcentrateFetch },
 ): LanguageModelV3 {
   const apiKey = options.apiKey?.trim();
   if (!apiKey) {
@@ -121,7 +130,7 @@ export function createConcentrateModel(
     name: "concentrate",
     apiKey,
     baseURL: CONCENTRATE_BASE_URL,
-    fetch: createConcentrateFetch(options.fetch),
+    fetch: createConcentrateFetch(options.fetch) as unknown as typeof fetch,
   });
   return withConcentrateDefaults(
     concentrate.responses(upstreamModelId),

--- a/src/core/ai/utils.ts
+++ b/src/core/ai/utils.ts
@@ -29,6 +29,7 @@ import {
 } from "./contextManagement";
 import { MANTLE_REGION, mantleBaseUrl, stripMantlePrefix } from "./mantle";
 import { getModelInfo } from "./models";
+import { createConcentrateModel } from "./providers/concentrate";
 import { createPensarModel } from "./providers/pensar";
 
 const log = scopedLogger(() => createLogger("ai:utils"));
@@ -180,12 +181,9 @@ export function getProviderModel(
     }
 
     case "concentrate": {
-      const concentrate = createOpenAICompatible({
-        name: "concentrate",
+      providerModel = createConcentrateModel(model, {
         apiKey: concentrateAPIKey,
-        baseURL: "https://api.concentrate.ai/v1",
       });
-      providerModel = concentrate(model.replace(/^concentrate:/, ""));
       break;
     }
 

--- a/src/core/observability/shutdown.test.ts
+++ b/src/core/observability/shutdown.test.ts
@@ -272,7 +272,11 @@ describe("installObservabilityExitHandlers", () => {
     install(runtime);
 
     process.emit("uncaughtException", new Error("first"));
-    process.emit("unhandledRejection", new Error("second"));
+    process.emit(
+      "unhandledRejection",
+      new Error("second"),
+      Promise.resolve(),
+    );
 
     await new Promise((resolve) => setTimeout(resolve, 120));
     expect(errors).toHaveLength(1);

--- a/src/core/observability/shutdown.test.ts
+++ b/src/core/observability/shutdown.test.ts
@@ -272,11 +272,7 @@ describe("installObservabilityExitHandlers", () => {
     install(runtime);
 
     process.emit("uncaughtException", new Error("first"));
-    process.emit(
-      "unhandledRejection",
-      new Error("second"),
-      Promise.resolve(),
-    );
+    process.emit("unhandledRejection", new Error("second"), Promise.resolve());
 
     await new Promise((resolve) => setTimeout(resolve, 120));
     expect(errors).toHaveLength(1);

--- a/src/core/providers/utils.test.ts
+++ b/src/core/providers/utils.test.ts
@@ -82,7 +82,7 @@ describe("getDefaultModelForConfig", () => {
 
     expect(model).not.toBeNull();
     expect(model?.provider).toBe("concentrate");
-    expect(model?.id).toBe("concentrate:claude-opus-4-6");
+    expect(model?.id).toBe("concentrate:glm-5.3");
     expect(available.length).toBeGreaterThan(1);
     expect(available.every((item) => item.provider === "concentrate")).toBe(
       true,

--- a/src/core/providers/utils.ts
+++ b/src/core/providers/utils.ts
@@ -22,7 +22,7 @@ const PREFERRED_MODEL_BY_PROVIDER: Record<string, string> = {
   openai: "gpt-5.6-sol",
   google: "gemini-3.1-pro-preview",
   openrouter: "anthropic/claude-opus-4.6",
-  concentrate: "concentrate:claude-opus-4-6",
+  concentrate: "concentrate:glm-5.3",
   bedrock: "anthropic.claude-opus-4-6-v1",
 };
 


### PR DESCRIPTION
## Summary

Add a production-oriented Concentrate provider over its OpenAI-compatible Responses API, including GLM 5.3 model metadata, always-on reasoning normalization, retry-aware errors, stateless requests, and a live ZDR contract test.

Related to pensarai/console#2794.

## Test Plan

- [x] Full Apex suite: 2,722 passed, 17 skipped
- [x] Type-check, build, and style check
- [x] Provider unit and response-transport coverage
- [ ] Live ZDR contract: request succeeds, but the AI SDK stream does not currently surface Concentrate reasoning-summary events as reasoning deltas

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Concentrate inference routing and default model selection change for users with only a Concentrate key; new external API surface but no auth or billing logic changes.
> 
> **Overview**
> Replaces the generic OpenAI-compatible Concentrate chat client with a dedicated **Responses API** provider (`/responses`), including retry-aware `APICallError` handling, **stateless** requests (`store: false`), and forced reasoning for **`concentrate:glm-5.3`**.
> 
> Adds **GLM-5.3** to the Concentrate catalog (1M context, 131K max output) and makes it the **default Concentrate model** when only that key is configured. Reasoning helpers now treat GLM 5.3 as always-on OpenAI-style reasoning with **`low` / `high` / `max`** efforts and UI effort remapping; exports **`modelRequiresReasoning`**.
> 
> Includes unit tests for transport/errors, updated integration expectations, and an opt-in live ZDR contract test (`RUN_CONCENTRATE_INTEGRATION`). Unrelated: shutdown test passes a promise to `unhandledRejection` for Node API correctness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f718095c35d6fa62e82855e9b2e69eaf14ac9f3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->