### PR TITLE
fix(observability): export open spans on shutdown

### DIFF
--- a/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
+++ b/src/core/agents/offSecAgent/offensiveSecurityAgent.ts
@@ -999,8 +999,9 @@ export class OffensiveSecurityAgent<TResult = void> {
           } finally {
             unregisterActiveRootSpan(span);
             // Ends only after runConsume's finalization (persistence +
-            // owned-resource disposal) has settled.
-            span.end();
+            // owned-resource disposal) has settled. Shutdown may have already
+            // ended it while that finalization was still in flight.
+            if (span.isRecording()) span.end();
           }
         },
       );

--- a/src/core/observability/active-root-spans.ts
+++ b/src/core/observability/active-root-spans.ts
@@ -21,7 +21,7 @@ export function unregisterActiveRootSpan(span: Span): void {
 export function endAllActiveRootSpans(): void {
   for (const span of activeRootSpans) {
     try {
-      span.end();
+      if (span.isRecording()) span.end();
     } catch {
       // A dead span must never block process teardown.
     }

--- a/src/core/observability/active-spans.ts
+++ b/src/core/observability/active-spans.ts
@@ -1,4 +1,4 @@
-import { SpanStatusCode } from "@opentelemetry/api";
+import { diag, SpanStatusCode } from "@opentelemetry/api";
 import type {
   ReadableSpan,
   Span as SdkSpan,
@@ -6,8 +6,10 @@ import type {
 } from "@opentelemetry/sdk-trace-base";
 
 export const INTERRUPTED_SPAN_ATTRIBUTE = "pensar.telemetry.interrupted";
+export const INTERRUPTED_ERROR_TYPE = "ApexProcessInterrupted";
 export const INTERRUPTED_SPAN_REASON =
   "Apex shut down before this span completed";
+const MAX_TRACKED_ACTIVE_SPANS = 10_000;
 
 function spanKey(span: Pick<ReadableSpan, "spanContext">): string {
   const context = span.spanContext();
@@ -18,11 +20,25 @@ function spanKey(span: Pick<ReadableSpan, "spanContext">): string {
  * Tracks every recording span owned by Apex's standalone SDK so shutdown can
  * finish spans that their instrumentation still has open. OpenTelemetry only
  * queues spans for export from `onEnd`; forceFlush alone cannot recover them.
+ *
+ * This processor must remain first in the provider's processor list: its
+ * shutdown hook is the final backstop for spans created during forceFlush,
+ * before downstream processors stop accepting ended spans.
  */
 export class ActiveSpanProcessor implements SpanProcessor {
   private readonly active = new Map<string, SdkSpan>();
+  private overflowWarned = false;
 
   onStart(span: SdkSpan): void {
+    if (this.active.size >= MAX_TRACKED_ACTIVE_SPANS) {
+      if (!this.overflowWarned) {
+        this.overflowWarned = true;
+        diag.warn(
+          `Apex active-span shutdown tracking reached ${MAX_TRACKED_ACTIVE_SPANS} spans; newer spans will not be retained`,
+        );
+      }
+      return;
+    }
     this.active.set(spanKey(span), span);
   }
 
@@ -33,20 +49,27 @@ export class ActiveSpanProcessor implements SpanProcessor {
   endAll(reason = INTERRUPTED_SPAN_REASON): void {
     // Spans start parent-first, so reverse insertion order closes the deepest
     // children before their parents. Copy first because span.end() calls onEnd.
-    const spans = [...this.active.values()].reverse();
-    for (const span of spans) {
-      if (!span.isRecording()) continue;
+    const spans = [...this.active.entries()].reverse();
+    for (const [key, span] of spans) {
       try {
-        span.setAttribute(INTERRUPTED_SPAN_ATTRIBUTE, true);
-        if (span.status.code !== SpanStatusCode.ERROR) {
-          span.setStatus({ code: SpanStatusCode.ERROR, message: reason });
+        if (span.isRecording()) {
+          span.setAttribute(INTERRUPTED_SPAN_ATTRIBUTE, true);
+          if (span.attributes["error.type"] === undefined) {
+            span.setAttribute("error.type", INTERRUPTED_ERROR_TYPE);
+          }
+          if (span.status.code !== SpanStatusCode.ERROR) {
+            span.setStatus({ code: SpanStatusCode.ERROR, message: reason });
+          }
+          span.end();
         }
-        span.end();
       } catch {
         // One faulty instrumentation span must not block the remaining flush.
+      } finally {
+        // Delete only the copied entry. A downstream onEnd hook may start a
+        // new span re-entrantly, which must survive for the shutdown backstop.
+        this.active.delete(key);
       }
     }
-    this.active.clear();
   }
 
   async forceFlush(): Promise<void> {}

--- a/src/core/observability/active-spans.ts
+++ b/src/core/observability/active-spans.ts
@@ -1,0 +1,57 @@
+import { SpanStatusCode } from "@opentelemetry/api";
+import type {
+  ReadableSpan,
+  Span as SdkSpan,
+  SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+
+export const INTERRUPTED_SPAN_ATTRIBUTE = "pensar.telemetry.interrupted";
+export const INTERRUPTED_SPAN_REASON =
+  "Apex shut down before this span completed";
+
+function spanKey(span: Pick<ReadableSpan, "spanContext">): string {
+  const context = span.spanContext();
+  return `${context.traceId}:${context.spanId}`;
+}
+
+/**
+ * Tracks every recording span owned by Apex's standalone SDK so shutdown can
+ * finish spans that their instrumentation still has open. OpenTelemetry only
+ * queues spans for export from `onEnd`; forceFlush alone cannot recover them.
+ */
+export class ActiveSpanProcessor implements SpanProcessor {
+  private readonly active = new Map<string, SdkSpan>();
+
+  onStart(span: SdkSpan): void {
+    this.active.set(spanKey(span), span);
+  }
+
+  onEnd(span: ReadableSpan): void {
+    this.active.delete(spanKey(span));
+  }
+
+  endAll(reason = INTERRUPTED_SPAN_REASON): void {
+    // Spans start parent-first, so reverse insertion order closes the deepest
+    // children before their parents. Copy first because span.end() calls onEnd.
+    const spans = [...this.active.values()].reverse();
+    for (const span of spans) {
+      if (!span.isRecording()) continue;
+      try {
+        span.setAttribute(INTERRUPTED_SPAN_ATTRIBUTE, true);
+        if (span.status.code !== SpanStatusCode.ERROR) {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: reason });
+        }
+        span.end();
+      } catch {
+        // One faulty instrumentation span must not block the remaining flush.
+      }
+    }
+    this.active.clear();
+  }
+
+  async forceFlush(): Promise<void> {}
+
+  async shutdown(): Promise<void> {
+    this.endAll();
+  }
+}

--- a/src/core/observability/runtime.ts
+++ b/src/core/observability/runtime.ts
@@ -21,6 +21,7 @@ import {
 import { version as apexVersion } from "../../../package.json";
 import { createLogger } from "../logger/structured";
 import { endAllActiveRootSpans } from "./active-root-spans";
+import { ActiveSpanProcessor } from "./active-spans";
 
 /**
  * Optional standalone OTLP/HTTP trace runtime. Apex keeps OTel disabled
@@ -34,7 +35,7 @@ export type ObservabilityShutdownResult = "completed" | "timed-out";
 
 export interface ObservabilityRuntime {
   forceFlush(): Promise<void>;
-  /** Idempotent and bounded: ends active root spans, flushes, shuts down. */
+  /** Idempotent and bounded: ends active spans, flushes, shuts down. */
   shutdown(): Promise<ObservabilityShutdownResult>;
 }
 
@@ -180,9 +181,13 @@ export function startObservabilityRuntime(
   const shutdownTimeoutMs =
     opts?.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
   const exporter = createTraceExporter(resolveTracesProtocol(env));
+  const activeSpans = new ActiveSpanProcessor();
   const provider = new BasicTracerProvider({
     resource: buildResource(env),
-    spanProcessors: opts?.spanProcessors ?? [new BatchSpanProcessor(exporter)],
+    spanProcessors: [
+      activeSpans,
+      ...(opts?.spanProcessors ?? [new BatchSpanProcessor(exporter)]),
+    ],
   });
   const contextManager = new AsyncLocalStorageContextManager();
   contextManager.enable();
@@ -225,9 +230,12 @@ export function startObservabilityRuntime(
       // Idempotent: every caller awaits the same bounded shutdown.
       if (!shutdownPromise) {
         const shutdownWork = async () => {
-          // End in-flight root runs first so their spans still export…
+          // OpenTelemetry only queues spans for export from onEnd(). Close all
+          // still-recording spans, deepest-first, before the final flush.
+          activeSpans.endAll();
+          // Clear the legacy root registry too. Its spans are already ended by
+          // the processor, but embedded/no-op callers may still register them.
           endAllActiveRootSpans();
-          // …then flush explicitly before processor/exporter teardown.
           try {
             await provider.forceFlush();
           } finally {

--- a/src/core/observability/runtime.ts
+++ b/src/core/observability/runtime.ts
@@ -233,12 +233,15 @@ export function startObservabilityRuntime(
           // OpenTelemetry only queues spans for export from onEnd(). Close all
           // still-recording spans, deepest-first, before the final flush.
           activeSpans.endAll();
-          // Clear the legacy root registry too. Its spans are already ended by
-          // the processor, but embedded/no-op callers may still register them.
+          // Clear stale references from the legacy root registry too. Its
+          // recording spans were already ended by the general tracker.
           endAllActiveRootSpans();
           try {
             await provider.forceFlush();
           } finally {
+            // Async work can start spans while forceFlush yields. End that
+            // final window explicitly before downstream processors shut down.
+            activeSpans.endAll();
             await provider.shutdown().catch((error) => {
               log.warn("OTLP export/shutdown failed", { error: String(error) });
             });

--- a/src/core/observability/shutdown.test.ts
+++ b/src/core/observability/shutdown.test.ts
@@ -17,7 +17,10 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getApexTracer } from "../observability";
-import { INTERRUPTED_SPAN_ATTRIBUTE } from "./active-spans";
+import {
+  INTERRUPTED_ERROR_TYPE,
+  INTERRUPTED_SPAN_ATTRIBUTE,
+} from "./active-spans";
 import {
   installObservabilityExitHandlers,
   resetObservabilityRuntime,
@@ -83,6 +86,21 @@ class HungProcessor implements SpanProcessor {
   async shutdown(): Promise<void> {
     await new Promise<void>(() => {});
   }
+}
+
+class StartSpanOnFlushProcessor implements SpanProcessor {
+  private started = false;
+
+  constructor(private readonly startSpan: () => void) {}
+
+  onStart(_span: SdkSpan): void {}
+  onEnd(_span: ReadableSpan): void {}
+  async forceFlush(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    this.startSpan();
+  }
+  async shutdown(): Promise<void> {}
 }
 
 function startWithProcessors(
@@ -185,12 +203,29 @@ describe("shutdown semantics", () => {
     for (const span of recorder.endedSpans) {
       expect(span.status.code).toBe(SpanStatusCode.ERROR);
       expect(span.attributes[INTERRUPTED_SPAN_ATTRIBUTE]).toBe(true);
+      expect(span.attributes["error.type"]).toBe(INTERRUPTED_ERROR_TYPE);
     }
     const [child, model, root] = recorder.endedSpans;
     expect(child?.parentSpanContext?.spanId).toBe(model?.spanContext().spanId);
     expect(model?.parentSpanContext?.spanId).toBe(root?.spanContext().spanId);
     expect(recorder.calls.at(-2)).toBe("forceFlush");
     expect(recorder.calls.at(-1)).toBe("shutdown");
+  });
+
+  it("ends spans started while the final forceFlush is in flight", async () => {
+    const exporter = new InMemorySpanExporter();
+    const recorder = new RecordingProcessor(new SimpleSpanProcessor(exporter));
+    const starter = new StartSpanOnFlushProcessor(() => {
+      getApexTracer().startSpan("late shutdown work");
+    });
+    const runtime = startWithProcessors([recorder, starter]);
+
+    await runtime.shutdown();
+
+    expect(recorder.endedSpans.map((span) => span.name)).toEqual([
+      "late shutdown work",
+    ]);
+    expect(recorder.calls).toEqual(["forceFlush", "onEnd", "shutdown"]);
   });
 });
 
@@ -483,6 +518,10 @@ describe("final export", () => {
                   name?: string;
                   spanId?: string;
                   parentSpanId?: string;
+                  attributes?: Array<{
+                    key?: string;
+                    value?: { boolValue?: boolean };
+                  }>;
                 }>;
               }>;
             }>;
@@ -498,6 +537,13 @@ describe("final export", () => {
       expect(root).toBeDefined();
       expect(model?.parentSpanId).toBe(root?.spanId);
       expect(tool?.parentSpanId).toBe(model?.spanId);
+      for (const span of [root, model, tool]) {
+        expect(
+          span?.attributes?.find(
+            (attribute) => attribute.key === INTERRUPTED_SPAN_ATTRIBUTE,
+          )?.value?.boolValue,
+        ).toBe(true);
+      }
     } finally {
       await new Promise((resolve) => receiver.server.close(resolve));
     }

--- a/src/core/observability/shutdown.test.ts
+++ b/src/core/observability/shutdown.test.ts
@@ -5,6 +5,7 @@
 // never touched; the final trace reaches a local OTLP receiver.
 
 import { createServer, type Server } from "node:http";
+import { SpanStatusCode } from "@opentelemetry/api";
 import type {
   ReadableSpan,
   Span as SdkSpan,
@@ -16,6 +17,7 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getApexTracer } from "../observability";
+import { INTERRUPTED_SPAN_ATTRIBUTE } from "./active-spans";
 import {
   installObservabilityExitHandlers,
   resetObservabilityRuntime,
@@ -50,6 +52,7 @@ afterEach(async () => {
 /** Span processor that records lifecycle call order. */
 class RecordingProcessor implements SpanProcessor {
   readonly calls: string[] = [];
+  readonly endedSpans: ReadableSpan[] = [];
   private readonly inner: SpanProcessor;
   constructor(inner: SpanProcessor) {
     this.inner = inner;
@@ -59,6 +62,7 @@ class RecordingProcessor implements SpanProcessor {
   }
   onEnd(span: ReadableSpan): void {
     this.calls.push("onEnd");
+    this.endedSpans.push(span);
     this.inner.onEnd(span);
   }
   async shutdown(): Promise<void> {
@@ -155,6 +159,38 @@ describe("shutdown semantics", () => {
     // with the final flush instead of leaking.
     expect(recorder.calls).toEqual(["onEnd", "forceFlush", "shutdown"]);
     expect((rootSpan as unknown as { ended: boolean }).ended).toBe(true);
+  });
+
+  it("ends every in-flight span child-first and marks it interrupted", async () => {
+    const exporter = new InMemorySpanExporter();
+    const recorder = new RecordingProcessor(new SimpleSpanProcessor(exporter));
+    const runtime = startWithProcessors([recorder]);
+    const tracer = getApexTracer();
+
+    tracer.startActiveSpan("invoke_agent default", (root) => {
+      tracer.startActiveSpan("ai.streamText", (model) => {
+        tracer.startSpan("ai.streamText.doStream");
+        expect(model.isRecording()).toBe(true);
+      });
+      expect(root.isRecording()).toBe(true);
+    });
+
+    await runtime.shutdown();
+
+    expect(recorder.endedSpans.map((span) => span.name)).toEqual([
+      "ai.streamText.doStream",
+      "ai.streamText",
+      "invoke_agent default",
+    ]);
+    for (const span of recorder.endedSpans) {
+      expect(span.status.code).toBe(SpanStatusCode.ERROR);
+      expect(span.attributes[INTERRUPTED_SPAN_ATTRIBUTE]).toBe(true);
+    }
+    const [child, model, root] = recorder.endedSpans;
+    expect(child?.parentSpanContext?.spanId).toBe(model?.spanContext().spanId);
+    expect(model?.parentSpanContext?.spanId).toBe(root?.spanContext().spanId);
+    expect(recorder.calls.at(-2)).toBe("forceFlush");
+    expect(recorder.calls.at(-1)).toBe("shutdown");
   });
 });
 
@@ -417,6 +453,51 @@ describe("final export", () => {
       expect(names).toContain("invoke_agent default");
       expect(names).toContain("ai.streamText");
       expect(names).toContain("invoke_agent recon-sub");
+    } finally {
+      await new Promise((resolve) => receiver.server.close(resolve));
+    }
+  });
+
+  it("shutdown exports a still-open root/model/tool tree with its hierarchy", async () => {
+    const receiver = await startReceiver();
+    try {
+      process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = `http://127.0.0.1:${receiver.port}/v1/traces`;
+      const runtime = startObservabilityRuntime();
+      const tracer = getApexTracer();
+
+      tracer.startActiveSpan("invoke_agent default", () => {
+        tracer.startActiveSpan("ai.streamText", () => {
+          tracer.startSpan("ai.streamText.doStream");
+        });
+      });
+
+      await runtime.shutdown();
+
+      const [body] = await receiver.waitForRequests(1);
+      const spans =
+        (
+          body as {
+            resourceSpans?: Array<{
+              scopeSpans?: Array<{
+                spans?: Array<{
+                  name?: string;
+                  spanId?: string;
+                  parentSpanId?: string;
+                }>;
+              }>;
+            }>;
+          }
+        ).resourceSpans?.flatMap(
+          (resource) =>
+            resource.scopeSpans?.flatMap((scope) => scope.spans ?? []) ?? [],
+        ) ?? [];
+      const root = spans.find((span) => span.name === "invoke_agent default");
+      const model = spans.find((span) => span.name === "ai.streamText");
+      const tool = spans.find((span) => span.name === "ai.streamText.doStream");
+
+      expect(root).toBeDefined();
+      expect(model?.parentSpanId).toBe(root?.spanId);
+      expect(tool?.parentSpanId).toBe(model?.spanId);
     } finally {
       await new Promise((resolve) => receiver.server.close(resolve));
     }


### PR DESCRIPTION
### What does this PR do?

Apex previously ended only registered root agent spans during SIGTERM shutdown. OpenTelemetry does not export a span until `span.end()` invokes the processor chain, so any still-open generation, tool, or nested agent spans were absent even though the provider was force-flushed. That left consumers with orphaned children and forced EvalGate to infer missing parents.

This change:
- installs a lightweight `SpanProcessor` ahead of the exporter to track every recording span owned by Apex’s standalone SDK
- ends all still-open spans in reverse start order (children before parents) before the final force-flush
- marks shutdown-ended spans with ERROR status and `pensar.telemetry.interrupted=true`
- avoids double-ending spans still present in the legacy root registry
- preserves embedded-host isolation because the processor exists only on Apex’s standalone provider

### How did you verify your code works?

- `bunx vitest run src/core/observability/shutdown.test.ts src/core/observability/runtime.test.ts src/core/observability/trace-contract.test.ts` (49 tests)
- Added an OTLP receiver integration test proving a still-open root/model/tool tree is exported with intact parent IDs during shutdown
- `bun run tsc`
- `bun run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bounded process shutdown and span lifecycle for the standalone OTLP runtime; incorrect ordering could affect trace export or double-end behavior, though guards limit blast radius to telemetry.
> 
> **Overview**
> **Fixes missing trace data on Apex shutdown** by closing every still-open span before OTLP flush, not only registered root agent runs. OpenTelemetry only exports spans after `onEnd`, so previously nested model/tool spans could disappear while consumers saw orphaned children.
> 
> Adds an **`ActiveSpanProcessor`** as the first processor on Apex’s standalone tracer provider. It tracks recording spans (with a cap), ends them **deepest-first** during shutdown, and tags them with `pensar.telemetry.interrupted`, ERROR status, and `ApexProcessInterrupted` when appropriate. **`startObservabilityRuntime` shutdown** now runs `endAll()` before `forceFlush`, clears the legacy root registry, then runs **`endAll()` again** after flush to catch spans started while flush yields.
> 
> **Idempotent `span.end()`**: root registry, agent `invoke_agent` finally blocks, and shutdown paths all guard with **`span.isRecording()`** so shutdown-forced ends don’t race normal run completion.
> 
> Tests cover child-first interruption, late spans during flush, and OTLP export of an open root/model/tool tree with parent links intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f53b28b53296eaf3d9351c2afbf2ce91b8a8c933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->