### PR TITLE
test(observability): pin helper model-call trace contract

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -69,6 +69,22 @@ Structured JSON logs carry `trace_id`/`span_id` when written inside a span,
 and `trace.jsonl` records carry a `correlation` object — connecting OTel
 traces, logs, and W&B uploads.
 
+## Failure diagnostics
+
+Model-call failures are recorded passively on the spans the AI SDK already
+emits. What each path carries on failure:
+
+| Path                                                                | Recorded on failure                                                                                                                                       | Known limits                                                                                                    |
+| ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Helper `generateText` (structured generate, summarize, tool repair) | `ai.generateText` and `ai.generateText.doGenerate` both end with error status and an `exception` event (`exception.type`, message, stack)                 | No `error.type` span attribute; a numeric HTTP status known to the thrown error is not projected onto the spans |
+| Streaming (`streamText`)                                            | A thrown provider error marks both spans; an in-stream error part is marked on the root `ai.streamText` span (the `doStream` span can complete unerrored) | Same attribute limits as the helper path                                                                        |
+| Shutdown                                                            | Open spans gain `pensar.telemetry.interrupted=true` and `error.type=ApexProcessInterrupted` unless an error type is already set                           | An interruption marker is not evidence that the run was cancelled                                               |
+
+A rejected request never generated: token attributes stay absent rather than
+zero, and a generic error stays generic — nothing invents a schema or
+transport diagnosis. Payload capture remains opt-in
+(`AI_TRACE_RECORD_PAYLOADS`).
+
 ## Shutdown behavior
 
 Standalone processes flush before exit on every path — normal completion,

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -80,9 +80,9 @@ emits. What each path carries on failure:
 | Streaming (`streamText`)                                            | A thrown provider error marks both spans; an in-stream error part is marked on the root `ai.streamText` span (the `doStream` span can complete unerrored) | Same attribute limits as the helper path                                                                        |
 | Shutdown                                                            | Open spans gain `pensar.telemetry.interrupted=true` and `error.type=ApexProcessInterrupted` unless an error type is already set                           | An interruption marker is not evidence that the run was cancelled                                               |
 
-A rejected request never generated: token attributes stay absent rather than
-zero, and a generic error stays generic — nothing invents a schema or
-transport diagnosis. Payload capture remains opt-in
+When a failed call has no recorded usage, token attributes remain absent.
+Missing usage does not establish zero consumption. Generic errors do not
+establish a schema or transport diagnosis. Payload capture remains opt-in
 (`AI_TRACE_RECORD_PAYLOADS`).
 
 ## Shutdown behavior

--- a/src/core/observability/trace-contract.test.ts
+++ b/src/core/observability/trace-contract.test.ts
@@ -550,8 +550,11 @@ describe("existing trace contract: payload policy", () => {
     expect(streamText.attributes["ai.response.text"]).toBeUndefined();
   });
 
-  it("AI_TRACE_RECORD_PAYLOADS=false excludes helper prompts and responses", async () => {
-    process.env.AI_TRACE_RECORD_PAYLOADS = "false";
+  it.each([
+    false,
+    true,
+  ])("helper payload capture follows AI_TRACE_RECORD_PAYLOADS=%s", async (enabled) => {
+    process.env.AI_TRACE_RECORD_PAYLOADS = String(enabled);
     mockState.model = objectResultModel();
 
     await generateObjectResponse({
@@ -560,9 +563,20 @@ describe("existing trace contract: payload policy", () => {
       prompt: "secret prompt",
     });
 
-    const wrapper = requireSpan(otel.getFinishedSpans(), "ai.generateText");
-    expect(wrapper.attributes["ai.prompt"]).toBeUndefined();
-    expect(wrapper.attributes["ai.response.text"]).toBeUndefined();
+    const spans = otel.getFinishedSpans();
+    const provider = requireSpan(spans, "ai.generateText.doGenerate");
+    if (enabled) {
+      expect(provider.attributes["ai.prompt.messages"]).toContain(
+        "secret prompt",
+      );
+      expect(provider.attributes["ai.response.text"]).toBe('{"answer": 42}');
+    } else {
+      expect(provider.attributes["ai.prompt.messages"]).toBeUndefined();
+      expect(provider.attributes["ai.response.text"]).toBeUndefined();
+      const wrapper = requireSpan(spans, "ai.generateText");
+      expect(wrapper.attributes["ai.prompt"]).toBeUndefined();
+      expect(wrapper.attributes["ai.response.text"]).toBeUndefined();
+    }
   });
 
   it("AI_TRACE_RECORD_PAYLOADS=true includes prompts, responses, reasoning, tool arguments, and tool results", async () => {

--- a/src/core/observability/trace-contract.test.ts
+++ b/src/core/observability/trace-contract.test.ts
@@ -5,7 +5,7 @@
 // registered per test; the provider model is a deterministic mock so no API
 // keys are needed and spans are reproducible.
 
-import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import { APICallError, type LanguageModelV3StreamPart } from "@ai-sdk/provider";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { simulateReadableStream, stepCountIs } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
@@ -30,7 +30,7 @@ vi.mock("../ai/utils", async () => {
 import type { OtelTestHarness } from "./testkit";
 
 // Imported AFTER vi.mock so streamResponse's closure picks up the stub.
-const { streamResponse } = await import("../ai");
+const { generateObjectResponse, streamResponse } = await import("../ai");
 const {
   createGenerationSpanTracker,
   getApexTracer,
@@ -137,6 +137,23 @@ function probeTool() {
     inputSchema: z.object({ q: z.string() }),
     execute: async (input: { q: string }) => `echo:${input.q}`,
   };
+}
+
+/** A helper-path (generateText) model that returns one JSON object. */
+function objectResultModel(): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    provider: "mock-anthropic",
+    modelId: MODEL,
+    doGenerate: async () => ({
+      content: [{ type: "text", text: '{"answer": 42}' }],
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: {
+        inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
+        outputTokens: { total: 5, text: 5, reasoning: undefined },
+      },
+      warnings: [],
+    }),
+  });
 }
 
 async function drain(stream: { fullStream: AsyncIterable<unknown> }) {
@@ -428,6 +445,94 @@ describe("existing trace contract: model spans", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Helper generateText path (structured generate, summarize, tool repair)
+// ---------------------------------------------------------------------------
+
+describe("existing trace contract: helper generateText path", () => {
+  it("structured helper calls emit a correlated wrapper/provider span pair", async () => {
+    mockState.model = objectResultModel();
+
+    const result = await generateObjectResponse({
+      model: MODEL,
+      schema: z.object({ answer: z.number() }),
+      prompt: "hi",
+    });
+
+    expect(result).toEqual({ answer: 42 });
+    const spans = otel.getFinishedSpans();
+    const wrapper = requireSpan(spans, "ai.generateText");
+    const provider = requireSpan(spans, "ai.generateText.doGenerate");
+    // Same correlation contract as the streaming path: the provider call is
+    // a child of the operation span, one trace, model attribution preserved.
+    expect(parentOf(spans, provider)?.spanContext().spanId).toBe(
+      wrapper.spanContext().spanId,
+    );
+    expect(provider.spanContext().traceId).toBe(wrapper.spanContext().traceId);
+    expect(provider.attributes["gen_ai.request.model"]).toBe(MODEL);
+    expect(provider.attributes["ai.telemetry.functionId"]).toBe(
+      "apex.structured.generate",
+    );
+    expect(provider.attributes["gen_ai.usage.input_tokens"]).toBe(10);
+    expect(wrapper.status.code).not.toBe(SpanStatusCode.ERROR);
+  });
+
+  it("a rejected helper call marks both spans failed without inventing usage or status facts", async () => {
+    // The production rejection shape: the provider call throws an APICallError
+    // whose numeric status is known only to the thrown error object.
+    const rejection = new APICallError({
+      message: "Request rejected: invalid request",
+      url: "https://api.example.com/v1/responses",
+      requestBodyValues: {},
+      statusCode: 400,
+      isRetryable: false,
+    });
+    let calls = 0;
+    mockState.model = new MockLanguageModelV3({
+      provider: "mock-anthropic",
+      modelId: MODEL,
+      doGenerate: async () => {
+        calls += 1;
+        throw rejection;
+      },
+    });
+
+    const thrown = await generateObjectResponse({
+      model: MODEL,
+      schema: z.object({ answer: z.number() }),
+      prompt: "hi",
+    }).catch((error: unknown) => error);
+
+    // Passive diagnostics: the original error identity and the single
+    // physical provider call are preserved.
+    expect(thrown).toBe(rejection);
+    expect(calls).toBe(1);
+
+    const spans = otel.getFinishedSpans();
+    for (const name of ["ai.generateText", "ai.generateText.doGenerate"]) {
+      const span = requireSpan(spans, name);
+      expect(span.status.code, name).toBe(SpanStatusCode.ERROR);
+      expect(
+        span.events.some(
+          (event) =>
+            event.name === "exception" &&
+            event.attributes?.["exception.type"] === "AI_APICallError",
+        ),
+        name,
+      ).toBe(true);
+    }
+
+    const provider = requireSpan(spans, "ai.generateText.doGenerate");
+    // A rejected request never generated: usage stays absent, not zero.
+    expect(provider.attributes["gen_ai.usage.input_tokens"]).toBeUndefined();
+    expect(provider.attributes["ai.usage.inputTokens"]).toBeUndefined();
+    // Known failure facts are not yet projected onto span attributes; filling
+    // that emitter gap is the follow-up passive-diagnostics change.
+    expect(provider.attributes["error.type"]).toBeUndefined();
+    expect(provider.attributes["http.response.status_code"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Payload policy
 // ---------------------------------------------------------------------------
 
@@ -443,6 +548,21 @@ describe("existing trace contract: payload policy", () => {
     const streamText = requireSpan(otel.getFinishedSpans(), "ai.streamText");
     expect(streamText.attributes["ai.prompt"]).toBeUndefined();
     expect(streamText.attributes["ai.response.text"]).toBeUndefined();
+  });
+
+  it("AI_TRACE_RECORD_PAYLOADS=false excludes helper prompts and responses", async () => {
+    process.env.AI_TRACE_RECORD_PAYLOADS = "false";
+    mockState.model = objectResultModel();
+
+    await generateObjectResponse({
+      model: MODEL,
+      schema: z.object({ answer: z.number() }),
+      prompt: "secret prompt",
+    });
+
+    const wrapper = requireSpan(otel.getFinishedSpans(), "ai.generateText");
+    expect(wrapper.attributes["ai.prompt"]).toBeUndefined();
+    expect(wrapper.attributes["ai.response.text"]).toBeUndefined();
   });
 
   it("AI_TRACE_RECORD_PAYLOADS=true includes prompts, responses, reasoning, tool arguments, and tool results", async () => {


### PR DESCRIPTION
## Stack

> [!NOTE]
> **Model-call diagnostics · PR 1 of 2**<br>
> Review and merge in table order; the second PR is based on the first.

| Step | Pull request | Focus |
| :---: | --- | --- |
| **1** | **[#1063](https://github.com/pensarai/apex/pull/1063)** | **Helper trace coverage** · `Current` |
| 2 | [#1064](https://github.com/pensarai/apex/pull/1064) | Bounded failure metadata |

### What does this PR do?

Helper calls through `generateObjectResponse` lacked a pinned trace contract. Add deterministic mock-model coverage for the `ai.generateText` operation and provider spans, helper/model attribution, exception events, absent usage, and opt-in payload capture. Document what each failure path records and the limits of that evidence.

No linked issue.

### How did you verify your code works?

Validated the committed tree in a clean worktree:

- `bun --no-env-file run test --maxWorkers=2 --minWorkers=1`: 2,726 passed, 22 skipped.
- `bun --no-env-file run tsc`, `lint`, and `format:check`: passed.
- Trace-contract tests use deterministic mock providers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and deterministic trace-contract tests only; no production telemetry or AI call behavior changes.
> 
> **Overview**
> Pins the **helper `generateText` trace contract** (structured generate via `generateObjectResponse`) before follow-up failure-metadata work. New contract tests assert `ai.generateText` / `ai.generateText.doGenerate` parent-child correlation, `apex.structured.generate` attribution, success usage, **`APICallError` failure** (both spans error + exception events, no invented token usage, no `error.type`/HTTP status on spans yet), and that **`AI_TRACE_RECORD_PAYLOADS`** gates helper prompts/responses like streaming.
> 
> **`docs/observability.md`** adds a **Failure diagnostics** section documenting what helper, streaming, and shutdown paths record on failure and explicit limits (absent usage ≠ zero tokens; interruption marker ≠ cancellation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c24b021924c4437959936f2aa8376e9f82014f06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

