### PR TITLE
docs(agents): add code-comments skill

### DIFF
--- a/.agents/skills/code-comments/SKILL.md
+++ b/.agents/skills/code-comments/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: code-comments
+description: Write tasteful, load-bearing comments in Apex source. Use when writing or editing code, JSDoc, TODOs, or file headers, or when deciding whether a comment should exist.
+---
+
+# Code comments
+
+How to comment when working on Apex. Read this before adding or rewriting comments.
+
+This is repository-development guidance for coding agents working on Apex. Keep it in the repo's `.agents/skills` tree only; do not copy or link it into `.claude/skills`, `.skills`, `skills`, `~/.agents/skills`, or `~/.pensar/skills`, because Apex scans those locations as runtime skills.
+
+## Invariants
+
+- A comment must carry information the code cannot recover. If a better name or a smaller function would make it unnecessary, do that instead.
+- Comment the why, the why-not, and the invariant. Never narrate the next line.
+- Place a load-bearing comment next to the code it constrains. Distant essays get skipped and do not protect the dangerous line.
+- Stale comments are bugs. If you change behavior a comment describes, update or delete it in the same edit.
+- Write for the next reader who was not in this conversation — human or agent. No session notes, "the user asked for this," or chat residue.
+- Default to one sentence. Two or three lines when the constraint needs them. No multi-paragraph docstrings and no labeled taxonomies (`CONTRACT`, `MUST`, `ARCHITECTURE`).
+- Don't comment-out code; git remembers. Don't add comments to code you did not touch.
+
+## Write one when
+
+- The obvious approach is wrong, and the next editor will "fix" it
+- Correctness depends on order, aliasing, re-entrancy, ownership, or a peer that is not visible here
+- A value, timeout, limit, or encoding looks arbitrary
+- The code works around a platform, SDK, or spec quirk (name the quirk)
+- A public contract is not expressible in the type (single-read streams, processor ordering, "do not route X through Y")
+- You spent real time learning something the next reader will not see
+- A TODO is still justified — say why it is deferred and what "done" means
+
+## Do not write one when
+
+- It restates the identifier, type, or the next statement
+- JSDoc would only echo parameter names and return types
+- The code is unclear and should be renamed or extracted instead
+- You are padding a change so it "looks documented"
+- The file already makes the point at the call site that matters
+
+Agents treat comments as durable memory. A precise invariant next to the line it protects prevents a locally reasonable, globally wrong edit. A paragraph of narration gets skipped or copied. Prefer the former.
+
+## House style
+
+Match neighboring Apex comments: natural prose, complete sentences, no banner art except where a test file already uses section rules.
+
+JSDoc is for exported types and methods when the types cannot carry the contract — who must call what, in what order, and what silently breaks. See `src/core/observability/active-spans.ts` and `src/core/api/index.ts`.
+
+An empty `catch` still needs the reason the error is swallowed.
+
+## Shape
+
+**Narration — delete it:**
+
+```
+// Reverse the spans
+const spans = [...this.active.entries()].reverse();
+```
+
+**Load-bearing — keep this shape:**
+
+```
+// Spans start parent-first, so reverse insertion order closes the deepest
+// children before their parents. Copy first because span.end() calls onEnd.
+```
+
+**Weak JSDoc:** `/** Tracks active spans. */`
+
+**Useful JSDoc:** states why `forceFlush` cannot recover open spans, and that this processor must stay first in the provider list.
+
+## Before you keep a comment
+
+1. Can the code say this instead?
+2. Will this still be true after the next obvious refactor?
+3. Is it next to the line it protects?
+4. Would skipping it let someone make a locally reasonable, globally wrong edit?

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ sst-env.d.ts
 .agents/skills/*
 !.agents/skills/.gitkeep
 !.agents/skills/create-skill/
+!.agents/skills/code-comments/
 !.agents/skills/pr/
 .claude/skills/*
 !.claude/skills/.gitkeep

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Bias to caution over speed on non-trivial work. Use judgment on trivial tasks.
 
 **Match the codebase's conventions, even if you disagree.** Conformance > taste. If a convention seems harmful, surface it — don't fork silently.
 
-**Avoid verbose comments.** Code should speak for itself — well-named identifiers and small functions beat prose. If context is genuinely non-obvious (a hidden constraint, a workaround, surprising behavior), a brief one-liner is fine. Don't narrate what the code does or write multi-paragraph docstrings.
+**Avoid verbose comments.** Code should speak for itself — well-named identifiers and small functions beat prose. If context is genuinely non-obvious (a hidden constraint, a workaround, surprising behavior), a brief one-liner is fine. Don't narrate what the code does or write multi-paragraph docstrings. The full standard is `.agents/skills/code-comments/SKILL.md`.
 
 **Fail loud.** "Completed" is wrong if anything was silently skipped. Default to surfacing uncertainty.
 
@@ -164,9 +164,11 @@ Enforced via the `import-x/no-internal-modules` ESLint rule in `eslint.config.js
 
 ### Skills
 
-Team-shared development-agent skills live at `.agents/skills/<name>/`. Use `/create-skill` to add a new one. The PR workflow below is developer-only and intentionally remains there: Apex scans `.claude/skills`, `.skills`, `skills`, `~/.agents/skills`, and `~/.pensar/skills` as runtime skill sources.
+Team-shared development-agent skills live at `.agents/skills/<name>/`. Use `/create-skill` to add a new one. Developer-only skills (PR workflow, code comments) intentionally remain there: Apex scans `.claude/skills`, `.skills`, `skills`, `~/.agents/skills`, and `~/.pensar/skills` as runtime skill sources.
 
 Before pull-request or merge-request work, read and follow `.agents/skills/pr/SKILL.md` (`/pr` in coding agents that discover repo `.agents` skills). It covers creating or updating PRs, preserving stack topology and formatting, babysitting CI, handling review or Bugbot findings, resolving conflicts, and performing explicitly authorized merges. The skill is the source of truth for the workflow; verify live GitHub state and operate on the latest head SHA.
+
+When writing or editing comments, JSDoc, or TODOs, read and follow `.agents/skills/code-comments/SKILL.md` (`/code-comments` in coding agents that discover repo `.agents` skills). Comment only what the code cannot say; do not narrate mechanics or add ceremony.
 
 ### Gotchas
 


### PR DESCRIPTION
## Summary

Adds a team-shared `/code-comments` skill for coding agents working on Apex. It is the same class as `/pr`: repository-development guidance in `.agents/skills` only, not a runtime skill Apex the product can load.

The skill tells agents to comment only what the code cannot recover — why, why-not, and invariants — and to keep those notes next to the line they protect. Narration, type-echoing JSDoc, session residue, and labeled comment taxonomies are out.

No linked issue

## Changes

- New `.agents/skills/code-comments/SKILL.md`, whitelisted in `.gitignore`
- `AGENTS.md` points at the skill the same way it points at `/pr`

## Validation

- `bun run format:check` — Prettier passed on markdown; Biome reported only pre-existing warnings (192) on untouched source
- Manual: confirmed the skill is not linked from `.claude/skills` or other Apex runtime skill scan paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and gitignore whitelist only; no runtime or application code changes.
> 
> **Overview**
> Adds a team-shared **`/code-comments`** agent skill at `.agents/skills/code-comments/SKILL.md`, parallel to `/pr`: it codifies when to write load-bearing comments (why, invariants, quirks) versus narration, echoing JSDoc, and session residue, with examples and a short checklist.
> 
> **`AGENTS.md`** now points the existing “avoid verbose comments” principle at that skill and documents that PR workflow and code comments are developer-only skills under `.agents/skills` (not Apex runtime skill paths). **`.gitignore`** whitelists `code-comments/` so the new skill is committed like `pr/` and `create-skill/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5402c62eb627e110cf03dc101fec76545599efc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->