### PR TITLE
feat(models): add DeepSeek V4.1 Flash via OpenRouter

### DIFF
--- a/src/core/ai/models/index.ts
+++ b/src/core/ai/models/index.ts
@@ -194,9 +194,12 @@ function lookupOutputBudgetByPattern(modelId: string): number {
     return 131_072;
   }
 
-  // DeepSeek (V3.1, R1, chat). Bedrock documents an 8K output window for
-  // DeepSeek V3.1; the rest of the family is no larger, so this is a safe floor
-  // that keeps new `deepseek.*` ids off the 4,096 catch-all.
+  // V4.1 Flash's larger output window must precede the legacy DeepSeek fallback.
+  if (modelId.includes("deepseek-v4.1-flash")) {
+    return 384_000;
+  }
+
+  // Keep the conservative 8K floor used by Bedrock's legacy DeepSeek models.
   if (modelId.includes("deepseek")) {
     return 8_192;
   }

--- a/src/core/ai/models/models.test.ts
+++ b/src/core/ai/models/models.test.ts
@@ -85,6 +85,15 @@ describe("getMaxOutputTokens", () => {
     expect(getMaxOutputTokens("zai.glm-5")).toBe(131_072);
   });
 
+  it("registers DeepSeek V4.1 Flash with its OpenRouter limits", () => {
+    expect(getModelInfo("deepseek/deepseek-v4.1-flash")).toMatchObject({
+      name: "DeepSeek V4.1 Flash",
+      provider: "openrouter",
+      contextLength: 1_048_576,
+    });
+    expect(getMaxOutputTokens("deepseek/deepseek-v4.1-flash")).toBe(384_000);
+  });
+
   it("recognizes the new Bedrock DeepSeek / Qwen output budgets", () => {
     // These three were silently inheriting the 4,096 catch-all, capping
     // replies far below each model's documented Bedrock limit.

--- a/src/core/ai/models/openrouter.ts
+++ b/src/core/ai/models/openrouter.ts
@@ -100,6 +100,12 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
     contextLength: 128000,
   },
   {
+    id: "deepseek/deepseek-v4.1-flash",
+    name: "DeepSeek V4.1 Flash",
+    provider: "openrouter",
+    contextLength: 1048576,
+  },
+  {
     id: "deepseek/deepseek-chat",
     name: "DeepSeek Chat",
     provider: "openrouter",


### PR DESCRIPTION
## Summary

Add DeepSeek V4.1 Flash (`deepseek/deepseek-v4.1-flash`) to Apex's curated OpenRouter models so it is selectable when OpenRouter is configured. Register its 1,048,576-token context window and 384,000-token output limit, with a specific budget rule ahead of the legacy DeepSeek 8,192-token fallback.

Limits were verified against OpenRouter's [model catalog](https://openrouter.ai/api/v1/models) and [route endpoints](https://openrouter.ai/api/v1/models/deepseek/deepseek-v4.1-flash/endpoints) on September 10, 2026. Regression coverage pins the model registration and output budget.

No linked issue

## Validation

- `bun run test` — 2,723 passed, 22 skipped. Reran outside the sandbox because existing tests write temporary fixtures under `~/.pensar`.
- `bun run tsc` — passed.
- `bun run lint` — passed with 192 existing warnings and 10 informational diagnostics; the three changed files have no diagnostics.
- `bun run format:check` — passed.
- Synthetic configuration smoke check — verified picker visibility, OpenRouter SDK model ID, output budget, and unchanged legacy DeepSeek budgets.

Live OpenRouter inference was not exercised.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry and token-budget lookup only; legacy DeepSeek budgets stay covered by existing tests.
> 
> **Overview**
> Adds **DeepSeek V4.1 Flash** (`deepseek/deepseek-v4.1-flash`) to the curated OpenRouter model list so it appears in the picker when OpenRouter is configured, with a **1,048,576** context window in the registry.
> 
> `getMaxOutputTokens` gains a **384,000**-token rule for `deepseek-v4.1-flash` **before** the generic DeepSeek **8,192** fallback, so this variant is not capped like legacy DeepSeek/Bedrock IDs. Tests lock in registration metadata and the output budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07c9fb8a502e976b3426421f0c2becbce0777397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->